### PR TITLE
build on clang jenkins now

### DIFF
--- a/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.h
+++ b/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.h
@@ -484,12 +484,10 @@ typedef struct dis_buffer dis_buffer_t;
 #define DB_STGY_ANY 0  /*@@@*/
 
 /* common Unix typedefs used in m68k_disasm.c */
-#if !defined(_SYS_TYPES_H)
 #define u_char unsigned char
 #define u_short unsigned short
 #define u_int unsigned int
 #define u_long unsigned long
-#endif
 typedef unsigned long vm68k_offset_t;
 typedef unsigned long db_expr_t; /*@@@*/
 typedef const char *db_sym_t;  /*@@@*/

--- a/libr/core/syscmd.c
+++ b/libr/core/syscmd.c
@@ -56,7 +56,9 @@ static void showfile(const int nth, const char *fpath, const char *name, int pri
 			case S_IFBLK: fch = 'b'; break;
 			case S_IFLNK: fch = 'l'; break;
 			case S_IFIFO: fch = 'p'; break;
+#ifdef S_IFSOCK
 			case S_IFSOCK: fch = 's'; break;
+#endif
 			}
 	}
 #else

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -2017,7 +2017,9 @@ static RList *r_debug_desc_native_list (int pid) {
 			type = perm = 0;
 			if (stat (file, &st) != -1) {
 				type  = st.st_mode & S_IFIFO  ? 'P':
+#ifdef S_IFSOCK
 					st.st_mode & S_IFSOCK ? 'S':
+#endif
 					st.st_mode & S_IFCHR  ? 'C':'-';
 			}
 			if (lstat(path, &st) != -1) {

--- a/libr/magic/apprentice.c
+++ b/libr/magic/apprentice.c
@@ -48,9 +48,7 @@
 #define	EATAB {while (isascii((ut8) *l) && isspace((ut8) *l))  ++l;}
 #define LOWCASE(l) (isupper((ut8) (l)) ? tolower((ut8) (l)) : (l))
 
-#ifdef __HAIKU__
 #define MAP_FILE 0
-#endif
 
 struct r_magic_entry {
 	struct r_magic *mp;

--- a/shlr/grub/fs/reiserfs.c
+++ b/shlr/grub/fs/reiserfs.c
@@ -39,15 +39,8 @@
 #include <grub/types.h>
 #include <grub/fshelp.h>
 
-#define MIN(a, b) \
-  ({ typeof (a) _a = (a); \
-     typeof (b) _b = (b); \
-     _a < _b ? _a : _b; })
-
-#define MAX(a, b) \
-  ({ typeof (a) _a = (a); \
-     typeof (b) _b = (b); \
-     _a > _b ? _a : _b; })
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 #define REISERFS_SUPER_BLOCK_OFFSET 0x10000
 #define REISERFS_MAGIC_LEN 12

--- a/shlr/grub/include/grub/misc.h
+++ b/shlr/grub/include/grub/misc.h
@@ -42,7 +42,7 @@
 #endif
 
 #define ALIGN_UP(addr, align) \
-	((addr + (typeof (addr)) align - 1) & ~((typeof (addr)) align - 1))
+	((addr + (int) align - 1) & ~((int) align - 1))
 #define ARRAY_SIZE(array) (sizeof (array) / sizeof (array[0]))
 #define COMPILE_TIME_ASSERT(cond) switch (0) { case 1: case !(cond): ; }
 


### PR DESCRIPTION
this will allow the clang build to work, removes some gcc specific stuff (typeof), adds some ifdefs, removes some stuff.

This is untested except for it builds, lmk.