### PR TITLE
Option to toggle invert scrolling of ASCII graph

### DIFF
--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1289,6 +1289,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI("graph.from", UT64_MAX, "");
 	SETI("graph.to", UT64_MAX, "");
 	SETI("graph.scroll", 5, "Scroll speed in ascii-art graph");
+	SETPREF("graph.invert_scroll", "false", "Invert scroll direction in ascii-art graph");
 
 	/* hud */
 	SETPREF("hud.path", "", "Set a custom path for the HUD file");

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1289,7 +1289,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI("graph.from", UT64_MAX, "");
 	SETI("graph.to", UT64_MAX, "");
 	SETI("graph.scroll", 5, "Scroll speed in ascii-art graph");
-	SETPREF("graph.invert_scroll", "false", "Invert scroll direction in ascii-art graph");
+	SETPREF("graph.invscroll", "false", "Invert scroll direction in ascii-art graph");
 
 	/* hud */
 	SETPREF("hud.path", "", "Set a custom path for the HUD file");

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -1865,10 +1865,10 @@ static void agraph_print (RAGraph *g, int is_interactive,
 		const char *cmdv;
 		(void)G (-g->can->sx, -g->can->sy);
 		snprintf (title, sizeof (title)-1,
-			"[0x%08"PFMT64x"]> %d VV @ %s (nodes %d edges %d zoom %d%%) %s mouse:%s movements-speed:%d scroll:%s",
+			"[0x%08"PFMT64x"]> %d VV @ %s (nodes %d edges %d zoom %d%%) %s mouse:%s movements-speed:%d",
 			fcn->addr, r_stack_size (g->history), fcn->name,
 			g->graph->n_nodes, g->graph->n_edges, g->zoom, g->is_callgraph?"CG":"BB",
-			mousemodes[mousemode], g->movspeed, g->invert_scroll ? "invert" : "normal");
+			mousemodes[mousemode], g->movspeed);
 		W (title);
 
 		r_cons_canvas_print (g->can);
@@ -1920,10 +1920,6 @@ static void agraph_toggle_speed (RAGraph *g, RCore *core) {
 	int alt = r_config_get_i (core->config, "graph.scroll");
 
 	g->movspeed = g->movspeed == DEFAULT_SPEED ? alt : DEFAULT_SPEED;
-}
-
-static void agraph_toggle_scroll_dir (RAGraph *g, RCore *core) {
-	g->invert_scroll = !g->invert_scroll;
 }
 
 static void agraph_init(RAGraph *g) {
@@ -2160,7 +2156,6 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 					" u      - select previous node\n"
 					" V      - toggle basicblock / call graphs\n"
 					" w      - toggle between movements speed 1 and graph.scroll\n"
-					" d      - toggle invert scroll direction\n"
 					" x/X    - jump to xref/ref\n"
 					" z/Z    - step / step over\n"
 					" +/-/0  - zoom in/out/default\n");
@@ -2264,9 +2259,6 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			  break;
 		case 'w':
 			  agraph_toggle_speed (g, core);
-			  break;
-		case 'd':
-			  agraph_toggle_scroll_dir(g, core);
 			  break;
 		case -1: // EOF
 		case 'q':

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2012,7 +2012,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 	int wheelspeed;
 	int w, h;
 	int ret;
-    int invscroll;
+	int invscroll;
 
 	fcn = _fcn? _fcn: r_anal_get_fcn_in (core->anal, core->offset, 0);
 	if (!fcn) {
@@ -2048,7 +2048,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 	core->cons->event_resize = (RConsEvent)agraph_refresh;
 
 	while (!exit_graph && !is_error) {
-        invscroll = r_config_get_i (core->config, "graph.invscroll");
+		invscroll = r_config_get_i (core->config, "graph.invscroll");
 		w = r_cons_get_size (&h);
 		ret = agraph_refresh (grd);
 		if (!ret) {

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2036,7 +2036,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		goto err_graph_new;
 	}
 	g->movspeed = r_config_get_i (core->config, "graph.scroll");
-	g->invert_scroll = r_config_get_i (core->config, "graph.invert_scroll");
+	g->invscroll = r_config_get_i (core->config, "graph.invscroll");
 
 	grd = R_NEW (struct agraph_refresh_data);
 	grd->g = g;
@@ -2183,8 +2183,8 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		case 'j':
 			if (r_cons_singleton()->mouse_event) {
 				switch (mousemode) {
-				case 0: can->sy += wheelspeed * (g->invert_scroll ? -1 : 1); break; // canvas-y
-				case 1: can->sx += wheelspeed * (g->invert_scroll ? -1 : 1); break; // canvas-x
+				case 0: can->sy += wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-y
+				case 1: can->sx += wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-x
 				case 2: get_anode(g->curnode)->y += wheelspeed; break; // node-y
 				case 3: get_anode(g->curnode)->x += wheelspeed; break; // node-x
 				}
@@ -2195,8 +2195,8 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		case 'k':
 			if (r_cons_singleton()->mouse_event) {
 				switch (mousemode) {
-				case 0: can->sy -= wheelspeed * (g->invert_scroll ? -1 : 1); break; // canvas-y
-				case 1: can->sx -= wheelspeed * (g->invert_scroll ? -1 : 1); break; // canvas-x
+				case 0: can->sy -= wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-y
+				case 1: can->sx -= wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-x
 				case 2: get_anode(g->curnode)->y -= wheelspeed; break; // node-y
 				case 3: get_anode(g->curnode)->x -= wheelspeed; break; // node-x
 				}
@@ -2217,10 +2217,10 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		case 'h': get_anode(g->curnode)->x -= g->movspeed; break;
 		case 'l': get_anode(g->curnode)->x += g->movspeed; break;
 
-		case 'K': can->sy -= g->movspeed * (g->invert_scroll ? -1 : 1); break;
-		case 'J': can->sy += g->movspeed * (g->invert_scroll ? -1 : 1); break;
-		case 'H': can->sx -= g->movspeed * (g->invert_scroll ? -1 : 1); break;
-		case 'L': can->sx += g->movspeed * (g->invert_scroll ? -1 : 1); break;
+		case 'K': can->sy -= g->movspeed * (g->invscroll ? -1 : 1); break;
+		case 'J': can->sy += g->movspeed * (g->invscroll ? -1 : 1); break;
+		case 'H': can->sx -= g->movspeed * (g->invscroll ? -1 : 1); break;
+		case 'L': can->sx += g->movspeed * (g->invscroll ? -1 : 1); break;
 		case 'e':
 			  can->linemode = !!!can->linemode;
 			  break;

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2012,6 +2012,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 	int wheelspeed;
 	int w, h;
 	int ret;
+    int invscroll;
 
 	fcn = _fcn? _fcn: r_anal_get_fcn_in (core->anal, core->offset, 0);
 	if (!fcn) {
@@ -2036,7 +2037,6 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		goto err_graph_new;
 	}
 	g->movspeed = r_config_get_i (core->config, "graph.scroll");
-	g->invscroll = r_config_get_i (core->config, "graph.invscroll");
 
 	grd = R_NEW (struct agraph_refresh_data);
 	grd->g = g;
@@ -2048,6 +2048,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 	core->cons->event_resize = (RConsEvent)agraph_refresh;
 
 	while (!exit_graph && !is_error) {
+        invscroll = r_config_get_i (core->config, "graph.invscroll");
 		w = r_cons_get_size (&h);
 		ret = agraph_refresh (grd);
 		if (!ret) {
@@ -2183,8 +2184,8 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		case 'j':
 			if (r_cons_singleton()->mouse_event) {
 				switch (mousemode) {
-				case 0: can->sy += wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-y
-				case 1: can->sx += wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-x
+				case 0: can->sy += wheelspeed * (invscroll ? -1 : 1); break; // canvas-y
+				case 1: can->sx += wheelspeed * (invscroll ? -1 : 1); break; // canvas-x
 				case 2: get_anode(g->curnode)->y += wheelspeed; break; // node-y
 				case 3: get_anode(g->curnode)->x += wheelspeed; break; // node-x
 				}
@@ -2195,8 +2196,8 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		case 'k':
 			if (r_cons_singleton()->mouse_event) {
 				switch (mousemode) {
-				case 0: can->sy -= wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-y
-				case 1: can->sx -= wheelspeed * (g->invscroll ? -1 : 1); break; // canvas-x
+				case 0: can->sy -= wheelspeed * (invscroll ? -1 : 1); break; // canvas-y
+				case 1: can->sx -= wheelspeed * (invscroll ? -1 : 1); break; // canvas-x
 				case 2: get_anode(g->curnode)->y -= wheelspeed; break; // node-y
 				case 3: get_anode(g->curnode)->x -= wheelspeed; break; // node-x
 				}
@@ -2217,10 +2218,10 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 		case 'h': get_anode(g->curnode)->x -= g->movspeed; break;
 		case 'l': get_anode(g->curnode)->x += g->movspeed; break;
 
-		case 'K': can->sy -= g->movspeed * (g->invscroll ? -1 : 1); break;
-		case 'J': can->sy += g->movspeed * (g->invscroll ? -1 : 1); break;
-		case 'H': can->sx -= g->movspeed * (g->invscroll ? -1 : 1); break;
-		case 'L': can->sx += g->movspeed * (g->invscroll ? -1 : 1); break;
+		case 'K': can->sy -= g->movspeed * (invscroll ? -1 : 1); break;
+		case 'J': can->sy += g->movspeed * (invscroll ? -1 : 1); break;
+		case 'H': can->sx -= g->movspeed * (invscroll ? -1 : 1); break;
+		case 'L': can->sx += g->movspeed * (invscroll ? -1 : 1); break;
 		case 'e':
 			  can->linemode = !!!can->linemode;
 			  break;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -535,7 +535,6 @@ typedef struct r_ascii_graph_t {
 	int is_small_nodes;
 	int zoom;
 	int movspeed;
-	int invscroll;
 
 	RStack *history;
 	RANode *update_seek_on;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -535,7 +535,7 @@ typedef struct r_ascii_graph_t {
 	int is_small_nodes;
 	int zoom;
 	int movspeed;
-	int invert_scroll;
+	int invscroll;
 
 	RStack *history;
 	RANode *update_seek_on;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -535,6 +535,7 @@ typedef struct r_ascii_graph_t {
 	int is_small_nodes;
 	int zoom;
 	int movspeed;
+	int invert_scroll;
 
 	RStack *history;
 	RANode *update_seek_on;


### PR DESCRIPTION
Toggles both HJKL and mouse wheel scrolling of canvas

I'm not a fan of what Apple call "natural scrolling". I prefer scrolling motions to follow cursor movement. So I thought I would add an option to invert the default scrolling behaviour of the ASCII graph.