### PR TITLE
Anal refactoring

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -80,7 +80,7 @@ R_API RAnal *r_anal_new() {
 	anal->decode = R_TRUE; // slow slow if not used
 	anal->gp = 0LL;
 	anal->sdb = sdb_new0 ();
-	anal->noncode = 0; // do not analyze data by default
+	anal->noncode = R_FALSE; // do not analyze data by default
 	anal->sdb_fcns = sdb_ns (anal->sdb, "fcns", 1);
 	anal->sdb_meta = sdb_ns (anal->sdb, "meta", 1);
 	r_space_init (&anal->meta_spaces,

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -11,18 +11,6 @@ R_LIB_VERSION(r_anal);
 static RAnalPlugin *anal_static_plugins[] =
 	{ R_ANAL_STATIC_PLUGINS };
 
-/*
-static RAnalVarType anal_default_vartypes[] =
-	{{ "char",  "c",  1 },
-	 { "byte",  "b",  1 },
-	 { "int",   "i",  4 },
-	 { "int32", "d",  4 },
-	 { "int64", "q",  8 },
-	 { "dword", "x",  4 },
-	 { "float", "f",  4 },
-	 { NULL,    NULL, 0 }};
-*/
-
 static void r_anal_type_init(RAnal *anal) {
 	Sdb *D = anal->sdb_types;
 	sdb_set (D, "unsigned int", "type", 0);
@@ -99,10 +87,6 @@ R_API RAnal *r_anal_new() {
 		meta_unset_for, meta_count_for, anal);
 	anal->sdb_hints = sdb_ns (anal->sdb, "hints", 1);
 	anal->sdb_xrefs = sdb_ns (anal->sdb, "xrefs", 1);
-	//anal->sdb_vars = sdb_ns (anal->sdb, "vars", 1); // its inside fcns right now
-	//anal->sdb_args = sdb_ns (anal->sdb, "args", 1);
-	//anal->sdb_ret = sdb_ns (anal->sdb, "ret", 1);
-	//anal->sdb_locals = sdb_ns (anal->sdb, "locals", 1);
 	anal->sdb_types = sdb_ns (anal->sdb, "types", 1);
 	anal->cb_printf = (PrintfCallback) printf;
 	r_anal_pin_init (anal);
@@ -131,11 +115,7 @@ R_API RAnal *r_anal_new() {
 		*static_plugin = *anal_static_plugins[i];
 		r_anal_add (anal, static_plugin);
 	}
-/*
-	for (i=0; anal_default_vartypes[i].name; i++)
-		r_anal_var_type_add (anal, anal_default_vartypes[i].name,
-				anal_default_vartypes[i].size, anal_default_vartypes[i].fmt);
-*/
+
 	return anal;
 }
 
@@ -152,8 +132,6 @@ R_API RAnal *r_anal_free(RAnal *a) {
 	r_list_free (a->plugins);
 	a->fcns->free = r_anal_fcn_free;
 	r_list_free (a->fcns);
-	// might provoke double frees since this is used in r_anal_fcn_insert()
-	//r_listrange_free (a->fcnstore);
 	r_space_fini (&a->meta_spaces);
 	r_anal_pin_fini (a);
 	r_list_free (a->refs);
@@ -167,7 +145,6 @@ R_API RAnal *r_anal_free(RAnal *a) {
 		r_anal_esil_free (a->esil);
 		a->esil = NULL;
 	}
-	// r_io_free(anal->iob.io); // need r_core (but recursive problem to fix)
 	memset (a, 0, sizeof (RAnal));
 	free (a);
 	return NULL;

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -109,7 +109,7 @@ R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb, ut64 addr, ut8 *buf, ut64 len, 
 			bb->type |= R_ANAL_BB_TYPE_LAST;
 			goto beach;
 		case R_ANAL_OP_TYPE_LEA:
-{
+		{
 			RAnalValue *src = op->src[0];
 			if (src && src->reg && anal->reg) {
 				const char *pc = anal->reg->name[R_REG_NAME_PC];
@@ -122,7 +122,7 @@ R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb, ut64 addr, ut8 *buf, ut64 len, 
 					r_anal_ref_add (anal, ptr, addr+idx-op->size, 'd');
 				}
 			}
-}
+		}
 		}
 		r_anal_op_free (op);
 	}

--- a/libr/anal/data.c
+++ b/libr/anal/data.c
@@ -59,7 +59,7 @@ static ut64 is_pointer(RIOBind *iob, const ut8 *buf, int endian, int size) {
 #if USE_IS_VALID_OFFSET
 	int r = iob->is_valid_offset (iob->io, n, 0);
 	return r? n: 0LL;
-#else 
+#else
 	// optimization to ignore very low and very high pointers
 	// this makes disasm 5x faster, but can result in some false positives
 	// we should compare with current offset, to avoid
@@ -110,43 +110,48 @@ R_API char *r_anal_data_to_string (RAnalData *d) {
 	}
 	strcat (line, "  ");
 	idx += 2;
-	if ((mallocsz-idx)>12)
-	switch (d->type) {
-	case R_ANAL_DATA_TYPE_STRING:
-		snprintf (line+idx, mallocsz-idx, "string \"%s\"", d->str);
-		idx = strlen (line);
-		break;
-	case R_ANAL_DATA_TYPE_WIDE_STRING:
-		strcat (line, "wide string");
-		break;
-	case R_ANAL_DATA_TYPE_NUMBER:
-		if (n32 == d->ptr)
-			snprintf (line+idx, mallocsz-idx, "number %d 0x%x", n32, n32);
-		else snprintf (line+idx, mallocsz-idx, "number %"PFMT64d" 0x%"PFMT64x,
-				d->ptr, d->ptr);
-		break;
-	case R_ANAL_DATA_TYPE_POINTER:
-		strcat (line, "pointer ");
-		sprintf (line+strlen (line), " 0x%08"PFMT64x, d->ptr);
-		break;
-	case R_ANAL_DATA_TYPE_INVALID:
-		strcat (line, "invalid");
-		break;
-	case R_ANAL_DATA_TYPE_HEADER:
-		strcat (line, "header");
-		break;
-	case R_ANAL_DATA_TYPE_SEQUENCE:
-		strcat (line, "sequence");
-		break;
-	case R_ANAL_DATA_TYPE_PATTERN:
-		strcat (line, "pattern");
-		break;
-	case R_ANAL_DATA_TYPE_UNKNOWN:
-		strcat (line, "unknown");
-		break;
-	default:
-		strcat (line, "(null)");
-		break;
+	if (mallocsz - idx > 12) {
+		switch (d->type) {
+		case R_ANAL_DATA_TYPE_STRING:
+			snprintf (line+idx, mallocsz-idx, "string \"%s\"", d->str);
+			idx = strlen (line);
+			break;
+		case R_ANAL_DATA_TYPE_WIDE_STRING:
+			strcat (line, "wide string");
+			break;
+		case R_ANAL_DATA_TYPE_NUMBER:
+			if (n32 == d->ptr) {
+				snprintf (line+idx, mallocsz-idx,
+					"number %d 0x%x", n32, n32);
+			} else {
+				snprintf (line+idx, mallocsz-idx,
+					"number %"PFMT64d" 0x%"PFMT64x,
+					d->ptr, d->ptr);
+			}
+			break;
+		case R_ANAL_DATA_TYPE_POINTER:
+			strcat (line, "pointer ");
+			sprintf (line+strlen (line), " 0x%08"PFMT64x, d->ptr);
+			break;
+		case R_ANAL_DATA_TYPE_INVALID:
+			strcat (line, "invalid");
+			break;
+		case R_ANAL_DATA_TYPE_HEADER:
+			strcat (line, "header");
+			break;
+		case R_ANAL_DATA_TYPE_SEQUENCE:
+			strcat (line, "sequence");
+			break;
+		case R_ANAL_DATA_TYPE_PATTERN:
+			strcat (line, "pattern");
+			break;
+		case R_ANAL_DATA_TYPE_UNKNOWN:
+			strcat (line, "unknown");
+			break;
+		default:
+			strcat (line, "(null)");
+			break;
+		}
 	}
 	return line;
 }
@@ -157,11 +162,12 @@ R_API RAnalData *r_anal_data_new_string (ut64 addr, const char *p, int len, int 
 	ad->str = NULL;
 	ad->addr = addr;
 	ad->type = type;
-	if (len == 0)
+	if (len == 0) {
 		len = strlen (p);
+	}
+
 	if (type == R_ANAL_DATA_TYPE_WIDE_STRING) {
 		/* TODO: add support for wide strings */
-		//eprintf ("r_anal_data_new_string: wide string not supported yet\n");
 	} else {
 		ad->str = malloc (len+1);
 		if (!ad->str) {
@@ -243,7 +249,6 @@ R_API RAnalData *r_anal_data (RAnal *anal, ut64 addr, const ut8 *buf, int size) 
 				is_pattern++;
 			}
 		}
-		//eprintf ("%d %d %d %d\n", is_sequence, is_pattern , len, size);
 		if (is_sequence>len-2) {
 			return r_anal_data_new (addr, R_ANAL_DATA_TYPE_SEQUENCE, -1,
 					buf, is_sequence);
@@ -310,7 +315,7 @@ R_API const char *r_anal_data_kind (RAnal *a, ut64 addr, const ut8 *buf, int len
 			break;
 		case R_ANAL_DATA_TYPE_STRING:
 			if (data->len>0) {
-				i += data->len; //strlen ((const char*)buf+i)+1;
+				i += data->len;
 			} else i+=word;
 			str++;
 			break;
@@ -318,13 +323,11 @@ R_API const char *r_anal_data_kind (RAnal *a, ut64 addr, const ut8 *buf, int len
 			i += word;
 		}
 		r_anal_data_free (data);
-        }
-//eprintf ("%d %d %d %d\n", inv, unk, num, str);
+	}
 	if (j<1) return "unknown";
 	if ((inv*100/j)>60) return "invalid";
 	if ((unk*100/j)>60) return "code";
 	if ((num*100/j)>60) return "code";
-//return "text";
 	if ((str*100/j)>40) return "text";
 	return "data";
 }

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -116,7 +116,7 @@ static int cb_analbbsplit (void *user, void *data) {
 static int cb_analnoncode(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
-	core->anal->noncode = node->i_value ? 1: 0; // obey section permissions
+	core->anal->noncode = node->i_value ? R_TRUE: R_FALSE; // obey section permissions
 	return R_TRUE;
 }
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -601,7 +601,7 @@ typedef struct r_anal_t {
 	Sdb *sdb_meta; // TODO: Future r_meta api
 	RSpaces meta_spaces;
 	PrintfCallback cb_printf;
-//moved from RAnalFcn
+	//moved from RAnalFcn
 	Sdb *sdb; // root
 	Sdb *sdb_refs;
 	Sdb *sdb_fcns;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -305,6 +305,7 @@ R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dept
 R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump);
 R_API int r_core_anal_fcn_list(RCore *core, const char *input, int rad);
 R_API void r_core_anal_fcn_labels(RCore *core, RAnalFunction *fcn, int rad);
+R_API int r_core_anal_fcn_clean(RCore *core, ut64 addr);
 R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts);
 R_API int r_core_anal_graph_fcn(RCore *core, char *input, int opts);
 R_API RList* r_core_anal_graph_to(RCore *core, ut64 addr, int n);


### PR DESCRIPTION
This patch starts refactoring/cleaning anal code.
* extract a cmd_anal_all function in cmd_anal.c
* in core/anal.c:
 * remove #if 0/1 because they just make the code less readable and there are a lot of them.
 * reindent code correctly
 * avoid macros in the middle of functions

Still a lot of work to add.
