### PR TITLE
w32 native debug list processes

### DIFF
--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -575,9 +575,11 @@ static RDebugPid *build_debug_pid(PROCESSENTRY32 *pe) {
 
 	if (w32_queryfullprocessimagename (process, 0, 
 		image_name, (PDWORD)&length)) {
+		CloseHandle(process);
 		return r_debug_pid_new (image_name, pe->th32ProcessID, 's', 0);
 	}
 
+	CloseHandle(process);
 	return r_debug_pid_new (pe->szExeFile, pe->th32ProcessID, 's', 0);
 }
 

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -565,7 +565,7 @@ static RDebugPid *build_debug_pid(PROCESSENTRY32 *pe) {
 	HANDLE process = OpenProcess (PROCESS_QUERY_LIMITED_INFORMATION,
 		FALSE, pe->th32ProcessID);
 
-	if (!process || w32_queryfullprocessimagename == NULL) {
+	if (process == INVALID_HANDLE_VALUE || w32_queryfullprocessimagename == NULL) {
 		return r_debug_pid_new (pe->szExeFile, pe->th32ProcessID, 's', 0);
 	}
 
@@ -573,7 +573,7 @@ static RDebugPid *build_debug_pid(PROCESSENTRY32 *pe) {
 	image_name[0] = '\0';
 	DWORD length = MAX_PATH;
 
-	if (w32_queryfullprocessimagename ((HANDLE)process, 0, 
+	if (w32_queryfullprocessimagename (process, 0, 
 		image_name, (PDWORD)&length)) {
 		return r_debug_pid_new (image_name, pe->th32ProcessID, 's', 0);
 	}
@@ -602,9 +602,9 @@ RList *w32_pids (int pid, RList *list) {
 			pe.th32ProcessID == pid || 
 			pe.th32ParentProcessID == pid) {
 	
-			RDebugPid *pid = build_debug_pid (&pe);
-			if (pid) {
-				r_list_append (list, pid);
+			RDebugPid *debug_pid = build_debug_pid (&pe);
+			if (debug_pid) {
+				r_list_append (list, debug_pid);
 			}
 		}
 	} while (Process32Next (process_snapshot, &pe));


### PR DESCRIPTION
Native w32 debugging "dp" does not filter for currently debugged processes only. Instead all processes are shown (like dp*)

I also added functionality to resolve the process names for more useful output.

Thats what it looks now:
```
[0x7735de9a]> dp
Selected: -1 16380
 - 0 s ???
 - 4 s ???
[...]
 - 12964 s ???
 - 27268 s ???
[0x7735de9a]> dp*
 - 0 s ???
 - 4 s ???
[...]
 - 12964 s ???
 - 27268 s ???
[0x7735de9a]>

```

And with the patch:
```
[0x7733b870]> dp
Selected: 9880 12968
 * 9880 s C:\Windows\System32\calc.exe
[0x7733b870]> dp*
 - 0 s [System Process]
 - 4 s System
 - 272 s smss.exe
 - 388 s csrss.exe
[...]
 - 27268 s C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
 - 24452 s C:\Windows\System32\notepad.exe
 - 14116 s \\192.168.100.4\share\radare2-w64-0.10.0-git\radare2.exe
 * 9880 s C:\Windows\System32\calc.exe
[0x7733b870]>
```