### PR TITLE
Add two-byte opcodes and fix some issues in x86_new assembler

### DIFF
--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -357,6 +357,10 @@ typedef struct opcode_t {
 #define SPECIAL_MASK 0x00000007
 
 Opcode opcodes[] = {
+	//////////////////////
+	// ONE BYTE OPCODES //
+	//////////////////////
+
 	/////// 0x0_ ///////
 	{"add", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x00}},
 	{"add", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x01}},
@@ -663,18 +667,324 @@ Opcode opcodes[] = {
 	// 0xFE: group 4
 	// 0xFF: group 5
 
-	// TWO BYTE OPCODES
+	//////////////////////
+	// TWO BYTE OPCODES //
+	//////////////////////
 
 	/////// 0x0F 0x0_ ///////
+	// 0x0F 0x00: group 6
+	// 0x0F 0x01: group 7
+	{"lar", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x02}},
+	{"lsl", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x03}},
+	// 0x0F 0x04-0x05: reserved
 	{"clts", {}, 2, {0x0F, 0x06}},
+	// 0x0F 0x07: reserved
+	{"invd", {}, 2, {0x0F, 0x08}},
 	{"wbinvd", {}, 2, {0x0F, 0x09}},
-	// ...
+	// 0x0F 0x0A: reserved
+	{"ud2", {}, 2, {0x0F, 0x0B}},
+	// 0x0F 0x0C: reserved
+	{"prefetch", {}, 2, {0x0F, 0x0D}},
+	{"femms", {}, 2, {0x0F, 0x0E}},
+	// 0x0F 0x0F: 3DNow! prefix
+
+	/////// 0x0F 0x1_ ///////
 	{"movups", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x10}},
 	{"movups", {OT_REGXMM | OT_MEMORY | OT_OWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x11}},
-	// ...
+	{"movlps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x12}},
+	{"movlps", {OT_REGXMM | OT_MEMORY | OT_QWORD, OT_REGXMM | OT_QWORD}, 2, {0x0F, 0x13}},
+	{"unpcklps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x14}},
+	{"unpckhps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x15}},
+	{"movhps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x16}},
+	{"movhps", {OT_REGXMM | OT_MEMORY | OT_QWORD, OT_REGXMM | OT_QWORD}, 2, {0x0F, 0x17}},
+	// 0x0F 0x18: group 16
+	// 0x0F 0x19-0x1F: reserved
+
+	/////// 0x0F 0x2_ ///////
 	{"mov", {OT_CONTROLREG, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x20}},
-	// ...
-	// many more
+	{"mov", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_DEBUGREG}, 2, {0x0F, 0x21}},
+	{"mov", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_CONTROLREG}, 2, {0x0F, 0x22}},
+	{"mov", {OT_DEBUGREG, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x23}},
+	// 0x0F 0x24-0x27: reserved
+	{"movaps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x28}},
+	{"movaps", {OT_REGXMM | OT_MEMORY | OT_OWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x29}},
+	{"cvtpi2ps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2A}},
+	{"movntps", {OT_MEMORY | OT_OWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x2B}},
+	{"cvttps2pi", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2C}},
+	{"cvtps2pi", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2D}},
+	{"ucomiss", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2E}},
+	{"comiss", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2F}},
+
+	/////// 0x0F 0x3_ ///////
+	{"wrmsr", {}, 2, {0x0F, 0x30}},
+	{"rdtsc", {}, 2, {0x0F, 0x31}},
+	{"rdmsr", {}, 2, {0x0F, 0x32}},
+	{"rdpmc", {}, 2, {0x0F, 0x33}},
+	{"sysenter", {}, 2, {0x0F, 0x34}},
+	{"sysexit", {}, 2, {0x0F, 0x35}},
+	// 0x0F 0x36-0x3F: reserved
+
+	/////// 0x0F 0x4_ ///////
+	{"cmovo", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x40}},
+	{"cmovno", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x41}},
+	{"cmovb", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x42}},
+	{"cmovnae", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x42}},
+	{"cmovc", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x42}},
+	{"cmovnb", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x43}},
+	{"cmovae", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x43}},
+	{"cmovnc", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x43}},
+	{"cmovz", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x44}},
+	{"cmove", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x44}},
+	{"cmovnz", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x45}},
+	{"cmovne", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x45}},
+	{"cmovbe", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x46}},
+	{"cmovna", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x46}},
+	{"cmovnbe", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x47}},
+	{"cmova", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x47}},
+	{"cmovs", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x48}},
+	{"cmovns", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x49}},
+	{"cmovp", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4A}},
+	{"cmovpe", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4A}},
+	{"cmovnp", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4B}},
+	{"cmovpo", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4B}},
+	{"cmovl", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4C}},
+	{"cmovnge", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4C}},
+	{"cmovnl", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4D}},
+	{"cmovge", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4D}},
+	{"cmovle", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4E}},
+	{"cmovng", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4E}},
+	{"cmovnle", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4F}},
+	{"cmovg", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4F}},
+
+	/////// 0x0F 0x5_ ///////
+	{"movmskps", {OT_GPREG | OT_DWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x50}},
+	{"sqrtps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x51}},
+	{"rsqrtps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x52}},
+	{"rcpps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x53}},
+	{"andps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x54}},
+	{"andnps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x55}},
+	{"orps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x56}},
+	{"xorps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x57}},
+	{"addps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x58}},
+	{"mulps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x59}},
+	{"cvtps2pd", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5A}},
+	{"cvtdq2ps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5B}},
+	{"subps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5C}},
+	{"minps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5D}},
+	{"divps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5E}},
+	{"maxps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5F}},
+
+	/////// 0x0F 0x6_ ///////
+	{"punpcklbw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x60}},
+	{"punpcklwd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x61}},
+	{"punpckldq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x62}},
+	{"packsswb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x63}},
+	{"pcmpgtb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x64}},
+	{"pcmpgtw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x65}},
+	{"pcmpgtd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x66}},
+	{"packuswb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x67}},
+	{"punpckhbw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x68}},
+	{"punpckhwd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x69}},
+	{"punpckhdq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x6A}},
+	{"packssdw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x6B}},
+	// 0x0F 0x6C-0x6D: reserved
+	{"movd", {OT_REGMMX | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0x6E}},
+	{"movq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x6F}},
+
+	/////// 0x0F 0x7_ ///////
+	{"pshufw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0x70}},
+	// 0x0F 0x71: group 12
+	// 0x0F 0x72: group 13
+	// 0x0F 0x73: group 14
+	{"pcmpeqb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x74}},
+	{"pcmpeqw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x75}},
+	{"pcmpeqd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x76}},
+	{"emms", {}, 2, {0x0F, 0x77}},
+	// 0x0F 0x77-0x7D: MMX UD TODO: what is that?
+	{"movd", {OT_GPREG | OT_DWORD, OT_REGMMX | OT_DWORD}, 2, {0x0F, 0x7E}},
+	{"movq", {OT_REGMMX | OT_MEMORY | OT_QWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0x7F}},
+
+	/////// 0x0F 0x8_ ///////
+	{"jo", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x80}},
+	{"jno", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x81}},
+	{"jb", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	{"jnae", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	{"jc", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	{"jnb", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	{"jae", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	{"jnc", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	{"jz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
+	{"je", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
+	{"jnz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
+	{"jne", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
+	{"jbe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
+	{"jna", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
+	{"jnbe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
+	{"ja", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
+	{"js", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x88}},
+	{"jns", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x89}},
+	{"jp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
+	{"jpe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
+	{"jnp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
+	{"jpo", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
+	{"jl", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
+	{"jnge", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
+	{"jnl", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
+	{"jge", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
+	{"jle", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
+	{"jng", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
+	{"jnle", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
+	{"jg", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
+
+	/////// 0x0F 0x9_ ///////
+	// TODO: what is the value of spec for these instructions?
+	{"seto", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x90}},
+	{"setno", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x91}},
+	{"setb", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x92}},
+	{"setnae", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x92}},
+	{"setc", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x92}},
+	{"setnb", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x93}},
+	{"setae", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x93}},
+	{"setnc", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x93}},
+	{"setz", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x94}},
+	{"sete", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x94}},
+	{"setnz", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x95}},
+	{"setne", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x95}},
+	{"setbe", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x96}},
+	{"setna", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x96}},
+	{"setnbe", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x97}},
+	{"seta", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x97}},
+	{"sets", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x98}},
+	{"setns", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x99}},
+	{"setp", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9A}},
+	{"setpe", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9A}},
+	{"setnp", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9B}},
+	{"setpo", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9B}},
+	{"setl", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9C}},
+	{"setnge", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9C}},
+	{"setnl", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9D}},
+	{"setge", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9D}},
+	{"setle", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9E}},
+	{"setng", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9E}},
+	{"setnle", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9F}},
+	{"setg", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9F}},
+
+	/////// 0x0F 0xA_ ///////
+	{"push", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA0}},
+	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA1}},
+	{"cpuid", {}, 2, {0x0F, 0xA2}},
+	{"bt", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xA3}},
+	{"shld", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xA4}},
+	{"shld", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xA5}},
+	// 0x0F 0xA6-0xA7: reserved
+	{"push", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA8}},
+	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA9}},
+	{"rsm", {}, 2, {0x0F, 0xAA}},
+	{"bts", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xAB}},
+	{"shrd", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xAC}},
+	{"shrd", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xAD}},
+	// 0x0F 0xAE: group 15
+	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0xAF}}, // ?
+
+	/////// 0x0F 0xB_ ///////
+	{"cmpxchg", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 2, {0x0F, 0xB0}},
+	{"cmpxchg", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xB1}},
+	{"lss", {OT_GPREG | OT_DWORD, OT_MEMORY}, 2, {0x0F, 0xB2}},
+	{"btr", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xB3}},
+	{"lfs", {OT_GPREG | OT_DWORD, OT_MEMORY}, 2, {0x0F, 0xB4}},
+	{"lgs", {OT_GPREG | OT_DWORD, OT_MEMORY}, 2, {0x0F, 0xB5}},
+	{"movzx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_BYTE}, 2, {0x0F, 0xB6}},
+	{"movzx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_WORD}, 2, {0x0F, 0xB7}},
+	// 0x0F 0xB8: reserved
+	// 0x0F 0xB9: group 10
+	// 0x0F 0xBA: group 8
+	{"btc", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xBB}},
+	{"bsf", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0xBC}},
+	{"bsr", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0xBD}},
+	{"movsx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_BYTE}, 2, {0x0F, 0xBE}},
+	{"movsx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_WORD}, 2, {0x0F, 0xBF}},
+
+	/////// 0x0F 0xC_ ///////
+	{"xadd", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 2, {0x0F, 0xC0}},
+	{"xadd", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xC1}},
+	{"cmpps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xC2}},
+	{"movnti", {OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xC3}},
+	{"pinsrw", {OT_REGMMX | OT_QWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xC4}},	// Will the operands be in the right order?
+	{"pextrw", {OT_GPREG | OT_DWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xC5}},	// Will the operands be in the right order?
+	{"shufps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xC6}},
+	// 0x0F 0xB7: group 9
+	{"bswap", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 2, {0x0F, 0xC8}},
+	{"bswap", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 2, {0x0F, 0xC9}},
+	{"bswap", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 2, {0x0F, 0xCA}},
+	{"bswap", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 2, {0x0F, 0xCB}},
+	{"bswap", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 2, {0x0F, 0xCC}},
+	{"bswap", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 2, {0x0F, 0xCD}},
+	{"bswap", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 2, {0x0F, 0xCE}},
+	{"bswap", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 2, {0x0F, 0xCF}},
+
+	/////// 0x0F 0xD_ ///////
+	// 0x0F 0xD0: reserved
+	{"psrlw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD1}},
+	{"psrld", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD2}},
+	{"psrlq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD3}},
+	// 0x0F 0xD4: reserved
+	{"pmulw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD5}},
+	// 0x0F 0xD6: reserved
+	{"pmovmskb", {OT_GPREG | OT_DWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xD7}},
+	{"psubusb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD8}},
+	{"psubusw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD9}},
+	{"pminub", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDA}},
+	{"pand", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDB}},
+	{"paddusb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDC}},
+	{"paddusw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDD}},
+	{"pmaxub", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDE}},
+	{"pandn", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDF}},
+
+	/////// 0x0F 0xE_ ///////
+	{"pavgb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE0}},
+	{"psraw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE1}},
+	{"psrad", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE2}},
+	{"pavgw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE3}},
+	{"pmulhuw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE4}},
+	{"pmulhw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE5}},
+	// 0x0F 0xE6: reserved
+	{"movntq", {OT_MEMORY | OT_QWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xE7}},
+	{"psubsb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE8}},
+	{"psubsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE9}},
+	{"pminsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEA}},
+	{"por", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEB}},
+	{"paddsb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEC}},
+	{"paddsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xED}},
+	{"pmaxsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEE}},
+	{"pxor", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEF}},
+
+	/////// 0x0F 0xF_ ///////
+	// 0x0F 0xF0: reserved
+	{"psllw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF1}},
+	{"pslld", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF2}},
+	{"pshllq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF3}},
+	// 0x0F 0xF4: reserved
+	{"pmaddwd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF5}},
+	{"psadbw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF6}},
+	{"maskmovq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xF7}},
+	{"psubb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF8}},
+	{"psubw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF9}},
+	{"psubd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFA}},
+	// 0x0F 0xFB: reserved
+	{"paddb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFC}},
+	{"paddw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFD}},
+	{"paddd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFE}},
+	// 0x0F 0xFF: reserved
+
+	////////////////////////
+	// THREE BYTE OPCODES //
+	////////////////////////
+
+	// TODO
+
+	///////////////////////////////////////////
+	// OPERATIONS WITH ADDITIONAL SPEC FIELD //
+	///////////////////////////////////////////
 
 	// IMMEDIATE GROUP 1
 	{"add", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 0},
@@ -709,7 +1019,9 @@ Opcode opcodes[] = {
 	// SHIFT GROUP 2
 	// TODO
 
-	// FPU OPERATIONS
+	////////////////////
+	// FPU OPERATIONS //
+	////////////////////
 	{"fadd", {(OT_FPUREG & OT_REG(0)) | OT_FPUSIZE, OT_FPUREG | OT_MEMORY | OT_DWORD}, 1, {0xD8}, SPECIAL_SPEC + 0},
 	// ...
 

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -147,6 +147,14 @@ static x86newTokenType getToken(const char *str, int *begin, int *end) {
 }
 
 /**
+ * Read decimal or hexadecimal number.
+ */
+static ut64 readNumber(const char *str) {
+	int hex = (str[0] == '0' && str[1] == 'x');
+	return strtol(str + 2*hex, 0, hex ? 16 : 10);
+}
+
+/**
  * Get the register denoted by str[0]..str[len-1].
  */
 static Register parseReg(const char *str, int len, ut32 *type) {
@@ -178,14 +186,7 @@ static Register parseReg(const char *str, int len, ut32 *type) {
 			return i;
 		} */
 	return X86R_UNDEFINED;
-}
 
-/**
- * Read decimal or hexadecimal number.
- */
-static ut64 readNumber(const char *str, x86newTokenType type) {
-	int hex = (str[0] == '0' && str[1] == 'x');
-	return strtol(str + 2*hex, 0, hex ? 16 : 10);
 }
 
 // Parse operand
@@ -267,7 +268,7 @@ static int parseOperand(const char *str, Operand *op) {
 					op->type = 0;	// Make the result invalid
 			}
 			else {
-				ut64 read = readNumber(str + pos, last_type);
+				ut64 read = readNumber(str + pos);
 				temp *= read;
 			}
 		}
@@ -278,7 +279,7 @@ static int parseOperand(const char *str, Operand *op) {
 	else {                             // immediate
 		// We don't know the size, so let's just set no size flag.
 		op->type = OT_IMMEDIATE;
-		op->immediate = readNumber(str + pos, last_type);
+		op->immediate = readNumber(str + pos);
 	}
 
 	return nextpos;

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -119,7 +119,7 @@ typedef enum tokentype_t {
  * Get the next token in str, starting at *begin. Write the index of the first
  * character after the token to *end. Return the type of the token.
  */
-static x86newTokenType getToken(const char *str, int *begin, int *end) {
+static x86newTokenType getToken(const char *str, size_t *begin, size_t *end) {
 	// Skip whitespace
 	while (isspace(str[*begin]))
 		++(*begin);
@@ -157,7 +157,7 @@ static ut64 readNumber(const char *str) {
 /**
  * Get the register at position pos in str. Increase pos afterwards.
  */
-static Register parseReg(const char *str, int *pos, ut32 *type) {
+static Register parseReg(const char *str, size_t *pos, ut32 *type) {
 	int i;
 	// Must be the same order as in enum register_t
 	const char *regs[] = { "eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi", NULL };
@@ -166,7 +166,7 @@ static Register parseReg(const char *str, int *pos, ut32 *type) {
 //	const char *regs64[] = { "rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi", NULL };
 
 	// Get token (especially the length)
-	int nextpos, length;
+	size_t nextpos, length;
 	const char *token;
 	getToken(str, pos, &nextpos);
 	token = str + *pos;
@@ -234,8 +234,7 @@ static Register parseReg(const char *str, int *pos, ut32 *type) {
 
 // Parse operand
 static int parseOperand(const char *str, Operand *op) {
-	int pos;
-	int nextpos = 0;
+	size_t pos, nextpos = 0;
 	x86newTokenType last_type;
 	int size_token = 1;
 
@@ -770,7 +769,7 @@ static ut8 translate_scale(int scale) {
  * Assemble instruction from table with the given operands.
  */
 static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
-	int l;
+	size_t l;
 	int op_ind;
 
 	// Write opcode
@@ -968,7 +967,7 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 static int assemble(RAsm *a, RAsmOp *ao, const char *str) {
 	ut64 offset = a->pc;
 	ut8 *data = ao->buf;
-	int pos = 0, nextpos;
+	size_t pos = 0, nextpos;
 	x86newTokenType ttype;
 	char mnemonic[12];
 	int op_ind, mnemonic_len;

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -958,7 +958,8 @@ static int assemble(RAsm *a, RAsmOp *ao, const char *str) {
 		for (op_ind = 0; op_ind < 3; ++op_ind) {
 			// Check if the flags of the operand are contained in the set of
 			// allowed flags for that operand.
-			if ((opcode_ptr->op[op_ind] & operands[op_ind].type) != operands[op_ind].type)
+			if ((opcode_ptr->op[op_ind] & operands[op_ind].type) != operands[op_ind].type
+					|| (opcode_ptr->op[op_ind] && !operands[op_ind].type))
 				break;
 		}
 

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -9,11 +9,26 @@
 #include <r_asm.h>
 
 /**
- * Types of operands: we describe them via a bit field. The first two bytes
- * describe the storage: that could be a memory location, an immediate or one
- * of several register types. The third byte masks the registers, since for
- * example FPU commands always have a fixed operand st(0). The fourth byte
- * describes the size of an operand.
+ * Types of operands: we describe them via a bit field. The first six bits
+ * describe how the operand should be encoded:
+ * - in the spec field of ModRM
+ * - in the rm field of modrm, together with mod, possibly SIB and displacement
+ * - as immediate after the instruction
+ * - nowhere at all. Some operands are implied in the opcode.
+ *
+ * The following ten bits describe what we expect to read in the assembly: this
+ * could be a register of a certain kind, a memory location or just a constant.
+ *
+ * Patterns to combine this information can be found in the OT_[A-Z]*OP macros.
+ * For example, OT_REGMEMOP(GP) = OT_GPREG | OT_MEMORY | OT_REGMEM describes an
+ * operand that can either be a general purpose register or a memory location,
+ * and which will be encoded in the rm field of the ModRM byte. OT_MEMADDROP =
+ * OT_MEMORY | OT_IMMEDIATE are written like memory operands in assembly, but
+ * encoded as immediates. Jump distances shall have an extra flag OT_JMPADDRESS
+ * because they are relative to the current location.
+ *
+ * The third byte masks the registers, since for example FPU commands always
+ * have a fixed operand st(0). The fourth byte describes the size of an operand.
  *
  * We implement them as bitfields to allow operations to describe what operands
  * are accepted. For example many accept a register or memory location in the
@@ -21,35 +36,39 @@
  *
  * +--------+--------+--------+--------+
  * |76543210|76543210|76543210|76543210|
- * |    size|spec.reg| xmfdcsg| imm mem|
+ * |    size|spec.reg| dcxmfsg mi| enc.|
  * +--------+--------+--------+--------+
  */
-#define REGTYPE_SHIFT   8
+#define ENCODING_SHIFT 0
+#define OPTYPE_SHIFT   6
 #define REGMASK_SHIFT  16
 #define OPSIZE_SHIFT   24
 
-// Memory operands or immediates
-#define OT_MEMORY      (1 << 0)
-#define OT_IMMEDIATE   (1 << 4)
-#define OT_JMPADDRESS  (1 << 5)
-#define OT_MEMADDRESS  (1 << 6)
-// OT_MEMORY | OT_MEMADDRESS are written like memory operands in assembly, but
-// encoded as immediates. Jump distances shall have an extra flag OT_JMPADDRESS
-// because they are relative to the offset.
+// How to encode the operand?
+#define OT_REGMEM      (1 << (ENCODING_SHIFT + 0))
+#define OT_SPECIAL     (1 << (ENCODING_SHIFT + 1))
+#define OT_IMMEDIATE   (1 << (ENCODING_SHIFT + 2))
+#define OT_JMPADDRESS  (1 << (ENCODING_SHIFT + 3))
 
-// Register types - by default, we allow all registers
+// Register indices - by default, we allow all registers
 #define OT_REGALL   (0xff << REGMASK_SHIFT)
-#define OT_GPREG      ((1 << (REGTYPE_SHIFT + 0)) | OT_REGALL)
-#define OT_SEGMENTREG ((1 << (REGTYPE_SHIFT + 1)) | OT_REGALL)
-#define OT_CONTROLREG ((1 << (REGTYPE_SHIFT + 2)) | OT_REGALL)
-#define OT_FPUREG     ((1 << (REGTYPE_SHIFT + 4)) | OT_REGALL)
-#define OT_DEBUGREG   ((1 << (REGTYPE_SHIFT + 3)) | OT_REGALL)
-#define OT_REGMMX     ((1 << (REGTYPE_SHIFT + 5)) | OT_REGALL)
-#define OT_REGXMM     ((1 << (REGTYPE_SHIFT + 6)) | OT_REGALL)
+
+// Memory or register operands: how is the operand written in assembly code?
+#define OT_MEMORY      (1 << (OPTYPE_SHIFT + 0))
+#define OT_CONSTANT    (1 << (OPTYPE_SHIFT + 1))
+#define OT_GPREG      ((1 << (OPTYPE_SHIFT + 2)) | OT_REGALL)
+#define OT_SEGMENTREG ((1 << (OPTYPE_SHIFT + 3)) | OT_REGALL)
+#define OT_FPUREG     ((1 << (OPTYPE_SHIFT + 4)) | OT_REGALL)
+#define OT_MMXREG     ((1 << (OPTYPE_SHIFT + 5)) | OT_REGALL)
+#define OT_XMMREG     ((1 << (OPTYPE_SHIFT + 6)) | OT_REGALL)
+#define OT_CONTROLREG ((1 << (OPTYPE_SHIFT + 7)) | OT_REGALL)
+#define OT_DEBUGREG   ((1 << (OPTYPE_SHIFT + 8)) | OT_REGALL)
 // more?
 
+#define OT_REGTYPE    ((OT_GPREG | OT_SEGMENTREG | OT_FPUREG | OT_MMXREG | OT_XMMREG | OT_CONTROLREG | OT_DEBUGREG) & ~OT_REGALL)
+
 // Register mask
-#define OT_REG(num)  ((1 << (REGMASK_SHIFT + (num))) | (0xff << REGTYPE_SHIFT))
+#define OT_REG(num)  ((1 << (REGMASK_SHIFT + (num))) | OT_REGTYPE)
 
 #define OT_UNKNOWN    (0 << OPSIZE_SHIFT)
 #define OT_BYTE       (1 << OPSIZE_SHIFT)
@@ -203,12 +222,12 @@ static Register parseReg(const char *str, size_t *pos, ut32 *type) {
 	if (!strncasecmp ("st", token, length))
 		*type = (OT_FPUREG & ~OT_REGALL);
 	if (!strncasecmp ("mm", token, length))
-		*type = (OT_REGMMX & ~OT_REGALL);
+		*type = (OT_MMXREG & ~OT_REGALL);
 	if (!strncasecmp ("xmm", token, length))
-		*type = (OT_REGXMM & ~OT_REGALL);
+		*type = (OT_XMMREG & ~OT_REGALL);
 
 	// Now read number, possibly with parantheses
-	if (*type & (OT_FPUREG | OT_REGMMX | OT_REGXMM) & ~OT_REGALL) {
+	if (*type & (OT_FPUREG | OT_MMXREG | OT_XMMREG) & ~OT_REGALL) {
 		Register reg = X86R_UNDEFINED;
 
 		// pass by '(',if there is one
@@ -225,7 +244,7 @@ static Register parseReg(const char *str, size_t *pos, ut32 *type) {
 		if (getToken(str, pos, &nextpos) == TT_SPECIAL && str[*pos] == ')')
 			*pos = nextpos;
 
-		*type |= (OT_REG(reg) & ~(0xff << REGTYPE_SHIFT));
+		*type |= (OT_REG(reg) & ~OT_REGTYPE);
 		return reg;
 	}
 
@@ -328,7 +347,7 @@ static int parseOperand(const char *str, Operand *op) {
 	}
 	else {                             // immediate
 		// We don't know the size, so let's just set no size flag.
-		op->type = OT_IMMEDIATE;
+		op->type = OT_CONSTANT;
 		op->immediate = readNumber(str + pos);
 	}
 
@@ -352,6 +371,15 @@ typedef struct opcode_t {
 	ut32 special;       // Special encoding
 } Opcode;
 
+// Macros for encoding
+#define OT_REGMEMOP(type)  (OT_##type##REG | OT_MEMORY | OT_REGMEM)
+#define OT_REGONLYOP(type) (OT_##type##REG | OT_REGMEM)
+#define OT_MEMONLYOP       (OT_MEMORY | OT_REGMEM)
+#define OT_MEMIMMOP        (OT_MEMORY | OT_IMMEDIATE)
+#define OT_REGSPECOP(type) (OT_##type##REG | OT_SPECIAL)
+#define OT_IMMOP           (OT_CONSTANT | OT_IMMEDIATE)
+#define OT_MEMADDROP       (OT_MEMORY | OT_IMMEDIATE)
+
 // Some operations are encoded via opcode + spec field
 #define SPECIAL_SPEC 0x00010000
 #define SPECIAL_MASK 0x00000007
@@ -362,85 +390,85 @@ Opcode opcodes[] = {
 	//////////////////////
 
 	/////// 0x0_ ///////
-	{"add", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x00}},
-	{"add", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x01}},
-	{"add", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x02}},
-	{"add", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x03}},
-	{"add", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x04}},
-	{"add", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x05}},
+	{"add", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x00}},
+	{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x01}},
+	{"add", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x02}},
+	{"add", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x03}},
+	{"add", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x04}},
+	{"add", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x05}},
 
 	{"push", {(OT_SEGMENTREG & OT_REG(X86R_ES))}, 1, {0x06}},
 	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_ES))}, 1, {0x07}},
 
-	{"or", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x08}},
-	{"or", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x09}},
-	{"or", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0A}},
-	{"or", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x0B}},
-	{"or", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x0C}},
-	{"or", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x0D}},
+	{"or", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x08}},
+	{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x09}},
+	{"or", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0A}},
+	{"or", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x0B}},
+	{"or", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x0C}},
+	{"or", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x0D}},
 
 	{"push", {(OT_SEGMENTREG & OT_REG(X86R_CS))}, 1, {0x0E}},
 	// Two byte opcodes start with 0x0F
 
 	/////// 0x1_ ///////
-	{"adc", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x10}},
-	{"adc", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x11}},
-	{"adc", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x12}},
-	{"adc", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x13}},
-	{"adc", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x14}},
-	{"adc", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x15}},
+	{"adc", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x10}},
+	{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x11}},
+	{"adc", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x12}},
+	{"adc", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x13}},
+	{"adc", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x14}},
+	{"adc", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x15}},
 
 	{"push", {(OT_SEGMENTREG & OT_REG(X86R_SS))}, 1, {0x16}},
 	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_SS))}, 1, {0x17}},
 
-	{"sbb", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x18}},
-	{"sbb", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x19}},
-	{"sbb", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x1A}},
-	{"sbb", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x1B}},
-	{"sbb", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x1C}},
-	{"sbb", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x1D}},
+	{"sbb", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x18}},
+	{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x19}},
+	{"sbb", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x1A}},
+	{"sbb", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x1B}},
+	{"sbb", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x1C}},
+	{"sbb", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x1D}},
 
 	{"push", {(OT_SEGMENTREG & OT_REG(X86R_DS))}, 1, {0x1E}},
 	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_DS))}, 1, {0x1F}},
 
 	/////// 0x2_ ///////
-	{"and", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x20}},
-	{"and", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x21}},
-	{"and", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x22}},
-	{"and", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x23}},
-	{"and", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x24}},
-	{"and", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x25}},
+	{"and", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x20}},
+	{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x21}},
+	{"and", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x22}},
+	{"and", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x23}},
+	{"and", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x24}},
+	{"and", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x25}},
 
 	// 0x26: ES segment prefix
 	{"daa", {}, 1, {0x27}},
 
-	{"sub", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x28}},
-	{"sub", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x29}},
-	{"sub", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x2A}},
-	{"sub", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x2B}},
-	{"sub", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x2C}},
-	{"sub", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x2D}},
+	{"sub", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x28}},
+	{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x29}},
+	{"sub", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x2A}},
+	{"sub", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x2B}},
+	{"sub", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x2C}},
+	{"sub", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x2D}},
 
 	// 0x2E: CS segment prefix
 	{"das", {}, 1, {0x2F}},
 
 	/////// 0x3_ ///////
-	{"xor", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x30}},
-	{"xor", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x31}},
-	{"xor", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x32}},
-	{"xor", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x33}},
-	{"xor", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x34}},
-	{"xor", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x35}},
+	{"xor", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x30}},
+	{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x31}},
+	{"xor", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x32}},
+	{"xor", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x33}},
+	{"xor", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x34}},
+	{"xor", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x35}},
 
 	// 0x36: SS segment prefix
 	{"aaa", {}, 1, {0x37}},
 
-	{"cmp", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x38}},
-	{"cmp", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x39}},
-	{"cmp", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x3A}},
-	{"cmp", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x3B}},
-	{"cmp", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x3C}},
-	{"cmp", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x3D}},
+	{"cmp", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x38}},
+	{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x39}},
+	{"cmp", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x3A}},
+	{"cmp", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x3B}},
+	{"cmp", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x3C}},
+	{"cmp", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x3D}},
 
 	// 0x3E: DS segment prefix
 	{"aas", {}, 1, {0x3F}},
@@ -484,16 +512,16 @@ Opcode opcodes[] = {
 	/////// 0x6_ ///////
 	{"pusha", {}, 1, {0x60}},	{"pushad", {}, 1, {0x60}},
 	{"popa", {}, 1, {0x61}},	{"popad", {}, 1, {0x61}},
-	{"bound", {OT_GPREG | OT_DWORD, OT_MEMORY | OT_QWORD}, 1, {0x62}},
-	{"arpl", {OT_GPREG | OT_MEMORY | OT_WORD, OT_GPREG | OT_WORD}, 1, {0x63}},
+	{"bound", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_QWORD}, 1, {0x62}},
+	{"arpl", {OT_REGMEMOP(GP) | OT_WORD, OT_REGSPECOP(GP) | OT_WORD}, 1, {0x63}},
 	// 0x64: FS segment prefix
 	// 0x65: GS segment prefix
 	// 0x66: operand size prefix
 	// 0x67: address size prefix
-	{"push", {OT_IMMEDIATE | OT_DWORD}, 1, {0x68}},
-	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x69}},
-	{"push", {OT_IMMEDIATE | OT_BYTE}, 1, {0x6A}},
-	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x6B}},
+	{"push", {OT_IMMOP | OT_DWORD}, 1, {0x68}},
+	{"imul", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x69}},
+	{"push", {OT_IMMOP | OT_BYTE}, 1, {0x6A}},
+	{"imul", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x6B}},
 	{"insb", {}, 1, {0x6C}},
 	{"ins", {}, 1, {0x6D}}, {"insd", {}, 1, {0x6D}},
 	{"insw", {}, 2, {0x66, 0x6D}},
@@ -502,48 +530,48 @@ Opcode opcodes[] = {
 	{"outsw", {}, 2, {0x66, 0x6F}},
 
 	/////// 0x7_ ///////
-	{"jo", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x70}},
-	{"jno", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x71}},
-	{"jb", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
-	{"jnae", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
-	{"jc", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
-	{"jnb", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
-	{"jae", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
-	{"jnc", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
-	{"jz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
-	{"je", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
-	{"jnz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
-	{"jne", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
-	{"jbe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
-	{"jna", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
-	{"jnbe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
-	{"ja", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
-	{"js", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x78}},
-	{"jns", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x79}},
-	{"jp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
-	{"jpe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
-	{"jnp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
-	{"jpo", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
-	{"jl", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
-	{"jnge", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
-	{"jnl", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
-	{"jge", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
-	{"jle", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
-	{"jng", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
-	{"jnle", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
-	{"jg", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
+	{"jo", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x70}},
+	{"jno", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x71}},
+	{"jb", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
+	{"jnae", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
+	{"jc", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
+	{"jnb", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
+	{"jae", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
+	{"jnc", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
+	{"jz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
+	{"je", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
+	{"jnz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
+	{"jne", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
+	{"jbe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
+	{"jna", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
+	{"jnbe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
+	{"ja", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
+	{"js", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x78}},
+	{"jns", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x79}},
+	{"jp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
+	{"jpe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
+	{"jnp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
+	{"jpo", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
+	{"jl", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
+	{"jnge", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
+	{"jnl", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
+	{"jge", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
+	{"jle", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
+	{"jng", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
+	{"jnle", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
+	{"jg", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
 
 	/////// 0x8_ ///////
 	// 0x80 -- 0x83: immediate group 1
 	// 0x84, 0x85: TODO: test
 	// 0x86, 0x87: TODO: xchg
-	{"mov", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 1, {0x88}},
-	{"mov", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 1, {0x89}},
-	{"mov", {OT_GPREG | OT_BYTE, OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x8A}},
-	{"mov", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 1, {0x8B}},
-	{"mov", {OT_MEMORY | OT_WORD, OT_SEGMENTREG | OT_WORD}, 1, {0x8C}}, // ?
-	{"lea", {OT_GPREG | OT_DWORD, OT_MEMORY | OT_DWORD}, 1, {0x8D}},	// allow all sizes?
-	{"mov", {OT_SEGMENTREG | OT_WORD, OT_MEMORY | OT_WORD}, 1, {0x8E}}, // ?
+	{"mov", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x88}},
+	{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x89}},
+	{"mov", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x8A}},
+	{"mov", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x8B}},
+	{"mov", {OT_MEMONLYOP | OT_WORD, OT_REGSPECOP(SEGMENT) | OT_WORD}, 1, {0x8C}}, // ?
+	{"lea", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_DWORD}, 1, {0x8D}},	// allow all sizes?
+	{"mov", {OT_REGSPECOP(SEGMENT) | OT_WORD, OT_MEMONLYOP | OT_WORD}, 1, {0x8E}}, // ?
 	{"pop", {}, 1, {0x8F}},  // ?
 
 	/////// 0x9_ ///////
@@ -569,8 +597,8 @@ Opcode opcodes[] = {
 	{"lahf", {}, 1, {0x9F}},
 
 	/////// 0xA_ ///////
-	{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_MEMORY | OT_MEMADDRESS | OT_BYTE}, 1, {0xA0}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_MEMORY | OT_MEMADDRESS | OT_DWORD}, 1, {0xA1}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_MEMIMMOP | OT_BYTE}, 1, {0xA0}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_MEMIMMOP | OT_DWORD}, 1, {0xA1}},
 	// 0xA2 -- 0xA3
 	{"movsb", {}, 1, {0xA4}},
 	{"movsd", {}, 1, {0xA5}},
@@ -590,61 +618,61 @@ Opcode opcodes[] = {
 	{"scasw", {}, 2, {0x66, 0xAF}},
 
 	/////// 0xB_ ///////
-	{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB0}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB1}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_DL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB2}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_BL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB3}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_AH)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB4}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_CH)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB5}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_DH)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB6}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_BH)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xB7}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xB8}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xB9}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xBA}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xBB}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xBC}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xBD}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xBE}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0xBF}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB0}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB1}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_DL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB2}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_BL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB3}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_AH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB4}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_CH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB5}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_DH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB6}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_BH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB7}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xB8}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xB9}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBA}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBB}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBC}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBD}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBE}},
+	{"mov", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBF}},
 
 	/////// 0xC_ ///////
 	// 0xC0 -- 0xC1: shift group 2
-	{"ret", {OT_IMMEDIATE | OT_WORD}, 1, {0xC2}},
+	{"ret", {OT_IMMOP | OT_WORD}, 1, {0xC2}},
 	{"ret", {}, 1, {0xC3}},
-	{"les", {OT_GPREG | OT_DWORD, OT_MEMORY | OT_BYTE}, 1, {0xC4}},
-	{"lds", {OT_GPREG | OT_DWORD, OT_MEMORY | OT_BYTE}, 1, {0xC5}},
+	{"les", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_BYTE}, 1, {0xC4}},
+	{"lds", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_BYTE}, 1, {0xC5}},
 	// 0xC6 -- 0xC7 mov group
-	{"enter", {OT_IMMEDIATE | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0xC8}},
+	{"enter", {OT_IMMOP | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0xC8}},
 	{"leave", {}, 1, {0xC9}},
-	{"retf", {OT_IMMEDIATE | OT_WORD}, 1, {0xCA}},
+	{"retf", {OT_IMMOP | OT_WORD}, 1, {0xCA}},
 	{"retf", {}, 1, {0xCB}},
 	{"int3", {}, 1, {0xCC}},
-	{"int", {OT_IMMEDIATE | OT_BYTE}, 1, {0xCD}},
+	{"int", {OT_IMMOP | OT_BYTE}, 1, {0xCD}},
 	{"into", {}, 1, {0xCE}},
-	{"iretd", {OT_IMMEDIATE | OT_BYTE}, 1, {0xCF}},
+	{"iretd", {OT_IMMOP | OT_BYTE}, 1, {0xCF}},
 
 	/////// 0xD_ ///////
 	// 0xD0 -- 0xD3: shift group 2
-	{"aam", {OT_IMMEDIATE | OT_BYTE}, 1, {0xD4}},  // ?
-	{"aad", {OT_IMMEDIATE | OT_BYTE}, 1, {0xD5}},  // ?
+	{"aam", {OT_IMMOP | OT_BYTE}, 1, {0xD4}},  // ?
+	{"aad", {OT_IMMOP | OT_BYTE}, 1, {0xD5}},  // ?
 	// 0xD6: reserved
 	{"xlatb", {}, 1, {0xD7}},
 	// 0xD8 -- 0xDF: FPU
 
 	/////// 0xE_ ///////
-	{"loopne", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0xE0}},
-	{"loope", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0xE1}},
-	{"loop", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0xE2}},
-	{"jcxz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0xE3}},
-	{"jecxz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0xE3}},
-	{"in", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0xE4}},
-	{"in", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0xE5}},
-	{"out", {OT_IMMEDIATE | OT_BYTE, (OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE}, 1, {0xE6}},
-	{"out", {OT_IMMEDIATE | OT_BYTE, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0xE7}},
-	{"call", {OT_IMMEDIATE | OT_DWORD}, 1, {0xE8}},
-	{"jmp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0xE9}},
-	{"jmp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0xEA}},  // ?
-	{"jmp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_BYTE}, 1, {0xEB}},
+	{"loopne", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE0}},
+	{"loope", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE1}},
+	{"loop", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE2}},
+	{"jcxz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE3}},
+	{"jecxz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE3}},
+	{"in", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xE4}},
+	{"in", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0xE5}},
+	{"out", {OT_IMMOP | OT_BYTE, (OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE}, 1, {0xE6}},
+	{"out", {OT_IMMOP | OT_BYTE, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0xE7}},
+	{"call", {OT_IMMOP | OT_DWORD}, 1, {0xE8}},
+	{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0xE9}},
+	{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0xEA}},  // ?
+	{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xEB}},
 	{"in", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, (OT_GPREG & OT_REG(X86R_DX)) | OT_WORD}, 1, {0xEC}},
 	{"in", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_DX)) | OT_WORD}, 1, {0xED}},
 	{"out", {(OT_GPREG & OT_REG(X86R_DX)) | OT_WORD, (OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE}, 1, {0xEE}},
@@ -674,8 +702,8 @@ Opcode opcodes[] = {
 	/////// 0x0F 0x0_ ///////
 	// 0x0F 0x00: group 6
 	// 0x0F 0x01: group 7
-	{"lar", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x02}},
-	{"lsl", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x03}},
+	{"lar", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x02}},
+	{"lsl", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x03}},
 	// 0x0F 0x04-0x05: reserved
 	{"clts", {}, 2, {0x0F, 0x06}},
 	// 0x0F 0x07: reserved
@@ -689,31 +717,31 @@ Opcode opcodes[] = {
 	// 0x0F 0x0F: 3DNow! prefix
 
 	/////// 0x0F 0x1_ ///////
-	{"movups", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x10}},
-	{"movups", {OT_REGXMM | OT_MEMORY | OT_OWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x11}},
-	{"movlps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x12}},
-	{"movlps", {OT_REGXMM | OT_MEMORY | OT_QWORD, OT_REGXMM | OT_QWORD}, 2, {0x0F, 0x13}},
-	{"unpcklps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x14}},
-	{"unpckhps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x15}},
-	{"movhps", {OT_REGXMM | OT_QWORD, OT_REGXMM | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x16}},
-	{"movhps", {OT_REGXMM | OT_MEMORY | OT_QWORD, OT_REGXMM | OT_QWORD}, 2, {0x0F, 0x17}},
+	{"movups", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x10}},
+	{"movups", {OT_REGMEMOP(XMM) | OT_OWORD, OT_REGSPECOP(XMM) | OT_OWORD}, 2, {0x0F, 0x11}},
+	{"movlps", {OT_REGSPECOP(XMM) | OT_QWORD, OT_REGMEMOP(XMM) | OT_QWORD}, 2, {0x0F, 0x12}},
+	{"movlps", {OT_REGMEMOP(XMM) | OT_QWORD, OT_REGSPECOP(XMM) | OT_QWORD}, 2, {0x0F, 0x13}},
+	{"unpcklps", {OT_REGSPECOP(XMM) | OT_QWORD, OT_REGMEMOP(XMM) | OT_QWORD}, 2, {0x0F, 0x14}},
+	{"unpckhps", {OT_REGSPECOP(XMM) | OT_QWORD, OT_REGMEMOP(XMM) | OT_QWORD}, 2, {0x0F, 0x15}},
+	{"movhps", {OT_REGSPECOP(XMM) | OT_QWORD, OT_REGMEMOP(XMM) | OT_QWORD}, 2, {0x0F, 0x16}},
+	{"movhps", {OT_REGMEMOP(XMM) | OT_QWORD, OT_REGSPECOP(XMM) | OT_QWORD}, 2, {0x0F, 0x17}},
 	// 0x0F 0x18: group 16
 	// 0x0F 0x19-0x1F: reserved
 
 	/////// 0x0F 0x2_ ///////
-	{"mov", {OT_CONTROLREG, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x20}},
-	{"mov", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_DEBUGREG}, 2, {0x0F, 0x21}},
-	{"mov", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_CONTROLREG}, 2, {0x0F, 0x22}},
-	{"mov", {OT_DEBUGREG, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x23}},
+	{"mov", {OT_CONTROLREG, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x20}},
+	{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_DEBUGREG}, 2, {0x0F, 0x21}},
+	{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_CONTROLREG}, 2, {0x0F, 0x22}},
+	{"mov", {OT_DEBUGREG, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x23}},
 	// 0x0F 0x24-0x27: reserved
-	{"movaps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x28}},
-	{"movaps", {OT_REGXMM | OT_MEMORY | OT_OWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x29}},
-	{"cvtpi2ps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2A}},
-	{"movntps", {OT_MEMORY | OT_OWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x2B}},
-	{"cvttps2pi", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2C}},
-	{"cvtps2pi", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2D}},
-	{"ucomiss", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2E}},
-	{"comiss", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x2F}},
+	{"movaps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x28}},
+	{"movaps", {OT_REGMEMOP(XMM) | OT_OWORD, OT_REGSPECOP(XMM) | OT_OWORD}, 2, {0x0F, 0x29}},
+	{"cvtpi2ps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x2A}},
+	{"movntps", {OT_MEMONLYOP | OT_OWORD, OT_REGSPECOP(XMM) | OT_OWORD}, 2, {0x0F, 0x2B}},
+	{"cvttps2pi", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x2C}},
+	{"cvtps2pi", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x2D}},
+	{"ucomiss", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x2E}},
+	{"comiss", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x2F}},
 
 	/////// 0x0F 0x3_ ///////
 	{"wrmsr", {}, 2, {0x0F, 0x30}},
@@ -725,193 +753,193 @@ Opcode opcodes[] = {
 	// 0x0F 0x36-0x3F: reserved
 
 	/////// 0x0F 0x4_ ///////
-	{"cmovo", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x40}},
-	{"cmovno", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x41}},
-	{"cmovb", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x42}},
-	{"cmovnae", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x42}},
-	{"cmovc", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x42}},
-	{"cmovnb", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x43}},
-	{"cmovae", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x43}},
-	{"cmovnc", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x43}},
-	{"cmovz", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x44}},
-	{"cmove", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x44}},
-	{"cmovnz", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x45}},
-	{"cmovne", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x45}},
-	{"cmovbe", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x46}},
-	{"cmovna", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x46}},
-	{"cmovnbe", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x47}},
-	{"cmova", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x47}},
-	{"cmovs", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x48}},
-	{"cmovns", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x49}},
-	{"cmovp", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4A}},
-	{"cmovpe", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4A}},
-	{"cmovnp", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4B}},
-	{"cmovpo", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4B}},
-	{"cmovl", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4C}},
-	{"cmovnge", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4C}},
-	{"cmovnl", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4D}},
-	{"cmovge", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4D}},
-	{"cmovle", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4E}},
-	{"cmovng", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4E}},
-	{"cmovnle", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4F}},
-	{"cmovg", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0x4F}},
+	{"cmovo", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x40}},
+	{"cmovno", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x41}},
+	{"cmovb", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x42}},
+	{"cmovnae", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x42}},
+	{"cmovc", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x42}},
+	{"cmovnb", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x43}},
+	{"cmovae", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x43}},
+	{"cmovnc", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x43}},
+	{"cmovz", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x44}},
+	{"cmove", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x44}},
+	{"cmovnz", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x45}},
+	{"cmovne", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x45}},
+	{"cmovbe", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x46}},
+	{"cmovna", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x46}},
+	{"cmovnbe", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x47}},
+	{"cmova", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x47}},
+	{"cmovs", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x48}},
+	{"cmovns", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x49}},
+	{"cmovp", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4A}},
+	{"cmovpe", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4A}},
+	{"cmovnp", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4B}},
+	{"cmovpo", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4B}},
+	{"cmovl", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4C}},
+	{"cmovnge", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4C}},
+	{"cmovnl", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4D}},
+	{"cmovge", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4D}},
+	{"cmovle", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4E}},
+	{"cmovng", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4E}},
+	{"cmovnle", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4F}},
+	{"cmovg", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x4F}},
 
 	/////// 0x0F 0x5_ ///////
-	{"movmskps", {OT_GPREG | OT_DWORD, OT_REGXMM | OT_OWORD}, 2, {0x0F, 0x50}},
-	{"sqrtps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x51}},
-	{"rsqrtps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x52}},
-	{"rcpps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x53}},
-	{"andps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x54}},
-	{"andnps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x55}},
-	{"orps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x56}},
-	{"xorps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x57}},
-	{"addps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x58}},
-	{"mulps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x59}},
-	{"cvtps2pd", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5A}},
-	{"cvtdq2ps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5B}},
-	{"subps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5C}},
-	{"minps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5D}},
-	{"divps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5E}},
-	{"maxps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD}, 2, {0x0F, 0x5F}},
+	{"movmskps", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGONLYOP(XMM) | OT_OWORD}, 2, {0x0F, 0x50}},
+	{"sqrtps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x51}},
+	{"rsqrtps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x52}},
+	{"rcpps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x53}},
+	{"andps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x54}},
+	{"andnps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x55}},
+	{"orps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x56}},
+	{"xorps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x57}},
+	{"addps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x58}},
+	{"mulps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x59}},
+	{"cvtps2pd", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x5A}},
+	{"cvtdq2ps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x5B}},
+	{"subps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x5C}},
+	{"minps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x5D}},
+	{"divps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x5E}},
+	{"maxps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x5F}},
 
 	/////// 0x0F 0x6_ ///////
-	{"punpcklbw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x60}},
-	{"punpcklwd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x61}},
-	{"punpckldq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x62}},
-	{"packsswb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x63}},
-	{"pcmpgtb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x64}},
-	{"pcmpgtw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x65}},
-	{"pcmpgtd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x66}},
-	{"packuswb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x67}},
-	{"punpckhbw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x68}},
-	{"punpckhwd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x69}},
-	{"punpckhdq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x6A}},
-	{"packssdw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x6B}},
+	{"punpcklbw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x60}},
+	{"punpcklwd", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x61}},
+	{"punpckldq", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x62}},
+	{"packsswb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x63}},
+	{"pcmpgtb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x64}},
+	{"pcmpgtw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x65}},
+	{"pcmpgtd", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x66}},
+	{"packuswb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x67}},
+	{"punpckhbw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x68}},
+	{"punpckhwd", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x69}},
+	{"punpckhdq", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x6A}},
+	{"packssdw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x6B}},
 	// 0x0F 0x6C-0x6D: reserved
-	{"movd", {OT_REGMMX | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0x6E}},
-	{"movq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x6F}},
+	{"movd", {OT_REGSPECOP(MMX) | OT_DWORD, OT_REGONLYOP(GP) | OT_DWORD}, 2, {0x0F, 0x6E}},
+	{"movq", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x6F}},
 
 	/////// 0x0F 0x7_ ///////
-	{"pshufw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0x70}},
+	{"pshufw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0x70}},
 	// 0x0F 0x71: group 12
 	// 0x0F 0x72: group 13
 	// 0x0F 0x73: group 14
-	{"pcmpeqb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x74}},
-	{"pcmpeqw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x75}},
-	{"pcmpeqd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0x76}},
+	{"pcmpeqb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x74}},
+	{"pcmpeqw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x75}},
+	{"pcmpeqd", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0x76}},
 	{"emms", {}, 2, {0x0F, 0x77}},
 	// 0x0F 0x77-0x7D: MMX UD TODO: what is that?
-	{"movd", {OT_GPREG | OT_DWORD, OT_REGMMX | OT_DWORD}, 2, {0x0F, 0x7E}},
-	{"movq", {OT_REGMMX | OT_MEMORY | OT_QWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0x7F}},
+	{"movd", {OT_REGONLYOP(GP) | OT_DWORD, OT_REGSPECOP(MMX) | OT_DWORD}, 2, {0x0F, 0x7E}},
+	{"movq", {OT_REGMEMOP(MMX) | OT_QWORD, OT_REGSPECOP(MMX) | OT_QWORD}, 2, {0x0F, 0x7F}},
 
 	/////// 0x0F 0x8_ ///////
-	{"jo", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x80}},
-	{"jno", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x81}},
-	{"jb", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
-	{"jnae", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
-	{"jc", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
-	{"jnb", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
-	{"jae", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
-	{"jnc", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
-	{"jz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
-	{"je", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
-	{"jnz", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
-	{"jne", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
-	{"jbe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
-	{"jna", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
-	{"jnbe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
-	{"ja", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
-	{"js", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x88}},
-	{"jns", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x89}},
-	{"jp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
-	{"jpe", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
-	{"jnp", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
-	{"jpo", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
-	{"jl", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
-	{"jnge", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
-	{"jnl", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
-	{"jge", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
-	{"jle", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
-	{"jng", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
-	{"jnle", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
-	{"jg", {OT_IMMEDIATE | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
+	{"jo", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x80}},
+	{"jno", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x81}},
+	{"jb", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	{"jnae", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	{"jc", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	{"jnb", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	{"jae", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	{"jnc", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	{"jz", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
+	{"je", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
+	{"jnz", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
+	{"jne", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
+	{"jbe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
+	{"jna", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
+	{"jnbe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
+	{"ja", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
+	{"js", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x88}},
+	{"jns", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x89}},
+	{"jp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
+	{"jpe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
+	{"jnp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
+	{"jpo", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
+	{"jl", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
+	{"jnge", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
+	{"jnl", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
+	{"jge", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
+	{"jle", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
+	{"jng", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
+	{"jnle", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
+	{"jg", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
 
 	/////// 0x0F 0x9_ ///////
 	// TODO: what is the value of spec for these instructions?
-	{"seto", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x90}},
-	{"setno", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x91}},
-	{"setb", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x92}},
-	{"setnae", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x92}},
-	{"setc", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x92}},
-	{"setnb", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x93}},
-	{"setae", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x93}},
-	{"setnc", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x93}},
-	{"setz", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x94}},
-	{"sete", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x94}},
-	{"setnz", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x95}},
-	{"setne", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x95}},
-	{"setbe", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x96}},
-	{"setna", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x96}},
-	{"setnbe", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x97}},
-	{"seta", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x97}},
-	{"sets", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x98}},
-	{"setns", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x99}},
-	{"setp", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9A}},
-	{"setpe", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9A}},
-	{"setnp", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9B}},
-	{"setpo", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9B}},
-	{"setl", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9C}},
-	{"setnge", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9C}},
-	{"setnl", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9D}},
-	{"setge", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9D}},
-	{"setle", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9E}},
-	{"setng", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9E}},
-	{"setnle", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9F}},
-	{"setg", {OT_GPREG | OT_MEMORY | OT_BYTE}, 1, {0x0F, 0x9F}},
+	{"seto", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x90}},
+	{"setno", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x91}},
+	{"setb", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x92}},
+	{"setnae", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x92}},
+	{"setc", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x92}},
+	{"setnb", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x93}},
+	{"setae", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x93}},
+	{"setnc", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x93}},
+	{"setz", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x94}},
+	{"sete", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x94}},
+	{"setnz", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x95}},
+	{"setne", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x95}},
+	{"setbe", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x96}},
+	{"setna", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x96}},
+	{"setnbe", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x97}},
+	{"seta", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x97}},
+	{"sets", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x98}},
+	{"setns", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x99}},
+	{"setp", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9A}},
+	{"setpe", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9A}},
+	{"setnp", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9B}},
+	{"setpo", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9B}},
+	{"setl", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9C}},
+	{"setnge", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9C}},
+	{"setnl", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9D}},
+	{"setge", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9D}},
+	{"setle", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9E}},
+	{"setng", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9E}},
+	{"setnle", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9F}},
+	{"setg", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9F}},
 
 	/////// 0x0F 0xA_ ///////
 	{"push", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA0}},
 	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA1}},
 	{"cpuid", {}, 2, {0x0F, 0xA2}},
-	{"bt", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xA3}},
-	{"shld", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xA4}},
-	{"shld", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xA5}},
+	{"bt", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xA3}},
+	{"shld", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xA4}},
+	{"shld", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xA5}},
 	// 0x0F 0xA6-0xA7: reserved
 	{"push", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA8}},
 	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA9}},
 	{"rsm", {}, 2, {0x0F, 0xAA}},
-	{"bts", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xAB}},
-	{"shrd", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xAC}},
-	{"shrd", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xAD}},
+	{"bts", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xAB}},
+	{"shrd", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xAC}},
+	{"shrd", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xAD}},
 	// 0x0F 0xAE: group 15
-	{"imul", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0xAF}}, // ?
+	{"imul", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0xAF}}, // ?
 
 	/////// 0x0F 0xB_ ///////
-	{"cmpxchg", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 2, {0x0F, 0xB0}},
-	{"cmpxchg", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xB1}},
-	{"lss", {OT_GPREG | OT_DWORD, OT_MEMORY}, 2, {0x0F, 0xB2}},
-	{"btr", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xB3}},
-	{"lfs", {OT_GPREG | OT_DWORD, OT_MEMORY}, 2, {0x0F, 0xB4}},
-	{"lgs", {OT_GPREG | OT_DWORD, OT_MEMORY}, 2, {0x0F, 0xB5}},
-	{"movzx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_BYTE}, 2, {0x0F, 0xB6}},
-	{"movzx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_WORD}, 2, {0x0F, 0xB7}},
+	{"cmpxchg", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 2, {0x0F, 0xB0}},
+	{"cmpxchg", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xB1}},
+	{"lss", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP}, 2, {0x0F, 0xB2}},
+	{"btr", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xB3}},
+	{"lfs", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP}, 2, {0x0F, 0xB4}},
+	{"lgs", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP}, 2, {0x0F, 0xB5}},
+	{"movzx", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_BYTE}, 2, {0x0F, 0xB6}},
+	{"movzx", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_WORD}, 2, {0x0F, 0xB7}},
 	// 0x0F 0xB8: reserved
 	// 0x0F 0xB9: group 10
 	// 0x0F 0xBA: group 8
-	{"btc", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xBB}},
-	{"bsf", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0xBC}},
-	{"bsr", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_DWORD}, 2, {0x0F, 0xBD}},
-	{"movsx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_BYTE}, 2, {0x0F, 0xBE}},
-	{"movsx", {OT_GPREG | OT_DWORD, OT_GPREG | OT_MEMORY | OT_WORD}, 2, {0x0F, 0xBF}},
+	{"btc", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xBB}},
+	{"bsf", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0xBC}},
+	{"bsr", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0xBD}},
+	{"movsx", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_BYTE}, 2, {0x0F, 0xBE}},
+	{"movsx", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_WORD}, 2, {0x0F, 0xBF}},
 
 	/////// 0x0F 0xC_ ///////
-	{"xadd", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_GPREG | OT_BYTE}, 2, {0x0F, 0xC0}},
-	{"xadd", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xC1}},
-	{"cmpps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xC2}},
-	{"movnti", {OT_MEMORY | OT_DWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xC3}},
-	{"pinsrw", {OT_REGMMX | OT_QWORD, OT_GPREG | OT_DWORD}, 2, {0x0F, 0xC4}},	// Will the operands be in the right order?
-	{"pextrw", {OT_GPREG | OT_DWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xC5}},	// Will the operands be in the right order?
-	{"shufps", {OT_REGXMM | OT_OWORD, OT_REGXMM | OT_MEMORY | OT_OWORD, OT_IMMEDIATE | OT_BYTE}, 2, {0x0F, 0xC6}},
+	{"xadd", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 2, {0x0F, 0xC0}},
+	{"xadd", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xC1}},
+	{"cmpps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xC2}},
+	{"movnti", {OT_MEMONLYOP | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xC3}},
+	{"pinsrw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGONLYOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xC4}},
+	{"pextrw", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGONLYOP(MMX) | OT_QWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xC5}},
+	{"shufps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xC6}},
 	// 0x0F 0xB7: group 9
 	{"bswap", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 2, {0x0F, 0xC8}},
 	{"bswap", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 2, {0x0F, 0xC9}},
@@ -924,56 +952,56 @@ Opcode opcodes[] = {
 
 	/////// 0x0F 0xD_ ///////
 	// 0x0F 0xD0: reserved
-	{"psrlw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD1}},
-	{"psrld", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD2}},
-	{"psrlq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD3}},
+	{"psrlw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xD1}},
+	{"psrld", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xD2}},
+	{"psrlq", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xD3}},
 	// 0x0F 0xD4: reserved
-	{"pmulw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD5}},
+	{"pmulw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xD5}},
 	// 0x0F 0xD6: reserved
-	{"pmovmskb", {OT_GPREG | OT_DWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xD7}},
-	{"psubusb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD8}},
-	{"psubusw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xD9}},
-	{"pminub", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDA}},
-	{"pand", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDB}},
-	{"paddusb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDC}},
-	{"paddusw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDD}},
-	{"pmaxub", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDE}},
-	{"pandn", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xDF}},
+	{"pmovmskb", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGONLYOP(MMX) | OT_QWORD}, 2, {0x0F, 0xD7}},
+	{"psubusb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xD8}},
+	{"psubusw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xD9}},
+	{"pminub", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xDA}},
+	{"pand", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xDB}},
+	{"paddusb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xDC}},
+	{"paddusw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xDD}},
+	{"pmaxub", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xDE}},
+	{"pandn", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xDF}},
 
 	/////// 0x0F 0xE_ ///////
-	{"pavgb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE0}},
-	{"psraw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE1}},
-	{"psrad", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE2}},
-	{"pavgw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE3}},
-	{"pmulhuw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE4}},
-	{"pmulhw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE5}},
+	{"pavgb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE0}},
+	{"psraw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE1}},
+	{"psrad", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE2}},
+	{"pavgw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE3}},
+	{"pmulhuw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE4}},
+	{"pmulhw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE5}},
 	// 0x0F 0xE6: reserved
-	{"movntq", {OT_MEMORY | OT_QWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xE7}},
-	{"psubsb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE8}},
-	{"psubsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xE9}},
-	{"pminsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEA}},
-	{"por", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEB}},
-	{"paddsb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEC}},
-	{"paddsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xED}},
-	{"pmaxsw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEE}},
-	{"pxor", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xEF}},
+	{"movntq", {OT_MEMONLYOP | OT_QWORD, OT_REGSPECOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE7}},
+	{"psubsb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE8}},
+	{"psubsw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xE9}},
+	{"pminsw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xEA}},
+	{"por", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xEB}},
+	{"paddsb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xEC}},
+	{"paddsw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xED}},
+	{"pmaxsw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xEE}},
+	{"pxor", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xEF}},
 
 	/////// 0x0F 0xF_ ///////
 	// 0x0F 0xF0: reserved
-	{"psllw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF1}},
-	{"pslld", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF2}},
-	{"pshllq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF3}},
+	{"psllw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF1}},
+	{"pslld", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF2}},
+	{"pshllq", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF3}},
 	// 0x0F 0xF4: reserved
-	{"pmaddwd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF5}},
-	{"psadbw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF6}},
-	{"maskmovq", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_QWORD}, 2, {0x0F, 0xF7}},
-	{"psubb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF8}},
-	{"psubw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xF9}},
-	{"psubd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFA}},
+	{"pmaddwd", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF5}},
+	{"psadbw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF6}},
+	{"maskmovq", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGONLYOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF7}},
+	{"psubb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF8}},
+	{"psubw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xF9}},
+	{"psubd", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xFA}},
 	// 0x0F 0xFB: reserved
-	{"paddb", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFC}},
-	{"paddw", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFD}},
-	{"paddd", {OT_REGMMX | OT_QWORD, OT_REGMMX | OT_MEMORY | OT_QWORD}, 2, {0x0F, 0xFE}},
+	{"paddb", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xFC}},
+	{"paddw", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xFD}},
+	{"paddd", {OT_REGSPECOP(MMX) | OT_QWORD, OT_REGMEMOP(MMX) | OT_QWORD}, 2, {0x0F, 0xFE}},
 	// 0x0F 0xFF: reserved
 
 	////////////////////////
@@ -987,34 +1015,34 @@ Opcode opcodes[] = {
 	///////////////////////////////////////////
 
 	// IMMEDIATE GROUP 1
-	{"add", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 0},
-	{"or", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 1},
-	{"adc", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 2},
-	{"sbb", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 3},
-	{"and", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 4},
-	{"sub", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 5},
-	{"xor", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 6},
-	{"cmp", {OT_GPREG | OT_MEMORY | OT_BYTE, OT_IMMEDIATE | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 7},
+	{"add", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 0},
+	{"or", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 1},
+	{"adc", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 2},
+	{"sbb", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 3},
+	{"and", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 4},
+	{"sub", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 5},
+	{"xor", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 6},
+	{"cmp", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 7},
 
-	{"add", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 0},
-	{"or", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 1},
-	{"adc", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 2},
-	{"sbb", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 3},
-	{"and", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 4},
-	{"sub", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 5},
-	{"xor", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 6},
-	{"cmp", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 7},
+	{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 0},
+	{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 1},
+	{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 2},
+	{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 3},
+	{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 4},
+	{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 5},
+	{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 6},
+	{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 7},
 
 	// Are there opcodes starting with 0x82?
 
-	{"add", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 0},
-	{"or", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 1},
-	{"adc", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 2},
-	{"sbb", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 3},
-	{"and", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 4},
-	{"sub", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 5},
-	{"xor", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 6},
-	{"cmp", {OT_GPREG | OT_MEMORY | OT_DWORD, OT_IMMEDIATE | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 7},
+	{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 0},
+	{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 1},
+	{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 2},
+	{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 3},
+	{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 4},
+	{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 5},
+	{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 6},
+	{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 7},
 
 	// SHIFT GROUP 2
 	// TODO
@@ -1022,11 +1050,11 @@ Opcode opcodes[] = {
 	////////////////////
 	// FPU OPERATIONS //
 	////////////////////
-	{"fadd", {(OT_FPUREG & OT_REG(0)) | OT_FPUSIZE, OT_FPUREG | OT_MEMORY | OT_DWORD}, 1, {0xD8}, SPECIAL_SPEC + 0},
+	{"fadd", {(OT_FPUREG & OT_REG(0)) | OT_FPUSIZE, OT_REGMEMOP(FPU) | OT_DWORD}, 1, {0xD8}, SPECIAL_SPEC + 0},
 	// ...
 
-	{"fadd", {(OT_FPUREG & OT_REG(0)) | OT_FPUSIZE, OT_MEMORY | OT_QWORD}, 1, {0xDC}, SPECIAL_SPEC + 0},
-	{"fadd", {OT_FPUREG, (OT_FPUREG & OT_REG(0)) | OT_FPUSIZE}, 1, {0xDC}, SPECIAL_SPEC + 0},
+	{"fadd", {(OT_FPUREG & OT_REG(0)) | OT_FPUSIZE, OT_MEMONLYOP | OT_QWORD}, 1, {0xDC}, SPECIAL_SPEC + 0},
+	{"fadd", {OT_REGONLYOP(FPU), (OT_FPUREG & OT_REG(0)) | OT_FPUSIZE}, 1, {0xDC}, SPECIAL_SPEC + 0},
 	// ...
 
 	{"fsin", {}, 2, {0xD9, 0xFE}}
@@ -1088,34 +1116,20 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 	for (l=0; l<opcode_ptr->op_len; ++l)
 		data[l] = opcode_ptr->opcode[l];
 
-	// What operands do we have and how do we encode them?
+	// Find register/memory- and spec-encoded operands
 	Operand *regmem_op = 0;
-	Operand *reg_op = 0;
+	Operand *spec_op = 0;
 
 	for (op_ind = 0; op_ind < 3 && opcode_ptr->op[op_ind] != 0; ++op_ind) {
-		// If operand can point to memory, it must be encoded via RM and SIB
-		// That is, if it isn't just a plain address.
-		// TODO: what about two register-only operands?
-		if (opcode_ptr->op[op_ind] & OT_MEMORY && !(opcode_ptr->op[op_ind] & (OT_IMMEDIATE | OT_MEMADDRESS))) {
+		if (opcode_ptr->op[op_ind] & OT_REGMEM)
 			regmem_op = &operands[op_ind];
-			continue;
-		}
 
-		// Remaining register operands are encoded via spec field, if that is
-		// necessary: sometimes operands are fixed to be a certain register.
-		if ((opcode_ptr->op[op_ind] & (0xff << REGTYPE_SHIFT))
-				&& !(~opcode_ptr->op[op_ind] & OT_REGALL))
-			reg_op = &operands[op_ind];
-	}
-
-	// If our opcode requires a spec field, then we might have to move an operand
-	if (opcode_ptr->special && regmem_op == 0) {
-		regmem_op = reg_op;
-		reg_op = 0;
+		if (opcode_ptr->op[op_ind] & OT_SPECIAL)
+			spec_op = &operands[op_ind];
 	}
 
 	// Are there any operands we have to encode?
-	if (regmem_op && (opcode_ptr->special || reg_op)) {
+	if (regmem_op && (opcode_ptr->special || spec_op)) {
 		ut8 mod = 0, spec = 0, rm = 0;
 		ut8 scale = 0, index = 0, base = 0;
 
@@ -1123,10 +1137,10 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 		if (opcode_ptr->special)
 			spec = opcode_ptr->special & SPECIAL_MASK;
 		else
-			spec = reg_op->reg;
+			spec = spec_op->reg;
 
 		// Analyze register/memory operand.
-		if (regmem_op->type & (0xff << REGTYPE_SHIFT)) {
+		if (regmem_op->type & OT_REGTYPE) {
 			mod = 3;
 			rm = regmem_op->reg;
 		}
@@ -1249,15 +1263,16 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 
 	// Write immediate(s), if required.
 	for (op_ind = 0; op_ind < 3; ++op_ind)
-		if (opcode_ptr->op[op_ind] & (OT_IMMEDIATE | OT_MEMADDRESS)) {
+		if (opcode_ptr->op[op_ind] & OT_IMMEDIATE) {
 			// Careful: the following is a slight HACK and wouldn't work for TBYTE
 			// immediates. (If there were any...)
 			int i;
 			int len = opcode_ptr->op[op_ind] >> OPSIZE_SHIFT;
 
 			// For memory address immediates: the value is somewhere else
-			if (opcode_ptr->op[op_ind] & OT_MEMADDRESS) {
+			if (opcode_ptr->op[op_ind] & OT_MEMORY) {
 				operands[op_ind].immediate = operands[op_ind].offset;
+				// TODO: make noise if indirect addressing components are present.
 				len = 4; // TODO: real address length
 			}
 

--- a/libr/asm/p/asm_x86_new.c
+++ b/libr/asm/p/asm_x86_new.c
@@ -797,16 +797,16 @@ static int write_asm(ut8 *data, Opcode *opcode_ptr, Operand *operands) {
 			reg_op = &operands[op_ind];
 	}
 
+	// If our opcode requires a spec field, then we might have to move an operand
+	if (opcode_ptr->special && regmem_op == 0) {
+		regmem_op = reg_op;
+		reg_op = 0;
+	}
+
 	// Are there any operands we have to encode?
 	if (regmem_op && (opcode_ptr->special || reg_op)) {
 		ut8 mod = 0, spec = 0, rm = 0;
 		ut8 scale = 0, index = 0, base = 0;
-
-		// If our opcode requires a spec field, then we might have to move an operand
-		if (opcode_ptr->special && regmem_op == 0) {
-			regmem_op = reg_op;
-			reg_op = 0;
-		}
 
 		// Write spec
 		if (opcode_ptr->special)

--- a/libr/asm/t/test.new
+++ b/libr/asm/t/test.new
@@ -21,6 +21,7 @@ asm_test 'aaa' 37
 asm_test 'stc' f9
 asm_test 'ret' c3
 asm_test 'rep stosd' f3ab
+asm_test 'rdtsc' 0f31
 
 # single byte with implicit operands
 asm_test 'pop ecx' 59
@@ -29,6 +30,7 @@ asm_test 'xchg eax, eax' 90
 asm_test 'xchg eax, edx' 92
 asm_test 'in eax, dx' ed
 asm_test 'out dx, al' ee
+asm_test 'bswap esi' 0fce
 
 # immediate operands
 asm_test 'int 0xab' cdab
@@ -52,14 +54,25 @@ asm_test 'fadd st(0), dword ptr [edx]' d802
 asm_test 'fadd st(0), qword ptr [edx]' dc02
 asm_test 'fadd st(1), st(0)' dcc1
 
+# MMX registers
+asm_test 'pcmpgtw mm(3), mm(7)' 0f65df
+asm_test 'punpckldq mm(3), qword ptr [edx+4*eax]' 0f621c82
+
 # XMM registers
 asm_test 'movups xmm(0), xmm(5)' 0f10c5
 asm_test 'movups xmm(3), oword ptr [esi]' 0f101e
 asm_test 'movups oword ptr [esi], xmm(7)' 0f113e
 
+# Mix of registers / register-only operations
+asm_test 'movd ebx, mm(2)' 0f7ed3
+asm_test 'movmskps edx, xmm(5)' 0f50d5
+asm_test 'pinsrw mm(3), eax, 3' 0fc4d803
+asm_test 'pextrw edx, mm(5), 1' 0fc5d501
+
 # complex
 asm_test 'imul eax, ecx, 21' 6bc115
 asm_test 'imul eax, ecx, 0x12345' 69c145230100
+asm_test 'shufps xmm(3), xmm(5), 0xab' 0fc6ddab
 
 # MEMORY operands
 # Immediates

--- a/libr/asm/t/test.new
+++ b/libr/asm/t/test.new
@@ -19,6 +19,7 @@ asm_test 'fsin' d9fe
 asm_test 'pushad' 60
 asm_test 'aaa' 37
 asm_test 'stc' f9
+asm_test 'ret' c3
 asm_test 'rep stosd' f3ab
 
 # single byte with implicit operands
@@ -31,6 +32,7 @@ asm_test 'out dx, al' ee
 
 # immediate operands
 asm_test 'int 0xab' cdab
+asm_test 'ret 0x1234' c23412
 asm_test 'mov eax, 0' b800000000
 asm_test 'mov edx, 0x12345678' ba78563412
 asm_test 'out 0x23, al' e623

--- a/libr/asm/t/test.new
+++ b/libr/asm/t/test.new
@@ -52,6 +52,11 @@ asm_test 'fadd st(0), dword ptr [edx]' d802
 asm_test 'fadd st(0), qword ptr [edx]' dc02
 asm_test 'fadd st(1), st(0)' dcc1
 
+# XMM registers
+asm_test 'movups xmm(0), xmm(5)' 0f10c5
+asm_test 'movups xmm(3), oword ptr [esi]' 0f101e
+asm_test 'movups oword ptr [esi], xmm(7)' 0f113e
+
 # complex
 asm_test 'imul eax, ecx, 21' 6bc115
 asm_test 'imul eax, ecx, 0x12345' 69c145230100

--- a/libr/asm/t/test.new
+++ b/libr/asm/t/test.new
@@ -46,6 +46,12 @@ asm_test 'add byte ptr [edx], al' 0002
 asm_test 'or [edx], eax' 0902
 asm_test 'lea eax, [eax+2*ecx]' 8d0448
 
+# FPU registers
+asm_test 'fadd st(0), st(1)' d8c1
+asm_test 'fadd st(0), dword ptr [edx]' d802
+asm_test 'fadd st(0), qword ptr [edx]' dc02
+asm_test 'fadd st(1), st(0)' dcc1
+
 # complex
 asm_test 'imul eax, ecx, 21' 6bc115
 asm_test 'imul eax, ecx, 0x12345' 69c145230100


### PR DESCRIPTION
This includes a number of fixes, more tests and all non-FPU two-byte opcodes without special encoding. Most importantly, the system of flags for operands was cleaned up. They now contain information about how to encode an operand, since this is not always obvious.