### PR TITLE
attempt to fix scan.converity bugs

### DIFF
--- a/libr/asm/p/asm_pic18c.c
+++ b/libr/asm/p/asm_pic18c.c
@@ -103,15 +103,21 @@ static struct {
 	{0x4, 0x4, "clrwdt", NO_ARG},
 	{0x3, 0x3, "sleep", NO_ARG},
 	{0x0, 0x0, "nop", NO_ARG},
-	{-1, -1, "invalid", NO_ARG},
+	{0x0, 0xffff, "invalid", NO_ARG},
 };
 
 static int pic_disassem(RAsm *a, RAsmOp *op, const ut8 *b, int l) {
 	int i;
+	if(l<2){//well noone loves reading bitstream of size zero or 1 !!
+		strncpy (op->buf_asm,"invalid", R_ASM_BUFSIZE);
+		op->size = l;
+		return -1;
+
+	}
 	ut16 instr = *(ut16 *)b; //instruction
-	for (i = 0; ops[i].opmin != -1 && !(ops[i].opmin == (ops[i].opmin & instr) && ops[i].opmax == (ops[i].opmax | instr)); i++)
-		;
-	if (ops[i].opmin == -1) {
+	// if still redundan code is reported think of this of instr=0x2
+	for (i = 0;ops[i].opmin != (ops[i].opmin & instr) || ops[i].opmax != (ops[i].opmax | instr); i++);
+	if (ops[i].opmin == 0 && ops[i].opmax==0xffff) {
 		strncpy (op->buf_asm, ops[i].name, R_ASM_BUFSIZE);
 		op->size = 2;
 		return -1;

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -17,7 +17,8 @@ R_LIB_VERSION_HEADER(r_asm);
 
 #define R_ASM_OPCODES_PATH R2_LIBDIR "/radare2/" R2_VERSION "/opcodes"
 // XXX too big!
-#define R_ASM_BUFSIZE 256
+// the 256th character is left for the null terminator
+#define R_ASM_BUFSIZE 255
 
 /* backward compatibility */
 #define R_ASM_ARCH_NONE R_SYS_ARCH_NONE
@@ -64,9 +65,9 @@ typedef struct r_asm_op_t {
 	int size; // instruction size
 	int payload; // size of payload (opsize = (size-payload))
 	// But this is pretty slow..so maybe we should add some accessors
-	ut8  buf[R_ASM_BUFSIZE];
-	char buf_asm[R_ASM_BUFSIZE];
-	char buf_hex[R_ASM_BUFSIZE];
+	ut8  buf[R_ASM_BUFSIZE+1];
+	char buf_asm[R_ASM_BUFSIZE+1];
+	char buf_hex[R_ASM_BUFSIZE+1];
 } RAsmOp;
 
 typedef struct r_asm_code_t {


### PR DESCRIPTION
I also hunted 4th illegal memory read
the first 2 bytes of b is always casted to (ut16) type
with out checking if b even contains 2 bytes
now it is handled it correctly (nothing is certain )