### PR TITLE
Fix to always save history when exiting

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -767,6 +767,7 @@ int main(int argc, char **argv, char **envp) {
 				prj = r_config_get (r.config, "file.project");
 				if (prj && *prj && r_cons_yesno ('y', "Do you want to save the project? (Y/n)"))
 					r_core_project_save (&r, prj);
+				r_line_hist_save (R2_HOMEDIR"/history");
 			} else {
 				// r_core_project_save (&r, prj);
 				if (debug) {

--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -767,7 +767,6 @@ int main(int argc, char **argv, char **envp) {
 				prj = r_config_get (r.config, "file.project");
 				if (prj && *prj && r_cons_yesno ('y', "Do you want to save the project? (Y/n)"))
 					r_core_project_save (&r, prj);
-				r_line_hist_save (R2_HOMEDIR"/history");
 			} else {
 				// r_core_project_save (&r, prj);
 				if (debug) {
@@ -777,6 +776,15 @@ int main(int argc, char **argv, char **envp) {
 			break;
 		}
 	}
+#if __UNIX__
+	if (isatty(0)) {
+#endif
+		 if (r_config_get_i(r.config, "scr.histsave") &&
+				r_config_get_i(r.config, "scr.interactive"))
+			r_line_hist_save (R2_HOMEDIR"/history");
+#if __UNIX__
+	}
+#endif
 	// TODO: kill thread
 
 	/* capture return value */

--- a/libr/core/cmd_quit.c
+++ b/libr/core/cmd_quit.c
@@ -19,12 +19,10 @@ static int cmd_quit(void *data, const char *input) {
 		return -2;
 	case '\0':
 		core->num->value = 0LL;
-		r_line_hist_save (R2_HOMEDIR"/history");
 		return -2;
 	default:
 		if (*input == ' ')
 			input++;
-		r_line_hist_save (R2_HOMEDIR"/history");
 		if (*input)
 			r_num_math (core->num, input);
 		else core->num->value = 0LL;

--- a/libr/core/cmd_quit.c
+++ b/libr/core/cmd_quit.c
@@ -3,9 +3,10 @@
 static int cmd_quit(void *data, const char *input) {
 	RCore *core = (RCore *)data;
 	const char* help_msg[] = {
-		"Usage:",  "q[!] [retval]", "",
+		"Usage:",  "q[!][!] [retval]", "",
 		"q","","quit program",
 		"q!","","force quit (no questions)",
+		"q!!","","force quit without saving history",
 		"q"," 1","quit with return value 1",
 		"q"," a-b","quit with return value a-b",
 		NULL};
@@ -15,6 +16,8 @@ static int cmd_quit(void *data, const char *input) {
 		r_core_cmd_help (core, help_msg);
 		break;
 	case '!':
+		if (input[1] == '!')
+			r_config_set (core->config, "scr.histsave", "false");
 		core->num->value = -1;
 		return -2;
 	case '\0':

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1165,6 +1165,7 @@ R_API int r_core_config_init(RCore *core) {
 #else
 	SETCB("scr.utf8", "false", &cb_utf8, "Show UTF-8 characters instead of ANSI");
 #endif
+	SETPREF("scr.histsave", "true", "Always save history on exit");
 	/* search */
 	SETCB("search.contiguous", "true", &cb_contiguous, "Accept contiguous/adjacent search hits");
 	SETICB("search.align", 0, &cb_searchalign, "Only catch aligned search hits");


### PR DESCRIPTION
When exiting radare by using ctrl+d or due to null stdin read it doesnt save
history as expected. Actually it was only saving when exiting using 'q'.