### PR TITLE
Fix vaddr problem in omf loader

### DIFF
--- a/libr/bin/format/omf/omf.c
+++ b/libr/bin/format/omf/omf.c
@@ -634,7 +634,7 @@ int r_bin_omf_get_entry(r_bin_omf_obj *obj, RBinAddr *addr) {
 				eprintf ("Invalid segment index for symbol _start\n");
 				return R_FALSE;
 			}			
-			addr->vaddr = obj->sections[obj->symbols[ct_sym]->seg_idx - 1]->vaddr + obj->symbols[ct_sym]->offset;
+			addr->vaddr = obj->sections[obj->symbols[ct_sym]->seg_idx - 1]->vaddr + obj->symbols[ct_sym]->offset + OMF_BASE_ADDR;
 			data = obj->sections[obj->symbols[ct_sym]->seg_idx - 1]->data;
 			while (data) {
 				offset += data->size;
@@ -677,7 +677,7 @@ int r_bin_omf_send_sections(RList *list, OMF_segment *section, r_bin_omf_obj *ob
 		new->size = data->size;
 		new->vsize = data->size;
 		new->paddr = data->paddr;
-		new->vaddr = section->vaddr + data->offset;
+		new->vaddr = section->vaddr + data->offset + OMF_BASE_ADDR;
 		new->srwx = R_BIN_SCN_EXECUTABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_READABLE;
 		r_list_append (list, new);
 		data = data->next;
@@ -707,5 +707,5 @@ ut64 r_bin_omf_get_vaddr_sym(r_bin_omf_obj *obj, OMF_symbol *sym) {
 		eprintf ("Invalid segment index for symbol %s\n", sym->name);
 		return 0;
 	}
-	return obj->sections[sym->seg_idx - 1]->vaddr + sym->offset;
+	return obj->sections[sym->seg_idx - 1]->vaddr + sym->offset + OMF_BASE_ADDR;
 }

--- a/libr/bin/format/omf/omf.h
+++ b/libr/bin/format/omf/omf.h
@@ -52,6 +52,9 @@ typedef struct {
 	OMF_record_handler *records;
 } r_bin_omf_obj;
 
+// this value was chosen arbitrarily to made the loader work correctly
+// if someone want to implement rellocation for omf he has to remove this
+#define OMF_BASE_ADDR 0x1000
 
 int r_bin_checksum_omf_ok(const char *buf, ut64 buf_size);
 r_bin_omf_obj *r_bin_internal_omf_load(const char *buf, ut64 size);

--- a/libr/bin/p/bin_omf.c
+++ b/libr/bin/p/bin_omf.c
@@ -44,7 +44,7 @@ static int check(RBinFile *arch) {
 }
 
 static ut64 baddr(RBinFile *arch) {
-	return 0;
+	return OMF_BASE_ADDR;
 }
 
 static RList *entries(RBinFile *arch) {
@@ -115,7 +115,8 @@ static RBinInfo *info(RBinFile *arch) {
 	ret->file = strdup (arch->file);
 	ret->bclass = strdup ("OMF");
 	ret->rclass = strdup ("omf");
-	ret->type = strdup ("OMF (Relocatable Object Module Format)");
+	// the "E" is here to made rva return the same value for 16 bit en 32 bits files
+	ret->type = strdup ("E OMF (Relocatable Object Module Format)");
 	ret->os = strdup ("any");
 	ret->machine = strdup ("i386");
 	ret->arch = strdup ("x86");


### PR DESCRIPTION
Fix all broken test related to vaddr for the omf loader.
The only broken tests remaining are because radare compute the baddr display for the entry point
with (vaddr - paddr) and this is wrong for omf beacause are split into multiple record in the file but this record must be contiguous in memory.