### PR TITLE
convert negative fp numbers to hex

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -28,7 +28,17 @@ static int format_output (char mode, const char *s) {
 	}
 	switch (mode) {
 	case 'I': printf ("%"PFMT64d"\n", n); break;
-	case '0': printf ("0x%"PFMT64x"\n", n); break;
+	case '0': {
+		if (s[strlen(s)-1]=='f') {
+			float f = (float) num->fvalue;
+			ut8 *p = (ut8*)&f;
+			printf ("Fx%02x%02x%02x%02x\n", p[3], p[2], p[1], p[0]);
+		}
+		else {
+			printf ("0x%"PFMT64x"\n", n);
+		}
+		}
+		break;
 	case 'F': {
 		  float *f = (float*)&n;
 		printf ("%ff\n", *f);

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -31,6 +31,7 @@ static int format_output (char mode, const char *s) {
 	case '0': {
 		int len = strlen(s);
 		if (len > 0 && s[len-1]=='f') {
+			switch (0) {case 0 : case sizeof(float) == 4:;}
 			float f = (float) num->fvalue;
 			ut8 *p = (ut8*)&f;
 			printf ("Fx%02x%02x%02x%02x\n", p[3], p[2], p[1], p[0]);

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -31,7 +31,7 @@ static int format_output (char mode, const char *s) {
 	case '0': {
 		int len = strlen(s);
 		if (len > 0 && s[len-1]=='f') {
-			switch (0) {case 0 : case sizeof(float) == 4:;}
+			R_STATIC_ASSERT(sizeof(float) == 4)
 			float f = (float) num->fvalue;
 			ut8 *p = (ut8*)&f;
 			printf ("Fx%02x%02x%02x%02x\n", p[3], p[2], p[1], p[0]);

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -29,16 +29,13 @@ static int format_output (char mode, const char *s) {
 	switch (mode) {
 	case 'I': printf ("%"PFMT64d"\n", n); break;
 	case '0': {
-		if (s[strlen(s)-1]=='f') {
+		int len = strlen(s);
+		if (len > 0 && s[len-1]=='f') {
 			float f = (float) num->fvalue;
 			ut8 *p = (ut8*)&f;
 			printf ("Fx%02x%02x%02x%02x\n", p[3], p[2], p[1], p[0]);
-		}
-		else {
-			printf ("0x%"PFMT64x"\n", n);
-		}
-		}
-		break;
+		} else printf ("0x%"PFMT64x"\n", n);
+		} break;
 	case 'F': {
 		  float *f = (float*)&n;
 		printf ("%ff\n", *f);

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -37,6 +37,8 @@ R_LIB_VERSION_HEADER(r_util);
 #define R_REFCTR_REF(x) x->refctr++
 #define R_REFCTR_UNREF(x) if (--x->refctr<=0) x->ref_free(x)
 
+#define R_STATIC_ASSERT(x) switch (0) {case 0: case (x):;}
+
 #if 0
 typedef struct {
 	R_REFCTR_CLASS;


### PR DESCRIPTION
Simple change to allow for negative floating point numbers in rax2. An example is rax2 -121.875f to return Fxc2f3c000.