### PR TITLE
core/anal: use r_bin_get_vaddr instead of raw vaddr and paddr fields

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1780,12 +1780,6 @@ R_API void r_bin_class_add_field (RBinFile *binfile, const char *classname, cons
 	//eprintf ("TODO add field: %s \n", name);
 }
 
-R_API ut64 r_bin_get_offset (RBin *bin) {
-	RBinFile *binfile = bin ? bin->cur : NULL;
-	if (binfile) return binfile->offset;
-	return UT64_MAX;
-}
-
 /* returns vaddr, rebased with the baseaddr of binfile, if va is enabled for
  * bin, paddr otherwise */
 R_API ut64 r_binfile_get_vaddr (RBinFile *binfile, ut64 paddr, ut64 vaddr) {

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1684,13 +1684,8 @@ R_API int r_core_anal_all(RCore *core) {
 	RBinAddr *binmain;
 	RBinAddr *entry;
 	RBinSymbol *symbol;
-	//ut64 baddr;
-	ut64 offset;
 	int depth = r_config_get_i (core->config, "anal.depth");
-	int va = core->io->va || core->io->debug;
 
-	//baddr = r_bin_get_baddr (core->bin);
-	offset = r_bin_get_offset (core->bin);
 	/* Analyze Functions */
 	/* Entries */
 	item = r_flag_get (core->flags, "entry0");
@@ -1704,23 +1699,28 @@ R_API int r_core_anal_all(RCore *core) {
 	r_cons_break (NULL, NULL);
 	/* Main */
 	if ((binmain = r_bin_get_sym (core->bin, R_BIN_SYM_MAIN)) != NULL) {
-		ut64 addr = va? binmain->vaddr: binmain->paddr;
+		ut64 addr = r_bin_get_vaddr (core->bin, binmain->paddr, binmain->vaddr);
 		r_core_anal_fcn (core, addr, -1, R_ANAL_REF_TYPE_NULL, depth);
 	}
-	if ((list = r_bin_get_entries (core->bin)) != NULL)
-		r_list_foreach (list, iter, entry)
-			r_core_anal_fcn (core, (offset + va) ? r_bin_a2b (core->bin, entry->vaddr)
-					: entry->paddr, -1, R_ANAL_REF_TYPE_NULL, depth);
+	if ((list = r_bin_get_entries (core->bin)) != NULL) {
+		r_list_foreach (list, iter, entry) {
+			ut64 addr = r_bin_get_vaddr (core->bin, entry->paddr, entry->vaddr);
+			r_core_anal_fcn (core, addr, -1, R_ANAL_REF_TYPE_NULL, depth);
+		}
+	}
 	/* Symbols (Imports are already analyzed by rabin2 on init) */
-	if ((list = r_bin_get_symbols (core->bin)) != NULL)
+	if ((list = r_bin_get_symbols (core->bin)) != NULL) {
 		r_list_foreach (list, iter, symbol) {
 			if (core->cons->breaked)
 				break;
 			if (!strcmp (symbol->type, "FUNC")) {
-				r_core_anal_fcn (core, va? symbol->vaddr:symbol->paddr,
-						-1, R_ANAL_REF_TYPE_NULL, depth);
+				ut64 addr = r_bin_get_vaddr (core->bin, symbol->paddr,
+					symbol->vaddr);
+				r_core_anal_fcn (core, addr, -1,
+					R_ANAL_REF_TYPE_NULL, depth);
 			}
 		}
+	}
 	/* Set fcn type to R_ANAL_FCN_TYPE_SYM for symbols */
 	r_list_foreach (core->anal->fcns, iter, fcni) {
 		if (core->cons->breaked)

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -474,7 +474,6 @@ R_API RBinObject * r_bin_object_find_by_arch_bits (RBinFile *binfile, const char
 R_API void r_bin_list_archs(RBin *bin, int mode);
 R_API void r_bin_set_user_ptr(RBin *bin, void *user);
 R_API RBuffer *r_bin_create (RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
-R_API ut64 r_bin_get_offset (RBin *bin);
 R_API ut64 r_bin_get_vaddr (RBin *bin, ut64 paddr, ut64 vaddr);
 R_API ut64 r_bin_a2b (RBin *bin, ut64 addr);
 R_API int r_bin_file_delete(RBin *bin, ut32 bin_fd);


### PR DESCRIPTION
@crowell 