### PR TITLE
rarun2 man page + clearenv fcn

### DIFF
--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -624,6 +624,7 @@ R_API int r_sys_sleep(int secs);
 R_API int r_sys_usleep(int usecs);
 R_API char *r_sys_getenv(const char *key);
 R_API int r_sys_setenv(const char *key, const char *value);
+R_API int r_sys_clearenv(void);
 R_API char *r_sys_whoami (char *buf);
 R_API char *r_sys_getdir(void);
 R_API int r_sys_chdir(const char *s);

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -50,6 +50,7 @@ R_API void r_run_reset(RRunProfile *p) {
 	p->_aslr = -1;
 }
 
+
 R_API int r_run_parse(RRunProfile *pf, const char *profile) {
 	char *p, *o, *str = strdup (profile);
 	for (o = p = str; (o = strchr (p, '\n')); p = o) {
@@ -284,6 +285,8 @@ R_API int r_run_parseline (RRunProfile *p, char *b) {
 			*v++ = 0;
 			r_sys_setenv (e, v);
 		}
+	} else if (!strcmp(b, "clearenv")) {
+		r_sys_clearenv ();
 	}
 	if (must_free == R_TRUE)
 		free (e);
@@ -304,6 +307,7 @@ R_API const char *r_run_help() {
 	"# aslr=no\n"
 	"setenv=FOO=BAR\n"
 	"# unsetenv=FOO\n"
+	"# clearenv=true"
 	"# envfile=environ.txt\n"
 	"timeout=3\n"
 	"# connect=localhost:8080\n"

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -31,6 +31,9 @@ int proc_pidpath(int pid, void * buffer, ut32 buffersize);
 # include <sys/stat.h>
 # include <errno.h>
 # include <signal.h>
+# include <unistd.h>
+extern char **environ;
+
 #ifdef __HAIKU__
 # define Sleep sleep
 #endif
@@ -183,6 +186,21 @@ R_API int r_sys_usleep(int usecs) {
 	// w32 api uses milliseconds
 	usecs /= 1000;
 	Sleep (usecs); // W32
+	return 0;
+#endif
+}
+
+R_API int r_sys_clearenv(void) {
+#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+	if (environ == NULL) {
+		return 0;
+	}
+	while (*environ != NULL) {
+		*environ++ = NULL;
+	}
+	return 0;
+#else
+#warning r_sys_clearenv : unimplemented for this platform
 	return 0;
 #endif
 }

--- a/man/rarun2.1
+++ b/man/rarun2.1
@@ -27,7 +27,7 @@ change directory before executing the program
 .It Ar chroot
 run the program in chroot. requires some previous setup
 .It Ar core
-set no limit the core file size 
+set no limit the core file size
 .It Ar connect
 connect stdin/stdout/stderr to a socket
 .It Ar envfile
@@ -75,7 +75,9 @@ execute the given command
 .It Ar timeout
 set a timeout
 .It Ar unsetenv
-unset the whole environnement
+unset one environment variable
+.It Ar clearenv
+unset the whole environment
 .El
 .Sh EXAMPLES
 Sample rarun2 script
@@ -86,6 +88,11 @@ Sample rarun2 script
   arg0=10
   stdin=foo.txt
   chdir=/tmp
+  clearenv=true
+  setenv=EGG=eggsy
+  setenv=NOFUN=nogames
+  unsetenv=NOFUN
+  # EGG will be the only env variable
   #chroot=.
   ./foo.rr2
 .Pp
@@ -100,7 +107,11 @@ Debugging a program redirecting io to another terminal
   $ tty ; clear ; sleep 999999
   /dev/ttyS010
   ## in another terminal run r2
-  $ r2 \-d rarun2 program=/bin/ls stdio=/dev/ttys010
+  $ r2 \-d /bin/ls -e dbg.profile=foo.rr2
+  $ cat foo.rr2
+  #!/usr/bin/rarun2
+  stdio=/dev/ttys010
+
 .Sh SEE ALSO
 .Pp
 .Xr radare2(1) ,


### PR DESCRIPTION
fix unsetenv wrong description
create clearenv keyword to erase all the env var
add some example for environment variable
fix r2 use of rarun2 example
