### PR TITLE
Rewrite remote gdb packet handling

### DIFF
--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -38,7 +38,6 @@ typedef struct libgdbr_t {
 	ssize_t send_len; // definses the maximal len for the given buffer
 	ssize_t send_max; // definses the maximal len for the given buffer
 	char* read_buff;
-	ssize_t read_len;
 	ssize_t read_max;
 
 	// is already handled (i.e. already send or ...)

--- a/shlr/gdb/include/packet.h
+++ b/shlr/gdb/include/packet.h
@@ -15,17 +15,6 @@
 #endif
 #endif
 
-typedef struct parsing_object_t {
-	char* buffer;
-	ssize_t length;
-	int start;
-	int end;
-	int position;
-	uint8_t checksum;
-	int acks;
-} parsing_object_t;
-
-int parse_packet(libgdbr_t* instance, int data_offset);
 /*!
  * \brief sends a packet sends a packet to the established connection
  * \param instance the "instance" of the current libgdbr session
@@ -39,10 +28,5 @@ int send_packet(libgdbr_t* instance);
  * \returns a failure code (currently -1) or 0 if call successfully
  */
 int read_packet(libgdbr_t* instance);
-void handle_data(parsing_object_t* current);
-void handle_chk(parsing_object_t* current);
-void handle_packet(parsing_object_t* current);
-void handle_escape(parsing_object_t* current);
-char get_next_token(parsing_object_t* current);
 
 #endif

--- a/shlr/gdb/src/core.c
+++ b/shlr/gdb/src/core.c
@@ -346,7 +346,6 @@ int gdbr_init(libgdbr_t* g) {
 		R_FREE (g->send_buff);
 		return -1;
 	}
-	g->read_len = 0;
 	g->sock = r_socket_new (0);
 	g->last_code = MSG_OK;
 	g->connected = 0;
@@ -395,7 +394,6 @@ int gdbr_cleanup(libgdbr_t* g) {
 	free (g->send_buff);
 	g->send_len = 0;
 	free (g->read_buff);
-	g->read_len = 0;
 	return 0;
 }
 
@@ -431,8 +429,7 @@ int gdbr_read_registers(libgdbr_t* g) {
 	if (ret < 0)
 		return ret;
 
-	if (read_packet (g) > 0) {
-		parse_packet (g, 0);
+	if (read_packet (g) >= 0) {
 		return handle_g (g);
 	}
 	return -1;
@@ -450,8 +447,7 @@ int gdbr_read_memory(libgdbr_t* g, ut64 address, ut64 len) {
 	if (ret < 0)
 		return ret;
 
-	if (read_packet (g) > 0) { 
-		parse_packet (g, 0);
+	if (read_packet (g) >= 0) {
 		return handle_m (g);
 	}
 	return -1;
@@ -476,8 +472,7 @@ int gdbr_write_memory(libgdbr_t* g, ut64 address, const uint8_t* data, ut64 len)
 	if (ret < 0)
 		return ret;
 
-	if (read_packet (g) > 0) {
-		parse_packet (g, 0);
+	if (read_packet (g) >= 0) {
 		return handle_M (g);
 	}
 	return -1;
@@ -503,8 +498,7 @@ int gdbr_send_command(libgdbr_t* g, char* command) {
 	free (cmd);
 	if (ret < 0) return ret;
 
-	if (read_packet (g) > 0) {
-		parse_packet (g, 1);
+	if (read_packet (g) >= 0) {
 		return handle_cmd (g);
 	}
 	return -1;
@@ -538,8 +532,7 @@ int gdbr_write_register(libgdbr_t* g, int index, char* value, int len) {
 	pack_hex (value, len, (command + ret));
 	if (send_command (g, command) < 0)
 		return -1;
-	if (read_packet (g) > 0) {
-		parse_packet (g, 0);
+	if (read_packet (g) >= 0) {
 		handle_P (g);
 	}
 	return 0;
@@ -666,8 +659,7 @@ int send_vcont(libgdbr_t* g, const char* command, int thread_id) {
 	if (ret < 0) return ret;
 	ret = send_command (g, tmp);
 	if (ret < 0) return ret;
-	if (read_packet (g) > 0) { 
-		parse_packet (g, 0);
+	if (read_packet (g) >= 0) {
 		return handle_cont (g);
 	}
 	return 0;
@@ -699,8 +691,7 @@ int set_bp(libgdbr_t* g, ut64 address, const char* conditions, enum Breakpoint t
 	ret = send_command (g, tmp);
 	if (ret < 0) return ret;
 
-	if (read_packet (g) > 0) {
-		parse_packet (g, 0);
+	if (read_packet (g) >= 0) {
 		return handle_setbp (g);
 	}
 	return 0;
@@ -746,8 +737,7 @@ int remove_bp(libgdbr_t* g, ut64 address, enum Breakpoint type) {
 	ret = send_command (g, tmp);
 	if (ret < 0) return ret;
 
-	if (read_packet (g) > 0) {
-		parse_packet (g, 0);
+	if (read_packet (g) >= 0) {
 		return handle_removebp (g);
 	}
 	return 0;

--- a/shlr/gdb/src/packet.c
+++ b/shlr/gdb/src/packet.c
@@ -1,157 +1,185 @@
 /* libgdbr - LGPL - Copyright 2014-2016 - defragger */
 
 #include "packet.h"
+#include "utils.h"
 
-#define DELTA_CHECK 0
+#define READ_TIMEOUT (250 * 1000)
 
-char get_next_token(parsing_object_t* po) {
-	return po->buffer[po->position++];
-}
+enum {
+	HEADER	= 1 << 0,
+	CHKSUM	= 1 << 1,
+	DUP	= 1 << 2,
+	ESC	= 1 << 3,
+};
 
-void handle_escape(parsing_object_t* po) {
-	char token;
-	if (po->position >= po->length) return;
-	token = get_next_token (po);
-	if (token == '}') handle_data (po);
-	else handle_escape (po);
-}
+struct parse_ctx {
+	unsigned long flags;
+	unsigned char last;
+	unsigned char sum;
+	int chksum_nibble;
+};
 
-void handle_chk(parsing_object_t* po) {
-	char checksum[3];
-	if (po->position >= po->length) return;
-	checksum[0] = get_next_token (po);
-	checksum[1] = get_next_token (po);
-	checksum[2] = '\0';
-	po->checksum = (uint8_t) strtol (checksum, NULL, 16);
-}
+static int append(libgdbr_t *g, char ch) {
+	char *ptr;
 
-void handle_data(parsing_object_t* po) {
-	char token;
-	if (po->position >= po->length) return;
-	token = get_next_token (po);
-	if (token == '#') {
-		po->end = po->position - 1; // subtract 2 cause of # itself and the incremented position after getNextToken
-		handle_chk (po);
-	} else if (token == '{') {
-		handle_escape (po);
-	} else handle_data (po);
-}
-
-void handle_packet(parsing_object_t* po) {
-	char token;
-	if (po->position >= po->length) return;
-	token = get_next_token (po);
-	if (token == '$') {
-		po->start = po->position;
-		handle_data (po);
-	}
-	else if	(token == '+') {
-		po->acks++;
-		handle_packet (po);
-	}
-}
-
-/**
- * helper function that should unpack
- * run-length encoded streams of data
- */
-int unpack_data(char* dst, char* src, uint64_t len) {
-	int i = 0;
-	char last = 0;
-	int ret_len = 0;
-	char* p_dst = dst;
-	while (i < len) {
-		if (src[i] == '*') {
-			if (++i >= len) {
-				eprintf ("Runlength decoding error\n");
-			}
-			char size = src[i++];
-			uint8_t runlength = size - 29;
-			ret_len += runlength - 2;
-			while (i < len && runlength-- > 0) {
-				*(p_dst++) = last;
-			}
-			continue;
+	if (g->data_len == g->data_max) {
+		ptr = realloc (g->data, g->data_max * 2);
+		if (!ptr) {
+			eprintf ("%s: Failed to reallocate buffer\n",
+				 __func__);
+			return -1;
 		}
-		last = src[i++];
-		*(p_dst++) = last;
-	}
-	return ret_len;
-}
 
-int parse_packet(libgdbr_t* g, int data_offset) {
-	int runlength;
-	uint64_t po_size, target_pos = 0;
-	parsing_object_t new;
-	memset (&new, 0, sizeof (parsing_object_t));
-	new.length = g->read_len;
-	new.buffer = g->read_buff;
-	while (new.position < new.length) {
-		handle_packet (&new);
-		new.start += data_offset;
-		po_size = new.end - new.start;
-#if DELTA_CHECK
-		if (po_size + target_pos > 4096) {
-			po_size = 4096 - target_pos;
-			if (po_size > 4096) break;
-		}
-#endif
-		runlength = unpack_data (g->data + target_pos,
-			new.buffer + new.start, po_size);
-		target_pos += po_size + runlength;
+		g->data = ptr;
+		g->data_max *= 2;
 	}
-	g->data_len = target_pos; // setting the resulting length
-	g->read_len = 0; // reset the read_buf len
+
+	g->data[g->data_len++] = ch;
 	return 0;
 }
 
-int send_packet(libgdbr_t* g) {
-	if (!g) {
-		eprintf ("Initialize libgdbr_t first\n");
-		return -1;
-	}
-	return r_socket_write (g->sock, g->send_buff, g->send_len);
-}
+static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
+	int i = 0;
+	int j = 0;
 
+	for (i = 0; i < len; i++) {
+		char cur = g->read_buff[i];
 
-// XXX hardcoded 4096 buff size
-int read_packet(libgdbr_t* g) {
-	int rc, po_size = 0;
-	if (!g) {
-		eprintf ("Initialize libgdbr_t first\n");
-		return -1;
-	}
-	while (r_socket_ready (g->sock, 0, 250 * 1000) > 0) {
-		int szdelta = (int)((st64)g->read_max - (st64)po_size);
-#if DELTA_CHECK
-		if (szdelta < 1) {
-			break;
-		}
-		if (po_size + szdelta > 4096) {
-			if (po_size < 4096) {
-				szdelta = g->read_max - po_size;
-			} else {
-				szdelta = -1;
+		if (ctx->flags & CHKSUM) {
+			ctx->sum -= hex2int (cur) << (ctx->chksum_nibble * 4);
+
+			if (!--ctx->chksum_nibble) {
+				continue;
 			}
-			if (szdelta < 1) {
+
+			if (i != len - 1) {
+				eprintf ("%s: Packet too long\n", __func__);
+				return -1;
+			}
+
+			if (ctx->sum != '#') {
+				eprintf ("%s: Invalid checksum\n", __func__);
+				return -1;
+			}
+
+			return 0;
+		}
+
+		ctx->sum += cur;
+
+		if (ctx->flags & ESC) {
+			if (append (g, cur ^ 0x20) < 0) {
+				return -1;
+			}
+
+			ctx->flags &= ~ESC;
+			continue;
+		}
+
+		if (ctx->flags & DUP) {
+			if (cur < 32 || cur > 126) {
+				eprintf ("%s: Invalid repeat count\n",
+					 __func__);
+				return -1;
+			}
+
+			for (j = cur - 29; j > 0; j--) {
+				if (append (g, ctx->last) < 0) {
+					return -1;
+				}
+			}
+
+			ctx->last = 0;
+			ctx->flags &= ~DUP;
+			continue;
+		}
+
+		switch (cur) {
+		case '$':
+			if (ctx->flags & HEADER) {
+				eprintf ("%s: More than one $\n", __func__);
+				return -1;
+			}
+
+			ctx->flags |= HEADER;
+			/* Disregard any characters preceding $ */
+			ctx->sum = 0;
+			break;
+
+		case '#':
+			ctx->flags |= CHKSUM;
+			ctx->chksum_nibble = 1;
+			break;
+
+		case '}':
+			ctx->flags |= ESC;
+			break;
+
+		case '*':
+			if (!ctx->last) {
+				eprintf ("%s: Invalid repeat\n", __func__);
+				return -1;
+			}
+
+			ctx->flags |= DUP;
+			break;
+
+		case '+':
+		case '-':
+			if (!(ctx->flags & HEADER)) {
+				/* TODO: Handle acks/nacks */
 				break;
 			}
+			/* Fall-through */
+		default:
+			if (append (g, cur) < 0) {
+				return -1;
+			}
+			ctx->last = cur;
 		}
-		rc = r_socket_read (g->sock,
-			((ut8*)g->read_buff + po_size), szdelta);
-		//if (rc < 1) break;
-		po_size += rc;
-		if (po_size > g_read_max) {
-			break;
-		}
-#else
-		po_size += r_socket_read (g->sock,
-			((ut8*)g->read_buff + po_size), szdelta);
-
-		if (po_size > 3 && g->read_buff[po_size - 3] == '#')
-			break;
-#endif
 	}
-	g->read_len = po_size;
-	return po_size;
+
+	return 1;
+}
+
+int read_packet(libgdbr_t *g) {
+	struct parse_ctx ctx = {0};
+	int ret;
+
+	if (!g) {
+		eprintf ("Initialize libgdbr_t first\n");
+		return -1;
+	}
+
+	g->data_len = 0;
+	while (r_socket_ready (g->sock, 0, READ_TIMEOUT) > 0) {
+		int sz;
+
+		sz = r_socket_read (g->sock, (void *)g->read_buff,
+				    g->read_max);
+		if (sz <= 0) {
+			eprintf ("%s: read failed\n", __func__);
+			return -1;
+		}
+
+		ret = unpack (g, &ctx, sz);
+		if (ret < 0) {
+			eprintf ("%s: unpack failed\n", __func__);
+			return -1;
+		}
+		if (!ret) {
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+int send_packet(libgdbr_t *g) {
+	if (!g) {
+		eprintf ("Initialize libgdbr_t first\n");
+		return -1;
+	}
+
+	return r_socket_write (g->sock, g->send_buff, g->send_len);
 }


### PR DESCRIPTION
This patch addresses several issues with the current implementation,
including:
- Excessive recursions
- Incorrect handling of the escape character
- Buffer size limitations