### PR TITLE
Fixed bug in r_core_lines_initcache

### DIFF
--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -79,7 +79,7 @@ R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr) {
 		return -1;
 	}
 
-	line_count = 1;
+	line_count = start_addr ? 0 : 1;
 	r_cons_break (NULL, NULL);
 	buf = malloc (bsz);
 	if (!buf) return -1;


### PR DESCRIPTION
`sl 1` wasn't working properly when `lines.from` was set different to 0