### PR TITLE
backtrace shows function names, fixed bug in 32,64 backtrace

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1217,8 +1217,13 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			i = 0;
 			list = r_debug_frames (core->dbg, addr);
 			r_list_foreach (list, iter, frame) {
-				r_cons_printf ("%d  0x%08"PFMT64x"  %d\n",
-					i++, frame->addr, frame->size);
+				if(frame->name) {
+					r_cons_printf ("%d  0x%08"PFMT64x"  %d [%s]\n",
+						i++, frame->addr, frame->size, frame->name);
+				} else {
+					r_cons_printf ("%d  0x%08"PFMT64x"  %d\n",
+						i++, frame->addr, frame->size);
+				}
 			}
 			r_list_purge (list);
 			break;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1220,6 +1220,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 				if(frame->name) {
 					r_cons_printf ("%d  0x%08"PFMT64x"  %d [%s]\n",
 						i++, frame->addr, frame->size, frame->name);
+					free(frame->name);
 				} else {
 					r_cons_printf ("%d  0x%08"PFMT64x"  %d\n",
 						i++, frame->addr, frame->size);

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -5,6 +5,7 @@
 #include <r_asm.h>
 #include <r_reg.h>
 #include <r_lib.h>
+#include <r_anal.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/param.h>
@@ -1930,17 +1931,33 @@ static int r_debug_native_bp_read(int pid, ut64 addr, int hw, int rwx) {
 static RList *r_debug_native_frames_x86_32(RDebug *dbg, ut64 at) {
 	RRegItem *ri;
 	RReg *reg = dbg->reg;
-	ut32 i, _esp, esp, ebp2;
-	RList *list = r_list_new ();
+	ut32 i, _esp, esp, eip, ebp2;
+	RList *list;
 	RIOBind *bio = &dbg->iob;
+	RAnalFunction *fcn;
+	RDebugFrame *frame;
 	ut8 buf[4];
 
+	// TODO : frame->size by using esil to emulate first instructions
+	list = r_list_new ();
 	list->free = free;
+
 	ri = (at==UT64_MAX)? r_reg_get (reg, "ebp", R_REG_TYPE_GPR): NULL;
 	_esp = (ut32) ((ri)? r_reg_get_value (reg, ri): at);
 		// TODO: implement [stack] map uptrace method too
 	esp = _esp;
-	for (i=0; i<MAXBT; i++) {
+
+	eip = r_reg_get_value (reg, r_reg_get (reg, "eip", R_REG_TYPE_GPR));
+	fcn = r_anal_get_fcn_in (dbg->anal, eip, R_ANAL_FCN_TYPE_NULL);
+	if (fcn != NULL) {
+		frame = R_NEW (RDebugFrame);
+		frame->addr = fcn->addr;
+		frame->size = 0;
+		frame->name = (fcn && fcn->name) ? strdup(fcn->name) : NULL;
+		r_list_append (list, frame);
+	}
+
+	for (i=1; i<MAXBT; i++) {
 		bio->read_at (bio->io, esp, (void *)&ebp2, 4);
 		if (ebp2 == UT32_MAX)
 			break;
@@ -1949,9 +1966,11 @@ static RList *r_debug_native_frames_x86_32(RDebug *dbg, ut64 at) {
 
 		// TODO: arch_is_call() here and this fun will be portable
 		if (buf[(ebp2-5)%4]==0xe8) {
-			RDebugFrame *frame = R_NEW (RDebugFrame);
+			fcn = r_anal_get_fcn_in (dbg->anal, ebp2, R_ANAL_FCN_TYPE_NULL);
+			frame = R_NEW (RDebugFrame);
 			frame->addr = ebp2;
 			frame->size = esp-_esp;
+			frame->name = (fcn && fcn->name) ? strdup (fcn->name) : NULL;
 			r_list_append (list, frame);
 		}
 		esp += 4;
@@ -1969,6 +1988,7 @@ static RList *r_debug_native_frames_x86_64(RDebug *dbg, ut64 at) {
 	RList *list;
 	RReg *reg = dbg->reg;
 	RIOBind *bio = &dbg->iob;
+	RAnalFunction *fcn;
 
 	_rip = r_reg_get_value (reg, r_reg_get (reg, "rip", R_REG_TYPE_GPR));
 	if (at == UT64_MAX) {
@@ -1981,20 +2001,15 @@ static RList *r_debug_native_frames_x86_64(RDebug *dbg, ut64 at) {
 	list = r_list_new ();
 	list->free = free;
 	bio->read_at (bio->io, _rip, (ut8*)&buf, 8);
-	/* %rbp=old rbp, %rbp+4 points to ret */
-	/* Plugin before function prelude: push %rbp ; mov %rsp, %rbp */
-	if (!memcmp (buf, "\x55\x89\xe5", 3) || !memcmp (buf, "\x89\xe5\x57", 3)) {
-		if (bio->read_at (bio->io, _rsp, (ut8*)&ptr, 8) != 8) {
-			eprintf ("read error at 0x%08"PFMT64x"\n", _rsp);
-			r_list_purge (list);
-			free (list);
-			return R_FALSE;
-		}
-		RDebugFrame *frame = R_NEW (RDebugFrame);
-		frame->addr = ptr;
-		frame->size = 0; // TODO ?
+
+	// TODO : frame->size by using esil to emulate first instructions
+	fcn = r_anal_get_fcn_in (dbg->anal, _rip, R_ANAL_FCN_TYPE_NULL);
+	if(fcn) {
+		frame = R_NEW (RDebugFrame);
+		frame->addr = fcn->addr;
+		frame->size = 0;
+		frame->name = (fcn->name) ? strdup (fcn->name) : NULL;
 		r_list_append (list, frame);
-		_rbp = ptr;
 	}
 
 	for (i=1; i<MAXBT; i++) {
@@ -2005,12 +2020,15 @@ static RList *r_debug_native_frames_x86_64(RDebug *dbg, ut64 at) {
 		bio->read_at (bio->io, _rbp+8, (ut8*)&ptr, 8);
 		if (!ptr || !_rbp)
 			break;
+		fcn = r_anal_get_fcn_in (dbg->anal, ptr, R_ANAL_FCN_TYPE_NULL);
 		frame = R_NEW (RDebugFrame);
 		frame->addr = ptr;
-		frame->size = 0; // TODO ?
+		frame->size = 0;
+		frame->name = (fcn && fcn->name) ? strdup (fcn->name) : NULL;
 		r_list_append (list, frame);
 		_rbp = ebp2;
 	}
+
 	return list;
 }
 

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -83,6 +83,7 @@ enum { // TODO: not yet used by r_debug
 typedef struct r_debug_frame_t {
 	ut64 addr;
 	int size;
+	char *name;
 } RDebugFrame;
 
 typedef struct r_debug_map_t {


### PR DESCRIPTION
Now backtrace shows function names when possible. Fixed two bugs
in 64bit backtrace doesn't record frame # 0 also in 32bit doesn't record frame # 0.