### PR TITLE
anal_mips_cs: fixed wrong order of operands in ESIL

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -32,10 +32,10 @@ static const char *arg(csh *handle, cs_insn *insn, char *buf, int n) {
 		{
 			int disp = insn->detail->mips.operands[n].mem.disp;
 		if (disp<0) {
-		sprintf (buf, "%s,%"PFMT64d",-",
+		sprintf (buf, "%"PFMT64d",%s,-",
+			(ut64)-insn->detail->mips.operands[n].mem.disp,
 			cs_reg_name (*handle,
-				insn->detail->mips.operands[n].mem.base),
-			(ut64)-insn->detail->mips.operands[n].mem.disp);
+				insn->detail->mips.operands[n].mem.base));
 		} else {
 		sprintf (buf, "%s,%"PFMT64d",+",
 			cs_reg_name (*handle,

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -563,7 +563,7 @@ R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf) {
 					isseparator (*ptr_start); ptr_start++);
 			}
 			ptr = strchr (ptr_start, '#'); /* Comments */
-			if (ptr && !R_BETWEEN ('0', ptr[1], '9'))
+			if (ptr && !R_BETWEEN ('0', ptr[1], '9') && ptr[1]!='-')
 				*ptr = '\0';
 			r_asm_set_pc (a, a->pc + ret);
 			off = a->pc;

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -584,7 +584,7 @@ R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf) {
 				}
 				if (is_a_label) {
 					//if (stage != 2) {
-					if (ptr_start[1] == 0 || ptr_start[1] == ' ') {
+					if (ptr_start[1] != 0 && ptr_start[1] != ' ') {
 						char food[64];
 						*ptr = 0;
 						snprintf (food, sizeof (food), "0x%"PFMT64x"", off);


### PR DESCRIPTION
when a memory reference had a negative offset, the ESIL subtraction was inverted