### PR TITLE
core/graph: extend r_core_visual_graph to accept a graph

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -974,7 +974,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		}
 		break;
 	case 'g': // "afg" - non-interactive VV
-		r_core_visual_graph (core, NULL, false);
+		r_core_visual_graph (core, NULL, NULL, false);
 		break;
 	case 'F': // "afF"
 	{
@@ -2791,6 +2791,18 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		free (o);
 		break;
 	}
+	case 'i': // "aggi" - open current core->graph in interactive mode
+	{
+		RANode *ran = r_agraph_get_first_node (core->graph);
+
+		r_agraph_set_title (core->graph, r_config_get (core->config, "graph.title"));
+		r_agraph_set_curnode (core->graph, ran);
+		core->graph->force_update_seek = true;
+		core->graph->need_set_layout = true;
+		core->graph->need_update_dim = true;
+		r_core_visual_graph(core, core->graph, NULL, true);
+		break;
+	}
 	case 'd': // "aggd" - dot format
 		r_cons_printf ("digraph code {\ngraph [bgcolor=white];\n"
 			"node [color=lightgray, style=filled shape=box "
@@ -2807,7 +2819,7 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		core->graph->can->linemode = 1;
 		core->graph->can->color = r_config_get_i (core->config, "scr.color");
 		r_agraph_set_title (core->graph,
-				r_config_get (core->config, "graph.title"));
+			r_config_get (core->config, "graph.title"));
 		r_agraph_print (core->graph);
 		break;
 	}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1200,6 +1200,7 @@ R_API int r_core_init(RCore *core) {
 	core->fs = r_fs_new ();
 	core->flags = r_flag_new ();
 	core->graph = r_agraph_new (r_cons_canvas_new (1, 1));
+	core->graph->need_reload_nodes = false;
 	core->asmqjmps_size = R_CORE_ASMQJMPS_NUM;
 	if (sizeof(ut64) * core->asmqjmps_size < core->asmqjmps_size) {
 		core->asmqjmps_size = 0;

--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -612,7 +612,7 @@ repeat:
 			} else if (strstr (action, "FcnInfo")) {
 				addPanelFrame ("FcnInfo", "afi", 0);
 			} else if (strstr (action, "Graph")) {
-				r_core_visual_graph (core, NULL, true);
+				r_core_visual_graph (core, NULL, NULL, true);
 			//	addPanelFrame ("Graph", "agf", 0);
 			} else if (strstr (action, "System Shell")) {
 				r_cons_set_raw (0);
@@ -820,7 +820,7 @@ repeat:
 				break;
 			}
 			ocolor = r_config_get_i (core->config, "scr.color");
-			r_core_visual_graph (core, NULL, true);
+			r_core_visual_graph (core, NULL, NULL, true);
 			r_config_set_i (core->config, "scr.color", ocolor);
 		}
 		break;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1091,7 +1091,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 				break;
 			}
 			ocolor = r_config_get_i (core->config, "scr.color");
-			r_core_visual_graph (core, NULL, true);
+			r_core_visual_graph (core, NULL, NULL, true);
 			r_config_set_i (core->config, "scr.color", ocolor);
 		}
 		break;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -608,6 +608,7 @@ R_API RAGraph *r_agraph_new(RConsCanvas *can);
 R_API void r_agraph_free(RAGraph *g);
 R_API void r_agraph_reset(RAGraph *g);
 R_API void r_agraph_set_title(RAGraph *g, const char *title);
+R_API RANode *r_agraph_get_first_node(const RAGraph *g);
 R_API RANode *r_agraph_get_node(const RAGraph *g, const char *title);
 R_API RANode *r_agraph_add_node(const RAGraph *g, const char *title, const char *body);
 R_API bool r_agraph_del_node(const RAGraph *g, const char *title);
@@ -618,6 +619,7 @@ R_API void r_agraph_print(RAGraph *g);
 R_API Sdb *r_agraph_get_sdb(RAGraph *g);
 R_API void r_agraph_foreach(RAGraph *g, RANodeCallback cb, void *user);
 R_API void r_agraph_foreach_edge(RAGraph *g, RAEdgeCallback cb, void *user);
+R_API void r_agraph_set_curnode(RAGraph *g, RANode *node);
 #endif
 
 #ifdef __cplusplus

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -223,7 +223,7 @@ R_API bool r_core_visual_hudstuff(RCore *core);
 R_API int r_core_visual_classes(RCore *core);
 R_API int r_core_visual_types(RCore *core);
 R_API int r_core_visual(RCore *core, const char *input);
-R_API int r_core_visual_graph(RCore *core, RAnalFunction *_fcn, int is_interactive);
+R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int is_interactive);
 R_API int r_core_fcn_graph(RCore *core, RAnalFunction *_fcn);
 R_API int r_core_visual_panels(RCore *core);
 R_API int r_core_visual_cmd(RCore *core, int ch);


### PR DESCRIPTION
Now it is possible to pass an already initialized RAGraph that can be
used in interactive mode, without being based on a function.