### PR TITLE
Fix build error on FreeBSD

### DIFF
--- a/configure
+++ b/configure
@@ -465,16 +465,16 @@ HAVE_LIB_DL="1"
 DL_LIBS="-ldl"
 else
 if [ "$HOST_OS" = "gnu/kfreebsd" ]; then
-USEROSTYPE="gnulinux"
+USEROSTYPE="bsd"
 else
 if [ "$HOST_OS" = "netbsd" ]; then
-USEROSTYPE="gnulinux"
+USEROSTYPE="bsd"
 else
 if [ "$HOST_OS" = "freebsd" ]; then
-USEROSTYPE="gnulinux"
+USEROSTYPE="bsd"
 else
 if [ "$HOST_OS" = "openbsd" ]; then
-USEROSTYPE="gnulinux"
+USEROSTYPE="bsd"
 else
 if [ "$HOST_OS" = "darwin" ]; then
 USEROSTYPE="darwin"; fi; fi; fi; fi; fi; fi; fi; fi; fi

--- a/configure.acr
+++ b/configure.acr
@@ -108,16 +108,16 @@ IFEQ USEROSTYPE auto ; {
 		DL_LIBS = -ldl ;
 	}{
 	IFEQ HOST_OS gnu/kfreebsd ; {
-		USEROSTYPE = gnulinux ;
+		USEROSTYPE = bsd ;
 	}{
 	IFEQ HOST_OS netbsd ; {
-		USEROSTYPE = gnulinux ;
+		USEROSTYPE = bsd ;
 	}{
 	IFEQ HOST_OS freebsd ; {
-		USEROSTYPE = gnulinux ;
+		USEROSTYPE = bsd ;
 	}{
 	IFEQ HOST_OS openbsd ; {
-		USEROSTYPE = gnulinux ;
+		USEROSTYPE = bsd ;
 	}{
 	IFEQ HOST_OS darwin ; {
 		USEROSTYPE = darwin ;


### PR DESCRIPTION
Commit 4784c5d380fbe626ff693c6fbc93de0ed9ff4836 introduced the "bsd" value for USEROSTYPE, but this was only changed in the configure file, not in the configure.acr file. In commit efa8fd99908f34f925b47f515882b24b5ca2e58b the configure.acr file was changed, so I assume the configure file was regenerated from it, and thus all BSD USEROSTYPE values changed back to "gnulinux". This caused compile errors on FreeBSD, and presumably on other BSDs too. 