### PR TITLE
CODINGSTYLE: move doc/syntax.md in the root directory and rename it

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -12,7 +12,7 @@ default:
 }
 ```
 
-* Lines should be at most 78 chars
+* Lines should be at most 78 chars. A tab is considered as 8 chars.
 
 * Braces open on the same line as the for/while/if/else/function/etc. Closing
   braces are put on a line of their own, except in the else of an if statement

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -9,7 +9,9 @@ CODE STYLE
 In order to contribute with patches or plugins we encourage you to
 use the same coding style as the rest of the code base.
 
-You may find some notes on this topic in doc/syntax and doc/vim
+You may find some notes on this topic in
+[CODINGSTYLE.md](https://github.com/radare/radare2/blob/master/CODINGSTYLE.md)
+and doc/vim
 
 MODULES
 -------

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You could also checkout the [radare2 book](https://radare.gitbooks.io/radare2boo
 
 # Coding Style
 
-Look at [doc/syntax.md](https://github.com/radare/radare2/blob/master/doc/syntax.md).
+Look at [CODINGSTYLE.md](https://github.com/radare/radare2/blob/master/CODINGSTYLE.md).
 
 # Webserver
 
@@ -135,8 +135,8 @@ html/js interface that sends ajax queries to the core and
 aims to implement an usable UI for phones, tablets and desktops.
 
     $ r2 -c=H /bin/ls
-    
-To use the webserver on Windows, you require a cmd instance 
+
+To use the webserver on Windows, you require a cmd instance
 with administrator rights. To start the webserver use command
 in the project root.
 


### PR DESCRIPTION
* CODINGSTYLE: specify that tabs are considered as 8 chars