### PR TITLE
fix dr7 mask value

### DIFF
--- a/libr/debug/p/native/drx.c
+++ b/libr/debug/p/native/drx.c
@@ -86,7 +86,7 @@ int drx_set(drxt *drx, int n, ut64 addr, int len, int rwx, int global) {
 	switch (rwx) {
 		case 1: rwx=0; break;
 		case 2: rwx=1; break;
-		case 4: rwx=2; break;
+		case 4: rwx=3; break;
 		default:
 			rwx=0;
 	}


### PR DESCRIPTION
Fixed the value at "case" to correct value, intel manual says for the valid values:
0 = execution
1 = write
3 = read/write

2 = only is avaliable in x64 and is used for debug ports
---------------------------------------------------------------------
R/W0 through R/W3 (read/write) fields (bits 16, 17, 20, 21, 24, 25, 28, and 29) — 
Specifies the breakpoint condition for the corresponding breakpoint. 
The DE (debug extensions) flag in control register CR4 determines how the bits in the R/W
n fields are interpreted. When the DE flag is set, the processor interprets bits as follows:
00 — Break on instruction execution only. 
01 — Break on data writes only.
10 — Break on I/O reads or writes.
11 — Break on data reads or writes but not instruction fetches.

When the DE flag is clear, the processor interprets the R/W n bits the same as for the Intel386™ and  ntel486™ processors, which is as follows:

00 — Break on instruction execution only.
01 — Break on data writes only.
10 — Undefined.
11 — Break on data reads or writes but not instruction fetches.
