### PR TITLE
debug_gdb: handle null return value from gdbr_read_registers

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -24,10 +24,13 @@ static int r_debug_gdb_step(RDebug *dbg) {
 }
 
 static int r_debug_gdb_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
-	gdbr_read_registers (desc);
 	int copy_size;
-	// read the len of the current area
 	int buflen = 0;
+	gdbr_read_registers (desc);
+	if (!desc) {
+		return -1;
+	}
+	// read the len of the current area
 	free (r_reg_get_bytes (dbg->reg, type, &buflen));
 	if (size<desc->data_len) {
 		eprintf ("r_debug_gdb_reg_read: small buffer %d vs %d\n",


### PR DESCRIPTION
This would crash when doing `r2 -d cat -c 'dh gdb'`

Now that just prints "r_debug_reg: error reading registers"