### PR TITLE
core/graph: rethink commands

### DIFF
--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -543,6 +543,13 @@ typedef struct r_ascii_node_t {
 	int klass;
 } RANode;
 
+#define R_AGRAPH_MODE_NORMAL 0
+#define R_AGRAPH_MODE_OFFSET 1
+#define R_AGRAPH_MODE_ESIL 2
+#define R_AGRAPH_MODE_ESIL_OFFSET 3
+#define R_AGRAPH_MODE_MINI 4
+#define R_AGRAPH_MODE_MAX 5
+
 typedef void (*RANodeCallback)(RANode *n, void *user);
 typedef void (*RAEdgeCallback)(RANode *from, RANode *to, void *user);
 
@@ -554,10 +561,9 @@ typedef struct r_ascii_graph_t {
 	Sdb *db;
 	Sdb *nodes; // Sdb with title(key)=RANode*(value)
 
-	int is_callgraph;
 	int is_instep;
-	int is_simple_mode;
-	int is_small_nodes;
+	int mode;
+	int is_callgraph;
 	int zoom;
 	int movspeed;
 


### PR DESCRIPTION
* add :cmd and / commands to the help
* use r to refresh the whole graph, not only update the layout
* use pd instead of pi in callgraph mode
* remove 'O' and 'p' commands
* use 's'/'S' instead of 'z'/'Z' for step/step over
* use page up/down to go to the top/bottom of the graph
* use 'C' to toggle asm.comments
* remove 'c' because it will be used for the cursor inside a node (TODO)
* remove 'e' because diagonal lines are broken
* use 'p'/'P' to switch between print modes (normal, normal with offset
  and bytes, esil, esil with offset and bytes, small nodes)