### PR TITLE
Fix for bug #3788

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -274,8 +274,9 @@ static int __cb_hit(RSearchKeyword *kw, void *user, ut64 addr) {
 		}
 	}
 
-	if (core->section && (core->section->rwx & R_IO_MAP))
-		base_addr = core->section->offset;
+	// reverting fix for bug 3788 since it breaks search in some cases
+//	if (core->section && (core->section->rwx & R_IO_MAP))
+//		base_addr = core->section->offset;
 
 	if (searchshow && kw && kw->keyword_length > 0) {
 		int len, i, extra, mallocsize;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -386,6 +386,7 @@ R_API RIOSection *r_io_section_get_name(RIO *io, const char *name);
 R_API RIOSection *r_io_section_get_i(RIO *io, int idx);
 R_API RIOSection *r_io_section_getv(RIO *io, ut64 vaddr);
 R_API RIOSection *r_io_section_mget(RIO *io, ut64 maddr);
+R_API RIOSection *r_io_section_mget_prev(RIO *io, ut64 maddr);
 R_API RIOSection *r_io_section_vget(RIO *io, ut64 addr);
 R_API RIOSection *r_io_section_pget(RIO *io, ut64 addr);
 R_API int r_io_section_set_archbits(RIO *io, ut64 addr, const char *arch, int bits);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -340,7 +340,10 @@ R_API int r_io_read(RIO *io, ut8 *buf, int len) {
 	if (io->enforce_rwx & R_IO_READ)
 		if (!(r_io_section_get_rwx (io, io->off) & R_IO_READ))
 			return -1;
-	ret = r_io_read_at (io, io->off, buf, len);
+	/* io->off is in maddr, but r_io_read_at works in vaddr */
+	ut64 vaddr = r_io_section_maddr_to_vaddr(io, io->off);
+	vaddr = (vaddr == UT64_MAX) ? io->off : vaddr;
+	ret = r_io_read_at (io, vaddr, buf, len);
 	if (ret > 0) io->off += ret;
 	return ret;
 }

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -274,6 +274,16 @@ R_API RIOSection *r_io_section_mget(RIO *io, ut64 maddr) {
 	return NULL;
 }
 
+R_API RIOSection *r_io_section_mget_prev(RIO *io, ut64 maddr) {
+	RIOSection *s;
+	RListIter *iter;
+	r_list_foreach_prev (io->sections, iter, s) {
+		if ((maddr >= s->offset && maddr < (s->offset + s->size)))
+			return s;
+	}
+	return NULL;
+}
+
 // XXX: rename this
 R_API ut64 r_io_section_get_offset(RIO *io, ut64 maddr) {
 	RIOSection *s = r_io_section_mget (io, maddr);
@@ -321,7 +331,9 @@ R_API ut64 r_io_section_vaddr_to_maddr_try(RIO *io, ut64 vaddr) {
 }
 
 /* returns the conversion from vaddr to maddr if the given vaddr is in a mapped
- * region, UT64_MAX otherwise */
+ * region, UT64_MAX otherwise.
+ * Special case for when s->vaddr
+ */
 R_API ut64 r_io_section_vaddr_to_maddr(RIO *io, ut64 vaddr) {
 	RListIter *iter;
 	RIOSection *s;
@@ -338,7 +350,7 @@ R_API ut64 r_io_section_vaddr_to_maddr(RIO *io, ut64 vaddr) {
 /* returns the conversion from file offset to vaddr if the given offset is
  * mapped somewhere, UT64_MAX otherwise */
 R_API ut64 r_io_section_maddr_to_vaddr(RIO *io, ut64 offset) {
-	RIOSection *s = r_io_section_mget (io, offset);
+	RIOSection *s = r_io_section_mget_prev (io, offset);
 	if (s) {
 		io->section = s;
 		return (s->vaddr + offset - s->offset);


### PR DESCRIPTION
Fix for bug #3788 

- `r_io_read` calls `r_io_read_at` with vaddrs, and not with maddr
- `r_io_section_maddr_to_vaddr` uses a reverse iterator to check the
  sections

Squashed commit of the following:

commit a31d359bf1c79b92f518fa8237c7f9d4cf146577
Author: Ricardo Quesada <ricardoquesada@gmail.com>
Date:   Wed Dec 9 11:40:54 2015 -0800

    fetches sections starting from the back

commit 0b687439ea6225c8db9f387cc93bc53300e297a7
Merge: 8485676 92c1631
Author: Ricardo Quesada <ricardoquesada@gmail.com>
Date:   Tue Dec 8 23:40:35 2015 -0800

    Merge branch 'master' of https://github.com/radare/radare2 into revert_3788

commit 8485676cf5c042d8c4e10c798b4fadb1a43df50c
Author: Ricardo Quesada <ricardoquesada@gmail.com>
Date:   Tue Dec 8 23:09:05 2015 -0800

    This seems to be the "correct" patch...

    ...but it breaks some tests... apprently searches a few bytes
    out of the section creating some false-positives hits

    I'm just commiting this PR to give an idea of where the bug is

commit 2e4b8de397a4ef23c02c3e08113cf6b984479275
Author: Ricardo Quesada <ricardoquesada@gmail.com>
Date:   Tue Dec 8 22:46:29 2015 -0800

    not good... reverting

commit 324afba7e2853ddb72750f7f8b38bf59af310873
Author: Ricardo Quesada <ricardoquesada@gmail.com>
Date:   Tue Dec 8 22:09:25 2015 -0800

    workaround for bug 3788

commit 6e6283eaa18edcca1987a8f4227f163a6926c430
Author: Ricardo Quesada <ricardoquesada@gmail.com>
Date:   Tue Dec 8 15:14:12 2015 -0800

    Reverts fix for bug #3788

    please, reopen bug #3788