### PR TITLE
Improve Darwin debugging support

### DIFF
--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -266,7 +266,7 @@ int xnu_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 #elif __arm__ || __arm64__ || __aarch64__
 		arm_unified_thread_state_t state;
 		R_DEBUG_REG_T *regs = &state;
-		ret = THREAD_GET_STATE (ARM_UNIFIED_THREAD_STATE);
+		ret = THREAD_GET_STATE (R_DEBUG_STATE_T);
 		if (ret == KERN_SUCCESS) {
 			if (state.ash.flavor == ARM_THREAD_STATE64) {
 				memcpy (buf, &state.ts_64,

--- a/libr/debug/p/native/xnu/xnu_debug.h
+++ b/libr/debug/p/native/xnu/xnu_debug.h
@@ -73,39 +73,15 @@ int ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
 #define R_DEBUG_STATE_T PPC_THREAD_STATE
 #define R_DEBUG_STATE_SZ PPC_THREAD_STATE_COUNT
 
-// iPhone > 5
-#elif __aarch64
-#	include <mach/aarch64/thread_status.h>
-#	ifndef AARCH64_THREAD_STATE
-#		define AARCH64_THREAD_STATE 1
-#	endif
-#	ifndef AARCH64_THREAD_STATE64
-#		define AARCH64_THREAD_STATE64 6
-#	endif
-#define R_DEBUG_REG_T aarch64_thread_state_t
-#define R_DEBUG_STATE_T AARCH64_THREAD_STATE
-#define R_DEBUG_STATE_SZ AARCH64_THREAD_STATE_COUNT
-
-// iPhone < 5
-#elif __arm
+// iPhone
+#elif __arm || __arm64 || __aarch64
 #	include <mach/arm/thread_status.h>
 #	ifndef ARM_THREAD_STATE
 #		define ARM_THREAD_STATE 1
 #	endif
-#ifndef ARM_THREAD_STATE64
-#	define ARM_THREAD_STATE64 6
-#endif
-#define R_DEBUG_REG_T arm_thread_state_t
-#define R_DEBUG_STATE_T ARM_THREAD_STATE
-#define R_DEBUG_STATE_SZ ARM_THREAD_STATE_COUNT
-#elif __arm64
-#	include <mach/arm/thread_status.h>
-#	ifndef ARM_THREAD_STATE
-#		define ARM_THREAD_STATE 1
+#	ifndef ARM_THREAD_STATE64
+#		define ARM_THREAD_STATE64 6
 #	endif
-#ifndef ARM_THREAD_STATE64
-#	define ARM_THREAD_STATE64 6
-#endif
 #define R_DEBUG_REG_T arm_unified_thread_state_t
 #define R_DEBUG_STATE_T ARM_UNIFIED_THREAD_STATE
 #define R_DEBUG_STATE_SZ ARM_UNIFIED_THREAD_STATE_COUNT


### PR DESCRIPTION
```
# ./radare2 -d /bin/ls
Success
pid: 5246
task: 2819
p/native/xnu/xnu_debug.c:87 ptrace (PT_ATTACH): Bad file descriptor
Attached debugger to pid = 5246, tid = 5246
Debugging pid = 5246, tid = 5246 now
Using BADDR 0x1000
bits 32
Attached debugger to pid = 5246, tid = 5246
PID=5246
[0x1fe91000]> dr
r0 = 0x00000000
r1 = 0x00000000
r2 = 0x00000000
r3 = 0x00000000
r4 = 0x00000000
r5 = 0x00000000
r6 = 0x00000000
r7 = 0x00000000
r8 = 0x00000000
r9 = 0x00000000
r10 = 0x00000000
r11 = 0x00000000
r12 = 0x00000000
r13 = 0x00128f64
r14 = 0x00000000
r15 = 0x1fe91000
cpsr = 0x00000010
[0x1fe91000]> dc
Application Support  Library  after  before  debugserver  frida-server-ios  radare2

==> Process finished

Child 5246 is dead
[0x1fe91000]>
```