### PR TITLE
Debian packaging system does not understand "x86_64". Use "amd64" ins…

### DIFF
--- a/sys/debian/radare2-dev/CONFIG
+++ b/sys/debian/radare2-dev/CONFIG
@@ -5,5 +5,8 @@ MAINTAINER=pancake <pancake@nopcode.org>
 
 include ../../../config-user.mk
 ARCH=$(shell uname -m)
+ifeq ($(ARCH),x86_64)
+ARCH=amd64
+endif
 #VERSION=0.10.0
 #ARCH=iphoneos-arm

--- a/sys/debian/radare2/CONFIG
+++ b/sys/debian/radare2/CONFIG
@@ -5,5 +5,8 @@ MAINTAINER=pancake <pancake@nopcode.org>
 
 include ../../../config-user.mk
 ARCH=$(shell uname -m)
+ifeq ($(ARCH),x86_64)
+ARCH=amd64
+endif
 #VERSION=0.10.0
 #ARCH=iphoneos-arm


### PR DESCRIPTION
…tead as an arch description.