### PR TITLE
Enable support for --syszip in libr/core/p/Makefile

### DIFF
--- a/libr/core/p/Makefile
+++ b/libr/core/p/Makefile
@@ -1,4 +1,5 @@
 include ../../config.mk
+include ../../../shlr/zip/deps.mk
 
 CFLAGS=-I../../include -Wall -shared -fPIC ${LDFLAGS_LIB} ${LDFLAGS_LINKPATH}..
 # XXX
@@ -12,7 +13,6 @@ CFLAGS+=-L../../syscall -lr_syscall -L../../socket -lr_socket -L../../search -lr
 CFLAGS+=-L../../diff -lr_diff -L../../lang -lr_lang -L../../debug -lr_debug
 CFLAGS+=-L../../bp -lr_bp -L../../reg -lr_reg -L../../asm -lr_asm
 CFLAGS+=../../../shlr/sdb/src/libsdb.a
-CFLAGS+=../../../shlr/zip/librz.a
 CFLAGS+=../../../shlr/gdb/lib/libgdbr.a
 CFLAGS+=../../../shlr/wind/libr_wind.a
 #CFLAGS+=-L../../anal -lr_anal -L../../core -lr_core


### PR DESCRIPTION
Hello,

Not sure if this is the right approach. Building radare2 --syszip doesn't work.

In general there is place for possible clean-ups, like:
binr/blob/Makefile
libr/io/Makefile
libr/util/Makefile
binr/rules.mk
