### PR TITLE
Fixed type issue in mingw64 build.

### DIFF
--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -6,7 +6,7 @@
 #include <tchar.h>
 
 #ifndef NTSTATUS
-#define NTSTATUS
+#define NTSTATUS DWORD
 #endif
 #ifndef WINAPI
 #define WINAPI


### PR DESCRIPTION
mingw64 build fails because of an complation error:

```
make[4]: Entering directory '/var/samba/workspace/radare2/source/libr/debug'
x86_64-w64-mingw32-gcc -c   -MD -D__WINDOWS__=1  -MD -D__WINDOWS__=1    -g -Wall -D__WINDOWS__=1 -DCORELIB -Ip/libbfwbf/include -I/var/samba/workspace/radare2/source/libr/../shlr/gdb/include/ -Ip/librapwrap/include -I/var/samba/workspace/radare2/source/libr/../shlr/wind/ -I/var/samba/workspace/radare2/source/libr/include -DGIT_TAP=\"0.9.9-922-gedd6c18\" -o p/debug_native.o p/debug_native.c
In file included from p/debug_native.c:35:0:
p/native/w32.c:102:13: warning: ‘DebugBreakProcess’ redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
 BOOL WINAPI DebugBreakProcess(
             ^
p/native/w32.c:172:26: warning: type defaults to ‘int’ in declaration of ‘w32_ntquerysysteminformation’ [-Wimplicit-int]
 static NTSTATUS WINAPI (*w32_ntquerysysteminformation)(ULONG, PVOID, ULONG, PULONG) = NULL;
                          ^
p/native/w32.c:173:26: warning: type defaults to ‘int’ in declaration of ‘w32_ntduplicateobject’ [-Wimplicit-int]
 static NTSTATUS WINAPI (*w32_ntduplicateobject)(HANDLE, HANDLE, HANDLE, PHANDLE, ACCESS_MASK, ULONG, ULONG) =NULL;
                          ^
p/native/w32.c:174:26: warning: type defaults to ‘int’ in declaration of ‘w32_ntqueryobject’ [-Wimplicit-int]
 static NTSTATUS WINAPI (*w32_ntqueryobject)(HANDLE, ULONG, PVOID, ULONG, PULONG) = NULL;
                          ^
p/native/w32.c: In function ‘w32_dbg_init’:
p/native/w32.c:266:52: error: expected expression before ‘)’ token
  w32_ntquerysysteminformation = (NTSTATUS WINAPI (*)(ULONG, PVOID, ULONG, PULONG))
                                                    ^
```

NTSTATUS needs to be defined as an 32 bit type. Strange enough mingw64 seems to have no definition for it, while mingw32 seems to have.