### PR TITLE
RBin: Display File Version info

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -31,6 +31,7 @@
 #define ACTION_PDB_DWNLD 0x100000
 #define ACTION_DLOPEN    0x200000
 #define ACTION_EXPORTS   0x400000
+#define ACTION_VERSIONINFO 0x800000
 
 static struct r_bin_t *bin = NULL;
 static char* output = NULL;
@@ -495,7 +496,7 @@ int main(int argc, char **argv) {
 #define is_active(x) (action&x)
 #define set_action(x) actions++; action |= x
 #define unset_action(x) action &= ~x
-	while ((c = getopt (argc, argv, "DjgAf:F:a:B:G:b:cC:k:K:dD:Mm:n:N:@:isSIHeElRwO:o:pPqQrvLhuxzZ")) != -1) {
+	while ((c = getopt (argc, argv, "DjgAf:F:a:B:G:b:cC:k:K:dD:Mm:n:N:@:isSVIHeElRwO:o:pPqQrvLhuxzZ")) != -1) {
 		switch (c) {
 		case 'g':
 			set_action (ACTION_CLASSES);
@@ -511,7 +512,9 @@ int main(int argc, char **argv) {
 			set_action (ACTION_MAIN);
 			set_action (ACTION_LIBS);
 			set_action (ACTION_RELOCS);
+			set_action (ACTION_VERSIONINFO);
 			break;
+		case 'V': set_action (ACTION_VERSIONINFO); break;
 		case 'q': rad = R_CORE_BIN_SIMPLE; break;
 		case 'j': rad = R_CORE_BIN_JSON; break;
 		case 'A': set_action (ACTION_LISTARCHS); break;
@@ -936,6 +939,7 @@ int main(int argc, char **argv) {
 	run_action ("dwarf", ACTION_DWARF, R_CORE_BIN_ACC_DWARF);
 	run_action ("pdb", ACTION_PDB, R_CORE_BIN_ACC_PDB);
 	run_action ("size", ACTION_SIZE, R_CORE_BIN_ACC_SIZE);
+	run_action ("versioninfo", ACTION_VERSIONINFO, R_CORE_BIN_ACC_VERSIONINFO);
 	if (action & ACTION_SRCLINE) {
 		rabin_show_srcline (at);
 	}

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -1361,7 +1361,6 @@ static PE_VS_VERSIONINFO *Pe_r_bin_pe_parse_version_info(struct PE_(r_bin_pe_obj
 	curAddr += VS_VERSION_INFO_UTF_16_LEN;
 
 	if (memcmp (vs_VersionInfo->szKey, VS_VERSION_INFO_UTF_16, VS_VERSION_INFO_UTF_16_LEN)) {
-		eprintf ("Warning: check (VS_VERSIONINFO szKey)\n");
 		free_VS_VERSIONINFO(vs_VersionInfo);
 		return NULL;
 	}

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -308,6 +308,7 @@ static int cmd_info(void *data, const char *input) {
 		case 'e': RBININFO ("entries", R_CORE_BIN_ACC_ENTRIES, NULL); break;
 		case 'M': RBININFO ("main", R_CORE_BIN_ACC_MAIN, NULL); break;
 		case 'm': RBININFO ("memory", R_CORE_BIN_ACC_MEM, NULL); break;
+		case 'V': RBININFO ("versioninfo", R_CORE_BIN_ACC_VERSIONINFO, NULL); break;
 		case 'z':
 			if (input[1] == 'z') {
 				char *ret;
@@ -452,6 +453,7 @@ static int cmd_info(void *data, const char *input) {
 				"ir|iR", "", "Relocs",
 				"is", "", "Symbols",
 				"iS ", "[entropy,sha1]", "Sections (choose which hash algorithm to use)",
+				"iV", "", "Display file version info)",
 				"iz", "", "Strings in data sections",
 				"izz", "", "Search for Strings in the whole binary",
 				NULL

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -419,6 +419,7 @@ R_API void r_core_sysenv_help(const RCore* core);
 #define R_CORE_BIN_ACC_SIZE     0x1000
 #define R_CORE_BIN_ACC_MEM	0x4000
 #define R_CORE_BIN_ACC_EXPORTS  0x8000
+#define R_CORE_BIN_ACC_VERSIONINFO 0x10000
 #define R_CORE_BIN_ACC_ALL	0x4FFF
 
 typedef struct r_core_bin_filter_t {

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -572,6 +572,7 @@ R_API char *r_str_escape(const char *buf);
 R_API char *r_str_escape_dot(const char *buf);
 R_API void r_str_uri_decode(char *buf);
 R_API char *r_str_uri_encode (const char *buf);
+R_API char *r_str_utf16_decode (const ut8 *s, int len);
 R_API char *r_str_utf16_encode (const char *s, int len);
 R_API char *r_str_home(const char *str);
 R_API int r_str_nlen (const char *s, int n);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1547,6 +1547,33 @@ R_API char *r_str_uri_encode (const char *s) {
 	return realloc (od, strlen (od)+1); // FIT
 }
 
+R_API char *r_str_utf16_decode (const ut8 *s, int len) {
+	int i = 0;
+	int j = 0;
+	char *result = NULL;
+	int count_unicode = 0;
+	int count_ascii = 0;
+	int lenresult = 0;
+	if (!s) return NULL;
+	for (i = 0; i < len && (s[i] || s[i+1]); i += 2) {
+		if (!s[i+1] && 0x20 <= s[i] && s[i] <= 0x7E) {
+			++count_ascii;
+		} else {
+			++count_unicode;
+		}
+	}
+	lenresult = 1 + count_ascii + count_unicode * 6; // len("\\uXXXX") = 6
+	if (!(result = calloc (1 + count_ascii + count_unicode * 6, 1))) return NULL;
+	for (i = 0; i < len && j < lenresult && (s[i] || s[i+1]); i += 2) {
+		if (!s[i+1] && 0x20 <= s[i] && s[i] <= 0x7E) {
+			result[j++] = s[i];
+		} else {
+			j += sprintf (&result[j], "\\u%.2hhx%.2hhx", s[i], s[i+1]);
+		}
+	}
+	return result;
+}
+
 R_API char *r_str_utf16_encode (const char *s, int len) {
 	int i;
 	char ch[4], *d, *od, *tmp;


### PR DESCRIPTION
Hi everyone this is my first contribution for radare2 :)

I added a new command **"iV"** and a **"-V"** option for rabin2 to display the [VS_VERSIONINFO](https://msdn.microsoft.com/en-us/library/windows/desktop/ms647001(v=vs.85).aspx) structure of PE files.

## example

```
➜  radare2 git:(pe_file_version_info) /tmp/r2/bin/rabin2 -V ~/shared/notepad_64.exe
Warning: check (VS_VERSIONINFO szKey) 
CompanyName=Microsoft Corporation 
FileDescription=Notepad
FileVersion=10.0.10586.0 (th2_release.151029-1700)
InternalName=Notepad
LegalCopyright=� Microsoft Corporation. All rights reserved.
OriginalFilename=NOTEPAD.EXE
ProductName=Microsoft� Windows� Operating System
ProductVersion=10.0.10586.0
```

Basically I get the information to display from sdb.

- I don't handle Unicode because strings are in UTF-16 and %lc expects 4 bytes encoding.
- Concerning `Warning: check (VS_VERSIONINFO szKey)` I think there is a problem with the parser because [it expects more than one](https://github.com/radare/radare2/commit/8737ad2b6512c5a174d1be6f4dc4357ed1d18d9c#diff-15f63750bbf1cea750d78c8cfc33a916R1581) VS_VERSIONINFO in the resource...