### PR TITLE
core/graph: improve switching between visual and graph mode

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -832,16 +832,29 @@ fin:
 	return rc;
 }
 
-/* seek basic block that contains address addr or just addr if there's no such
- * basic block */
-R_API int r_core_anal_bb_seek(RCore *core, ut64 addr) {
+/* returns the address of the basic block that contains addr or UT64_MAX if
+ * there is no such basic block */
+R_API ut64 r_core_anal_get_bbaddr(RCore *core, ut64 addr) {
 	RAnalBlock *bbi;
 	RAnalFunction *fcni;
 	RListIter *iter, *iter2;
-	r_list_foreach (core->anal->fcns, iter, fcni)
-		r_list_foreach (fcni->bbs, iter2, bbi)
-			if (addr >= bbi->addr && addr < bbi->addr+bbi->size)
-				return r_core_seek (core, bbi->addr, R_FALSE);
+	r_list_foreach (core->anal->fcns, iter, fcni) {
+		r_list_foreach (fcni->bbs, iter2, bbi) {
+			if (addr >= bbi->addr && addr < bbi->addr+bbi->size) {
+				return bbi->addr;
+			}
+		}
+	}
+	return UT64_MAX;
+}
+
+/* seek basic block that contains address addr or just addr if there's no such
+ * basic block */
+R_API int r_core_anal_bb_seek(RCore *core, ut64 addr) {
+	ut64 bbaddr = r_core_anal_get_bbaddr (core, addr);
+	if (bbaddr != UT64_MAX) {
+		addr = bbaddr;
+	}
 	return r_core_seek (core, addr, R_FALSE);
 }
 

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -301,6 +301,7 @@ R_API int r_core_anal_data (RCore *core, ut64 addr, int count, int depth);
 R_API void r_core_anal_coderefs(RCore *core, ut64 addr, int gv);
 R_API int r_core_anal_refs(RCore *core, const char *input);
 R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head);
+R_API ut64 r_core_anal_get_bbaddr(RCore *core, ut64 addr);
 R_API int r_core_anal_bb_seek(RCore *core, ut64 addr);
 R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth);
 R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump);


### PR DESCRIPTION
Seek to the selected graph node when exiting from the graph mode and
select the node that contains the current offset on entering.

* core/anal: add r_core_anal_getbbaddr API

should fix #3062 