### PR TITLE
Return codes for pd[bf] commands.

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1421,7 +1421,7 @@ static int cmd_print(void *data, const char *input) {
 					}
 				} else {
 					eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
-					core->num->value = 2;
+					core->num->value = -1;
 				}
 			}
 			break;
@@ -1475,7 +1475,7 @@ static int cmd_print(void *data, const char *input) {
 				} else {
 					eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
 					processed_cmd = R_TRUE;
-					core->num->value = 2;
+					core->num->value = -1;
 				}
 			}
 			l = 0;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1419,7 +1419,10 @@ static int cmd_print(void *data, const char *input) {
 						free (block);
 						pd_result = 0;
 					}
-				} else eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
+				} else {
+					eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
+					core->num->value = 2;
+				}
 			}
 			break;
 		case 'f': // "pdf"
@@ -1472,6 +1475,7 @@ static int cmd_print(void *data, const char *input) {
 				} else {
 					eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
 					processed_cmd = R_TRUE;
+					core->num->value = 2;
 				}
 			}
 			l = 0;


### PR DESCRIPTION
The `pd[bf]` commands do not set a return code in case there
is no function at the address. This patch makes it also return `2`
along with printing an error to stderr. The error code can be checked
for with the `??` command.

There's something funny going on though, if the analyze step err's with
for example 'Function too big ...' the address still will be flagged
with the func flag (as reported by `ai`) but both `pd[bf]` will
hit the wall.

Signed-off-by: Pavel Odvody <podvody@redhat.com>