### PR TITLE
Always use ut32 for unix timestamps. Also handle endianness properly

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -259,9 +259,8 @@ static int rax (char *str, int len, int last) {
 	} else if (flags & 2048) { // -t
 		ut32 n = r_num_math (num, str);
 		RPrint *p = r_print_new ();
-		p->big_endian = 0; // TODO: honor endian here
-		r_mem_copyendian ((ut8*) &n, (ut8*) &n, 8, 0); // fix endian here
-		r_print_date_unix (p, (const ut8*)&n, sizeof (ut64));
+		r_mem_copyendian ((ut8*) &n, (ut8*) &n, 4, !(flags & 2));
+		r_print_date_unix (p, (const ut8*)&n, sizeof (ut32));
 		r_print_free (p);
 		return R_TRUE;
 	} else if (flags & 4096) { // -E

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2782,12 +2782,12 @@ static int cmd_print(void *data, const char *input) {
 		switch (input[1]) {
 		case ' ':
 		case '\0':
-			for (l=0; l<len; l+=sizeof (time_t))
-				r_print_date_unix (core->print, core->block+l, sizeof (time_t));
+			for (l=0; l<len; l+=sizeof (ut32))
+				r_print_date_unix (core->print, core->block+l, sizeof (ut32));
 			break;
 		case 'd':
-			for (l=0; l<len; l+=4)
-				r_print_date_dos (core->print, core->block+l, 4);
+			for (l=0; l<len; l+=sizeof (ut32))
+				r_print_date_dos (core->print, core->block+l, sizeof (ut32));
 			break;
 		case 'n':
 			core->print->big_endian = !core->print->big_endian;
@@ -2798,9 +2798,9 @@ static int cmd_print(void *data, const char *input) {
 		case '?':{
 			const char* help_msg[] = {
 			"Usage: pt", "[dn]", "print timestamps",
-			"pt", "", "print unix time (32 bit `cfg.big_endian`",
-			"ptd","", "print dos time (32 bit `cfg.big_endian`",
-			"ptn","", "print ntfs time (64 bit `cfg.big_endian`",
+			"pt", "", "print unix time (32 bit `cfg.bigendian`)",
+			"ptd","", "print dos time (32 bit `cfg.bigendian`)",
+			"ptn","", "print ntfs time (64 bit `cfg.bigendian`)",
 			NULL};
 			r_core_cmd_help (core, help_msg);
 			}

--- a/libr/util/p_date.c
+++ b/libr/util/p_date.c
@@ -31,13 +31,13 @@ R_API int r_print_date_dos(RPrint *p, ut8 *buf, int len) {
 }
 
 R_API int r_print_date_unix(RPrint *p, const ut8 *buf, int len) {
-	time_t t;
+	time_t t = 0;
 	char s[256];
 	int ret = 0;
 	const struct tm* time;
 
-	if (p != NULL && len >= sizeof(t)) {
-		r_mem_copyendian ((ut8*)&t, buf, sizeof(time_t), p->big_endian);
+	if (p != NULL && len >= sizeof(ut32)) {
+		r_mem_copyendian ((ut8*)&t, buf, sizeof(ut32), !p->big_endian);
 		// "%d:%m:%Y %H:%M:%S %z",
 		if (p->datefmt[0]) {
 			t += p->datezone * (60*60);
@@ -93,7 +93,7 @@ R_API int r_print_date_w32(RPrint *p, const ut8 *buf, int len) {
 	char datestr[256];
 
 	if (p && len >= sizeof (ut64)) {
-		r_mem_copyendian ((ut8*)&l, buf, sizeof (ut64), p->big_endian);
+		r_mem_copyendian ((ut8*)&l, buf, sizeof (ut64), !p->big_endian);
 		l /= 10000000; // 100ns to s
 		l = (l > L ? l-L : 0); // isValidUnixTime?
 		t = (time_t) l; // TODO limit above!


### PR DESCRIPTION
Because it turns out `sizeof(time_t)` is 8 in 64 bit platforms, but that results in really broken `pt` results, where half of the lines are 'invalid date'

Also, endianness handling was swapped in the case of `pt` and non-existent in the case of `rax2 -t` (the latter actually did a weird hack to swap endianness twice and get valid results).

Now `rax2 -t` supports the `-e` parameter to swap endianness.

The usage of `r_mem_copyendian` with `r_print` now matches what's done in other places, with `!p->big_endian` instead of `p->big_endian`, because 0 means swap and 1 means do nothing. Terrible function.

This also fixes some valgrind warnings about uninitialized values (when copying 4 bytes to a 8 byte `time_t`)

-------

Example `pt` output right at an offset which should have a valid 32 bit little endian timestamp:

```
[0x0000009d]> pt
Invalid time
1427729556-08-26 19:48:32 +0000
Invalid time
Invalid time
Invalid time
Invalid time
483478831-01-22 22:06:10 +0000
72881-04-26 04:48:00 +0000
597755874-12-15 17:51:03 +0000
[...]
```

After this patch:

```
[0x0000009d]> pt
2012-11-02 03:43:17 +0000
2012-11-02 03:43:17 +0000
1978-08-03 11:22:40 +0000
1975-05-10 04:13:52 +0000
1970-01-01 00:01:19 +0000
1970-01-01 01:27:09 +0000
2021-10-26 20:47:42 +0000
2031-10-11 19:10:56 +0000
[...]
```

(Partial) Valgrind output of just `rax2 -t 1351827797`

```
$ valgrind --tool=memcheck rax2 -t 1351827797
==11503== Memcheck, a memory error detector
==11503== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==11503== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==11503== Command: rax2 -t 1351827797
==11503==
==11503== Conditional jump or move depends on uninitialised value(s)
==11503==    at 0x513448C: __offtime (in /usr/lib/libc-2.21.so)
==11503==    by 0x5136516: __tz_convert (in /usr/lib/libc-2.21.so)
==11503==    by 0x4E5FC67: r_print_date_unix (p_date.c:44)
==11503==    by 0x401FB0: rax (rax2.c:264)
==11503==    by 0x402697: main (rax2.c:378)
==11503==
==11503== Conditional jump or move depends on uninitialised value(s)
==11503==    at 0x5134792: __offtime (in /usr/lib/libc-2.21.so)
==11503==    by 0x5136516: __tz_convert (in /usr/lib/libc-2.21.so)
==11503==    by 0x4E5FC67: r_print_date_unix (p_date.c:44)
==11503==    by 0x401FB0: rax (rax2.c:264)
==11503==    by 0x402697: main (rax2.c:378)
==11503==
==11503== Conditional jump or move depends on uninitialised value(s)
==11503==    at 0x5134537: __offtime (in /usr/lib/libc-2.21.so)
==11503==    by 0x5136516: __tz_convert (in /usr/lib/libc-2.21.so)
==11503==    by 0x4E5FC67: r_print_date_unix (p_date.c:44)
==11503==    by 0x401FB0: rax (rax2.c:264)
==11503==    by 0x402697: main (rax2.c:378)
==11503==
[...]
==11503== ERROR SUMMARY: 78 errors from 22 contexts (suppressed: 0 from 0)
```