### PR TITLE
Bin plugin with initial Nintendo 3DS support

### DIFF
--- a/libr/bin/format/nin/n3ds.h
+++ b/libr/bin/format/nin/n3ds.h
@@ -1,0 +1,33 @@
+
+/*
+https://www.3dbrew.org/wiki/FIRM
+More formats to support: https://www.3dbrew.org/wiki/Category:File_formats
+*/
+
+#ifndef NIN_N3DS_H
+#define NIN_N3DS_H
+
+#include <r_types_base.h>
+
+struct n3ds_firm_sect_hdr
+{
+	ut32 offset;
+	ut32 address;
+	ut32 size;
+	ut32 type; /* ('0'=ARM9/'1'=ARM11) */
+	ut8 sha256[0x20];
+} __attribute__((packed));
+
+struct n3ds_firm_hdr
+{
+	ut8 magic[4];
+	ut8 reserved1[4];
+	ut32 arm11_ep;
+	ut32 arm9_ep;
+	ut8 reserved2[0x30];
+	struct n3ds_firm_sect_hdr sections[4];
+	ut8 rsa2048[0x100];
+} __attribute__((packed));
+
+#endif /* NIN_N3DS_H */
+

--- a/libr/bin/p/Makefile
+++ b/libr/bin/p/Makefile
@@ -12,7 +12,8 @@ ALL_TARGETS=
 FORMATS=any.mk elf.mk elf64.mk pe.mk pe64.mk te.mk mach0.mk
 FORMATS+=bios.mk mach064.mk fatmach0.mk dyldcache.mk java.mk
 FORMATS+=dex.mk fs.mk ningb.mk coff.mk ningba.mk xbe.mk zimg.mk
-FORMATS+=omf.mk cgc.mk dol.mk nes.mk mbn.mk psxexe.mk spc700.mk vsf.mk
+FORMATS+=omf.mk cgc.mk dol.mk nes.mk mbn.mk psxexe.mk spc700.mk
+FORMATS+=vsf.mk nin3ds.mk
 include $(FORMATS)
 
 all: ${ALL_TARGETS}

--- a/libr/bin/p/bin_nin3ds.c
+++ b/libr/bin/p/bin_nin3ds.c
@@ -1,0 +1,163 @@
+/* radare - LGPL - 2016 - a0rtega */
+
+#include <r_types.h>
+#include <r_util.h>
+#include <r_lib.h>
+#include <r_bin.h>
+#include <string.h>
+
+#include "nin/n3ds.h"
+
+static int check(RBinFile *arch);
+static int check_bytes(const ut8 *buf, ut64 length);
+
+static struct n3ds_firm_hdr loaded_header;
+
+static int check(RBinFile *arch) {
+	const ut8 *bytes = arch ? r_buf_buffer (arch->buf) : NULL;
+	ut64 sz = arch ? r_buf_size (arch->buf): 0;
+	return check_bytes (bytes, sz);
+}
+
+static int check_bytes(const ut8 *buf, ut64 length) {
+	if (!buf || length < sizeof(struct n3ds_firm_hdr)) return false;
+	return (!memcmp(buf, "FIRM", 4));
+}
+
+static void * load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+	return memcpy (&loaded_header, buf, sizeof(struct n3ds_firm_hdr));
+}
+
+static int load(RBinFile *arch) {
+	const ut8 *bytes = arch ? r_buf_buffer (arch->buf) : NULL;
+	ut64 sz = arch ? r_buf_size (arch->buf): 0;
+	if (!arch || !arch->o)
+		return false;
+	arch->o->bin_obj = load_bytes (arch, bytes, sz, arch->o->loadaddr, arch->sdb);
+	return check_bytes (bytes, sz);
+}
+
+static int destroy(RBinFile *arch) {
+	r_buf_free (arch->buf);
+	arch->buf = NULL;
+	return true;
+}
+
+static RList* sections(RBinFile *arch) {
+	RList *ret = NULL;
+	RBinSection *sections[4] = {NULL, NULL, NULL, NULL};
+	int i, corrupt = R_FALSE;
+
+	if (!(ret = r_list_new ()))
+		return NULL;
+
+	/* FIRM has always 4 sections, normally the 4th section is not used */
+	for (i=0; i<4; i++) {
+		/* Check if section is used */
+		if (loaded_header.sections[i].size) {
+			sections[i] = R_NEW0(RBinSection);
+			/* Firmware Type ('0'=ARM9/'1'=ARM11) */
+			if (loaded_header.sections[i].type == 0x0)
+				strncpy(sections[i]->name, "arm9", 4);
+			else if (loaded_header.sections[i].type == 0x1)
+				strncpy(sections[i]->name, "arm11", 5);
+			else {
+				corrupt = R_TRUE;
+				break;
+			}
+			sections[i]->size = loaded_header.sections[i].size;
+			sections[i]->vsize = loaded_header.sections[i].size;
+			sections[i]->paddr = loaded_header.sections[i].offset;
+			sections[i]->vaddr = loaded_header.sections[i].address;
+			sections[i]->srwx = r_str_rwx ("mrwx");
+			sections[i]->add = true;
+		}
+	}
+
+	/* Append sections or free them if file is corrupt to avoid memory leaks */
+	for (i=0; i<4; i++) {
+		if (sections[i]) {
+			if (corrupt)
+				free(sections[i]);
+			else
+				r_list_append(ret, sections[i]);
+		}
+	}
+	if (corrupt) {
+		r_list_free(ret);
+		return NULL;
+	}
+
+	return ret;
+}
+
+static RList* entries(RBinFile *arch) {
+	RList *ret = r_list_new ();
+	RBinAddr *ptr9 = NULL, *ptr11 = NULL;
+
+	if (arch && arch->buf) {
+		if (!ret)
+			return NULL;
+		ret->free = free;
+		if (!(ptr9 = R_NEW0 (RBinAddr))) {
+			r_list_free (ret);
+			return NULL;
+		}
+		if (!(ptr11 = R_NEW0 (RBinAddr))) {
+			r_list_free (ret);
+			free (ptr9);
+			return NULL;
+		}
+
+		/* ARM9 entry point */
+		ptr9->vaddr = loaded_header.arm9_ep;
+		r_list_append (ret, ptr9);
+
+		/* ARM11 entry point */
+		ptr11->vaddr = loaded_header.arm11_ep;
+		r_list_append (ret, ptr11);
+	}
+	return ret;
+}
+
+static RBinInfo* info(RBinFile *arch) {
+	RBinInfo *ret = R_NEW0 (RBinInfo);
+	if (!ret) return NULL;
+
+	if (!arch || !arch->buf) {
+		free (ret);
+		return NULL;
+	}
+
+	ret->type = strdup ("FIRM");
+	ret->machine = strdup ("Nintendo 3DS");
+	ret->os = strdup ("n3ds");
+	ret->arch = strdup ("arm");
+	ret->has_va = true;
+	ret->bits = 32;
+
+	return ret;
+}
+
+struct r_bin_plugin_t r_bin_plugin_nin3ds = {
+	.name = "nin3ds",
+	.desc = "Nintendo 3DS FIRM format r_bin plugin",
+	.license = "LGPL3",
+	.load = &load,
+	.load_bytes = &load_bytes,
+	.destroy = &destroy,
+	.check = &check,
+	.check_bytes = &check_bytes,
+	.entries = &entries,
+	.sections = &sections,
+	.info = &info,
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_BIN,
+	.data = &r_bin_plugin_nin3ds,
+	.version = R2_VERSION
+};
+#endif
+

--- a/libr/bin/p/bin_nin3ds.c
+++ b/libr/bin/p/bin_nin3ds.c
@@ -31,8 +31,7 @@ static void * load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loadaddr,
 static int load(RBinFile *arch) {
 	const ut8 *bytes = arch ? r_buf_buffer (arch->buf) : NULL;
 	ut64 sz = arch ? r_buf_size (arch->buf): 0;
-	if (!arch || !arch->o)
-		return false;
+	if (!arch || !arch->o) return false;
 	arch->o->bin_obj = load_bytes (arch, bytes, sz, arch->o->loadaddr, arch->sdb);
 	return check_bytes (bytes, sz);
 }
@@ -48,8 +47,7 @@ static RList* sections(RBinFile *arch) {
 	RBinSection *sections[4] = {NULL, NULL, NULL, NULL};
 	int i, corrupt = R_FALSE;
 
-	if (!(ret = r_list_new ()))
-		return NULL;
+	if (!(ret = r_list_new ())) return NULL;
 
 	/* FIRM has always 4 sections, normally the 4th section is not used */
 	for (i=0; i<4; i++) {
@@ -77,10 +75,8 @@ static RList* sections(RBinFile *arch) {
 	/* Append sections or free them if file is corrupt to avoid memory leaks */
 	for (i=0; i<4; i++) {
 		if (sections[i]) {
-			if (corrupt)
-				free(sections[i]);
-			else
-				r_list_append(ret, sections[i]);
+			if (corrupt) free(sections[i]);
+			else r_list_append(ret, sections[i]);
 		}
 	}
 	if (corrupt) {
@@ -96,8 +92,7 @@ static RList* entries(RBinFile *arch) {
 	RBinAddr *ptr9 = NULL, *ptr11 = NULL;
 
 	if (arch && arch->buf) {
-		if (!ret)
-			return NULL;
+		if (!ret) return NULL;
 		ret->free = free;
 		if (!(ptr9 = R_NEW0 (RBinAddr))) {
 			r_list_free (ret);

--- a/libr/bin/p/nin3ds.mk
+++ b/libr/bin/p/nin3ds.mk
@@ -1,0 +1,10 @@
+OBJ_NIN3DS=bin_nin3ds.o
+
+STATIC_OBJ+=${OBJ_NIN3DS}
+TARGET_NIN3DS=bin_nin3ds.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_NIN3DS}
+
+${TARGET_NIN3DS}: ${OBJ_NIN3DS}
+	${CC} $(call libname,bin_nin3ds) ${CFLAGS} $(OBJ_NIN3DS) $(LINK) $(LDFLAGS) \
+	-L../../magic -lr_magic

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -549,6 +549,7 @@ extern RBinPlugin r_bin_plugin_coff;
 extern RBinPlugin r_bin_plugin_ningb;
 extern RBinPlugin r_bin_plugin_ningba;
 extern RBinPlugin r_bin_plugin_ninds;
+extern RBinPlugin r_bin_plugin_nin3ds;
 extern RBinPlugin r_bin_plugin_xbe;
 extern RBinXtrPlugin r_bin_xtr_plugin_fatmach0;
 extern RBinXtrPlugin r_bin_xtr_plugin_dyldcache;

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -112,6 +112,7 @@ bin.mach064
 bin.mbn
 bin.mz
 bin.nes
+bin.nin3ds
 bin.ninds
 bin.ningb
 bin.ningba

--- a/plugins.nogpl.cfg
+++ b/plugins.nogpl.cfg
@@ -69,6 +69,7 @@ bin.java
 bin.mach0
 bin.mach064
 bin.mz
+bin.nin3ds
 bin.ninds
 bin.ningb
 bin.ningba

--- a/plugins.tiny.cfg
+++ b/plugins.tiny.cfg
@@ -41,6 +41,7 @@ bin.mach064
 bin.ningb
 bin.ningba
 bin.ninds
+bin.nin3ds
 bin.xbe
 bin_xtr.fatmach0
 bin_xtr.dyldcache


### PR DESCRIPTION
This PR adds initial support for Nintendo 3DS file formats.

It can load decrypted [FIRM](https://www.3dbrew.org/wiki/FIRM) files (sections, EPs). More related file formats could be added in the future.

We can't publicly upload or link testcases for copyright reasons. Consider merging.

Cheers!