### PR TITLE
demangle afl and disassembly

### DIFF
--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -346,9 +346,11 @@ R_API int r_bin_lang_type(RBinFile *binfile, const char *def, const char *sym) {
 R_API char *r_bin_demangle (RBinFile *binfile, const char *def, const char *str) {
 	int type = -1;
 	RBin *bin = binfile->rbin;
-	if (!strncmp (str, "imp.", 4)) {
+
+	if (!strncmp (str, "sym.", 4))
 		str += 4;
-	}
+	if (!strncmp (str, "imp.", 4))
+		str += 4;
 	if (!strncmp (str, "__", 2)) {
 		type = R_BIN_NM_CXX;
 		str++;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -628,20 +628,23 @@ static void handle_show_xrefs (RCore *core, RDisasmState *ds) {
 	RList *xrefs;
 	RAnalRef *refi;
 	RListIter *iter;
+	bool demangle = r_config_get_i (core->config, "bin.demangle");
+	const char *lang = demangle ? r_config_get (core->config, "bin.lang") : NULL;
+	char *name, *tmp;
 	int count = 0;
-	if (!ds->show_xrefs) return;
-	if (!ds->show_comments) return;
-
+	if (!ds->show_xrefs)
+		return;
+	if (!ds->show_comments)
+		return;
 	/* show xrefs */
 	xrefs = r_anal_xref_get (core->anal, ds->at);
 	if (!xrefs) return;
-
 	if (r_list_length (xrefs) > ds->maxrefs) {
 		RAnalFunction *f = r_anal_get_fcn_in (core->anal,
-			ds->at, R_ANAL_FCN_TYPE_NULL);
+						ds->at, R_ANAL_FCN_TYPE_NULL);
 		beginline (core, ds, f);
 		r_cons_printf ("%s; XREFS: ", ds->show_color?
-			ds->pal_comment: "");
+				ds->pal_comment: "");
 		r_list_foreach (xrefs, iter, refi) {
 			r_cons_printf ("%s 0x%08"PFMT64x"  ",
 				r_anal_xrefs_type_tostring (refi->type), refi->addr);
@@ -664,14 +667,23 @@ static void handle_show_xrefs (RCore *core, RDisasmState *ds) {
 		if (refi->at == ds->at) {
 			RAnalFunction *fun = r_anal_get_fcn_in (
 				core->anal, refi->at, -1);
+			name = strdup (fun ? fun->name : "unk");
+			if (demangle) {
+				tmp = r_bin_demangle (core->bin->cur, lang, name);
+				if (tmp) {
+					free (name);
+					name = tmp; 
+				}
+			}
 
 			beginline (core, ds, fun);
 			r_cons_printf ("%s; %s XREF from 0x%08"PFMT64x" (%s)%s\n",
 				COLOR (ds, pal_comment),
 				r_anal_xrefs_type_tostring (refi->type),
 				refi->addr,
-				fun ? fun->name : "unk",
+				name,
 				COLOR_RESET (ds));
+			R_FREE (name);
 		}
 	}
 	r_list_free (xrefs);
@@ -764,20 +776,30 @@ static int var_comparator (const RAnalVar *a, const RAnalVar *b){
 
 static void handle_show_functions (RCore *core, RDisasmState *ds) {
 	RAnalFunction *f;
+	bool demangle = r_config_get_i (core->config, "bin.demangle");
+	const char *lang = demangle ? r_config_get (core->config, "bin.lang") : NULL;
+	char *fcn_name;
 	char *sign;
 	if (!core || !ds || !ds->show_functions)
 		return;
 	f = r_anal_get_fcn_in (core->anal, ds->at, R_ANAL_FCN_TYPE_NULL);
-	if (!f) return;
-	if (f->addr != ds->at) {
+	if (!f)
 		return;
+	if (f->addr != ds->at)
+		return;
+	if (demangle) {
+		fcn_name = r_bin_demangle (core->bin->cur, lang, f->name);
+		if (!fcn_name)
+			fcn_name = strdup (f->name);
+	} else {
+		fcn_name = f->name;
 	}
 	sign = r_anal_fcn_to_string (core->anal, f);
 	if (f->type == R_ANAL_FCN_TYPE_LOC) {
 		r_cons_printf ("%s%s ", COLOR (ds, color_fline),
 			core->cons->vline[LINE_CROSS]); // |-
 		r_cons_printf ("%s%s%s %d\n", COLOR (ds, color_floc),
-			f->name, COLOR_RESET (ds), f->size);
+			fcn_name, COLOR_RESET (ds), f->size);
 	} else {
 		const char *space = ds->show_fcnlines ? " " : "";
 		const char *fcntype;
@@ -804,12 +826,14 @@ static void handle_show_functions (RCore *core, RDisasmState *ds) {
 		r_cons_printf ("%s%s%s%s%s(%s) %s%s %d\n",
 			COLOR (ds, color_fline), ds->pre,
 			space, COLOR_RESET (ds), COLOR (ds, color_fname),
-			fcntype, f->name, COLOR_RESET (ds), f->size);
+			fcntype, fcn_name, COLOR_RESET (ds), f->size);
 	}
-	if (sign) r_cons_printf ("// %s\n", sign);
+	if (sign)
+		r_cons_printf ("// %s\n", sign);
 	R_FREE (sign);
 	handle_set_pre (ds, core->cons->vline[LINE_VERT]);
-	if (ds->show_fcnlines) ds->pre = r_str_concat (ds->pre, " ");
+	if (ds->show_fcnlines)
+		ds->pre = r_str_concat (ds->pre, " ");
 	ds->stackptr = 0;
 	if (ds->vars) {
 		char spaces[32];
@@ -847,6 +871,8 @@ static void handle_show_functions (RCore *core, RDisasmState *ds) {
 		// it's already empty, but rlist instance is still there
 		r_list_free (args);
 	}
+	if (demangle)
+		free (fcn_name);
 }
 
 static void handle_print_pre (RCore *core, RDisasmState *ds, bool tail) {
@@ -985,24 +1011,33 @@ static void handle_show_flags_option(RCore *core, RDisasmState *ds) {
 		bool printed = false;
 
 		r_list_foreach (flaglist, iter, flag) {
-			if (f && f->addr == flag->offset && !strcmp (flag->name, f->name)) {
+			if (f && f->addr == flag->offset && !strcmp (flag->name, f->name))
 				// do not show flags that have the same name as the function
 				continue;
-			}
 			beginline (core, ds, f);
-			if (ds->show_offset) r_cons_printf (";-- ");
-			if (ds->show_color) r_cons_strcat (ds->color_flag);
+			if (ds->show_offset)
+				r_cons_printf (";-- ");
+			if (ds->show_color)
+				r_cons_strcat (ds->color_flag);
 			beginch = (iter->p && printed) ? ", " : "";
 			if (ds->asm_demangle) {
-				if (ds->show_functions) r_cons_printf ("%s:\n", flag->realname);
-				else r_cons_printf ("%s%s", beginch, flag->realname);
+				const char *lang = r_config_get (core->config, "bin.lang");
+				char *name = r_bin_demangle (core->bin->cur, lang, flag->realname);
+				if (!name)
+					name = strdup (flag->realname);
+				if (ds->show_functions)
+					r_cons_printf ("%s:\n", name);
+				else
+					r_cons_printf ("%s%s", beginch, name);
+				R_FREE (name);
 			} else {
 				if (ds->show_functions) r_cons_printf ("%s:\n", flag->name);
 				else r_cons_printf ("%s%s", beginch, flag->name);
 			}
 			printed = true;
 		}
-		if (printed && !ds->show_functions) r_cons_printf (":\n");
+		if (printed && !ds->show_functions)
+			r_cons_printf (":\n");
 	}
 }
 
@@ -2476,9 +2511,8 @@ toro:
 				inc = 0; //delta;
 				idx = 0;
 				of = f;
-				if (len == l) {
+				if (len == l)
 					break;
-				}
 				continue;
 			} else {
 				ds->lines--;
@@ -2631,7 +2665,8 @@ toro:
 		inc = ds->oplen;
 		if (ds->midflags == R_MIDFLAGS_REALIGN && skip_bytes)
 			inc = skip_bytes;
-		if (inc < 1) inc = 1;
+		if (inc < 1)
+			inc = 1;
 	}
 	if (nbuf == buf) {
 		free (buf);
@@ -2827,7 +2862,7 @@ r_reg_arena_push (core->anal->reg);
 				ds->opstr = (tmpopstr)? tmpopstr: strdup (ds->asmop.buf_asm);
 			}
 		}
-		if (ret<1) {
+		if (ret < 1) {
 			err = 1;
 			ret = 1;
 		}

--- a/libr/flags/flags.c
+++ b/libr/flags/flags.c
@@ -23,7 +23,7 @@ static ut64 num_callback (RNum *user, const char *name, int *ok) {
 	RList *list;
 
 	if (ok) *ok = 0;
-	
+
 	list = r_hashtable64_lookup (f->ht_name, r_str_hash64 (name));
 	if (list) {
 		RFlagItem *item = r_list_get_top (list);
@@ -130,7 +130,7 @@ R_API void r_flag_list(RFlag *f, int rad, const char *pfx) {
 			 }
 			 if (flag->alias) {
 				 r_cons_printf ("fa %s %s\n", flag->name, flag->alias);
-				 if (flag->comment && *flag->comment) 
+				 if (flag->comment && *flag->comment)
 					 r_cons_printf ("\"fC %s %s\"\n",
 						flag->name, flag->comment);
 			 } else {
@@ -189,28 +189,30 @@ R_API RFlagItem *r_flag_get_i2(RFlag *f, ut64 off) {
 	RFlagItem *item = NULL;
 #if USE_SDB
 	char buf[128];
-	if (!f) return NULL;
+	if (!f)
+		return NULL;
 	char * foo = sdb_get (db, sdb_itoa (off, buf, 16), 0);
 	return r_flag_get (f, foo);
 #else
 	RListIter *iter;
 	RList *list = r_hashtable64_lookup (f->ht_off, XOROFF (off));
-	if (!list) return NULL;
+	if (!list)
+		return NULL;
 	r_list_foreach (list, iter, item) {
 		// XXX: hack, because some times the hashtable is poluted by ghost values
 		if (item->offset != off)
 			continue;
+		if (!item->name)
+			continue;
 		/* catch sym. first */
-		if (!strncmp (item->name, "loc.", 4)) {
+		if (!strncmp (item->name, "loc.", 4))
 			continue;
-		}
-		if (!strncmp (item->name, "fcn.", 4)) {
+		if (!strncmp (item->name, "fcn.", 4))
 			continue;
-		}
-		if (!strncmp (item->name, "section.", 4)) {
+		if (!strncmp (item->name, "section.", 4))
 			continue;
-		}
-		if (r_str_nlen(item->name, 5) > 4 && item->name[3] == '.') {
+		if (r_str_nlen(item->name, 5) > 4 &&
+		    item->name[3] == '.') {
 			oitem = item;
 			break;
 		}
@@ -282,7 +284,7 @@ sdb_set (db, sdb_itoa (off, buf, 16), name, 0);
 	if (!name || !*name)
 		return NULL;
 	if (dup) {
-// XXX: doesnt works well 
+// XXX: doesnt works well
 		item = R_NEW0 (RFlagItem);
 		if (!r_flag_item_set_name (item, name, NULL)) {
 			eprintf ("Invalid flag name '%s'.\n", name);


### PR DESCRIPTION
Before

<img width="1384" alt="captura de pantalla 2016-02-07 a las 22 24 37" src="https://cloud.githubusercontent.com/assets/3474042/12875425/509c32f0-cdea-11e5-9177-66e0d71c1397.png">

```
afl
0x00008984  4  1  sym.__ZL27AMFI_entitlements_destroyed
0x00008988  8  3  sym.__ZL25AMFI_entitlements_created
0x00008990  8  1  sym.__ZL13hashCacheLock
0x00008998  8  1  sym.__ZL9hashCache
0x000089a0  4  1  sym.__ZL19numHashCacheEntries
0x000089a4  1  1  sym.__ZL22allowInvalidSignatures
0x000089a5  3  1  sym.__ZL19lvEnforceThirdParty
0x000089a8  8  1  sym.__ZL22numJitHashCacheEntries
0x000089b0  8  1  sym.__ZL12jitHashCache
0x000089b8  8  1  sym.__ZL16jitHashCacheLock
```

After e bin.demangle=true

<img width="1439" alt="captura de pantalla 2016-02-07 a las 22 24 57" src="https://cloud.githubusercontent.com/assets/3474042/12875426/597092b8-cdea-11e5-8d39-1e8aee2c7716.png">

```
afl
0x00008984  4  1  AMFI_entitlements_destroyed
0x00008988  8  3  AMFI_entitlements_created
0x00008990  8  1  hashCacheLock
0x00008998  8  1  hashCache
0x000089a0  4  1  numHashCacheEntries
0x000089a4  1  1  allowInvalidSignatures
0x000089a5  3  1  lvEnforceThirdParty
0x000089a8  8  1  numJitHashCacheEntries
0x000089b0  8  1  jitHashCache
0x000089b8  8  1  jitHashCacheLock
```

In the disassembly you can read ` jmp sym.__ZN34AppleMobileFileIntegrityUserClientC2EPK11OSMetaClass` but this can't be substitute easily since this change is performed in `filter` that is called in `r_parse_filter` and parser doesn't have access to `RCore`. I'm sure @radare has a better solution for this