### PR TITLE
add support for multiple instances of r2pipe under windows

### DIFF
--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -129,7 +129,10 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 	BOOL bSuccess = FALSE;
 	SECURITY_ATTRIBUTES saAttr;
 	int res=0;
-	hPipeInOut = CreateNamedPipe("\\\\.\\pipe\\R2PIPE_IN",
+	sprintf(buf,"R2PIPE_IN%x",_getpid());
+	SetEnvironmentVariable("R2PIPE_PATH",buf);
+	sprintf(buf,"\\\\.\\pipe\\R2PIPE_IN%x",_getpid());
+	hPipeInOut = CreateNamedPipe(buf,
 		PIPE_ACCESS_DUPLEX,PIPE_TYPE_MESSAGE | \
 		PIPE_READMODE_MESSAGE | \
 		PIPE_WAIT,PIPE_UNLIMITED_INSTANCES,


### PR DESCRIPTION
Exported a environment variable R2PIPE_PATH with the name pipe to use. The generated name use a process pid to ensure a unique id for each instance of r2. The python plugin only need retrieve this environment variable and create namepipe