### PR TITLE
Fix #838

### DIFF
--- a/libr/bin/format/omf/omf.c
+++ b/libr/bin/format/omf/omf.c
@@ -696,6 +696,7 @@ int r_bin_omf_send_sections(RList *list, OMF_segment *section, r_bin_omf_obj *ob
 		new->vaddr = section->vaddr + data->offset + OMF_BASE_ADDR;
 		new->srwx = R_BIN_SCN_EXECUTABLE | R_BIN_SCN_WRITABLE |
 			R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+		new->add = true;
 		r_list_append (list, new);
 		data = data->next;
 	}

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -162,6 +162,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->paddr = 0;
 	ptr->vaddr = art.image_base;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -172,6 +173,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->paddr = art.bitmap_offset;
 	ptr->vaddr = art.image_base + art.bitmap_offset;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -182,6 +184,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->size = art.oat_file_end - art.oat_file_begin;
 	ptr->vsize = ptr->size;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -192,6 +195,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->size = art.oat_data_end - art.oat_data_begin;
 	ptr->vsize = ptr->size;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	return ret;

--- a/libr/bin/p/bin_bios.c
+++ b/libr/bin/p/bin_bios.c
@@ -94,6 +94,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vaddr = 0xf0000;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
 		R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -88,11 +88,12 @@ static RList *sections(RBinFile *arch) {
 		}
 
 		ptr = R_NEW0 (RBinSection);
-		strncpy (ptr->name, coffname, R_BIN_SIZEOF_STRINGS); 
+		strncpy (ptr->name, coffname, R_BIN_SIZEOF_STRINGS);
 
 		ptr->size = obj->scn_hdrs[i].s_size;
 		ptr->vsize = obj->scn_hdrs[i].s_size;
 		ptr->paddr = obj->scn_hdrs[i].s_scnptr;
+		ptr->add = true;
 
 		ptr->srwx = R_BIN_SCN_MAP;
 		if (obj->scn_hdrs[i].s_flags&COFF_SCN_MEM_READ)
@@ -155,7 +156,7 @@ static RList *symbols(RBinFile *arch) {
 		}
 
 		if (obj->symbols[i].n_scnum < obj->hdr.f_nscns) {
-			ptr->paddr = obj->scn_hdrs[obj->symbols[i].n_scnum].s_scnptr + 
+			ptr->paddr = obj->scn_hdrs[obj->symbols[i].n_scnum].s_scnptr +
 				obj->symbols[i].n_value;
 		}
 
@@ -269,7 +270,7 @@ static int check_bytes(const ut8 *buf, ut64 length) {
 #if 0
 TODO: do more checks here to avoid false positives
 
-ut16 MACHINE 
+ut16 MACHINE
 ut16 NSECTIONS
 ut32 DATE
 ut32 PTRTOSYMTABLE

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -406,7 +406,7 @@ static int *parse_class (RBinFile *binfile, struct r_bin_dex_obj_t *bin, struct 
 		omi = MI;
 		// the mi is diff
 #if 0
-		index into the method_ids list for the identity of this method (includes the name and descriptor), represented as a difference from the index of previous element in the list. The index of the first element in a list is represented directly. 
+		index into the method_ids list for the identity of this method (includes the name and descriptor), represented as a difference from the index of previous element in the list. The index of the first element in a list is represented directly.
 #endif
 		p = r_uleb128 (p, p_end-p, &MA);
 		p = r_uleb128 (p, p_end-p, &MC);
@@ -692,7 +692,7 @@ static RList* classes (RBinFile *arch) {
 		class = R_NEW0 (RBinClass);
 		// get source file name (ClassName.java)
 		// TODO: use RConstr here
-		//class->name = strdup (name[0]<0x41? name+1: name); 
+		//class->name = strdup (name[0]<0x41? name+1: name);
 		class->name = dex_class_name_byid (bin, entry.class_id);
 		// find reference to this class instance
 		char *cn = getClassName(class->name);
@@ -851,6 +851,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->size = ptr->vsize = sizeof (struct dex_header_t);
 		ptr->paddr= ptr->vaddr = 0;
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -859,6 +860,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->paddr= ptr->vaddr = sizeof (struct dex_header_t);
 		ptr->size = bin->code_from - ptr->vaddr; // fix size
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -866,6 +868,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vaddr = ptr->paddr = bin->code_from; //ptr->vaddr = fsym;
 		ptr->size = bin->code_to - ptr->paddr;
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -882,6 +885,7 @@ static RList* sections(RBinFile *arch) {
 			//ptr->size = ptr->vsize = 1024;
 		}
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; //|2;
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	return ret;

--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -116,6 +116,7 @@ static RList* sections(RBinFile *arch) {
 		s->size = dol->text_size[i];
 		s->vsize = s->size;
 		s->srwx = r_str_rwx ("mr-x");
+		s->add = true;
 		r_list_append (ret, s);
 	}
 	/* data sections */
@@ -129,6 +130,7 @@ static RList* sections(RBinFile *arch) {
 		s->size = dol->data_size[i];
 		s->vsize = s->size;
 		s->srwx = r_str_rwx ("mr--");
+		s->add = true;
 		r_list_append (ret, s);
 	}
 	/* bss section */
@@ -139,6 +141,7 @@ static RList* sections(RBinFile *arch) {
 	s->size = dol->bss_size;
 	s->vsize = s->size;
 	s->srwx = r_str_rwx ("-rw-");
+	s->add = true;
 	r_list_append (ret, s);
 
 	return ret;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -106,6 +106,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = sections[i].size;
 		ptr->paddr = sections[i].offset + obj->boffset;
 		ptr->vaddr = sections[i].addr;
+		ptr->add = true;
 		if (ptr->vaddr == 0)
 			ptr->vaddr = ptr->paddr;
 		ptr->srwx = sections[i].srwx | R_BIN_SCN_MAP;

--- a/libr/bin/p/bin_mbn.c
+++ b/libr/bin/p/bin_mbn.c
@@ -121,6 +121,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->paddr = sb.paddr + 40;
 	ptr->vaddr = sb.vaddr;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
+	ptr->add = true;
 	ptr->has_strings = true;
 	r_list_append (ret, ptr);
 
@@ -133,6 +134,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vaddr = sb.sign_va;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 	ptr->has_strings = true;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	if (sb.cert_sz && sb.cert_va > sb.vaddr) {
@@ -145,6 +147,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vaddr = sb.cert_va;
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
 		ptr->has_strings = true;
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	return ret;

--- a/libr/bin/p/bin_mz.c
+++ b/libr/bin/p/bin_mz.c
@@ -122,6 +122,7 @@ static RList * sections(RBinFile *arch) {
 		ptr->paddr = segments[i].paddr;
 		ptr->vaddr = segments[i].paddr;
 		ptr->srwx = r_str_rwx ("mrwx");
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	free ((void *)segments);

--- a/libr/bin/p/bin_nes.c
+++ b/libr/bin/p/bin_nes.c
@@ -93,6 +93,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vaddr = ROM_START_ADDRESS;
 	ptr->vsize = ROM_SIZE;
 	ptr->srwx = R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -77,6 +77,7 @@ static RList* sections(RBinFile *arch) {
 	ptr9->paddr = loaded_header.arm9_rom_offset;
 	ptr9->vaddr = loaded_header.arm9_ram_address;
 	ptr9->srwx = r_str_rwx ("mrwx");
+	ptr9->add = true;
 	r_list_append (ret, ptr9);
 
 	strncpy (ptr7->name, "arm7", 5);
@@ -85,6 +86,7 @@ static RList* sections(RBinFile *arch) {
 	ptr7->paddr = loaded_header.arm7_rom_offset;
 	ptr7->vaddr = loaded_header.arm7_ram_address;
 	ptr7->srwx = r_str_rwx ("mrwx");
+	ptr7->add = true;
 	r_list_append (ret, ptr7);
 
 	return ret;

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -111,6 +111,7 @@ static RList* sections(RBinFile *arch){
 	rombank[0]->vsize = 0x4000;
 	rombank[0]->vaddr = 0;
 	rombank[0]->srwx = r_str_rwx ("mrx");
+	rombank[0]->add = true;
 
 	r_list_append (ret, rombank[0]);
 
@@ -121,6 +122,7 @@ static RList* sections(RBinFile *arch){
 		rombank[i]->vaddr = i*0x10000-0xc000;			//spaaaaaaaaaaaaaaaace!!!
 		rombank[i]->size = rombank[i]->vsize = 0x4000;
 		rombank[i]->srwx = r_str_rwx ("mrx");
+		rombank[i]->add = true;
 		r_list_append (ret,rombank[i]);
 	}
 	return ret;

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -85,6 +85,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->paddr = 8*4;
 	ptr->vaddr = ptr->paddr;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	// add data segment
 	datasize = r_mem_get_num (arch->buf->buf+8, 4, big_endian);
@@ -97,6 +98,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->paddr = textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_MAP; // rw-
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	// ignore bss or what
@@ -111,6 +113,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->paddr = datasize+textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	// add spsz segment
@@ -124,6 +127,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->paddr = symssize+datasize+textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	// add pcsz segment
@@ -137,6 +141,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->paddr = spszsize+symssize+datasize+textsize+(8*4);
 		ptr->vaddr = ptr->paddr;
 		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
+		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
 	return ret;

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -112,6 +112,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->vsize = sections[i].vsize;
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
+		ptr->add = true;
 		ptr->srwx = R_BIN_SCN_MAP;
 		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].flags))
 			ptr->srwx |= R_BIN_SCN_EXECUTABLE;

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -126,6 +126,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = ptr->size = pai.num_reloc_entries * sizeof (ut32);
 	ptr->vaddr = ptr->paddr = pai.reloc_list_start;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	if (ptr->vaddr<textsize)
 		textsize = ptr->vaddr;
@@ -137,6 +138,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = ptr->size = 0;
 	ptr->vaddr = ptr->paddr = pai.sym_table_addr;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	if (ptr->vaddr<textsize)
 		textsize = ptr->vaddr;
@@ -148,6 +150,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = ptr->size = textsize - ptr->paddr;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
 		R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -156,6 +159,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = ptr->size = sizeof (PebbleAppInfo);
 	ptr->vaddr = ptr->paddr = 0;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	return ret;

--- a/libr/bin/p/bin_psxexe.c
+++ b/libr/bin/p/bin_psxexe.c
@@ -72,6 +72,7 @@ static RList* sections(RBinFile* arch) {
 	sect->vaddr = psxheader.t_addr;
 	sect->vsize = psxheader.t_size;
 	sect->srwx = R_BIN_SCN_MAP | R_BIN_SCN_EXECUTABLE;
+	sect->add = true;
 
 	r_list_append (ret, sect);
 	return ret;

--- a/libr/bin/p/bin_rar.c
+++ b/libr/bin/p/bin_rar.c
@@ -107,6 +107,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->paddr = 0;
 	ptr->vaddr = ptr->paddr;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP; // r--
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	/* rarvm code */
@@ -116,6 +117,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vsize = ptr->size = sz - 0x9a;
 	ptr->vaddr = ptr->paddr = 0x9a;
 	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP; // r-x
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -256,6 +256,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->paddr = ptr->vaddr = 0;
 	ptr->size = ptr->vsize = 0x100;
 	ptr->srwx = R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -264,6 +265,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->paddr = ptr->vaddr = 0x100;
 	ptr->size = ptr->vsize = sizeof (SMD_Header);
 	ptr->srwx = R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 
 	if (!(ptr = R_NEW0 (RBinSection)))
@@ -277,6 +279,7 @@ static RList* sections(RBinFile *arch) {
 	}
 	ptr->size = ptr->vsize = arch->buf->length - ptr->paddr;
 	ptr->srwx = R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/libr/bin/p/bin_spc700.c
+++ b/libr/bin/p/bin_spc700.c
@@ -63,6 +63,7 @@ static RList* sections(RBinFile *arch) {
 	ptr->vaddr = 0x0;
 	ptr->vsize = RAM_SIZE;
 	ptr->srwx = R_BIN_SCN_MAP;
+	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -107,6 +107,7 @@ static RList* sections(RBinFile *arch) {
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr;
 		ptr->srwx = R_BIN_SCN_MAP;
+		ptr->add = true;
 		if (R_BIN_TE_SCN_IS_EXECUTABLE (sections[i].flags))
 			ptr->srwx |= R_BIN_SCN_EXECUTABLE;
 		if (R_BIN_TE_SCN_IS_WRITABLE (sections[i].flags))

--- a/libr/bin/p/bin_vsf.c
+++ b/libr/bin/p/bin_vsf.c
@@ -160,6 +160,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0xa000;
 			ptr->vsize = 1024 * 8;	// BASIC size (8k)
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 
 			// KERNAL (0xe000 - 0xffff)
@@ -171,6 +172,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8;	// KERNAL size (8k)
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 
 			// CHARGEN section ignored
@@ -185,6 +187,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0x4000;
 			ptr->vsize = 1024 * 28;	// BASIC size (28k)
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 
 			// MONITOR (0xb000 - 0xbfff)
@@ -197,6 +200,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0xb000;
 			ptr->vsize = 1024 * 4;	// BASIC size (4k)
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 
 			// EDITOR (0xc000 - 0xcfff)
@@ -208,6 +212,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0xc000;
 			ptr->vsize = 1024 * 4;	// BASIC size (4k)
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 
 			// KERNAL (0xe000 - 0xffff)
@@ -219,6 +224,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8;	// KERNAL size (8k)
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 
 			// CHARGEN section ignored
@@ -240,6 +246,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 		} else {
 			// RAM C128 (0x0000 - 0xffff): Bank 0
@@ -256,6 +263,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 
 			if (!(ptr = R_NEW0 (RBinSection)))
@@ -266,6 +274,7 @@ static RList* sections(RBinFile* arch) {
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
 			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			ptr->add = true;
 			r_list_append (ret, ptr);
 		}
 	}
@@ -375,7 +384,7 @@ static RList* symbols(RBinFile *arch) {
 		{0xd022, "VIC_BG_COLOR1"},
 		{0xd023, "VIC_BG_COLOR2"},
 		{0xd024, "VIC_BG_COLOR3"},
-		
+
 		// 128 stuff
 		{0xd02F, "VIC_KBD_128"},
 		{0xd030, "VIC_CLK_128"},

--- a/libr/bin/p/bin_xbe.c
+++ b/libr/bin/p/bin_xbe.c
@@ -149,6 +149,7 @@ static RList* sections(RBinFile *arch) {
 		item->vaddr = sect[i].vaddr;
 		item->size  = sect[i].size;
 		item->vsize = sect[i].vsize;
+		item->add = true;
 
 		item->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
 		if (sect[i].flags & SECT_FLAG_X)

--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -1489,8 +1489,9 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 
 			}
 			r_meta_add (r->anal, R_META_TYPE_COMMENT, addr, addr, str);
-			r_io_section_add (r->io, section->paddr, addr, section->size,
-				section->vsize, section->srwx, section->name, 0, fd);
+			if (section->add)
+				r_io_section_add (r->io, section->paddr, addr, section->size,
+					section->vsize, section->srwx, section->name, 0, fd);
 		} else if (IS_MODE_SIMPLE (mode)) {
 			char *hashstr = NULL;
 			if (chksum) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2382,7 +2382,7 @@ static int cmd_print(void *data, const char *input) {
 					case 'w' : type = "wide" ; break;
 					case 'a' : type = "ascii"; break;
 					case 'u' : type = "utf" ; break;
-					default : type = "unkown" ; break;
+					default : type = "unknown" ; break;
 				}
 				r_cons_printf (",\"type\":\"%s\"}", type);
 				r_cons_newline ();

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -282,6 +282,7 @@ typedef struct r_bin_section_t {
 	const char *arch;
 	int bits;
 	bool has_strings;
+	bool add; // indicates when you want to add the section to io `S` command
 } RBinSection;
 
 typedef struct r_bin_class_t {

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -2533,6 +2533,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			section->size = bin->cp_size;
 			section->paddr = bin->cp_offset + baddr;
 			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+			section->add = true;
 			r_list_append (sections, section);
 		}
 		section = NULL;
@@ -2544,6 +2545,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			section->size = bin->fields_size;
 			section->paddr = bin->fields_offset + baddr;
 			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+			section->add = true;
 			r_list_append (sections, section);
 			section = NULL;
 			r_list_foreach (bin->fields_list, iter, fm_type) {
@@ -2554,6 +2556,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
 					section->paddr = fm_type->attr_offset + baddr;
 					section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+					section->add = true;
 					r_list_append (sections, section);
 				}
 			}
@@ -2566,6 +2569,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			section->size = bin->methods_size;
 			section->paddr = bin->methods_offset + baddr;
 			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE | R_BIN_SCN_MAP;
+			section->add = true;
 			r_list_append (sections, section);
 			section = NULL;
 			r_list_foreach (bin->methods_list, iter, fm_type) {
@@ -2576,6 +2580,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
 					section->paddr = fm_type->attr_offset + baddr;
 					section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+					section->add = true;
 					r_list_append (sections, section);
 				}
 			}
@@ -2588,6 +2593,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			section->size = bin->interfaces_size;
 			section->paddr = bin->interfaces_offset + baddr;
 			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+			section->add = true;
 			r_list_append (sections, section);
 		}
 		section = NULL;
@@ -2599,6 +2605,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin) {
 			section->size = bin->attrs_size;
 			section->paddr = bin->attrs_offset + baddr;
 			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_MAP;
+			section->add = true;
 			r_list_append (sections, section);
 		}
 		section = NULL;


### PR DESCRIPTION
To fix the issue and to avoid having the phdr sections in `iS` and `S` I had to add a new var in `RBinSection` that indicates when you want to include that section with `r_io_section_add` in `bin_sections`. If there is a problem with this approach we can think a better solution.

I renamed the `phdr` sections to `LOAD` and fix the `vsz` issue perhaps this fix your issue @ret2libc take a look at it and tell me. Because of this changes we map less memory and some test are broken but I'll send a PR to r2r to reflect these changes. 

Also I took a look how the base address is calculated and I fixed it (at least i think so) since there may be more than one `PT_LOAD` and we must ensure to choose the minimum `vaddr` and then it must be congruent to page size. Normally, the `vaddr` is directly the `baddr` but a tweaked ELF file from a CTF maybe may fool us.

I think that is all. If there is any issue comment ;)
