### PR TITLE
Return -1 if the function was not found

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1404,7 +1404,10 @@ static int cmd_print(void *data, const char *input) {
 							r_cons_printf ("-[false]-> 0x%08"PFMT64x"\n", b->fail);
 						r_cons_printf ("--\n");
 					}
-				} else eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
+				} else {
+					eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
+					core->num->value = -1;
+				}
 				pd_result = R_TRUE;
 			}
 			break;
@@ -1424,7 +1427,7 @@ static int cmd_print(void *data, const char *input) {
 					}
 				} else {
 					eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
-					core->num->value = 2;
+					core->num->value = -1;
 				}
 			}
 			break;
@@ -1478,7 +1481,7 @@ static int cmd_print(void *data, const char *input) {
 				} else {
 					eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
 					processed_cmd = R_TRUE;
-					core->num->value = 2;
+					core->num->value = -1;
 				}
 			}
 			l = 0;


### PR DESCRIPTION
Changed the return code of pd[rbf] to `-1` in case the function 
cannot be found at the address.

As for the `radare/radare2-regressions`, this branch shows
11% brokenness (30 tests failed), while currently upstream 
branch shows 13% brokenness (37 failed).