### PR TITLE
Avoid overwriting r_version.h if it didn't change.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,15 @@ GIT_TIP=$(shell git rev-parse HEAD 2>/dev/null || echo HEAD)
 GIT_NOW=$(shell date +%Y-%m-%d)
 
 libr/include/r_version.h:
-	echo "#ifndef R_VERSION_H" > $@
-	echo "#define R_VERSION_H 1" >> $@
-	echo "#define R2_VERSION_COMMIT $(R2VC)" >> $@
-	echo '#define R2_GITTAP "$(GIT_TAP)"' >> $@
-	echo '#define R2_GITTIP "$(GIT_TIP)"' >> $@
-	echo '#define R2_BIRTH "$(GIT_NOW)"' >> $@
-	echo '#endif' >> $@
+	echo "#ifndef R_VERSION_H" > $@.tmp
+	echo "#define R_VERSION_H 1" >> $@.tmp
+	echo "#define R2_VERSION_COMMIT $(R2VC)" >> $@.tmp
+	echo '#define R2_GITTAP "$(GIT_TAP)"' >> $@.tmp
+	echo '#define R2_GITTIP "$(GIT_TIP)"' >> $@.tmp
+	echo '#define R2_BIRTH "$(GIT_NOW)"' >> $@.tmp
+	echo '#endif' >> $@.tmp
+	diff -q $@.tmp $@ || mv -f $@.tmp $@
+	rm -f $@.tmp
 
 plugins.cfg:
 	@if [ ! -e config-user.mk ]; then echo ; \


### PR DESCRIPTION
when the file gets changed, everything needs to be rebuilt.
hopefully this avoids rebuilding everything when not necessary.
