### PR TITLE
Implemented missing r_debug_native_kill for win32

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1172,7 +1172,7 @@ static int r_debug_native_kill(RDebug *dbg, int pid, int tid, int sig) {
 	int ret = R_FALSE;
 	if (pid==0) pid = dbg->pid;
 #if __WINDOWS__ && !__CYGWIN__
-	ret = w32_terminate_process(dbg, pid);
+	ret = w32_terminate_process (dbg, pid);
 #else
 #if 0
 	if (thread) {

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1170,7 +1170,7 @@ static int r_debug_native_bp_read(int pid, ut64 addr, int hw, int rwx) {
 // TODO: implement own-defined signals
 static int r_debug_native_kill(RDebug *dbg, int pid, int tid, int sig) {
 	int ret = R_FALSE;
-	if (pid==0) pid = dbg->pid;
+	if (pid == 0) pid = dbg->pid;
 #if __WINDOWS__ && !__CYGWIN__
 	ret = w32_terminate_process (dbg, pid);
 #else

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1169,23 +1169,11 @@ static int r_debug_native_bp_read(int pid, ut64 addr, int hw, int rwx) {
 
 // TODO: implement own-defined signals
 static int r_debug_native_kill(RDebug *dbg, int pid, int tid, int sig) {
-#if __WINDOWS__ && !__CYGWIN__
-	// TODO: implement thread support signaling here
-	eprintf ("TODO: r_debug_native_kill\n");
-#if 0
-	HANDLE hProcess; // XXX
-	static uint WM_CLOSE = 0x10;
-	static bool CloseWindow(IntPtr hWnd) {
-		hWnd = FindWindowByCaption (0, "explorer");
-		SendMessage(hWnd, WM_CLOSE, NULL, NULL);
-		CloseWindow(hWnd);
-		return true;
-	}
-	TerminateProcess (hProcess, 1);
-#endif
-	return R_FALSE;
-#else
 	int ret = R_FALSE;
+	if (pid==0) pid = dbg->pid;
+#if __WINDOWS__ && !__CYGWIN__
+	ret = w32_terminate_process(dbg, pid);
+#else
 #if 0
 	if (thread) {
 // XXX this is linux>2.5 specific..ugly
@@ -1195,7 +1183,6 @@ static int r_debug_native_kill(RDebug *dbg, int pid, int tid, int sig) {
 		}
 	} else {
 #endif
-		if (pid==0) pid = dbg->pid;
 		if ((r_sandbox_kill (pid, sig) != -1))
 			ret = R_TRUE;
 		if (errno == 1) // EPERM
@@ -1203,8 +1190,8 @@ static int r_debug_native_kill(RDebug *dbg, int pid, int tid, int sig) {
 #if 0
 //	}
 #endif
-	return ret;
 #endif
+	return ret;
 }
 
 struct r_debug_desc_plugin_t r_debug_desc_plugin_native;

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -615,4 +615,29 @@ RList *w32_pids (int pid, RList *list) {
 	return list;
 }
 
+int w32_terminate_process (RDebug *dbg, int pid) {
+	HANDLE process = dbg->process_handle;
+	if (process == INVALID_HANDLE_VALUE) {
+		return R_FALSE;
+	}
+
+	/* stop debugging if we are still attached */
+	DebugActiveProcessStop (pid);
+	if (TerminateProcess (process, 1) == 0) {
+		print_lasterr ((char *)__FUNCTION__, "TerminateProcess");
+		return R_FALSE;
+
+	}
+	DWORD ret_wait;
+	/* wait up to one second to give the process some time to exit */
+	if ((ret_wait = WaitForSingleObject (process, 1000)) != 0) {
+		if (ret_wait == WAIT_TIMEOUT) {
+			eprintf ("(%d) Waiting for process to terminate timed out.\n",
+						pid);
+		}
+		return R_FALSE;
+	}
+	return R_TRUE;
+}
+
 #include "maps/windows.c"

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -630,13 +630,16 @@ int w32_terminate_process (RDebug *dbg, int pid) {
 	}
 	DWORD ret_wait;
 	/* wait up to one second to give the process some time to exit */
-	if ((ret_wait = WaitForSingleObject (process, 1000)) != 0) {
-		if (ret_wait == WAIT_TIMEOUT) {
-			eprintf ("(%d) Waiting for process to terminate timed out.\n",
-						pid);
-		}
+	ret_wait = WaitForSingleObject (process, 1000);
+	if (ret_wait == WAIT_FAILED) {
+		print_lasterr ((char *)__FUNCTION__, "WaitForSingleObject");
 		return R_FALSE;
 	}
+	if (ret_wait == WAIT_TIMEOUT) {
+		eprintf ("(%d) Waiting for process to terminate timed out.\n", pid);
+		return R_FALSE;
+	}
+
 	return R_TRUE;
 }
 


### PR DESCRIPTION
Implementation for native win32 to terminate a process was completely missing. 