### PR TITLE
pf.elf_phdr fix

### DIFF
--- a/libr/bin/d/elf32
+++ b/libr/bin/d/elf32
@@ -1,4 +1,4 @@
 pfo elf_enums
 pf.elf_header [16]z[2]E[2]Exxxxxwwwwww ident (elf_type)type (elf_machine)machine version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
-pf.elf_phdr wxxxwwww type offset vaddr paddr filesz memsz flags align
+pf.elf_phdr xxxxxxxx type offset vaddr paddr filesz memsz flags align
 pf.elf_shdr xxxxxxxxxx name type flags addr offset size link info addralign entsize

--- a/libr/bin/d/elf64
+++ b/libr/bin/d/elf64
@@ -1,4 +1,4 @@
 pfo elf_enums
 pf.elf_header [16]z[2]E[2]Exqqqxwwwwww ident (elf_type)type (elf_machine)machine version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
-pf.elf_phdr qqqqqqqq type offset vaddr paddr filesz memsz flags align
+pf.elf_phdr xxqqqqqq type flags offset vaddr paddr filesz memsz align
 pf.elf_shdr xxqqqqxxqq name type flags addr offset size link info addralign entsize

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -113,12 +113,12 @@ static int Elf_(r_bin_elf_init_phdr)(struct Elf_(r_bin_elf_obj_t) *bin) {
 	sdb_num_set (bin->kv, "elf_shdr_size.offset", sizeof (Elf_(Shdr)), 0);
 #if R_BIN_ELF64
 	sdb_num_set (bin->kv, "elf_phdr.offset", bin->ehdr.e_phoff, 0);
-	sdb_set (bin->kv, "elf_phdr.format", "qqqqqqqq type offset vaddr paddr filesz memsz flags align", 0);
+	sdb_set (bin->kv, "elf_phdr.format", "xxqqqqqq type flags offset vaddr paddr filesz memsz align", 0);
 	sdb_num_set (bin->kv, "elf_shdr.offset", bin->ehdr.e_shoff, 0);
 	sdb_set (bin->kv, "elf_shdr.format", "xxqqqqxxqq name type flags addr offset size link info addralign entsize", 0);
 #else
 	sdb_num_set (bin->kv, "elf_phdr.offset", bin->ehdr.e_phoff, 0);
-	sdb_set (bin->kv, "elf_phdr.format", "wxxxwwww type offset vaddr paddr filesz memsz flags align", 0);
+	sdb_set (bin->kv, "elf_phdr.format", "xxxxxxxx type offset vaddr paddr filesz memsz flags align", 0);
 	sdb_num_set (bin->kv, "elf_shdr.offset", bin->ehdr.e_shoff, 0);
 	sdb_set (bin->kv, "elf_shdr.format", "xxxxxxxxxx name type flags addr offset size link info addralign entsize", 0);
 #endif


### PR DESCRIPTION
In 32-bit mode a size of some program header fields has been wrong. In other case the 'flags' field has been moved to appropriate place as well.