### PR TITLE
use tree instead of a graph to trace call/ret

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -915,7 +915,6 @@ R_API int r_core_init(RCore *core) {
 	r_core_cmd_init (core);
 	core->dbg = r_debug_new (R_TRUE);
 	r_core_bind (core, &core->dbg->corebind);
-	core->dbg->graph->printf = (PrintfCallback)r_cons_printf;
 	core->dbg->printf = (PrintfCallback)r_cons_printf;
 	core->dbg->anal = core->anal; // XXX: dupped instance.. can cause lost pointerz
 	//r_debug_use (core->dbg, "native");

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -166,7 +166,8 @@ typedef struct r_debug_t {
 	RList *maps; // <RDebugMap>
 	RList *maps_user; // <RDebugMap>
 	RList *snaps; // <RDebugSnap>
-	RGraph *graph;
+	RTree *tree;
+	Sdb *tracenodes;
 	Sdb *sgnls;
 	RCoreBind corebind;
 #if __WINDOWS__
@@ -365,6 +366,8 @@ R_API int r_debug_arg_set (RDebug *dbg, int fast, int num, ut64 value);
 
 /* pid */
 R_API int r_debug_thread_list(RDebug *dbg, int pid);
+
+R_API void r_debug_tracenodes_reset (RDebug *dbg);
 
 R_API void r_debug_trace_reset (RDebug *dbg);
 R_API int r_debug_trace_pc (RDebug *dbg);

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -254,22 +254,17 @@ typedef void (*RTreeNodeVisitCb)(RTreeNode *n, RTreeVisitor *vis);
 
 /* graph api */
 typedef struct r_graph_node_t {
-	RList *parents; // <RGraphNode>
-	RList *children; // <RGraphNode>
-	ut64 addr;
+	unsigned int idx;
 	void *data;
-	int refs;
 	RListFree free;
 } RGraphNode;
 
 typedef struct r_graph_t {
-	RList *path; // <RGraphNode>
-	RGraphNode *root;
-	RList *roots; // <RGraphNode>
-	RListIter *cur; // ->data = RGraphNode*
-	RList *nodes; // <RGraphNode>
-	PrintfCallback printf;
-	int level;
+	unsigned int n_nodes;
+	unsigned int capacity;
+	int last_index;
+	RGraphNode **nodes;
+	RList **adjacency;
 } RGraph;
 
 #ifdef R_API
@@ -292,18 +287,15 @@ R_API void r_tree_free (RTree *t);
 R_API void r_tree_dfs (RTree *t, RTreeVisitor *vis);
 R_API void r_tree_bfs (RTree *t, RTreeVisitor *vis);
 
-R_API RGraphNode *r_graph_node_new (ut64 addr, void *data);
-R_API void r_graph_node_free (RGraphNode *n);
-R_API void r_graph_traverse(RGraph *t);
-R_API RGraph * r_graph_new (void);
-R_API void r_graph_free (RGraph* t);
-R_API RGraphNode* r_graph_get_current (RGraph *t, ut64 addr);
-R_API RGraphNode* r_graph_get_node (RGraph *t, ut64 addr, boolt c);
-R_API void r_graph_reset (RGraph *t);
-R_API void r_graph_add (RGraph *t, ut64 from, ut64 addr, void *data);
-R_API void r_graph_plant(RGraph *t);
-R_API void r_graph_push (RGraph *t, ut64 addr, void *data);
-R_API RGraphNode* r_graph_pop(RGraph *t);
+R_API RGraphNode *r_graph_get_node (RGraph *g, unsigned int idx);
+R_API RList *r_graph_get_nodes (RGraph *g);
+R_API RGraph *r_graph_new (void);
+R_API void r_graph_free (RGraph* g);
+R_API void r_graph_reset (RGraph *g);
+R_API RGraphNode *r_graph_add_node (RGraph *g, void *data);
+R_API void r_graph_add_edge (RGraph *g, RGraphNode *from, RGraphNode *to);
+R_API RList *r_graph_get_neighbours (RGraph *g, RGraphNode *n);
+R_API int r_graph_adjacent (RGraph *g, RGraphNode *from, RGraphNode *to);
 
 R_API boolt r_file_truncate (const char *filename, ut64 newsize);
 R_API ut64 r_file_size(const char *str);

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -211,6 +211,13 @@ typedef struct r_list_range_t {
 	//RListComparator c;
 } RListRange;
 
+/* stack api */
+typedef struct r_stack_t {
+	void **elems;
+	unsigned int n_elems;
+	int top;
+} RStack;
+
 /* graph api */
 typedef struct r_graph_node_t {
 	RList *parents; // <RGraphNode>
@@ -232,6 +239,12 @@ typedef struct r_graph_t {
 } RGraph;
 
 #ifdef R_API
+R_API RStack *r_stack_new (unsigned int n);
+R_API void r_stack_free (RStack *s);
+R_API int r_stack_push (RStack *s, void *el);
+R_API void *r_stack_pop (RStack *s);
+R_API int r_stack_is_empty (RStack *s);
+
 R_API RGraphNode *r_graph_node_new (ut64 addr, void *data);
 R_API void r_graph_node_free (RGraphNode *n);
 R_API void r_graph_traverse(RGraph *t);

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -227,6 +227,31 @@ typedef struct r_queue_t {
 	unsigned int size;
 } RQueue;
 
+/* tree api */
+struct r_tree_t;
+
+typedef struct r_tree_node_t {
+	struct r_tree_node_t *parent;
+	struct r_tree_t *tree;
+	RList *children; // <RTreeNode>
+	unsigned int n_children;
+	int depth;
+	RListFree free;
+	void *data;
+} RTreeNode;
+
+typedef struct r_tree_t {
+	RTreeNode *root;
+} RTree;
+
+typedef struct r_tree_visitor_t {
+	void (*pre_visit)(RTreeNode *, struct r_tree_visitor_t *);
+	void (*post_visit)(RTreeNode *, struct r_tree_visitor_t *);
+	void (*discover_child)(RTreeNode *, struct r_tree_visitor_t *);
+	void *data;
+} RTreeVisitor;
+typedef void (*RTreeNodeVisitCb)(RTreeNode *n, RTreeVisitor *vis);
+
 /* graph api */
 typedef struct r_graph_node_t {
 	RList *parents; // <RGraphNode>
@@ -259,6 +284,13 @@ R_API void r_queue_free (RQueue *q);
 R_API int r_queue_enqueue (RQueue *q, void *el);
 R_API void *r_queue_dequeue (RQueue *q);
 R_API int r_queue_is_empty (RQueue *q);
+
+R_API RTree *r_tree_new (void);
+R_API RTreeNode *r_tree_add_node (RTree *t, RTreeNode *node, void *child_data);
+R_API void r_tree_reset (RTree *t);
+R_API void r_tree_free (RTree *t);
+R_API void r_tree_dfs (RTree *t, RTreeVisitor *vis);
+R_API void r_tree_bfs (RTree *t, RTreeVisitor *vis);
 
 R_API RGraphNode *r_graph_node_new (ut64 addr, void *data);
 R_API void r_graph_node_free (RGraphNode *n);

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -218,6 +218,15 @@ typedef struct r_stack_t {
 	int top;
 } RStack;
 
+/* queue api */
+typedef struct r_queue_t {
+	void **elems;
+	unsigned int capacity;
+	unsigned int front;
+	int rear;
+	unsigned int size;
+} RQueue;
+
 /* graph api */
 typedef struct r_graph_node_t {
 	RList *parents; // <RGraphNode>
@@ -244,6 +253,12 @@ R_API void r_stack_free (RStack *s);
 R_API int r_stack_push (RStack *s, void *el);
 R_API void *r_stack_pop (RStack *s);
 R_API int r_stack_is_empty (RStack *s);
+
+R_API RQueue *r_queue_new (int n);
+R_API void r_queue_free (RQueue *q);
+R_API int r_queue_enqueue (RQueue *q, void *el);
+R_API void *r_queue_dequeue (RQueue *q);
+R_API int r_queue_is_empty (RQueue *q);
 
 R_API RGraphNode *r_graph_node_new (ut64 addr, void *data);
 R_API void r_graph_node_free (RGraphNode *n);

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -11,7 +11,7 @@ OBJS+=sandbox.o calc.o thread.o thread_lock.o thread_msg.o
 OBJS+=strpool.o bitmap.o strht.o p_date.o p_format.o print.o
 OBJS+=p_seven.o slist.o randomart.o log.o zip.o debruijn.o
 OBJS+=utf8.o strbuf.o lib.o name.o
-OBJS+=diff.o bdiff.o stack.o queue.o
+OBJS+=diff.o bdiff.o stack.o queue.o tree.o
 
 # DO NOT BUILD r_big api (not yet used and its buggy)
 ifeq (1,0)

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -11,7 +11,7 @@ OBJS+=sandbox.o calc.o thread.o thread_lock.o thread_msg.o
 OBJS+=strpool.o bitmap.o strht.o p_date.o p_format.o print.o
 OBJS+=p_seven.o slist.o randomart.o log.o zip.o debruijn.o
 OBJS+=utf8.o strbuf.o lib.o name.o
-OBJS+=diff.o bdiff.o
+OBJS+=diff.o bdiff.o stack.o
 
 # DO NOT BUILD r_big api (not yet used and its buggy)
 ifeq (1,0)

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -11,7 +11,7 @@ OBJS+=sandbox.o calc.o thread.o thread_lock.o thread_msg.o
 OBJS+=strpool.o bitmap.o strht.o p_date.o p_format.o print.o
 OBJS+=p_seven.o slist.o randomart.o log.o zip.o debruijn.o
 OBJS+=utf8.o strbuf.o lib.o name.o
-OBJS+=diff.o bdiff.o stack.o
+OBJS+=diff.o bdiff.o stack.o queue.o
 
 # DO NOT BUILD r_big api (not yet used and its buggy)
 ifeq (1,0)

--- a/libr/util/queue.c
+++ b/libr/util/queue.c
@@ -1,0 +1,79 @@
+/* radare - LGPL - Copyright 2007-2015 - ret2libc */
+
+#include <r_util.h>
+
+R_API RQueue *r_queue_new (int n) {
+	RQueue *q = R_NEW0 (RQueue);
+	q->elems = calloc (n, sizeof(void *));
+	if (!q->elems)
+		return NULL;
+
+	q->front = 0;
+	q->rear = -1;
+	q->size = 0;
+	q->capacity = n;
+	return q;
+}
+
+R_API void r_queue_free (RQueue *q) {
+	free (q->elems);
+	free (q);
+}
+
+static int is_full (RQueue *q) {
+	 return q->size == q->capacity;
+}
+
+static int increase_capacity (RQueue *q) {
+	unsigned int new_capacity = q->capacity * 2;
+	void **newelems;
+	int i, tmp_front;
+
+	newelems = calloc (new_capacity, sizeof(void *));
+	if (!newelems)
+		return R_FALSE;
+
+	i = -1;
+	tmp_front = q->front;
+	while (i + 1 < q->size) {
+		i++;
+		newelems[i] = q->elems[tmp_front];
+		tmp_front = (tmp_front + 1) % q->capacity;
+	}
+
+	free (q->elems);
+	q->elems = newelems;
+	q->front = 0;
+	q->rear = i;
+	q->capacity = new_capacity;
+	return R_TRUE;
+}
+
+R_API int r_queue_enqueue (RQueue *q, void *el) {
+	if (is_full(q)) {
+		int res = increase_capacity (q);
+		if (!res)
+			return R_FALSE;
+	}
+
+	q->rear = (q->rear + 1) % q->capacity;
+	q->elems[q->rear] = el;
+	q->size++;
+	return R_TRUE;
+}
+
+R_API void *r_queue_dequeue (RQueue *q) {
+	void *res;
+
+	if (r_queue_is_empty (q))
+		return NULL;
+
+	res = q->elems[q->front];
+	q->front = (q->front + 1) % q->capacity;
+	q->size--;
+	return res;
+}
+
+R_API int r_queue_is_empty (RQueue *q) {
+	return q->size == 0;
+}

--- a/libr/util/stack.c
+++ b/libr/util/stack.c
@@ -1,0 +1,47 @@
+/* radare - LGPL - Copyright 2007-2015 - ret2libc */
+
+#include <r_util.h>
+
+R_API RStack *r_stack_new (unsigned int n) {
+	RStack *s = R_NEW0 (RStack);
+	s->elems = calloc(n, sizeof(void *));
+	if (!s->elems)
+		return NULL;
+
+	s->n_elems = n;
+	s->top = -1;
+	return s;
+}
+
+R_API void r_stack_free (RStack *s) {
+	free (s->elems);
+	free (s);
+}
+
+R_API int r_stack_push (RStack *s, void *el) {
+	if (s->top == s->n_elems - 1) {
+		/* reallocate the stack */
+		s->n_elems *= 2;
+		s->elems = realloc (s->elems, s->n_elems * sizeof(void *));
+		if (!s->elems)
+			return R_FALSE;
+	}
+
+	s->top++;
+	s->elems[s->top] = el;
+	return R_TRUE;
+}
+
+R_API void *r_stack_pop (RStack *s) {
+	void *res;
+	if (s->top == -1)
+		return NULL;
+
+	res = s->elems[s->top];
+	s->top--;
+	return res;
+}
+
+R_API int r_stack_is_empty (RStack *s) {
+	return s->top == -1;
+}

--- a/libr/util/t/Makefile
+++ b/libr/util/t/Makefile
@@ -17,6 +17,7 @@ BINS+=test_str
 BINS+=test_file_slurp_hexpairs
 BINS+=test_cmd_str
 BINS+=test_stack
+BINS+=test_queue
 
 all: ${BINS}
 

--- a/libr/util/t/Makefile
+++ b/libr/util/t/Makefile
@@ -19,6 +19,7 @@ BINS+=test_cmd_str
 BINS+=test_stack
 BINS+=test_queue
 BINS+=test_tree
+BINS+=test_graph
 
 all: ${BINS}
 

--- a/libr/util/t/Makefile
+++ b/libr/util/t/Makefile
@@ -16,11 +16,12 @@ BINS+=test_sys
 BINS+=test_str
 BINS+=test_file_slurp_hexpairs
 BINS+=test_cmd_str
+BINS+=test_stack
 
 all: ${BINS}
 
 ${BINS}: $(addsuffix .o,$(BINS))
-	$(CC) $(LDFLAGS) -o $@ $< 
+	$(CC) $(LDFLAGS) -o $@ $@.o
 
 myclean:
 	rm -f ${BINS} *.o

--- a/libr/util/t/Makefile
+++ b/libr/util/t/Makefile
@@ -18,6 +18,7 @@ BINS+=test_file_slurp_hexpairs
 BINS+=test_cmd_str
 BINS+=test_stack
 BINS+=test_queue
+BINS+=test_tree
 
 all: ${BINS}
 

--- a/libr/util/t/test_graph.c
+++ b/libr/util/t/test_graph.c
@@ -1,0 +1,86 @@
+#include <r_util.h>
+
+void check_list(RList *act, RList *exp, char *descr) {
+	RListIter *ita = r_list_iterator(act);
+	RListIter *ite = r_list_iterator(exp);
+
+	while (r_list_iter_next(ita) && r_list_iter_next(ite)) {
+		int a = (int)r_list_iter_get(ita);
+		int e = (int)r_list_iter_get(ite);
+
+		if (a != e) {
+			printf("[-][%s] test failed (actual: %d; expected: %d)\n", descr, a, e);
+		}
+	}
+
+	if (!ita && !ite) {
+		printf("[+][%s] test passed (lists have same elements)\n", descr);
+	} else {
+		printf("[-][%s] test failed (one list shorter or different)\n", descr);
+	}
+}
+
+void check (int n, int exp, char *descr) {
+	if (n == exp) {
+		printf("[+][%s] test passed (actual: %d; expected: %d)\n", descr, n, exp);
+	} else {
+		printf("[-][%s] test failed (actual: %d; expected: %d)\n", descr, n, exp);
+	}
+}
+
+void check_ptr (void *act, void *exp, char *descr) {
+	check((int)act, (int)exp, descr);
+}
+
+int main(int argc, char **argv) {
+	RGraph *g = r_graph_new();
+
+	check(g->n_nodes, 0, "n_nodes.start");
+	r_graph_add_node(g, (void *)1);
+	check(g->n_nodes, 1, "n_nodes.insert");
+	r_graph_reset(g);
+	check(g->n_nodes, 0, "n_nodes.reset");
+
+	RGraphNode *gn = r_graph_add_node(g, (void *)1);
+	check_ptr(r_graph_get_node(g, gn->idx), gn, "get_node.1");
+	RGraphNode *gn2 = r_graph_add_node(g, (void *)2);
+	check_ptr(r_graph_get_node(g, gn2->idx), gn2, "get_node.2");
+	r_graph_add_edge(g, gn, gn2);
+	check(r_graph_adjacent(g, gn, gn2), R_TRUE, "is_adjacent.1");
+	RList *exp_gn_neigh = r_list_new();
+	r_list_append(exp_gn_neigh, gn2);
+	check_list(r_graph_get_neighbours(g, gn), exp_gn_neigh, "get_neighbours.1");
+
+	RGraphNode *gn3 = r_graph_add_node(g, (void *)3);
+	r_graph_add_edge(g, gn, gn3);
+	r_list_append(exp_gn_neigh, gn3);
+	check_list(r_graph_get_neighbours(g, gn), exp_gn_neigh, "get_neighbours.2");
+	r_list_free(exp_gn_neigh);
+
+	RGraphNode *gn4 = r_graph_add_node(g, (void *)4);
+	RGraphNode *gn5 = r_graph_add_node(g, (void *)5);
+	RGraphNode *gn6 = r_graph_add_node(g, (void *)6);
+	RGraphNode *gn7 = r_graph_add_node(g, (void *)7);
+	RGraphNode *gn8 = r_graph_add_node(g, (void *)8);
+	RGraphNode *gn9 = r_graph_add_node(g, (void *)9);
+	RGraphNode *gn10 = r_graph_add_node(g, (void *)10);
+	RList *exp_nodes = r_list_new();
+	r_list_append(exp_nodes, gn);
+	r_list_append(exp_nodes, gn2);
+	r_list_append(exp_nodes, gn3);
+	r_list_append(exp_nodes, gn4);
+	r_list_append(exp_nodes, gn5);
+	r_list_append(exp_nodes, gn6);
+	r_list_append(exp_nodes, gn7);
+	r_list_append(exp_nodes, gn8);
+	r_list_append(exp_nodes, gn9);
+	r_list_append(exp_nodes, gn10);
+	RList *nodes = r_graph_get_nodes(g);
+	check(g->n_nodes, 10, "n_nodes.again");
+	check_list(nodes, exp_nodes, "get_all_nodes");
+	r_list_free(exp_nodes);
+	r_list_free(nodes);
+
+	r_graph_free (g);
+	return 0;
+}

--- a/libr/util/t/test_queue.c
+++ b/libr/util/t/test_queue.c
@@ -1,0 +1,64 @@
+#include <r_util.h>
+
+void check (int n, int exp) {
+	if (n == exp) {
+		printf("[+] test passed (actual: %d; expected: %d)\n", n, exp);
+	} else {
+		printf("[-] test failed (actual: %d; expected: %d)\n", n, exp);
+	}
+}
+
+void check_empty(RQueue *q, int exp) {
+	if (r_queue_is_empty(q) == exp) {
+		printf("[+] test passed (stack empty status)\n");
+	} else {
+		printf("[-] test failed (stack empty status)\n");
+	}
+}
+
+int main(int argc, char **argv) {
+	RQueue *q = r_queue_new(5);
+	int n;
+
+	check_empty(q, R_TRUE);
+	r_queue_enqueue(q, (void *)1);
+	r_queue_enqueue(q, (void *)2);
+	r_queue_enqueue(q, (void *)3);
+	r_queue_enqueue(q, (void *)4);
+	r_queue_enqueue(q, (void *)5);
+	r_queue_enqueue(q, (void *)6);
+	r_queue_enqueue(q, (void *)7);
+	r_queue_enqueue(q, (void *)8);
+	n = (int)r_queue_dequeue(q);
+	check(n, 1);
+	n = (int)r_queue_dequeue(q);
+	check(n, 2);
+	n = (int)r_queue_dequeue(q);
+	check(n, 3);
+	n = (int)r_queue_dequeue(q);
+	check(n, 4);
+	n = (int)r_queue_dequeue(q);
+	check(n, 5);
+	n = (int)r_queue_dequeue(q);
+	check(n, 6);
+	n = (int)r_queue_dequeue(q);
+	check(n, 7);
+	check_empty(q, R_FALSE);
+	n = (int)r_queue_dequeue(q);
+	check(n, 8);
+	n = (int)r_queue_dequeue(q);
+	check(n, 0);
+	check_empty(q, R_TRUE);
+
+	r_queue_enqueue(q, (void *)1);
+	r_queue_enqueue(q, (void *)2);
+	n = (int)r_queue_dequeue(q);
+	r_queue_enqueue(q, (void *)3);
+	n = (int)r_queue_dequeue(q);
+	check(n, 2);
+
+	check_empty(q, R_FALSE);
+
+	r_queue_free(q);
+	return 0;
+}

--- a/libr/util/t/test_stack.c
+++ b/libr/util/t/test_stack.c
@@ -1,0 +1,68 @@
+#include <r_util.h>
+
+void check (int n, int exp) {
+	if (n == exp) {
+		printf("[+] test passed (actual: %d; expected: %d)\n", n, exp);
+	} else {
+		printf("[-] test failed (actual: %d; expected: %d)\n", n, exp);
+	}
+}
+
+void check_empty(RStack *s, int exp) {
+	if (r_stack_is_empty(s) == exp) {
+		printf("[+] test passed (stack empty status)\n");
+	} else {
+		printf("[-] test failed (stack empty status)\n");
+	}
+}
+
+int main(int argc, char **argv) {
+	RStack *s = r_stack_new(5);
+	int n;
+
+	r_stack_push(s, (void *)10);
+	r_stack_push(s, (void *)1);
+	r_stack_push(s, (void *)2);
+	r_stack_push(s, (void *)3);
+	r_stack_push(s, (void *)4);
+	r_stack_push(s, (void *)5);
+	r_stack_push(s, (void *)6);
+	r_stack_push(s, (void *)8);
+	r_stack_push(s, (void *)9);
+	r_stack_push(s, (void *)6);
+	n = (int)r_stack_pop(s);
+	check(n, 6);
+	n = (int)r_stack_pop(s);
+	check(n, 9);
+	n = (int)r_stack_pop(s);
+	check(n, 8);
+	n = (int)r_stack_pop(s);
+	check(n, 6);
+	n = (int)r_stack_pop(s);
+	check(n, 5);
+	n = (int)r_stack_pop(s);
+	check(n, 4);
+	n = (int)r_stack_pop(s);
+	check(n, 3);
+	n = (int)r_stack_pop(s);
+	check(n, 2);
+	n = (int)r_stack_pop(s);
+	check(n, 1);
+	check_empty(s, R_FALSE);
+	n = (int)r_stack_pop(s);
+	check(n, 10);
+
+	check_empty(s, R_TRUE);
+	n = (int)r_stack_pop(s);
+	check(n, 0);
+	n = (int)r_stack_pop(s);
+	check(n, 0);
+	check_empty(s, R_TRUE);
+
+	r_stack_push(s, (void *)10);
+	r_stack_push(s, (void *)1);
+	check_empty(s, R_FALSE);
+
+	r_stack_free(s);
+	return 0;
+}

--- a/libr/util/t/test_tree.c
+++ b/libr/util/t/test_tree.c
@@ -1,0 +1,117 @@
+#include <r_util.h>
+
+void sum_node(RTreeNode *n, RTreeVisitor *vis) {
+	int cur = (int)vis->data;
+	vis->data = (void *)(size_t)(cur + (int)n->data);
+}
+
+void add_to_list(RTreeNode *n, RTreeVisitor *vis) {
+	RList *res = (RList *)vis->data;
+	r_list_append(res, n->data);
+}
+
+void check_list(RList *act, RList *exp, char *descr) {
+	RListIter *ita = r_list_iterator(act);
+	RListIter *ite = r_list_iterator(exp);
+
+	while (r_list_iter_next(ita) && r_list_iter_next(ite)) {
+		int a = (int)r_list_iter_get(ita);
+		int e = (int)r_list_iter_get(ite);
+
+		if (a != e) {
+			printf("[-][%s] test failed (actual: %d; expected: %d)\n", descr, a, e);
+		}
+	}
+
+	if (!ita && !ite) {
+		printf("[+][%s] test passed (lists have same elements)\n", descr);
+	} else {
+		printf("[-][%s] test failed (one list shorter or different)\n", descr);
+	}
+}
+
+void check (int n, int exp, char *descr) {
+	if (n == exp) {
+		printf("[+][%s] test passed (actual: %d; expected: %d)\n", descr, n, exp);
+	} else {
+		printf("[-][%s] test failed (actual: %d; expected: %d)\n", descr, n, exp);
+	}
+}
+
+int main(int argc, char **argv) {
+	RTreeVisitor calc = { 0 };
+	RTreeVisitor lister = { 0 };
+	RTree *t = r_tree_new();
+
+	calc.pre_visit = (RTreeNodeVisitCb)sum_node;
+	calc.data = (void *)0;
+
+	r_tree_add_node (t, NULL, (void *)1);
+	r_tree_bfs(t, &calc);
+	check((int)calc.data, 1, "calc.data.root");
+
+	r_tree_add_node(t, t->root, (void *)2);
+	RTreeNode *s = r_tree_add_node(t, t->root, (void *)3);
+	RTreeNode *u = r_tree_add_node(t, t->root, (void *)4);
+	calc.data = (void *)0;
+	r_tree_bfs(t, &calc);
+	check((int)calc.data, 10, "calc.data.childs");
+
+	r_tree_add_node(t, s, (void *)5);
+	r_tree_add_node(t, s, (void *)10);
+	r_tree_add_node(t, u, (void *)11);
+	lister.pre_visit = (RTreeNodeVisitCb)add_to_list;
+
+	RList *exp1 = r_list_new();
+	r_list_append(exp1, (void *)1);
+	r_list_append(exp1, (void *)2);
+	r_list_append(exp1, (void *)3);
+	r_list_append(exp1, (void *)4);
+	r_list_append(exp1, (void *)5);
+	r_list_append(exp1, (void *)10);
+	r_list_append(exp1, (void *)11);
+	lister.data = r_list_new();
+	r_tree_bfs(t, &lister);
+	check_list((RList *)lister.data, exp1, "lister.bfs");
+	r_list_free(exp1);
+	r_list_free((RList *)lister.data);
+
+	RList *exp2 = r_list_new();
+	r_list_append(exp2, (void *)1);
+	r_list_append(exp2, (void *)2);
+	r_list_append(exp2, (void *)3);
+	r_list_append(exp2, (void *)5);
+	r_list_append(exp2, (void *)10);
+	r_list_append(exp2, (void *)4);
+	r_list_append(exp2, (void *)11);
+	lister.data = r_list_new();
+	r_tree_dfs(t, &lister);
+	check_list((RList *)lister.data, exp2, "lister.preorder");
+	r_list_free(exp2);
+	r_list_free((RList *)lister.data);
+
+
+	r_tree_reset(t);
+	RTreeNode *root = r_tree_add_node(t, NULL, "root");
+	RTreeNode *first = r_tree_add_node(t, root, "first");
+	r_tree_add_node(t, root, "second");
+	r_tree_add_node(t, root, "third");
+	r_tree_add_node(t, first, "f_first");
+	r_tree_add_node(t, first, "f_second");
+
+	RList *exp3 = r_list_new();
+	r_list_append(exp3, "root");
+	r_list_append(exp3, "first");
+	r_list_append(exp3, "f_first");
+	r_list_append(exp3, "f_second");
+	r_list_append(exp3, "second");
+	r_list_append(exp3, "third");
+	lister.data = r_list_new();
+	r_tree_dfs(t, &lister);
+	check_list((RList *)lister.data, exp3, "lister.reset.preorder");
+	r_list_free(exp3);
+	r_list_free((RList *)lister.data);
+
+	r_tree_free(t);
+	return 0;
+}

--- a/libr/util/tree.c
+++ b/libr/util/tree.c
@@ -1,0 +1,150 @@
+/* radare - LGPL - Copyright 2007-2015 - ret2libc */
+
+#include <r_util.h>
+
+static void tree_dfs_node (RTreeNode *r, RTreeVisitor *vis) {
+	RStack *s;
+	RListIter *it;
+	RTreeNode *n;
+
+	s = r_stack_new (16);
+	r_stack_push (s, r);
+	while (!r_stack_is_empty (s)) {
+		RTreeNode *el = (RTreeNode *)r_stack_pop (s);
+
+		if (vis->pre_visit)
+			vis->pre_visit (el, vis);
+
+		r_list_foreach_prev (el->children, it, n) {
+			if (vis->discover_child)
+				vis->discover_child (n, vis);
+			r_stack_push (s, n);
+		}
+
+		if (vis->post_visit)
+			vis->post_visit (el, vis);
+	}
+
+	r_stack_free (s);
+}
+
+static void r_tree_node_free (RTreeNode *n) {
+	r_list_free (n->children);
+	if (n->free)
+		n->free (n->data);
+	free (n);
+}
+
+static void node_free (RTreeNode *n, RTreeVisitor *vis) {
+	r_tree_node_free (n);
+}
+
+static void free_all_children (RTree *t) {
+	RTreeVisitor vis = { 0 };
+	vis.post_visit = (RTreeNodeVisitCb)node_free;
+	r_tree_bfs (t, &vis);
+}
+
+static void update_depth (RTreeNode *n, RTreeVisitor *vis) {
+	n->depth = n->parent ? n->parent->depth + 1 : 0;
+}
+
+static RTreeNode *node_new (RTree *t, void *data) {
+	RTreeNode *n = R_NEW0 (RTreeNode);
+	n->parent = NULL;
+	n->children = r_list_new ();
+	n->children->free = NULL;
+	n->n_children = 0;
+	n->data = data;
+	n->free = NULL;
+	n->depth = 0;
+	n->tree = t;
+	return n;
+}
+
+R_API RTree *r_tree_new (void) {
+	RTree *t = R_NEW0 (RTree);
+	t->root = NULL;
+	return t;
+}
+
+R_API void r_tree_free (RTree* t) {
+	if (!t)
+		return;
+
+	free_all_children (t);
+	free (t);
+}
+
+R_API void r_tree_reset (RTree *t) {
+	if (!t)
+		return;
+
+	free_all_children (t);
+	t->root = NULL;
+}
+
+/* add a node in the RTree t as a child of the RTreeNode node.
+ * NOTE: the first call to this function, should add the root
+ *       of the tree so the node will be NULL. */
+/* TODO: allow to replace the root of the tree and make it a child of the new
+ *       node */
+R_API RTreeNode *r_tree_add_node (RTree *t, RTreeNode *node, void *child_data) {
+	RTreeNode *child;
+	RTreeVisitor vis = { 0 };
+
+	/* a NULL node is allowed only the first time, to set the root */
+	if (!t || (node && node->tree != t) || (t->root && !node))
+		return NULL;
+
+	child = node_new (t, child_data);
+	if (!node && !t->root) {
+		t->root = child;
+	} else if (node) {
+		r_list_append (node->children, child);
+		node->n_children++;
+	}
+	child->parent = node;
+
+	/* update depth */
+	vis.pre_visit = (RTreeNodeVisitCb)update_depth;
+	tree_dfs_node (child, &vis);
+
+	return child;
+}
+
+R_API void r_tree_dfs (RTree *t, RTreeVisitor *vis) {
+	if (!t || !t->root)
+		return;
+
+	tree_dfs_node (t->root, vis);
+}
+
+R_API void r_tree_bfs (RTree *t, RTreeVisitor *vis) {
+	RQueue *q;
+
+	if (!t || !t->root)
+		return;
+
+	q = r_queue_new (16);
+	r_queue_enqueue (q, t->root);
+	while (!r_queue_is_empty (q)) {
+		 RTreeNode *el = (RTreeNode *)r_queue_dequeue (q);
+		 RTreeNode *n;
+		 RListIter *it;
+
+		 if (vis->pre_visit)
+			 vis->pre_visit (el, vis);
+
+		 r_list_foreach (el->children, it, n) {
+			 if (vis->discover_child)
+				 vis->discover_child (n, vis);
+			 r_queue_enqueue (q, n);
+		 }
+
+		 if (vis->post_visit)
+			 vis->post_visit (el, vis);
+	}
+
+	r_queue_free (q);
+}


### PR DESCRIPTION
At the moment, the tracing of calls and returns is done with a graph that keeps track of who calls what. The problem is that with a graph we can't print the actual execution trace of the program, but only a sort of callgraph dynamically calculated. 

Instead, with a tree we can print the real execution trace of the traced part of the program (also with recursive functions). Moreover, from the tree we can easily calculate the callgraph for the 'dtg' command.

During the tracing it creates the tree and at the end of the tracing it prints the tree. When the command 'dtg' is invoked, it converts the tree in a call graph printed as a dot file (to maintain the same semantics that we have now).


I've added:
* a tree implementation
* a stack and queue implementation (used to visit the tree, but it can also be used in the future to implement visits on graph or history or a list of command to execute, etc)

I've changed:
* the graph implementation to make it more generic
