### PR TITLE
Fix to print all length ROP chains from rop.chain=X to 2

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -971,11 +971,13 @@ static int r_core_search_rop(RCore *core, ut64 from, ut64 to, int opt, const cha
 					if (!hitlist)
 						continue;
 
-					if (json) {
-						print_rop (core, hitlist, 'j', &json_first);
-					} else {
+
+					/* Print all chains from rop.len=X to rop.len=2 */
+					if (json) mode = 'j';
+					do {
 						print_rop (core, hitlist, mode, &json_first);
-					}
+						hitlist->head = hitlist->head->n;
+					} while (hitlist->head->n);
 				}
 
 				if (increment != 1) {


### PR DESCRIPTION
It might produce duplicated gadgets as side effect :(

Maybe a better approach would be adding an  evar to select if you want all gadget lengths printed or not.