### PR TITLE
Prl lines enhancement

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1123,7 +1123,6 @@ R_API int r_core_init(RCore *core) {
 	core->oobi = NULL;
 	core->oobi_len = 0;
 	core->printidx = 0;
-	core->lines_cache = NULL;
 	core->lastcmd = NULL;
 	core->cmdqueue = NULL;
 	core->cmdrepeat = true;
@@ -1297,7 +1296,6 @@ R_API RCore *r_core_fini(RCore *c) {
 	r_buf_free (c->yank_buf);
 	r_agraph_free (c->graph);
 	R_FREE (c->asmqjmps);
-	R_FREE (c->lines_cache);
 	sdb_free (c->sdb);
 	return NULL;
 }

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -158,8 +158,6 @@ typedef struct r_core_t {
 	int cmdremote;
 	char *lastsearch;
 	bool fixedblock;
-	ut64* lines_cache;
-	int lines_cache_sz;
 } RCore;
 
 R_API int r_core_bind(RCore *core, RCoreBind *bnd);
@@ -181,7 +179,6 @@ R_API RBin *r_core_get_bin (RCore *core);
 R_API RConfig *r_core_get_config (RCore *core);
 R_API RAsmOp *r_core_disassemble (RCore *core, ut64 addr);
 R_API int r_core_init(RCore *core);
-R_API int r_core_init_lines_cache(RCore *core, ut64 start_addr, ut64 end_addr);
 R_API RCore *r_core_new(void);
 R_API RCore *r_core_free(RCore *core);
 R_API RCore *r_core_fini(RCore *c);
@@ -190,6 +187,8 @@ R_API RCore *r_core_cast(void *p);
 R_API int r_core_config_init(RCore *core);
 R_API int r_core_prompt(RCore *core, int sync);
 R_API int r_core_prompt_exec(RCore *core);
+R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr);
+R_API int r_core_lines_currline (RCore *core);
 R_API void r_core_prompt_loop(RCore *core);
 R_API int r_core_cmd(RCore *core, const char *cmd, int log);
 R_API void r_core_cmd_repeat(RCore *core, int next);

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -69,6 +69,8 @@ typedef struct r_print_t {
 	RReg *reg;
 	RRegItem* (*get_register)(RReg *reg, const char *name, int type);
 	ut64 (*get_register_value)(RReg *reg, RRegItem *item);
+	ut64* lines_cache;
+	int lines_cache_sz;
 } RPrint;
 
 #ifdef R_API

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -846,6 +846,8 @@ R_API ut64 r_des_ip (ut64 state, int inv);
 R_API ut64 r_des_expansion (ut32 half);
 R_API ut32 r_des_p (ut32 half);
 
+R_API int r_util_lines_getline (ut64 *lines_cache, int lines_cache_sz, ut64 off);
+
 /* Some "secured" functions, to do basic operation (mul, sub, add...) on integers */
 static inline int UT64_ADD(ut64 *r, ut64 a, ut64 b) {
 	if(UT64_MAX - a < b)


### PR DESCRIPTION
* Added `slc` subcommand to free lines cache.
* Added `sl?` help submenu.
* `prl` now uses absolute line numbers if lines_cache is available
* Some refactoring

Implements #3866