### PR TITLE
Fixes

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1795,40 +1795,60 @@ static int cmd_search(void *data, const char *input) {
 		}
 		break;
 	case 'v':
-		if (input[2] == 'j') {
-			json = R_TRUE;
-			param_offset++;
+		if (input[1]){
+			if (input[2] == 'j') {
+				json = R_TRUE;
+				param_offset++;
+			}
 		}
 		r_search_reset (core->search, R_SEARCH_KEYWORD);
 		r_search_set_distance (core->search, (int)
 			r_config_get_i (core->config, "search.distance"));
 		switch (input[1]) {
 		case '8':
-			n64 = r_num_math (core->num, input+param_offset);
-			r_mem_copyendian ((ut8*)&n64, (const ut8*)&n64,
-				8, !core->assembler->big_endian);
-			r_search_kw_add (core->search,
-				r_search_keyword_new ((const ut8*)&n64, 8, NULL, 0, NULL));
+			if (input[param_offset]){
+				n64 = r_num_math (core->num, input+param_offset);
+				r_mem_copyendian ((ut8*)&n64, (const ut8*)&n64,
+					8, !core->assembler->big_endian);
+				r_search_kw_add (core->search,
+					r_search_keyword_new ((const ut8*)&n64, 8, NULL, 0, NULL));
+				break;
+			}
+			eprintf ("Usage: /v[1248] value\n");
 			break;
 		case '1':
-			n8 = (ut8)r_num_math (core->num, input+param_offset);
-			r_search_kw_add (core->search,
-				r_search_keyword_new ((const ut8*)&n8, 1, NULL, 0, NULL));
+			if (input[param_offset]){
+				n8 = (ut8)r_num_math (core->num, input+param_offset);
+				r_search_kw_add (core->search,
+					r_search_keyword_new ((const ut8*)&n8, 1, NULL, 0, NULL));
+				break;
+			}
+			eprintf ("Usage: /v[1248] value\n");
 			break;
 		case '2':
-			n16 = (ut16)r_num_math (core->num, input+param_offset);
-			r_mem_copyendian ((ut8*)&n16, (ut8*)&n16,
-				2, !core->assembler->big_endian);
-			r_search_kw_add (core->search,
-				r_search_keyword_new ((const ut8*)&n16, 2, NULL, 0, NULL));
+			if (input[param_offset]){
+				n16 = (ut16)r_num_math (core->num, input+param_offset);
+				r_mem_copyendian ((ut8*)&n16, (ut8*)&n16,
+					2, !core->assembler->big_endian);
+				r_search_kw_add (core->search,
+					r_search_keyword_new ((const ut8*)&n16, 2, NULL, 0, NULL));
+				break;
+			}
+			eprintf ("Usage: /v[1248] value\n");
 			break;
 		default: // default size
 		case '4':
-			n32 = (ut32)r_num_math (core->num, input+param_offset);
-			r_mem_copyendian ((ut8*)&n32, (const ut8*)&n32,
-				4, !core->assembler->big_endian);
-			r_search_kw_add (core->search,
-				r_search_keyword_new ((const ut8*)&n32, 4, NULL, 0, NULL));
+			if (input[param_offset-1]) {
+				if (input[param_offset]){
+					n32 = (ut32)r_num_math (core->num, input+param_offset);
+					r_mem_copyendian ((ut8*)&n32, (const ut8*)&n32,
+						4, !core->assembler->big_endian);
+					r_search_kw_add (core->search,
+						r_search_keyword_new ((const ut8*)&n32, 4, NULL, 0, NULL));
+					break;
+				}
+			}
+			eprintf ("Usage: /v[1248] value\n");
 			break;
 		}
 // TODO: Add support for /v4 /v8 /v2

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -74,7 +74,7 @@ static void cmd_write_op (RCore *core, const char *input) {
 		if (input[2]){
 			r_core_write_op (core, input+3, input[1]);
 			r_core_block_read (core, 0);
-		}
+		} else eprintf ("Missing argument\n");
 		break;
 	case 'R':
 		r_core_cmd0 (core, "wr $b");

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -71,8 +71,10 @@ static void cmd_write_op (RCore *core, const char *input) {
 		}
 	case '2':
 	case '4':
-		r_core_write_op (core, input+3, input[1]);
-		r_core_block_read (core, 0);
+		if (input[2]){
+			r_core_write_op (core, input+3, input[1]);
+			r_core_block_read (core, 0);
+		}
 		break;
 	case 'R':
 		r_core_cmd0 (core, "wr $b");

--- a/libr/core/io.c
+++ b/libr/core/io.c
@@ -150,7 +150,8 @@ R_API int r_core_write_op(RCore *core, const char *arg, char op) {
 	} else
 	if (op=='2' || op=='4') {
 		op -= '0';
-		for (i=0; i<core->blocksize; i+=op) {
+		// if i < core->blocksize would pass the test but buf[i+3] goes beyond the buffer
+		for (i=0; i<core->blocksize-3; i+=op) {
 			/* endian swap */
 			ut8 tmp = buf[i];
 			buf[i] = buf[i+3];

--- a/libr/core/io.c
+++ b/libr/core/io.c
@@ -151,15 +151,17 @@ R_API int r_core_write_op(RCore *core, const char *arg, char op) {
 	if (op=='2' || op=='4') {
 		op -= '0';
 		// if i < core->blocksize would pass the test but buf[i+3] goes beyond the buffer
-		for (i=0; i<core->blocksize-3; i+=op) {
-			/* endian swap */
-			ut8 tmp = buf[i];
-			buf[i] = buf[i+3];
-			buf[i+3] = tmp;
-			if (op==4) {
-				tmp = buf[i+1];
-				buf[i+1] = buf[i+2];
-				buf[i+2] = tmp;
+		if (core->blocksize > 3) {
+			for (i=0; i<core->blocksize-3; i+=op) {
+				/* endian swap */
+				ut8 tmp = buf[i];
+				buf[i] = buf[i+3];
+				buf[i+3] = tmp;
+				if (op==4) {
+					tmp = buf[i+1];
+					buf[i+1] = buf[i+2];
+					buf[i+2] = tmp;
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
I was testing the command wo2  but I was getting this output but I don't know if that is correct. I assume that io is broken or something

```
[0x100001058]> wo2 4
r_io_write: cannot write on fd 6
```
In master instead this
```
[0x100001058]> wo2 4
r_io_write: cannot write on fd 6
r2(42481,0x7fff783a5300) malloc: *** error for object 0x7fcb72c33280: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```
A proof that we need more test and coverage :(