### PR TITLE
fix #1503

### DIFF
--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -7,7 +7,7 @@
 static void pair(const char *a, const char *b) {
 	char ws[16];
 	int al = strlen (a);
-	if (!b) b = "";
+	if (!b) return;  //b = "";
 	memset (ws, ' ', sizeof (ws));
 	al = PAIR_WIDTH-al;
 	if (al<0) al = 0;
@@ -288,8 +288,8 @@ static int bin_info (RCore *r, int mode) {
 	if (mode & R_CORE_BIN_JSON) {
 		r_cons_printf ("{\"type\":\"%s\","
 			"\"class\":\"%s\","
-			"\"endian\":\"%s\","
-			"\"machine\":\"%s\","
+			/*"\"endian\":\"%s\","*/
+			/*"\"machine\":\"%s\","*/
 			"\"arch\":\"%s\","
 			"\"os\":\"%s\","
 			"\"lang\":\"%s\","
@@ -298,7 +298,7 @@ static int bin_info (RCore *r, int mode) {
 			"\"nx\":%s,"
 			"\"crypto\":%s,"
 			"\"va\":%s,"
-			"\"bits\":%d,"
+			/*"\"bits\":%d,"*/
 			"\"stripped\":%s,"
 			"\"static\":%s,"
 			"\"linenums\":%s,"
@@ -306,8 +306,8 @@ static int bin_info (RCore *r, int mode) {
 			"\"relocs\":%s}",
 			STR(info->rclass), // type
 			STR(info->bclass), // class
-			info->big_endian? "big": "little",
-			STR(info->machine),
+			/*info->big_endian? "big": "little",*/
+			/*STR(info->machine),*/
 			STR(info->arch),
 			STR(info->os),
 			info->lang?info->lang:"",
@@ -316,7 +316,7 @@ static int bin_info (RCore *r, int mode) {
 			r_str_bool (info->has_nx),
 			r_str_bool (info->has_crypto),
 			r_str_bool (info->has_va),
-			info->bits,
+			/*info->bits,*/
 			r_str_bool ((R_BIN_DBG_STRIPPED & info->dbg_info)),
 			r_str_bool (r_bin_is_static (r->bin)),//R_BIN_DBG_STATIC (info->dbg_info)),
 			r_str_bool ((R_BIN_DBG_LINENUMS & info->dbg_info)),
@@ -378,9 +378,9 @@ static int bin_info (RCore *r, int mode) {
 		} else {
 			// if type is 'fs' show something different?
 			//r_cons_printf ("# File info\n");
-
-			pair ("file", info->file);
-			pair ("type", info->type);
+			
+			/*pair ("file", info->file);*/
+			/*pair ("type", info->type);*/
 			pair ("pic", r_str_bool (info->has_pi));
 			pair ("canary", r_str_bool (info->has_canary));
 			pair ("nx", r_str_bool (info->has_nx));
@@ -390,11 +390,11 @@ static int bin_info (RCore *r, int mode) {
 			pair ("class", info->bclass);
 			pair ("lang", info->lang? info->lang: "unknown");
 			pair ("arch", info->arch);
-			pair ("bits", sdb_fmt (0, "%d", info->bits));
-			pair ("machine", info->machine);
+			/*pair ("bits", sdb_fmt (0, "%d", info->bits));*/
+			/*pair ("machine", info->machine);*/
 			pair ("os", info->os);
 			pair ("subsys", info->subsystem);
-			pair ("endian", info->big_endian? "big": "little");
+			/*pair ("endian", info->big_endian? "big": "little");*/
 			pair ("strip", r_str_bool (R_BIN_DBG_STRIPPED &info->dbg_info));
 			pair ("static", r_str_bool (r_bin_is_static (r->bin)));
 			pair ("linenum", r_str_bool (R_BIN_DBG_LINENUMS &info->dbg_info));

--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -289,7 +289,7 @@ static int bin_info (RCore *r, int mode) {
 		r_cons_printf ("{\"type\":\"%s\","
 			"\"class\":\"%s\","
 			/*"\"endian\":\"%s\","*/
-			/*"\"machine\":\"%s\","*/
+			"\"machine\":\"%s\","
 			"\"arch\":\"%s\","
 			"\"os\":\"%s\","
 			"\"lang\":\"%s\","
@@ -307,7 +307,7 @@ static int bin_info (RCore *r, int mode) {
 			STR(info->rclass), // type
 			STR(info->bclass), // class
 			/*info->big_endian? "big": "little",*/
-			/*STR(info->machine),*/
+			STR(info->machine),
 			STR(info->arch),
 			STR(info->os),
 			info->lang?info->lang:"",
@@ -391,7 +391,7 @@ static int bin_info (RCore *r, int mode) {
 			pair ("lang", info->lang? info->lang: "unknown");
 			pair ("arch", info->arch);
 			/*pair ("bits", sdb_fmt (0, "%d", info->bits));*/
-			/*pair ("machine", info->machine);*/
+			pair ("machine", info->machine);
 			pair ("os", info->os);
 			pair ("subsys", info->subsystem);
 			/*pair ("endian", info->big_endian? "big": "little");*/

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -133,13 +133,23 @@ static void r_core_file_info (RCore *core, int mode) {
 	}
 }
 
+static int bin_is_executable (RBinObject *obj){
+	RListIter *it;
+	RBinSection* sec;
+	r_list_foreach (obj->sections, it, sec){
+		if (R_BIN_SCN_EXECUTABLE & sec->srwx)
+			return R_TRUE;
+	}
+	return R_FALSE;
+}
+
 static void cmd_info_bin(RCore *core, ut64 offset, int va, int mode) {
 	RBinObject *obj = r_bin_cur_object (core->bin); 
 	if (core->file) {
 		if (mode == R_CORE_BIN_JSON)
 			r_cons_printf ("{\"core\":");
 		r_core_file_info (core, mode);
-		if (obj->bin_obj){
+		if (bin_is_executable (obj)){
 				if (mode == R_CORE_BIN_JSON)
 					r_cons_printf (",\"bin\":");
 				r_core_bin_info (core, R_CORE_BIN_ACC_INFO,

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -71,19 +71,19 @@ static void r_core_file_info (RCore *core, int mode) {
 		case R_CORE_BIN_JSON:
 			r_cons_printf ("\"type\":\"%s\","
 			/*"\"os\":\"%s\","*/
-			"\"machine\":\"%s\","
+			/*"\"machine\":\"%s\","*/
 			"\"bits\":%d,"
 			"\"endian\":\"%s\","
 			, STR(info->type)
 			/*, STR(info->os)*/
-			, STR(info->machine)
+			/*, STR(info->machine)*/
 			, info->bits
 			, info->big_endian? "big": "little");
 			break;
 		default:
 			pair ("type", info->type);
 			/*pair ("os", info->os);*/
-			pair ("machine", info->machine);
+			/*pair ("machine", info->machine);*/
 			pair ("bits", sdb_fmt (0, "%d", info->bits));
 			pair ("endian", info->big_endian? "big": "little");
 			break;
@@ -134,12 +134,12 @@ static void r_core_file_info (RCore *core, int mode) {
 }
 
 static void cmd_info_bin(RCore *core, ut64 offset, int va, int mode) {
-	RBinInfo *info = r_bin_get_info (core->bin);
+	RBinObject *obj = r_bin_cur_object (core->bin); 
 	if (core->file) {
 		if (mode == R_CORE_BIN_JSON)
 			r_cons_printf ("{\"core\":");
 		r_core_file_info (core, mode);
-		if (!strncmp (info->type, "Executable file", 15)){
+		if (obj->bin_obj){
 				if (mode == R_CORE_BIN_JSON)
 					r_cons_printf (",\"bin\":");
 				r_core_bin_info (core, R_CORE_BIN_ACC_INFO,

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -2538,45 +2538,53 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "constant_pool");
 			section->size = bin->cp_size;
 			section->paddr = bin->cp_offset + baddr;
-			section->srwx = 0;
+			section->srwx = R_BIN_SCN_READABLE;
 			r_list_append (sections, section);
 		}
 		section = NULL;
 	}
 	if (bin->fields_count > 0) {
 		section = R_NEW0 (RBinSection);
-		strcpy (section->name, "fields");
-		section->size = bin->fields_size;
-		section->paddr = bin->fields_offset + baddr;
-		section->srwx = 0;
-		r_list_append (sections, section);
-		section = NULL;
-		r_list_foreach (bin->fields_list, iter, fm_type) {
-			if (fm_type->attr_offset == 0) continue;
-			section = R_NEW0 (RBinSection);
-			snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
-			section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
-			section->paddr = fm_type->attr_offset + baddr;
-			section->srwx = 0;
+		if (section){
+			strcpy (section->name, "fields");
+			section->size = bin->fields_size;
+			section->paddr = bin->fields_offset + baddr;
+			section->srwx = R_BIN_SCN_READABLE;
 			r_list_append (sections, section);
+			section = NULL;
+			r_list_foreach (bin->fields_list, iter, fm_type) {
+				if (fm_type->attr_offset == 0) continue;
+				section = R_NEW0 (RBinSection);
+				if (section){
+					snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
+					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
+					section->paddr = fm_type->attr_offset + baddr;
+					section->srwx = R_BIN_SCN_READABLE;
+					r_list_append (sections, section);
+				}
+			}
 		}
 	}
 	if (bin->methods_count > 0) {
 		section = R_NEW0 (RBinSection);
-		strcpy (section->name, "methods");
-		section->size = bin->methods_size;
-		section->paddr = bin->methods_offset + baddr;
-		section->srwx = 0;
-		r_list_append (sections, section);
-		section = NULL;
-		r_list_foreach (bin->methods_list, iter, fm_type) {
-			if (fm_type->attr_offset == 0) continue;
-			section = R_NEW0 (RBinSection);
-			snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
-			section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
-			section->paddr = fm_type->attr_offset + baddr;
-			section->srwx = 0;
+		if (section){ 
+			strcpy (section->name, "methods");
+			section->size = bin->methods_size;
+			section->paddr = bin->methods_offset + baddr;
+			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
 			r_list_append (sections, section);
+			section = NULL;
+			r_list_foreach (bin->methods_list, iter, fm_type) {
+				if (fm_type->attr_offset == 0) continue;
+				section = R_NEW0 (RBinSection);
+				if (section){
+					snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
+					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
+					section->paddr = fm_type->attr_offset + baddr;
+					section->srwx = R_BIN_SCN_READABLE;
+					r_list_append (sections, section);
+				}
+			}
 		}
 	}
 	if (bin->interfaces_count > 0) {
@@ -2585,7 +2593,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "interfaces");
 			section->size = bin->interfaces_size;
 			section->paddr = bin->interfaces_offset + baddr;
-			section->srwx = 0;
+			section->srwx = R_BIN_SCN_READABLE;
 			r_list_append (sections, section);
 		}
 		section = NULL;
@@ -2596,6 +2604,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "attributes");
 			section->size = bin->attrs_size;
 			section->paddr = bin->attrs_offset + baddr;
+			section->srwx = R_BIN_SCN_READABLE;
 			r_list_append (sections, section);
 		}
 		section = NULL;


### PR DESCRIPTION
Let me know if this is the behavior and also If it continues having some repeated fields that I couldn't see. Before to merge perhaps is needed to upgrade the regression repository but I wanted to receive feedback before. So after confirmation that is ok I will update the necessary test.

I decided to erase the bin information for those files that are not executable because these fields are either empty or false.

There are fields that are equal in core and bin and I decided to keep them in the core since for the images, pdf the bin information is not showed. However the fields "machine" and "os" with these kind of files are empty, so would be better to move them in the bin_info? ( I did this for "os" field but not with "machine") since in the json output these fields will be empty and we can save some bytes.

 

![captura de pantalla 2015-04-07 a las 19 52 55](https://cloud.githubusercontent.com/assets/3474042/7029968/7b0d6ca4-dd61-11e4-9200-9d9d71b2a1b4.png)
![captura de pantalla 2015-04-07 a las 19 56 56](https://cloud.githubusercontent.com/assets/3474042/7029969/7b21e454-dd61-11e4-8ff3-95f490bcc17d.png)
![captura de pantalla 2015-04-07 a las 19 55 25](https://cloud.githubusercontent.com/assets/3474042/7029970/7b268522-dd61-11e4-921b-5c88da829b50.png)
![captura de pantalla 2015-04-07 a las 20 17 55](https://cloud.githubusercontent.com/assets/3474042/7030203/389e267c-dd63-11e4-8880-8f0f984aef03.png)