### PR TITLE
The "afb+" commands emitted by "afl*" are not working properly

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1066,7 +1066,7 @@ static void fcn_list_bbs(RAnalFunction *fcn) {
 	RListIter *iter;
 
 	r_list_foreach (fcn->bbs, iter, bbi) {
-		r_cons_printf ("afb+ 0x%08"PFMT64x" 0x%08"PFMT64x" %04"PFMT64d" ",
+		r_cons_printf ("afb+ 0x%08"PFMT64x" 0x%08"PFMT64x" %d ",
 				fcn->addr, bbi->addr, bbi->size);
 		r_cons_printf ("0x%08"PFMT64x" ", bbi->jump);
 		r_cons_printf ("0x%08"PFMT64x" ", bbi->fail);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -225,7 +225,6 @@ R_API int r_core_project_open(RCore *core, const char *prjfile) {
 	}
 	ret = r_core_cmd_file (core, prj);
 	r_anal_project_load (core->anal, prjfile);
-	r_core_cmd0 (core, "s entry0");
 	free (filepath);
 	free (prj);
 	return ret;


### PR DESCRIPTION
This PR contains two very small fixes that addresses issues I've encountered while tried to use the project save/load feature.

1. The "afb+" commands that are emitted by "afl*" are not working properly because the size values are printed using %04PFMT64d, which means they are 0-padded, therefore interpreted as octal numbers during command parsing. Because of this, for example graph view is broken on loaded projects. You can see the problem here:

```
[0x00400720]> afl*
f entry0 42 0x00400720
af+ 0x00400720 42 entry0 f n
afb+ 0x00400720 0x00400720 0042 0xffffffffffffffff 0xffffffffffffffff n n
...

[0x00400720]> afb+ 0x00400720 0x00400720 0042 0xffffffffffffffff 0xffffffffffffffff n n
[0x00400720]> afl*
f entry0 42 0x00400720
af+ 0x00400720 42 entry0 f n
afb+ 0x00400720 0x00400720 0034 0xffffffffffffffff 0xffffffffffffffff n n
...
```

Because RAnalBlock.size is an int, I think it is safe to use "%d" as format string here (and it is also used in libr/core/p/core_anal.c to print "afb+" commands).

2. Since "Ps" saves the current seek as part of the project file, I don't think seeking to "entry0" is the expected behaviour when loading projects.

Cheers,
Toma