### PR TITLE
Fix pxw bug

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2609,7 +2609,8 @@ static int cmd_print(void *data, const char *input) {
 			r_print_hexdump (core->print, core->offset, core->block, len, 32, 2);
 			break;
 		case 'H':
-			for (i=0; i+2<len; i+=2) {
+			len = len - (len % 2);
+			for (i = 0; i < len; i += 2) {
 				const char *a, *b;
 				char *fn;
 				RPrint *p = core->print;
@@ -2642,7 +2643,8 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'Q':
 			// TODO. show if flag name, or inside function
-			for (i=0; i+8<len; i+=8) {
+			len = len - (len % 8);
+			for (i = 0; i < len; i += 8) {
 				const char *a, *b;
 				char *fn;
 				RPrint *p = core->print;

--- a/libr/util/mem.c
+++ b/libr/util/mem.c
@@ -152,41 +152,42 @@ R_API int r_mem_set_num (ut8 *dest, int dest_size, ut64 num, int endian) {
 // TODO: rename to r_mem_swap() */
 R_API void r_mem_copyendian (ut8 *dest, const ut8 *orig, int size, int endian) {
 	ut8 buffer[8];
-        if (endian) {
+	if (endian) {
 		if (dest != orig)
 			memmove (dest, orig, size);
-        } else
-	switch (size) {
-	case 1:
-		*dest = *orig;
-		break;
-	case 2:
-		*buffer = *orig;
-		dest[0] = orig[1];
-		dest[1] = buffer[0];
-		break;
-	case 4:
-		memcpy (buffer, orig, 4);
-		dest[0] = buffer[3];
-		dest[1] = buffer[2];
-		dest[2] = buffer[1];
-		dest[3] = buffer[0];
-		break;
-	case 8:
-		memcpy (buffer, orig, 8);
-		dest[0] = buffer[7];
-		dest[1] = buffer[6];
-		dest[2] = buffer[5];
-		dest[3] = buffer[4];
-		dest[4] = buffer[3];
-		dest[5] = buffer[2];
-		dest[6] = buffer[1];
-		dest[7] = buffer[0];
-		break;
-	default:
-		if (dest != orig)
-			memmove (dest, orig, size);
-		//eprintf ("Invalid endian copy of size: %d\n", size);
+	} else {
+		switch (size) {
+		case 1:
+			*dest = *orig;
+			break;
+		case 2:
+			*buffer = *orig;
+			dest[0] = orig[1];
+			dest[1] = buffer[0];
+			break;
+		case 4:
+			memcpy (buffer, orig, 4);
+			dest[0] = buffer[3];
+			dest[1] = buffer[2];
+			dest[2] = buffer[1];
+			dest[3] = buffer[0];
+			break;
+		case 8:
+			memcpy (buffer, orig, 8);
+			dest[0] = buffer[7];
+			dest[1] = buffer[6];
+			dest[2] = buffer[5];
+			dest[3] = buffer[4];
+			dest[4] = buffer[3];
+			dest[5] = buffer[2];
+			dest[6] = buffer[1];
+			dest[7] = buffer[0];
+			break;
+		default:
+			if (dest != orig)
+				memmove (dest, orig, size);
+			//eprintf ("Invalid endian copy of size: %d\n", size);
+		}
 	}
 }
 

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -540,6 +540,7 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 	int last_sparse = 0;
 	const char *a, *b;
 
+	len = len - (len % step);
 	if (p) {
 		pairs = p->pairs;
 		use_sparse = p->flags & R_PRINT_FLAGS_SPARSE;


### PR DESCRIPTION
When i do
```
pxw 3
```
it shouldn't print any value because 3 bytes are not enough to make a dword. Moreover, ASAN reports a heap overflow for this reason.

PR for tests at https://github.com/radare/radare2-regressions/pull/199/files