### PR TITLE
Improve r_hex_str2bin

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -708,6 +708,7 @@ int main(int argc, char **argv) {
 			*p2++ = 0;
 			data = malloc (strlen (p2)+1);
 			datalen = r_hex_str2bin (p2, data);
+			if (datalen < 0) datalen = -datalen;
 		} else {
 			data = NULL;
 			datalen = 0;

--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -111,14 +111,12 @@ static int rasm_disasm(char *buf, ut64 offset, int len, int bits, int ascii, int
 		clen = strlen (buf);
 		data = (ut8*)buf;
 	} else {
-		for (; *ptr; ptr++)
-			if (*ptr!=' ' && *ptr!='\n' && *ptr!='\r')
-				if (!(++word%2)) clen++;
-		data = malloc (clen+1);
-		if (r_hex_str2bin (buf, data)<1) {
+		clen = r_hex_str2bin (buf, NULL);
+		if ((int)clen < 1 || !(data = malloc (clen))) {
 			ret = 0;
 			goto beach;
 		}
+		r_hex_str2bin (buf, data);
 	}
 
 	if (!len || clen <= len)

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -449,7 +449,7 @@ R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, const char *hexstr) {
 	if (!(buf = malloc (1+strlen (hexstr))))
 		return NULL;
 	len = r_hex_str2bin (hexstr, buf);
-	if (len == -1) {
+	if (len < 1) {
 		free (buf);
 		return NULL;
 	}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1616,7 +1616,7 @@ repeat_arroba:
 					buf = malloc (strlen (ptr+2)+1);
 					if (buf) {
 						len = r_hex_str2bin (ptr+2, buf);
-						r_core_block_size (core, len);
+						r_core_block_size (core, R_ABS(len));
 						memcpy (core->block, buf, core->blocksize);
 						core->fixedblock = true;
 						free (buf);

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -5,9 +5,9 @@ R_API int cmd_write_hexpair(RCore* core, const char* pairs) {
 	int len = r_hex_str2bin (pairs, buf);
 	if (len != 0) {
 		if (len < 0)
-			len = -len + 1;
+			len = -len;
 		if (len<core->blocksize)
-			buf[len] = (core->block[len] & 0xf) | (buf[len] & 0xf0);
+			buf[len-1] |= core->block[len-1] & 0xf;
 		r_core_write_at (core, core->offset, buf, len);
 		if (r_config_get_i (core->config, "cfg.wseek"))
 			r_core_seek_delta (core, len);
@@ -16,7 +16,7 @@ R_API int cmd_write_hexpair(RCore* core, const char* pairs) {
 		eprintf ("Error: invalid hexpair string\n");
 	free (buf);
 
-	return !!!len;
+	return !len;
 }
 
 static void cmd_write_bits(RCore *core, int set, ut64 val) {
@@ -370,7 +370,7 @@ static int cmd_write(void *data, const char *input) {
 				{
 				ut8 *bin_buf = malloc(str_len);
 				const int bin_len = r_hex_str2bin(str, bin_buf);
-				if (bin_len == 0) {
+				if (bin_len <= 0) {
 					fail = 1;
 				} else {
 					buf = malloc(str_len * 4 + 1);

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -4,10 +4,11 @@ R_API int cmd_write_hexpair(RCore* core, const char* pairs) {
 	ut8 *buf = malloc (strlen (pairs) + 1);
 	int len = r_hex_str2bin (pairs, buf);
 	if (len != 0) {
-		if (len < 0)
+		if (len < 0) {
 			len = -len;
-		if (len<core->blocksize)
-			buf[len-1] |= core->block[len-1] & 0xf;
+			if (len < core->blocksize)
+				buf[len-1] |= core->block[len-1] & 0xf;
+		}
 		r_core_write_at (core, core->offset, buf, len);
 		if (r_config_get_i (core->config, "cfg.wseek"))
 			r_core_seek_delta (core, len);

--- a/libr/core/io.c
+++ b/libr/core/io.c
@@ -108,7 +108,7 @@ R_API int r_core_write_op(RCore *core, const char *arg, char op) {
 	memcpy (buf, core->block, core->blocksize);
 	if (op!='e') {
 		len = r_hex_str2bin (arg, (ut8 *)str);
-		if (len==-1) {
+		if (len < 0) {
 			eprintf ("Invalid hexpair string\n");
 			goto beach;
 		}

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -178,95 +178,45 @@ R_API char *r_hex_bin2strdup(const ut8 *in, int len) {
 }
 
 R_API int r_hex_str2bin(const char *in, ut8 *out) {
-	int len = 0, j = 0;
-	const char *ptr;
-	ut8 c = 0, d = 0;
-	int outbuf = 0;
+	long nibbles = 0;
 
-	if (!in || !*in)
-		return 0;
-	if (!strncmp (in, "0x", 2))
-		in += 2;
-	if (!out) {
-		outbuf = 1;
-		out = malloc (strlen (in)+1);
-	}
-	for (ptr = in; ; ptr++) {
+	while (in && *in) {
+		ut8 tmp;
+
+		/* skip hex prefix */
+		if (*in == '0' && in[1] == 'x') {
+			in += 2;
+		}
+
+		/* read hex digits */
+		while (!r_hex_to_byte(out ? &out[nibbles/2] : &tmp, *in)) {
+			nibbles++;
+			in++;
+		}
+		if (*in == '\0') break;
+
 		/* comments */
-		if (*ptr=='#') {
-			while (*ptr && *ptr != '\n') ptr++;
-			if (!ptr[0])
-				break;
-			ptr--;
+		if (*in == '#' || (*in == '/' && in[1] == '/')) {
+			if ((in = strchr (in, '\n')))
+				in++;
 			continue;
 		}
-		if (*ptr == '/' && ptr[1]=='*') {
-			while (*ptr && ptr[1]) {
-				if (*ptr == '*' && ptr[1]=='/')
-					break;
-				ptr++;
-			}
-			if (!ptr[0] || !ptr[1])
-				break;
-			ptr++;
+		if (*in == '/' && in[1] == '*') {
+			if ((in = strstr (in, "*/")))
+				in += 2;
 			continue;
-		}
-		/* ignored chars */
-		if (*ptr==':' || *ptr=='\n' || *ptr=='\t' || *ptr=='\r' || *ptr==' ')
-			continue;
-
-		if (j==2) {
-			out[len] = c;
-			len++;
-			c = j = 0;
-			if (ptr[0]==' ')
-				continue;
 		}
 
-		/* break after len++ */
-		if (ptr[0] == '\0') break;
+		/* ignore character */
+		in++;
+	}
 
-		d = c;
-		if (ptr[0]=='0' && ptr[1]=='x' ){ //&& c==0) {
-			ut64 addr = r_num_get (NULL, ptr);
-			unsigned int addr32 = (ut32) addr;
-			if (addr>>32) {
-				// 64 bit fun
-			} else {
-				// 32 bit fun
-				ut8 *addrp = (ut8*) &addr32;
-				// XXX always copy in native endian?
-				out[len++] = addrp[0];
-				out[len++] = addrp[1];
-				out[len++] = addrp[2];
-				out[len++] = addrp[3];
-				while (*ptr && *ptr!=' ' && *ptr!='\t')
-					ptr++;
-				j = 0;
-			}
-			/* Go back one character, the loop head does ptr++. */
-			ptr--;
-			continue;
-		}
-		if (r_hex_to_byte (&c, ptr[0])) {
-			//eprintf("binstr: Invalid hexa string at %d ('0x%02x') (%s).\n", (int)(ptr-in), ptr[0], in);
-			goto beach;
-		}
-		c |= d;
-		if (j++ == 0) c <<= 4;
+	if (nibbles % 2) {
+		if (out) r_hex_to_byte(&out[nibbles/2], '0');
+		return -(nibbles+1)/2;
 	}
-	// has nibbles. requires a mask
-beach:
-	if (j) {
-		out[len] = c;
-		len = -len;
-	}
-	if (outbuf) {
-		free (out);
-	} else {
-		out[R_ABS(len)] = 0;
-	}
-	return (int)len;
+
+	return nibbles/2;
 }
 
 R_API int r_hex_str2binmask(const char *in, ut8 *out, ut8 *mask) {
@@ -276,13 +226,14 @@ R_API int r_hex_str2binmask(const char *in, ut8 *out, ut8 *mask) {
 	memcpy (out, in, ilen);
 	for (ptr=out; *ptr; ptr++) if (*ptr=='.') *ptr = '0';
 	len = r_hex_str2bin ((char*)out, out);
-	if (len<0) { has_nibble = 1; len = -len; }
+	if (len<0) { has_nibble = 1; len = -(len+1); }
 	if (len != -1) {
 		memcpy (mask, in, ilen);
 		if (has_nibble)
 			memcpy (mask+ilen, "f0", 3);
 		for (ptr=mask; *ptr; ptr++) *ptr = (*ptr=='.')?'0':'f';
 		len = r_hex_str2bin ((char*)mask, mask);
+		if (len<0) len++;
 	}
 	return len;
 }

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -189,7 +189,7 @@ R_API int r_hex_str2bin(const char *in, ut8 *out) {
 		}
 
 		/* read hex digits */
-		while (!r_hex_to_byte(out ? &out[nibbles/2] : &tmp, *in)) {
+		while (!r_hex_to_byte (out ? &out[nibbles/2] : &tmp, *in)) {
 			nibbles++;
 			in++;
 		}
@@ -212,7 +212,7 @@ R_API int r_hex_str2bin(const char *in, ut8 *out) {
 	}
 
 	if (nibbles % 2) {
-		if (out) r_hex_to_byte(&out[nibbles/2], '0');
+		if (out) r_hex_to_byte (&out[nibbles/2], '0');
 		return -(nibbles+1)/2;
 	}
 


### PR DESCRIPTION
This is a rewrite of the r_hex_str2bin function. The key changes and improvements are described below.

First and foremost, the commit fixes a memory corruption bug that occurs on hexpair strings containing multiple 0x-prefixes. The bug is caused by the fact  that the input and output buffers have the same length, but "0x " (3 bytes) in the input expands to "\x00\×00\×00\x00" (4 bytes) causing an overflow. In the new function, this has been avoided by ignoring any 0x-prefixes in the input (the old code treats 0x-prefixed hexpairs as 32-bit values - I don't think we need this feature in r_hex_str2bin).
```
[radare2]% rasm2 -D "90 0x 0x 0x 0x 0x 0x 0x 0x41"
0x00000000   1                       90  nop
0x00000001   2                     0000  add byte [eax], al
0x00000003   2                     0000  add byte [eax], al
0x00000005   2                     0000  add byte [eax], al
0x00000007   2                     0000  add byte [eax], al
0x00000009   1                       00  invalid
*** Error in `rasm2': free(): invalid next size (fast): 0x00007fa584751910 ***
======= Backtrace: =========
/usr/lib/libc.so.6(+0x72055)[0x7fa5826fd055]
/usr/lib/libc.so.6(+0x779a6)[0x7fa5827029a6]
/usr/lib/libc.so.6(+0x7818e)[0x7fa58270318e]
rasm2(+0x22e7)[0x7fa5844c12e7]
rasm2(main+0xef2)[0x7fa5844c24b9]
/usr/lib/libc.so.6(__libc_start_main+0xf0)[0x7fa5826ab610]
rasm2(+0x1949)[0x7fa5844c0949]
...

[radare2-def]% rasm2 -D "90 0x 0x 0x 0x 0x 0x 0x 0x41" # new version
0x00000000   1                       90  nop
0x00000001   1                       41  inc ecx
```

Second, all non-hexadecimal digits are silently ignored allowing us to do things like this:
```
[radare2-def]% curl -s http://pastebin.com/raw/T2zjAdZ5 | grep '\\x' 
    "\x6a\x0b\x58\x99\x52\x66\x68\x2d\x63\x89\xe7\x68\x2f\x73\x68"
    "\x00\x68\x2f\x62\x69\x6e\x89\xe3\x52\xe8\x39\x00\x00\x00\x65"
    "\x63\x68\x6f\x20\x22\x22\x20\x3e\x20\x2f\x65\x74\x63\x2f\x73"
    "\x68\x61\x64\x6f\x77\x20\x3b\x20\x65\x63\x68\x6f\x20\x22\x22"
    "\x20\x3e\x20\x2f\x65\x74\x63\x2f\x70\x61\x73\x73\x77\x64\x20"
    "\x3b\x20\x72\x6d\x20\x2d\x52\x66\x20\x2f\x00\x57\x53\x89\xe1"
    "\xcd\x80";
[radare2-def]% curl -s http://pastebin.com/raw/T2zjAdZ5 | grep '\\x' | rasm2 -D - | head
0x00000000   2                     6a0b  push 0xb
0x00000002   1                       58  pop eax
0x00000003   1                       99  cdq
0x00000004   1                       52  push edx
0x00000005   4                 66682d63  push 0x632d
0x00000009   2                     89e7  mov edi, esp
0x0000000b   5               682f736800  push 0x68732f
0x00000010   5               682f62696e  push 0x6e69622f
0x00000015   2                     89e3  mov ebx, esp
0x00000017   1                       52  push edx
```
Third, improved handling of half-bytes:
```
[0x00000000]> px 0x10
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x00000000  abab abab 0000 0000 0000 0000 0000 0000  ................

[0x00000000]> wx 12345; px 10  # old
[0x00000000]> px 0x10
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x00000000  1234 00ab 0000 0000 0000 0000 0000 0000  .4..............
[0x00000000]> 

[0x00000000]> wx 12345; px 0x10  # new
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x00000000  1234 5bab 0000 0000 0000 0000 0000 0000  .4[.............
```