### PR TITLE
Re-fix #2987 - further fix for file handle leak on windows

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -663,6 +663,8 @@ R_API void r_file_mmap_free (RMmap *m) {
 		CloseHandle (m->fm);
 	if (m->fh != INVALID_HANDLE_VALUE)
 		CloseHandle (m->fh);
+	if (m->buf)
+		UnmapViewOfFile (m->buf);
 #endif
 	if (m->fd == -1) {
 		free (m);
@@ -670,8 +672,6 @@ R_API void r_file_mmap_free (RMmap *m) {
 	}
 #if __UNIX__
 	munmap (m->buf, m->len);
-#elif __WINDOWS__
-	UnmapViewOfFile (m->buf);
 #endif
 	close (m->fd);
 	free (m);


### PR DESCRIPTION
File handles on windows could still get leaked because ```UnmapViewOfFile``` was never reached, thus mapped region was never unmapped, Thus also keeping the underlying file handle ```m->fm``` open. (see https://msdn.microsoft.com/en-us/library/windows/desktop/aa366882(v=vs.85).aspx)