### PR TITLE
[re,m]alloc size MUST depend on requested length

### DIFF
--- a/libr/util/strpool.c
+++ b/libr/util/strpool.c
@@ -24,9 +24,9 @@ R_API char *r_strpool_empty (RStrpool *p) {
 }
 
 R_API char *r_strpool_alloc (RStrpool *p, int l) {
-	char *ret = p->str+p->len;
-	if ((p->len+l)>=p->size) {
-		p->size += R_STRPOOL_INC;
+	char *ret = p->str + p->len;
+	if ((p->len + l) >= p->size) {
+		p->size = p->len + l;
 		ret = realloc (p->str, p->size);
 		if (!ret) return NULL;
 		p->str = ret;


### PR DESCRIPTION
This is just a suggestion for discussion. What if after 
```C
p->size += R_STRPOOL_INC
```
expression
```C
((p->len + l) >= p->size)
```
is still true?