### PR TITLE
Fix for #3285 (Increment pc before executing esil op)

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -891,12 +891,11 @@ SETL/SETNGE
 			if (a->decode) {
 				char* arg = getarg (&gop, 0, 0, NULL);
 				esilprintf (op,
-						"%d,%s,+,"
+						"%s,"
 						"%d,%s,-=,%s,"
 						"=[],"
 						"%s,%s,=",
-						op->size, pc,
-						rs, sp, sp, arg, pc);
+						pc, rs, sp, sp, arg, pc);
 				free (arg);
 			}
 			break;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1379,6 +1379,10 @@ eprintf ("ESIL %s\n", op.esil);
 eprintf ("EMULATE %s\n", R_STRBUF_SAFEGET (&op.esil));
 sleep (1);
 #endif
+	// Always increment pc register before executing op.esil
+	if (op.size<1) op.size = 1; // avoid inverted stepping
+	r_reg_setv (core->anal->reg, name, addr + op.size);
+
 	if (ret) {
 		//r_anal_esil_eval (core->anal, input+2);
 		RAnalEsil *esil = core->anal->esil;
@@ -1389,7 +1393,6 @@ sleep (1);
 		r_anal_esil_dumpstack (esil);
 		r_anal_esil_stack_free (esil);
 	}
-	ut64 newaddr = r_reg_getv (core->anal->reg, name);
 
 	ut64 follow = r_config_get_i (core->config, "dbg.follow");
 	if (follow>0) {
@@ -1397,11 +1400,7 @@ sleep (1);
 		if ((pc<core->offset) || (pc > (core->offset+follow)))
 			r_core_cmd0 (core, "sr pc");
 	}
-	if (addr == newaddr) {
-		if (op.size<1)
-			op.size = 1; // avoid inverted stepping
-		r_reg_setv (core->anal->reg, name, addr + op.size);
-	}
+
 	if (core->dbg->trace->enabled) {
 		RReg *reg = core->dbg->reg;
 		core->dbg->reg = core->anal->reg;


### PR DESCRIPTION
- Increments pc before evaluating the esil op, instead of doing it after
- Fixes CALL instruction at anal_x86_cs.c

Other architectures supporting ESIL, should be also reviewed before merging this PR in order to check if they require further fixes such as the `call` fix for `x86`.