### PR TITLE
m68k_disasm: replace macro by inline function to please coverity

### DIFF
--- a/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.c
+++ b/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.c
@@ -178,6 +178,16 @@ static const char *const fpcregs[3] = {
   "fpiar", "fpsr", "fpcr"
 };
 
+static inline void PRINT_FPREG(dis_buffer_t *dbuf, unsigned int reg) {
+  addstr(dbuf, reg<8?fpregs[reg]:"f?");
+}
+static inline void PRINT_DREG(dis_buffer_t *dbuf, unsigned int reg) {
+  addstr(dbuf, reg<8?dregs[reg]:"d?");
+}
+static inline void PRINT_AREG(dis_buffer_t *dbuf, unsigned int reg) {
+  addstr(dbuf, reg<8?aregs[reg]:"a?");
+}
+
 static char asm_buffer[256];
 static char info_buffer[256];
 static int db_radix = 16;

--- a/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.h
+++ b/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.h
@@ -474,9 +474,6 @@ typedef struct dis_buffer dis_buffer_t;
 #else
 #define IS_INST(inst,val) ((inst/**/_MASK & (val)) == inst/**/_INST)
 #endif
-#define PRINT_FPREG(dbuf, reg) addstr(dbuf, reg<8?fpregs[reg]:"f?")
-#define PRINT_DREG(dbuf, reg) addstr(dbuf, reg<8?dregs[reg]:"d?")
-#define PRINT_AREG(dbuf, reg) addstr(dbuf, reg<8?aregs[reg]:"a?")
 
 #undef NBBY
 #define NBBY 256  /*@@@*/


### PR DESCRIPTION
I also moved them from the header to the source file, because they are referring to functions that only exist in the source file's compilation unit.
If all goes well this will remove 10 issues at once.