### PR TITLE
Fix #2741

### DIFF
--- a/libr/egg/lang.c
+++ b/libr/egg/lang.c
@@ -251,6 +251,11 @@ static void rcc_element(REgg *egg, char *str) {
 			mode = NORMAL;
 			break;
 		case SYSCALL:
+			if (nsyscalls > 255){
+				eprintf ("global-buffer-overflow in syscalls\n");
+				break;
+			}
+			//XXX the mem for name and arg are not freed - MEMLEAK
 			syscalls[nsyscalls].name = strdup (dstvar);
 			syscalls[nsyscalls].arg = strdup (str);
 			nsyscalls++;
@@ -352,7 +357,7 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 					for (i=0; i<nsyscalls; i++)
 						if (!strcmp (syscalls[i].name, callname)) {
 							free (oldstr);
-							return syscalls[i].arg;
+							return strdup(syscalls[i].arg);
 						}
 					eprintf ("Unknown arg for syscall '%s'\n", callname);
 				} else eprintf ("NO CALLNAME '%s'\n", callname);


### PR DESCRIPTION
Where should the content of syscalls be freed? 

If gs was called more than 256 was producing a global buffer overflow. I don't know if that change impacts on the functionality since I don't know yet the use of syscalls, if it can be overwritten or not.