### PR TITLE
Fixed accept prototype for linux x64 and darwin

### DIFF
--- a/libr/include/sflib/darwin-x86-32/sflib.h
+++ b/libr/include/sflib/darwin-x86-32/sflib.h
@@ -54,7 +54,7 @@ static inline _sfsyscall4(long, ptrace, int, request, pid_t, pid, void *,addr, v
 // recvmsg
 // sendmsg
 static inline _sfsyscall6(ssize_t, recvfrom, int, s, void * , buf, size_t, len, int, flags, struct sockaddr * , from, socklen_t * , fromlen)
-static inline _sfsyscall3(int, accept, int,s, struct sockaddr *,addr, socklen_t,addrlen);
+static inline _sfsyscall3(int, accept, int,s, struct sockaddr *,addr, socklen_t *,addrlen);
 // getpeername
 // getsockname
 static inline _sfsyscall2( int, access, const char *, pathname, int, mode )

--- a/libr/include/sflib/darwin-x86-64/sflib.h
+++ b/libr/include/sflib/darwin-x86-64/sflib.h
@@ -54,7 +54,7 @@ static inline _sfsyscall4(long, ptrace, int, request, pid_t, pid, void *,addr, v
 // recvmsg
 // sendmsg
 static inline _sfsyscall6(ssize_t, recvfrom, int, s, void * , buf, size_t, len, int, flags, struct sockaddr * , from, socklen_t * , fromlen)
-static inline _sfsyscall3(int, accept, int,s, struct sockaddr *,addr, socklen_t,addrlen);
+static inline _sfsyscall3(int, accept, int,s, struct sockaddr *,addr, socklen_t *,addrlen);
 // getpeername
 // getsockname
 static inline _sfsyscall2( int, access, const char *, pathname, int, mode )

--- a/libr/include/sflib/linux-x86-64/sflib.h
+++ b/libr/include/sflib/linux-x86-64/sflib.h
@@ -72,7 +72,7 @@ static inline _sfsyscall0( pid_t, getpid )
 // sendfile
 static inline _sfsyscall3(int, socket, int,domain, int,type, int,protocol)
 static inline _sfsyscall3(int,connect, int,sockfd, const struct sockaddr *,serv_addr, socklen_t,addrlen)
-static inline _sfsyscall3(int, accept, int,s, struct sockaddr *,addr, socklen_t,addrlen);
+static inline _sfsyscall3(int, accept, int,s, struct sockaddr *,addr, socklen_t *,addrlen);
 static inline _sfsyscall6(ssize_t, sendto, int, s, const void *, msg, size_t, len, int, flags, const struct sockaddr *, to, socklen_t, tolen)
 static inline _sfsyscall6(ssize_t, recvfrom, int, s, void * , buf, size_t, len, int, flags, struct sockaddr * , from, socklen_t * , fromlen)
 // sendmsg


### PR DESCRIPTION
The prototype for syscall accept in various sflib.h headers is incorrect: a socklen_t type is used instead of socklen_t *. This affects (at least) code compiled by ragg2-cc.