### PR TITLE
Added ecc command to output the palette as CSS.

### DIFF
--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -284,23 +284,22 @@ R_API void r_cons_pal_list (int rad) {
 			r_cons_printf ("\"%s\":[%d,%d,%d]%s",
 				keys[i].name, r, g, b, hasnext);
 			break;
-        case 'c':
+		case 'c': {
 			r = g = b = 0;
 			r_cons_rgb_parse (*color, &r, &g, &b, NULL);
 			hasnext = (keys[i+1].name) ? "\n" : "";
-
-            //Need to replace the '.' char because this is not valid CSS
-            char *name = strdup(keys[i].name);
-            int len = strlen(name);
-            int j;
-            for(j=0; j < len; j++){
-                if(name[j] == '.')
-                    name[j] = '_';
-            }
-            r_cons_printf (".%s { color: rgb(%d, %d, %d); }%s",
-                    name, r, g, b, hasnext);
-            free(name);
-            break;
+			//Need to replace the '.' char because this is not valid CSS
+			char *name = strdup(keys[i].name);
+			int j, len = strlen(name);
+			for(j=0; j < len; j++) {
+				if(name[j] == '.')
+					name[j] = '_';
+			}
+			r_cons_printf (".%s { color: rgb(%d, %d, %d); }%s",
+				name, r, g, b, hasnext);
+			free(name);
+			}
+			break;
 		case '*':
 		case 'r':
 		case 1:

--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -284,6 +284,23 @@ R_API void r_cons_pal_list (int rad) {
 			r_cons_printf ("\"%s\":[%d,%d,%d]%s",
 				keys[i].name, r, g, b, hasnext);
 			break;
+        case 'c':
+			r = g = b = 0;
+			r_cons_rgb_parse (*color, &r, &g, &b, NULL);
+			hasnext = (keys[i+1].name) ? "\n" : "";
+
+            //Need to replace the '.' char because this is not valid CSS
+            char *name = strdup(keys[i].name);
+            int len = strlen(name);
+            int j;
+            for(j=0; j < len; j++){
+                if(name[j] == '.')
+                    name[j] = '_';
+            }
+            r_cons_printf (".%s { color: rgb(%d, %d, %d); }%s",
+                    name, r, g, b, hasnext);
+            free(name);
+            break;
 		case '*':
 		case 'r':
 		case 1:

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -59,6 +59,7 @@ static int cmd_eval(void *data, const char *input) {
 			"ecr","","set random palette",
 			"ecs","","show a colorful palette",
 			"ecj","","show palette in JSON",
+			"ecc","","show palette in CSS",
 			"eco"," dark|white","load white color scheme template",
 			"ec"," prompt red","change color of prompt",
 			"ec"," prompt red blue","change color and background of prompt",
@@ -108,6 +109,7 @@ static int cmd_eval(void *data, const char *input) {
 		case 's': r_cons_pal_show (); break;
 		case '*': r_cons_pal_list (1); break;
 		case 'j': r_cons_pal_list ('j'); break;
+		case 'c': r_cons_pal_list ('c'); break;
 		case '\0': r_cons_pal_list (0); break;
 		case 'r': r_cons_pal_random (); break;
 		default: {


### PR DESCRIPTION
Addresses issue #1736

Adds the "ecc" command which will output the current palette as css.
Every key is turned into a class, and the '.' character is changed into '_' because
css class names are not allowed to contain '.'.