### PR TITLE
Makefiles: use "git clone --depth 1 ..." when possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ tests:
 	@if [ -d $(R2R) ]; then \
 		cd $(R2R) ; git clean -xdf ; git pull ; \
 	else \
-		git clone ${R2R_URL} $(R2R); \
+		git clone --depth 1 ${R2R_URL} $(R2R); \
 	fi
 	cd $(R2R) ; ${MAKE}
 

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -69,7 +69,7 @@ libwind:
 
 sdb-sync sync-sdb:
 	rm -rf sdb sdb.vc
-	git clone ${SDB_URL} sdb.vc
+	git clone --depth 1 ${SDB_URL} sdb.vc
 	mkdir -p sdb
 	cp -rf ${SYNCFILES} sdb
 	rm -rf sdb.vc $I/sdb
@@ -103,7 +103,7 @@ HFILES+=elf.h libtcc.h config.h i386-tok.h
 .PHONY: sdb-sync sync-sdb sdbclean
 tcc-sync sync-tcc:
 	rm -rf _
-	git clone git://repo.or.cz/tinycc.git _
+	git clone --depth 1 git://repo.or.cz/tinycc.git _
 	cd _ ; ./configure --prefix=${PREFIX}
 	mkdir -p tcc
 	for a in ${CFILES} ${HFILES} ; do cp -f _/$$a tcc ; done

--- a/shlr/udis86/Makefile
+++ b/shlr/udis86/Makefile
@@ -14,7 +14,7 @@ $(OUT):
 sync:
 	rm -rf tmp
 	mkdir -p tmp
-	git clone git://github.com/radare/udis86.git
+	git clone --depth 1 git://github.com/radare/udis86.git
 	cd udis86/libudis86 ; ${PYTHON} ../scripts/ud_itab.py ../docs/x86/optable.xml .
 	cp -f udis86/libudis86/*.[ch] .
 	rm -rf udis86


### PR DESCRIPTION
When cloning {sdb,tcc,udis86,radare-regressions} repos: slightly reduces build time with slow connections.