### PR TITLE
Add message when visually assembling in read-only

### DIFF
--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -215,6 +215,13 @@ static int cmd_write(void *data, const char *input) {
 	if (!input)
 		return 0;
 
+	if (r_core_file_is_readonly(core))
+	{
+		eprintf ("Write commands are disabled because file is read-only (use -w flags)\n");
+		if (!strchr(input, '?'))
+			return 0;
+	}
+
 	#define WSEEK(x,y) if (wseek)r_core_seek_delta (x,y)
 	wseek = r_config_get_i (core->config, "cfg.wseek");
 	str = ostr = strdup ((input&&*input)?input+1:"");

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -975,3 +975,8 @@ R_API RCoreFile * r_core_file_cur (RCore *r) {
 	// Add any locks here
 	return r->file;
 }
+
+R_API int r_core_file_is_readonly(RCore *core)
+{
+	return core->file && core->file->desc && !(core->file->desc->flags & R_IO_WRITE);
+}

--- a/libr/core/vasm.c
+++ b/libr/core/vasm.c
@@ -20,6 +20,9 @@ static int readline_callback(void *_a, const char *str) {
 	r_cons_printf ("Write your favourite %s-%d opcode...\n\n",
 		r_config_get (a->core->config, "asm.arch"),
 		r_config_get_i (a->core->config, "asm.bits"));
+	if (r_core_file_is_readonly(a->core)) {
+		r_cons_printf ("File has been opened in read-only mode. To save results, use -w flag\n");
+	}
 	if (*str == '?') {
 		r_cons_printf ("0> ?\n\n"
 			"Visual assembler help:\n\n"
@@ -57,8 +60,9 @@ R_API void r_core_visual_asm(RCore *core, ut64 off) {
 	r_line_readline_cb (readline_callback, &cva);
 
 	if (cva.acode && cva.acode->len>0)
-		if (r_cons_yesno ('y', "Save changes? (Y/n)"))
-			r_core_cmdf (core, "wx %s @ 0x%"PFMT64x,
-				cva.acode->buf_hex, off);
+		if (!r_core_file_is_readonly(core))
+			if (r_cons_yesno ('y', "Save changes? (Y/n)"))
+				r_core_cmdf (core, "wx %s @ 0x%"PFMT64x,
+					cva.acode->buf_hex, off);
 	r_asm_code_free (cva.acode);
 }

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -735,7 +735,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 		}
 		break;
 	case 'a':
-		if (core->file && core->file->desc && !(core->file->desc->flags & 2)) {
+		if (r_core_file_is_readonly(core)) {
 			r_cons_printf ("\nFile has been opened in read-only mode. Use -w flag\n");
 			r_cons_any_key (NULL);
 			return R_TRUE;
@@ -881,7 +881,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 		break;
 	case 'i':
 	case 'I':
-		if (core->file && core->file->desc &&!(core->file->desc->flags & 2)) {
+		if (r_core_file_is_readonly(core)) {
 			r_cons_printf ("\nFile has been opened in read-only mode. Use -w flag\n");
 			r_cons_any_key (NULL);
 			return R_TRUE;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -248,6 +248,7 @@ R_API int r_core_set_file_by_fd (RCore * core, ut64 bin_fd);
 R_API int r_core_set_file_by_name (RBin * bin, const char * name);
 R_API RBinFile * r_core_bin_cur (RCore *core);
 R_API ut32 r_core_file_cur_fd (RCore *core);
+R_API int r_core_file_is_readonly(RCore *core);
 
 #define R_CORE_FOREIGN_ADDR -1
 R_API int r_core_yank(RCore *core, ut64 addr, int len);


### PR DESCRIPTION
The visual 'A' command now warns that the modification will not be saved. No
confirmation is then asked for (not) saving the changes.