### PR TITLE
Fix Android MIPS and X86 builds

### DIFF
--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -5,7 +5,6 @@
 #include <r_lib.h>
 #include <r_asm.h>
 #include <r_anal.h>
-#include "../../asm/arch/riscv/riscv-opc.c"
 #include "../../asm/arch/riscv/riscv.h"
 
 #define NARGS_SEQ(_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,\


### PR DESCRIPTION
It is strange, this commit fixes android builds for MIPS64 and X86: http://ci.rada.re/job/radare2-android-mips64/ and http://ci.rada.re/job/radare2-android-x86/ but breaks OSX-clang Travis CI and Windows Cygwin builds 