### PR TITLE
add support for sr lowercase register name

### DIFF
--- a/libr/debug/reg.c
+++ b/libr/debug/reg.c
@@ -207,7 +207,10 @@ R_API int r_debug_reg_set(struct r_debug_t *dbg, const char *name, ut64 num) {
 
 R_API ut64 r_debug_reg_get(RDebug *dbg, const char *name) {
 	// ignores errors
-	return r_debug_reg_get_err (dbg, name, NULL);
+	char upper_name[16];
+	strncpy (upper_name, name, sizeof (upper_name));
+	r_str_case (upper_name, true);
+	return r_debug_reg_get_err (dbg, (const char *)upper_name, NULL);
 }
 
 R_API ut64 r_debug_reg_get_err(RDebug *dbg, const char *name, int *err) {


### PR DESCRIPTION
`sr pc` was not working because it should be `sr PC` iirc there was an issue for this but i couldn't find it. I don't know if there will be an issue for this little change just wait to travis or @radare to blame.