### PR TITLE
Haiku port (partial)

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -172,7 +172,7 @@ typedef void (*PrintfCallback)(const char *str, ...);
 #elif R_INLINE
   #define R_API inline
 #else
-  #if defined(__GNUC__)
+  #if defined(__GNUC__) && __GNUC__ >= 4
     #define R_API __attribute__((visibility("default")))
   #else
     #define R_API

--- a/libr/include/sdb/types.h
+++ b/libr/include/sdb/types.h
@@ -9,7 +9,7 @@
 #define eprintf(x,y...) fprintf(stderr,x,##y)
 
 #ifndef SDB_API
-#if defined(__GNUC__)
+#if defined(__GNUC__) && __GNUC__ >= 4
 #define SDB_API __attribute__((visibility("default")))
 #else
 #define SDB_API

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -131,9 +131,9 @@ static char *getstr(const char *src) {
 		{
 			char *pat = strchr (src+1, '@');
 			if (pat) {
+				int i, len, rep = atoi (src+1);
 				*pat++ = 0;
-				int i, rep = atoi (src+1);
-				int len = strlen (pat);
+				len = strlen (pat);
 				if (rep>0) {
 					char *buf = malloc (rep);
 					for(i=0;i<rep;i++) {

--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -152,9 +152,9 @@ R_API int r_socket_connect (RSocket *s, const char *host, const char *port, int 
 	}
 	return true;
 #elif __UNIX__ || defined(__CYGWIN__)
-	if (!proto) proto = R_SOCKET_PROTO_TCP;
 	int gai, ret;
 	struct addrinfo hints, *res, *rp;
+	if (!proto) proto = R_SOCKET_PROTO_TCP;
 	signal (SIGPIPE, SIG_IGN);
 	if (proto == R_SOCKET_PROTO_UNIX) {
 		if (!r_socket_unix_connect (s, host))

--- a/libr/util/debruijn.c
+++ b/libr/util/debruijn.c
@@ -108,6 +108,8 @@ static char* cyclic_pattern_long() {
 R_API int r_debruijn_offset(ut64 value, int guest_endian) {
 	ut64 needle_l[2];  // Hold the value as a string.
 	char* needle, *pattern;
+	int n, host_endian, retval;
+	char* pch;
 
 	if (value == 0)
 		return -1;
@@ -123,14 +125,14 @@ R_API int r_debruijn_offset(ut64 value, int guest_endian) {
 
 	// we should not guess the endian. its already handled by other functions 
 	// and configure by the user in cfg.bigendian
-	int n = 1;
+	n = 1;
 	// little endian if true
-	int host_endian = (*(char*)&n == 1) ? 1 : 0;
+	host_endian = (*(char*)&n == 1) ? 1 : 0;
 	if (host_endian != guest_endian)
 		reverse_string (needle);
 
-	char* pch = strstr (pattern, needle);
-	int retval = -1;
+	pch = strstr (pattern, needle);
+	retval = -1;
 	if (pch != NULL)
 		retval = (int)(pch - pattern);
 	free (pattern);

--- a/libr/util/p_date.c
+++ b/libr/util/p_date.c
@@ -56,7 +56,6 @@ R_API int r_print_date_unix(RPrint *p, const ut8 *buf, int len) {
 
 R_API int r_print_date_get_now(RPrint *p, char *str) {
 	int ret = 0;
-        *str = 0;
 #if __UNIX__
         struct tm curt; /* current time */
         time_t l;
@@ -66,6 +65,7 @@ R_API int r_print_date_get_now(RPrint *p, char *str) {
 		"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 		"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 
+        *str = 0;
         l = time(0);
         localtime_r (&l, &curt);
 	// XXX localtime is affected by the timezone. 
@@ -81,6 +81,7 @@ R_API int r_print_date_get_now(RPrint *p, char *str) {
 		ret = sizeof(time_t);
 	}
 #else
+        *str = 0;
 #warning r_print_date_now NOT IMPLEMENTED FOR THIS PLATFORM
 #endif
 	return ret;

--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -1083,7 +1083,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 		const char *formatname, int mode, const char *setval, char *ofield) {
 	int nargs, i, j, invalid, nexti, idx, times, otimes, endian, isptr = 0;
 	char *args = NULL, *bracket, tmp, last = 0;
-	ut64 addr = 0, addr64 = 0, seeki = 0;;
+	ut64 addr = 0, addr64 = 0, seeki = 0;
 	static int slide = 0, oldslide = 0;
 	char namefmt[8], *field = NULL;
 	const char *arg = NULL;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -36,11 +36,11 @@ static int r_print_stereogram_private(const char *bump, int w, int h, char *out,
 	const char *string = "Az+|.-=/^@_pT";
 	const int string_len = strlen (string);
 
-	if (!bump || !out)
-		return 0;
 	int x, y, s, l = 0, l2 = 0, ch;
 	int skip = 7;
 	int bumpi = 0, outi = 0;
+	if (!bump || !out)
+		return 0;
 	for (y = 0; bump[bumpi] && outi<size; y++) {
 		l = l2 = 0;
 		for (x = 0; bump[bumpi] && outi<size && x<w; x++) {
@@ -994,8 +994,8 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size) {
 	p->cb_printf ("\n");
 	for (i=0; i<size; i++) {
 		ut8 next = (i+1<size)? arr[i+1]:0;
-		p->cb_printf ("%02x %04x |", i, arr[i]);
 			int base = 0;
+		p->cb_printf ("%02x %04x |", i, arr[i]);
 			if (next<INC) base = 1;
 		if (next<arr[i]) {
 			//if (arr[i]>0 && i>0) p->cb_printf ("  ");

--- a/libr/util/sandbox.c
+++ b/libr/util/sandbox.c
@@ -216,8 +216,9 @@ R_API DIR* r_sandbox_opendir (const char *path) {
 }
 
 R_API int r_sys_stop () {
+	int pid;
 	if (enabled) return R_FALSE;
-	int pid = r_sys_getpid ();
+	pid = r_sys_getpid ();
 #ifndef SIGSTOP
 #define SIGSTOP 19
 #endif

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -796,6 +796,7 @@ R_API char* r_str_replace_thunked(char *str, char *clean, int *thunk, int clen,
 	slen = strlen (str) + 1;
 
 	for (i = 0; i < clen; ) {
+		int newo;
 		bias = 0;
 		p = (char *)r_mem_mem (
 			(const ut8*)clean + i, clen - i,
@@ -806,7 +807,7 @@ R_API char* r_str_replace_thunked(char *str, char *clean, int *thunk, int clen,
 		 * we need delta to keep track of it*/
 		str_p = str + thunk[i] + delta;
 
-		int newo = thunk[i + klen] - thunk[i];
+		newo = thunk[i + klen] - thunk[i];
 		r_str_ansi_filter(str_p, NULL, NULL, newo);
 		scnd = strdup (str_p + newo);
 		bias = vlen - newo;

--- a/shlr/sdb/src/sdb.c
+++ b/shlr/sdb/src/sdb.c
@@ -475,8 +475,8 @@ SDB_API int sdb_set (Sdb* s, const char *key, const char *val, ut32 cas) {
 
 static int sdb_foreach_list_cb(void *user, const char *k, const char *v) {
 	SdbList *list = (SdbList *)user;
-	list->free = free;
 	SdbKv *kv = R_NEW0 (SdbKv);
+	list->free = free;
 	/* fake read-only */
 	kv->key = (char *)k;
 	kv->value = (char*)v;

--- a/shlr/sdb/src/types.h
+++ b/shlr/sdb/src/types.h
@@ -9,7 +9,7 @@
 #define eprintf(x,y...) fprintf(stderr,x,##y)
 
 #ifndef SDB_API
-#if defined(__GNUC__)
+#if defined(__GNUC__) && __GNUC__ >= 4
 #define SDB_API __attribute__((visibility("default")))
 #else
 #define SDB_API

--- a/shlr/zip/zip/zip_set_file_compression.c
+++ b/shlr/zip/zip/zip_set_file_compression.c
@@ -42,6 +42,7 @@ zip_set_file_compression(struct zip *za, zip_uint64_t idx,
 			 zip_int32_t method, zip_uint32_t flags)
 {
     struct zip_entry *e;
+    zip_int32_t old_method;
 
     if (idx >= za->nentry) {
 	_zip_error_set(&za->error, ZIP_ER_INVAL, 0);
@@ -60,7 +61,7 @@ zip_set_file_compression(struct zip *za, zip_uint64_t idx,
 
     e = za->entry+idx;
     
-    zip_int32_t old_method = (e->orig == NULL ? ZIP_CM_DEFAULT : e->orig->comp_method);
+    old_method = (e->orig == NULL ? ZIP_CM_DEFAULT : e->orig->comp_method);
     
     /* XXX: revisit this when flags are supported, since they may require a recompression */
     


### PR DESCRIPTION
Some fixes for Haiku (gcc2)

While we can compile stuff with gcc4, we still use gcc2 for the base system, so it makes sense to try and build with it anyway (although there are still some other issues to fix).

Mostly C89.