### PR TITLE
Boring typo fixes

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -2130,7 +2130,7 @@ R_API void r_core_anal_fcn_merge (RCore *core, ut64 addr, ut64 addr2) {
 	RAnalFunction *f1 = r_anal_get_fcn_at (core->anal, addr, 0);
 	RAnalFunction *f2 = r_anal_get_fcn_at (core->anal, addr2, 0);
 	if (!f1 || !f2) {
-		eprintf ("Cant find function\n");
+		eprintf ("Cannot find function\n");
 		return;
 	}
 	// join all basic blocks from f1 into f2 if they are not

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -149,7 +149,7 @@ static int var_cmd(RCore *core, const char *str) {
 				RAnalVar *var = r_anal_var_get (core->anal, fcn->addr,
 								(char)type, atoi (str + 2), R_ANAL_VAR_SCOPE_LOCAL);
 				if (!var) {
-					eprintf ("Can not find variable in: '%s'\n", str);
+					eprintf ("Cannot find variable in: '%s'\n", str);
 					res = false;
 					break;
 				}
@@ -918,7 +918,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 						r_cons_printf ("%c 0x%08" PFMT64x " -> 0x%08" PFMT64x "\n",
 							ref->type, ref->at, ref->addr);
 					}
-				} else eprintf ("Cant find function\n");
+				} else eprintf ("Cannot find function\n");
 			}
 #else
 #warning TODO_ FCNOLD sdbize xrefs here
@@ -2980,7 +2980,7 @@ static void cmd_anal_trace(RCore *core, const char *input) {
 					core->anal->esil->db_trace = sdb_new0 ();
 				}
 			} else {
-				eprintf ("TODO: ate- cant delete specific logs. Use ate-*\n");
+				eprintf ("TODO: ate- cannot delete specific logs. Use ate-*\n");
 			}
 			break;
 		case ' ': {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1864,7 +1864,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 				free (bpi->name);
 				bpi->name = strdup (input + 3);
 			} else {
-				eprintf ("Cant find breakpoint at "
+				eprintf ("Cannot find breakpoint at "
 					"0x%08"PFMT64x"\n", core->offset);
 			}
 		} else {
@@ -1936,7 +1936,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 						"'%s'\n", input+2);
 				}
 			} else {
-				eprintf ("Can't place a breakpoint here. "
+				eprintf ("Cannot place a breakpoint here. "
 					"No mapped memory\n");
 			}
 		}

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -116,7 +116,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			}
 			if (r_core_bin_delete (core, binfile_num, -1)){
 				if (!r_bin_file_delete (core->bin, fd))
-					eprintf ("Cant find an RBinFile associated with that fd.\n");
+					eprintf ("Cannot find an RBinFile associated with that fd.\n");
 			} else {
 				eprintf ("Couldn't erase because there must be 1 bin object loaded\n");
 			}

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -336,7 +336,7 @@ static int cmd_type(void *data, const char *input) {
 					free (fmt);
 				}// else eprintf ("Cannot find '%s' type\n", input+1);
 				r_cons_printf ("}\n");
-			} //else eprintf ("Cant find type at 0x%llx\n", addr);
+			} //else eprintf ("Cannot find type at 0x%llx\n", addr);
 		 }
 		break;
 	case '?':

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -122,7 +122,7 @@ R_API int r_core_project_list(RCore *core, int mode) {
 R_API int r_core_project_delete(RCore *core, const char *prjfile) {
 	char *path;
 	if (r_sandbox_enable (0)) {
-		eprintf ("Cant delete project in sandbox mode\n");
+		eprintf ("Cannot delete project in sandbox mode\n");
 		return 0;
 	}
 	path = r_core_project_file (core, prjfile);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1418,7 +1418,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 		break;
 	case 'Y':
 		if (!core->yank_buf) {
-			r_cons_strcat ("Can't paste, clipboard is empty.\n");
+			r_cons_strcat ("Cannot paste, clipboard is empty.\n");
 			r_cons_flush ();
 			r_cons_any_key (NULL);
 			r_cons_clear00 ();

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -508,7 +508,7 @@ static void r_debug_lstLibAdd(DWORD pid,LPVOID lpBaseOfDll, HANDLE hFile,char * 
 		}
 		lstLibPtr++;
 	}
-	eprintf("r_debug_lstLibAdd: Cant find slot\n");
+	eprintf("r_debug_lstLibAdd: Cannot find slot\n");
 }
 
 static void * r_debug_findlib(void * BaseOfDll) {

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -461,7 +461,7 @@ R_API void r_egg_finalize(REgg *egg) {
 		} else {
 			// TODO: use r_buf_cpy_buf or what
 			if (b->length+b->cur > egg->bin->length) {
-				eprintf ("Fuck this shit. Cant patch outside\n");
+				eprintf ("Fuck this shit. Cannot patch outside\n");
 				return;
 			}
 			memcpy (egg->bin->buf + b->cur, b->buf, b->length);

--- a/libr/egg/lang.c
+++ b/libr/egg/lang.c
@@ -819,7 +819,7 @@ static void rcc_next(REgg *egg) {
 							for (q=s; *q; q++)
 								r_egg_lang_parsechar (egg, *q);
 							free (s);
-						} else eprintf ("Cant get @syscall payload\n");
+						} else eprintf ("Cannot get @syscall payload\n");
 					}
 					docall = 0;
 					break;

--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -233,18 +233,18 @@ static int mach_write_at(RIO *io, RIOMach *riom, const void *buf, int len, ut64 
 	operms = tsk_getperm (task, pageaddr);
 	if (!tsk_setperm (io, task, pageaddr, pagesize, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY)) {
 		perror ("setperm");
-		eprintf ("io.mach: cant set page perms for %d bytes at 0x%08"
+		eprintf ("io.mach: Cannot set page perms for %d bytes at 0x%08"
 			PFMT64x"\n", (int)pagesize, (ut64)pageaddr);
 		//return -1;
 	}
 	if (!tsk_write (task, vaddr, buf, len)) {
 		perror ("write");
-		eprintf ("io.mach: cant write on memory\n");
+		eprintf ("io.mach: Cannot write on memory\n");
 		len = -1;
 	}
 	if (operms) {
 		if (!tsk_setperm (io, task, pageaddr, pagesize, operms)) {
-			eprintf ("io.mach: cant restore page perms\n");
+			eprintf ("io.mach: Cannot restore page perms\n");
 			return -1;
 		}
 	}
@@ -279,7 +279,7 @@ static int debug_attach(int pid) {
 
 #if SUSPEND
 	if (task_suspend (this->port) != KERN_SUCCESS) {
-		eprintf ("cannot suspend task\n");
+		eprintf ("Cannot suspend task\n");
 		return -1; // false
 	}
 #endif


### PR DESCRIPTION
* Can't -> Cannot (since most of error messages use second form)
* Define function message hint fixed ('df' -> 'af')
```
-				r_cons_message("Not in a function. Type 'df' to define it here");
+				r_cons_message("Not in a function. Type 'af' to define it here");
```