### PR TITLE
Use APT addon on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
   - ./configure --prefix=`pwd`/install > /dev/null  # TODO: Might enable some of the additional features.
   - make -s > /dev/null
   - make install > /dev/null
-  - PATH=`pwd`/install/bin:$PATH && \
-    LD_LIBRARY_PATH=`pwd`/install/lib:$LD_LIBRARY_PATH && \
-    cd radare2-regressions && \
-    VERBOSE=1 make $TESTS   # Run the tests, report only regressions as errors.
+  - export PATH=${TRAVIS_BUILD_DIR}/install/bin:${PATH}
+  - export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/install/lib:${LD_LIBRARY_PATH}
+  - cd radare2-regressions
+  - VERBOSE=1 make $TESTS   # Run the tests, report only regressions as errors.

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,16 @@ env:
   #- TESTS=commands         # r2 commands related
   - TESTS=tools            # tools related 
 
-  
+# Force build on container-based infrastructure
+sudo: false
+
 # Additional depencies like capstone are downloaded by the r2 makefiles.
+addons:
+  apt:
+    packages:
+      - dc # GNU dc, used by r2r.
+
 install:
-  - sudo apt-get install dc # GNU dc, used by r2r.
   - git clone `doc/repo REGRESSIONS`
   # This little hack will prevent the test names from being erased in the
   # travis logfile.
@@ -74,9 +80,12 @@ script:
   # Limit the stack size (to 32MiB) to make ThreadSanitizer happy.
   - ulimit -s 32768
   # Now on to actually building stuff...
-  - ./configure > /dev/null  # TODO: Might enable some of the additional features.
+# Set prefix for which we don't need sudo
+  - ./configure --prefix=`pwd`/install > /dev/null  # TODO: Might enable some of the additional features.
   - make -s > /dev/null
-  - sudo make install > /dev/null
+  - make install > /dev/null
+  - PATH=`pwd`/install/bin:$PATH
+  - LD_LIBRARY_PATH=`pwd`/install/lib:$LD_LIBRARY_PATH
   - cd radare2-regressions
   # Run the tests, report only regressions as errors.
   - VERBOSE=1 make $TESTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,8 +84,7 @@ script:
   - ./configure --prefix=`pwd`/install > /dev/null  # TODO: Might enable some of the additional features.
   - make -s > /dev/null
   - make install > /dev/null
-  - PATH=`pwd`/install/bin:$PATH
-  - LD_LIBRARY_PATH=`pwd`/install/lib:$LD_LIBRARY_PATH
-  - cd radare2-regressions
-  # Run the tests, report only regressions as errors.
-  - VERBOSE=1 make $TESTS
+  - PATH=`pwd`/install/bin:$PATH && \
+    LD_LIBRARY_PATH=`pwd`/install/lib:$LD_LIBRARY_PATH && \
+    cd radare2-regressions && \
+    VERBOSE=1 make $TESTS   # Run the tests, report only regressions as errors.


### PR DESCRIPTION
This should hpefully enable builds on container-based infrastructure, which are faster than builds on the old infrastructure. (see http://docs.travis-ci.com/user/workers/container-based-infrastructure/)

The most important part was the recently enabled possibility to install packages without `sudo` via the [APT addon](http://docs.travis-ci.com/user/apt/). Sudo isn't allowed on container-based infrastructure.