### PR TITLE
Fix setting of PKG_CONFIG_PATH and DYLD_LIBRARY_PATH in env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -10,8 +10,8 @@ new_env='
 LIBR_PLUGINS=${pfx}/lib/radare2
 PATH=$pfx/bin:${PATH}
 LD_LIBRARY_PATH=$pfx/lib:$LD_LIBRARY_PATH
-DYLD_LIBRARY_PATH=$pfx/lib:$LD_LIBRARY_PATH
-PKG_CONFIG_PATH=$PWD/libr/
+DYLD_LIBRARY_PATH=$pfx/lib:$DYLD_LIBRARY_PATH
+PKG_CONFIG_PATH=$pfx/lib/pkgconfig:$PKG_CONFIG_PATH
 '
 
 [ -n "$2" ] && SHELL=$2


### PR DESCRIPTION
PKG_CONFIG_PATH was definitely being set incorrectly, as radare2-binding's configure script was complaining about not finding r_core via pkg-config.
I wasn't noticing any issues related to DYLD_LIBRARY_PATH, but it looked like it was clobbering the old value of it with LD_LIBRARY_PATH, rather than just prepending the new value.