### PR TITLE
w32 debugging hanging on "dc" after exception from non-main threads

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -522,6 +522,7 @@ repeat:
 			dbg->tid=tmp;
 			winbreak=0;
 		}
+		ret = retwait;
 #endif
 		r_bp_restore (dbg->bp, R_FALSE); // unset sw breakpoints
 		//r_debug_recoil (dbg);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -522,7 +522,9 @@ repeat:
 			dbg->tid=tmp;
 			winbreak=0;
 		}
-		ret = retwait;
+		if (retwait != R_DBG_REASON_DEAD) {
+			ret = dbg->tid;
+		}
 #endif
 		r_bp_restore (dbg->bp, R_FALSE); // unset sw breakpoints
 		//r_debug_recoil (dbg);

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -479,7 +479,7 @@ static int w32_dbg_wait(RDebug *dbg, int pid) {
 		case EXCEPTION_DEBUG_EVENT:
 			next_event = debug_exception_event (&de);
 			if (!next_event) {
-				return de.dwThreadId;
+				return R_DBG_REASON_TRAP;
 			} else {
 				r_debug_native_continue (dbg, pid, tid, -1);
 			}


### PR DESCRIPTION
When a non-main thread causes the debugger to pause execution, the next "dc" will try continuing from main thread instead of the halted one.

Trying to step up to more complicated things than calc.exe, that's from a heavily multi-threaded process:
```
[0x0008dbf8]> dc
resuming executing for pid 28176, tid 30384    <---- resuming main thread
pausing execution for pid = 28176, tid = 12076 with code 2     
(28176) Created thread 12076 (start @ 0000000000B6FD95)
resuming executing for pid 28176, tid 12076                            
pausing execution for pid = 28176, tid = 12076 with code 1    <----- other thread paused b/c of exception
unknown exception
Debugging pid = 28176, tid = 30384 now    <---- *eek* debugger selects main thread again
[0x0000002b]> dc
resuming executing for pid 28176, tid 30384    <---- and finally tries to resume the wrong thread
Error detected in r_debug_native_continue/ContinueDebugEvent: Falscher Parameter.

debug_contp: error             <-- hangs forever
```


imho the problem is the way we feed ``ret`` directly from ```dbg->h->cont()``` directly into ``r_debug_select`` as third argument (``tid`` argument):
https://github.com/radare/radare2/blob/master/libr/debug/debug.c#L515
https://github.com/radare/radare2/blob/master/libr/debug/debug.c#L558

I now take ``retwait`` for it, as ``r_debug_wait`` should ultimatively better know which thread was actually paused after it returns from debugging.

However it feels weird, as I think those APIs are meant to actually return things like ```R_DBG_REASON_TRAP```

With the patch:
```
(30488) Loading library at 0000000076AB0000 (C:\Windows\SysWOW64\imm32.dll)
(30488) Loading library at 0000000075440000 (C:\Windows\SysWOW64\msctf.dll)
(30488) MS_VC_EXCEPTION (406d1388) in thread 29764
[0x0008dbf8]> dc
(30488) MS_VC_EXCEPTION (406d1388) in thread 29764
[0x0008dbf8]> dc
(30488) MS_VC_EXCEPTION (406d1388) in thread 29764
[0x0008dbf8]> dc
(30488) Created thread 21936 (start @ 0000000000B6FD95)
(30488) MS_VC_EXCEPTION (406d1388) in thread 21936
[0x002ee0e8]> dc
(30488) Created thread 28104 (start @ 0000000000B6FD95)
(30488) MS_VC_EXCEPTION (406d1388) in thread 29764
[0x0008dbf8]> dc
(30488) Created thread 13648 (start @ 0000000000B6FD95)
(30488) MS_VC_EXCEPTION (406d1388) in thread 29764
[0x0008dbf8]> dc
(30488) Created thread 21000 (start @ 0000000000B6FD95)
(30488) MS_VC_EXCEPTION (406d1388) in thread 29764
[0x0008dbf8]> dc
(30488) Created thread 22784 (start @ 0000000000B6FD95)
(30488) MS_VC_EXCEPTION (406d1388) in thread 29764
[0x0008dbf8]> dc
(30488) MS_VC_EXCEPTION (406d1388) in thread 21000
[0x02a9e0e8]> dc
(30488) Created thread 10508 (start @ 0000000000B6FD95)
(30488) MS_VC_EXCEPTION (406d1388) in thread 10508
[0x02f6e0e8]>
```

Those MS_VC_EXCEPTION are quite common in visual studio applications, so I added a case for them as well. 

MS uses this exception for overcome design flaws in their APIs. In this particular case, they are all exceptions to broadcast debug names for those threads to the debugger (read: setThreadName() API they never had). See https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx