### PR TITLE
Fix for issues #3902 and #3899

### DIFF
--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -2,16 +2,12 @@
 
 static void __init_seek_line (RCore *core) {
 	ut64 from, to;
-	int lines = 0;
 
 	r_config_bump (core->config, "lines.to");
 	from = r_config_get_i (core->config, "lines.from");
 	to = r_config_get_i (core->config, "lines.to");
-	lines = r_core_lines_initcache (core, from, to);
-	if (lines == -1) {
+	if (r_core_lines_initcache (core, from, to) == -1) {
 		eprintf ("ERROR: \"lines.from\" and \"lines.to\" must be set\n");
-	} else {
-		eprintf ("Found %d lines\n", lines-1);
 	}
 }
 
@@ -69,6 +65,7 @@ R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr) {
 	int bsz = core->blocksize;
 	char *buf;
 	ut64 off = start_addr;
+	ut64 baddr = r_config_get_i (core->config, "bin.baddr");
 	if (start_addr == UT64_MAX || end_addr == UT64_MAX) {
 		return -1;
 	}
@@ -80,6 +77,7 @@ R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr) {
 	}
 
 	line_count = start_addr ? 0 : 1;
+	core->print->lines_cache[0] = start_addr ? 0 : baddr;
 	r_cons_break (NULL, NULL);
 	buf = malloc (bsz);
 	if (!buf) return -1;
@@ -90,7 +88,7 @@ R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr) {
 		r_io_read_at (core->io, off, (ut8*)buf, bsz);
 		for (i=0; i<bsz; i++) {
 			if (buf[i] == '\n') {
-				core->print->lines_cache[line_count] = off+i+1;
+				core->print->lines_cache[line_count] = start_addr ? off+i+1 : off+i+1+baddr;
 				line_count++;
 				if (line_count % bsz == 0) {
 					ut64 *tmp = realloc (core->print->lines_cache,
@@ -386,25 +384,41 @@ static int cmd_seek(void *data, const char *input) {
 				"sl", " [line]", "Seek to absolute line",
 				"sl", "[+-][line]", "Seek to relative line",
 				"slc", "", "Clear line cache",
+				"sll", "", "Show total number of lines",
 				NULL };
-			if (!core->print->lines_cache) {
-				__init_seek_line (core);
-			}
 			switch (input[1]) {
 			case 0:
+				if (!core->print->lines_cache) {
+					__init_seek_line (core);
+				}
 				__get_current_line (core);
 				break;
 			case ' ':
+				if (!core->print->lines_cache) {
+					__init_seek_line (core);
+				}
 				__seek_line_absolute (core, sl_arg);
 				break;
 			case '-':
+				if (!core->print->lines_cache) {
+					__init_seek_line (core);
+				}
 				__seek_line_relative (core, -sl_arg);
 				break;
 			case '+':
+				if (!core->print->lines_cache) {
+					__init_seek_line (core);
+				}
 				__seek_line_relative (core, sl_arg);
 				break;
 			case 'c':
 				__clean_lines_cache (core);
+				break;
+			case 'l':
+				if (!core->print->lines_cache) {
+					__init_seek_line (core);
+				}
+				eprintf ("%d lines\n", core->print->lines_cache_sz-1);
 				break;
 			case '?':
 				r_core_cmd_help (core, help_msg);

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -65,7 +65,7 @@ R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr) {
 	int bsz = core->blocksize;
 	char *buf;
 	ut64 off = start_addr;
-	ut64 baddr = r_config_get_i (core->config, "bin.baddr");
+	ut64 baddr; 
 	if (start_addr == UT64_MAX || end_addr == UT64_MAX) {
 		return -1;
 	}
@@ -75,6 +75,9 @@ R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr) {
 	if (!core->print->lines_cache) {
 		return -1;
 	}
+
+	RIOSection *s = r_io_section_mget (core->io, core->offset);
+	baddr = s ? s->offset : r_config_get_i (core->config, "bin.baddr");
 
 	line_count = start_addr ? 0 : 1;
 	core->print->lines_cache[0] = start_addr ? 0 : baddr;

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1332,7 +1332,7 @@ static int cb_linesto(void *user, void *data) {
 		core->print->lines_cache_sz = -1; //r_core_lines_initcache (core, from, to);
 		return false;
 	}
-	if (to > io_sz) {
+	if (to > from+io_sz) {
 		eprintf ("ERROR: \"lines.to\" can't exceed addr 0x%08"PFMT64x
 			" 0x%08"PFMT64x" %d\n", from, to, io_sz);
 		return true;


### PR DESCRIPTION
* If lines.from is 0, `sl 1` seeks to baddr
* Added `sll` command to show total number of lines and removed the other
messages