### PR TITLE
w32 native debugging hangs on "dc" after ctrl+c

### DIFF
--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -666,7 +666,9 @@ void w32_break_process (void *d) {
 					"DebugBreakProcess");
 	}
 	if (process != INVALID_HANDLE_VALUE && w32_dbgbreak != NULL) {
-		w32_dbgbreak (process);
+		if (!w32_dbgbreak (process)) {
+			print_lasterr ((char *)__FUNCTION__, "DebugBreakProcess");
+		}
 	}
 	CloseHandle (lib);
 }


### PR DESCRIPTION
This is again due to an invalid tid change, then trying to resume the debugger on a thread that did not cause the halt.

```
(25620) MS_VC_EXCEPTION (406d1388) in thread 14324
auto resume 25620 14324
continueing 25620 14324    <--- process fully functional running
{ctrl+c} break signal.
event interrupt
{ctrl+c} pressed.
paused execution for pid=25620 tid=14372, code=2    <---- new thread by DebugBreakProcess()
(25620) Created thread 14372 (start @ 0000000077403760)
continueing 25620 14372
paused execution for pid=25620 tid=14372, code=1    <---- Breakpoint in new thread
[0x0000002b]> dc
continueing 25620 3608    <---- Resuming wrong thread
Error detected in r_debug_native_continue/ContinueDebugEvent: Falscher Parameter.

debug_contp: error    <---- hangs
```

WINAPI DebugBreakProcess is called on CTRL+C. This causes a new thread to be created within the debugged process and hitting an breakpoint inside this thread. I think the old code around ``winbreak`` variable was meant as some sort of fix for #3080, which is now no longer needed and even causing this trouble.

With the changes I cant trigger hangups anymore and everything continues and exits succesfully.

```
(20200) Debug string
(20200) MS_VC_EXCEPTION (406d1388) in thread 9008
(20200) Created thread 4540 (start @ 0000000000B6FD95)
(20200) MS_VC_EXCEPTION (406d1388) in thread 4540
{ctrl+c} pressed.
(20200) Created thread 29856 (start @ 0000000077403760)
[0x00000000]> dc
(20200) Finished thread 29856
{ctrl+c} pressed.
(20200) Created thread 31344 (start @ 0000000077403760)    <---- thread from DebugBreakProcess()
[0x00000000]> dc    <---- breakpoint 
(20200) Finished thread 31344    <---- resume correct thread
{ctrl+c} pressed.
(20200) Created thread 23476 (start @ 0000000077403760)
[0x00000000]> dc
(20200) Finished thread 23476
{ctrl+c} pressed.
(20200) Created thread 8432 (start @ 0000000077403760)
[0x00000000]> dc
(20200) Finished thread 8432
(20200) Finished thread 31260
(20200) Unloading library at 0000000073150000
(20200) Finished thread 9992
(20200) Finished thread 1896
(20200) Finished thread 19496
(20200) Finished thread 18548
(20200) Unloading library at 0000000026F00000
(20200) Unloading library at 0000000026400000
(20200) Unloading library at 0000000023000000
(20200) Unloading library at 0000000022300000
(20200) Unloading library at 0000000024100000
(20200) Unloading library at 00000000073F0000
(20200) Unloading library at 0000000006B10000
(20200) Finished thread 10268
(20200) Finished thread 4540
(20200) Finished thread 20184
(20200) Finished thread 13040
(20200) Finished thread 24460
(20200) Finished thread 4672
(20200) Finished thread 22112
(20200) Finished thread 24196
(20200) Finished thread 21528
(20200) Finished thread 25572
(20200) Finished thread 17272
(20200) Finished thread 18936
(20200) Finished thread 27108
(20200) Finished thread 28316
(20200) Finished thread 19184
(20200) Finished thread 8952
(20200) Finished thread 24244
(20200) Finished thread 8468
(20200) Finished thread 28064
(20200) Finished thread 20456
(20200) Finished thread 7072
(20200) Finished thread 22516
(20200) Finished thread 11504
(20200) Finished thread 28796
(20200) Finished thread 17440
(20200) Process 20200 exited with exit code 1
[0x00000000]> dc

==> Process finished

Debugging pid = -1, tid = -1 now
Debugging pid = -1, tid = 9008 now
[0x00000000]>
```

