### PR TITLE
Get the first flag coincidence in autoname

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -175,9 +175,11 @@ R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump) {
 				if (!strncmp (f->name, "sym.imp.", 8)) {
 					free (do_call);
 					do_call = strdup (f->name+8);
+					break;
 				} else if (!strncmp (f->name, "reloc.", 6)) {
 					free (do_call);
 					do_call = strdup (f->name+6);
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
The r_core_anal_fcn_autoname function (aaa) replaces a call using related flag names. These flags are iterated but when the function finds a coincidence, it does not follows to the naming process and sometimes, the call name does not belongs to the real one.