### PR TITLE
Fix build with --with-syszip

### DIFF
--- a/shlr/gdb/Makefile
+++ b/shlr/gdb/Makefile
@@ -14,7 +14,7 @@ MINOR=1
 LD=$(CC)
 LDFLAGS+=-L${LIBR}/socket -lr_socket
 LDFLAGS+=-L${LIBR}/util -lr_util
-LDFLAGS+=../zip/librz.a
+include ../../libr/zip/deps.mk
 #OSTYPE=windows
 include ../../libr/socket/deps.mk
 


### PR DESCRIPTION
I had to apply this patch to be able to package radare2 in NetBSD's pkgsrc repository.