### PR TITLE
Fix dietline cursor position

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -853,7 +853,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 						i = sizeof (I.buffer.data)-1;
 					}
 				} else i = 0;
-				len = I.buffer.length-i;
+				len = I.buffer.index-i;
 				fwrite (I.buffer.data+i, 1, len, stdout);
 			}
 			fflush (stdout);


### PR DESCRIPTION
Fixes the following unfilled bug I complained about on IRC:

Steps to reproduce:

1 Run "r2 -"
2 Type "abc"
3 Press the left arrow key - Cursor will stay at the end of the line

It was introduced in https://github.com/radare/radare2/commit/756406939541a40bb3f2f71e3a06eed0c23c84f8 (3 days ago).