### PR TITLE
make p={p,e} error out instead of segfault

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1622,6 +1622,10 @@ static int cmd_print(void *data, const char *input) {
 			switch (input1) {
 			case 'p':
 			case 'e':
+				if (fsz==UT64_MAX) {
+					eprintf ("Cannot determine file size\n");
+					goto beach;
+				}
 				nbsz = fsz / nbsz;
 				break;
 			}


### PR DESCRIPTION
It's probably better to error out than simply crash. I'll probably be working on this more as I find time