### PR TITLE
Fix #3628

### DIFF
--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -76,13 +76,17 @@ static void r_core_file_info (RCore *core, int mode) {
 			pair ("type", info->type);
 			break;
 		}
-	} else fn = (cf && cf->desc) ? cf->desc->name : NULL;
+	} else {
+		fn = (cf && cf->desc) ? cf->desc->name : NULL;
+	}
 	if (cf && mode == R_CORE_BIN_JSON) {
 		const char *uri = fn;
 		if (!uri) {
 			if (cf->desc && cf->desc->uri && *cf->desc->uri) {
 				uri = cf->desc->uri;
-			} else uri = "";
+			} else {
+				uri = "";
+			}
 		}
 		r_cons_printf (",\"file\":\"%s\"", uri);
 		if (dbg) dbg = R_IO_WRITE | R_IO_EXEC;

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1,15 +1,25 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
 
+
+static inline ut32 find_binfile_id_by_fd (RBin *bin, ut32 fd) {
+	RListIter *it;
+	RBinFile *bf;
+	r_list_foreach (bin->binfiles, it, bf) {
+		if (bf->fd == fd) return bf->id;
+	}
+	return UT32_MAX;
+
+}
+
 static void cmd_open_bin(RCore *core, const char *input) {
 	const char* help_msg[] = {
 		"Usage:", "ob", " # List open binary files backed by fd",
 		"ob", "", "List opened binfiles and bin objects",
-		"ob", " [binfile #]", "Same as obo.",
-		"obb", " [binfile #]", "Prioritize by binfile number with current selected object",
-		"ob-", " [binfile #]", "Delete binfile",
+		"ob", " [fd # bobj #]", "Prioritize by fd number and object number",
+		"obb", " [fd #]", "Prioritize by fd number with current selected object",
+		"ob-", " [fd #]", "Delete binfile by fd",
 		"obd", " [binobject #]", "Delete binfile object numbers, if more than 1 object is loaded",
 		"obo", " [binobject #]", "Prioritize by bin object number",
-		"obs", " [bf #] [bobj #]", "Prioritize by binfile and object numbers",
 		NULL};
 	const char *value = NULL;
 	ut32 binfile_num = -1, binobj_num = -1;
@@ -21,78 +31,101 @@ static void cmd_open_bin(RCore *core, const char *input) {
 	case '*':
 		r_core_bin_list (core, input[1]);
 		break;
-	case 's':
-		value = *(input+2) ? input+3 : NULL;
-		if (!value) {
-			eprintf ("Invalid binfile number.");
-			break;
-		}
-		binfile_num = *value && r_is_valid_input_num_value (core->num, value) ?
-			r_get_input_num_value (core->num, value) : UT32_MAX;
-
-		if (binfile_num == UT32_MAX) {
-			eprintf ("Invalid binfile number.");
-			break;
-		}
-
-		value = *(value+1) ? r_str_tok (value+1, ' ', -1) : NULL;
-		value = value && *(value+1) ? value+1 : NULL;
-
-		binobj_num = value && binfile_num != -1 &&
-			r_is_valid_input_num_value (core->num, value) ?
-			r_get_input_num_value (core->num, value) : UT32_MAX;
-
-		if (binobj_num == UT32_MAX) {
-			eprintf ("Invalid bin object number.");
-			break;
-		}
-		r_core_bin_raise (core, binfile_num, binobj_num);
-		break;
 	case 'b':
-		value = *(input+2) ? input+3 : NULL;
+	{
+		ut32 fd;
+		value = *(input + 3) ? input + 3 : NULL;
 		if (!value) {
-			eprintf ("Invalid binfile number.");
+			eprintf ("Invalid fd number.");
 			break;
 		}
-		binfile_num = *value && r_is_valid_input_num_value (core->num, value) ?
+		binfile_num = UT32_MAX;
+		fd = *value && r_is_valid_input_num_value (core->num, value) ?
 			r_get_input_num_value (core->num, value) : UT32_MAX;
-
+		binfile_num = find_binfile_id_by_fd (core->bin, fd);
 		if (binfile_num == UT32_MAX) {
-			eprintf ("Invalid binfile number.");
+			eprintf ("Invalid fd number.");
 			break;
 		}
-		value = *(value+1) ? r_str_tok (value+1, ' ', -1) : NULL;
-		value = value && *(value+1) ? value+1 : NULL;
 		r_core_bin_raise (core, binfile_num, -1);
 		break;
+	}
 	case ' ':
-	case 'o':
-		value = *(input+2) ? input+3 : NULL;
-		if (!value) {
-			eprintf ("Invalid binfile number.");
+	{
+		ut32 fd;
+		int n;
+		const char *tmp;
+		char *v;
+		v = input[2] ? strdup (input + 2) : NULL;
+		if (!v) {
+			eprintf ("Invalid arguments");
 			break;
 		}
-		binobj_num = *value && r_is_valid_input_num_value (core->num, value) ?
-			r_get_input_num_value (core->num, value) : UT32_MAX;
+		n = r_str_word_set0 (v);
+		if (n < 2 || n > 2) {
+			eprintf ("Invalid arguments\n");
+			eprintf ("usage: ob fd obj\n");
+			free (v);
+			break;
+		}
+		tmp = r_str_word_get0 (v, 0);
+		fd  = *v && r_is_valid_input_num_value (core->num, tmp) ?
+			r_get_input_num_value (core->num, tmp) : UT32_MAX;
+		tmp = r_str_word_get0 (v, 1);
+		binobj_num  = *v && r_is_valid_input_num_value (core->num, tmp) ?
+			r_get_input_num_value (core->num, tmp) : UT32_MAX;
+		binfile_num = find_binfile_id_by_fd (core->bin, fd);
+		r_core_bin_raise (core, binfile_num, binobj_num);
+		free (v);
+		break;
+	}
+	case 'o':
+		value = input[3] ? input + 3 : NULL;
+		if (!value) {
+			eprintf ("Invalid argument");
+			break;
+		}
+		binobj_num  = *value && r_is_valid_input_num_value (core->num, value) ?
+				r_get_input_num_value (core->num, value) : UT32_MAX;
 		if (binobj_num == UT32_MAX) {
-			eprintf ("Invalid bin object number.");
+			eprintf ("Invalid binobj_num");
 			break;
 		}
 		r_core_bin_raise (core, -1, binobj_num);
 		break;
 	case '-': // "ob-"
+		//FIXME this command doesn't remove nothing
 		if (input[2] == '*') {
-			r_cons_printf ("[i] Deleted %d binfiles\n", r_bin_file_delete_all (core->bin));
+			//FIXME this only delete from a list but it doesn't free any space
+			r_cons_printf ("[i] Deleted %d binfiles\n",
+					r_bin_file_delete_all (core->bin));
 		} else {
-			if (!r_bin_file_delete (core->bin, r_num_math (core->num, input+2))) {
-				eprintf ("Cant find an RBinFile associated with that fd.\n");
+			ut32 fd;
+			value = input[3] ? input + 3 : NULL;
+			if (!value) {
+				eprintf ("Invalid argument\n");
+				break;
+			}
+			fd  = *value && r_is_valid_input_num_value (core->num, value) ?
+					r_get_input_num_value (core->num, value) : UT32_MAX;
+
+			binfile_num = find_binfile_id_by_fd (core->bin, fd);
+			if (binfile_num == UT32_MAX) {
+				eprintf ("Invalid fd\n");
+				break;
+			}
+			if (r_core_bin_delete (core, binfile_num, -1)){
+				if (!r_bin_file_delete (core->bin, fd))
+					eprintf ("Cant find an RBinFile associated with that fd.\n");
+			} else {
+				eprintf ("Couldn't erase because there must be 1 bin object loaded\n");
 			}
 		}
 		break;
 	case 'd': // backward compat, must be deleted
-		value = *(input+2) ? input+2 : NULL;
+		value = input[2] ? input + 2 : NULL;
 		if (!value) {
-			eprintf ("Invalid binfile number.");
+			eprintf ("Invalid bin object number.");
 			break;
 		}
 		binobj_num = *value && r_is_valid_input_num_value (core->num, value) ?

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -19,7 +19,7 @@ static int cmd_seek(void *data, const char *input) {
 				r_core_seek (core, off, 1);
 			}
 		} else eprintf ("|Usage| 'sr PC' seek to program counter register\n");
-	} else
+	}
 	if (*input) {
 		const char *inputnum = strchr (input, ' ');
 		int sign = 1;

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -376,6 +376,7 @@ static int r_core_file_do_load_for_io_plugin (RCore *r, ut64 baseaddr, ut64 load
 
 	if (!desc) return false;
 	r_io_use_desc (r->io, desc);
+
 	if ( !r_bin_load_io (r->bin, desc, baseaddr, loadaddr, xtr_idx)) {
 		//eprintf ("Failed to load the bin with an IO Plugin.\n");
 		return false;

--- a/libr/core/io.c
+++ b/libr/core/io.c
@@ -437,9 +437,11 @@ R_API int r_core_block_read(RCore *core, int next) {
 	}
 	if (core->file && core->switch_file_view) {
 		r_io_use_desc (core->io, core->file->desc);
-		r_core_bin_set_by_fd (core, core->file->desc->fd);	//needed?
+		r_core_bin_set_by_fd (core, core->file->desc->fd); //needed?
 		core->switch_file_view = 0;
-	} else	r_io_use_fd (core->io, core->io->raised);		//possibly not needed
+	} else	{
+		r_io_use_fd (core->io, core->io->raised); //possibly not needed
+	}
 	return r_io_read_at (core->io, core->offset+((next)?core->blocksize:0), core->block, core->blocksize);
 }
 


### PR DESCRIPTION
I've deleted the `obs` and the same action is made by `ob fd bobj` 

https://asciinema.org/a/7uibt3kgq2gqchghnr28hzx3w

The command `ob-` doesn't remove nothing because in the function `r_bin_object_delete` you can see the following.

```
	// lazy way out, always leaving at least 1 bin object loaded
	if (binfile && (r_list_length (binfile->objs) > 1)) {
		binfile->o = NULL;
		r_list_delete_data (binfile->objs, obj);
		obj = (RBinObject *) r_list_get_n (binfile->objs, 0);
		res = obj && binfile && r_bin_file_set_cur_binfile_obj (bin, binfile, obj);
	}

```
And always there is a obj per binfile. I don't know if this is made on purpose.

Also i've noticed that when it's opened a new file with the command `o` or `io` a new binfile is created, instead of attach a new binobj to a binfile already created. 

https://asciinema.org/a/9qvam77ahdkg3600m0l810y57

If this fix is correct i will push some test in r2r.