### PR TITLE
Fix typos in help strings in libr/core/cmd.c

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -265,11 +265,11 @@ static int cmd_yank(void *data, const char *input) {
 		"yz", " 16", "copy up to 16 zero terminated string bytes into clipboard",
 		"yz", " @ 0x200", "copy up to blocksize zero terminated string bytes into clipboard from 0x200",
 		"yz", " 16 @ 0x200", "copy up to 16 zero terminated string bytes into clipboard from 0x200",
-		"yp", "", "print contents of clipboardn",
+		"yp", "", "print contents of clipboard",
 		"yx", "", "print contents of clipboard in hexadecimal",
 		"yt", " 64 0x200", "copy 64 bytes from current seek to 0x200",
 		"yf", " 64 0x200", "file copy 64 bytes from 0x200 from file (opens w/ io), use -1 for all bytes",
-		"yfa", " file copy", "copy all bytes from from file (opens w/ io)",
+		"yfa", " file copy", "copy all bytes from file (opens w/ io)",
 		"yy", " 0x3344", "paste clipboard",
 		NULL};
 		r_core_cmd_help (core, help_msg);


### PR DESCRIPTION
Remove bogus 'n' from the end of yp command help
Remove duplicate 'from' in yfa's help