### PR TITLE
Add missing include for strtoull(3)

### DIFF
--- a/shlr/sdb/src/util.c
+++ b/shlr/sdb/src/util.c
@@ -8,6 +8,8 @@
 #include <sys/time.h>
 #endif
 
+#include <stdlib.h>
+
 // XXX deprecate or wtf? who uses this??
 SDB_API int sdb_check_value(const char *s) {
 	if (!s || *s=='$')
@@ -268,4 +270,3 @@ SDB_API int sdb_isjson (const char *k) {
 		return 0;
 	return 1;
 }
-


### PR DESCRIPTION
While there why not to implement this:

 ret = !strncmp (s, "0x", 2)?
strtoull (s+2, &p, 16):
strtoull (s, &p, 10);

with strtoull(s,&p,0)?