### PR TITLE
Fix #3852 & changes in midflags

### DIFF
--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -1119,10 +1119,6 @@ static void snFini(SymName *sn) {
 	R_FREE (sn->methflag);
 }
 
-static bool isHidden(RBinSymbol *s) {
-	if (!s->bind || !s->type) return false;
-	return (!strcmp (s->bind, "LOCAL") && !strcmp (s->type, "NOTYPE"));
-}
 
 static bool isAnExport(RBinSymbol *s) {
 	/* workaround for some bin plugs */
@@ -1168,8 +1164,6 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 		snInit (r, &sn, symbol, lang);
 
 		if (IS_MODE_SET (mode)) {
-			if (isHidden (symbol))
-				continue;
 			if (is_arm) {
 				int force_bits = 0;
 				if (va && symbol->bits == 16)
@@ -1268,8 +1262,6 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 			RBinPlugin *plugin;
 			char *name;
 
-			if (isHidden (symbol))
-				continue;
 			if (bin_demangle) {
 				char *mn = r_bin_demangle (r->bin->cur, lang, symbol->name);
 				if (mn) {


### PR DESCRIPTION
This incorporates again the local symbol from ELF to flag space and fix #3852. 

The midflags thing  

```
+			int skip_bytes = handleMidFlags (core, ds, true);
+			if (skip_bytes >= 0) {
+				ds->at += skip_bytes;
+				handle_show_flags_option (core, ds);
+				ds->at -= skip_bytes;
+			}
```

Before my change, if a flag was found, `ds->at` was updated accordingly at that position and the next iteration r2 will disassemble from that point producing invalid instructions. One example of this in `t/disasm/midflags` 

```
0x00000000      31ed           xor ebp, ebp
 0x00000002      49             dec ecx
 0x00000003  ~   89d1           mov ecx, edx
  ;-- mid.flag:
 0x00000004      d15e48         rcr dword [esi + 0x48], 1
```

You can see that `d1` appears twice. We have another example in the issue #3684, `33f9` is analyze twice as well.

```
r2 example.elf
[0x00000b00]> pd 3 @ 0x356
            0x00000356    00f033f9       bl sym.app_uart_get
            ;-- $d_62:
            0x00000358    33f90028       invalid
            0x0000035c    fad1           bne 0x354
```

 With my patch we get the following

```
 0x00000000      31ed           xor ebp, ebp
 0x00000002      49             dec ecx
  ;-- mid.flag:
 0x00000003  ~   89d1           mov ecx, edx
 0x00000005      5e             pop esi

[0x00000b00]> pd 3 @ 0x356
    ;-- $d_62:
            0x00000356  ~   00f033f9       bl sym.app_uart_get
            0x0000035a      0028           cmp r0, 0
            0x0000035c      fad1           bne 0x354

```

As how I understand this, if we find a flag in the middle of the instruction we should update `ds->at` and call `handle_show_flag_options` and then we should revert `ds->at` to disassemble from the last position and produce correct disassembly. 

Perhaps my interpretation about how midflags should work or how @radare wants it is wrong so tests are more than welcome and if we come up with different cases will be helpful to know it this works in all the situations.


###### QUESTION

Why are we calling these functions twice in the case of `handle_print_labels` return true? Does it reorder the output again or something?
```
                handle_show_functions (core, ds);
                handle_show_xrefs (core, ds);
                handle_print_pre (core, ds, false);
                handle_print_lines_left (core, ds);

                f = r_anal_get_fcn_in (core->anal, ds->addr, 0);
                if (handle_print_labels (core, ds, f)) {
                        handle_show_functions (core, ds);
                        handle_show_xrefs (core, ds);
                        handle_print_pre (core, ds, false);
                        handle_print_lines_left (core, ds);
                }
```


In r2r there is a pr to update tests.