### PR TITLE
Fix for issue #3766

### DIFF
--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -4,7 +4,7 @@
 #include "r_util.h"
 #include <stdio.h>
 
-/* int c; ret = hex_to_byet(&c, 'c'); */
+/* int c; ret = hex_to_byte(&c, 'c'); */
 R_API int r_hex_to_byte(ut8 *val, ut8 c) {
 	if ('0' <= c && c <= '9')      *val = (ut8)(*val) * 16 + (c-'0');
 	else if (c >= 'A' && c <= 'F') *val = (ut8)(*val) * 16 + (c-'A'+10);


### PR DESCRIPTION
https://github.com/radare/radare2/issues/3766 fix

**NOTE**: this implementation is not IDA compatible, if we try to disassemble byte sequence *b841424345*
radare2 will output:
```
  mov eax, 'ABCE'
```
IDA will output:
```
  mov     eax, 'ECBA'
```

If you think that IDA-like output is an issue, I can fix this.