### PR TITLE
io/p/io_debug,io/p/io_mach: use strtol instead of strcmp + atoi

### DIFF
--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -364,18 +364,15 @@ static int __plugin_open(RIO *io, const char *file, ut8 many) {
 
 static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 	char uri[128];
-	int pid;
 	if (__plugin_open (io, file,  0)) {
 		const char *pidfile = file + 6;
-		if (!strcmp (pidfile, "0")) {
-			pid = 0;
-		} else {
-			pid = atoi (pidfile);
-			if (pid <1) pid = -1;
-		}
+		char *endptr;
+		int pid = (int)strtol (pidfile, &endptr, 10);
+		if (endptr == pidfile || pid < 0) pid = -1;
+
 		if (pid == -1) {
 			pid = fork_and_ptraceme (io, io->bits, file+6);
-			if (pid==-1)
+			if (pid == -1)
 				return NULL;
 #if __WINDOWS__
 			sprintf (uri, "w32dbg://%d", pid);

--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -216,20 +216,16 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 	RIODesc *ret = NULL;
 	RIOMach *riom;
 	const char *pidfile;
-	char *pidpath;
+	char *pidpath, *endptr;
 	int pid;
 	task_t task;
 	if (!__plugin_open (io, file, 0))
 		return NULL;
 	pidfile = file+(file[0]=='a'?9:7);
-	if (!strcmp (pidfile, "0")) {
-		/* tfp0 */
-		pid = 0;
-	} else {
-		pid = atoi (pidfile);
-		if (pid<1)
-			return NULL;
-	}
+	pid = (int)strtol (pidfile, &endptr, 10);
+	if (endptr == pidfile || pid < 0)
+		return NULL;
+
 	task = debug_attach (pid);
 	if ((int)task == -1) {
 		switch (errno) {


### PR DESCRIPTION
it should be the same semantically, but without the need to have two different cases, one for 0 and one for the other numbers.

strtol returns in endptr the first invalid character and it's equal to the original string in case the string doesn't contain any digit.