### PR TITLE
Four tiny fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ purge-doc:
 	rm -f "${DESTDIR}${MANDIR}/man1/r2.1"
 
 user-wrap=echo "\#!/bin/sh" > ~/bin/"$1" \
-; echo "${PWD}/env.sh '${PREFIX}' '$1' \$$@" >> ~/bin/"$1" \
+; echo "${PWD}/env.sh '${PREFIX}' '$1' \"\$$@\"" >> ~/bin/"$1" \
 ; chmod +x ~/bin/"$1" ;
 
 user-install:

--- a/env.sh
+++ b/env.sh
@@ -47,5 +47,11 @@ if [ -z "$*" ]; then
 	echo "==> Back to system shell..."
 	echo
 else
-	eval $new_env $*
+	if [ $# -gt 1 ]; then 
+		par=""
+		for p in `seq 1 $(($#-1))`; do par=$par"\$$p "; done
+		eval $new_env $par "\"\$$#\""
+	else
+		eval $new_env $*
+	fi
 fi

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -671,7 +671,7 @@ R_API int r_anal_fcn_add(RAnal *a, ut64 addr, ut64 size, const char *name, int t
 	fcn->addr = addr;
 	fcn->size = size;
 	free (fcn->name);
-	if (!name || !strncmp (name, "fcn.", 4)) {
+	if (!name) {
 		fcn->name = r_str_newf ("fcn.%08"PFMT64x, fcn->addr);
 	} else {
 		fcn->name = strdup (name);

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2785,7 +2785,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			break;
 		case ':':
 			r_core_visual_prompt_input (core);
-			g->need_reload_nodes = true;
+			get_bbupdate (g, core, fcn);
 			break;
 		case 'w':
 			agraph_toggle_speed (g, core);

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2785,6 +2785,7 @@ R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interacti
 			break;
 		case ':':
 			r_core_visual_prompt_input (core);
+			g->need_reload_nodes = true;
 			break;
 		case 'w':
 			agraph_toggle_speed (g, core);

--- a/sys/purge.sh
+++ b/sys/purge.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+MAKE=make
+gmake --help >/dev/null 2>&1
+[ $? = 0 ] && MAKE=gmake
+
+
 PREFIX="$1"
 if [ -z "${PREFIX}" ]; then
 	PREFIX=/usr
@@ -6,4 +12,4 @@ fi
 [ -z "${SUDO}" ] && SUDO=sudo
 echo "Uninstalling r2 from ${PREFIX}..."
 ./configure --prefix="${PREFIX}"
-${SUDO} make purge
+${SUDO} ${MAKE} purge


### PR DESCRIPTION
This PR contains 4 commits with the following small fixes:

- commit 1e5c855343b060e0321c68d4dd20ba63caa1a661: sys/purge.sh uses "make" directly, so that it doesn't work on systems where "gmake" should be used (e.g. on FreeBSD). I've copied the check from install.sh into purge.sh, and it works now.

- commit c9c618214de7ff9298a96e10abc1e28e5a5fe4d0: When radare2 is installed using sys/user.sh, the executables are called using wrapper shell scripts. Parameters are not quoted properly, so for example `rasm2 'mov eax,0x1337'` simply won't work. This is because the shell eats up the quotes, so rasm2 will think that 'mov' is the entire code you want to assemble. I think I've fixed this in this commit.

- commit aa5cd4dd9025b777adc29a73687c96e0f82984a5: Function names are not preserved during a project save/load cycle. This is because in the "af+" implementation there is a check that changes the function name to "fcn.\<addr\>" if the function name starts with "fcn.". Since "fcn." is prepended to every function's name that was created with "af" or renamed with "afn", every manually changed function names will be reverted. I don't really know the reason behind that check, but I've found it save to remove.

- commit 7cd4f097b631a54325f74337dc1560ef6910d755: When using the prompt (with the ':' key) in graph mode to e.g. rename local vars or arguments, one have to refresh the graph manually to reflect these changes. I think there is no drawback in refreshing it automatically.

Regards,
Toma