### PR TITLE
Config for max string buffer size

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -397,6 +397,12 @@ int main(int argc, char **argv) {
 	r_lib_opendir (l, getenv ("LIBR_PLUGINS"));
 	r_lib_opendir (l, homeplugindir);
 	r_lib_opendir (l, R2_LIBDIR"/radare2/"R2_VERSION);
+	
+	char *maxstrbuf = r_sys_getenv ("RABIN2_MAXSTRBUF");
+	if (maxstrbuf) {
+		r_config_set (core.config, "bin.maxstrbuf", maxstrbuf);
+		free(maxstrbuf);
+	}
 
 #define is_active(x) (action&x)
 #define set_action(x) actions++; action |= x
@@ -677,6 +683,8 @@ int main(int argc, char **argv) {
 	}
 
 	bin->minstrlen = r_config_get_i (core.config, "bin.minstr");
+	bin->maxstrbuf = r_config_get_i (core.config, "bin.maxstrbuf");
+
 	r_bin_force_plugin (bin, forcebin);
 	if (!r_bin_load (bin, file, baddr, laddr, xtr_idx, fd, rawstr)) {
 		if (!r_bin_load (bin, file, baddr, laddr, xtr_idx, fd, rawstr)) {

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -248,9 +248,9 @@ static void get_strings_range(RBinFile *arch, RList *list, int min, ut64 from, u
 
 	if (arch->rawstr != 2) {
 		ut64 size = to-from;
-		// in case of dump ignore here // only 2MB
-		if (size != 0 && size > 1024*1024*2) {
-			eprintf ("WARNING: bin_strings buffer is too big (0x%08"PFMT64x"). Use -zzz\n", size);
+		// in case of dump ignore here
+		if (size != 0 && size > arch->rbin->maxstrbuf) {
+			eprintf ("WARNING: bin_strings buffer is too big (0x%08"PFMT64x"). Use -zzz or set bin.maxstrbuf (RABIN2_MAXSTRBUF) in r2 (rabin2)\n", size);
 			return;
 		}
 	}

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1028,6 +1028,21 @@ static int cb_rawstr(void *user, void *data) {
 	return true;
 }
 
+static int cb_binmaxstrbuf(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	if (core->bin) {
+		int v = node->i_value;
+		ut64 old_v = core->bin->maxstrbuf;
+		if (v<1) v = 4; // HACK
+		core->bin->maxstrbuf = v;
+		if (v>old_v)
+			r_core_bin_refresh_strings (core);
+		return true;
+	}
+	return true;
+}
+
 static int cb_binmaxstr(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -1235,6 +1250,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("bin.dwarf", "true", "Load dwarf information on startup if available");
 	SETICB("bin.minstr", 0, &cb_binminstr, "Minimum string length for r_bin");
 	SETICB("bin.maxstr", 0, &cb_binmaxstr, "Maximum string length for r_bin");
+	SETICB("bin.maxstrbuf", 1024*1024*2, & cb_binmaxstrbuf, "Maximum size of range to load strings from");
 	SETCB("bin.rawstr", "false", &cb_rawstr, "Load strings from raw binaries");
 	SETPREF("bin.strings", "true", "Load strings from rbin on startup");
 	SETPREF("bin.classes", "true", "Load classes from rbin on startup");

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -327,6 +327,7 @@ static int r_core_file_do_load_for_debug (RCore *r, ut64 baseaddr, const char *f
 		//\\ r_config_set (r->config, "bin.rawstr", "true");
 		// get bin.minstr
 		r->bin->minstrlen = r_config_get_i (r->config, "bin.minstr");
+		r->bin->maxstrbuf = r_config_get_i (r->config, "bin.maxstrbuf");
 	} else if (binfile) {
 		RBinObject *obj = r_bin_get_object (r->bin);
 		RBinInfo * info = obj ? obj->info : NULL;
@@ -365,6 +366,7 @@ static int r_core_file_do_load_for_io_plugin (RCore *r, ut64 baseaddr, ut64 load
 		// r_config_set (r->config, "bin.rawstr", "true");
 		// get bin.minstr
 		r->bin->minstrlen = r_config_get_i (r->config, "bin.minstr");
+		r->bin->maxstrbuf = r_config_get_i (r->config, "bin.maxstrbuf");
 	} else if (binfile) {
 		RBinObject *obj = r_bin_get_object (r->bin);
 		RBinInfo * info = obj ? obj->info : NULL;
@@ -414,6 +416,7 @@ R_API int r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 	}
 
 	r->bin->minstrlen = r_config_get_i (r->config, "bin.minstr");
+	r->bin->maxstrbuf = r_config_get_i (r->config, "bin.maxstrbuf");
 	if (is_io_load) {
 		// TODO? necessary to restore the desc back?
 		// RIODesc *oldesc = desc;
@@ -440,6 +443,7 @@ R_API int r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 		r_config_set_i (r->config, "io.va", false);
 		// get bin.minstr
 		r->bin->minstrlen = r_config_get_i (r->config, "bin.minstr");
+		r->bin->maxstrbuf = r_config_get_i (r->config, "bin.maxstrbuf");
 	} else if (binfile) {
 		RBinObject *obj = r_bin_get_object (r->bin);
 		RBinInfo * info = obj ? obj->info : NULL;

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -177,6 +177,7 @@ typedef struct r_bin_t {
 	/* preconfigured values */
 	int minstrlen;
 	int maxstrlen;
+	ut64 maxstrbuf;
 	int rawstr;
 	Sdb *sdb;
 	RList/*<RBinPlugin>*/ *plugins;


### PR DESCRIPTION
I ran into  binary which caused the warning
> WARNING: bin_strings buffer is too big (0x005a92ec). Use -zzz

This changeset introduces bin.maxstrrange, the warning isn't emitted nor is searching for strings skipped in ranges smaller than its configured value.