### PR TITLE
Webui: trivial changes on cursor behaviour and style

### DIFF
--- a/shlr/www/m/styles.css
+++ b/shlr/www/m/styles.css
@@ -117,6 +117,9 @@ html, body {
   background-color: #00BCD4;
   color: #37474F;
 }
+.mdl-navigation__link:hover {
+  cursor: pointer;
+}
 .demo-navigation .mdl-navigation__link .material-icons {
   font-size: 24px;
   color: rgba(255, 255, 255, 0.56);

--- a/shlr/www/m/styles.css
+++ b/shlr/www/m/styles.css
@@ -115,7 +115,7 @@ html, body {
 }
 .demo-layout .demo-navigation .mdl-navigation__link:hover {
   background-color: #00BCD4;
-  color: #37474F;
+  color: #37474F !important;
 }
 .mdl-navigation__link:hover {
   cursor: pointer;

--- a/shlr/www/p/lib/css/tree.jquery.css
+++ b/shlr/www/p/lib/css/tree.jquery.css
@@ -48,6 +48,10 @@ ul.jqtree-tree .jqtree-element {
     margin-left: 0;
 }
 
+span.addr {
+    cursor: default;
+}
+
 ul.jqtree-tree li.jqtree-folder {
     margin-bottom: 4px;
 }

--- a/shlr/www/p/lib/css/tree.jquery.css
+++ b/shlr/www/p/lib/css/tree.jquery.css
@@ -48,7 +48,9 @@ ul.jqtree-tree .jqtree-element {
     margin-left: 0;
 }
 
-span.addr {
+span.addr:hover, 
+div#strings .jqtree-title-folder:hover,
+div#types .jqtree-title-folder:hover {
     cursor: default;
 }
 


### PR DESCRIPTION
* `1d8c7`: links on left menu use pointer (not text) cursor when those are double-clickable (/p) or always (/m)
* `8b4b7`: extending pointer behaviour on /p subsections from upper menu (Strings, Types)
* `a4a26`: foreground color for hovered links on left menu was very similar to background color; now enforced to the originally defined darker color