### PR TITLE
Fix signed char boundaries when assembling jump

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1201,7 +1201,7 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 				}
 
 				dst -= offset;
-				if (dst>-0x80 && dst<0x7f) {
+				if (-0x80 <= (dst-2) && (dst-2) <= 0x7f) {
 					/* relative byte address */
 					data[l++] = 0xeb;
 					data[l++] = (char)(dst-2);


### PR DESCRIPTION
Signed char can be between -0x80 and 0x7f. The offset in the jump must be
computed taking into account the instruction length.