### PR TITLE
xnu: get rid of ptrace even for attach and detach

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -130,7 +130,8 @@ R_API int r_bp_stepy_continuation(RBreakpoint *bp) {
 static RBreakpointItem *r_bp_add(RBreakpoint *bp, const ut8 *obytes, ut64 addr, int size, int hw, int rwx) {
 	int ret;
 	RBreakpointItem *b;
-	if (addr == UT64_MAX || size < 1) return NULL;
+	if (addr == UT64_MAX || size < 1)
+		return NULL;
 	if (r_bp_get_in (bp, addr, rwx)) {
 		eprintf ("Breakpoint already set at this address.\n");
 		return NULL;
@@ -172,11 +173,15 @@ R_API int r_bp_add_fault(RBreakpoint *bp, ut64 addr, int size, int rwx) {
 R_API RBreakpointItem* r_bp_add_sw(RBreakpoint *bp, ut64 addr, int size, int rwx) {
 	RBreakpointItem *item;
 	ut8 *bytes;
-	if (size < 1) size = 1;
+	if (size < 1)
+		size = 1;
 	bytes = calloc (1, size);
-	if (bytes == NULL) return NULL;
-	if (bp->iob.read_at) bp->iob.read_at (bp->iob.io, addr, bytes, size);
-	else memset (bytes, 0, size);
+	if (bytes == NULL)
+		return NULL;
+	if (bp->iob.read_at)
+		bp->iob.read_at (bp->iob.io, addr, bytes, size);
+	else
+		memset (bytes, 0, size);
 	item = r_bp_add (bp, bytes, addr, size, R_BP_TYPE_SW, rwx);
 	free (bytes);
 	return item;

--- a/libr/bp/io.c
+++ b/libr/bp/io.c
@@ -3,58 +3,12 @@
 #include <r_bp.h>
 #include "../config.h"
 
-// TODO: rename from r_debug_ ... 
-#if 0
-R_API int r_debug_bp_enable(struct r_debug_t *dbg, ut64 addr, int set)
-{
-	struct r_bp_item_t *bp = r_bp_enable(dbg->bp, addr, set);
-	struct r_io_bind_t *iob;
-	if (bp) {
-		iob = &dbg->bp->iob;
-		iob->set_fd(iob->io, dbg->pid); // HUH?
-		if (set) iob->write_at(iob->io, addr, bp->bbytes, bp->size);
-		else iob->write_at(iob->io, addr, bp->obytes, bp->size);
-	}
-	return (bp!=NULL)?true:false;
-}
-
-// XXX this must be implemented in r_bp.. not here!!1
-R_API int r_debug_bp_add(struct r_debug_t *dbg, ut64 addr, int size, int hw, int rwx)
-{
-	ut8 *buf;
-	int ret = false;
-	struct r_bp_item_t *bp;
-	struct r_io_bind_t *iob;
-	if (dbg->bp->iob.init == false) {
-		eprintf("No dbg->read callback defined\n");
-		return -1; // return -1?
-	}
-	iob = &dbg->bp->iob;
-	/* read bytes affected */
-	buf = (ut8 *)malloc(size);
-	if (buf == NULL)
-		return -1;
-	iob->set_fd(iob->io, dbg->pid);
-	iob->read_at(iob->io, addr, buf, size);
-	/* register breakpoint in r_bp */
-	// XXX. bpadd here?!?
-	if (hw) bp = r_bp_add_sw(&dbg->bp, buf, addr, size, 0, R_BP_EXEC);
-	else bp = r_bp_add_sw(&dbg->bp, buf, addr, size, 0, R_BP_EXEC);
-	if (bp) {
-		if (dbg->h && (!dbg->h->bp_write || !dbg->h->bp_write(dbg->pid, addr, size, hw, rwx )))
-			iob->write_at(iob->io, addr, bp->bbytes, size);
-		/* if already set, r_bp should return false */
-		ret = true;
-	}
-	free(buf);
-	return ret;
-}
-#endif
+// TODO: rename from r_debug_ ...
 
 /**
  * reflect all r_bp stuff in the process using dbg->bp_write or ->breakpoint
  */
-R_API int r_bp_restore(struct r_bp_t *bp, int set) {
+R_API int r_bp_restore(RBreakpoint *bp, int set) {
 	RListIter *iter;
 	RBreakpointItem *b;
 
@@ -66,12 +20,14 @@ R_API int r_bp_restore(struct r_bp_t *bp, int set) {
 			//eprintf ("Setting bp at 0x%08"PFMT64x"\n", b->addr);
 			if (b->hw || !b->bbytes)
 				eprintf ("hw breakpoints not yet supported\n");
-			else bp->iob.write_at (bp->iob.io, b->addr, b->bbytes, b->size);
+			else
+				bp->iob.write_at (bp->iob.io, b->addr, b->bbytes, b->size);
 		} else {
 			//eprintf ("Clearing bp at 0x%08"PFMT64x"\n", b->addr);
 			if (b->hw || !b->obytes)
 				eprintf ("hw breakpoints not yet supported\n");
-			else bp->iob.write_at (bp->iob.io, b->addr, b->obytes, b->size);
+			else
+				bp->iob.write_at (bp->iob.io, b->addr, b->obytes, b->size);
 		}
 	}
 	return true;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1550,7 +1550,8 @@ static int bypassbp(RCore *core) {
 	r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, false);
 	addr = r_debug_reg_get (core->dbg, "PC");
 	bpi = r_bp_get_at (core->dbg->bp, addr);
-	if (!bpi) return false;
+	if (!bpi)
+		return false;
 	/* XXX 2 if libr/debug/debug.c:226 is enabled */
 	r_debug_step (core->dbg, 1);
 	return true;
@@ -1629,8 +1630,8 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 	switch (input[1]) {
 	case '.':
 		if (input[2]) {
-			int bpsz = strcmp (core->dbg->arch, "arm")? 1: 4;
-			ut64 addr = r_num_tail (core->num, core->offset, input+2);
+			int bpsz = strcmp (core->dbg->arch, "arm") ? 1 : 4;
+			ut64 addr = r_num_tail (core->num, core->offset, input +2);
 			if (validAddress (core, addr)) {
 				bpi = hwbp
 				? r_bp_add_hw (core->dbg->bp, addr, bpsz, R_BP_PROT_EXEC)
@@ -1742,23 +1743,17 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					if (f->offset != addr) {
 						int delta = (int)(frame->addr - f->offset);
 						if (delta > 0) {
-							snprintf (flagdesc,
-								sizeof(flagdesc),
-								"%s+%d",
-								f->name, delta);
+							snprintf (flagdesc, sizeof(flagdesc),
+								"%s+%d", f->name, delta);
 						} else if (delta < 0) {
-							snprintf (flagdesc,
-								sizeof(flagdesc),
-								"%s%d",
-								f->name, delta);
+							snprintf (flagdesc, sizeof(flagdesc),
+								"%s%d", f->name, delta);
 						} else {
-							snprintf (flagdesc,
-								sizeof(flagdesc),
+							snprintf (flagdesc, sizeof(flagdesc),
 								"%s", f->name);
 						}
 					} else {
-						snprintf (flagdesc,
-							sizeof(flagdesc),
+						snprintf (flagdesc, sizeof(flagdesc),
 							"%s", f->name);
 					}
 				} else {
@@ -1772,23 +1767,17 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					if (f->offset != addr) {
 						int delta = (int)(frame->addr - 1 - f->offset);
 						if (delta > 0) {
-							snprintf (flagdesc2,
-								sizeof(flagdesc2),
-								"%s+%d",
-								f->name, delta + 1);
+							snprintf (flagdesc2, sizeof(flagdesc2),
+								"%s+%d", f->name, delta + 1);
 						} else if (delta<0) {
-							snprintf (flagdesc2,
-								sizeof(flagdesc2),
-								"%s%d",
-								f->name, delta + 1);
+							snprintf (flagdesc2, sizeof(flagdesc2),
+								"%s%d", f->name, delta + 1);
 						} else {
-							snprintf (flagdesc2,
-								sizeof(flagdesc2),
+							snprintf (flagdesc2, sizeof(flagdesc2),
 								"%s+1", f->name);
 						}
 					} else {
-						snprintf (flagdesc2,
-							sizeof (flagdesc2),
+						snprintf (flagdesc2, sizeof (flagdesc2),
 							"%s", f->name);
 					}
 				} else {
@@ -2582,7 +2571,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 		break;
 	case ' ':
 		old_pid = core->dbg->pid;
-		pid = atoi (input+2);
+		pid = atoi (input + 2);
 		bypassbp (core);
 		r_reg_arena_swap (core->dbg->reg, true);
 		r_debug_select (core->dbg, pid, core->dbg->tid);

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1564,6 +1564,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI("stack.delta", 0,  "Delta for the stack dump");
 
 	SETCB("dbg.libs", "", &cb_dbg_libs, "If set stop when loading matching libname");
+	SETI("dbg.hwbp", 0, "Set HW or SW breakpoints");
 	SETCB("dbg.unlibs", "", &cb_dbg_unlibs, "If set stop when unloading matching libname");
 	SETPREF("dbg.slow", "false", "Show stack and regs in visual mode in a slow but verbose mode");
 

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -263,7 +263,7 @@ R_API int r_debug_start(RDebug *dbg, const char *cmd) {
 
 R_API int r_debug_detach(RDebug *dbg, int pid) {
 	if (dbg->h && dbg->h->detach)
-		return dbg->h->detach (pid);
+		return dbg->h->detach (dbg, pid);
 	return false;
 }
 
@@ -555,7 +555,8 @@ repeat:
 		if (retwait != R_DEBUG_REASON_DEAD) {
 			ret = dbg->tid;
 		}
-		if (retwait == R_DEBUG_REASON_NEW_LIB || retwait == R_DEBUG_REASON_EXIT_LIB) {
+		if (retwait == R_DEBUG_REASON_NEW_LIB ||
+		    retwait == R_DEBUG_REASON_EXIT_LIB) {
 			goto repeat;
 		}
 #endif

--- a/libr/debug/p/debug_bf.c
+++ b/libr/debug/p/debug_bf.c
@@ -131,7 +131,7 @@ eprintf ("input = %llx\n", o->bfvm->input);
 	return true;
 }
 
-static int r_debug_bf_detach(int pid) {
+static int r_debug_bf_detach(RDebug *dbg, int pid) {
 	// reset vm?
 	return true;
 }

--- a/libr/debug/p/debug_esil.c
+++ b/libr/debug/p/debug_esil.c
@@ -79,7 +79,7 @@ eprintf ("input = %llx\n", o->bfvm->input);
 	return true;
 }
 
-static int __esil_detach(int pid) {
+static int __esil_detach(RDebug *dbg, int pid) {
 	// reset vm?
 	return true;
 }

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -179,7 +179,7 @@ static int r_debug_gdb_attach(RDebug *dbg, int pid) {
 	return true;
 }
 
-static int r_debug_gdb_detach(int pid) {
+static int r_debug_gdb_detach(RDebug *dbg, int pid) {
 	gdbr_disconnect(desc);
 	free (reg_buf);
 	return true;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -165,14 +165,14 @@ static int r_debug_native_attach (RDebug *dbg, int pid) {
 #endif
 }
 
-static int r_debug_native_detach (int pid) {
+static int r_debug_native_detach (RDebug *dbg, int pid) {
 #if __WINDOWS__ && !__CYGWIN__
 	return w32_detach (pid)? 0 : -1;
 #elif __CYGWIN__
 	#warning "r_debug_native_detach not supported on this platform"
 	return -1;
 #elif __APPLE__
-	return xnu_dettach (pid);
+	return xnu_detach (dbg, pid);
 #elif __BSD__
 	return ptrace (PT_DETACH, pid, NULL, 0);
 #else
@@ -907,8 +907,6 @@ static int r_debug_native_init (RDebug *dbg) {
 	dbg->h->desc = r_debug_desc_plugin_native;
 #if __WINDOWS__ && !__CYGWIN__
 	return w32_dbg_init ();
-#elif __APPLE__
-	return xnu_init ();
 #else
 	return true;
 #endif

--- a/libr/debug/p/debug_rap.c
+++ b/libr/debug/p/debug_rap.c
@@ -41,7 +41,7 @@ static int r_debug_rap_attach(RDebug *dbg, int pid) {
 	return true;
 }
 
-static int r_debug_rap_detach(int pid) {
+static int r_debug_rap_detach(RDebug *dbg, int pid) {
 // XXX TODO PID must be a socket here !!1
 //	close (pid);
 	//XXX Maybe we should continue here?

--- a/libr/debug/p/debug_wind.c
+++ b/libr/debug/p/debug_wind.c
@@ -135,7 +135,7 @@ static int r_debug_wind_attach (RDebug *dbg, int pid) {
 	return true;
 }
 
-static int r_debug_wind_detach (int pid) {
+static int r_debug_wind_detach (RDebug *dbg, int pid) {
 	return true;
 }
 

--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -18,22 +18,19 @@
 #include <mach/mach_host.h>
 #include <mach/host_priv.h>
 
-//we will this pipe to communicate with xnu_exception_thread
-static int exc_pipe[2];
-
+static task_t task_dbg = -1;
 #include "xnu_debug.h"
 #include "xnu_threads.c"
 #if XNU_USE_EXCTHR
 #include "xnu_excthreads.c"
 #endif
 
-//TODO dbg->tid is update accordingly for mulithreaded applications??
-
-
 static thread_t getcurthread (RDebug *dbg) {
 	thread_array_t threads = NULL;
 	unsigned int n_threads = 0;
 	task_t t = pid_to_task (dbg->pid);
+	if (!t)
+		return -1;
 	if (task_threads (t, &threads, &n_threads))
 		return -1;
 	if (n_threads < 1)
@@ -46,7 +43,10 @@ static thread_t getcurthread (RDebug *dbg) {
 
 static xnu_thread_t* get_xnu_thread(RDebug *dbg, int tid) {
 	RListIter *it = NULL;
-	if (!dbg) return false;
+	if (!dbg)
+		return NULL;
+	if (tid < 0)
+		return NULL;
 	if (!xnu_update_thread_list (dbg)) {
 		eprintf ("Failed to update thread_list xnu_reg_write\n");
 		return NULL;
@@ -61,7 +61,7 @@ static xnu_thread_t* get_xnu_thread(RDebug *dbg, int tid) {
 			  (RListComparator)&thread_find);
 	if (it)
 		return (xnu_thread_t *)it->data;
-	eprintf ("Thread not found xnu_reg_write\n");
+	eprintf ("Thread not found get_xnu_thread\n");
 	return NULL;
 }
 
@@ -74,24 +74,24 @@ static task_t task_for_pid_workaround(int Pid) {
 	kern_return_t kr;
 	int i;
 	if (Pid == -1)
-		return -1;
+		return 0;
 
 	kr = processor_set_default (myhost, &psDefault);
 	if (kr != KERN_SUCCESS)
-		return -1;
+		return 0;
 
 	kr = host_processor_set_priv (myhost, psDefault, &psDefault_control);
 	if (kr != KERN_SUCCESS) {
 		eprintf ("host_processor_set_priv failed with error 0x%x\n", kr);
 		//mach_error ("host_processor_set_priv",kr);
-		return -1;
+		return 0;
 	}
 
 	numTasks = 0;
 	kr = processor_set_tasks (psDefault_control, &tasks, &numTasks);
 	if (kr != KERN_SUCCESS) {
 		eprintf ("processor_set_tasks failed with error %x\n", kr);
-		return -1;
+		return 0;
 	}
 
 	/* kernel task */
@@ -104,7 +104,7 @@ static task_t task_for_pid_workaround(int Pid) {
 		if (pid == Pid)
 			return (tasks[i]);
 	}
-	return -1;
+	return 0;
 }
 
 bool xnu_step(RDebug *dbg) {
@@ -118,15 +118,13 @@ bool xnu_step(RDebug *dbg) {
 
 #else
 	int ret = 0;
-	int exc;
 	//we must find a way to get the current thread not just the firt one
 	task_t task = pid_to_task (dbg->pid);
-	task_suspend (task);
-	if (task < 1) {
-		perror ("pid_to_task");
+	if (!task) {
 		eprintf ("step failed on task %d for pid %d\n", task, dbg->tid);
 		return false;
 	}
+	task_suspend (task);
 	xnu_thread_t *th = get_xnu_thread (dbg, getcurthread (dbg));
 	if (!th)
 		return false;
@@ -135,7 +133,7 @@ bool xnu_step(RDebug *dbg) {
 		eprintf ("xnu_step modificy_trace_bit error\n");
 		return false;
 	}
-	thread_resume (th->tid);
+	thread_resume (th->th_port);
 	return ret;
 #endif
 }
@@ -148,31 +146,39 @@ int xnu_attach(RDebug *dbg, int pid) {
         }
 	return pid;
 #else
-	int ret, exc;
-	task_t task = pid_to_task (pid);
 	dbg->pid = pid;
-	ret = xnu_create_exception_thread (dbg);
-	if (!ret) {
+	if (!xnu_create_exception_thread (dbg)) {
 		eprintf ("error setting up exception thread\n");
 		return -1;
 	}
+	//task_suspend (pid_to_task (pid));
+#if 0
 	if (ptrace (PT_ATTACHEXC, pid, 0, 0) == -1) {
 		perror ("ptrace (PT_ATTACHEXC)");
 		return -1;
 	}
 	usleep(250000);
+#endif
 	return pid;
 #endif
 }
 
-int xnu_dettach(int pid) {
+int xnu_detach(RDebug *dbg, int pid) {
 #if XNU_USE_PTRACE
 	return ptrace (PT_DETACH, pid, NULL, 0);
 #else
+	kern_return_t kr;
 	//do the cleanup necessary
-	//XXX check for errors
+	//XXX check for errors and ref counts
 	(void)xnu_restore_exception_ports (pid);
-	ptrace (PT_DETACH, pid, NULL, 0);
+	kr = mach_port_deallocate (mach_task_self (), task_dbg);
+	if (kr != KERN_SUCCESS) {
+		eprintf ("failed to deallocate port %s-%d\n",
+			__FILE__, __LINE__);
+	}
+	//we mark the task as not longer available since we deallocated the ref
+	task_dbg = -2;
+	r_list_free (dbg->threads);
 #endif
 }
 
@@ -183,6 +189,9 @@ int xnu_continue(RDebug *dbg, int pid, int tid, int sig) {
 	return ptrace (PT_CONTINUE, pid, (void*)(size_t)1,
 			(int)(size_t)data) == 0;
 #else
+	task_t task = pid_to_task (pid);
+	if (!task)
+		return false;
 	xnu_thread_t *th  = get_xnu_thread (dbg, getcurthread (dbg));
 	if (!th) {
 		eprintf ("failed to get thread in xnu_continue\n");
@@ -191,12 +200,11 @@ int xnu_continue(RDebug *dbg, int pid, int tid, int sig) {
 	//disable trace bit if enable
 	if (th->stepping) {
 		if (!clear_trace_bit (dbg, th)) {
-			eprintf ("error clearing trace bit\n");
+			eprintf ("error clearing trace bit in xnu_continue\n");
 			return false;
 		}
 	}
-	task_resume (pid_to_task (pid));
-	thread_resume (th->tid);
+	task_resume (task);
 	return true;
 #endif
 }
@@ -230,6 +238,8 @@ const char *xnu_reg_profile(RDebug *dbg) {
 int xnu_reg_write(RDebug *dbg, int type, const ut8 *buf, int size) {
 	bool ret;
 	xnu_thread_t *th = get_xnu_thread (dbg, getcurthread (dbg));
+	if (!th)
+		return 0;
 	switch (type) {
 	case R_REG_TYPE_DRX:
 		memcpy (&th->drx, buf, R_MIN (size, sizeof (th->drx)));
@@ -247,6 +257,8 @@ int xnu_reg_write(RDebug *dbg, int type, const ut8 *buf, int size) {
 int xnu_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 	bool ret;
 	xnu_thread_t *th = get_xnu_thread (dbg, getcurthread (dbg));
+	if (!th)
+		return 0;
 	switch (type) {
 	case R_REG_TYPE_SEG:
 	case R_REG_TYPE_FLG:
@@ -274,15 +286,14 @@ int xnu_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 RDebugMap *xnu_map_alloc(RDebug *dbg, ut64 addr, int size) {
 	kern_return_t ret;
 	ut8 *base = (ut8 *)addr;
+	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
 	bool anywhere = !VM_FLAGS_ANYWHERE;
-
-	if (addr == -1) anywhere = VM_FLAGS_ANYWHERE;
-
-	ret = vm_allocate (pid_to_task (dbg->tid),
-			(vm_address_t*)&base,
-			(vm_size_t)size,
-			anywhere);
-
+	if (!th)
+		return NULL;
+	if (addr == -1)
+		anywhere = VM_FLAGS_ANYWHERE;
+	ret = vm_allocate (th->th_port, (vm_address_t *)&base,
+			  (vm_size_t)size, anywhere);
 	if (ret != KERN_SUCCESS) {
 		printf("vm_allocate failed\n");
 		return NULL;
@@ -292,7 +303,10 @@ RDebugMap *xnu_map_alloc(RDebug *dbg, ut64 addr, int size) {
 }
 
 int xnu_map_dealloc (RDebug *dbg, ut64 addr, int size) {
-	int ret = vm_deallocate (pid_to_task (dbg->tid),
+	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
+	if (!th)
+		return false;
+	int ret = vm_deallocate (th->th_port,
 		(vm_address_t)addr, (vm_size_t)size);
 	if (ret != KERN_SUCCESS) {
 		perror ("vm_deallocate");
@@ -349,7 +363,7 @@ RList *xnu_thread_list (RDebug *dbg, int pid, RList *list) {
 		thread->state_size = sizeof (thread->gpr);
 		memcpy (&state, &thread->gpr, sizeof (R_REG_T));
 		r_list_append (list, r_debug_pid_new (thread->name,
-			thread->tid, 's', CPU_PC));
+			thread->th_port, 's', CPU_PC));
 	}
 	return list;
 }
@@ -365,11 +379,12 @@ static vm_prot_t unix_prot_to_darwin(int prot) {
 int xnu_map_protect (RDebug *dbg, ut64 addr, int size, int perms) {
 	int ret;
 	// TODO: align pointers
-	ret = vm_protect (pid_to_task (dbg->tid),
-			(vm_address_t)addr,
-			(vm_size_t)size,
-			(boolean_t)0, /* maximum protection */
-			VM_PROT_COPY|perms); //unix_prot_to_darwin (perms));
+	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
+	if (!th)
+		return false;
+	ret = vm_protect (th->th_port, (vm_address_t)addr,
+			 (vm_size_t)size, (boolean_t)0,
+			 VM_PROT_COPY | perms);
 	if (ret != KERN_SUCCESS) {
 		printf("vm_protect failed\n");
 		return false;
@@ -378,19 +393,20 @@ int xnu_map_protect (RDebug *dbg, ut64 addr, int size, int perms) {
 }
 
 task_t pid_to_task (int pid) {
-	static task_t old_task = -1;
-	static task_t old_pid = -1;
+	static int old_pid = -1;
 	task_t task = -1;
 	int err;
 
-	/* xlr8! */
-	if (old_task != -1 && old_pid == pid)
-		return old_task;
+	/* it means that we are done with the task*/
+	if (task_dbg == -2)
+		return 0;
+	if (task_dbg != -1 && old_pid == pid)
+		return task_dbg;
 
 	err = task_for_pid (mach_task_self (), (pid_t)pid, &task);
 	if ((err != KERN_SUCCESS) || !MACH_PORT_VALID (task)) {
 		task = task_for_pid_workaround (pid);
-		if (task == -1) {
+		if (task == 0) {
 			eprintf ("Failed to get task %d for pid %d.\n",
 				(int)task, (int)pid);
 			eprintf ("Reason: 0x%x: %s\n", err,
@@ -398,11 +414,11 @@ task_t pid_to_task (int pid) {
 			eprintf ("You probably need to run as root or sign "
 				"the binary.\n Read doc/ios.md || doc/osx.md\n"
 				" make -C binr/radare2 ios-sign || osx-sign\n");
-			return -1;
+			return 0;
 		}
 	}
 	old_pid = pid;
-	old_task = task;
+	task_dbg = task;
 	return task;
 }
 
@@ -552,17 +568,20 @@ vm_address_t get_kernel_base(task_t ___task) {
 	int count;
 
 	ret = task_for_pid (mach_task_self(), 0, &task);
-	if (ret != KERN_SUCCESS) return 0;
+	if (ret != KERN_SUCCESS)
+		return 0;
 	ut64 naddr;
 	eprintf ("%d vs %d\n", task, ___task);
-	for (count=128; count; count--) {
+	for (count = 128; count; count--) {
 		// get next memory region
 		naddr = addr;
 		ret = vm_region_recurse_64 (task, (vm_address_t*)&naddr,
 					   (vm_size_t*)&size, &depth,
 					   (vm_region_info_t)&info, &info_count);
-		if (ret != KERN_SUCCESS) break;
-		if (size<1) break;
+		if (ret != KERN_SUCCESS)
+			break;
+		if (size < 1)
+			break;
 		if (addr == naddr) {
 			addr += size;
 			continue;
@@ -576,6 +595,9 @@ vm_address_t get_kernel_base(task_t ___task) {
 		}
 		addr += size;
 	}
+	ret = mach_port_deallocate (mach_task_self (), 0);
+	if (ret != KERN_SUCCESS)
+		eprintf ("leaking kernel port %s-%d\n", __FILE__, __LINE__);
 	return (vm_address_t)0;
 }
 
@@ -638,6 +660,8 @@ static RList *xnu_dbg_modules(RDebug *dbg) {
 	ut64 addr, file_path_address;
 	RDebugMap *mr = NULL;
 	RList *list = NULL;
+	if (!task)
+		return NULL;
 
 	kr = task_info (task, TASK_DYLD_INFO, (task_info_t) &info, &count);
 	if (kr != KERN_SUCCESS)
@@ -720,7 +744,10 @@ RList *xnu_dbg_maps(RDebug *dbg, int only_modules) {
 	RDebugMap *mr = NULL;
 	RList *list = NULL;
 	int i = 0;
-	if (only_modules) return xnu_dbg_modules (dbg);
+	if (!task)
+		return NULL;
+	if (only_modules)
+		return xnu_dbg_modules (dbg);
 
 #if __arm64__ || __aarch64__
 	size = osize = 16384; // acording to frida
@@ -765,7 +792,7 @@ RList *xnu_dbg_maps(RDebug *dbg, int only_modules) {
 			char depthstr[32];
 			if (depth>0)
 				snprintf (depthstr, sizeof (depthstr), "_%d", depth);
-			else 
+			else
 				depthstr[0] = 0;
 
 			if (info.max_protection != info.protection)
@@ -800,13 +827,6 @@ RList *xnu_dbg_maps(RDebug *dbg, int only_modules) {
 		size = 0;
 	}
 	return list;
-}
-
-//TODO xnu_deinit
-int xnu_init (void) {
-	if (pipe (exc_pipe) == -1)
-		eprintf ("failed to create pipe for communication");
-	return true;
 }
 
 #endif

--- a/libr/debug/p/native/xnu/xnu_debug.h
+++ b/libr/debug/p/native/xnu/xnu_debug.h
@@ -177,7 +177,7 @@ int xnu_reg_write (RDebug *dgb, int type, const ut8 *buf, int size);
 const char *xnu_reg_profile (RDebug *dbg);
 int xnu_attach (RDebug *dbg, int pid);
 bool xnu_step (RDebug *dbg);
-int xnu_dettach (int pid);
+int xnu_detach (RDebug *dbg, int pid);
 int xnu_continue (RDebug *dbg, int pid, int tid, int sig);
 RDebugMap *xnu_map_alloc (RDebug *dbg, ut64 addr, int size);
 int xnu_map_dealloc (RDebug *dbg, ut64 addr, int size);

--- a/libr/debug/p/native/xnu/xnu_threads.h
+++ b/libr/debug/p/native/xnu/xnu_threads.h
@@ -45,21 +45,23 @@ typedef struct _exception_info {
 	mach_port_t exception_port;
 } xnu_exception_info;
 
+
+//XXX use radare types
 typedef struct _xnu_thread {
-	thread_t tid; //mach_port // XXX bad naming here
+	thread_t th_port; //mach_port // XXX bad naming here
 	char *name; //name of thread
 	thread_basic_info_data_t basic_info; //need this?
-	int stepping; // thread is stepping or not //TODO implement stepping
+	ut8 stepping; // thread is stepping or not //TODO implement stepping
 	R_REG_T gpr; // type R_REG_T using unified API XXX bad naming
 	R_DEBUG_REG_T drx; // type R_DEBUG_REG_T using unified API
 	//task_t thtask;
 	void *state;
-	int state_size;
+	ut32 state_size;
 #if __arm || __arm64 || __aarch64
 	void *oldstate;
 #endif
-	int flavor;
-	unsigned int count;
+	ut16 flavor;
+	ut32 count;
 } xnu_thread_t;
 
 typedef struct _exc_msg {

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -222,7 +222,7 @@ typedef struct r_debug_plugin_t {
 	RDebugInfo* (*info)(RDebug *dbg, const char *arg);
 	int (*startv)(int argc, char **argv);
 	int (*attach)(RDebug *dbg, int pid);
-	int (*detach)(int pid);
+	int (*detach)(RDebug *dbg, int pid);
 	int (*select)(int pid, int tid);
 	RList *(*threads)(RDebug *dbg, int pid);
 	RList *(*pids)(int pid);


### PR DESCRIPTION
this still is wip 

i've get rid of ptrace even for attach and detach. The reason is that with just having a reference to a task is enough and is not needed ptrace as I thought.

i am trying to clean code and so, to avoid leaking ports https://robert.sesek.com/2012/1/debugging_mach_ports.html

I've change the way to handle exceptions, avoiding `mach_exc_server` since this comes from `.defs` files and for iOS there is not such file. I've tried to set a breakpoint to then make `dc`  to see if i am able to receive the event of a breakpoint but for some reason `libr/io/p/io_mach.c` gives and error due to permission issue on the mapping (i have to review more closely but today I hadn't more time). I am stuck there but i think this can be merged if i've not broken nothing.
 

