### PR TITLE
Skip first packet when connecting to gdbserver

### DIFF
--- a/shlr/gdb/src/core.c
+++ b/shlr/gdb/src/core.c
@@ -408,6 +408,7 @@ int gdbr_connect(libgdbr_t* g, const char* host, int port) {
 	if (!ret) return -1;
 	ret = r_socket_connect_tcp (g->sock, host, tmp, 200);
 	if (!ret) return -1;
+	read_packet (g);
 	g->connected = 1;
 	// TODO add config possibility here
 	ret = send_command (g, message);


### PR DESCRIPTION
QEMU seems to send a T02thread message upon connection. This can get the
client side out of sync wrt requests & responses.

To work around this, read a packet after a connection is made. This
could time out, but that should be harmless.