### PR TITLE
Add command to analyze references

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1647,14 +1647,18 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 				break;
 			}
 
-			// Validate the reference. If virtual addressing is enabled,
-			// we allow only references to virtual addresses in order to
-			// reduce the number of false positives.
+			// Validate the reference. If virtual addressing is enabled, we
+			// allow only references to virtual addresses in order to reduce
+			// the number of false positives. In debugger mode, the reference
+			// must point to a mapped memory region.
 			if (type == R_ANAL_REF_TYPE_NULL)
 				continue;
 			if (!r_core_is_valid_offset (core, xref_to))
 				continue;
-			if (core->io->va) {
+			if (r_config_get_i (core->config, "cfg.debug")) {
+				if (!r_debug_map_get (core->dbg, xref_to))
+					continue;
+			} else if (core->io->va) {
 				RListIter *iter;
 				RIOSection *s;
 				r_list_foreach (core->io->sections, iter, s) {

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1607,7 +1607,6 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 		while (at+i < to && i < ret-OPSZ) {
 			RAnalRefType type;
 			ut64 xref_from, xref_to;
-			const char *cmd;
 
 			xref_from = at+i;
 			r_anal_op_fini (&op);

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1649,7 +1649,15 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to) {
 			if (!r_core_is_valid_offset (core, xref_to))
 				continue;
 			if (core->io->va) {
-				if (!r_io_section_exists_for_vaddr (core->io, xref_to, 0))
+				RListIter *iter;
+				RIOSection *s;
+				r_list_foreach (core->io->sections, iter, s) {
+					if (xref_to >= s->vaddr && xref_to < s->vaddr + s->vsize) {
+						if (s->vaddr != 0)
+							break;
+					}
+				}
+				if (!iter)
 					continue;
 			}
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1973,7 +1973,7 @@ static boolt cmd_anal_refs(RCore *core, const char *input) {
 		"axc", " addr [at]", "add code jmp ref // unused?",
 		"axC", " addr [at]", "add code call ref",
 		"axd", " addr [at]", "add data ref",
-		"axa", " [sz]", "analyze sz bytes of instructions for refs",
+		"axa", "[j*] [sz]", "analyze sz bytes of instructions for refs",
 		"axj", "", "list refs in json format",
 		"axF", " [flg-glob]", "find data/code references of flags",
 		"axt", " [addr]", "find data/code references to this address",
@@ -2163,12 +2163,23 @@ static boolt cmd_anal_refs(RCore *core, const char *input) {
 		{
 			ut64 from, to;
 			char *ptr;
-			int n;
+			int rad, n;
+			const char* help_msg_axa[] = {
+				"Usage:", "axa", "[j*] [sz] # search xrefs",
+				"axa", " [sz]", "analyze xrefs in current section or sz bytes of code",
+				"axaj", " [sz]", "list found xrefs in JSON format",
+				"axa*", " [sz]", "list found xrefs in radare commands format",
+				NULL};
 
 			if (input[1] == '?') {
-				eprintf ("Usage: axa [sz]\n");
+				r_core_cmd_help (core, help_msg_axa);
 				break;
 			}
+
+			if (input[1] == 'j' || input[1] == '*') {
+				rad = input[1];
+				input++;
+			} else rad = 0;
 
 			from = to = 0;
 			ptr = strdup (r_str_trim_head ((char*)input+1));
@@ -2200,7 +2211,7 @@ static boolt cmd_anal_refs(RCore *core, const char *input) {
 			if (from == 0 && to == 0)
 				return R_FALSE;
 
-			r_core_anal_search_xrefs (core, from, to);
+			r_core_anal_search_xrefs (core, from, to, rad);
 		}
 		break;
 	default:

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1973,7 +1973,6 @@ static boolt cmd_anal_refs(RCore *core, const char *input) {
 		"axc", " addr [at]", "add code jmp ref // unused?",
 		"axC", " addr [at]", "add code call ref",
 		"axd", " addr [at]", "add data ref",
-		"axa", "[j*] [sz]", "analyze sz bytes of instructions for refs",
 		"axj", "", "list refs in json format",
 		"axF", " [flg-glob]", "find data/code references of flags",
 		"axt", " [addr]", "find data/code references to this address",
@@ -2157,71 +2156,6 @@ static boolt cmd_anal_refs(RCore *core, const char *input) {
 			}
 			r_anal_ref_add (core->anal, addr, at, input[0]);
 			free (ptr);
-		}
-		break;
-	case 'a':
-		{
-			ut64 from, to;
-			char *ptr;
-			int rad, n;
-			const char* help_msg_axa[] = {
-				"Usage:", "axa", "[j*] [sz] # search xrefs",
-				"axa", " [sz]", "analyze xrefs in current section or sz bytes of code",
-				"axaj", " [sz]", "list found xrefs in JSON format",
-				"axa*", " [sz]", "list found xrefs in radare commands format",
-				NULL};
-
-			if (input[1] == '?') {
-				r_core_cmd_help (core, help_msg_axa);
-				break;
-			}
-
-			if (input[1] == 'j' || input[1] == '*') {
-				rad = input[1];
-				input++;
-			} else rad = 0;
-
-			from = to = 0;
-			ptr = strdup (r_str_trim_head ((char*)input+1));
-			n = r_str_word_set0 (ptr);
-			if (n == 0) {
-				int rwx = R_IO_EXEC;
-				// get boundaries of current memory map, section or io map
-				if (r_config_get_i (core->config, "cfg.debug")) {
-					RDebugMap *map = r_debug_map_get (core->dbg, core->offset);
-					if (map) {
-						from = map->addr;
-						to = map->addr_end;
-						rwx = map->perm;
-					}
-				} else if (core->io->va) {
-					RIOSection *section = r_io_section_vget (core->io, core->offset);
-					if (section) {
-						from = section->vaddr;
-						to = section->vaddr + section->vsize;
-						rwx = section->rwx;
-					}
-				} else {
-					RIOMap *map = r_io_map_get (core->io, core->offset);
-					from = core->offset;
-					to = r_io_size (core->io) + (map? map->to:0);
-				}
-				if (from == 0 && to == 0)
-					eprintf ("Cannot determine xref search boundaries\n");
-				else if (!(rwx & R_IO_EXEC))
-					eprintf ("Warning: Searching xrefs in non-executable region\n");
-			} else if (n == 1) {
-				from = core->offset;
-				to = core->offset + r_num_math (core->num, r_str_word_get0 (ptr, 0));
-			} else {
-				eprintf ("Invalid number of arguments\n");
-			}
-			free (ptr);
-
-			if (from == 0 && to == 0)
-				return R_FALSE;
-
-			r_core_anal_search_xrefs (core, from, to, rad);
 		}
 		break;
 	default:
@@ -2676,6 +2610,7 @@ static int cmd_anal(void *data, const char *input) {
 		"aa*", "", "analyze all flags starting with sym. (af @@ sym.*)",
 		"aaa", "", "autoname functions after aa (see afna)",
 		"aac", " [len]", "analyze function calls (af @@ `pi len~call[1]`)",
+		"aar", " [len]", "analyze len bytes of instructions for references",
 		"aas", " [len]", "analyze symbols (af @@= `isq~[0]`)",
 		"aap", "", "find and analyze function preludes",
 		NULL};
@@ -2771,6 +2706,71 @@ static int cmd_anal(void *data, const char *input) {
 			r_cons_break_end ();
 			if (input[1] == 'a') // "aaa"
 				r_core_cmd0 (core, ".afna @@ fcn.*"); break; // "aaa"
+			break;
+		case 'r':
+			{
+				ut64 from, to;
+				char *ptr;
+				int rad, n;
+				const char* help_msg_aar[] = {
+					"Usage:", "aar", "[j*] [sz] # search and analyze xrefs",
+					"aar", " [sz]", "analyze xrefs in current section or sz bytes of code",
+					"aarj", " [sz]", "list found xrefs in JSON format",
+					"aar*", " [sz]", "list found xrefs in radare commands format",
+					NULL};
+
+				if (input[2] == '?') {
+					r_core_cmd_help (core, help_msg_aar);
+					break;
+				}
+
+				if (input[2] == 'j' || input[2] == '*') {
+					rad = input[2];
+					input++;
+				} else rad = 0;
+
+				from = to = 0;
+				ptr = strdup (r_str_trim_head ((char*)input+2));
+				n = r_str_word_set0 (ptr);
+				if (n == 0) {
+					int rwx = R_IO_EXEC;
+					// get boundaries of current memory map, section or io map
+					if (r_config_get_i (core->config, "cfg.debug")) {
+						RDebugMap *map = r_debug_map_get (core->dbg, core->offset);
+						if (map) {
+							from = map->addr;
+							to = map->addr_end;
+							rwx = map->perm;
+						}
+					} else if (core->io->va) {
+						RIOSection *section = r_io_section_vget (core->io, core->offset);
+						if (section) {
+							from = section->vaddr;
+							to = section->vaddr + section->vsize;
+							rwx = section->rwx;
+						}
+					} else {
+						RIOMap *map = r_io_map_get (core->io, core->offset);
+						from = core->offset;
+						to = r_io_size (core->io) + (map? map->to:0);
+					}
+					if (from == 0 && to == 0)
+						eprintf ("Cannot determine xref search boundaries\n");
+					else if (!(rwx & R_IO_EXEC))
+						eprintf ("Warning: Searching xrefs in non-executable region\n");
+				} else if (n == 1) {
+					from = core->offset;
+					to = core->offset + r_num_math (core->num, r_str_word_get0 (ptr, 0));
+				} else {
+					eprintf ("Invalid number of arguments\n");
+				}
+				free (ptr);
+
+				if (from == 0 && to == 0)
+					return R_FALSE;
+
+				r_core_anal_search_xrefs (core, from, to, rad);
+			}
 			break;
 		default: r_core_cmd_help (core, help_msg_aa); break;
 		}

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -295,7 +295,7 @@ R_API ut64 r_core_anal_address (RCore *core, ut64 addr);
 R_API void r_core_anal_undefine (RCore *core, ut64 off);
 R_API void r_core_anal_hint_list (RAnal *a, int mode);
 R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref);
-R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to);
+R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad);
 R_API int r_core_anal_data (RCore *core, ut64 addr, int count, int depth);
 R_API void r_core_anal_refs(RCore *core, ut64 addr, int gv);
 R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -295,6 +295,7 @@ R_API ut64 r_core_anal_address (RCore *core, ut64 addr);
 R_API void r_core_anal_undefine (RCore *core, ut64 off);
 R_API void r_core_anal_hint_list (RAnal *a, int mode);
 R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref);
+R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to);
 R_API int r_core_anal_data (RCore *core, ut64 addr, int count, int depth);
 R_API void r_core_anal_refs(RCore *core, ut64 addr, int gv);
 R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head);


### PR DESCRIPTION
I wrote this because the xref search functionality of radare2 (`aa;af;axt`) is unreliable as fuck. Related issues: #2763 and maybe #1888.

# The problem

    [0x0061a2b4]> aa; af; ii~GetDriveTypeA
    ordinal=011 plt=0x0023a0d0 bind=NONE type=FUNC name=KERNEL32.dll_GetDriveTypeA
    [0x0061a2b4]> axt sym.imp.KERNEL32.dll_GetDriveTypeA
    [0x0061a2b4]>

So no references found to the imported API. The reason is that the recursive analysis `aa` fails to recognize/process some functions in the binary so xrefs in those functions are not added to the sdb. The current workaround is to use the refsearch command `/r` which is so slow that it is almost unusable. For a 2MB .text section:

    [0x0061a2b4]> ?t /r sym.imp.KERNEL32.dll_GetDriveTypeA
    64.766510
    ax 0x0063a0d0 0x0050c2a1
    ax 0x0063a0d0 0x0050c345
    ax 0x0063a0d0 0x00618432
    [0x0061a2b4]> 

Over a minute. Hence, it is more practical to constantly switch between r2 and Olly/IDA to find xrefs. This is unacceptable because xrefs are one of the few navigation operation available when analyzing unknown binaries without debug symbols.

# Proposed solution

The solution is not to improve the function analysis and recognition because it can never be 100% accurate (the whole "function" concept may not hold when working with obfuscated code). Thus, I implemented `axa` command that disassembles, linearly from low to high addresses, every instruction in the current section looking for references. Overlapping instructions (i.e., those which begin in the middle of an instruction) are skipped to speed up the analysis. Found references are added to the sdb so that they can be queried efficiently using `axt` and `axf` commands.

    [0x0061a2b4]> ?t axa  # This must be done only once
    22.797811
    [0x0061a2b4]> ?t axt sym.imp.KERNEL32.dll_GetDriveTypeA
    0.000124
    C 0x50c2a1 call dword [sym.imp.KERNEL32.dll_GetDriveTypeA]
    C 0x50c345 call dword [sym.imp.KERNEL32.dll_GetDriveTypeA]
    C 0x618432 call dword [sym.imp.KERNEL32.dll_GetDriveTypeA]

That is faster than `/r` by a factor of ~3. Note that subsequent searches are practically free because `axa` needs to be executed only once; `/r` takes a minute per search.

The interface:

    [0x0061a2b4]> ax?~axa
    | axa[j*] [sz]    analyze sz bytes of instructions for refs
    [0x0061a2b4]> axa?
    |Usage: axa[j*] [sz] # search xrefs
    | axa [sz]   analyze xrefs in current section or sz bytes of code
    | axaj [sz]  list found xrefs in JSON format
    | axa* [sz]  list found xrefs in radare commands format
    [0x0061a2b4]> 

The introduced `axa` command is architecture-independent. Analyzing xrefs in an ARM binary:

    [0x000148b8]> axa* 50
    axd 0x000148d4 0x000148c0
    axd 0x000148d8 0x000148c4
    axd 0x00014914 0x000148c8
    axd 0x00014916 0x000148cc
    axc 0x00013b34 0x000148d0
    axc 0x00014978 0x000148e4
    [0x000148b8]> pd 1 @@= `axa* 50~[2]`  # Show referencing instructions
    0x000148c0    0c209fe5     ldr r2, [pc, 0xc]         ; [0x148d4:4]=0xe6a730 
    0x000148c4    0c009fe5     ldr r0, [pc, 0xc]         ; [0x148d8:4]=0xffffffd4 
    0x000148c8    02208fe0     add r2, pc, r2
    0x000148cc    00008fe0     add r0, pc, r0
    0x000148d0    97fcffea     b sym.imp.__cxa_atexit
    0x000148e4    2300003a     blo 0x14978

# Notes

* This is my first contribution to the project. Please review the code.
* The organization of the code can probably be improved. I implemented the search logic in `libr/core/anal.c` because `/r` was implemented there. However, `libr/anal/*.c` might be a better place for the core search functionality (?)
* Is the command name `axa` OK? #2763 suggested `aar`.
* References are validated by checking that they point to a mapped memory region (if in debugger mode) or a section (non-debugger mode).
* I tested the code on multiple architectures in both debugger and non-debugger modes. It also works on plain files without virtual addressing although I don't know what the use-case would be. Support for all the distinct modes and output formats made the code a bit messy, but I hope it is not too bad...