### PR TITLE
dbg.libs/dbg.unlibs implementation.

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -556,6 +556,9 @@ repeat:
 		if (retwait != R_DEBUG_REASON_DEAD) {
 			ret = dbg->tid;
 		}
+		if (retwait == R_DEBUG_REASON_NEW_LIB || retwait == R_DEBUG_REASON_EXIT_LIB) {
+			goto repeat;
+		}
 #endif
 		r_bp_restore (dbg->bp, false); // unset sw breakpoints
 		//r_debug_recoil (dbg);

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -258,8 +258,8 @@ static int r_debug_native_wait (RDebug *dbg, int pid) {
 	if (mode) {
 		RDebugInfo *r = r_debug_native_info (dbg, "");
 		if (r && r->lib) {
-			if (tracelib (dbg, mode? "load":"unload", r->lib))
-				r_debug_native_continue (dbg, pid, dbg->tid, r->signum);
+			if (tracelib (dbg, mode=='l'? "load":"unload", r->lib))
+				status=R_DEBUG_REASON_TRAP;
 		} else {
 			eprintf ("%soading unknown library.\n", mode?"L":"Unl");
 		}

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -478,9 +478,11 @@ typedef struct{
 } LIB_ITEM, *PLIB_ITEM;
 LPVOID lstLib = 0;
 PLIB_ITEM lstLibPtr = 0;
+/*
 static char * r_debug_get_dll() {
 	return lstLibPtr->Path;
 }
+*/
 static  PLIB_ITEM  r_debug_get_lib_item() {
 	return lstLibPtr;
 }
@@ -585,6 +587,7 @@ static int w32_dbg_wait(RDebug *dbg, int pid) {
 			if (dllname) {
 				free (dllname);
 			}
+			next_event = 1;
 		        return R_DEBUG_REASON_NEW_LIB;
 			/*
 			r_debug_native_continue (dbg, pid, tid, -1);
@@ -602,6 +605,7 @@ static int w32_dbg_wait(RDebug *dbg, int pid) {
 				if (dllname)
 					free(dllname);
 			}
+			next_event = 1;
 			return R_DEBUG_REASON_EXIT_LIB;
                         /*
 			r_debug_native_continue (dbg, pid, tid, -1);
@@ -822,10 +826,13 @@ static RDebugInfo* w32_info (RDebug *dbg, const char *arg) {
 	rdi->status = R_DBG_PROC_SLEEP; // TODO: Fix this
 	rdi->pid = dbg->pid;
 	rdi->tid = dbg->tid;
+	rdi->lib = (void *) r_debug_get_lib_item();
 	rdi->uid = -1;// TODO
 	rdi->gid = -1;// TODO
-	rdi->libname = r_debug_get_dll();
-	rdi->lib = (void *) r_debug_get_lib_item();
+	rdi->cwd = NULL;
+	rdi->exe = NULL;
+	rdi->cmdline = NULL;
+	rdi->libname = NULL;
 	return rdi;
 }
 


### PR DESCRIPTION
Implementation dll break at load/unload in windows debugger engine.
- dbg.libs implemented
- dbg.unlibs implemented

ex: e dbg.libs=kernel32.dll
      e dbg.unlibs=*            