### PR TITLE
cons/dietline: show the same number of items per line

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -426,13 +426,13 @@ R_API void r_line_autocomplete() {
 			}
 		}
 		for (len = i = 0; i < argc && argv[i]; i++) {
-			slen = strlen (argv[i]);
-			len += (slen > col) ? (slen + sep) : (col + sep);
 			if (len + col > cols) {
 				printf ("\n");
 				len = 0;
 			}
-			printf ("%-*s   ", col-sep, argv[i]);
+			printf ("%-*s   ", col - sep, argv[i]);
+			slen = strlen (argv[i]);
+			len += (slen > col) ? (slen + sep) : (col + sep);
 		}
 		printf ("\n");
 	}


### PR DESCRIPTION
It fixes a bug when showing options for autocompletion, where the first
row has less items than the others. With this patch every line, except
the last, should have the same number of elements.