### PR TITLE
w32 native debugging process and thread HANDLE refactoring

### DIFF
--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -170,9 +170,6 @@ typedef struct r_debug_t {
 	Sdb *tracenodes;
 	Sdb *sgnls;
 	RCoreBind corebind;
-#if __WINDOWS__
-	HANDLE process_handle;
-#endif
 	int trace_forks;
 	int trace_execs;
 	int trace_clone;


### PR DESCRIPTION
Contains two patches:
- First only removes "process_handle" from RDebug
- Second also fixes a couple HANDLE mismatches and replaces tid2handler()

Please @skuater have a look :)

See various comments below.