### PR TITLE
fix to allow unlimited data transmision via windows named pipes

### DIFF
--- a/shlr/sdb/src/sdb_version.h
+++ b/shlr/sdb/src/sdb_version.h
@@ -1,1 +1,0 @@
-#define SDB_VERSION "0.9.8"


### PR DESCRIPTION
- Changed pipe type to PIPE_WAIT
- Changed loop transmision to send chunks of 4096

NOTE: is needed update r2pipe for python to allow this changes work correctly.