### PR TITLE
#2207 add nice(2) support for rarun2 on UNIX

### DIFF
--- a/libr/include/r_socket.h
+++ b/libr/include/r_socket.h
@@ -176,6 +176,7 @@ typedef struct r_run_profile_t {
 	char *_connect;
 	char *_listen;
 	int _timeout;
+    int _nice;
 } RRunProfile;
 
 R_API RRunProfile *r_run_new(const char *str);


### PR DESCRIPTION
A trite test file.

<code>
#!/usr/bin/rarun2
program=/bin/ls
arg1=-a
arg2=-l
nice=9
</code>

No Windows support (yet), as I do not have it on my working machine.
Negative values are fine if the user has sufficient privileges according to the man.
errno is used here, because -1 is among the new niceness values that can be returned.