### PR TITLE
Implemented 'zp' command

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -54,6 +54,7 @@ R_API bool r_sign_add(RSign *sig, RAnal *anal, int type, const char *name, const
 		break;
 	case R_SIGN_HEAD: // function prefix (push ebp..)
 	case R_SIGN_BYTE: // function mask
+	case R_SIGN_BODY: // function body
 		if (!(data = r_anal_strmask (anal, arg))) {
 			r_sign_item_free (si);
 			break;
@@ -75,6 +76,8 @@ R_API bool r_sign_add(RSign *sig, RAnal *anal, int type, const char *name, const
 				sig->s_head++;
 			else if (type==R_SIGN_BYTE)
 				sig->s_byte++;
+			else if(type == R_SIGN_BODY)
+				sig->s_func++;
 		}
 		break;
 	default:
@@ -181,7 +184,7 @@ R_API RSignItem *r_sign_check(RSign *sig, const ut8 *buf, int len) {
 		return NULL;
 
 	r_list_foreach (sig->items, iter, si) {
-		if (si->type == R_SIGN_BYTE) {
+		if ((si->type == R_SIGN_BYTE) || (si->type == R_SIGN_BODY)) {
 			int l = (len>si->size)?si->size:len;
 			if (!r_mem_cmp_mask (buf, si->bytes, si->mask, l))
 				return si;

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -84,6 +84,7 @@ static int cmd_zign(void *data, const char *input) {
 	case 'b':
 	case 'h':
 	case 'f':
+	case 'p':
 		if (*(input+1) == '\0' || *(input+2) == '\0')
 			eprintf ("Usage: z%c [name] [arg]\n", *input);
 		else{
@@ -156,6 +157,9 @@ static int cmd_zign(void *data, const char *input) {
 							if (si->type == 'f')
 								r_cons_printf ("f sign.fun_%s_%d @ 0x%08"PFMT64x"\n",
 									si->name, idx, ini+idx); //core->offset);
+							else if(si->type == 'p')
+								r_cons_printf ("afn sign.fun_%s_%d 0x%08"PFMT64x"\n",
+										si->name, idx, ini+idx);
 							else r_cons_printf ("f sign.%s @ 0x%08"PFMT64x"\n",
 								si->name, ini+idx); //core->offset+idx);
 							eprintf ("- Found %d matching function signatures\r", count);
@@ -214,6 +218,7 @@ static int cmd_zign(void *data, const char *input) {
 			"zn", " namespace", "Define namespace for following zignatures (until zn-)",
 			"zn", "", "Display current namespace",
 			"zn-", "", "Unset namespace",
+			"zp", " name bytes", "define new zignature for function body",
 			"NOTE:", "", "bytes can contain '.' (dots) to specify a binary mask",
 			NULL};
 			r_core_cmd_help (core, help_msg);

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -17,6 +17,7 @@ enum {
 	R_SIGN_FUNC = 'f',
 	R_SIGN_HEAD = 'h',
 	R_SIGN_ANAL = 'a',
+	R_SIGN_BODY = 'p',
 };
 
 /* signature struct */


### PR DESCRIPTION
I have implemented the 'zp' command ('zf' is already used) with is similar to 'zb' one, but instead of create flags in rename function by checking its signature, I have tested it with PS-X loader and it works good.

For example I had this listing:
```
│     │ │   0x8012b74c      0887040c       jal fcn.80121c20
│     │ │   0x8012b750      00000000       nop
│     │ │   0x8012b754      0ab0040c       jal fcn.8012c028
│     │ │   0x8012b758      00000000       nop
│     │┌──< 0x8012b75c      daad0408       j 0x8012b768               
│     │││   0x8012b760      ffff0224       li v0, -1
│     └───> 0x8012b764      21100000       move v0, zero
│      ││   ; JMP XREF from 0x8012b75c (fcn.8012b63c)
│     ┌└──> 0x8012b768      49004014       bnez v0, 0x8012b890        
│     │ │   0x8012b76c      ffff0224       li v0, -1
│     │ │   0x8012b770      cfb4040c       jal fcn.8012d33c
```

And after running this zignature file: https://dl.dropboxusercontent.com/u/40206233/psxbios_zp.z with zp commands inside:

```
[0x8012b6f8]> . ./psxbioszp.z 
[0x8012b6f8]> .z/ 0x80010000 0x80010000+1572864
```

This the result:
```

│     │ │   0x8012b74c      0887040c       jal sign.fun_psxbios.p.printf_1121312 ; SysCall yay!!!
│     │ │   0x8012b750      00000000       nop
│     │ │   0x8012b754      0ab0040c       jal fcn.8012c028
│     │ │   0x8012b758      00000000       nop
│     │┌──< 0x8012b75c      daad0408       j 0x8012b768               
│     │││   0x8012b760      ffff0224       li v0, -1
│     └───> 0x8012b764      21100000       move v0, zero
│      ││   ; JMP XREF from 0x8012b75c (fcn.8012b63c)
│     ┌└──> 0x8012b768      49004014       bnez v0, 0x8012b890        
│     │ │   0x8012b76c      ffff0224       li v0, -1
│     │ │   0x8012b770      cfb4040c       jal fcn.8012d33c
│     │ │   0x8012b774      00000000       nop
│     │┌──< 0x8012b778      2b004010       beqz v0, 0x8012b828        
│     │││   0x8012b77c      00000000       nop
│     │││   0x8012b780      1380023c       lui v0, 0x8013

```

And all syscalls are detected and renamed correctly:
```
[0x8012b6f8]> afl~psxbios
0x8012f604  12  2  sign.fun_psxbios.p.InitHeap_1177092
0x8012d8f8  12  2  sign.fun_psxbios.p.setjmp_1169656
0x8012d910  12  2  sign.fun_psxbios.p._96_remove_1169680
0x8012d928  12  2  sign.fun_psxbios.p.ReturnFromExecption_1169704
0x8012d938  12  2  sign.fun_psxbios.p.ResetEntryInt_1169720
0x8012d948  12  2  sign.fun_psxbios.p.HookEntryInt_1169736
0x80121c20  12  2  sign.fun_psxbios.p.printf_1121312
0x80126104  12  2  sign.fun_psxbios.p.memcpy_1138948
0x8012a690  12  2  sign.fun_psxbios.p.GPU_cw_1156752
0x80121c10  12  2  sign.fun_psxbios.p.memset_1121296
0x801226d0  12  2  sign.fun_psxbios.p.strlen_1124048
0x8012cfe4  12  2  sign.fun_psxbios.p.FlushCache_1167332
0x8012c79c  12  2  sign.fun_psxbios.p.puts_1165212
0x8012ce5c  12  2  sign.fun_psxbios.p.ChangeClearPAD_1166940
0x8012cf84  12  2  sign.fun_psxbios.p.PAD_init_1167236
0x8012cf64  12  2  sign.fun_psxbios.p.InitPAD_1167204
0x8012cf74  12  2  sign.fun_psxbios.p.StartPAD_1167220
0x8012ce4c  12  2  sign.fun_psxbios.p.PAD_dr_1166924
0x8012ce3c  12  2  sign.fun_psxbios.p.StopPAD_1166908
```

There is room for improvement, because afn try to rename places where there are no functions defined, in fact it prints these messages:

```
Cannot find function 'sign.fun_psxbios.p.GPU_cw_946120' at 0x800f6fc8
Cannot find function 'sign.fun_psxbios.p.StopPAD_962464' at 0x800fafa0
Cannot find function 'sign.fun_psxbios.p.PAD_dr_962480' at 0x800fafb0
Cannot find function 'sign.fun_psxbios.p.ChangeClearPAD_962496' at 0x800fafc0
Cannot find function 'sign.fun_psxbios.p.InitPAD_962760' at 0x800fb0c8
Cannot find function 'sign.fun_psxbios.p.StartPAD_962776' at 0x800fb0d8
Cannot find function 'sign.fun_psxbios.p.PAD_init_962792' at 0x800fb0e8
Cannot find function 'sign.fun_psxbios.p.FlushCache_962888' at 0x800fb148
Cannot find function 'sign.fun_psxbios.p._96_remove_965220' at 0x800fba64
Cannot find function 'sign.fun_psxbios.p.ReturnFromExecption_965244' at 0x800fba7c
Cannot find function 'sign.fun_psxbios.p.ResetEntryInt_965260' at 0x800fba8c
Cannot find function 'sign.fun_psxbios.p.HookEntryInt_965276' at 0x800fba9c
Cannot find function 'sign.fun_psxbios.p.InitHeap_966692' at 0x800fc024
Cannot find function 'sign.fun_psxbios.p.write_993932' at 0x80102a8c
Cannot find function 'sign.fun_psxbios.p.exit_994204' at 0x80102b9c
Cannot find function 'sign.fun_psxbios.p.malloc_994220' at 0x80102bac
Cannot find function 'sign.fun_psxbios.p.free_994232' at 0x80102bb8
Cannot find function 'sign.fun_psxbios.p.calloc_994244' at 0x80102bc4
```