### PR TITLE
Fix #3724

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -476,6 +476,7 @@ int main(int argc, char **argv, char **envp) {
 		}
 	} else if (strcmp (argv[optind-1], "--")) {
 		if (debug) {
+			if (asmbits) r_config_set (r.config, "asm.bits", asmbits);
 			r_config_set (r.config, "search.in", "raw"); // implicit?
 			r_config_set_i (r.config, "io.va", false); // implicit?
 			r_config_set (r.config, "cfg.debug", "true");


### PR DESCRIPTION
It's true that r2 detects automatically the bits of the binary in `r_core_bin_load` at line 564 but after `r_core_file_open` when `fork_and_ptraceme` is called at line 554 , so it's necessary to pass the -b switch to change `assembler->bits`. However, `r_config_set` was called as well after all the debug thing accordingly `assembler->bits` was never changed. I don't know if this was working before 

