### PR TITLE
Fix 2369 - move bits and endian from core to bin info

### DIFF
--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -288,7 +288,7 @@ static int bin_info (RCore *r, int mode) {
 	if (mode & R_CORE_BIN_JSON) {
 		r_cons_printf ("{\"type\":\"%s\","
 			"\"class\":\"%s\","
-			/*"\"endian\":\"%s\","*/
+			"\"endian\":\"%s\","
 			"\"machine\":\"%s\","
 			"\"arch\":\"%s\","
 			"\"os\":\"%s\","
@@ -298,7 +298,7 @@ static int bin_info (RCore *r, int mode) {
 			"\"nx\":%s,"
 			"\"crypto\":%s,"
 			"\"va\":%s,"
-			/*"\"bits\":%d,"*/
+			"\"bits\":%d,"
 			"\"stripped\":%s,"
 			"\"static\":%s,"
 			"\"linenums\":%s,"
@@ -306,7 +306,7 @@ static int bin_info (RCore *r, int mode) {
 			"\"relocs\":%s}",
 			STR(info->rclass), // type
 			STR(info->bclass), // class
-			/*info->big_endian? "big": "little",*/
+			info->big_endian? "big": "little",
 			STR(info->machine),
 			STR(info->arch),
 			STR(info->os),
@@ -316,7 +316,7 @@ static int bin_info (RCore *r, int mode) {
 			r_str_bool (info->has_nx),
 			r_str_bool (info->has_crypto),
 			r_str_bool (info->has_va),
-			/*info->bits,*/
+			info->bits,
 			r_str_bool ((R_BIN_DBG_STRIPPED & info->dbg_info)),
 			r_str_bool (r_bin_is_static (r->bin)),//R_BIN_DBG_STATIC (info->dbg_info)),
 			r_str_bool ((R_BIN_DBG_LINENUMS & info->dbg_info)),
@@ -379,8 +379,6 @@ static int bin_info (RCore *r, int mode) {
 			// if type is 'fs' show something different?
 			//r_cons_printf ("# File info\n");
 			
-			/*pair ("file", info->file);*/
-			/*pair ("type", info->type);*/
 			pair ("pic", r_str_bool (info->has_pi));
 			pair ("canary", r_str_bool (info->has_canary));
 			pair ("nx", r_str_bool (info->has_nx));
@@ -390,11 +388,11 @@ static int bin_info (RCore *r, int mode) {
 			pair ("class", info->bclass);
 			pair ("lang", (info->lang && *info->lang)? info->lang: NULL);//"unknown");
 			pair ("arch", info->arch);
-			/*pair ("bits", sdb_fmt (0, "%d", info->bits));*/
+			pair ("bits", sdb_fmt (0, "%d", info->bits));
 			pair ("machine", info->machine);
 			pair ("os", info->os);
 			pair ("subsys", info->subsystem);
-			/*pair ("endian", info->big_endian? "big": "little");*/
+			pair ("endian", info->big_endian? "big": "little");
 			pair ("strip", r_str_bool (R_BIN_DBG_STRIPPED &info->dbg_info));
 			pair ("static", r_str_bool (r_bin_is_static (r->bin)));
 			pair ("linenum", r_str_bool (R_BIN_DBG_LINENUMS &info->dbg_info));

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -69,28 +69,15 @@ static void r_core_file_info (RCore *core, int mode) {
 		fn = info->file;
 		switch (mode) {
 		case R_CORE_BIN_JSON:
-			r_cons_printf ("\"type\":\"%s\","
-			/*"\"os\":\"%s\","*/
-			/*"\"machine\":\"%s\","*/
-			"\"bits\":%d,"
-			"\"endian\":\"%s\","
-			, STR(info->type)
-			/*, STR(info->os)*/
-			/*, STR(info->machine)*/
-			, info->bits
-			, info->big_endian? "big": "little");
+			r_cons_printf ("\"type\":\"%s\"", STR(info->type));
 			break;
 		default:
 			pair ("type", info->type);
-			/*pair ("os", info->os);*/
-			/*pair ("machine", info->machine);*/
-			pair ("bits", sdb_fmt (0, "%d", info->bits));
-			pair ("endian", info->big_endian? "big": "little");
 			break;
 		}
 	} else fn = (cf && cf->desc) ? cf->desc->name : NULL;
 	if (cf && mode == R_CORE_BIN_JSON) {
-		r_cons_printf ("\"file\":\"%s\"", fn);
+		r_cons_printf (",\"file\":\"%s\"", fn);
 		if (dbg) dbg = R_IO_WRITE | R_IO_EXEC;
 		if (cf->desc) {
 			/*r_cons_printf (",\"uri\":\"%s\"", cf->desc->uri);*/
@@ -123,7 +110,6 @@ static void r_core_file_info (RCore *core, int mode) {
 			pair ("blksz", sdb_fmt (0, "0x%"PFMT64x,
 				(ut64)core->io->desc->obsz));
 			pair ("mode", r_str_rwx_i (cf->desc->flags & 7));
-			/*pair ("uri", cf->desc->uri);*/
 		}
 		pair ("block", sdb_fmt (0, "0x%x", core->blocksize));
 		if (binfile && binfile->curxtr)

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -77,7 +77,7 @@ static void r_core_file_info (RCore *core, int mode) {
 		}
 	} else fn = (cf && cf->desc) ? cf->desc->name : NULL;
 	if (cf && mode == R_CORE_BIN_JSON) {
-		r_cons_printf (",\"file\":\"%s\"", fn);
+		r_cons_printf (",\"file\":\"%s\"", fn ? fn : cf->desc->uri);
 		if (dbg) dbg = R_IO_WRITE | R_IO_EXEC;
 		if (cf->desc) {
 			/*r_cons_printf (",\"uri\":\"%s\"", cf->desc->uri);*/
@@ -100,7 +100,7 @@ static void r_core_file_info (RCore *core, int mode) {
 		r_cons_printf ("}");
 	} else if (cf && mode != R_CORE_BIN_SIMPLE) {
 		//r_cons_printf ("# Core file info\n");
-		pair ("file", fn);
+		pair ("file", fn ? fn : cf->desc->uri);
 		if (dbg) dbg = R_IO_WRITE | R_IO_EXEC;
 		if (cf->desc) {
 			if (cf->desc->referer && *cf->desc->referer)


### PR DESCRIPTION
This fix the issue. I've made also a PR in the regression repository to reflect this change.