### PR TITLE
Fix a memleak in anal plugin

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -123,6 +123,11 @@ R_API void r_anal_plugin_free (RAnalPlugin *p) {
 	if (p && p->fini) {
 		p->fini (p);
 	}
+	/*
+	 * This could lead to a double free in the case a plugin
+	 * implements a fini function with a free to the plugin itself
+	 */
+	free (p);
 }
 
 R_API RAnal *r_anal_free(RAnal *a) {


### PR DESCRIPTION
After some work that I have promised to @radare I will try to close the huge amount of memory that we are leaking. Among other things we are not managing the plugins in the correct way. I think that this is an known issue.

@ret2libc you could be interested on these cases

```
...

==42681== 4,160 bytes in 65 blocks are definitely lost in loss record 245 of 262
==42681==    at 0x100070BB1: calloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==42681==    by 0x1000EABFF: r_agraph_add_node (graph.c:2137)
==42681==    by 0x1000ED72B: get_bbnodes (graph.c:1460)
==42681==    by 0x1000ED3C1: reload_nodes (graph.c:1561)
==42681==    by 0x1000ECEED: agraph_reload_nodes (in /Users/alvaro_fe/projects/reverse/radare2/r2/libr/core/libr_core.dylib)
==42681==    by 0x1000EA720: check_changes (graph.c:1958)
==42681==    by 0x1000EA909: agraph_print (graph.c:1988)
==42681==    by 0x1000EC7FA: agraph_refresh (in /Users/alvaro_fe/projects/reverse/radare2/r2/libr/core/libr_core.dylib)
==42681==    by 0x1000EB872: r_core_visual_graph (graph.c:2330)
==42681==    by 0x1000E2425: r_core_visual_cmd (visual.c:1040)
==42681==    by 0x1000E66DD: r_core_visual (visual.c:1729)
==42681==    by 0x1000A4EBE: cmd_visual (cmd.c:780)
==42681==
==42681== 9,834 (9,536 direct, 298 indirect) bytes in 149 blocks are definitely lost in loss record 257 of 262
==42681==    at 0x100070BB1: calloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==42681==    by 0x1000EABFF: r_agraph_add_node (graph.c:2137)
==42681==    by 0x1000EFAE4: create_dummy_nodes (graph.c:484)
==42681==    by 0x1000EF398: set_layout (graph.c:1388)
==42681==    by 0x1000ECB1A: agraph_set_layout (graph.c:1723)
==42681==    by 0x1000EA7C9: check_changes (graph.c:1966)
==42681==    by 0x1000EA909: agraph_print (graph.c:1988)
==42681==    by 0x1000EC7FA: agraph_refresh (in /Users/alvaro_fe/projects/reverse/radare2/r2/libr/core/libr_core.dylib)
==42681==    by 0x1000EB872: r_core_visual_graph (graph.c:2330)
==42681==    by 0x1000E2425: r_core_visual_cmd (visual.c:1040)
==42681==    by 0x1000E66DD: r_core_visual (visual.c:1729)
==42681==    by 0x1000A4EBE: cmd_visual (cmd.c:780)
==42681==
==42681== 20,016 (7,080 direct, 12,936 indirect) bytes in 295 blocks are definitely lost in loss record 260 of 262
==42681==    at 0x100070BB1: calloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==42681==    by 0x1011A861A: r_list_new (list.c:149)
==42681==    by 0x1000F1664: compute_vertical_nodes (graph.c:661)
==42681==    by 0x1000F0004: place_dummies (graph.c:904)
==42681==    by 0x1000EF474: set_layout (graph.c:1406)
==42681==    by 0x1000ECB1A: agraph_set_layout (graph.c:1723)
==42681==    by 0x1000EA7C9: check_changes (graph.c:1966)
==42681==    by 0x1000EA909: agraph_print (graph.c:1988)
==42681==    by 0x1000EC7FA: agraph_refresh (in /Users/alvaro_fe/projects/reverse/radare2/r2/libr/core/libr_core.dylib)
==42681==    by 0x1000EB872: r_core_visual_graph (graph.c:2330)
==42681==    by 0x1000E2425: r_core_visual_cmd (visual.c:1040)
==42681==    by 0x1000E66DD: r_core_visual (visual.c:1729)
==42681==
==42681== 24,832 (2,320 direct, 22,512 indirect) bytes in 58 blocks are definitely lost in loss record 261 of 262
==42681==    at 0x100070BB1: calloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==42681==    by 0x1000F0706: remove_dummy_nodes (graph.c:1330)
==42681==    by 0x1000EF61B: set_layout (graph.c:1429)
==42681==    by 0x1000ECB1A: agraph_set_layout (graph.c:1723)
==42681==    by 0x1000EA7C9: check_changes (graph.c:1966)
==42681==    by 0x1000EA909: agraph_print (graph.c:1988)
==42681==    by 0x1000EC7FA: agraph_refresh (in /Users/alvaro_fe/projects/reverse/radare2/r2/libr/core/libr_core.dylib)
==42681==    by 0x1000EB872: r_core_visual_graph (graph.c:2330)
==42681==    by 0x1000E2425: r_core_visual_cmd (visual.c:1040)
==42681==    by 0x1000E66DD: r_core_visual (visual.c:1729)
==42681==    by 0x1000A4EBE: cmd_visual (cmd.c:780)
==42681==    by 0x1001061D8: r_cmd_call (cmd_api.c:185)
```