### PR TITLE
Fixes

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2220,6 +2220,10 @@ R_API RAGraph *r_agraph_new(RConsCanvas *can) {
 
 static void visual_offset (RCore *core) {
 	char buf[256];
+	int cols, rows;
+	cols = r_cons_get_size (&rows);
+	r_cons_gotoxy (0,rows);
+	r_cons_flush ();
 	r_line_set_prompt ("[offset]> ");
 	strcpy (buf, "s ");
 	if (r_cons_fgets (buf+2, sizeof (buf)-3, 0, NULL) >0) {

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2392,9 +2392,9 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 					" r      - relayout\n"
 					" R      - randomize colors\n"
 					" o      - go/seek to given offset\n"
-					" U/b    - undo/redo seek\n"
+					" u/U    - undo/redo seek\n"
 					" p      - toggle mini-graph\n"
-					" u      - select previous node\n"
+					" b      - select previous node\n"
 					" V      - toggle basicblock / call graphs\n"
 					" w      - toggle between movements speed 1 and graph.scroll\n"
 					" x/X    - jump to xref/ref\n"
@@ -2407,7 +2407,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			visual_offset (core);
 			print_agraph (g,core,grd);
 			break;
-		case 'U':
+		case 'u':
 			{
 			ut64 off = r_io_sundo (core->io, core->offset);
 			if (off != UT64_MAX){
@@ -2416,7 +2416,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			} else eprintf ("Can not undo\n");
 			}
 			break;
-		case 'b':
+		case 'U':
 			{	
 			ut64 off = r_io_sundo_redo (core->io);
 			if (off != UT64_MAX){
@@ -2489,7 +2489,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			  agraph_toggle_small_nodes (g);
 			  agraph_update_seek (g, get_anode (g->curnode), R_TRUE);
 			  break;
-		case 'u':
+		case 'b':
 			  agraph_undo_node(g);
 			  break;
 		case '.':

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -1990,16 +1990,16 @@ static int agraph_refresh(struct agraph_refresh_data *grd) {
 	RCore *core = grd->core;
 	RAGraph *g = grd->g;
 	RAnalFunction **fcn = grd->fcn;
+	RAnalFunction *f;
 
-	/* allow to change the current function only during debugging */
-	if (g->is_instep && core->io->debug) {
-		RAnalFunction *f;
+	/* allow to change the current function during debugging */
+	if (g->is_instep && core->io->debug) 
 		r_core_cmd0 (core, "sr pc");
-		f = r_anal_get_fcn_in (core->anal, core->offset, 0);
-		if (f && f != *fcn) {
-			*fcn = f;
-			g->need_reload_nodes = R_TRUE;
-		}
+
+	f = r_anal_get_fcn_in (core->anal, core->offset, 0);
+	if (f && f != *fcn) {
+		*fcn = f;
+		g->need_reload_nodes = R_TRUE;
 	}
 
 	return agraph_print (g, grd->fs, core, *fcn);
@@ -2228,18 +2228,6 @@ static void visual_offset (RCore *core) {
 	}
 }
 
-static void print_agraph (RAGraph *g, RCore *core, struct agraph_refresh_data *grd){
-	RAnalFunction **fcn = grd->fcn;
-	RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset, 0);
-	if (f && f != *fcn){
-		*fcn = f;
-		g->need_reload_nodes = R_TRUE;
-	}
-	agraph_print (g, grd->fs, core, *fcn);
-	return;
-}
-
-
 R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interactive) {
 	int exit_graph = R_FALSE, is_error = R_FALSE;
 	struct agraph_refresh_data *grd;
@@ -2405,14 +2393,12 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			break;
 		case 'o':
 			visual_offset (core);
-			print_agraph (g,core,grd);
 			break;
 		case 'u':
 			{
 			ut64 off = r_io_sundo (core->io, core->offset);
 			if (off != UT64_MAX){
 				r_core_seek (core, off, 1);
-				print_agraph (g,core,grd);
 			} else eprintf ("Can not undo\n");
 			}
 			break;
@@ -2421,7 +2407,6 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			ut64 off = r_io_sundo_redo (core->io);
 			if (off != UT64_MAX){
 				r_core_seek (core,off, 1);
-				print_agraph (g,core,grd);
 			} else eprintf ("Can not redo\n");
 			break;
 			}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1,6 +1,6 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
 
-#include "r_core.h"
+#include <r_core.h>
 
 #define NPF 7
 static int blocksize = 0;


### PR DESCRIPTION
I've added the following commands in the Visual Ascii Graph

- `o` to go/seek . It's the same as the visual mode.

- `U` tu undo the seek. I've used this because of issue #2906 but I'd rather to use `u` 
to be consistent with visual mode.
- `b` to redo. I've used this because I didn't know what to use xD. But I would like to use `U` to follow the same rules as in visual mode. 

What do you think about this, your preferences ...? 

My preferences is to be consistent between visual mode and visual ascii graph to use the same commands as much as possible 