### PR TITLE
Fix warning: array subscript has type ‘char’

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -82,11 +82,11 @@ R_API ut64 r_core_get_asmqjmps(RCore *core, const char *str) {
 		int len = strlen (str);
 
 		for (i = 0; i < len - 1; ++i) {
-			if (!isupper (str[i])) return UT64_MAX;
+			if (!isupper ((unsigned char)str[i])) return UT64_MAX;
 			pos *= R_CORE_ASMQJMPS_LETTERS;
 			pos += str[i] - 'A' + 1;
 		}
-		if (!islower (str[i])) return UT64_MAX;
+		if (!islower ((unsigned char)str[i])) return UT64_MAX;
 		pos *= R_CORE_ASMQJMPS_LETTERS;
 		pos += str[i] - 'a';
 		return core->asmqjmps[pos + 1];

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2375,7 +2375,7 @@ static void goto_asmqjmps(RCore *core) {
 		r_cons_printf ("%c", ch);
 		r_cons_flush ();
 
-		cont = isalpha (ch) && !islower (ch);
+		cont = isalpha ((unsigned char)ch) && !islower ((unsigned char)ch);
 	} while (i < R_CORE_ASMQJMPS_LEN_LETTERS && cont);
 
 	obuf[i] = '\0';


### PR DESCRIPTION
Caught on NetBSD.