### PR TITLE
V810: fixes

### DIFF
--- a/libr/asm/arch/v810/v810_disas.c
+++ b/libr/asm/arch/v810/v810_disas.c
@@ -120,35 +120,23 @@ static const char *sysreg_names[] = {
 	[V810_SREG_ADTRE]	= "ADTRE",
 };
 
-static inline ut8 get_opcode(const ut16 instr) {
-	return (instr >> 10) & 0x3F;
-}
-
-static inline ut8 get_reg1(const ut16 instr) {
-	return instr & 0x1F;
-}
-
-static inline ut8 get_reg2(const ut16 instr) {
-	return (instr >> 5) & 0x1F;
-}
-
 static int decode_reg_reg(const ut16 instr, struct v810_cmd *cmd) {
 	ut8 opcode;
 
-	opcode = get_opcode(instr);
+	opcode = OPCODE(instr);
 
 	if (opcode >= sizeof(instrs) / sizeof(char *)) {
 		return -1;
 	}
 
-	snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "%s", instrs[opcode]);
+	snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "%s", instrs[opcode]);
 
 	if (opcode == V810_JMP) {
-		snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "[r%u]",
-				get_reg1(instr));
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "[r%u]",
+				REG1(instr));
 	} else {
-		snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "r%u, r%u",
-				get_reg1(instr), get_reg2(instr));
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "r%u, r%u",
+				REG1(instr), REG2(instr));
 	}
 
 	return 2;
@@ -156,48 +144,46 @@ static int decode_reg_reg(const ut16 instr, struct v810_cmd *cmd) {
 
 static int decode_imm_reg(const ut16 instr, struct v810_cmd *cmd) {
 	ut8 opcode;
-	st8 immed;
+	ut8 immed;
 
-	opcode = get_opcode(instr);
+	opcode = OPCODE(instr);
 
 	if (opcode >= sizeof(instrs) / sizeof(char *)) {
 		return -1;
 	}
 
-	snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "%s", instrs[opcode]);
+	snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "%s", instrs[opcode]);
 
-	immed = get_reg1(instr);
-
-	if (immed & 0x10) {
-		immed |= 0xE0;
-	}
+	immed = IMM5(instr);
 
 	switch (opcode) {
-		case V810_MOV_IMM5:
-		case V810_ADD_IMM5:
-		case V810_CMP_IMM5:
-			snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "%d, r%u",
-					immed, get_reg2(instr));
-			break;
-		case V810_LDSR:
-		case V810_STSR:
-			immed = immed & 0x1F;
-			if (sysreg_names[(ut8)immed]) {
-				snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "%s, r%u",
-						sysreg_names[(ut8)immed], get_reg2(instr));
-				break;
-			}
-		case V810_SETF:
-		case V810_SHL_IMM5:
-		case V810_SHR_IMM5:
-		case V810_SAR_IMM5:
-			snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "%u, r%u",
-					immed & 0x1F, get_reg2(instr));
-			break;
-		case V810_TRAP:
-			snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "%u",
-					immed & 0x1F);
-			break;
+	case V810_MOV_IMM5:
+	case V810_ADD_IMM5:
+	case V810_CMP_IMM5:
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "%hhd, r%u",
+				(st8)SEXT5(immed), REG2(instr));
+		break;
+	case V810_LDSR:
+	case V810_STSR:
+		if (immed > 0x19 || (immed > 0x7 && immed < 0x18)) {
+			snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "s%hhu, r%u",
+					immed, REG2(instr));
+		} else if (sysreg_names[immed]) {
+			snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "%s, r%u",
+					sysreg_names[immed], REG2(instr));
+		}
+		break;
+	case V810_SETF:
+	case V810_SHL_IMM5:
+	case V810_SHR_IMM5:
+	case V810_SAR_IMM5:
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "%u, r%u",
+				immed, REG2(instr));
+		break;
+	case V810_TRAP:
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "%u",
+				immed);
+		break;
 	}
 
 	return 2;
@@ -208,90 +194,68 @@ static int decode_bcond(const ut16 instr, struct v810_cmd *cmd) {
 	ut8 cond;
 
 	cond = (instr >> 9) & 0xF;
-	disp = instr & 0x1FE;
-	if (disp & (1<<8))
-		disp |= 0xFE00;
+	disp = DISP9(instr);
 
 	if (cond == V810_COND_NOP) {
-		snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "nop");
+		snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "nop");
 	} else {
-		snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "b%s", conds[cond]);
-		snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "%d", disp);
+		snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "b%s", conds[cond]);
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "%d", disp);
 	}
 
 	return 2;
 }
 
-static int decode_jump(const ut8 *instr, struct v810_cmd *cmd) {
-	ut16 word1, word2;
-	st32 disp;
-
-	r_mem_copyendian((ut8*)&word1, instr, 2, LIL_ENDIAN);
-	r_mem_copyendian((ut8*)&word2, instr + 2, 2, LIL_ENDIAN);
-
-	disp = ((word1 & 0x3FF) << 16) | word2;
-	if (disp & (1<<25))
-		disp |= 0xFC000000;
-
-	snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
-			instrs[get_opcode(word1)]);
-	snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "%d", disp);
+static int decode_jump(const ut16 word1, const ut16 word2, struct v810_cmd *cmd) {
+	snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
+			instrs[OPCODE(word1)]);
+	snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "%d",
+			DISP26(word1, word2));
 
 	return 4;
 }
 
-static int decode_3operands(const ut8 *instr, struct v810_cmd *cmd) {
-	ut16 word1, word2;
+static int decode_3operands(const ut16 word1, const ut16 word2, struct v810_cmd *cmd) {
+	snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
+			instrs[OPCODE(word1)]);
 
-	r_mem_copyendian((ut8*)&word1, instr, 2, LIL_ENDIAN);
-	r_mem_copyendian((ut8*)&word2, instr + 2, 2, LIL_ENDIAN);
-
-	snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
-			instrs[get_opcode(word1)]);
-
-	if (get_opcode(word1) == V810_ADDI) {
-		snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "%d, r%d, r%d",
-				(st16) word2, get_reg1(word1), get_reg2(word1));
+	if (OPCODE(word1) == V810_ADDI) {
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "%d, r%d, r%d",
+				(st16) word2, REG1(word1), REG2(word1));
 	} else {
-		snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "0x%x, r%d, r%d",
-				word2, get_reg1(word1), get_reg2(word1));
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "0x%x, r%d, r%d",
+				word2, REG1(word1), REG2(word1));
 	}
 
 	return 4;
 }
 
-static int decode_load_store(const ut8 *instr, struct v810_cmd *cmd) {
-	ut16 word1;
-	st16 word2;
+static int decode_load_store(const ut16 word1, const ut16 word2, struct v810_cmd *cmd) {
+	snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
+		instrs[OPCODE(word1)]);
 
-	r_mem_copyendian((ut8*)&word1, instr, 2, LIL_ENDIAN);
-	r_mem_copyendian((ut8*)&word2, instr + 2, 2, LIL_ENDIAN);
-
-	snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
-		instrs[get_opcode(word1)]);
-
-	switch (get_opcode(word1)) {
-		case V810_STB:
-		case V810_STH:
-		case V810_STW:
-		case V810_OUTB:
-		case V810_OUTH:
-		case V810_OUTW:
-			snprintf(cmd->operands, V810_INSTR_MAXLEN - 1,
-					"r%d, %d[r%d]",
-					get_reg2(word1), word2, get_reg1(word1));
-			break;
-		case V810_LDB:
-		case V810_LDH:
-		case V810_LDW:
-		case V810_INB:
-		case V810_INH:
-		case V810_INW:
-		case V810_CAXI:
-			snprintf(cmd->operands, V810_INSTR_MAXLEN - 1,
-					"%d[r%d], r%d",
-					word2, get_reg1(word1), get_reg2(word1));
-			break;
+	switch (OPCODE(word1)) {
+	case V810_STB:
+	case V810_STH:
+	case V810_STW:
+	case V810_OUTB:
+	case V810_OUTH:
+	case V810_OUTW:
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1,
+				"r%d, %hd[r%d]",
+				REG2(word1), (st16)word2, REG1(word1));
+		break;
+	case V810_LDB:
+	case V810_LDH:
+	case V810_LDW:
+	case V810_INB:
+	case V810_INH:
+	case V810_INW:
+	case V810_CAXI:
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1,
+				"%hd[r%d], r%d",
+				(st16)word2, REG1(word1), REG2(word1));
+		break;
 	}
 
 	return 4;
@@ -300,131 +264,133 @@ static int decode_load_store(const ut8 *instr, struct v810_cmd *cmd) {
 static int decode_bit_op(const ut16 instr, struct v810_cmd *cmd) {
 	ut8 subop;
 
-	subop = get_reg1(instr);
-	snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "%s", bit_instrs[subop]);
+	subop = REG1(instr);
+	snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "%s", bit_instrs[subop]);
 
 	return 2;
 }
 
-static int decode_extended(const ut8 *instr, struct v810_cmd *cmd) {
-	ut8 subop;
-	ut16 word1, word2;
+static int decode_extended(const ut16 word1, const ut16 word2, struct v810_cmd *cmd) {
+	ut8 subop = OPCODE(word2)>>2;
+	if (subop > 0xC)
+		return -1;
 
-	r_mem_copyendian((ut8*)&word1, instr, 2, LIL_ENDIAN);
-	r_mem_copyendian((ut8*)&word2, instr + 2, 2, LIL_ENDIAN);
-
-	subop = get_opcode(word2)>>2;
-
-	snprintf(cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
+	snprintf (cmd->instr, V810_INSTR_MAXLEN - 1, "%s",
 			ext_instrs[subop]);
 
 	switch (subop) {
-		case V810_EXT_CMPF_S:
-		case V810_EXT_CVT_WS:
-		case V810_EXT_CVT_SW:
-		case V810_EXT_ADDF_S:
-		case V810_EXT_SUBF_S:
-		case V810_EXT_MULF_S:
-		case V810_EXT_DIVF_S:
-		case V810_EXT_REV:
-		case V810_EXT_TRNC_SW:
-		case V810_EXT_MPYHW:
-			snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "r%d, r%d",
-					get_reg1(word1), get_reg2(word1));
-			break;
-		case V810_EXT_XB:
-		case V810_EXT_XH:
-			snprintf(cmd->operands, V810_INSTR_MAXLEN - 1, "r%d",
-					get_reg2(word1));
-			break;
-		default:
-			return -1;
+	case V810_EXT_CMPF_S:
+	case V810_EXT_CVT_WS:
+	case V810_EXT_CVT_SW:
+	case V810_EXT_ADDF_S:
+	case V810_EXT_SUBF_S:
+	case V810_EXT_MULF_S:
+	case V810_EXT_DIVF_S:
+	case V810_EXT_REV:
+	case V810_EXT_TRNC_SW:
+	case V810_EXT_MPYHW:
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "r%d, r%d",
+				REG1(word1), REG2(word1));
+		break;
+	case V810_EXT_XB:
+	case V810_EXT_XH:
+		snprintf (cmd->operands, V810_INSTR_MAXLEN - 1, "r%d",
+				REG2(word1));
+		break;
+	default:
+		return -1;
 	}
 
 	return 4;
 }
 
-int v810_decode_command(const ut8 *instr, struct v810_cmd *cmd) {
+int v810_decode_command(const ut8 *instr, int len, struct v810_cmd *cmd) {
 	int ret;
-	ut16 in;
+	ut16 word1 = 0;
+	ut16 word2 = 0;
 
-	r_mem_copyendian((ut8*)&in, instr, 2, LIL_ENDIAN);
+	r_mem_copyendian ((ut8*)&word1, instr, 2, LIL_ENDIAN);
+	if (len >= 4)
+		r_mem_copyendian ((ut8*)&word2, instr + 2, 2, LIL_ENDIAN);
 
-	switch (get_opcode(in)) {
-		case V810_MOV:
-		case V810_ADD:
-		case V810_SUB:
-		case V810_CMP:
-		case V810_SHL:
-		case V810_SHR:
-		case V810_JMP:
-		case V810_SAR:
-		case V810_MUL:
-		case V810_DIV:
-		case V810_MULU:
-		case V810_DIVU:
-		case V810_OR:
-		case V810_AND:
-		case V810_NOT:
-		case V810_XOR:
-			ret = decode_reg_reg(in, cmd);
-			break;
-		case V810_MOV_IMM5:
-		case V810_ADD_IMM5:
-		case V810_SETF:
-		case V810_CMP_IMM5:
-		case V810_SHL_IMM5:
-		case V810_SHR_IMM5:
-		case V810_CLI:
-		case V810_SAR_IMM5:
-		case V810_TRAP:
-		case V810_RETI:
-		case V810_HALT:
-		case V810_LDSR:
-		case V810_STSR:
-		case V810_SEI:
-			ret = decode_imm_reg(in, cmd);
-			break;
-		case V810_MOVEA:
-		case V810_ADDI:
-		case V810_ORI:
-		case V810_ANDI:
-		case V810_XORI:
-		case V810_MOVHI:
-			ret = decode_3operands(instr, cmd);
-			break;
-		case V810_JR:
-		case V810_JAL:
-			ret = decode_jump(instr, cmd);
-			break;
-		case V810_LDB:
-		case V810_LDH:
-		case V810_LDW:
-		case V810_STB:
-		case V810_STH:
-		case V810_STW:
-		case V810_INB:
-		case V810_INH:
-		case V810_CAXI:
-		case V810_INW:
-		case V810_OUTB:
-		case V810_OUTH:
-		case V810_OUTW:
-			ret = decode_load_store(instr, cmd);
-			break;
-		case V810_BSTR:
-			ret = decode_bit_op(in, cmd);
-			break;
-		case V810_EXT:
-			ret = decode_extended(instr, cmd);
-			break;
-		default:
-			if ((get_opcode(in) >> 3) == 0x4) {
-				ret = decode_bcond(in, cmd);
-			} else {
-				ret = -1;
-			}
+	switch (OPCODE(word1)) {
+	case V810_MOV:
+	case V810_ADD:
+	case V810_SUB:
+	case V810_CMP:
+	case V810_SHL:
+	case V810_SHR:
+	case V810_JMP:
+	case V810_SAR:
+	case V810_MUL:
+	case V810_DIV:
+	case V810_MULU:
+	case V810_DIVU:
+	case V810_OR:
+	case V810_AND:
+	case V810_NOT:
+	case V810_XOR:
+		ret = decode_reg_reg (word1, cmd);
+		break;
+	case V810_MOV_IMM5:
+	case V810_ADD_IMM5:
+	case V810_SETF:
+	case V810_CMP_IMM5:
+	case V810_SHL_IMM5:
+	case V810_SHR_IMM5:
+	case V810_CLI:
+	case V810_SAR_IMM5:
+	case V810_TRAP:
+	case V810_RETI:
+	case V810_HALT:
+	case V810_LDSR:
+	case V810_STSR:
+	case V810_SEI:
+		ret = decode_imm_reg (word1, cmd);
+		break;
+	case V810_MOVEA:
+	case V810_ADDI:
+	case V810_ORI:
+	case V810_ANDI:
+	case V810_XORI:
+	case V810_MOVHI:
+		ret = decode_3operands (word1, word2, cmd);
+		break;
+	case V810_JR:
+	case V810_JAL:
+		ret = decode_jump (word1, word2, cmd);
+		break;
+	case V810_LDB:
+	case V810_LDH:
+	case V810_LDW:
+	case V810_STB:
+	case V810_STH:
+	case V810_STW:
+	case V810_INB:
+	case V810_INH:
+	case V810_CAXI:
+	case V810_INW:
+	case V810_OUTB:
+	case V810_OUTH:
+	case V810_OUTW:
+		ret = decode_load_store (word1, word2, cmd);
+		break;
+	case V810_BSTR:
+		ret = decode_bit_op (word1, cmd);
+		break;
+	case V810_EXT:
+		ret = decode_extended (word1, word2, cmd);
+		break;
+	default:
+		if ((OPCODE(word1) >> 3) == 0x4) {
+			ret = decode_bcond (word1, cmd);
+		} else {
+			ret = -1;
+		}
 	}
+
+	if ((ret > 0) && (len < ret))
+		ret = -1;
 
 	return ret;
 }

--- a/libr/asm/arch/v810/v810_disas.h
+++ b/libr/asm/arch/v810/v810_disas.h
@@ -3,18 +3,18 @@
 
 #define V810_INSTR_MAXLEN     24
 
-#define OPCODE(instr) ((instr >> 10) & 0x3F)
-#define REG1(instr) (instr & 0x1F)
-#define REG2(instr) ((instr >> 5) & 0x1F)
-#define IMM5(instr) REG1(instr)
-#define COND(instr) ((instr >> 9) & 0xF)
+#define OPCODE(instr) (((instr) >> 10) & 0x3F)
+#define REG1(instr) ((instr) & 0x1F)
+#define REG2(instr) (((instr) >> 5) & 0x1F)
+#define IMM5(instr) REG1((instr))
+#define COND(instr) (((instr) >> 9) & 0xF)
 
-#define SEXT5(imm) ((imm & 0x10) ? (imm | 0xE0) : imm)
-#define SEXT9(imm) ((imm & 0x100) ? (imm | 0xFFFFFE00) : imm)
-#define SEXT26(imm) ((imm & 0x2000000) ? (imm | 0xFC000000) : imm)
+#define SEXT5(imm) (((imm) & 0x10) ? (imm) | 0xE0 : (imm))
+#define SEXT9(imm) (((imm) & 0x100) ? (imm) | 0xFFFFFE00 : (imm))
+#define SEXT26(imm) (((imm) & 0x2000000) ? (imm) | 0xFC000000 : (imm))
 
-#define DISP9(instr) SEXT9(word1 & 0x1FE)
-#define DISP26(word1, word2) SEXT26(((word1 & 0x3FF) << 16) | word2)
+#define DISP9(word1) SEXT9((word1) & 0x1FE)
+#define DISP26(word1, word2) SEXT26((((word1) & 0x3FF) << 16) | (word2))
 
 enum v810_cmd_opcodes {
 	V810_MOV		= 0x0,
@@ -141,6 +141,6 @@ struct v810_cmd {
 	char operands[V810_INSTR_MAXLEN];
 };
 
-int v810_decode_command(const ut8 *instr, struct v810_cmd *cmd);
+int v810_decode_command(const ut8 *instr, int len, struct v810_cmd *cmd);
 
 #endif /* R2_V810_DISASM_H */

--- a/libr/asm/p/asm_v810.c
+++ b/libr/asm/p/asm_v810.c
@@ -14,7 +14,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		.operands = ""
 	};
 	if (len < 2) return -1;
-	int ret = v810_decode_command (buf, &cmd);
+	int ret = v810_decode_command (buf, len, &cmd);
 	if (ret > 0) {
 		snprintf (op->buf_asm, R_ASM_BUFSIZE, "%s %s",
 			  cmd.instr, cmd.operands);


### PR DESCRIPTION
* Proper bound checking when decoding.
* Reuse some macros.
* Fix some warnings.
* Follow code style guidelines.

`op->size` was being determined after the first 2 bytes, which meant that 4-byte instructions could be read from a 2-byte buffer.
```asm
$ rasm2 -a v810 -d ffff
out.w r31, -19210[r31]
$ rasm2 -a v810 -d ffff
out.w r31, -26506[r31]
$ rasm2 -a v810 -d ffff
out.w r31, -9848[r31]
```

This should hopefully be fixed, along with some other minor issues.