### PR TITLE
Fix a buffer over-read in /c command

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1208,8 +1208,12 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 
 		if (maxhits && count >= maxhits)
 			break;
-		if ((hits = r_core_asm_strsearch (core, input+2,
-				param->from, param->to, maxhits))) {
+
+		if (outmode == 0) hits = NULL;
+		else hits = r_core_asm_strsearch (core, input+2,
+				param->from, param->to, maxhits);
+
+		if (hits) {
 			r_list_foreach (hits, iter, hit) {
 				if (r_cons_singleton()->breaked)
 					break;


### PR DESCRIPTION
```
alvaro_fe@macbook 12:21 ~/Projects/Reverse/radare2/r2 r2 /bin/ls                                                                                                                            [master] git:r2
 -- Greetings, human.
[0x100001058]> /c
=================================================================
==76442==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000010993 at pc 0x000109b560d7 bp 0x7fff571e0f70 sp 0x7fff571e0f68
READ of size 1 at 0x602000010993 thread T0
    #0 0x109b560d6 in r_core_asm_strsearch (/usr/lib/libr_core.dylib+0x37e0d6)
    #1 0x10990d065 in do_asm_search (/usr/lib/libr_core.dylib+0x135065)
    #2 0x1098f41a6 in cmd_search (/usr/lib/libr_core.dylib+0x11c1a6)
    #3 0x109af832c in r_cmd_call (/usr/lib/libr_core.dylib+0x32032c)
    #4 0x1099e16ee in r_core_cmd_subst_i (/usr/lib/libr_core.dylib+0x2096ee)
    #5 0x109831d96 in r_core_cmd_subst (/usr/lib/libr_core.dylib+0x59d96)
    #6 0x10982b76d in r_core_cmd (/usr/lib/libr_core.dylib+0x5376d)
    #7 0x1097f97f4 in r_core_prompt_exec (/usr/lib/libr_core.dylib+0x217f4)
    #8 0x108a22762 in main (/usr/bin/r2+0x10000d762)
    #9 0x7fff9566a5c8 in start (/usr/lib/system/libdyld.dylib+0x35c8)
    #10 0x1  (<unknown module>)

ASAN:SIGSEGV
==76442==AddressSanitizer: while reporting a bug found another one. Ignoring.
```

The issue was that in the case of `/c0` input+2 was producing a buffer over-read