### PR TITLE
Some memory leak fixes

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -40,6 +40,7 @@ R_API RBreakpoint *r_bp_new() {
 R_API RBreakpoint *r_bp_free(RBreakpoint *bp) {
 	r_list_free (bp->bps);
 	r_list_free (bp->plugins);
+	r_list_free (bp->traces);
 	free (bp);
 	return NULL;
 }

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -36,6 +36,7 @@ R_API RCmd *r_cmd_free(RCmd *cmd) {
 	int i;
 	if (!cmd) return NULL;
 	r_cmd_alias_free (cmd);
+	r_cmd_macro_free (&cmd->macro);
 	// dinitialize plugin commands
 	r_core_plugin_deinit(cmd);
 	r_list_free (cmd->plist);
@@ -248,6 +249,11 @@ R_API void r_cmd_macro_init(RCmdMacro *mac) {
 	mac->user = NULL;
 	mac->cmd = NULL;
 	mac->macros = r_list_new ();
+}
+
+R_API void r_cmd_macro_free(RCmdMacro *mac) {
+	r_list_free (mac->macros);
+	mac->macros = NULL;
 }
 
 // XXX add support single line function definitions

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -110,11 +110,13 @@ R_API RDebug *r_debug_free(RDebug *dbg) {
 	//r_reg_free(&dbg->reg);
 	r_list_free (dbg->snaps);
 	r_list_free (dbg->maps);
+	r_list_free (dbg->maps_user);
 	sdb_free (dbg->sgnls);
 	r_tree_free (dbg->tree);
 	sdb_foreach (dbg->tracenodes, (SdbForeachCallback)free_tracenodes_entry, dbg);
 	sdb_free (dbg->tracenodes);
 	//r_debug_plugin_free();
+	free (dbg->btalgo);
 	r_debug_trace_free (dbg);
 	free (dbg);
 	return NULL;

--- a/libr/debug/plugin.c
+++ b/libr/debug/plugin.c
@@ -38,8 +38,10 @@ R_API int r_debug_use(RDebug *dbg, const char *str) {
 			eprintf ("Cannot retrieve reg profile from debug plugin (%s)\n", dbg->h->name);
 		} else {
 			r_reg_set_profile_string (dbg->reg, p);
-			if (dbg->anal)
+			if (dbg->anal) {
+				r_reg_free(dbg->anal->reg);
 				dbg->anal->reg = dbg->reg;
+			}
 			if (dbg->h->init)
 				dbg->h->init (dbg);
 			r_reg_set_profile_string (dbg->reg, p);

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -116,6 +116,7 @@ R_API char **r_cmd_alias_keys(RCmd *cmd, int *sz);
 R_API int r_cmd_alias_set (RCmd *cmd, const char *k, const char *v, int remote);
 R_API char *r_cmd_alias_get (RCmd *cmd, const char *k, int remote);
 R_API void r_cmd_alias_free (RCmd *cmd);
+R_API void r_cmd_macro_free (RCmdMacro *mac);
 
 #ifdef __cplusplus
 }

--- a/libr/lang/lang.c
+++ b/libr/lang/lang.c
@@ -96,7 +96,7 @@ R_API void r_lang_undef(RLang *lang, const char *name) {
 			}
 		}
 	} else {
-		r_list_purge (lang->defs);
+		r_list_free (lang->defs);
 		lang->defs = NULL;
 	}
 }

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -86,7 +86,7 @@ R_API void r_reg_free_internal(RReg *reg) {
 		}
 	}
 	for (i = 0; i<R_REG_TYPE_LAST; i++) {
-		r_list_purge (reg->regset[i].regs);
+		r_list_free (reg->regset[i].regs);
 		reg->regset[i].regs = r_list_newf ((RListFree)r_reg_item_free);
 	}
 	reg->size = 0;
@@ -98,11 +98,14 @@ R_API void r_reg_free(RReg *reg) {
 	if (!reg) 
 		return;
 
-	for (i = 0; i < R_REG_TYPE_LAST; i++) {
-		r_list_purge (reg->regset[i].pool);
-		reg->regset[i].pool = NULL;
-	}
 	r_reg_free_internal (reg);
+	for (i = 0; i < R_REG_TYPE_LAST; i++) {
+		r_list_free (reg->regset[i].pool);
+		r_list_free (reg->regset[i].regs);
+		reg->regset[i].pool = NULL;
+		reg->regset[i].regs = NULL;
+		reg->regset[i].arena = NULL;
+	}
 	free (reg);
 }
 

--- a/libr/syscall/syscall.c
+++ b/libr/syscall/syscall.c
@@ -24,6 +24,7 @@ R_API RSyscall* r_syscall_new() {
 
 R_API void r_syscall_free(RSyscall *s) {
 	sdb_free (s->db);
+	free(s->os);
 	memset (s, 0, sizeof (RSyscall));
 	free (s);
 }

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -163,9 +163,8 @@ R_API RLibHandler *r_lib_get_handler(RLib *lib, int type) {
 
 R_API R_API int r_lib_close(RLib *lib, const char *file) {
 	RLibPlugin *p;
-	RListIter *iter;
-	/* No _safe loop necessary because we return immediately after the delete. */
-	r_list_foreach (lib->plugins, iter, p) {
+	RListIter *iter, *iter_tmp;
+	r_list_foreach_safe (lib->plugins, iter, iter_tmp, p) {
 		if ((file==NULL || (!strcmp (file, p->file)))) {
 			int ret = 0;
 			if (p->handler && p->handler->constructor) {
@@ -174,8 +173,13 @@ R_API R_API int r_lib_close(RLib *lib, const char *file) {
 			}
 			free (p->file);
 			r_list_delete (lib->plugins, iter);
-			return ret;
+			if (file != NULL) {
+				return ret;
+			}
 		}
+	}
+	if (file == NULL) {
+		return 0;
 	}
 	// delete similar plugin name
 	r_list_foreach (lib->plugins, iter, p) {


### PR DESCRIPTION
A few hours of work yesterday. Pull requesting since i'm not doing much progress on this stuff today.

Just dealing with the simplest use case mentioned in #1222, filtering to definite leaks only.

    valgrind --leak-check=full --show-leak-kinds=definite r2 =true

Before:

    definitely lost: 64,328 bytes in 672 blocks

After:

    definitely lost: 62,440 bytes in 600 blocks