### PR TITLE
Fix array subscript vulnerability

### DIFF
--- a/shlr/sdb/src/match.c
+++ b/shlr/sdb/src/match.c
@@ -24,7 +24,7 @@ enum MatchFlag {
 static inline int mycmp(const char *a, const char *b, int n, int any) {
 	int i, j;
 	for (i=j=0; a[i] && b[j] && j<n; i++) {
-		if (tolower(a[i]) == tolower(b[j])) {
+		if (tolower((const unsigned char)a[i]) == tolower((const unsigned char)b[j])) {
 			j++;
 		} else {
 			if (!any) return 0;


### PR DESCRIPTION
match.c: In function 'mycmp':
match.c:27:3: warning: array subscript has type 'char' [-Wchar-subscripts]
   if (tolower(a[i]) == tolower(b[j])) {
   ^
match.c:27:3: warning: array subscript has type 'char' [-Wchar-subscripts]

Problem caught on NetBSD.