### PR TITLE
NetBSD declares forkpty(3) in <util.h>

### DIFF
--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -12,7 +12,6 @@
 #include <sys/stat.h>
 #if __APPLE__
 #include <spawn.h>
-#include <util.h>
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -38,6 +37,9 @@
 #if __linux__ && !__ANDROID__
 #include <sys/personality.h>
 #include <pty.h>
+#endif
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <util.h>
 #endif
 #endif
 


### PR DESCRIPTION
```
OPENPTY(3)                 Library Functions Manual                 OPENPTY(3)

NAME
     openpty, login_tty, forkpty -- tty utility functions

LIBRARY
     System Utilities Library (libutil, -lutil)

SYNOPSIS
     #include <util.h>

     int
     openpty(int *amaster, int *aslave, char *name, struct termios *termp,
         struct winsize *winp);

     int
     login_tty(int fd);

     pid_t
     forkpty(int *amaster, char *name, struct termios *termp,
         struct winsize *winp);
```