### PR TITLE
Fix build with --with-syszip

### DIFF
--- a/shlr/gdb/Makefile
+++ b/shlr/gdb/Makefile
@@ -14,7 +14,7 @@ MINOR=1
 LD=$(CC)
 LDFLAGS+=-L${LIBR}/socket -lr_socket
 LDFLAGS+=-L${LIBR}/util -lr_util
-LDFLAGS+=../zip/librz.a
+include ../../shlr/zip/deps.mk
 #OSTYPE=windows
 include ../../libr/socket/deps.mk
 


### PR DESCRIPTION
I had to apply this patch to import radare2 0.9.9 into NetBSD's pkgsrc repository.