### PR TITLE
Remove redundant inclusion of ../../shlr/zip/deps.mk

### DIFF
--- a/shlr/gdb/Makefile
+++ b/shlr/gdb/Makefile
@@ -14,7 +14,6 @@ MINOR=1
 LD=$(CC)
 LDFLAGS+=-L${LIBR}/socket -lr_socket
 LDFLAGS+=-L${LIBR}/util -lr_util
-include ../../shlr/zip/deps.mk
 #OSTYPE=windows
 include ../../libr/socket/deps.mk
 


### PR DESCRIPTION
The underlying issue of invalid inclusion of zip was fixed.. twice in pkgsrc on NetBSD.