### PR TITLE
Multiple fixes

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1373,6 +1373,14 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 		} else
 		if (!strcmp (op, "nop")) {
 			data[l++] = 0x90;
+		} else
+		if (!strcmp (op, "clac")) {
+			memcpy (data+l, "\x0f\x01\xca", 3);
+			l += 3;
+		} else
+		if (!strcmp (op, "stac")) {
+			memcpy (data+l, "\x0f\x01\xcb", 3);
+			l += 3;
 		}
 		return l;
 	}

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -970,8 +970,15 @@ R_API void r_io_sort_maps(RIO *io) {
 
 // THIS IS pread.. a weird one
 static ut8 *r_io_desc_read(RIO *io, RIODesc *desc, ut64 *out_sz) {
-	ut8 *buf = NULL;
+	ut8 *env, *buf = NULL;
 	ut64 off = 0;
+	ut64 r_io_max_alloc = R_IO_MAX_ALLOC;
+
+	if (env = r_sys_getenv("R_IO_MAX_ALLOC")) {
+		r_io_max_alloc = atol(env);
+		free(env);
+	}
+
 
 	if (!io || !desc || !out_sz) {
 		return NULL;
@@ -985,7 +992,10 @@ static ut8 *r_io_desc_read(RIO *io, RIODesc *desc, ut64 *out_sz) {
 	off = io->off;
 
 	if (*out_sz == UT64_MAX) return buf;
-	if (*out_sz > R_IO_MAX_ALLOC) {
+	if (*out_sz > r_io_max_alloc) {
+		eprintf("WARNING: File is greater than %lu bytes.\nTry setting " \
+					"R_IO_MAX_ALLOC environment variable with the desired max " \
+					"allocation bytes.\n", r_io_max_alloc);
 		return buf;
 	}
 


### PR DESCRIPTION
- Add CLAC/STAC (SMAP) instructions support for the assembler
- Temporary workaround for the buffer size limit when analyzing large files