### PR TITLE
Unbreak build with pkgsrc's capstone-3.0.3

### DIFF
--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -576,7 +576,7 @@ RAnalPlugin r_anal_plugin_m68k_cs = {
 	.name = "m68k.cs (unsupported)",
 	.desc = "Capstone M68K analyzer (unsupported)",
 	.license = "BSD",
-	.arch = "m68k",
+	.arch = R_SYS_ARCH_M68K,
 	.bits = 32,
 };
 #endif


### PR DESCRIPTION
struct r_anal_plugin_t (RAnalPlugin) defines arch as int.
Use the proper symbol for m68k: R_SYS_ARCH_M68K.

Caught on NetBSD.