### PR TITLE
Fix double free in xnu_debug.c:744

### DIFF
--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -734,7 +734,7 @@ static RList *xnu_dbg_modules(RDebug *dbg) {
 		size = mach0_size (dbg, addr);
 		mr = r_debug_map_new (file_path, addr, addr + size, 7, 0);
 		if (mr == NULL) {
-			free (info_array);
+			//free (info_array);
 			eprintf ("Cannot create r_debug_map_new\n");
 			break;
 		}


### PR DESCRIPTION
info_array is freed on xnu_debug.c:737 and when it breaks out of the for() loop, info_array is freed again on xnu_debug.c:744 resulting in double free.

this fix comments out xnu_debug.c:737 so that an attempt to free released memory is not made.