### PR TITLE
Fix parsing of `aar[?*j]` commands

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2880,9 +2880,6 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 		"aarj", " [sz]", "list found xrefs in JSON format",
 		"aar*", " [sz]", "list found xrefs in radare commands format",
 		NULL};
-	if (*input) {
-		input++;
-	}
 	if (*input == '?') {
 		r_core_cmd_help (core, help_msg_aar);
 		return 0;


### PR DESCRIPTION
The commands `aar?`, `aar*` and `aarj` are parsed incorrectly. Currently, the command parser requires an extra character before the [?\*j] specifier (e.g., `aar ?` and `aarX*` work as expected). The responsible lines are [libr/core/cmd_anal.c#L2883-L2885](https://github.com/radare/radare2/blame/891931b775bc5acb4a6511bbeace5767f07be0e0/libr/core/cmd_anal.c#L2883-L2885).
```c
    2883 if (*input) {
    2884     input++;
    2885 }
```
Commit 7dc293b added the `if (*input)` check around the `input++` line to fix spurious error messages in r2 -A  #3254 caused by invalid parameters read after the '\0' terminator. Obviously the `input++` should not have been there in the first place.

This commit fixes the parsing of `aar[?*j]` by removing the three lines. According to my tests, the patch does not cause regression in `r2 -A`.