### PR TITLE
Update README.md with N3DS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ code, debugging programs, attaching to remote gdb servers, ..
    * **File Formats:**
 	* bios, CGC, dex, elf, elf64, filesystem, java, fatmach0, mach0,
    mach0-64, MZ, PE, PE+, TE, COFF, plan9, dyldcache, Commodore VICE emulator, 
-   Gameboy and Nintendo DS ROMs
+   Game Boy (Advance), Nintendo DS ROMs and Nintendo 3DS FIRMs.
 
    * **Operating Systems:**
 	* Android, GNU/Linux, [Net|Free|Open]BSD, iOS, OSX, QNX, w32,


### PR DESCRIPTION
As mentioned in #3909. It also updates GB(A) support.

For some reason some formats are missing tho, NES? Pebble? PSX? dol? Not very common maybe?