### PR TITLE
Grep enhancements

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -375,7 +375,7 @@ R_API void r_cons_reset() {
 	I.grep.line = -1;
 	I.grep.str = NULL;
 	memset (I.grep.tokens, 0, R_CONS_GREP_TOKENS);
-	I.grep.columns_used = 0;
+	I.grep.tokens_used = 0;
 }
 
 R_API const char *r_cons_get_buffer() {
@@ -384,7 +384,7 @@ R_API const char *r_cons_get_buffer() {
 
 R_API void r_cons_filter() {
 	/* grep*/
-	if (I.grep.nstrings>0 || I.grep.columns_used || I.grep.line!=-1 || I.grep.less || I.grep.json)
+	if (I.grep.nstrings>0 || I.grep.tokens_used || I.grep.line!=-1 || I.grep.less || I.grep.json)
 		r_cons_grepbuf (I.buffer, I.buffer_len);
 	/* html */
 	/* TODO */

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -374,8 +374,8 @@ R_API void r_cons_reset() {
 	I.grep.nstrings = 0; // XXX
 	I.grep.line = -1;
 	I.grep.str = NULL;
-	I.grep.tokenfrom = 0;
-	I.grep.tokento = ST32_MAX;
+	memset (I.grep.tokens, 0, R_CONS_GREP_TOKENS);
+	I.grep.columns_used = 0;
 }
 
 R_API const char *r_cons_get_buffer() {
@@ -384,7 +384,7 @@ R_API const char *r_cons_get_buffer() {
 
 R_API void r_cons_filter() {
 	/* grep*/
-	if (I.grep.nstrings>0||I.grep.tokenfrom!=0||I.grep.tokento!=ST32_MAX||I.grep.line!=-1 || I.grep.less || I.grep.json)
+	if (I.grep.nstrings>0 || I.grep.columns_used || I.grep.line!=-1 || I.grep.less || I.grep.json)
 		r_cons_grepbuf (I.buffer, I.buffer_len);
 	/* html */
 	/* TODO */

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -44,18 +44,8 @@ R_API void r_cons_grep(const char *str) {
 		return;
 
 	cons = r_cons_singleton ();
-	cons->grep.str = NULL;
-	cons->grep.neg = 0;
-	cons->grep.amp = 0;
-	cons->grep.end = 0;
-	cons->grep.less = 0;
-	cons->grep.json = 0;
+	memset (&(cons->grep), 0, sizeof (cons->grep));
 	cons->grep.line = -1;
-	cons->grep.begin = 0;
-	cons->grep.counter = 0;
-	cons->grep.nstrings = 0;
-	memset (cons->grep.tokens, 0, R_CONS_GREP_TOKENS);
-	cons->grep.tokens_used = 0;
 
 	while (*str) {
 		switch (*str) {

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -8,8 +8,8 @@
 
 R_API void r_cons_grep_help() {
 	eprintf (
-"|Usage: [command]~[modifier][word,word][[column]][:line]\n"
-"| modifiers\n"
+"|Usage: [command]~[modifier][word,word][endmodifier][[column]][:line]\n"
+"| modifiers:\n"
 "|   &    all words must match to grep the line\n"
 "|   ^    words must be placed at the beginning of line\n"
 "|   !    negate grep\n"
@@ -17,10 +17,17 @@ R_API void r_cons_grep_help() {
 "|   ..   internal 'less'\n"
 "|   {}   json indentation\n"
 "|   {}.. less json indentation\n"
+"| endmodifiers:\n"
+"|   $    words must be placed at the end of line\n"
+"| column:\n"
+"|   [n]   show only column n\n"
+"|   [n-m] show column n to m\n"
+"|   [n-]  show all columns starting from column n\n"
 "| examples:\n"
-"|   i~:0   # show fist line of 'i' output\n"
-"|   pd~mov # disasm and grep for mov\n"
-"|   pi~[0] # show only opcode\n"
+"|   i~:0     # show fist line of 'i' output\n"
+"|   pd~mov   # disasm and grep for mov\n"
+"|   pi~[0]   # show only opcode\n"
+"|   i~0x400$ # show lines ending with 0x400\n"
 	);
 }
 

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -124,7 +124,7 @@ R_API void r_cons_grep(const char *str) {
 			case ']':  // fallthrough to handle ']' like ','
 			case ',':
 				for (; range_begin <= range_end; range_begin++) {
-					if (range_begin >= R_CONS_GREP_TOKENS || range_begin < 0) {
+					if (range_begin >= R_CONS_GREP_TOKENS) {
 						fail = 1;
 						break;
 					}

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -52,14 +52,14 @@ R_API void r_cons_grep(const char *str) {
 	while (*str) {
 		switch (*str) {
 		case '.':
-			if (str[1]=='.') {
+			if (str[1] == '.') {
 				cons->grep.less = 1;
 				return;
 			}
 			str++;
 			break;
 		case '{':
-			if (str[1]=='}') {
+			if (str[1] == '}') {
 				cons->grep.json = 1;
 				if (!strncmp (str, "{}..", 4))
 					cons->grep.less = 1;
@@ -72,7 +72,7 @@ R_API void r_cons_grep(const char *str) {
 		case '^': str++; cons->grep.begin = 1;  break;
 		case '!': str++; cons->grep.neg = 1; break;
 		case '?': str++; cons->grep.counter = 1;
-			if (*str=='?') {
+			if (*str == '?') {
 				r_cons_grep_help ();
 				return;
 			}
@@ -81,19 +81,19 @@ R_API void r_cons_grep(const char *str) {
 		}
 	} while_end:
 
-	len = strlen (str)-1;
+	len = strlen (str) - 1;
 	if (len > R_CONS_GREP_BUFSIZE - 1) {
 		eprintf("r_cons_grep: too long!\n");
 		return;
 	}
-	if (len>0 && str[len] == '?') {
+	if (len > 0 && str[len] == '?') {
 		cons->grep.counter = 1;
-		strncpy (buf, str, R_MIN (len, sizeof (buf)-1));
+		strncpy (buf, str, R_MIN (len, sizeof (buf) - 1));
 		buf[len]=0;
 		len--;
-	} else strncpy (buf, str, sizeof (buf)-1);
+	} else strncpy (buf, str, sizeof (buf) - 1);
 
-	if (len>1 && buf[len]=='$' && buf[len-1]!='\\') {
+	if (len > 1 && buf[len] == '$' && buf[len - 1] != '\\') {
 		cons->grep.end = 1;
 		buf[len] = 0;
 	}
@@ -101,23 +101,23 @@ R_API void r_cons_grep(const char *str) {
 	ptr3 = strchr (ptr, '['); // column number
 	if (ptr3) {
 		ptr3[0] = '\0';
-		cons->grep.tokenfrom = r_num_get (cons->num, ptr3+1);
-		ptr3 = strchr (ptr3+1, '-');
+		cons->grep.tokenfrom = r_num_get (cons->num, ptr3 + 1);
+		ptr3 = strchr (ptr3 + 1, '-');
 		if (ptr3) {
-			cons->grep.tokento = r_num_get (cons->num, ptr3+1);
+			cons->grep.tokento = r_num_get (cons->num, ptr3 + 1);
 			if (cons->grep.tokento == 0)
 				cons->grep.tokento = ST32_MAX;
 		} else cons->grep.tokento = cons->grep.tokenfrom;
-		if (cons->grep.tokenfrom<0)
+		if (cons->grep.tokenfrom < 0)
 			cons->grep.tokenfrom = 0;
-		if (cons->grep.tokento<0)
+		if (cons->grep.tokento < 0)
 			cons->grep.tokento = ST32_MAX;
 	}
 	ptr2 = strchr (ptr, ':'); // line number
 	if (ptr2) {
 		*ptr2 = '\0';
-		cons->grep.line = r_num_get (cons->num, ptr2+1);
-		if (cons->grep.line<0)
+		cons->grep.line = r_num_get (cons->num, ptr2 + 1);
+		if (cons->grep.line < 0)
 			cons->grep.line = -1;
 	}
 	free (cons->grep.str);
@@ -127,16 +127,16 @@ R_API void r_cons_grep(const char *str) {
 			optr = ptr;
 			ptr = strchr (ptr, ','); // grep keywords
 			if (ptr) *ptr++ = '\0';
-			wlen = strlen (optr);	
-			if (wlen==0) continue;
-			if (wlen>=R_CONS_GREP_WORD_SIZE-1) {
+			wlen = strlen (optr);
+			if (wlen == 0) continue;
+			if (wlen >= R_CONS_GREP_WORD_SIZE - 1) {
 				eprintf ("grep string too long\n");
 				continue;
 			}
 			strncpy (cons->grep.strings[cons->grep.nstrings],
-				optr, R_CONS_GREP_WORD_SIZE-1);
+				optr, R_CONS_GREP_WORD_SIZE - 1);
 			cons->grep.nstrings++;
-			if (cons->grep.nstrings>R_CONS_GREP_WORDS-1) {
+			if (cons->grep.nstrings > R_CONS_GREP_WORDS - 1) {
 				eprintf ("too many grep strings\n");
 				break;
 			}
@@ -165,7 +165,7 @@ R_API int r_cons_grepbuf(char *buf, int len) {
 		free (cons->buffer);
 		cons->buffer = out;
 		cons->buffer_len = strlen (out);
-		cons->buffer_sz = cons->buffer_len +1;
+		cons->buffer_sz = cons->buffer_len + 1;
 		cons->grep.json = 0;
 		if (cons->grep.less) {
 			cons->grep.less = 0;
@@ -185,21 +185,21 @@ R_API int r_cons_grepbuf(char *buf, int len) {
 		return 0;
 	}
 	if (!cons->buffer) {
-		cons->buffer_len = len+20;
+		cons->buffer_len = len + 20;
 		cons->buffer = malloc (cons->buffer_len);
 		cons->buffer[0] = 0;
 	}
 	out = tbuf = calloc (1, len);
 	tline = malloc (len);
 	cons->lines = 0;
-	while ((int)(size_t)(in-buf)<len) {
+	while ((int)(size_t)(in-buf) < len) {
 		p = strchr (in, '\n');
 		if (!p) {
 			free (tbuf);
 			free (tline);
 			return 0;
 		}
-		l = p-in;
+		l = p - in;
 		if (l > 0) {
 			memcpy (tline, in, l);
 			tl = r_str_ansi_filter (tline, NULL, NULL, l);
@@ -210,17 +210,17 @@ R_API int r_cons_grepbuf(char *buf, int len) {
 				if (cons->grep.line == -1 ||
 					(cons->grep.line != -1 && cons->grep.line == cons->lines)) {
 					memcpy (out, tline, ret);
-					memcpy (out+ret, "\n", 1);
-					out += ret+1;
-					buffer_len += ret+1;
+					memcpy (out + ret, "\n", 1);
+					out += ret + 1;
+					buffer_len += ret + 1;
 				}
 				cons->lines++;
 			} else if (ret < 0) {
 				free (tbuf);
 				free (tline);
 				return 0;
-			} 
-			in += l+1;
+			}
+			in += l + 1;
 		} else in++;
 	}
 	memcpy (buf, tbuf, len);
@@ -228,7 +228,7 @@ R_API int r_cons_grepbuf(char *buf, int len) {
 	free (tbuf);
 	free (tline);
 	if (cons->grep.counter) {
-		if (cons->buffer_len<10) cons->buffer_len = 10; // HACK
+		if (cons->buffer_len < 10) cons->buffer_len = 10; // HACK
 		snprintf (cons->buffer, cons->buffer_len, "%d\n", cons->lines);
 		cons->buffer_len = strlen (cons->buffer);
 	}
@@ -242,20 +242,20 @@ R_API int r_cons_grep_line(char *buf, int len) {
 	int hit = cons->grep.neg;
 	int i, j, outlen = 0;
 
-	in = calloc (1, len+1);
-	out = calloc (1, len+2);
+	in = calloc (1, len + 1);
+	out = calloc (1, len + 2);
 	memcpy (in, buf, len);
 
-	if (cons->grep.nstrings>0) {
+	if (cons->grep.nstrings > 0) {
 		int ampfail = cons->grep.amp;
-		for (i=0; i<cons->grep.nstrings; i++) {
+		for (i = 0; i < cons->grep.nstrings; i++) {
 			char *p = strstr (in, cons->grep.strings[i]);
 			if (!p) {
 				ampfail = 0;
 				continue;
 			}
 			if (cons->grep.begin)
-				hit = (p == in)? 1: 0;
+				hit = (p == in) ? 1 : 0;
 			else hit = !cons->grep.neg;
 			// TODO: optimize without strlen without breaking t/feat_grep (grep end)
 			if (cons->grep.end && (strlen (cons->grep.strings[i]) != strlen (p)))
@@ -271,17 +271,17 @@ R_API int r_cons_grep_line(char *buf, int len) {
 		if ((cons->grep.tokenfrom != 0 || cons->grep.tokento != ST32_MAX) &&
 			(cons->grep.line == -1 || cons->grep.line == cons->lines)) {
 			const int delims_count = sizeof (delims) / 2;
-			for (i=0; i<len; i++) for (j=0; j<delims_count; j++)
+			for (i = 0; i < len; i++) for (j = 0; j < delims_count; j++)
 				if (in[i] == delims[j][0])
 					in[i] = ' ';
-			for (i=0; i <= cons->grep.tokento; i++) {
-				tok = (char *) strtok (i?NULL:in, " ");
+			for (i = 0; i <= cons->grep.tokento; i++) {
+				tok = (char *) strtok (i ? NULL : in, " ");
 				if (tok) {
 					if (i >= cons->grep.tokenfrom) {
 						int toklen = strlen (tok);
-						memcpy (out+outlen, tok, toklen);
-						memcpy (out+outlen+toklen, " ", 2);
-						outlen += toklen+1;
+						memcpy (out + outlen, tok, toklen);
+						memcpy (out + outlen + toklen, " ", 2);
+						outlen += toklen + 1;
 					}
 				} else {
 					if (!(*out)) {
@@ -291,8 +291,8 @@ R_API int r_cons_grep_line(char *buf, int len) {
 					} else break;
 				}
 			}
-			outlen = outlen>0? outlen - 1: 0;
-			if (outlen>len) { // should never happen
+			outlen = outlen > 0 ? outlen - 1 : 0;
+			if (outlen > len) { // should never happen
 				eprintf ("r_cons_grep_line: wtf, how you reach this?\n");
 				free (in);
 				free (out);
@@ -376,7 +376,7 @@ R_API int r_cons_html_print(const char *ptr) {
 		} else
 		if (esc == 2) {
 			// TODO: use dword comparison here
-			if (ptr[0]=='2' && ptr[1]=='J') {
+			if (ptr[0] == '2' && ptr[1] == 'J') {
 				printf ("<hr />\n");
 				fflush(stdout);
 				ptr++;
@@ -393,28 +393,28 @@ R_API int r_cons_html_print(const char *ptr) {
 				str = ptr + 1;
 				esc = 0;
 			} else
-			if (ptr[0]=='0' && ptr[1]==';' && ptr[2]=='0') {
+			if (ptr[0] == '0' && ptr[1] == ';' && ptr[2] == '0') {
 				r_cons_gotoxy (0, 0);
 				ptr += 4;
 				esc = 0;
 				str = ptr;
 				continue;
 			} else
-			if (ptr[0]=='0' && ptr[1]=='m') {
+			if (ptr[0] == '0' && ptr[1] == 'm') {
 				str = (++ptr) + 1;
 				esc = inv = 0;
 				continue;
 				// reset color
 			} else
-			if (ptr[0]=='7' && ptr[1]=='m') {
-				str = (++ptr) +1;
+			if (ptr[0] == '7' && ptr[1] == 'm') {
+				str = (++ptr) + 1;
 				inv = 128;
 				esc = 0;
 				continue;
 				// reset color
 			} else
-			if (ptr[0]=='3' && ptr[2]=='m') {
-				printf ("<font color='%s'>", gethtmlcolor (ptr[1], inv?"#fff":"#000"));
+			if (ptr[0] == '3' && ptr[2] == 'm') {
+				printf ("<font color='%s'>", gethtmlcolor (ptr[1], inv ? "#fff" : "#000"));
 				fflush(stdout);
 				tag_font = 1;
 				ptr = ptr + 1;
@@ -422,14 +422,14 @@ R_API int r_cons_html_print(const char *ptr) {
 				esc = 0;
 				continue;
 			} else
-			if (ptr[0]=='4' && ptr[2]=='m') {
+			if (ptr[0] == '4' && ptr[2] == 'm') {
 				printf ("<font style='background-color:%s'>",
-						gethtmlcolor (ptr[1], inv?"#000":"#fff"));
+						gethtmlcolor (ptr[1], inv ? "#000" : "#fff"));
 				fflush(stdout);
 			}
-		} 
+		}
 		len++;
 	}
-	write (1, str, ptr-str);
+	write (1, str, ptr - str);
 	return len;
 }

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -8,7 +8,7 @@
 
 R_API void r_cons_grep_help() {
 	eprintf (
-"|Usage: [command]~[modifier][word,word][[column][:line]\n"
+"|Usage: [command]~[modifier][word,word][[column]][:line]\n"
 "| modifiers\n"
 "|   &    all words must match to grep the line\n"
 "|   ^    words must be placed at the beginning of line\n"
@@ -18,7 +18,7 @@ R_API void r_cons_grep_help() {
 "|   {}   json indentation\n"
 "|   {}.. less json indentation\n"
 "| examples:\n"
-"|   i~:0   # show fist line o 'i' output\n"
+"|   i~:0   # show fist line of 'i' output\n"
 "|   pd~mov # disasm and grep for mov\n"
 "|   pi~[0] # show only opcode\n"
 	);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -51,7 +51,7 @@ typedef struct r_cons_grep_t {
 	int json;
 	int line;
 	int tokens[R_CONS_GREP_TOKENS];
-	int columns_used;
+	int tokens_used;
 	int amp;
 	int neg;
 	int begin;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -38,6 +38,7 @@ extern "C" {
 
 #define R_CONS_GREP_WORDS 10
 #define R_CONS_GREP_WORD_SIZE 64
+#define R_CONS_GREP_TOKENS 64
 
 R_LIB_VERSION_HEADER(r_cons);
 
@@ -49,8 +50,8 @@ typedef struct r_cons_grep_t {
 	int less;
 	int json;
 	int line;
-	int tokenfrom;
-	int tokento;
+	int tokens[R_CONS_GREP_TOKENS];
+        int columns_used;
 	int amp;
 	int neg;
 	int begin;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -51,7 +51,7 @@ typedef struct r_cons_grep_t {
 	int json;
 	int line;
 	int tokens[R_CONS_GREP_TOKENS];
-        int columns_used;
+	int columns_used;
 	int amp;
 	int neg;
 	int begin;


### PR DESCRIPTION
Grep (~) is now able to print specific columns. E.g.:
```bash
⚔ r2 malloc://1024
[0x00000000]> wx 102030405060708090
[0x00000000]> px~:1[3,5,0-1]
0x00000000 1020 5060 9000
```
Apart from that i updated the usage message to include more info of already available features like '$' and cleaned up libr/cons/grep.c to conform to the coding guidelines.