### PR TITLE
Added comment prefix using asm.flgoff

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1087,7 +1087,7 @@ static void handle_show_flags_option(RCore *core, RDisasmState *ds) {
 				handle_print_lines_left (core, ds);
 			}
 			handle_print_offset (core, ds);
-			r_cons_printf (" ");
+			r_cons_printf (";-- ");
 		} else {
 			if (ds->show_functions) {
 				r_cons_printf ((f && ds->at > f->addr)?"| ": "  ");


### PR DESCRIPTION
When using the new option “asm.flgoff = true” the disasm will look like:

0x08048d60 ;-- section_end..plt:
0x08048d60 ;-- section..text:

Instead of:

0x08048d60 section_end..plt:
0x08048d60 section..text:

This patch keeps always the prefix “;—“