### PR TITLE
Fix #3724

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -379,6 +379,10 @@ int main(int argc, char **argv, char **envp) {
 		}
 	}
 
+	if (asmarch) r_config_set (r.config, "asm.arch", asmarch);
+	if (asmbits) r_config_set (r.config, "asm.bits", asmbits);
+	if (asmos) r_config_set (r.config, "asm.os", asmos);
+
 	if (help > 0) {
 		r_list_free (evals);
 		r_list_free (cmds);
@@ -662,9 +666,6 @@ int main(int argc, char **argv, char **envp) {
 			r_config_set_i (r.config, "scr.utf8", true);
 		}
 #endif
-		if (asmarch) r_config_set (r.config, "asm.arch", asmarch);
-		if (asmbits) r_config_set (r.config, "asm.bits", asmbits);
-		if (asmos) r_config_set (r.config, "asm.os", asmos);
 
 		(void)r_core_bin_update_arch_bits (&r);
 

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -267,7 +267,7 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 
 		(void)posix_spawnattr_setflags (&attr, ps_flags);
 #if __i386__ || __x86_64__
-		cpu = CPU_TYPE_I386;
+		cpu = CPU_TYPE_X86;
 		if (bits == 64) cpu |= CPU_ARCH_ABI64;
 #else
 		cpu = CPU_TYPE_ANY;


### PR DESCRIPTION
This fix the -b thing but r2 doesn't detect automatically if the binary is 32 or 64 when debugging