### PR TITLE
Fix 'dr' and '/' in visual mode.

### DIFF
--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -405,7 +405,7 @@ ignore:
 	r_cons_set_raw (1);
 	if (read (0, buf, 1)==-1)
 		return -1;
-	//r_cons_set_raw (0);
+	r_cons_set_raw (0);
 #endif
 	return r_cons_controlz (buf[0]);
 }


### PR DESCRIPTION
Uncomments the following line in libr/cons/input.c:
408     //r_cons_set_raw (0);

This resolves the freezing console issue on 'dr' and '/' commands in visual mode.