### PR TITLE
Remote GDB performance fixes

### DIFF
--- a/shlr/gdb/src/packet.c
+++ b/shlr/gdb/src/packet.c
@@ -147,6 +147,9 @@ int read_packet(libgdbr_t* g) {
 #else
 		po_size += r_socket_read (g->sock,
 			((ut8*)g->read_buff + po_size), szdelta);
+
+		if (po_size > 3 && g->read_buff[po_size - 3] == '#')
+			break;
 #endif
 	}
 	g->read_len = po_size;


### PR DESCRIPTION
This set aims to improve performance when debugging over the gdb remote protocol.

Before:
```
$ time r2 -d a.out -D gdb gdb://localhost:1234 -qc 'pd'
...
real	**0m10.132s**
user	0m0.017s
sys	0m0.014s
```

After:
```
$ time r2 -d a.out -D gdb gdb://localhost:1234 -qc 'pd'
...
real	**0m0.030s**
user	0m0.018s
sys	0m0.011s
```