### PR TITLE
pxl segmentation fault fix

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -864,6 +864,9 @@ static int cmd_print(void *data, const char *input) {
 				if (l>0) {
 					len = l;
 					if (l>tbs) {
+						if (input[0] == 'x' && input[1] == 'l') {
+							l *= core->print->cols;
+						}
 						if (!r_core_block_size (core, l)) {
 							eprintf ("This block size is too big. Did you mean 'p%c @ %s' instead?\n",
 								*input, input+2);


### PR DESCRIPTION
'pxl %value%' has been crushed the program in some cases. When %value% is more than 0x1000 r_core_block_size() reallocates the block forgetting that %value% is a number of lines, not a number of bytes, so we should reallocate %value% * 16 bytes. 
This number depending on how much memory the system can give us. For example, %value% is 0x400680 and r_core_block_size() successfully reallocs the buffer with size 0x401000, but later in r_print_hexdump() we try to print 0x4006800 bytes.