### PR TITLE
anal af helpmsg fix

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -992,7 +992,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			"afr", " ([name]) ([addr])", "analyze functions recursively",
 			"af+", " addr size name [type] [diff]", "hand craft a function (requires afb+)",
 			"af-", " [addr]", "clean all function analysis data (or function at addr)",
-			"afa", "[?] [idx] [type] [name]", "add function argument",
+			"afa", "[?] [idx] [name] ([type])", "add function argument",
 			"af[aAv?]", "[arg]", "manipulate args, fastargs and variables in function",
 			"afb+", " fa a sz [j] [f] ([t]( [d]))", "add bb to function @ fcnaddr",
 			"afb", " [addr]", "List basic blocks of given function",


### PR DESCRIPTION
Seems like help message at https://github.com/radare/radare2/blob/master/libr/core/cmd_anal.c#L995 is outdated (the *type* and *name* fields positioned in wrong order).

Copied it from https://github.com/radare/radare2/blob/master/libr/core/cmd_anal.c#L40
