### PR TITLE
Wrote tests x86_new assembler and fixed some bugs

### DIFF
--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -870,7 +870,8 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 		if (mod != 3 && rm == 4)
 			data[l++] = make_SIB(scale, index, base);
 
-		if (regmem_op->type & OT_MEMORY && (mod > 0 || (mod == 0 && rm == 5))) {
+		if (regmem_op->type & OT_MEMORY &&
+				(mod > 0 || (mod == 0 && rm == 5) || (mod == 0 && rm == 4 && base == 5))) {
 			if (mod == 1) {
 				data[l++] = *(ut8 *)&regmem_op->offset;
 			}

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -111,8 +111,7 @@ typedef struct operand_t {
 typedef enum tokentype_t {
 	TT_EOF,
 	TT_WORD,
-	TT_DECIMAL,
-	TT_HEXADECIMAL,
+	TT_NUMBER,
 	TT_SPECIAL
 } x86newTokenType;
 
@@ -137,16 +136,10 @@ static x86newTokenType getToken(const char *str, int *begin, int *end) {
 		return TT_WORD;
 	}
 	else if (isdigit(str[*begin])) {   // number token
-		x86newTokenType type = TT_DECIMAL;
-		if (str[*begin] == '0' && str[*begin + 1] == 'x') {
-			*begin += 2;
-			type = TT_HEXADECIMAL;
-		}
-
 		*end = *begin;
 		while (isalnum(str[*end]))     // accept alphanumeric characters, because hex.
 			++(*end);
-		return type;
+		return TT_NUMBER;
 	}
 	else {                             // special character: [, ], +, *, ...
 		*end = *begin + 1;
@@ -192,7 +185,8 @@ static Register parseReg(const char *str, int len, ut32 *type) {
  * Read decimal or hexadecimal number.
  */
 static ut64 readNumber(const char *str, x86newTokenType type) {
-	return strtol(str, 0, type == TT_DECIMAL ? 10 : 16);
+	int hex = (str[0] == '0' && str[1] == 'x');
+	return strtol(str + 2*hex, 0, hex ? 16 : 10);
 }
 
 // Parse operand

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -847,6 +847,9 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 				if (regmem_op->scale[0] == 1 && regmem_op->scale[1] == 0 && regmem_op->regs[0] != 4) {
 					rm = regmem_op->regs[0];
 				}
+				else if (regmem_op->scale[0] == 0) {  // Special case: [0x0]
+					rm = 5;
+				}
 				else {      // Otherwise, we need a SIB byte
 					if (regmem_op->scale[1] == 0) {
 						if (regmem_op->scale[0] != 1)
@@ -873,15 +876,16 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 		if (mod != 3 && rm == 4)
 			data[l++] = make_SIB(scale, index, base);
 
-		if (regmem_op->type & OT_MEMORY && regmem_op->offset) {
+		if (regmem_op->type & OT_MEMORY && (mod > 0 || (mod == 0 && rm == 5))) {
 			if (mod == 1) {
 				data[l++] = *(ut8 *)&regmem_op->offset;
 			}
 			else {
-				data[l++] = *((ut8 *)&regmem_op->offset + 0);
-				data[l++] = *((ut8 *)&regmem_op->offset + 1);
-				data[l++] = *((ut8 *)&regmem_op->offset + 2);
-				data[l++] = *((ut8 *)&regmem_op->offset + 3);
+				ut8 *offset_ptr = (ut8 *)&regmem_op->offset;
+				data[l++] = *(offset_ptr + 0);
+				data[l++] = *(offset_ptr + 1);
+				data[l++] = *(offset_ptr + 2);
+				data[l++] = *(offset_ptr + 3);
 			}
 		}
 	}

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -131,7 +131,7 @@ static x86newTokenType getToken(const char *str, int *begin, int *end) {
 	}
 	else if (isalpha(str[*begin])) {   // word token
 		*end = *begin;
-		while (isalpha(str[*end]))
+		while (isalnum(str[*end]))
 			++(*end);
 		return TT_WORD;
 	}

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -932,7 +932,7 @@ static int assemble(RAsm *a, RAsmOp *ao, const char *str) {
 
 	// Parse operands
 	int op_ind = 0;
-	x86newTokenType ttype = TT_SPECIAL;
+	x86newTokenType ttype = getToken(str, &pos, &nextpos);
 	while (op_ind < 3 && ttype != TT_EOF) {
 		// Read operand
 		pos += parseOperand(str + pos, &operands[op_ind++]);

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -437,9 +437,9 @@ Opcode opcodes[] = {
 	// 0x66: operand size prefix
 	// 0x67: address size prefix
 	{"push", {OT_IMMEDIATE | OT_DWORD}, 1, {0x68}},
-	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x69}}, // ?
+	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x69}},
 	{"push", {OT_IMMEDIATE | OT_BYTE}, 1, {0x6A}},
-	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x6B}}, // ?
+	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x6B}},
 	{"insb", {}, 1, {0x6C}},
 	{"ins", {}, 1, {0x6D}}, {"insd", {}, 1, {0x6D}},
 	{"insw", {}, 2, {0x66, 0x6D}},
@@ -483,10 +483,10 @@ Opcode opcodes[] = {
 	// 0x80 -- 0x83: immediate group 1
 	// 0x84, 0x85: TODO: test
 	// 0x86, 0x87: TODO: xchg
-	{"mov", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x88}},
-	{"mov", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x89}},
-	{"mov", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x8A}},
-	{"mov", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x8B}},
+	{"mov", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x88}},
+	{"mov", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x89}},
+	{"mov", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x8A}},
+	{"mov", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x8B}},
 	{"mov", {OT_MEMORY | OT_WORD, OT_SEGMENTREG | OT_WORD}, 1, {0x8C}}, // ?
 	{"lea", {OT_GPREG | OT_DWORD, OT_MEMORY | OT_DWORD}, 1, {0x8D}},	// allow all sizes?
 	{"mov", {OT_SEGMENTREG | OT_WORD, OT_MEMORY | OT_WORD}, 1, {0x8E}}, // ?

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -794,7 +794,7 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 				return 0;
 
 			// Which components do we have?
-			if (regmem_op->offset) {
+			if (regmem_op->offset || regmem_op->regs[0] == X86R_EBP) {
 				if (regmem_op->scale[0] == 0) {
 					mod = 0;
 					rm = 5;

--- a/libr/asm/t/test.new
+++ b/libr/asm/t/test.new
@@ -1,0 +1,83 @@
+#!/bin/sh
+asm_test() {
+	res=`rasm2 -ax86.new -b32 "$1"`
+	disas=`rasm2 -d -ax86 -b32 $res | tr "\\n" ";"`
+	printf "Assembled $1 to $res\n"
+	if [ "$res" = "$2" ]; then
+		echo -e "\x1b[32mOK\x1b[0m ($disas)"
+	else
+		echo -e "\x1b[31mFAILED\x1b[0m ($disas), expected $2"
+	fi
+}
+
+# PARSER tests
+asm_test 'int3' cc
+
+# OPCODES
+# operations without operands
+asm_test 'fsin' d9fe
+asm_test 'pushad' 60
+asm_test 'aaa' 37
+asm_test 'stc' f9
+asm_test 'rep stosd' f3ab
+
+# single byte with implicit operands
+asm_test 'pop ecx' 59
+asm_test 'push edi' 57
+asm_test 'xchg eax, eax' 90
+asm_test 'xchg eax, edx' 92
+asm_test 'in eax, dx' ed
+asm_test 'out dx, al' ee
+
+# immediate operands
+asm_test 'int 0xab' cdab
+asm_test 'mov eax, 0' b800000000
+asm_test 'mov edx, 0x12345678' ba78563412
+asm_test 'out 0x23, al' e623
+asm_test 'add eax, 0x12' 0512000000 # or 83C012 ?
+asm_test 'add eax, 0x12345678' 0578563412
+asm_test 'add dword ptr [esp+4], 0x12' 8344240412
+asm_test 'add dword ptr [esp+4], 0x12345678' 8144240478563412
+
+# register/memory
+asm_test 'add byte ptr [edx], al' 0002
+asm_test 'or [edx], eax' 0902
+asm_test 'lea eax, [eax+2*ecx]' 8d0448
+
+# complex
+asm_test 'imul eax, ecx, 21' 6bc115
+asm_test 'imul eax, ecx, 0x12345' 69c145230100
+
+# MEMORY operands
+# Immediates
+asm_test 'mov eax, dword ptr [0]' 8b0500000000
+asm_test 'mov eax, dword ptr [0x12345678]' 8b0578563412
+
+# indirect addressing
+asm_test 'cmp edi, [esi+0x8]' 3b7e08
+asm_test 'cmp ebx, [esp+0x8]' 3b5c2408
+asm_test 'cmp edi, [ebp+0x500]' 3bbd00050000
+
+asm_test 'add eax, dword ptr [0]' 030500000000
+asm_test 'add eax, dword ptr [edx]' 0302
+asm_test 'add eax, dword ptr [edx + 4]' 034204
+asm_test 'add eax, dword ptr [edx + 0x12345678]' 038278563412
+asm_test 'add eax, dword ptr [ebp]' 034500
+asm_test 'add eax, dword ptr [ebp + 4]' 034504
+asm_test 'add eax, dword ptr [ebp + 0x12345678]' 038578563412
+asm_test 'add eax, dword ptr [esp]' 030424
+asm_test 'add eax, dword ptr [esp + 4]' 03442404
+asm_test 'add eax, dword ptr [esp + 0x12345678]' 03842478563412
+asm_test 'add eax, dword ptr [0x12 + 2*ecx]' 03044d12000000
+asm_test 'add eax, dword ptr [0x12345678 + 2*ecx]' 03044d78563412
+asm_test 'add eax, dword ptr [eax + 2*ecx]' 030448
+asm_test 'add eax, dword ptr [eax + 2*ecx + 4]' 03444804
+asm_test 'add eax, dword ptr [eax + 2*ecx + 0x12345678]' 03844878563412
+asm_test 'add eax, dword ptr [5*eax]' 030480
+asm_test 'add eax, dword ptr [1 + 41*57 + eax]' 038022090000
+
+# jump addresses
+asm_test 'je 0x17' 7415
+asm_test 'jmp 0x12345678' e973563412
+asm_test 'jmp 0x17' eb15
+asm_test 'je 0x17; jmp 0x17' 7415eb13

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1161,14 +1161,10 @@ if (
 			}
 			if (strtab_section->sh_size> ST32_MAX) {
 				eprintf ("size (syms strtab)");
-				free (ret);
-				free (strtab);
 				return NULL;
 			}
 			if ((strtab = (char *)calloc (1, 8+strtab_section->sh_size)) == NULL) {
 				eprintf ("malloc (syms strtab)");
-				free (ret);
-				free (strtab);
 				return NULL;
 			}
 			if (r_buf_read_at (bin->b, strtab_section->sh_offset,
@@ -1223,7 +1219,6 @@ if (
 				} else continue;
 				if ((ret = realloc (ret, (ret_ctr + 1) * sizeof (struct r_bin_elf_symbol_t))) == NULL) {
 					perror ("realloc (symbols|imports)");
-					free (sym);
 					return NULL;
 				}
 #if 0
@@ -1307,7 +1302,6 @@ if (
 			} else break;
 		}
 	}
-	free (strtab);
 	return ret;
 }
 

--- a/libr/fs/fs.c
+++ b/libr/fs/fs.c
@@ -580,10 +580,8 @@ R_API int r_fs_prompt (RFS *fs, const char *root) {
 		fgets (buf, sizeof (buf)-1, stdin);
 		if (feof (stdin)) break;
 		buf[strlen (buf)-1] = '\0';
-		if (!strcmp (buf, "q") || !strcmp (buf, "exit")) {
-			r_list_free (list);
+		if (!strcmp (buf, "q") || !strcmp (buf, "exit"))
 			return R_TRUE;
-		}
 		if (buf[0]=='!') {
 			r_sandbox_system (buf+1, 1);
 		} else


### PR DESCRIPTION
There is now a test script in `libr/asm/t/test.new`. Most tests pass, except for not always selecting the shortest bytecode. And we don't understand prefixes yet. More tests would have to be added later, but many opcodes are not yet there.