### PR TITLE
pf: fix offset/size handling of 'X' (hexpairs) type

### DIFF
--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -629,20 +629,21 @@ static int r_print_format_10bytes(const RPrint* p, int mode, const char* setval,
 }
 
 static int r_print_format_hexpairs(const RPrint* p, int endian, int mode,
-		const char* setval, ut64 seeki, ut8* buf, int size) {
+		const char* setval, ut64 seeki, ut8* buf, int i, int size) {
 	int j;
+	size = (size==-1) ? 1 : size;
 	if (MUSTSET) {
 		p->printf ("?e pf X not yet implemented\n");
 	} else if (MUSTSEE) {
 		size = (size < 1) ? 1 : size;
 		p->printf ("0x%08"PFMT64x" = ", seeki);
 		j=0;
-		for (; j<10; j++)
-				p->printf ("%02x ", buf[j]);
+		for (; j<size; j++)
+				p->printf ("%02x ", buf[i+j]);
 		p->printf (" ... (");
 		for (j=0; j<size; j++)
 			if (IS_PRINTABLE (buf[j]))
-				p->printf ("%c", buf[j]);
+				p->printf ("%c", buf[i+j]);
 			else
 				p->printf (".");
 		p->printf (")");
@@ -911,7 +912,8 @@ int r_print_format_struct_size(const char *f, RPrint *p, int mode) {
 			case 'c':
 			case 'b':
 			case '.':
-				size+=tabsize*1;
+			case 'X':
+				size += tabsize*1;
 				break;
 			case 'w':
 				size += tabsize*2;
@@ -1322,7 +1324,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 				break;
 			case 'X':
 				size = r_print_format_hexpairs (p, endian, mode,
-					setval, seeki, buf, size);
+					setval, seeki, buf, i, size);
 				i += size;
 				break;
 			case 'T':


### PR DESCRIPTION
Not really sure if this is how it was supposed to behave, but you can answer that by merging this \o/

Before:

```
[0x00000000]> wx 09080706050403020100010203040506070809
[0x00000000]> pf XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
0x00000000 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000001 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000002 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000003 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000004 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000005 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000006 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000007 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000008 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000009 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000000a = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000000b = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000000c = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000000d = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000000e = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000000f = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000010 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000011 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000012 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000013 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000014 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000015 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000016 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000017 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000018 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000019 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000001a = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000001b = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000001c = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000001d = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000001e = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x0000001f = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000020 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000021 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000022 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000023 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000024 = 09 08 07 06 05 04 03 02 01 00  ... (.)
0x00000025 = 09 08 07 06 05 04 03 02 01 00  ... (.)
```

After:

```
[0x00000000]> pf X[2]X[8]X[16]X
0x00000000 = 09  ... (.)
0x00000001 = 08 07  ... (..)
0x00000003 = 06 05 04 03 02 01 00 01  ... (........)
0x0000000b = 02 03 04 05 06 07 08 09 00 00 00 00 00 00 00 00  ... (................)
[0x00000000]> pf XXXXXXX
0x00000000 = 09  ... (.)
0x00000001 = 08  ... (.)
0x00000002 = 07  ... (.)
0x00000003 = 06  ... (.)
0x00000004 = 05  ... (.)
0x00000005 = 04  ... (.)
0x00000006 = 03  ... (.)
```