### PR TITLE
Fix r_list_join when list1 is empty

### DIFF
--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -131,7 +131,10 @@ R_API int r_list_join (RList *list1, RList *list2) {
 		return 0;
 	if (r_list_empty (list2))
 		return 0;
-	if (list1->tail == NULL) {
+	if (r_list_empty (list1)) {
+        list1->head = list2->head;
+        list1->tail = list2->tail;
+    } else if (list1->tail == NULL) {
 		list1->tail = list2->head;
 	} else if (list2->head != NULL) {
 		list1->tail->n = list2->head;

--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -132,9 +132,9 @@ R_API int r_list_join (RList *list1, RList *list2) {
 	if (r_list_empty (list2))
 		return 0;
 	if (r_list_empty (list1)) {
-        list1->head = list2->head;
-        list1->tail = list2->tail;
-    } else if (list1->tail == NULL) {
+		list1->head = list2->head;
+		list1->tail = list2->tail;
+	} else if (list1->tail == NULL) {
 		list1->tail = list2->head;
 	} else if (list2->head != NULL) {
 		list1->tail->n = list2->head;


### PR DESCRIPTION
This also fixes the local vars definition in functions with no arguments