### PR TITLE
core/cmd_debug: add parameters to 'dtc' command

### DIFF
--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1149,6 +1149,7 @@ R_API int r_core_config_init(RCore *core) {
 	else r_config_set_i (cfg, "dbg.follow", 32);
 	r_config_desc (cfg, "dbg.follow", "Follow program counter when pc > core->offset + dbg.follow");
 	SETCB("dbg.swstep", "false", &cb_swstep, "Force use of software steps (code analysis+breakpoint)");
+	SETPREF("dbg.shallow_trace", "false", "While tracing, avoid following calls outside specified range");
 
 	r_config_set_getter (cfg, "dbg.swstep", (RConfigCallback)__dbg_swstep_getter);
 


### PR DESCRIPTION
* displays only calls inside a specified range
* stop at a specific address
* add variable dbg.shallow_trace that, if set, skip calls outside the
  specified range (you can lose some instructions if the called function
  can jump back to code into the range)