### PR TITLE
Fixed argument check in env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -7,7 +7,7 @@ getabsolutepath() {
 
 pfx=$(getabsolutepath "$1")
 
-if [ -z "$pfx" ]; then
+if [ -z "$1" ]; then
 	echo "Usage: ./env.sh [destdir|prefix] [program]"
 	exit 1
 fi


### PR DESCRIPTION
If you just run `./env.sh` without arguments it doesn't actually give you the usage error. 

The reason is that the getabsolutepath function returns a path no matter if $1 is given or not. It returns `pwd` by default I believe.

I don't know if this is the fix you want, but it works. Simply check if `arg1` actually exists instead of `pfx`.

If this breaks people, they weren't using env.sh correctly in the first place and relying on undefined behaviour. 