### PR TITLE
socket/run: split r_run_start to make debugging easier

### DIFF
--- a/binr/rarun2/rarun2.c
+++ b/binr/rarun2/rarun2.c
@@ -24,8 +24,13 @@ int main(int argc, char **argv) {
 		for (i = *file?1:2; i<argc; i++)
 			r_run_parseline (p, argv[i]);
 	}
-	if (!p)
+	if (!p) return 1;
+
+	ret = r_run_config_env (p);
+	if (ret) {
+		printf("error while configuring the environment.\n");
 		return 1;
+	}
 	ret = r_run_start (p);
 	r_run_free (p);
 	return ret;

--- a/libr/include/r_socket.h
+++ b/libr/include/r_socket.h
@@ -208,6 +208,7 @@ R_API int r_run_parse(RRunProfile *pf, const char *profile);
 R_API void r_run_free (RRunProfile *r);
 R_API int r_run_parseline (RRunProfile *p, char *b);
 R_API const char *r_run_help(void);
+R_API int r_run_config_env(RRunProfile *p);
 R_API int r_run_start(RRunProfile *p);
 R_API void r_run_reset(RRunProfile *p);
 R_API int r_run_parsefile (RRunProfile *p, const char *b);

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -424,12 +424,9 @@ R_API const char *r_run_help() {
 	"# nice=5\n";
 }
 
-R_API int r_run_start(RRunProfile *p) {
-#if __APPLE__
-	posix_spawnattr_t attr = {0};
-	pid_t pid = -1;
-#endif
+R_API int r_run_config_env(RRunProfile *p) {
 	int ret;
+
 	if (!p->_program && !p->_system) {
 		printf ("No program or system rule defined\n");
 		return 1;
@@ -623,6 +620,16 @@ R_API int r_run_start(RRunProfile *p) {
 		eprintf ("timeout not supported for this platform\n");
 #endif
 	}
+	return 0;
+}
+
+R_API int r_run_start(RRunProfile *p) {
+#if __APPLE__
+	posix_spawnattr_t attr = {0};
+	pid_t pid = -1;
+#endif
+	int ret;
+
 #if __APPLE__
 	posix_spawnattr_init (&attr);
 	if (p->_args[0]) {


### PR DESCRIPTION
During the environment configuration we may fork and spawn other
processes that we don't really care about. Splitting r_run_start, allows
to call ptrace only after this initial work is done.

TODO: it doesn't work yet when you use stdin/stdout/stderr with "!cmd"