### PR TITLE
Rename flag

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -212,17 +212,9 @@ static RAnalBlock* appendBasicBlock (RAnal *anal, RAnalFunction *fcn, ut64 addr)
 		return R_ANAL_RET_ERROR; }
 
 #define VARPREFIX "local"
-//#define VARPREFIX "var"
 #define ARGPREFIX "arg"
 static char *get_varname (RAnal *a, const char *pfx, int idx) {
-	char *s;
-	int word = a->bits / 8;
-	if (idx%word) {
-		s = r_str_newf ("%s_%d_%d", pfx, idx/word, R_ABS(idx%word));
-	} else {
-		s = r_str_newf ("%s_%d", pfx, idx/word);
-	}
-	return s;
+	return r_str_newf ("%s_%xh", pfx, idx);
 }
 
 static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 len, int depth);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -426,11 +426,13 @@ repeat:
 				varname = get_varname (anal, ARGPREFIX, R_ABS(op.ptr));
 				r_anal_var_add (anal, fcn->addr, 1, op.ptr,
 						'a', NULL, anal->bits/8, varname);
+				r_anal_var_access (anal, fcn->addr, 'a', 1, op.ptr, 1, op.addr);
 				// TODO: DIR_IN?
 			} else {
 				varname = get_varname (anal, VARPREFIX, R_ABS(op.ptr));
 				r_anal_var_add (anal, fcn->addr, 1, -op.ptr,
 						'v', NULL, anal->bits/8, varname);
+				r_anal_var_access (anal, fcn->addr, 'v', 1, -op.ptr, 1, op.addr);
 			}
 			free (varname);
 			break;
@@ -439,11 +441,11 @@ repeat:
 			if (((int)op.ptr) > 0) {
 				varname = get_varname (anal, ARGPREFIX, R_ABS(op.ptr));
 				r_anal_var_add (anal, fcn->addr, 1, op.ptr, 'a', NULL, anal->bits/8, varname);
-				r_anal_var_access (anal, fcn->addr, 'a', 0, op.ptr, 0, op.addr);
+				r_anal_var_access (anal, fcn->addr, 'a', 1, op.ptr, 0, op.addr);
 			} else {
 				varname = get_varname (anal, VARPREFIX, R_ABS(op.ptr));
 				r_anal_var_add (anal, fcn->addr, 1, -op.ptr, 'v', NULL, anal->bits/8, varname);
-				r_anal_var_access (anal, fcn->addr, 'v', 0, -op.ptr, 0, -op.addr);
+				r_anal_var_access (anal, fcn->addr, 'v', 1, -op.ptr, 0, op.addr);
 			}
 			free (varname);
 			break;

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -4,6 +4,14 @@
 #include <r_util.h>
 #include <r_list.h>
 
+#define SDB_VARUSED_FMT "qzdq"
+struct VarUsedType {
+	ut64 fcn_addr;
+	char *type;
+	ut32 scope;
+	st64 delta;
+};
+
 R_API RAnalOp *r_anal_op_new () {
 	RAnalOp *op = R_NEW0 (RAnalOp);
 	if (!op) return NULL;
@@ -32,6 +40,7 @@ R_API void r_anal_op_fini(RAnalOp *op) {
 	if (((ut64)(size_t)op->mnemonic) == UT64_MAX) {
 		return;
 	}
+	r_anal_var_free (op->var);
 	r_anal_value_free (op->src[0]);
 	r_anal_value_free (op->src[1]);
 	r_anal_value_free (op->src[2]);
@@ -45,6 +54,19 @@ R_API void r_anal_op_free(void *_op) {
 	if (!_op) return;
 	r_anal_op_fini (_op);
 	free (_op);
+}
+
+static RAnalVar *get_used_var(RAnal *anal, RAnalOp *op) {
+	char *inst_key = sdb_fmt (0, "inst.0x%"PFMT64x".vars", op->addr);
+	char *var_def = sdb_get (anal->sdb_fcns, inst_key, 0);
+	struct VarUsedType vut;
+	RAnalVar *res;
+
+	if (!var_def) return NULL;
+	sdb_fmt_tobin (var_def, SDB_VARUSED_FMT, &vut);
+	res = r_anal_var_get (anal, vut.fcn_addr, vut.type[0], vut.scope, vut.delta);
+	sdb_fmt_free (&vut, SDB_VARUSED_FMT);
+	return res;
 }
 
 R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
@@ -64,6 +86,7 @@ R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 		anal->cur && anal->cur->op && strcmp (anal->cur->name, "null")) {
 		ret = anal->cur->op (anal, op, addr, data, len);
 		op->addr = addr;
+		op->var = get_used_var (anal, op);
 		if (ret < 1) op->type = R_ANAL_OP_TYPE_ILL;
 	} else {
 		if (!memcmp (data, "\xff\xff\xff\xff", R_MIN(4, len))) {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -517,7 +517,6 @@ SETL/SETNGE
 				if (INSOP(0).mem.base == X86_REG_RIP) {
 					op->ptr += addr + insn->size;
 				} else if (INSOP(0).mem.base == X86_REG_RBP || INSOP(0).mem.base == X86_REG_EBP) {
-					op->ptr = UT64_MAX;
 					op->stackop = R_ANAL_STACK_SET;
 					op->stackptr = regsz;
 				} else {

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -287,42 +287,12 @@ R_API int r_anal_var_rename (RAnal *a, ut64 var_addr, int scope, char kind, cons
 	return 1;
 }
 
-// afvt local_48 int
-#if 0
-R_API int r_anal_var_retype(RAnal *a, ut64 var_addr, int scope, char kind, const char *old_name, const char *new_type) {
-	char key[128];
-	char *stored_name;
-	int delta;
-	if (!r_anal_var_check_name (old_name))
-		return 0;
-	if (scope>0) { // local
-		SETKEY ("var.0x%"PFMT64x".%c.%d.%s", var_addr, kind, scope, old_name);
-		delta = sdb_num_get (DB, key, 0);
-		sdb_unset (DB, key, 0);
-		SETKEY ("var.0x%"PFMT64x".%c.%d.%s", var_addr, kind, scope, old_name);
-		sdb_num_set (DB, key, delta, 0);
-		SETKEY ("var.0x%"PFMT64x".%s.%d.%d", var_addr, new_type, scope, delta);
-		sdb_array_set (DB, key, R_ANAL_VAR_SDB_NAME, old_name, 0);
-	} else { // global
-		SETKEY ("var.0x%"PFMT64x, var_addr);
-		stored_name = sdb_array_get (DB, key, R_ANAL_VAR_SDB_NAME, 0);
-		if (!stored_name) return 0;
-		if (stored_name != old_name) return 0;
-		sdb_unset (DB, key, 0);
-		SETKEY ("var.0x%"PFMT64x, var_addr);
-		//sdb_array_set (DB, key, R_ANAL_VAR_SDB_NAME, new_name, 0);
-	}
-	// var.sdb_hash(old_name)=var_addr.scope.delta
-	return 1;
-}
-#endif
-
 // avr
 R_API int r_anal_var_access (RAnal *a, ut64 var_addr, char kind, int scope, int delta, int xs_type, ut64 xs_addr) {
 	const char *var_global;
 	const char *xs_type_str = xs_type? "writes": "reads";
-// TODO: kind is not used
-	if (scope>0) { // local
+	// TODO: kind is not used
+	if (scope > 0) { // local
 		char *var_local = sdb_fmt (0, "var.0x%"PFMT64x".%d.%d.%s",
 			var_addr, scope, delta, xs_type_str);
 		char *inst_key = sdb_fmt (1, "inst.0x%"PFMT64x".vars", xs_addr);
@@ -349,34 +319,6 @@ R_API void r_anal_var_access_clear (RAnal *a, ut64 var_addr, int scope, int delt
 	sdb_unset (DB, key, 0);
 	sdb_unset (DB, key2, 0);
 }
-
-#if 0
-#if FCN_SDB
-#if 0
-  fcn.0x80480.v=8,16,24
-  fcn.0x80480.v.8=name,type
-#endif
-	char key[1024], val[1024], *e;
-	if (EXISTS("fcn.0x%08"PFMT64x, fna)) {
-		SETKEY("fcn.0x%08"PFMT64x".%c", fna, kind);
-		if (sdb_array_contains_num (DB, key, delta, 0))
-			return false;
-		e = sdb_encode (name, -1);
-		if (e) {
-			sdb_array_push (DB, key, e, 0);
-			sdb_array_push_num (DB, key, delta, 0);
-			free (e);
-		} else {
-			eprintf ("Cannot encode string\n");
-		}
-	} else {
-		eprintf ("r_anal_fcn_local_add: cannot find function.\n");
-		return false;
-	}
-#endif
-	return true;
-}
-#endif
 
 R_API int r_anal_fcn_var_del_bydelta (RAnal *a, ut64 fna, const char kind, int scope, ut32 delta) {
 	int idx;

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -233,9 +233,11 @@ R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int d
 }
 
 R_API void r_anal_var_free (RAnalVar *av) {
-	free (av->name);
-	free (av->type);
-	free (av);
+	if (av) {
+		free (av->name);
+		free (av->type);
+		free (av);
+	}
 }
 
 /* (columns) elements in the array value */
@@ -323,6 +325,10 @@ R_API int r_anal_var_access (RAnal *a, ut64 var_addr, char kind, int scope, int 
 	if (scope>0) { // local
 		char *var_local = sdb_fmt (0, "var.0x%"PFMT64x".%d.%d.%s",
 			var_addr, scope, delta, xs_type_str);
+		char *inst_key = sdb_fmt (1, "inst.0x%"PFMT64x".vars", xs_addr);
+		char *var_def = sdb_fmt(2, "0x%"PFMT64x",%c,0x%x,0x%x", var_addr,
+			kind, scope, delta);
+		sdb_set (DB, inst_key, var_def, 0);
 		return sdb_array_add_num (DB, var_local, xs_addr, 0);
 	}
 	// global

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -660,6 +660,30 @@ typedef struct r_anal_hint_t {
 	int immbase;
 } RAnalHint;
 
+typedef struct r_anal_var_access_t {
+	ut64 addr;
+	int set;
+} RAnalVarAccess;
+
+#define R_ANAL_VAR_KIND_ARG 'a'
+#define R_ANAL_VAR_KIND_VAR 'v'
+#define R_ANAL_VAR_KIND_REG 'r'
+
+// generic for args and locals
+typedef struct r_anal_var_t {
+	char *name;		/* name of the variable */
+	char *type; // cparse type of the variable
+	char kind; // 'a'rg, 'v'ar ..
+	ut64 addr;		// not used correctly?
+	ut64 eaddr;		// not used correctly?
+	int size;
+	int delta;		/* delta offset inside stack frame */
+	int scope;		/* global, local... | in, out... */
+	/* probably dupped or so */
+	RList/*RAnalVarAccess*/ *accesses; /* list of accesses for this var */
+	RList/*RAnalValue*/ *stores;   /* where this */
+} RAnalVar;
+
 // mul*value+regbase+regidx+delta
 typedef struct r_anal_value_t {
 	int absolute; // if true, unsigned cast is used
@@ -698,6 +722,7 @@ typedef struct r_anal_op_t {
 	int ptrsize;    /* f.ex: zero extends for 8, 16 or 32 bits only */
 	st64 stackptr;  /* stack pointer */
 	int refptr;     /* if (0) ptr = "reference" else ptr = "load memory of refptr bytes" */
+	RAnalVar *var;  /* local var/arg used by this instruction */
 	RAnalValue *src[3];
 	RAnalValue *dst;
 	struct r_anal_op_t *next; // XXX deprecate
@@ -750,30 +775,6 @@ typedef struct r_anal_bb_t {
 	struct r_anal_bb_t *jumpbb;
 	RList /*struct r_anal_bb_t*/ *cases;
 } RAnalBlock;
-
-typedef struct r_anal_var_access_t {
-	ut64 addr;
-	int set;
-} RAnalVarAccess;
-
-#define R_ANAL_VAR_KIND_ARG 'a'
-#define R_ANAL_VAR_KIND_VAR 'v'
-#define R_ANAL_VAR_KIND_REG 'r'
-
-// generic for args and locals
-typedef struct r_anal_var_t {
-	char *name;		/* name of the variable */
-	char *type; // cparse type of the variable
-	char kind; // 'a'rg, 'v'ar ..
-	ut64 addr;		// not used correctly?
-	ut64 eaddr;		// not used correctly?
-	int size;
-	int delta;		/* delta offset inside stack frame */
-	int scope;		/* global, local... | in, out... */
-	/* probably dupped or so */
-	RList/*RAnalVarAccess*/ *accesses; /* list of accesses for this var */
-	RList/*RAnalValue*/ *stores;   /* where this */
-} RAnalVar;
 
 typedef enum {
 	R_ANAL_REF_TYPE_NULL = 0,


### PR DESCRIPTION
* change the arg/var names. If the var is at ebp-0x360, the var will be named local_360h
* fix a bug in x86 stack operation analysis
* add field "var" to RAnalOp. During function analysis the information related to the local variables are stored in SDB. Later, when you do r_anal_op, it will automatically load those information from SDB and create a RAnalVar stored in op.var.
* add 'Vdn' to rename local variables/arguments/function/flags used by the instruction under the cursor