### PR TITLE
Fix and extend xtensa support

### DIFF
--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -24,7 +24,7 @@ static ut64 decodeRelative (ut64 addr, const ut8 *buf) {
 	return res;
 }
 
-// XXX Not all instructions implemented yet.
+//Not all instructions implemented yet.
 static int xtensa_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (op == NULL)
 		return 1;
@@ -35,7 +35,7 @@ static int xtensa_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	bool is_call = (buf[0] & 0xf) == 5;
 	bool is_jmp = (buf[0] & 0xf) == 6;
 	bool is_jmp2 = (buf[0]>=0x80 && (buf[0] & 0xf) == 0xc);
-	//bool is_bl = (buf[0] & 0xf) == 7;
+        bool is_bbxi = (buf[0] & 0xf) == 7;
 	if (is_call) {
 		op->type = R_ANAL_OP_TYPE_CALL;
 		op->jump = decodeRelative (addr, buf);
@@ -47,6 +47,10 @@ static int xtensa_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		offset = offset | (buf[1] & 0xf0) >> 4;
 		op->jump = addr + offset + 4;
 		op->fail = addr + op->size;
+	} else if (is_bbxi) {
+                op->type = R_ANAL_OP_TYPE_CJMP;
+                op->jump = addr + buf[2] + 4;
+                op->fail = addr + op->size;
 	} else if (is_jmp) {
 		if (((buf[0] >> 4)&0x3) == 0) {
 			op->type = R_ANAL_OP_TYPE_JMP;


### PR DESCRIPTION
I fixed the jump addresses on the cjmp commands and added the bnei/bbci/etc. instructions (with correct jump addresses). Tested on esp8266 binaries.