### PR TITLE
Fixed bugs in windows debugger

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -73,7 +73,22 @@ static ut64 getBaddrFromDebugger(RCore *r, const char *file) {
 	RDebugMap *map;
 	if (!r || !r->io || !r->io->desc)
 		return 0LL;
+#if __WINDOWS__
+	typedef struct {
+		int pid;
+		int tid;
+		PROCESS_INFORMATION pi;
+	} RIOW32Dbg;
+	RIODesc *d = r->io->desc;
+	if (!strcmp ("w32dbg", d->plugin->name)) {
+		RIOW32Dbg *g = d->data;
+		r->io->desc->fd = g->pid;
+		//r_debug_attach (r->dbg,g->pid);  // no es necesario ya se hacen unos cuantos attach antes y despues ....
+	}
+	return r->io->winbase;
+#else
 	r_debug_attach (r->dbg, r->io->desc->fd);
+#endif
 	r_debug_map_sync (r->dbg);
 	abspath = r_file_abspath (file);
 	if (!abspath) abspath = strdup (file);

--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -1403,7 +1403,6 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 	RListIter *iter;
 	int i = 0;
 	int fd = -1;
-
 	sections = r_bin_get_sections (r->bin);
 
 	if (IS_MODE_JSON (mode)) r_cons_printf ("[");

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -515,8 +515,13 @@ static int cb_cfgdebug(void *user, void *data) {
 		if (!strcmp (dbgbackend, "bf"))
 			r_config_set (core->config, "asm.arch", "bf");
 		if (core->file) {
+#if __WINDOWS__
+			r_debug_select (core->dbg, core->dbg->pid,
+					core->dbg->tid);
+#else
 			r_debug_select (core->dbg, core->file->desc->fd,
 					core->file->desc->fd);
+#endif
 		}
 	} else {
 		if (core->dbg) r_debug_use (core->dbg, NULL);

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -305,10 +305,16 @@ static int r_core_file_do_load_for_debug (RCore *r, ut64 baseaddr, const char *f
 	if (!desc) return false;
 	if (cf && desc) {
 		int newpid = desc->fd;
+#if __WINDOWS__
+		r_debug_select (r->dbg, r->dbg->pid, r->dbg->tid);
+#else
 		r_debug_select (r->dbg, newpid, newpid);
+#endif
 	}
 #if !__linux__
+#if !__WINDOWS__
 	baseaddr = get_base_from_maps (r, filenameuri);
+#endif
 	if (baseaddr != UT64_MAX) {
 		r_config_set_i (r->config, "bin.baddr", baseaddr);
 	}

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -132,7 +132,8 @@ static int r_debug_native_step (RDebug *dbg) {
 // return thread id
 static int r_debug_native_attach (RDebug *dbg, int pid) {
 	if (!dbg || pid == dbg->pid)
-		return pid;
+		//return pid;
+		return dbg->tid;
 #if __linux__
 	return linux_attach (dbg, pid);
 #elif __WINDOWS__ && !__CYGWIN__

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -146,6 +146,7 @@ typedef struct r_io_t {
 	int ff;
 	int autofd;
 	int aslr;
+	ut64 winbase;
 	char *runprofile;
 	char *args;
 	/* Core Callbacks  (used by rap) */

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -197,6 +197,7 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 	if (th != INVALID_HANDLE_VALUE) CloseHandle (th);
 
 	eprintf ("Spawned new process with pid %d, tid = %d\n", pid, tid);
+	io->winbase = de.u.CreateProcessInfo.lpBaseOfImage;
         return pid;
 
 err_fork:


### PR DESCRIPTION
- Fixed some bugs in debugger attach/select for windows. In windows fd != pid 
- Fixed getBaddrFromDebugger function to get base addres from debug events
- Fixed  r_debug_native_attach, this function return pid as tid, in windows its needed the correct tid. 
    !!! This change can affect other debuggers if something fail revert the comment line!!!