### PR TITLE
format/elf: fix paddr2vaddr and vaddr2paddr conversions

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1150,6 +1150,10 @@ R_API int r_bin_list(RBin *bin) {
 	return R_FALSE;
 }
 
+R_API ut64 r_binfile_get_baddr (RBinFile *binfile) {
+	return binfile && binfile->o ? binfile->o->baddr : 0LL;
+}
+
 R_API ut64 r_bin_get_baddr(RBin *bin) {
 	RBinObject *o = r_bin_cur_object (bin);
 	if (o) return o->baddr;

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -101,6 +101,8 @@ int Elf_(r_bin_elf_has_va)(struct Elf_(r_bin_elf_obj_t) *bin);
 ut64 Elf_(r_bin_elf_get_section_addr)(struct Elf_(r_bin_elf_obj_t) *bin, const char *section_name);
 ut64 Elf_(r_bin_elf_get_section_offset)(struct Elf_(r_bin_elf_obj_t) *bin, const char *section_name);
 ut64 Elf_(r_bin_elf_get_baddr)(struct Elf_(r_bin_elf_obj_t) *bin);
+ut64 Elf_(r_bin_elf_p2v)(struct Elf_(r_bin_elf_obj_t) *bin, ut64 paddr);
+ut64 Elf_(r_bin_elf_v2p)(struct Elf_(r_bin_elf_obj_t) *bin, ut64 vaddr);
 ut64 Elf_(r_bin_elf_get_boffset)(struct Elf_(r_bin_elf_obj_t) *bin);
 ut64 Elf_(r_bin_elf_get_entry_offset)(struct Elf_(r_bin_elf_obj_t) *bin);
 ut64 Elf_(r_bin_elf_get_main_offset)(struct Elf_(r_bin_elf_obj_t) *bin);

--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -647,7 +647,8 @@ static int bin_entry (RCore *r, int mode, ut64 baddr, ut64 laddr, int va) {
 				r_cons_printf ("f entry%i 1 @ 0x%08"PFMT64x"\n", i, vaddr);
 				r_cons_printf ("s entry%i\n", i);
 			} else {
-				if (!baddr) {
+				/* XXX: just a temporary workaround */
+				if (!baddr && vaddr > paddr) {
 					baddr = vaddr - paddr;
 				}
 				r_cons_printf (

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -404,6 +404,7 @@ R_API int r_bin_file_ref_by_bind (RBinBind * binb);
 R_API int r_bin_file_ref (RBin *bin, RBinFile * a);
 R_API int r_bin_list(RBin *bin);
 R_API RBinObject *r_bin_get_object(RBin *bin);
+R_API ut64 r_binfile_get_baddr (RBinFile *binfile);
 R_API ut64 r_bin_get_baddr(RBin *bin);
 R_API void r_bin_set_baddr(RBin *bin, ut64 baddr);
 R_API ut64 r_bin_get_boffset(RBin *bin);


### PR DESCRIPTION
The conversion from paddr to vaddr and viceversa shouldn't be done simply by subtracting/adding a baseaddr, but looking at the program headers that are the only things that really matter to create the process image of a binary.