### PR TITLE
esil x86: fix for rip relative references no longer required

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -88,13 +88,8 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop) {
 		{
 		const char *base = cs_reg_name (handle, op.mem.base);
 		const char *index = cs_reg_name (handle, op.mem.index);
-		int riprelative = (op.mem.base == X86_REG_RIP);
 		int scale = op.mem.scale;
 		st64 disp = op.mem.disp;
-		if (riprelative) {
-			// fix rip relative references
-			disp += op.size;
-		}
 		if (scale>1) {
 			if (set>1) {
 				if (base) {


### PR DESCRIPTION
The fix required for relative rip references is no longer required since 371ebd35d884796b08251e38770c8cdc790f3045 as the pc is now incremented prior to evaluating the ESIL expression.