### PR TITLE
fix for is_string ignoring \r, \n and \t as valid characters

### DIFF
--- a/libr/anal/data.c
+++ b/libr/anal/data.c
@@ -16,12 +16,12 @@ static int is_string (const ut8 *buf, int size, int *len) {
 			*len = i;
 			return 1;
 		}
+		if (buf[i]==10||buf[i]==13||buf[i]==9) {
+			continue;
+		}
 		if (buf[i]<32 || buf[i]>127) {
 			// not ascii text
 			return 0;
-		}
-		if (buf[i]==10||buf[i]==13||buf[i]==9) {
-			continue;
 		}
 		if (!IS_PRINTABLE (buf[i])) {
 			*len = i;


### PR DESCRIPTION
* This fixes refprt strings on disassembly

Hope this doesn't break anything depending on r_anal_data(). Also this code seems dupe to me, but I left it as it was....

data.c - is_string()
```C
		if (buf[i]<32 || buf[i]>127) {
			// not ascii text
			return 0;
		}
		if (!IS_PRINTABLE (buf[i])) {
			*len = i;
			return 0;
		}
```
