### PR TITLE
Show ptr automatic comments in the web UI

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2496,6 +2496,14 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		// wanted the numerical values of the type information
 		r_cons_printf (",\"type_num\":%"PFMT64d, analop.type);
 		r_cons_printf (",\"type2_num\":%"PFMT64d, analop.type2);
+
+		if (analop.refptr) {
+			ds->analop = analop;
+			r_cons_printf (",\"ptr_info\":\"");
+			handle_print_ptr (core, ds, nb_bytes+256, j);
+			r_cons_printf ("\"");
+		}
+
 		// handle switch statements
 		if (analop.switch_op && r_list_length (analop.switch_op->cases) > 0) {
 			// XXX - the java caseop will still be reported in the assembly,

--- a/shlr/www/enyo/js/disasm.js
+++ b/shlr/www/enyo/js/disasm.js
@@ -669,6 +669,9 @@ function html_for_instruction(ins) {
   } else {
     idump += '<div class="instructiondesc">' + opcode + '</div> ';
   }
+  if (ins.ptr_info) {
+    idump += '<span class="comment ec_comment comment_' + address_canonicalize(offset) + '">' + escapeHTML(ins.ptr_info) + '</span>';
+  }
 
   if (ins.comment && asm_cmtright) {
     idump += '<span class="comment ec_comment comment_' + address_canonicalize(offset) + '"> ; ' + escapeHTML(ins.comment) + '</span>';


### PR DESCRIPTION
So that comments like:

    ldr r1, [pc, 0x14]                ; [0x244:4]=0x80003a5

Appear in the web interface, like they do in the command line.