### PR TITLE
Fixes translation of X86_INS_LEAVE instruction to esil

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -679,7 +679,7 @@ SETL/SETNGE
 		case X86_INS_LEAVE:
 			op->type = R_ANAL_OP_TYPE_POP;
 			if (a->decode) {
-				esilprintf (op, "%s,%s,=,%s,[%d],%s,%d,%s,-=",
+				esilprintf (op, "%s,%s,=,%s,[%d],%s,=,%d,%s,+=",
 					bp, sp, sp, rs, bp, rs, sp);
 			}
 			op->stackop = R_ANAL_STACK_INC;


### PR DESCRIPTION
Fixed translation of X86_INS_LEAVE instruction to esil, as it was not properly popping EBP and fixing ESP.