### PR TITLE
load in memory only phdrs + physical size (for ELF)

### DIFF
--- a/libr/bin/format/omf/omf.c
+++ b/libr/bin/format/omf/omf.c
@@ -685,7 +685,8 @@ int r_bin_omf_send_sections(RList *list, OMF_segment *section, r_bin_omf_obj *ob
 		new->vsize = data->size;
 		new->paddr = data->paddr;
 		new->vaddr = section->vaddr + data->offset + OMF_BASE_ADDR;
-		new->srwx = R_BIN_SCN_EXECUTABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_READABLE;
+		new->srwx = R_BIN_SCN_EXECUTABLE | R_BIN_SCN_WRITABLE |
+			R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 		r_list_append (list, new);
 		data = data->next;
 	}

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -153,7 +153,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = art.image_size; // TODO: align?
 	ptr->paddr = 0;
 	ptr->vaddr = art.image_base;
-	ptr->srwx = 4; // r--
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -163,7 +163,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = art.bitmap_size;
 	ptr->paddr = art.bitmap_offset;
 	ptr->vaddr = art.image_base + art.bitmap_offset;
-	ptr->srwx = 5; // r-x
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -173,7 +173,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vaddr = art.oat_begin;
 	ptr->size = art.oat_end - art.oat_begin;
 	ptr->vsize = ptr->size;
-	ptr->srwx = 5; // r-x
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -183,7 +183,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vaddr = art.oat_data_begin;
 	ptr->size = art.oat_data_end - art.oat_data_begin;
 	ptr->vsize = ptr->size;
-	ptr->srwx = 4; // r--
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 	r_list_append (ret, ptr);
 
 	return ret;

--- a/libr/bin/p/bin_bios.c
+++ b/libr/bin/p/bin_bios.c
@@ -92,7 +92,8 @@ static RList* sections(RBinFile *arch) {
 //printf ("SIZE %d\n", ptr->size);
 	ptr->paddr = arch->buf->length - ptr->size;
 	ptr->vaddr = 0xf0000;
-	ptr->srwx = 7;
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
+		R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -94,7 +94,7 @@ static RList *sections(RBinFile *arch) {
 		ptr->vsize = obj->scn_hdrs[i].s_size;
 		ptr->paddr = obj->scn_hdrs[i].s_scnptr;
 
-		ptr->srwx = 0;
+		ptr->srwx = R_BIN_SCN_MAP;
 		if (obj->scn_hdrs[i].s_flags&COFF_SCN_MEM_READ)
 			ptr->srwx |= R_BIN_SCN_READABLE;
 		if (obj->scn_hdrs[i].s_flags&COFF_SCN_MEM_WRITE)

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -847,7 +847,7 @@ static RList* sections(RBinFile *arch) {
 		strcpy (ptr->name, "header");
 		ptr->size = ptr->vsize = sizeof (struct dex_header_t);
 		ptr->paddr= ptr->vaddr = 0;
-		ptr->srwx = 4;
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -855,14 +855,14 @@ static RList* sections(RBinFile *arch) {
 		//ptr->size = ptr->vsize = fsym;
 		ptr->paddr= ptr->vaddr = sizeof (struct dex_header_t);
 		ptr->size = bin->code_from - ptr->vaddr; // fix size
-		ptr->srwx = 4;
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
 		strcpy (ptr->name, "code");
 		ptr->vaddr = ptr->paddr = bin->code_from; //ptr->vaddr = fsym;
 		ptr->size = bin->code_to - ptr->paddr;
-		ptr->srwx = 4|1;
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -878,7 +878,7 @@ static RList* sections(RBinFile *arch) {
 			dprintf ("Hack\n");
 			//ptr->size = ptr->vsize = 1024;
 		}
-		ptr->srwx = 4; //|2;
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; //|2;
 		r_list_append (ret, ptr);
 	}
 	return ret;

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -175,7 +175,7 @@ static RList* sections(RBinFile *arch) {
 			ptr->vsize = memsz;
 			ptr->paddr = paddr;
 			ptr->vaddr = vaddr;
-			ptr->srwx = perms;
+			ptr->srwx = perms | R_BIN_SCN_MAP;
 			r_list_append (ret, ptr);
 			n++;
 		}
@@ -194,7 +194,8 @@ static RList* sections(RBinFile *arch) {
 			ptr->vsize = arch->size;
 			ptr->paddr = 0;
 			ptr->vaddr = 0x10000;
-			ptr->srwx = 7;
+			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
+				R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
 			r_list_append (ret, ptr);
 		}
 	}
@@ -203,12 +204,15 @@ static RList* sections(RBinFile *arch) {
 	if (ptr) {
 		ut64 ehdr_size = sizeof (obj->ehdr);
 
+		if (arch->size < ehdr_size) {
+			ehdr_size = arch->size;
+		}
 		sprintf (ptr->name, "ehdr");
 		ptr->paddr = 0;
 		ptr->vaddr = obj->baddr;
 		ptr->size = ehdr_size;
 		ptr->vsize = ehdr_size;
-		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE;
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_MAP;
 		r_list_append (ret, ptr);
 	}
 

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -111,7 +111,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vaddr = sections[i].addr;
 		if (ptr->vaddr == 0)
 			ptr->vaddr = ptr->paddr;
-		ptr->srwx = sections[i].srwx;
+		ptr->srwx = sections[i].srwx | R_BIN_SCN_MAP;
 		r_list_append (ret, ptr);
 	}
 	free (sections);

--- a/libr/bin/p/bin_mz.c
+++ b/libr/bin/p/bin_mz.c
@@ -121,7 +121,7 @@ static RList * sections(RBinFile *arch) {
 		ptr->vsize = segments[i].size;
 		ptr->paddr = segments[i].paddr;
 		ptr->vaddr = segments[i].paddr;
-		ptr->srwx = r_str_rwx ("rwx") | R_BIN_SCN_MAP;
+		ptr->srwx = r_str_rwx ("rwxm");
 		r_list_append (ret, ptr);
 	}
 	free ((void *)segments);

--- a/libr/bin/p/bin_mz.c
+++ b/libr/bin/p/bin_mz.c
@@ -121,7 +121,7 @@ static RList * sections(RBinFile *arch) {
 		ptr->vsize = segments[i].size;
 		ptr->paddr = segments[i].paddr;
 		ptr->vaddr = segments[i].paddr;
-		ptr->srwx = r_str_rwx ("rwx");
+		ptr->srwx = r_str_rwx ("rwx") | R_BIN_SCN_MAP;
 		r_list_append (ret, ptr);
 	}
 	free ((void *)segments);

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -76,7 +76,7 @@ static RList* sections(RBinFile *arch) {
 	ptr9->vsize = loaded_header.arm9_size;
 	ptr9->paddr = loaded_header.arm9_rom_offset;
 	ptr9->vaddr = loaded_header.arm9_ram_address;
-	ptr9->srwx = r_str_rwx ("rwx");
+	ptr9->srwx = r_str_rwx ("rwx") | R_BIN_SCN_MAP;
 	r_list_append (ret, ptr9);
 
 	strncpy (ptr7->name, "arm7", 5);
@@ -84,7 +84,7 @@ static RList* sections(RBinFile *arch) {
 	ptr7->vsize = loaded_header.arm7_size;
 	ptr7->paddr = loaded_header.arm7_rom_offset;
 	ptr7->vaddr = loaded_header.arm7_ram_address;
-	ptr7->srwx = r_str_rwx ("rwx");
+	ptr7->srwx = r_str_rwx ("rwx") | R_BIN_SCN_MAP;
 	r_list_append (ret, ptr7);
 
 	return ret;

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -76,7 +76,7 @@ static RList* sections(RBinFile *arch) {
 	ptr9->vsize = loaded_header.arm9_size;
 	ptr9->paddr = loaded_header.arm9_rom_offset;
 	ptr9->vaddr = loaded_header.arm9_ram_address;
-	ptr9->srwx = r_str_rwx ("rwx") | R_BIN_SCN_MAP;
+	ptr9->srwx = r_str_rwx ("rwxm");
 	r_list_append (ret, ptr9);
 
 	strncpy (ptr7->name, "arm7", 5);
@@ -84,7 +84,7 @@ static RList* sections(RBinFile *arch) {
 	ptr7->vsize = loaded_header.arm7_size;
 	ptr7->paddr = loaded_header.arm7_rom_offset;
 	ptr7->vaddr = loaded_header.arm7_ram_address;
-	ptr7->srwx = r_str_rwx ("rwx") | R_BIN_SCN_MAP;
+	ptr7->srwx = r_str_rwx ("rwxm");
 	r_list_append (ret, ptr7);
 
 	return ret;

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -116,7 +116,7 @@ static RList* sections(RBinFile *arch){
 	rombank[0]->size = 0x4000;
 	rombank[0]->vsize = 0x4000;
 	rombank[0]->vaddr = 0;
-	rombank[0]->srwx = r_str_rwx ("rx") | R_BIN_SCN_MAP;
+	rombank[0]->srwx = r_str_rwx ("rxm");
 
 	r_list_append (ret, rombank[0]);
 
@@ -126,7 +126,7 @@ static RList* sections(RBinFile *arch){
 		rombank[i]->paddr = i*0x4000;
 		rombank[i]->vaddr = i*0x10000-0xc000;			//spaaaaaaaaaaaaaaaace!!!
 		rombank[i]->size = rombank[i]->vsize = 0x4000;
-		rombank[i]->srwx = r_str_rwx ("rx") | R_BIN_SCN_MAP;
+		rombank[i]->srwx = r_str_rwx ("rxm");
 		r_list_append (ret,rombank[i]);
 	}
 	return ret;

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -116,7 +116,7 @@ static RList* sections(RBinFile *arch){
 	rombank[0]->size = 0x4000;
 	rombank[0]->vsize = 0x4000;
 	rombank[0]->vaddr = 0;
-	rombank[0]->srwx = r_str_rwx ("rx");
+	rombank[0]->srwx = r_str_rwx ("rx") | R_BIN_SCN_MAP;
 
 	r_list_append (ret, rombank[0]);
 
@@ -126,7 +126,7 @@ static RList* sections(RBinFile *arch){
 		rombank[i]->paddr = i*0x4000;
 		rombank[i]->vaddr = i*0x10000-0xc000;			//spaaaaaaaaaaaaaaaace!!!
 		rombank[i]->size = rombank[i]->vsize = 0x4000;
-		rombank[i]->srwx=r_str_rwx ("rx");
+		rombank[i]->srwx = r_str_rwx ("rx") | R_BIN_SCN_MAP;
 		r_list_append (ret,rombank[i]);
 	}
 	return ret;

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -82,7 +82,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = textsize + (textsize%4096);
 	ptr->paddr = 8*4;
 	ptr->vaddr = ptr->paddr;
-	ptr->srwx = 5; // r-x
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
 	r_list_append (ret, ptr);
 	// add data segment
 	datasize = r_mem_get_num (arch->buf->buf+8, 4, big_endian);
@@ -94,7 +94,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = datasize + (datasize%4096);
 		ptr->paddr = textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = 6; // rw-
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_MAP; // rw-
 		r_list_append (ret, ptr);
 	}
 	// ignore bss or what
@@ -108,7 +108,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = symssize + (symssize%4096);
 		ptr->paddr = datasize+textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = 4; // r--
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 		r_list_append (ret, ptr);
 	}
 	// add spsz segment
@@ -121,7 +121,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = spszsize + (spszsize%4096);
 		ptr->paddr = symssize+datasize+textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = 4; // r--
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 		r_list_append (ret, ptr);
 	}
 	// add pcsz segment
@@ -134,7 +134,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = pcszsize + (pcszsize%4096);
 		ptr->paddr = spszsize+symssize+datasize+textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = 4; // r--
+		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 		r_list_append (ret, ptr);
 	}
 	return ret;

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -113,7 +113,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = sections[i].vsize;
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
-		ptr->srwx = 0;
+		ptr->srwx = R_BIN_SCN_MAP;
 		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].flags))
 			ptr->srwx |= R_BIN_SCN_EXECUTABLE;
 		if (R_BIN_PE_SCN_IS_WRITABLE (sections[i].flags))

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -125,7 +125,7 @@ static RList* sections(RBinFile *arch) {
 	strcpy (ptr->name, "relocs");
 	ptr->vsize = ptr->size = pai.num_reloc_entries * sizeof (ut32);
 	ptr->vaddr = ptr->paddr = pai.reloc_list_start;
-	ptr->srwx = 6;
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_MAP;
 	r_list_append (ret, ptr);
 	if (ptr->vaddr<textsize)
 		textsize = ptr->vaddr;
@@ -136,7 +136,7 @@ static RList* sections(RBinFile *arch) {
 	strcpy (ptr->name, "symtab");
 	ptr->vsize = ptr->size = 0;
 	ptr->vaddr = ptr->paddr = pai.sym_table_addr;
-	ptr->srwx = 4;
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 	r_list_append (ret, ptr);
 	if (ptr->vaddr<textsize)
 		textsize = ptr->vaddr;
@@ -146,7 +146,8 @@ static RList* sections(RBinFile *arch) {
 	strcpy (ptr->name, "text");
 	ptr->vaddr = ptr->paddr = 0x80;
 	ptr->vsize = ptr->size = textsize - ptr->paddr;
-	ptr->srwx = 7;
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
+		R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -154,7 +155,7 @@ static RList* sections(RBinFile *arch) {
 	strcpy (ptr->name, "header");
 	ptr->vsize = ptr->size = sizeof (PebbleAppInfo);
 	ptr->vaddr = ptr->paddr = 0;
-	ptr->srwx = 4;
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 	r_list_append (ret, ptr);
 
 	return ret;

--- a/libr/bin/p/bin_rar.c
+++ b/libr/bin/p/bin_rar.c
@@ -106,7 +106,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->size = ptr->vsize = 0x9a;
 	ptr->paddr = 0;
 	ptr->vaddr = ptr->paddr;
-	ptr->srwx = 4; // r--
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 	r_list_append (ret, ptr);
 
 	/* rarvm code */
@@ -115,7 +115,7 @@ static RList* sections(RBinFile *arch) {
 	strncpy (ptr->name, "rarvm", R_BIN_SIZEOF_STRINGS);
 	ptr->vsize = ptr->size = sz - 0x9a;
 	ptr->vaddr = ptr->paddr = 0x9a;
-	ptr->srwx = 5; // rw-
+	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -106,15 +106,15 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = sections[i].vsize;
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr;
-		ptr->srwx = 0;
+		ptr->srwx = R_BIN_SCN_MAP;
 		if (R_BIN_TE_SCN_IS_EXECUTABLE (sections[i].flags))
-			ptr->srwx |= 0x1;
+			ptr->srwx |= R_BIN_SCN_EXECUTABLE;
 		if (R_BIN_TE_SCN_IS_WRITABLE (sections[i].flags))
-			ptr->srwx |= 0x2;
+			ptr->srwx |= R_BIN_SCN_WRITABLE;
 		if (R_BIN_TE_SCN_IS_READABLE (sections[i].flags))
-			ptr->srwx |= 0x4;
+			ptr->srwx |= R_BIN_SCN_SHAREABLE;
 		if (R_BIN_TE_SCN_IS_SHAREABLE (sections[i].flags))
-			ptr->srwx |= 0x8;
+			ptr->srwx |= R_BIN_SCN_SHAREABLE;
 		/* All TE files have _TEXT_RE section, which is 16-bit, because of
 		 * CPU start in this mode */
 		if (!strncmp(ptr->name, "_TEXT_RE", 8))

--- a/libr/bin/p/bin_xbe.c
+++ b/libr/bin/p/bin_xbe.c
@@ -150,11 +150,11 @@ static RList* sections(RBinFile *arch) {
 		item->size  = sect[i].size;
 		item->vsize = sect[i].vsize;
 
-		item->srwx |= 4;
+		item->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 		if (sect[i].flags & SECT_FLAG_X)
-			item->srwx |= 1;
+			item->srwx |= R_BIN_SCN_EXECUTABLE;
 		if (sect[i].flags & SECT_FLAG_W)
-			item->srwx |= 2;
+			item->srwx |= R_BIN_SCN_WRITABLE;
 		r_list_append (ret, item);
 	}
 	free (sect);

--- a/libr/core/cmd_section.c
+++ b/libr/core/cmd_section.c
@@ -232,12 +232,11 @@ static int cmd_section(void *data, const char *input) {
 		}
 		break;
 	case '\0':
-		r_io_section_list (core->io, core->offset, 0);
+		r_io_section_list (core->io, core->offset, R_FALSE);
 		break;
 	case '*':
-		r_io_section_list (core->io, core->offset, 1);
+		r_io_section_list (core->io, core->offset, R_TRUE);
 		break;
 	}
 	return 0;
 }
-

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -17,10 +17,11 @@ extern "C" {
 
 R_LIB_VERSION_HEADER (r_bin);
 
-#define R_BIN_SCN_EXECUTABLE 0x1
-#define R_BIN_SCN_WRITABLE   0x2
-#define R_BIN_SCN_READABLE   0x4
-#define R_BIN_SCN_SHAREABLE  0x8
+#define R_BIN_SCN_EXECUTABLE (1 << 0)
+#define R_BIN_SCN_WRITABLE   (1 << 1)
+#define R_BIN_SCN_READABLE   (1 << 2)
+#define R_BIN_SCN_SHAREABLE  (1 << 3)
+#define R_BIN_SCN_MAP        (1 << 4)
 
 #define R_BIN_DBG_STRIPPED 0x01
 #define R_BIN_DBG_STATIC   0x02

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -9,10 +9,12 @@
 extern "C" {
 #endif
 
-#define R_IO_READ  4
-#define R_IO_WRITE 2
-#define R_IO_EXEC  1
-#define R_IO_RW R_IO_READ | R_IO_WRITE
+/* these should be equals to R_BIN_SCN_* permissions */
+#define R_IO_EXEC  (1 << 0)
+#define R_IO_WRITE (1 << 1)
+#define R_IO_READ  (1 << 2)
+#define R_IO_MAP   (1 << 4)
+#define R_IO_RW    (R_IO_READ | R_IO_WRITE)
 
 #define R_IO_SEEK_SET 0
 #define R_IO_SEEK_CUR 1

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -212,7 +212,6 @@ R_API RIOSection *r_io_section_vget(RIO *io, ut64 vaddr) {
 	RListIter *iter;
 	RIOSection *s;
 	r_list_foreach (io->sections, iter, s) {
-		//if (!s->vaddr) continue;
 		if (vaddr >= s->vaddr && vaddr < s->vaddr + s->vsize)
 			return s;
 	}
@@ -223,8 +222,7 @@ R_API RIOSection *r_io_section_mget(RIO *io, ut64 maddr) {
 	RIOSection *s;
 	RListIter *iter;
 	r_list_foreach (io->sections, iter, s) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		if ((maddr >= s->offset && maddr < (s->offset + s->size)))
 			return s;
 	}
@@ -255,8 +253,7 @@ R_API int r_io_section_overlaps(RIO *io, RIOSection *s) {
 	RIOSection *s2;
 
 	r_list_foreach (io->sections, iter, s2) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		if (s != s2) {
 			if (s->offset >= s2->offset) {
 				if (s2->offset+s2->size < s->offset)
@@ -277,8 +274,7 @@ R_API ut64 r_io_section_vaddr_to_offset(RIO *io, ut64 vaddr) {
 	RIOSection *s;
 
 	r_list_foreach (io->sections, iter, s) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		if (vaddr >= s->vaddr && vaddr < s->vaddr + s->vsize) {
 			/* XXX: Do we need this hack?
 			if (s->vaddr == 0) // hack
@@ -325,8 +321,7 @@ R_API ut64 r_io_section_next(RIO *io, ut64 o) {
 
 	r_list_foreach (io->sections, iter, s) {
 		ut64 addr = s->vaddr;
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		if (o < addr) {
 			if (newsec) {
 				if (addr<newsec)
@@ -359,8 +354,7 @@ R_API RList *r_io_section_get_in_paddr_range(RIO *io, ut64 addr, ut64 endaddr) {
 	RList *sections = r_list_new ();
 	ut64 sec_from, sec_to;
 	r_list_foreach (io->sections, iter, s) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		sec_from = s->offset;
 		sec_to = sec_from + s->size;
 		if (sec_from <= addr && addr < sec_to) r_list_append (sections, s);
@@ -376,8 +370,7 @@ R_API RList *r_io_section_get_in_vaddr_range(RIO *io, ut64 addr, ut64 endaddr) {
 	RList *sections = r_list_new ();
 	ut64 sec_from, sec_to;
 	r_list_foreach (io->sections, iter, s) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		sec_from = s->vaddr;
 		sec_to = sec_from + s->vsize;
 		if (sec_from <= addr && addr < sec_to) r_list_append(sections, s);
@@ -392,8 +385,7 @@ R_API RIOSection * r_io_section_get_first_in_paddr_range(RIO *io, ut64 addr, ut6
 	RListIter *iter;
 	ut64 sec_from, sec_to;
 	r_list_foreach (io->sections, iter, s) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		sec_to = s->offset + s->size;
 		sec_from = s->offset;
 		if (sec_from <= addr && addr < sec_to) break;
@@ -410,8 +402,7 @@ R_API RIOSection * r_io_section_get_first_in_vaddr_range(RIO *io, ut64 addr, ut6
 	RListIter *iter;
 	ut64 sec_from, sec_to;
 	r_list_foreach (io->sections, iter, s) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		sec_to = s->vaddr + s->vsize;
 		sec_from = s->vaddr;
 		if (sec_from <= addr && addr < sec_to) break;
@@ -447,8 +438,7 @@ R_API RIOSection *r_io_section_getv_bin_id(RIO *io, ut64 vaddr, ut32 bin_id) {
 	RListIter *iter;
 	RIOSection *s;
 	r_list_foreach (io->sections, iter, s) {
-		if (!s->vaddr)
-			continue;
+		if (!(s->rwx & R_IO_MAP)) continue;
 		if (s->bin_id != bin_id) continue;
 		if (vaddr >= s->vaddr && vaddr < s->vaddr + s->vsize)
 			return s;

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -174,26 +174,45 @@ R_API int r_str_binstr2bin(const char *str, ut8 *out, int outlen) {
 R_API int r_str_rwx(const char *str) {
 	int ret = atoi (str);
 	if (!ret) {
-		ret |= strchr (str, 'r')?4:0;
-		ret |= strchr (str, 'w')?2:0;
-		ret |= strchr (str, 'x')?1:0;
+		ret |= strchr (str, 'm') ? 16 : 0;
+		ret |= strchr (str, 'r') ? 4 : 0;
+		ret |= strchr (str, 'w') ? 2 : 0;
+		ret |= strchr (str, 'x') ? 1 : 0;
 	}
 	return ret;
 }
 
 R_API const char *r_str_rwx_i(int rwx) {
-	static const char *rwxstr[16] = {
-		[0] = "---",
-		[1] = "--x",
-		[2] = "-w-",
-		[3] = "-wx",
-		[4] = "r--",
-		[5] = "r-x",
-		[6] = "rw-",
-		[7] = "rwx",
+	static const char *rwxstr[24] = {
+		[0] = "----",
+		[1] = "--x-",
+		[2] = "-w--",
+		[3] = "-wx-",
+		[4] = "r---",
+		[5] = "r-x-",
+		[6] = "rw--",
+		[7] = "rwx-",
+
+		[8] =  "----",
+		[9] =  "--x-",
+		[10] = "-w--",
+		[11] = "-wx-",
+		[12] = "r---",
+		[13] = "r-x-",
+		[14] = "rw--",
+		[15] = "rwx-",
+
+		[16] = "---m",
+		[17] = "--xm",
+		[18] = "-w-m",
+		[19] = "-wxm",
+		[20] = "r--m",
+		[21] = "r-xm",
+		[22] = "rw-m",
+		[23] = "rwxm",
 		/* ... */
 	};
-	return rwxstr[rwx&7]; // 15 for srwx
+	return rwxstr[rwx % 24]; // 15 for srwx
 }
 
 R_API const char *r_str_bool(int b) {

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -2569,7 +2569,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "constant_pool");
 			section->size = bin->cp_size;
 			section->paddr = bin->cp_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 			r_list_append (sections, section);
 		}
 		section = NULL;
@@ -2580,7 +2580,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "fields");
 			section->size = bin->fields_size;
 			section->paddr = bin->fields_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 			r_list_append (sections, section);
 			section = NULL;
 			r_list_foreach (bin->fields_list, iter, fm_type) {
@@ -2590,7 +2590,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 					snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
 					section->paddr = fm_type->attr_offset + baddr;
-					section->srwx = R_BIN_SCN_READABLE;
+					section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 					r_list_append (sections, section);
 				}
 			}
@@ -2602,7 +2602,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "methods");
 			section->size = bin->methods_size;
 			section->paddr = bin->methods_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
 			r_list_append (sections, section);
 			section = NULL;
 			r_list_foreach (bin->methods_list, iter, fm_type) {
@@ -2612,7 +2612,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 					snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
 					section->paddr = fm_type->attr_offset + baddr;
-					section->srwx = R_BIN_SCN_READABLE;
+					section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 					r_list_append (sections, section);
 				}
 			}
@@ -2624,7 +2624,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "interfaces");
 			section->size = bin->interfaces_size;
 			section->paddr = bin->interfaces_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 			r_list_append (sections, section);
 		}
 		section = NULL;
@@ -2635,7 +2635,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "attributes");
 			section->size = bin->attrs_size;
 			section->paddr = bin->attrs_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 			r_list_append (sections, section);
 		}
 		section = NULL;


### PR DESCRIPTION
As discussed, sections with vaddr == 0 can exist and to check whether a section is really mapped by IO or not we can't use the vaddr. So I introduced a new flag R_BIN_SCN_MAP and R_IO_MAP that can be used together with R_BIN_SCN_READABLE/WRITABLE/ETC. and R_IO_READ/WRITE/EXEC.
Each binary plugin choose which sections need to be mapped and mark them as R_BIN_SCN_MAP. This flag is later passed to the RIOSection and it's used to understand if a section has to be considered mapped or not.

NOTES: 
* rwx and srwx fields in RIOSection and RBinSection have been renamed to flags because they can contain not only strictly permission things.
* ```S``` and other similar commands will now show if a section is mapped or not. The format will be ```rwxm``` instead of ```rwx```

tests: https://github.com/radare/radare2-regressions/pull/214