### PR TITLE
fix segfault due to a double free

### DIFF
--- a/libr/asm/arch/tms320/c55x_plus/decode_funcs.c
+++ b/libr/asm/arch/tms320/c55x_plus/decode_funcs.c
@@ -1098,9 +1098,6 @@ st8 *get_opers(ut8 oper_byte)
 			case 5u:
 				res =  strcat_dup(reg_name, " <= #0", 1);
 			}
-			// free (reg_name); Causes segfault
-			// TODO: still can leak
-free(reg_name);
 			return res;
 		}
 		reg_name = get_reg_name_1((oper_byte & 0xF) + 128);

--- a/libr/asm/arch/tms320/c55x_plus/decode_funcs.c
+++ b/libr/asm/arch/tms320/c55x_plus/decode_funcs.c
@@ -1098,6 +1098,7 @@ st8 *get_opers(ut8 oper_byte)
 			case 5u:
 				res =  strcat_dup(reg_name, " <= #0", 1);
 			}
+			//TODO: still can leak
 			return res;
 		}
 		reg_name = get_reg_name_1((oper_byte & 0xF) + 128);


### PR DESCRIPTION


The issue was that the previous call to strcat_dup was freeing the pointer s1 and thus reg_name didn't have a pointer longer valid. 

The function strcat_dup is in libr/asm/arch/tms320/c55x_plus/utils.c

But if strcat_dup is not able to allocate memory to res -line 26- a NULL is returned and all that pointers are not freed and in this case reg_name.

I think either the caller should free the pointer or the callee.

What do you think? 