### PR TITLE
Esil delay slot with internal state

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -61,7 +61,7 @@
 #define ES_IS_NEGATIVE(arg) "1,"arg",<<<,1,&"
 
 // jump to address
-#define ES_J(addr) addr",pc,="
+#define ES_J(addr) addr",$jt,=,1,$ds,="
 
 // call with delay slot
 #define ES_CALL_DR(ra, addr) "pc,4,+,"ra",=,"ES_J(addr)
@@ -70,6 +70,9 @@
 // call without delay slot
 #define ES_CALL_NDR(ra, addr) "pc,"ra",=,"ES_J(addr)
 #define ES_CALL_ND(addr) ES_CALL_NDR("ra", addr)
+
+// emit ERR trap if executed in a delay slot
+#define ES_TRAP_DS() "0,$ds,>,?{,$$,1,TRAP,BREAK,}"
 
 // sign extend 32 -> 64
 #define ES_SIGN_EXT64(arg) \
@@ -190,104 +193,104 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case MIPS_INS_BAL:
 	case MIPS_INS_JAL:
-		r_strbuf_appendf (&op->esil, ES_CALL_D ("%s"), ARG (0));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () "," ES_CALL_D ("%s"), ARG (0));
 		break;
 	case MIPS_INS_JALR:
 	case MIPS_INS_JALRS:
 		if (OPCOUNT () < 2) {
-			r_strbuf_appendf (&op->esil, ES_CALL_D ("%s"), ARG (0));
+			r_strbuf_appendf (&op->esil, ES_TRAP_DS () "," ES_CALL_D ("%s"), ARG (0));
 		} else {
 			PROTECT_ZERO () {
-				r_strbuf_appendf (&op->esil, ES_CALL_DR ("%s","%s"), ARG (0), ARG (1));
+				r_strbuf_appendf (&op->esil, ES_TRAP_DS () "," ES_CALL_DR ("%s","%s"), ARG (0), ARG (1));
 			}
 		}
 		break;
 	case MIPS_INS_JALRC: // no delay
 		if (OPCOUNT () < 2) {
-			r_strbuf_appendf (&op->esil, ES_CALL_ND ("%s"), ARG (0));
+			r_strbuf_appendf (&op->esil, ES_TRAP_DS () "," ES_CALL_ND ("%s"), ARG (0));
 		} else {
 			PROTECT_ZERO () {
-				r_strbuf_appendf (&op->esil, ES_CALL_NDR ("%s","%s"), ARG (0), ARG (1));
+				r_strbuf_appendf (&op->esil, ES_TRAP_DS () "," ES_CALL_NDR ("%s","%s"), ARG (0), ARG (1));
 			}
 		}
 		break;
 	case MIPS_INS_JRADDIUSP:
 		// increment stackpointer in X and jump to %ra
-		r_strbuf_appendf (&op->esil, "%d,sp,+=,ra,pc,=", ARG (0));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",%d,sp,+=,"ES_J ("ra"), ARG (0));
 		break;
 	case MIPS_INS_JR:
 	case MIPS_INS_JRC:
 	case MIPS_INS_J:
 	case MIPS_INS_B: // ???
 		// jump to address with conditional
-		r_strbuf_appendf (&op->esil, ES_J ("%s"), ARG (0));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () "," ES_J ("%s"), ARG (0));
 		break;
 	case MIPS_INS_BNE:  // bne $s, $t, offset
-		r_strbuf_appendf (&op->esil, "%s,%s,==,$z,!,?{,"ES_J ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",%s,%s,==,$z,!,?{,"ES_J ("%s")",}",
 			ARG (0), ARG (1), ARG (2));
 		break;
 	case MIPS_INS_BEQ:
-		r_strbuf_appendf (&op->esil, "%s,%s,==,$z,?{,"ES_J ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",%s,%s,==,$z,?{,"ES_J ("%s")",}",
 			ARG (0), ARG (1), ARG (2));
 		break;
 	case MIPS_INS_BZ:
 	case MIPS_INS_BEQZ:
 	case MIPS_INS_BEQZC:
-		r_strbuf_appendf (&op->esil, "%s,0,==,$z,?{,"ES_J ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",%s,0,==,$z,?{,"ES_J ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BNEZ:
-		r_strbuf_appendf (&op->esil, "%s,0,==,$z,!,?{,"ES_J ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",%s,0,==,$z,!,?{,"ES_J ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BEQZALC:
-		r_strbuf_appendf (&op->esil, "%s,0,==,$z,?{,"ES_CALL_ND ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",%s,0,==,$z,?{,"ES_CALL_ND ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BLEZ:
 	case MIPS_INS_BLEZC:
-		r_strbuf_appendf (&op->esil, "0,%s,==,$z,?{,"ES_J ("%s")",BREAK,},",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,%s,==,$z,?{,"ES_J ("%s")",BREAK,},",
 			ARG (0), ARG (1));
-		r_strbuf_appendf (&op->esil, "1,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",1,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BGEZ:
 	case MIPS_INS_BGEZC:
-		r_strbuf_appendf (&op->esil, "0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BGEZAL:
-		r_strbuf_appendf (&op->esil, "0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_CALL_D ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_CALL_D ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BGEZALC:
-		r_strbuf_appendf (&op->esil, "0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_CALL_ND ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_CALL_ND ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BGTZALC:
-		r_strbuf_appendf (&op->esil, "0,%s,==,$z,?{,BREAK,},", ARG(0));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,%s,==,$z,?{,BREAK,},", ARG(0));
 		r_strbuf_appendf (&op->esil, "0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_CALL_ND ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BLTZAL:
-		r_strbuf_appendf (&op->esil, "1,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_CALL_D ("%s")",}", ARG(0), ARG(1));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",1,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_CALL_D ("%s")",}", ARG(0), ARG(1));
 		break;
 	case MIPS_INS_BLTZ:
 	case MIPS_INS_BLTZC:
-		r_strbuf_appendf (&op->esil, "1,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J ("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",1,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J ("%s")",}",
 			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BGTZ:
 	case MIPS_INS_BGTZC:
-		r_strbuf_appendf (&op->esil, "0,%s,==,$z,?{,BREAK,},", ARG (0));
-		r_strbuf_appendf (&op->esil, "0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J("%s")",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,%s,==,$z,?{,BREAK,},", ARG (0));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J("%s")",}",
 			ARG (0), ARG (1));		
 		break;
 	case MIPS_INS_BTEQZ:
-		r_strbuf_appendf (&op->esil, "0,t,==,$z,?{,"ES_J ("%s")",}", ARG (0));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,t,==,$z,?{,"ES_J ("%s")",}", ARG (0));
 		break;
 	case MIPS_INS_BTNEZ:
-		r_strbuf_appendf (&op->esil, "0,t,==,$z,!,?{,"ES_J ("%s")",}", ARG (0));
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,t,==,$z,!,?{,"ES_J ("%s")",}", ARG (0));
 		break;
 	case MIPS_INS_MOV:
 	case MIPS_INS_MOVE:

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1457,11 +1457,6 @@ static int esil_step(RCore *core, ut64 until_addr, const char *until_expr) {
 
 		delay_slot--;
 
-		if (((st64)delay_slot) >= 0) {
-			// save decreased delay slot counter
-			r_anal_esil_reg_write (esil, "$ds", delay_slot);
-		}
-
 		if (((st64)delay_slot) <= 0) {
 			// no delay slot, or just consumed
 			ut64 jump_target_set = 0;
@@ -1475,9 +1470,13 @@ static int esil_step(RCore *core, ut64 until_addr, const char *until_expr) {
 			}
 		}
 
-		if (((st64)delay_slot)>=0 && !esil->trap) {
-			// emulate the instruction and its delay slots in the same 'aes' step
-			goto repeat;
+		if (((st64)delay_slot)>=0) {
+			// save decreased delay slot counter
+			r_anal_esil_reg_write (esil, "$ds", delay_slot);
+			if (!esil->trap) {
+				// emulate the instruction and its delay slots in the same 'aes' step
+				goto repeat;
+			}
 		}
 	}
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -977,8 +977,9 @@ typedef struct r_anal_esil_t {
 	int debug;
 	ut64 flags;
 	ut64 address;
-	int delay;
-	ut64 delay_addr;
+	int delay; 				// mapped to $ds in ESIL
+	ut64 jump_target; 		// mapped to $jt in ESIL
+	int jump_target_set; 	// mapped to $js in ESIL
 	int trap;
 	ut32 trap_code; // extend into a struct to store more exception info?
 	// parity flag? done with cur


### PR DESCRIPTION
It's an attempt to implement delay slots in an architecture independent way, similar to what unicorn engine does.

This is implemented by adding three ESIL internal registers which are read/write:

- **$ds**, stores the delay slot state it means "is this instruction executing inside a delay slot" ? and can be treated as a counter for architectures which require more than one instruction inside delay slots

- **$jt**, stores the target address of a branch, it must be used instead of manipulating PC directly in the ESIL implementation of branches requiring a delay slot

- **$js**, if 1 means "the jump target has been set" - it is set automatically on writing to $jt and it's cleared by esil_step

all of these new registers can be read and written like any register. To permit this, all ESIL internal registers can now be handled like "real" registers now - this requires review.

All existing regression tests are not affected by this change.

The logic to handle delay slots is still inside the esil_step function, but now all architectures should support it by using the new registers. I did it with MIPS, the others are still to be ported and tested properly in regressions.

Since not all instructions are allowed in a delay slot, esil_step perform a basic check on the "op.type" field, but more specific checks can be performed ESIL-side by each arch implementation, like i did in MIPS.

