### PR TITLE
Syncing debug maps before checking validity of an breakpoint address

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2268,7 +2268,7 @@ R_API void r_core_cmd_repeat(RCore *core, int next) {
 		switch (core->lastcmd[1]) {
 		case 's':
 		case 'c':
-			r_core_cmd0 (core, "sr pc && pd 1");
+			r_core_cmd0 (core, "sr pc ; pd 1");
 		}
 		break;
 	case 'p': // print

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1476,6 +1476,7 @@ static int validAddress(RCore *core, ut64 addr) {
 	if (!r_config_get_i (core->config, "dbg.bpinmaps")) {
 		return core->num->value = 1;
 	}
+	r_debug_map_sync (core->dbg);
 	r_list_foreach (core->dbg->maps, iter, map) {
 		if (addr >= map->addr && addr < map->addr_end) {
 			return core->num->value = 1;


### PR DESCRIPTION
When memory maps get updated, radare does not always keep track of memory maps properly, e.g. when checking whether a breakpoint is at an valid address or not. 

This is caused by not running "r_debug_map_sync" before validating a breakpoint address. When explicitely forcing an sync (e.g. by running dm*) setting the breakpoint works.

All tests performed with 32bit windows version of radare (crosscompiled using i686-w64-mingw32-gcc).

```
Attached debugger to pid = 4776, tid = 1140
Debugging pid = 4776, tid = 1140 now
Try: '=!pid'
[0x776c01b4]> dc
(4776) Loading library at 776B0000 (C:\Windows\SysWOW64\ntdll.dll)
...
(4776) Loading library at 73320000 (C:\Windows\SysWOW64\winmm.dll)
[0x7775129c]> db 0x46d485
Can't place a breakpoint here. No mapped memory           <--- This is wrong because no r_debug_map_sync was run yet
[0x7775129c]> dm*    <-- Force sync by showing maps
f map.****.exe.____ 0x00001000 0x00400000
f map.****.exe___UPX0.____ 0x0003d000 0x00401000
f map.****.exe___UPX1. 0x00030000 0x0043e000
f map.****.exe___.rsrc.____ 0x00006000 0x0046e000
f map.ntdll.dll.____ 0x00010000 0x776b0000
...
f map.WINMM.dll___.reloc.m___ 0x00002264 0x7334f000
[0x7775129c]> db 0x46d485
[0x7775129c]>  .. worked now ..
```

I now added a sync right before the check is done.

Also fixed broken command in r_core_cmd_repeat as it seems there is no "&&" in radare commands?!