### PR TITLE
improve cursor movements

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1141,8 +1141,8 @@ static int cmd_print_pxA(RCore *core, int len, const char *data) {
 	int cols = r_config_get_i (core->config, "hex.cols");
 	int show_color = r_config_get_i (core->config, "scr.color");
 	int onechar = r_config_get_i (core->config, "hex.onechar");
-	int show_cursor = core->print->cur_enabled;
 	int bgcolor_in_heap = false;
+	bool show_cursor = core->print->cur_enabled;
 	char buf[2];
 	char *bgcolor, *fgcolor, *text;
 	ut64 i, c, oi;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1555,6 +1555,7 @@ static int cmd_print(void *data, const char *input) {
 	ut64 n, nbsz, obsz, fsz;
 	ut64 tmpseek = UT64_MAX;
 
+	r_print_init_rowoffsets (core->print);
 	off = UT64_MAX;
 	l = len = core->blocksize;
 	if (input[0] && input[1]) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1160,14 +1160,13 @@ static void handle_print_stackptr (RCore *core, RDisasmState *ds) {
 
 static void handle_print_offset (RCore *core, RDisasmState *ds) {
 	if (core->screen_bounds) {
-		int r, R;
-		(void)r_cons_get_size (&R);
-		(void)r_cons_get_cursor (&r);
-		//r_cons_printf ("(%d,%d)/(%d,%d) ", r,c, R, C);
-		if (r+1>=R) {
-			//	r_cons_printf ("LAST (0x%llx)\n", ds->at);
-			if (core->screen_bounds == 1LL)
-				core->screen_bounds = ds->at;
+		int r, rc;
+
+		(void)r_cons_get_size (&r);
+		(void)r_cons_get_cursor (&rc);
+
+		if (rc > r - 1 && core->screen_bounds == 1) {
+			core->screen_bounds = ds->at;
 		}
 	}
 	if (ds->show_offset) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2541,6 +2541,7 @@ toro:
 			if (ds->hint->size) ds->analop.size = ds->hint->size;
 			if (ds->hint->ptr) ds->analop.ptr = ds->hint->ptr;
 		}
+		r_print_set_rowoff (core->print, ds->lines, ds->at - ds->addr);
 		if (ds->midflags) {
 			skip_bytes = handleMidFlags (core, ds, true);
 			if (skip_bytes && ds->midflags == R_MIDFLAGS_SHOW)
@@ -2663,6 +2664,8 @@ toro:
 		r_config_set_i (core->config, "asm.bits", ds->oldbits);
 		ds->oldbits = 0;
 	}
+	r_print_set_rowoff (core->print, ds->lines, ds->at);
+	r_print_set_rowoff (core->print, ds->lines + 1, UT32_MAX);
 	// TODO: this should be called from deinit_ds()
 	r_anal_op_fini (&ds->analop);
 	// TODO: this too (must review)

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -132,6 +132,8 @@ typedef struct r_core_t {
 	char *lastcmd;
 	int cmdrepeat;
 	ut64 inc;
+	// represents the first not-visible offset on the screen
+	// (only when in visual disasm mode)
 	ut64 screen_bounds;
 	int rtr_n;
 	RCoreRtrHost rtr_host[RTR_MAX_HOSTS];

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -82,6 +82,8 @@ typedef struct r_print_t {
 	ut32 *row_offsets;
 	// size of row_offsets
 	int row_offsets_sz;
+	// when true it makes visual mode flush the buffer to screen
+	bool vflush;
 } RPrint;
 
 #ifdef R_API

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -76,6 +76,12 @@ typedef struct r_print_t {
 	ut64* lines_cache;
 	int lines_cache_sz;
 	int lines_abs;
+
+	// offset of the first byte of each printed row.
+	// Last elements is marked with a UT32_MAX.
+	ut32 *row_offsets;
+	// size of row_offsets
+	int row_offsets_sz;
 } RPrint;
 
 #ifdef R_API
@@ -135,6 +141,10 @@ R_API void r_print_2bpp_tiles(RPrint *p, ut8 *buf, ut32 tiles);
 R_API char * r_print_colorize_opcode (char *p, const char *reg, const char *num);
 R_API const char * r_print_color_op_type ( RPrint *p, ut64 anal_type);
 R_API void r_print_set_interrupted(int i);
+R_API void r_print_init_rowoffsets(RPrint *p);
+R_API ut32 r_print_rowoff(RPrint *p, int i);
+R_API void r_print_set_rowoff(RPrint *p, int i, ut32 offset);
+R_API int r_print_row_at_off(RPrint *p, ut32 offset);
 // WIP
 R_API int r_print_unpack7bit(const char *src, char *dest);
 R_API int r_print_pack7bit(const char *src, char *dest);

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -49,10 +49,14 @@ typedef struct r_print_t {
 	int width;
 	int limit;
 	int bits;
-	int cur_enabled;
+	// true if the cursor is enabled, false otherwise
+	bool cur_enabled;
+	// offset of the selected byte from the first displayed one
 	int cur;
-	int cols;
+	// offset of the selected byte from the first displayed one, when a
+	// range of bytes is selected.
 	int ocur;
+	int cols;
 	int flags;
 	int addrmod;
 	int col;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -194,6 +194,7 @@ R_API RPrint *r_print_new() {
 	p->lines_cache = NULL;
 	p->row_offsets_sz = 0;
 	p->row_offsets = NULL;
+	p->vflush = true;
 	return p;
 }
 

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -176,7 +176,7 @@ R_API RPrint *r_print_new() {
 	p->col = 0;
 	p->width = 78;
 	p->cols = 16;
-	p->cur_enabled = R_FALSE;
+	p->cur_enabled = false;
 	p->cur = p->ocur = -1;
 	p->formats = r_strht_new ();
 	p->addrmod = 4;


### PR DESCRIPTION
This patch (should) do the following things:
* remove globals from core/visual.c file, about cursor, curset, ocur, cols, etc.
* when using a disassembler mode, keep a cache of instructions delta, so that you can know where each instruction starts
* rewrite the cursor movements in core/visual.c to make the cursor more "predictable". This means that when you move with 'j','k' you will really go to the next/prev displayed instruction. 
* fix some bugs with the current implementation, for example sometimes the cursor goes out of the screen because of some comments in the middle of the disassembly.