### PR TITLE
Fix for /Rl to print every length gadget from rop.len=X to 2

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -792,6 +792,7 @@ static int r_core_search_rop(RCore *core, ut64 from, ut64 to, int opt, const cha
 	char* tok, *gregexp = NULL;
 	char* grep_arg = NULL;
 	const ut8 crop = r_config_get_i (core->config, "rop.conditional");	//decide if cjmp, cret, and ccall should be used too for the gadget-search
+	const ut8 subchain = r_config_get_i (core->config, "rop.subchains");
 	const ut8 max_instr = r_config_get_i (core->config, "rop.len");
 	const ut8 prot = r_config_get_i (core->config, "rop.nx") ? R_IO_READ|R_IO_WRITE|R_IO_EXEC : R_IO_EXEC;
 	if (max_count == 0) {
@@ -974,7 +975,7 @@ static int r_core_search_rop(RCore *core, ut64 from, ut64 to, int opt, const cha
 
 					if (json) mode = 'j';
 
-					if (mode == 'l') {
+					if ((mode == 'l') && subchain) {
 						do {
 							print_rop (core, hitlist, mode, &json_first);
 							hitlist->head = hitlist->head->n;

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -972,8 +972,13 @@ static int r_core_search_rop(RCore *core, ut64 from, ut64 to, int opt, const cha
 					if (!hitlist)
 						continue;
 
-					if (json) {
-						print_rop (core, hitlist, 'j', &json_first);
+					if (json) mode = 'j';
+
+					if (mode == 'l') {
+						do {
+							print_rop (core, hitlist, mode, &json_first);
+							hitlist->head = hitlist->head->n;
+						} while (hitlist->head->n);
 					} else {
 						print_rop (core, hitlist, mode, &json_first);
 					}

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1319,6 +1319,7 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* rop */
 	SETI("rop.len", 5, "Maximum ROP gadget length");
+	SETPREF("rop.subchains", "false", "Display every length gadget from rop.len=X to 2 in /Rl");
 	SETPREF("rop.conditional", "false", "Include conditional jump, calls and returns in ropsearch");
 	SETPREF("rop.nx", "false", "Include NX/XN/XD sections in ropsearch");
 


### PR DESCRIPTION
It might still produce dupes, but there is no easy way to avoid it, and this is better than nothing...

Please close #2611 and merge this one.