### PR TITLE
Need -lutil for forkpty on OpenBSD

### DIFF
--- a/libr/socket/Makefile
+++ b/libr/socket/Makefile
@@ -5,7 +5,8 @@ OBJS=socket.o proc.o http.o http_server.o
 OBJS+=rap_server.o run.o r2pipe.o
 DEPS=r_util
 
-ifneq (,$(findstring linux,${OSTYPE})$(findstring android,${OSTYPE}))
+ifneq (,$(findstring linux,${OSTYPE})$(findstring android,${OSTYPE})\
+	$(findstring bsd,${OSTYPE}))
 LDFLAGS+=-lutil
 endif
 ifneq (,$(findstring mingw32,${OSTYPE})$(findstring mingw64,${OSTYPE}))


### PR DESCRIPTION
forkpty lives in util.h and libutil on atleast OpenBSD. With this diff it builds for me on OpenBSD. This post seems to indicate it might also work for NetBSD: https://lists.gnu.org/archive/html/bug-gnulib/2009-12/msg00094.html but maybe someone using NetBSD can comment on this?

Build failure before:
```
[ ... ]
/home/github/radare2/libr/socket/libr_socket.so: undefined reference to `forkpty'
collect2: ld returned 1 exit status
../rules.mk:66: recipe for target 'rabin2' failed
gmake[2]: *** [rabin2] Error 1
gmake[2]: Leaving directory '/home/github/radare2/binr/rabin2'
$
```
```
$ nm /usr/lib/libutil.so.12.1 |grep forkpty
00004ab0 T forkpty
$ nm libr/socket/libr_socket.so |grep forkpty
         U forkpty
$ 
$ ldd libr/socket/libr_socket.so
libr/socket/libr_socket.so:
  Start            End              Type Open Ref GrpRef Name
  000001665ff98000 00000166603a3000 dlib 1    0   0      /home/github/radare2/libr/socket/libr_socket.so
  000001667fd47000 00000166801a5000 rlib 0    1   0      /usr/local/lib/libr_util.so
  000001661f44e000 000001661f860000 rlib 0    2   0      /usr/lib/libpthread.so.19.0
```

After patch:
```
$ ./binr/rabin2/rabin2 -v
rabin2 0.10.0-git 9191 @ openbsd-little-x86-64 git.0.9.9-1082-g1b3f471
commit: 1b3f4719208f4abfaa790a602b0ca290b8bf2aec build: 2015-10-05
```