### PR TITLE
Add type and flags enums to elf_[ps]hdr structs

### DIFF
--- a/libr/bin/d/elf32
+++ b/libr/bin/d/elf32
@@ -1,4 +1,4 @@
 pfo elf_enums
 pf.elf_header [16]z[2]E[2]Exxxxxwwwwww ident (elf_type)type (elf_machine)machine version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
-pf.elf_phdr xxxxxxxx type offset vaddr paddr filesz memsz flags align
-pf.elf_shdr xxxxxxxxxx name type flags addr offset size link info addralign entsize
+pf.elf_phdr [4]Exxxxx[4]Ex (elf_p_type)type offset vaddr paddr filesz memsz (elf_p_flags)flags align
+pf.elf_shdr x[4]E[4]Exxxxxxx name (elf_s_type)type (elf_s_flags_32)flags addr offset size link info addralign entsize

--- a/libr/bin/d/elf64
+++ b/libr/bin/d/elf64
@@ -1,4 +1,4 @@
 pfo elf_enums
 pf.elf_header [16]z[2]E[2]Exqqqxwwwwww ident (elf_type)type (elf_machine)machine version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
-pf.elf_phdr xxqqqqqq type flags offset vaddr paddr filesz memsz align
-pf.elf_shdr xxqqqqxxqq name type flags addr offset size link info addralign entsize
+pf.elf_phdr [4]E[4]Eqqqqqq (elf_p_type)type (elf_p_flags)flags offset vaddr paddr filesz memsz align
+pf.elf_shdr x[4]E[8]Eqqqxxqq name (elf_s_type)type (elf_s_flags_64)flags addr offset size link info addralign entsize

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -125,14 +125,14 @@ static int init_phdr(struct Elf_(r_bin_elf_obj_t) *bin) {
 	sdb_num_set (bin->kv, "elf_shdr_size.offset", sizeof (Elf_(Shdr)), 0);
 #if R_BIN_ELF64
 	sdb_num_set (bin->kv, "elf_phdr.offset", bin->ehdr.e_phoff, 0);
-	sdb_set (bin->kv, "elf_phdr.format", "xxqqqqqq type flags offset vaddr paddr filesz memsz align", 0);
+	sdb_set (bin->kv, "elf_phdr.format", "[4]E[4]Eqqqqqq (elf_p_type)type (elf_p_flags)flags offset vaddr paddr filesz memsz align", 0);
 	sdb_num_set (bin->kv, "elf_shdr.offset", bin->ehdr.e_shoff, 0);
-	sdb_set (bin->kv, "elf_shdr.format", "xxqqqqxxqq name type flags addr offset size link info addralign entsize", 0);
+	sdb_set (bin->kv, "elf_shdr.format", "x[4]E[8]Eqqqxxqq name (elf_s_type)type (elf_s_flags_64)flags addr offset size link info addralign entsize", 0);
 #else
 	sdb_num_set (bin->kv, "elf_phdr.offset", bin->ehdr.e_phoff, 0);
-	sdb_set (bin->kv, "elf_phdr.format", "xxxxxxxx type offset vaddr paddr filesz memsz flags align", 0);
+	sdb_set (bin->kv, "elf_phdr.format", "[4]Exxxxx[4]Ex (elf_p_type)type offset vaddr paddr filesz memsz (elf_p_flags)flags align", 0);
 	sdb_num_set (bin->kv, "elf_shdr.offset", bin->ehdr.e_shoff, 0);
-	sdb_set (bin->kv, "elf_shdr.format", "xxxxxxxxxx name type flags addr offset size link info addralign entsize", 0);
+	sdb_set (bin->kv, "elf_shdr.format", "x[4]E[4]Exxxxxxx name (elf_s_type)type (elf_s_flags_32)flags addr offset size link info addralign entsize", 0);
 #endif
 	// Usage example:
 	// > pf `k bin/cur/info/elf.phdr.format` @ `k bin/cur/info/elf.phdr.offset`


### PR DESCRIPTION
Nothing special here, just added the types of elf_phdr.type, elf_phdr.flags, elf_shdr.type and elf_shdr.flags fields into the elf32/elf64 definition files.

Demo (elf64):
```
% r2 /lib64/ld-linux-x86-64.so.2
 -- The door controls time and space.
[0x00000d80]> pfo elf64.old
[0x00000d80]> pf.elf_phdr @ 0x40+0x38*1; pf.elf_shdr @ 0x280d8+0x40*0x15
  type : 0x00000078 = 0x00000001
 flags : 0x0000007c = 0x00000006
offset : 0x00000080 = (qword) 0x0000000000021ba0
 vaddr : 0x00000088 = (qword) 0x0000000000221ba0
 paddr : 0x00000090 = (qword) 0x0000000000221ba0
filesz : 0x00000098 = (qword) 0x00000000000013e4
 memsz : 0x000000a0 = (qword) 0x0000000000001590
 align : 0x000000a8 = (qword) 0x0000000000200000
     name : 0x00028618 = 0x00000011
     type : 0x0002861c = 0x00000003
    flags : 0x00028620 = (qword) 0x0000000000000000
     addr : 0x00028628 = (qword) 0x0000000000000000
   offset : 0x00028630 = (qword) 0x0000000000022f95
     size : 0x00028638 = (qword) 0x00000000000000cd
     link : 0x00028640 = 0x00000000
     info : 0x00028644 = 0x00000000
addralign : 0x00028648 = (qword) 0x0000000000000001
  entsize : 0x00028650 = (qword) 0x0000000000000000
[0x00000d80]> pfo elf64.new
[0x00000d80]> pf.elf_phdr @ 0x40+0x38*1; pf.elf_shdr @ 0x280d8+0x40*0x15
              type : 0x00000078 =  type (enum) = 0x1 ; PT_LOAD
             flags : 0x0000007c =  flags (enum) = 0x6 ; PF_Read_Write
            offset : 0x00000080 = (qword) 0x0000000000021ba0
             vaddr : 0x00000088 = (qword) 0x0000000000221ba0
             paddr : 0x00000090 = (qword) 0x0000000000221ba0
            filesz : 0x00000098 = (qword) 0x00000000000013e4
             memsz : 0x000000a0 = (qword) 0x0000000000001590
             align : 0x000000a8 = (qword) 0x0000000000200000
                 name : 0x00028618 = 0x00000011
                 type : 0x0002861c =  type (enum) = 0x3 ; SHT_STRTAB
                flags : 0x00028620 =  flags (enum) = 0x0 ; SF64_None
                 addr : 0x00028628 = (qword) 0x0000000000000000
               offset : 0x00028630 = (qword) 0x0000000000022f95
                 size : 0x00028638 = (qword) 0x00000000000000cd
                 link : 0x00028640 = 0x00000000
                 info : 0x00028644 = 0x00000000
            addralign : 0x00028648 = (qword) 0x0000000000000001
              entsize : 0x00028650 = (qword) 0x0000000000000000
[0x00000d80]> 
```

Demo (elf32):
```
% r2 /lib/ld-linux.so.2 
 -- vm is like a small cow in ascii
[0x00000b50]> pfo elf32.old
[0x00000b50]> pf.elf_phdr @ 0x34+0x20*1; pf.elf_shdr @ 0x2716c+0x28*0x15
  type : 0x00000054 = 0x00000001
offset : 0x00000058 = 0x00021c80
 vaddr : 0x0000005c = 0x00022c80
 paddr : 0x00000060 = 0x00022c80
filesz : 0x00000064 = 0x00000bb8
 memsz : 0x00000068 = 0x00000c78
 flags : 0x0000006c = 0x00000006
 align : 0x00000070 = 0x00001000
     name : 0x000274b4 = 0x00000011
     type : 0x000274b8 = 0x00000003
    flags : 0x000274bc = 0x00000000
     addr : 0x000274c0 = 0x00000000
   offset : 0x000274c4 = 0x00022849
     size : 0x000274c8 = 0x000000cb
     link : 0x000274cc = 0x00000000
     info : 0x000274d0 = 0x00000000
addralign : 0x000274d4 = 0x00000001
  entsize : 0x000274d8 = 0x00000000
[0x00000b50]> pfo elf32.new
[0x00000b50]> pf.elf_phdr @ 0x34+0x20*1; pf.elf_shdr @ 0x2716c+0x28*0x15
              type : 0x00000054 =  type (enum) = 0x1 ; PT_LOAD
            offset : 0x00000058 = 0x00021c80
             vaddr : 0x0000005c = 0x00022c80
             paddr : 0x00000060 = 0x00022c80
            filesz : 0x00000064 = 0x00000bb8
             memsz : 0x00000068 = 0x00000c78
             flags : 0x0000006c =  flags (enum) = 0x6 ; PF_Read_Write
             align : 0x00000070 = 0x00001000
                 name : 0x000274b4 = 0x00000011
                 type : 0x000274b8 =  type (enum) = 0x3 ; SHT_STRTAB
                flags : 0x000274bc =  flags (enum) = 0x0 ; SF32_None
                 addr : 0x000274c0 = 0x00000000
               offset : 0x000274c4 = 0x00022849
                 size : 0x000274c8 = 0x000000cb
                 link : 0x000274cc = 0x00000000
                 info : 0x000274d0 = 0x00000000
            addralign : 0x000274d4 = 0x00000001
              entsize : 0x000274d8 = 0x00000000
[0x00000b50]> 
```

Note that the indentation weirdness has something to do with printing enum types (the issue is not related to this patch).