### PR TITLE
config-user: Fix build for wacky git setups

### DIFF
--- a/config-user.mk.acr
+++ b/config-user.mk.acr
@@ -68,7 +68,7 @@ LIBZIP=@LIBZIP@
 SSL_CFLAGS=@SSL_CFLAGS@
 SSL_LDFLAGS=@SSL_LDFLAGS@
 
-GIT_TIP=$(shell (git log HEAD^..HEAD 2>&1 || echo HEAD) |head -n1|cut -d ' ' -f2)
+GIT_TIP=$(shell (git rev-parse HEAD 2>/dev/null || echo HEAD ))
 GIT_TAP=$(shell (git describe --tags 2>/dev/null || echo ${VERSION} ))
 
 # cache compiler flags at configure time #


### PR DESCRIPTION
My personal git setup uses log.decorate = short. The `git log` magic
to extract the current revision breaks badly in this case, causing
$(GIT_TIP) to become "(HEAD". This heavily confuses bash and the build
breaks as a result.

Use the lower-level `git rev-parse` plumbing command to fetch the full
commit hash rather than grepping on the porcelain output.