### PR TITLE
Fix #3852 & changes in midflags

### DIFF
--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -1119,10 +1119,6 @@ static void snFini(SymName *sn) {
 	R_FREE (sn->methflag);
 }
 
-static bool isHidden(RBinSymbol *s) {
-	if (!s->bind || !s->type) return false;
-	return (!strcmp (s->bind, "LOCAL") && !strcmp (s->type, "NOTYPE"));
-}
 
 static bool isAnExport(RBinSymbol *s) {
 	/* workaround for some bin plugs */
@@ -1168,8 +1164,6 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 		snInit (r, &sn, symbol, lang);
 
 		if (IS_MODE_SET (mode)) {
-			if (isHidden (symbol))
-				continue;
 			if (is_arm) {
 				int force_bits = 0;
 				if (va && symbol->bits == 16)
@@ -1268,8 +1262,6 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 			RBinPlugin *plugin;
 			char *name;
 
-			if (isHidden (symbol))
-				continue;
 			if (bin_demangle) {
 				char *mn = r_bin_demangle (r->bin->cur, lang, symbol->name);
 				if (mn) {

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -426,6 +426,18 @@ static int cb_strpurge(void *user, void *data) {
 	return true;
 }
 
+static int cb_midflags (void *user, void *data) {
+	RConfigNode *node = (RConfigNode *)data;
+	if (node->value[0] == '?') {
+		eprintf ("Valid values for asm.midflags:\n");
+		eprintf ("0\t do not show middle flags\n");
+		eprintf ("1\t print the middfle flag without realign instruction\n");
+		eprintf ("2\t realign the instruction at the middfle flag\n");
+		return false;
+	}
+	return true;
+}
+
 static int cb_strfilter(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
@@ -1414,7 +1426,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB("asm.invhex", "false", &cb_asm_invhex, "Show invalid instructions as hexadecimal numbers");
 	SETPREF("asm.bytes", "true", "Display the bytes of each instruction");
 	SETPREF("asm.flagsinbytes", "false",  "Display flags inside the bytes space");
-	SETPREF("asm.midflags", "true", "Realign disassembly if there is a flag in the middle of an instruction");
+	SETICB("asm.midflags", 1, &cb_midflags, "Realign disassembly if there is a flag in the middle of an instruction");
 	SETPREF("asm.cmtflgrefs", "true", "Show comment flags associated to branch reference");
 	SETPREF("asm.cmtright", "true", "Show comments at right of disassembly if they fit in screen");
 	SETI("asm.cmtcol", 70, "Align comments at column 60");


### PR DESCRIPTION
This brings the local symbols to the flag space.

As i had commented in the pr I closed, midflags now is an int with the following values

```
asm.midflags = 0 <------ don't show midflags
asm.midflags = 1 <------ just print the midflags but don't realign the instruction
asm.midflags = 2 <------ realign the instruction
```

the rationale behind this is that in average use (at least i think so) you just only want the flag printed because if you realign the probability to get invalid disassembly is high, so is up to the user to configure that variable to avoid the anti disasm tricks or other nuances. The value `1` is the default

it would be great doing this in a dynamic way but i don't know how, maybe defining a flag space for such special flags, thus we can eschew realign globally. However, the issue would be how to detect those special flags without the user interaction.

I think that by now we can go with this and avoid users opening issues because he/she gets invalid instructions.

pr in r2r to update test