### PR TITLE
Cleanup binr/*/*.c

### DIFF
--- a/binr/r2agent/r2agent.c
+++ b/binr/r2agent/r2agent.c
@@ -15,12 +15,12 @@ int main() {
 
 static int usage (int v) {
 	printf ("Usage: r2agent [-adhs] [-p port]\n"
-	"  -a       listen for everyone (localhost by default)\n"
-	"  -d       run in daemon mode (background)\n"
-	"  -h       show this help message\n"
-	"  -s       run in sandbox mode\n"
-	"  -p 8392  specify listening port (defaults to 8080)\n");
-	return !!!v;
+	"  -a        listen for everyone (localhost by default)\n"
+	"  -d        run in daemon mode (background)\n"
+	"  -h        show this help message\n"
+	"  -s        run in sandbox mode\n"
+	"  -p [port] specify listening port (defaults to 8080)\n");
+	return !v;
 }
 
 int main(int argc, char **argv) {
@@ -29,10 +29,9 @@ int main(int argc, char **argv) {
 	int c, timeout = 3;
 	int dodaemon = 0;
 	int dosandbox = 0;
-	int listenlocal = 1; 
+	int listenlocal = 1;
 	const char *port = "8080";
 
-	// TODO: add flag to specify if listen in local or 0.0.0.0
 	while ((c = getopt (argc, argv, "ahp:ds")) != -1) {
 		switch (c) {
 		case 'a':
@@ -49,17 +48,19 @@ int main(int argc, char **argv) {
 		case 'p':
 			port = optarg;
 			break;
+		default:
+			return usage (0);
 		}
 	}
 	if (optind != argc)
-		return usage (1);
+		return usage (0);
 	if (dodaemon) {
 #if LIBC_HAVE_FORK
 		int pid = fork ();
 #else
 		int pid = -1;
 #endif
-		if (pid >0) {
+		if (pid > 0) {
 			printf ("%d\n", pid);
 			return 0;
 		}
@@ -86,17 +87,17 @@ int main(int argc, char **argv) {
 		if (!strcmp (rs->method, "GET")) {
 			if (!strncmp (rs->path, "/proc/kill/", 11)) {
 				// TODO: show page here?
-				int pid = atoi (rs->path+11);
-				if (pid>0) kill (pid, 9);
+				int pid = atoi (rs->path + 11);
+				if (pid > 0) kill (pid, 9);
 			} else
 			if (!strncmp (rs->path, "/file/open/", 11)) {
 				int pid;
 				int session_port = 3000 + r_num_rand (1024);
-				char *filename = rs->path +11;
+				char *filename = rs->path + 11;
 				int filename_len = strlen (filename);
 				char *cmd;
 
-				if (!(cmd = malloc (filename_len+40))) {
+				if (!(cmd = malloc (filename_len + 40))) {
 					perror ("malloc");
 					return 1;
 				}
@@ -106,7 +107,7 @@ int main(int argc, char **argv) {
 				// TODO: use r_sys api to get pid when running in bg
 				pid = r_sys_cmdbg (cmd);
 				free (cmd);
-				result = result_heap = malloc (1024+filename_len);
+				result = result_heap = malloc (1024 + filename_len);
 				if (!result) {
 					perror ("malloc");
 					return 1;

--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -51,7 +51,7 @@ static int verify_version(int show) {
 	};
 
 	if (show) printf ("%s  r2\n", base);
-	for (i=ret=0; vcs[i].name; i++) {
+	for (i = ret = 0; vcs[i].name; i++) {
 		struct vcs_t *v = &vcs[i];
 		const char *name = v->callback ();
 		if (!ret && strcmp (base, name))
@@ -60,7 +60,7 @@ static int verify_version(int show) {
 	}
 	if (ret) {
 		if (show) eprintf ("WARNING: r2 library versions mismatch!\n");
-		else	eprintf ("WARNING: r2 library versions mismatch! See r2 -V\n");
+		else eprintf ("WARNING: r2 library versions mismatch! See r2 -V\n");
 	}
 	return ret;
 }
@@ -113,7 +113,7 @@ static ut64 getBaddrFromDebugger(RCore *r, const char *file) {
 }
 
 static int main_help(int line) {
-	if (line<2) {
+	if (line < 2) {
 		printf ("Usage: r2 [-dDwntLqv] [-P patch] [-p prj] [-a arch] [-b bits] [-i file]\n"
 			"          [-s addr] [-B blocksize] [-c cmd] [-e k=v] file|pid|-|--|=\n");
 	}
@@ -155,7 +155,7 @@ static int main_help(int line) {
 		" -v, -V       show radare2 version (-V show lib versions)\n"
 		" -w           open file in write mode\n"
 		" -z, -zz      do not load strings or load them even in raw\n");
-	if (line==2)
+	if (line == 2)
 		printf (
 		"Scripts:\n"
 		" system   "R2_PREFIX"/share/radare2/radare2rc\n"
@@ -189,8 +189,8 @@ static void list_io_plugins(RIO *io) {
 		RIOList *il = list_entry (pos, RIOList, list);
 		// read, write, debug, proxy
 		str[0] = 'r';
-		str[1] = il->plugin->write? 'w': '_';
-		str[2] = il->plugin->isdbg? 'd': '_';
+		str[1] = il->plugin->write ? 'w' : '_';
+		str[2] = il->plugin->isdbg ? 'd' : '_';
 		str[3] = 0;
 		printf ("%s  %-11s %s (%s)\n", str, il->plugin->name,
 			il->plugin->desc, il->plugin->license);
@@ -210,7 +210,7 @@ static int rabin_delegate(RThread *th) {
 				nptr = strchr (ptr, '\n');
 				if (nptr) *nptr = 0;
 				r_core_cmd (&r, ptr, 0);
-				if (nptr) ptr = nptr+1;
+				if (nptr) ptr = nptr + 1;
 				if (th) r_th_lock_leave(th->user);
 			} while (nptr);
 		//r_core_cmd (&r, cmd, 0);
@@ -268,7 +268,7 @@ int main(int argc, char **argv, char **envp) {
 	if (r_sys_getenv ("R_DEBUG"))
 		r_sys_crash_handler ("gdb --pid %d");
 
-	if (argc<2) {
+	if (argc < 2) {
 		r_list_free (cmds);
 		r_list_free (evals);
 		return main_help (1);
@@ -281,11 +281,11 @@ int main(int argc, char **argv, char **envp) {
 				struct dirent* de = readdir (d);
 				if (!de) break;
 				ret = strlen (de->d_name);
-				if (!strcmp (".d", de->d_name+ret-2)) {
+				if (!strcmp (".d", de->d_name + ret - 2)) {
 					// TODO:
 					// do more checks to ensure it is a project
 					// show project info (opened? file? ..?)
-					printf ("%.*s\n", ret-2, de->d_name);
+					printf ("%.*s\n", ret - 2, de->d_name);
 				}
 			}
 		}
@@ -306,7 +306,7 @@ int main(int argc, char **argv, char **envp) {
 #if USE_THREADS
 "t"
 #endif
-	))!=-1) {
+	)) != -1) {
 		switch (c) {
 		case '=':
 			r.cmdremote = 1;
@@ -353,7 +353,7 @@ int main(int argc, char **argv, char **envp) {
 		case 'F': forcebin = optarg; break;
 		case 'h': help++; break;
 		case 'i':
-			if (cmdfilei+1 < (sizeof (cmdfile)/sizeof (*cmdfile)))
+			if (cmdfilei + 1 < (sizeof (cmdfile) / sizeof (*cmdfile)))
 				cmdfile[cmdfilei++] = optarg;
 			break;
 		case 'k':
@@ -369,7 +369,7 @@ int main(int argc, char **argv, char **envp) {
 		case 'l': r_lib_open (r.lib, optarg); break;
 		case 'L': list_io_plugins (r.io); return 0;
 		case 'm': mapaddr = r_num_math (r.num, optarg); break;
-		case 'n': run_anal --; break;
+		case 'n': run_anal--; break;
 		case 'N': run_rc = 0; break;
 		case 'p':
 			r_config_set (r.config, "file.project", optarg);
@@ -393,7 +393,7 @@ int main(int argc, char **argv, char **envp) {
 		default:
 			r_list_free (evals);
 			r_list_free (cmds);
-			return 1;
+			help++;
 		}
 	}
 
@@ -479,9 +479,9 @@ int main(int argc, char **argv, char **envp) {
 		/* stdin/batch mode */
 		ut8 *buf = (ut8 *)r_stdin_slurp (&sz);
 		close (0);
-		if (sz>0) {
+		if (sz > 0) {
 			char path[1024];
-			snprintf (path, sizeof (path)-1, "malloc://%d", sz);
+			snprintf (path, sizeof (path) - 1, "malloc://%d", sz);
 			fh = r_core_file_open (&r, path, perms, mapaddr);
 			if (fh) {
 				r_io_write_at (r.io, 0, buf, sz);
@@ -569,7 +569,7 @@ int main(int argc, char **argv, char **envp) {
 					diskfile = diskfile? diskfile + 3: file;
 					fh = r_core_file_open (&r, file, perms, mapaddr);
 					if (fh != NULL)
-						r_debug_use (r.dbg, is_gdb? "gdb": debugbackend);
+						r_debug_use (r.dbg, is_gdb ? "gdb" : debugbackend);
 					/* load symbols when doing r2 -d ls */
 					// NOTE: the baddr is redefined to support PIE/ASLR
 					baddr = getBaddrFromDebugger (&r, diskfile);
@@ -610,7 +610,7 @@ int main(int argc, char **argv, char **envp) {
 								if (debug) {
 									// XXX: incorrect for PIE binaries
 									filepath = file? strstr (file, "://"): NULL;
-									filepath = filepath? filepath+3: pfile;
+									filepath = filepath ? filepath + 3 : pfile;
 								}
 								if (r.file && r.file->desc && r.file->desc->name)
 									filepath = r.file->desc->name;
@@ -622,7 +622,7 @@ int main(int argc, char **argv, char **envp) {
 								}
 							}
 						} else {
-							if (run_anal<0) {
+							if (run_anal < 0) {
 								// PoC -- must move -rk functionalitiy into rcore
 								// this may be used with caution (r2 -nn $FILE)
 								r_core_cmdf (&r, ".!rabin2 -rk '' '%s'", r.file->desc->name);
@@ -646,18 +646,18 @@ int main(int argc, char **argv, char **envp) {
 			if (pfile && *pfile) {
 				if (perms & R_IO_WRITE)
 					eprintf ("Cannot open '%s' for writing.\n", pfile);
-				else	eprintf ("Cannot open '%s'\n", pfile);
-			} else	eprintf ("Missing file to open\n");
+				else eprintf ("Cannot open '%s'\n", pfile);
+			} else eprintf ("Missing file to open\n");
 			return 1;
 		}
 		if (r.file == NULL) // no given file
 			return 1;
 #if USE_THREADS
-		if (run_anal>0 && threaded) {
+		if (run_anal > 0 && threaded) {
 			// XXX: if no rabin2 in path that may fail
 			// TODO: pass -B 0 ? for pie bins?
 			rabin_cmd = r_str_newf ("rabin2 -rSIeMzisR%s %s",
-					(debug||r.io->va)?"":"p", r.file->desc->name);
+					(debug || r.io->va) ? "" : "p", r.file->desc->name);
 			/* TODO: only load data if no project is used */
 			lock = r_th_lock_new ();
 			rabin_th = r_th_new (&rabin_delegate, lock, 0);
@@ -763,16 +763,16 @@ int main(int argc, char **argv, char **envp) {
 	}
 	/* run -i flags */
 	cmdfile[cmdfilei] = 0;
-	for (i=0; i<cmdfilei; i++) {
+	for (i = 0; i < cmdfilei; i++) {
 		if (!r_file_exists (cmdfile[i])) {
 			eprintf ("Script '%s' not found.\n", cmdfile[i]);
 			return 1;
 		}
 		ret = r_core_run_script (&r, cmdfile[i]);
 		//ret = r_core_cmd_file (&r, cmdfile[i]);
-		if (ret ==-2)
+		if (ret == -2)
 			eprintf ("Cannot open '%s'\n", cmdfile[i]);
-		if (ret<0 || (ret==0 && quiet))
+		if (ret < 0 || (ret == 0 && quiet))
 			return 0;
 	}
 /////
@@ -815,13 +815,13 @@ int main(int argc, char **argv, char **envp) {
 #if USE_THREADS
 			do {
 				int err = r_core_prompt (&r, false);
-				if (err<1) {
+				if (err < 1) {
 					// handle ^D
 					break;
 				}
 				if (lock) r_th_lock_enter (lock);
 				/* -1 means invalid command, -2 means quit prompt loop */
-				if ((ret = r_core_prompt_exec (&r))==-2)
+				if ((ret = r_core_prompt_exec (&r)) == -2)
 					break;
 				if (lock) r_th_lock_leave (lock);
 				if (rabin_th && !r_th_wait_async (rabin_th)) {

--- a/binr/radiff2/radiff2.c
+++ b/binr/radiff2/radiff2.c
@@ -59,18 +59,18 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 		}
 		if (op->a_len == op->b_len) {
 			printf ("wx ");
-			for (i=0; i<op->b_len; i++)
+			for (i = 0; i < op->b_len; i++)
 				printf ("%02x", op->b_buf[i]);
 			printf (" @ 0x%08"PFMT64x"\n", op->b_off);
 		} else {
-			if ((op->a_len)>0)
+			if ((op->a_len) > 0)
 				printf ("r-%d @ 0x%08"PFMT64x"\n",
-					op->a_len, op->a_off+delta);
+					op->a_len, op->a_off + delta);
 			if (op->b_len> 0) {
 				printf ("r+%d @ 0x%08"PFMT64x"\n",
-					op->b_len, op->b_off+delta);
+					op->b_len, op->b_off + delta);
 				printf ("wx ");
-				for (i=0; i<op->b_len; i++)
+				for (i = 0; i < op->b_len; i++)
 					printf ("%02x", op->b_buf[i]);
 				printf (" @ 0x%08"PFMT64x"\n", op->b_off+delta);
 			}
@@ -86,10 +86,10 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 		json_started = 1;
 		printf ("{\"offset\":%"PFMT64d",", op->a_off);
 		printf("\"from\":\"");
-		for (i = 0;i<op->a_len;i++)
+		for (i = 0; i < op->a_len; i++)
 			printf ("%02x", op->a_buf[i]);
 		printf ("\", \"to\":\"");
-		for (i=0; i<op->b_len; i++)
+		for (i = 0; i < op->b_len; i++)
 			printf ("%02x", op->b_buf[i]);
 		printf ("\"}"); //,\n");
 		return 1;
@@ -128,7 +128,7 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 			}
 		} else {
 			printf (" => ");
-			for (i=0; i < op->b_len; i++)
+			for (i = 0; i < op->b_len; i++)
 				printf ("%02x", op->b_buf[i]);
 			printf (" 0x%08"PFMT64x"\n", op->b_off);
 		}
@@ -174,19 +174,19 @@ static void dump_cols (ut8 *a, int as, ut8 *b, int bs, int w) {
 		eprintf ("Invalid column width\n");
 		return ;
 	}
-	for (i=0; i<sz; i+=w) {
-		printf ("0x%08x%c ", i, (memcmp (a+i, b+i, 8))? ' ': '!');
-		for (j=0; j<w; j++)
-			printf ("%02x", a[i+j]);
+	for (i = 0; i < sz; i += w) {
+		printf ("0x%08x%c ", i, (memcmp (a + i, b + i, 8)) ? ' ' : '!');
+		for (j = 0; j < w; j++)
+			printf ("%02x", a[i + j]);
 		printf (" ");
-		for (j=0; j<w; j++)
-                	printf ("%c", IS_PRINTABLE (a[i+j])?a[i+j]:'.');
+		for (j = 0; j < w; j++)
+			printf ("%c", IS_PRINTABLE (a[i + j]) ? a[i + j] : '.');
 		printf ("   ");
-		for (j=0; j<w; j++)
-			printf ("%02x", b[i+j]);
+		for (j = 0; j < w; j++)
+			printf ("%02x", b[i + j]);
 		printf (" ");
-		for (j=0; j<w; j++)
-                	printf ("%c", IS_PRINTABLE (b[i+j])? b[i+j]:'.');
+		for (j = 0; j < w; j++)
+			printf ("%c", IS_PRINTABLE (b[i + j]) ? b[i + j] : '.');
 		printf ("\n");
 	}
 	if (as != bs)
@@ -197,7 +197,7 @@ static void handle_sha256 (const ut8 *block, int len) {
 	int i = 0;
 	RHash *ctx = r_hash_new (true, R_HASH_SHA256);
 	const ut8 *c = r_hash_do_sha256 (ctx, block, len);
-	for (i=0; i<R_HASH_SIZE_SHA256; i++) printf ("%02x", c[i]);
+	for (i = 0; i < R_HASH_SIZE_SHA256; i++) printf ("%02x", c[i]);
 	r_hash_free (ctx);
 }
 
@@ -273,17 +273,17 @@ int main(int argc, char **argv) {
 		}
 	}
 	
-	if (argc<3 || optind+2>argc)
+	if (argc < 3 || optind + 2 > argc)
 		return show_help (0);
 
-	if (optind<argc) {
+	if (optind < argc) {
 		file = argv[optind];
 	} else {
 		file = NULL;
 	}
 	
-	if (optind+1<argc) {
-		file2 = argv[optind+1];
+	if (optind + 1 < argc) {
+		file2 = argv[optind + 1];
 	} else {
 		file2 = NULL;
 	}
@@ -311,7 +311,7 @@ int main(int argc, char **argv) {
 		r_anal_diff_setup_i (c->anal, diffops, threshold, threshold);
 		r_anal_diff_setup_i (c2->anal, diffops, threshold, threshold);
 		if (mode == MODE_GRAPH) {
-			char *words = strdup (addr? addr: "0");
+			char *words = strdup (addr ? addr : "0");
 			char *second = strstr (words, ",");
 			if (second) {
 				ut64 off;
@@ -324,8 +324,10 @@ int main(int argc, char **argv) {
 				r_core_gdiff (c, c2, false); // compute the diff
 				r_core_anal_graph (c, off, R_CORE_ANAL_GRAPHBODY | R_CORE_ANAL_GRAPHDIFF);
 			} else {
-				r_core_anal_fcn (c, r_num_math (c->num, words), UT64_MAX, R_ANAL_REF_TYPE_NULL, 0);
-				r_core_anal_fcn (c2, r_num_math (c2->num, words), UT64_MAX, R_ANAL_REF_TYPE_NULL, 0);
+				r_core_anal_fcn (c, r_num_math (c->num, words),
+						UT64_MAX, R_ANAL_REF_TYPE_NULL, 0);
+				r_core_anal_fcn (c2, r_num_math (c2->num, words),
+						UT64_MAX, R_ANAL_REF_TYPE_NULL, 0);
 				r_core_gdiff (c, c2, gdiff_mode);
 				r_core_anal_graph (c, r_num_math (c->num, addr),
 					R_CORE_ANAL_GRAPHBODY | R_CORE_ANAL_GRAPHDIFF);
@@ -354,7 +356,7 @@ int main(int argc, char **argv) {
 	switch (mode) {
 	case MODE_COLS:
 		{
-			int cols = (r_cons_get_size (NULL)>112)?16:8;
+			int cols = (r_cons_get_size (NULL) > 112) ? 16 : 8;
 			dump_cols (bufa, sza, bufb, szb, cols);
 		}
 		break;

--- a/binr/rafind2/rafind2.c
+++ b/binr/rafind2/rafind2.c
@@ -32,16 +32,16 @@ static struct r_print_t *pr = NULL;
 static RList *keywords;
 
 static int hit(RSearchKeyword *kw, void *user, ut64 addr) {
-	int delta = addr-cur;
+	int delta = addr - cur;
 	if (rad) {
 		printf ("f hit%d_%d 0x%08"PFMT64x" ; %s\n", 0, kw->count, addr, curfile);
 	} else {
 		if (showstr) {
-			printf ("0x%"PFMT64x" %s\n", addr, buf+delta);
+			printf ("0x%"PFMT64x" %s\n", addr, buf + delta);
 		} else {
 			printf ("0x%"PFMT64x"\n", addr);
 			if (pr) {
-				r_print_hexdump (pr, addr, (ut8*)buf+delta, 78, 16, true);
+				r_print_hexdump (pr, addr, (ut8*)buf + delta, 78, 16, true);
 				r_cons_flush ();
 			}
 		}
@@ -135,8 +135,8 @@ static int rafind_open(char *file) {
 	r_io_seek (io, from, R_IO_SEEK_SET);
 	//printf("; %s 0x%08"PFMT64x"-0x%08"PFMT64x"\n", file, from, to);
 	for (cur = from; !last && cur < to; cur += bsize) {
-		if ((cur+bsize)>to) {
-			bsize = to-cur;
+		if ((cur + bsize) > to) {
+			bsize = to - cur;
 			last = true;
 		}
 		ret = r_io_pread (io, cur, buf, bsize);
@@ -228,13 +228,15 @@ int main(int argc, char **argv) {
 		case 'Z':
 			showstr = 1;
 			break;
+		default:
+			return show_help (argv[0], 1);
 		}
 	}
 
 	if (optind == argc)
 		return show_help (argv[0], 1);
 
-	for (;optind < argc;optind++)
+	for (; optind < argc; optind++)
 		rafind_open (argv[optind]);
 
 	return 0;

--- a/binr/ragg2/ragg2.c
+++ b/binr/ragg2/ragg2.c
@@ -82,7 +82,7 @@ static int create (const char *format, const char *arch, int bits, const ut8 *co
 }
 
 static int openfile (const char *f, int x) {
-	int fd = open (f, O_RDWR|O_CREAT, 0644);
+	int fd = open (f, O_RDWR | O_CREAT, 0644);
 	if (fd == -1) {
 		fd = open (f, O_RDWR);
 		if (fd == -1) return -1;
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
 	char *shellcode = NULL;
 	char *encoder = NULL;
 	char *sequence = NULL;
-	int bits = (R_SYS_BITS & R_SYS_BITS_64)? 64: 32;
+	int bits = (R_SYS_BITS & R_SYS_BITS_64) ? 64 : 32;
 	int fmt = 0;
 	const char *ofile = NULL;
 	int ofileauto = 0;
@@ -154,9 +154,9 @@ int main(int argc, char **argv) {
 					ut8 *b;
 					*p++ = 0;
 					off = r_num_math (NULL, arg);
-					b = malloc (strlen (optarg)+1);
+					b = malloc (strlen (optarg) + 1);
 					len = r_hex_str2bin (p, b);
-					if (len>0) r_egg_patch (egg, off, (const ut8*)b, len);
+					if (len > 0) r_egg_patch (egg, off, (const ut8*)b, len);
 					else eprintf ("Invalid hexstr for -w\n");
 					free (b);
 				} else eprintf ("Missing colon in -w\n");
@@ -180,7 +180,7 @@ int main(int argc, char **argv) {
 			if (p) {
 				*p = 0;
 				off = r_num_math (NULL, optarg);
-				n = r_num_math (NULL, p+1);
+				n = r_num_math (NULL, p + 1);
 				*p = ':';
 				// TODO: honor endianness here
 				r_egg_patch (egg, off, (const ut8*)&n, 4);
@@ -192,7 +192,7 @@ int main(int argc, char **argv) {
 			char *p = strchr (optarg, ':');
 			if (p) {
 				ut64 n, off = r_num_math (NULL, optarg);
-				n = r_num_math (NULL, p+1);
+				n = r_num_math (NULL, p + 1);
 				// TODO: honor endianness here
 				r_egg_patch (egg, off, (const ut8*)&n, 8);
 			} else eprintf ("Missing colon in -d\n");
@@ -220,8 +220,8 @@ int main(int argc, char **argv) {
 			{
 			char *p = strchr (optarg, '=');
 			if (p) {
-				*p=0;
-				r_egg_option_set (egg, optarg, p+1);
+				*p = 0;
+				r_egg_option_set (egg, optarg, p + 1);
 			} else r_egg_option_set (egg, optarg, "true");
 			}
 			break;
@@ -301,7 +301,7 @@ int main(int argc, char **argv) {
 		if (!strcmp (file, "-")) {
 			char buf[1024];
 			for (;;) {
-				fgets (buf, sizeof (buf)-1, stdin);
+				fgets (buf, sizeof (buf) - 1, stdin);
 				if (feof (stdin)) break;
 				r_egg_load (egg, buf, 0);
 			}
@@ -328,7 +328,7 @@ int main(int argc, char **argv) {
 	if (contents) {
 		int l;
 		char *buf = r_file_slurp (contents, &l);
-		if (buf && l>0) {
+		if (buf && l > 0) {
 			r_egg_raw (egg, (const ut8*)buf, l);
 		} else eprintf ("Error loading '%s'\n", contents);
 		free (buf);
@@ -344,9 +344,9 @@ int main(int argc, char **argv) {
 
 	// add raw bytes
 	if (bytes) {
-		ut8 *b = malloc (strlen (bytes)+1);
+		ut8 *b = malloc (strlen (bytes) + 1);
 		int len = r_hex_str2bin (bytes, b);
-		if (len>0) {
+		if (len > 0) {
 			if (!r_egg_raw (egg, b, len)) {
 				eprintf ("Unknown '%s'\n", shellcode);
 				return 1;
@@ -363,7 +363,7 @@ int main(int argc, char **argv) {
 		if (file) {
 			char *o, *q, *p = strdup (file);
 			if ( (o = strchr (p, '.')) ) {
-				while ( (q = strchr (o+1, '.')) )
+				while ( (q = strchr (o + 1, '.')) )
 					o = q;
 				*o = 0;
 				fd = openfile (p, ISEXEC);
@@ -428,11 +428,11 @@ int main(int argc, char **argv) {
 			case 'r':
 				if (show_str) {
 					printf ("\"");
-					for (i=0; i<b->length; i++)
+					for (i = 0; i < b->length; i++)
 						printf ("\\x%02x", b->buf[i]);
 					printf ("\"\n");
 				} else if (show_hex) {
-					for (i=0; i<b->length; i++)
+					for (i = 0; i < b->length; i++)
 						printf ("%02x", b->buf[i]);
 					printf ("\n");
 				} // else show_raw is_above()

--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -35,7 +35,7 @@ static void do_hash_seed(const char *seed) {
 		return;
 	}
 	_s = &s;
-	s.buf = (ut8*)malloc (strlen (seed)+128);
+	s.buf = (ut8*)malloc (strlen (seed) + 128);
 	if (!s.buf) {
 		_s = NULL;
 		return;
@@ -45,11 +45,11 @@ static void do_hash_seed(const char *seed) {
 		sptr++;
 	} else s.prefix = 0;
 	if (!strncmp (sptr, "s:", 2)) {
-		strcpy ((char*)s.buf, sptr+2);
-		s.len = strlen (sptr+2);
+		strcpy ((char*)s.buf, sptr + 2);
+		s.len = strlen (sptr + 2);
 	} else {
 		s.len = r_hex_str2bin (sptr, s.buf);
-		if (s.len<1) {
+		if (s.len < 1) {
 			strcpy ((char*)s.buf, sptr);
 			s.len = strlen (sptr);
 		}
@@ -59,10 +59,10 @@ static void do_hash_seed(const char *seed) {
 static void do_hash_hexprint (const ut8 *c, int len, int ule, int rad) {
 	int i;
 	if (ule) {
-		for (i=len-1; i>=0; i--)
+		for (i = len - 1; i >= 0; i--)
 			printf ("%02x", c[i]);
 	} else {
-		for (i=0; i<len; i++)
+		for (i = 0; i < len; i++)
 			printf ("%02x", c[i]);
 	}
 	if (rad != 'j')
@@ -77,7 +77,7 @@ static void do_hash_print(RHash *ctx, int hash, int dlen, int rad, int ule) {
 	case 0:
 		if (!quiet)
 			printf ("0x%08"PFMT64x"-0x%08"PFMT64x" %s: ",
-				from, to>0?to-1:0, hname);
+				from, to > 0 ? to - 1 : 0, hname);
 		do_hash_hexprint (c, dlen, ule, rad);
 		break;
 	case 1:
@@ -99,7 +99,7 @@ static void do_hash_print(RHash *ctx, int hash, int dlen, int rad, int ule) {
 
 static int do_hash_internal(RHash *ctx, int hash, const ut8 *buf, int len, int rad, int print, int le) {
 	int dlen;
-	if (len<0)
+	if (len < 0)
 		return 0;
 	dlen = r_hash_calculate (ctx, hash, buf, len);
 	if (!dlen) return 0;
@@ -110,12 +110,12 @@ static int do_hash_internal(RHash *ctx, int hash, const ut8 *buf, int len, int r
 			eprintf ("entropy: %10f\n", e);
 		} else {
 			printf ("0x%08"PFMT64x"-0x%08"PFMT64x" %10f: ",
-					from, to>0?to-1:0, e);
+					from, to > 0 ? to - 1 : 0, e);
 			r_print_progressbar (NULL, 12.5 * e, 60);
 			printf ("\n");
 		}
 	} else {
-		if (iterations>0)
+		if (iterations > 0)
 			r_hash_do_spice (ctx, hash, iterations, _s);
 		do_hash_print (ctx, hash, dlen, rad, le);
 	}
@@ -133,14 +133,14 @@ static int do_hash(const char *file, const char *algo, RIO *io, int bsize, int r
 		return 1;
 	}
 	fsize = r_io_size (io);
-	if (fsize <1) {
+	if (fsize < 1) {
 		eprintf ("rahash2: Invalid file size\n");
 		return 1;
 	}
-	if (bsize<0) bsize = fsize / -bsize;
+	if (bsize < 0) bsize = fsize / -bsize;
 	if (bsize == 0 || bsize > fsize) bsize = fsize;
 	if (to == 0LL) to = fsize;
-	if (from>to) {
+	if (from > to) {
 		eprintf ("rahash2: Invalid -f -t range\n");
 		return 1;
 	}
@@ -148,7 +148,7 @@ static int do_hash(const char *file, const char *algo, RIO *io, int bsize, int r
 		eprintf ("rahash2: Unknown file size\n");
 		return 1;
 	}
-	buf = malloc (bsize+1);
+	buf = malloc (bsize + 1);
 	if (!buf)
 		return 1;
 	ctx = r_hash_new (R_TRUE, algobit);
@@ -156,7 +156,7 @@ static int do_hash(const char *file, const char *algo, RIO *io, int bsize, int r
 	if (rad == 'j')
 		printf ("[");
 	if (incremental) {
-		for (i=1; i<0x800000; i<<=1) {
+		for (i = 1; i < 0x800000; i <<= 1) {
 			if (algobit & i) {
 				int hashbit = i & algobit;
 				int dlen = r_hash_size (hashbit);
@@ -172,8 +172,8 @@ static int do_hash(const char *file, const char *algo, RIO *io, int bsize, int r
 					do_hash_internal (ctx,
 						hashbit, s.buf, s.len, rad, 0, ule);
 				}
-				for (j=from; j<to; j+=bsize) {
-					int len = ((j+bsize)>to)? (to-j): bsize;
+				for (j = from; j < to; j+= bsize) {
+					int len = ((j + bsize) > to) ? (to - j) : bsize;
 					r_io_pread (io, j, buf, len);
 					do_hash_internal (ctx, hashbit, buf,
 						len, rad, 0, ule);
@@ -183,7 +183,7 @@ static int do_hash(const char *file, const char *algo, RIO *io, int bsize, int r
 						s.len, rad, 0, ule);
 				}
 				r_hash_do_end (ctx, i);
-				if (iterations>0)
+				if (iterations > 0)
 					r_hash_do_spice (ctx, i, iterations, _s);
 				if (!*r_hash_name (i))
 					continue;
@@ -198,7 +198,7 @@ static int do_hash(const char *file, const char *algo, RIO *io, int bsize, int r
 		/* iterate over all algorithm bits */
 		if (s.buf)
 			eprintf ("Warning: Seed ignored on per-block hashing.\n");
-		for (i=1; i<0x800000; i<<=1) {
+		for (i = 1; i < 0x800000; i <<= 1) {
 			ut64 f, t, ofrom, oto;
 			if (algobit & i) {
 				int hashbit = i & algobit;
@@ -206,12 +206,12 @@ static int do_hash(const char *file, const char *algo, RIO *io, int bsize, int r
 				oto = to;
 				f = from;
 				t = to;
-				for (j=f; j<t; j+=bsize) {
-					int nsize = (j+bsize<fsize)? bsize: (fsize-j);
+				for (j = f; j < t; j += bsize) {
+					int nsize = (j + bsize < fsize) ? bsize : (fsize - j);
 					r_io_pread (io, j, buf, bsize);
 					from = j;
-					to = j+bsize;
-					if (to>fsize)
+					to = j + bsize;
+					if (to > fsize)
 						to = fsize;
 					do_hash_internal (ctx, hashbit, buf, nsize, rad, 1, ule);
 				}
@@ -256,10 +256,10 @@ static int do_help(int line) {
 static void algolist() {
 	ut64 bits;
 	int i;
-	for (i=0; ; i++) {
-		bits = ((ut64)1)<<i;
+	for (i = 0; ; i++) {
+		bits = ((ut64)1) << i;
 		const char *name = r_hash_name (bits);
-		if (!name||!*name) break;
+		if (!name || !*name) break;
 		printf ("%s\n", name);
 	}
 }
@@ -294,9 +294,8 @@ int main(int argc, char **argv) {
 		switch (c) {
 		case 'q': quiet = 1; break;
 		case 'i':
-			if (!optarg) return 1;
 			iterations = atoi (optarg);
-			if (iterations<0) {
+			if (iterations < 0) {
 				eprintf ("error: -i argument must be positive\n");
 				return 1;
 			}
@@ -314,13 +313,13 @@ int main(int argc, char **argv) {
 		case 'B': incremental = 0; break;
 		case 'b': bsize = (int)r_num_math (NULL, optarg); break;
 		case 'f': from = r_num_math (NULL, optarg); break;
-		case 't': to = 1+r_num_math (NULL, optarg); break;
+		case 't': to = 1 + r_num_math (NULL, optarg); break;
 		case 'v': return blob_version ("rahash2");
 		case 'h': return do_help (0);
 		case 's': setHashString (optarg, 0); break;
 		case 'x': setHashString (optarg, 1); break;
 		case 'c': compareStr = optarg; break;
-		default: eprintf ("rahash2: Unknown flag\n"); return 1;
+		default: return do_help(0);
 		}
 	}
 	if (compareStr) {
@@ -357,11 +356,11 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 	}
-	if ((st64)from>=0 && (st64)to<0) {
+	if ((st64)from >= 0 && (st64)to < 0) {
 		to = 0; // end of file
 	}
 	if (from || to) {
-		if (to && from>=to) {
+		if (to && from >= to) {
 			eprintf ("Invalid -f or -t offsets\n");
 			return 1;
 		}
@@ -375,15 +374,15 @@ int main(int argc, char **argv) {
 			hashstr = malloc (INSIZE);
 			if (!hashstr)
 				return 1;
-			res = fread ((void*)hashstr, 1, INSIZE-1, stdin);
-			if (res<1) res = 0;
+			res = fread ((void*)hashstr, 1, INSIZE - 1, stdin);
+			if (res < 1) res = 0;
 			hashstr[res] = '\0';
 			hashstr_len = res;
 		}
 		if (hashstr_hex) {
-			ut8 *out = malloc ((strlen (hashstr)+1)*2);
+			ut8 *out = malloc ((strlen (hashstr) + 1) * 2);
 			hashstr_len = r_hex_str2bin (hashstr, out);
-			if (hashstr_len<1) {
+			if (hashstr_len < 1) {
 				eprintf ("Invalid hex string\n");
 				free (out);
 				return 1;
@@ -414,7 +413,7 @@ int main(int argc, char **argv) {
 		switch (b64mode) {
 		case 1: // encode
 			{
-			char *out = malloc (((hashstr_len+1)*4)/3);
+			char *out = malloc (((hashstr_len + 1) * 4) / 3);
 			if (out) {
 				r_base64_encode (out, (const ut8*)hashstr, hashstr_len);
 				printf ("%s\n", out);
@@ -452,7 +451,7 @@ int main(int argc, char **argv) {
 					str[strsz] = 0;
 				}
 				algobit = r_hash_name_to_bits (algo);
-				for (i=1; i<0x800000; i<<=1) {
+				for (i = 1; i < 0x800000; i <<= 1) {
 					if (algobit & i) {
 						int hashbit = i & algobit;
 						ctx = r_hash_new (R_TRUE, hashbit);
@@ -473,17 +472,17 @@ int main(int argc, char **argv) {
 		}
 		return ret;
 	}
-	if (optind>=argc)
+	if (optind >= argc)
 		return do_help (1);
 	if (numblocks) {
 		bsize = -bsize;
-	} else if (bsize<0) {
+	} else if (bsize < 0) {
 		eprintf ("rahash2: Invalid block size\n");
 		return 1;
 	}
 
 	io = r_io_new ();
-	for (ret=0, i=optind; i<argc; i++) {
+	for (ret = 0, i = optind; i < argc; i++) {
 		switch (b64mode) {
 		case 1: // encode
 			{
@@ -494,7 +493,7 @@ int main(int argc, char **argv) {
 				eprintf ("Cannot open file\n");
 				continue;
 			}
-			out = malloc (((binlen+1)*4)/3);
+			out = malloc (((binlen + 1) * 4) / 3);
 			if (out) {
 				r_base64_encode (out, bin, binlen);
 				printf ("%s\n", out);
@@ -512,7 +511,7 @@ int main(int argc, char **argv) {
 				eprintf ("Cannot open file\n");
 				continue;
 			}
-			out = malloc (binlen+1);
+			out = malloc (binlen + 1);
 			if (out) {
 				outlen = r_base64_decode (out, (const char*)bin, binlen);
 				write (1, out, outlen);
@@ -526,7 +525,7 @@ int main(int argc, char **argv) {
 				int sz = 0;
 				ut8 *buf = (ut8*)r_stdin_slurp (&sz);
 				char *uri = r_str_newf ("malloc://%d", sz);
-				if (sz>0) {
+				if (sz > 0) {
 					if (!r_io_open_nomap (io, uri, 0, 0)) {
 						eprintf ("rahash2: Cannot open malloc://1024\n");
 						return 1;

--- a/binr/rarun2/rarun2.c
+++ b/binr/rarun2/rarun2.c
@@ -7,7 +7,7 @@ int main(int argc, char **argv) {
 	char *file;
 	RRunProfile *p;
 	int i, ret;
-	if (argc==1 || !strcmp (argv[1], "-h")) {
+	if (argc == 1 || !strcmp (argv[1], "-h")) {
 		eprintf ("Usage: rarun2 [-v] [script.rr2] [directive ..]\n");
 		printf ("%s", r_run_help ());
 		return 1;
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
 		p = r_run_new (file);
 	} else {
 		p = r_run_new (NULL);
-		for (i = *file?1:2; i<argc; i++)
+		for (i = *file ? 1 : 2; i < argc; i++)
 			r_run_parseline (p, argv[i]);
 	}
 	if (!p) return 1;

--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -64,17 +64,17 @@ static void rasm2_list(RAsm *a, const char *arch) {
 			if (h->cpus && !strcmp (arch, h->name)) {
 				char *c = strdup (h->cpus);
 				int n = r_str_split (c, ',');
-				for (i=0;i<n;i++)
+				for (i = 0; i < n; i++)
 					printf ("%s\n", r_str_word_get0 (c, i));
 				free (c);
 				break;
 			}
 		} else {
 			bits[0] = 0;
-			if (h->bits&8) strcat (bits, "8 ");
-			if (h->bits&16) strcat (bits, "16 ");
-			if (h->bits&32) strcat (bits, "32 ");
-			if (h->bits&64) strcat (bits, "64 ");
+			if (h->bits & 8) strcat (bits, "8 ");
+			if (h->bits & 16) strcat (bits, "16 ");
+			if (h->bits & 32) strcat (bits, "32 ");
+			if (h->bits & 64) strcat (bits, "64 ");
 			feat = "__";
 			if (h->assemble && h->disassemble)  feat = "ad";
 			if (h->assemble && !h->disassemble) feat = "a_";
@@ -82,19 +82,19 @@ static void rasm2_list(RAsm *a, const char *arch) {
 			feat2 = has_esil (anal, h->name);
 			printf ("%s%s  %-9s  %-11s %-7s %s\n",
 				feat, feat2, bits, h->name,
-				h->license?h->license:"unknown", h->desc);
+				h->license ? h->license : "unknown", h->desc);
 		}
 	}
 }
  // TODO: move into libr/anal/stack.c ?
 
 static char *stackop2str(int type) {
-        switch (type) {
-	case R_ANAL_STACK_NULL:     return strdup ("null");
-	case R_ANAL_STACK_NOP:      return strdup ("nop");
+	switch (type) {
+	case R_ANAL_STACK_NULL: return strdup ("null");
+	case R_ANAL_STACK_NOP: return strdup ("nop");
 	//case R_ANAL_STACK_INCSTACK: return strdup ("incstack");
-	case R_ANAL_STACK_GET:      return strdup ("get");
-	case R_ANAL_STACK_SET:      return strdup ("set");
+	case R_ANAL_STACK_GET: return strdup ("get");
+	case R_ANAL_STACK_SET: return strdup ("set");
         }
         return strdup ("unknown");
 }
@@ -174,7 +174,7 @@ static int rasm_disasm(char *buf, ut64 offset, int len, int bits, int ascii, int
 		len /= 8;
 
 	if (bin) {
-		if (len<0) return false;
+		if (len < 0) return false;
 		clen = len; // XXX
 		data = (ut8*)buf;
 	} else if (ascii) {
@@ -199,7 +199,7 @@ static int rasm_disasm(char *buf, ut64 offset, int len, int bits, int ascii, int
 			if (r_anal_op (anal, &aop, offset, data + ret, len - ret) > 0) {
 				printf ("%s\n", R_STRBUF_SAFEGET (&aop.esil));
 			}
-			if (aop.size<1) {
+			if (aop.size < 1) {
 				eprintf ("Invalid\n");
 				break;
 			}
@@ -211,7 +211,7 @@ static int rasm_disasm(char *buf, ut64 offset, int len, int bits, int ascii, int
 		r_asm_set_pc (a, offset);
 		while ((len - ret) > 0) {
 			int dr = r_asm_disassemble (a, &op, data+ret, len-ret);
-			if (dr == -1 || op.size<1) {
+			if (dr == -1 || op.size < 1) {
 				op.size = 1;
 				strcpy (op.buf_asm, "invalid");
 				sprintf (op.buf_hex, "%02x", data[ret]);
@@ -238,10 +238,10 @@ static void print_buf(char *str) {
 	int i;
 	if (coutput) {
 		printf ("\"");
-		for (i=1; *str; str+=2, i+=2) {
-			if (!(i%41)) {
+		for (i = 1; *str; str += 2, i += 2) {
+			if (!(i % 41)) {
 				printf ("\" \\\n\"");
-				i=1;
+				i = 1;
 			}
 			printf ("\\x%c%c", *str, str[1]);
 		}
@@ -262,11 +262,11 @@ static int rasm_asm(const char *buf, ut64 offset, ut64 len, int bits, int bin) {
 			write (1, acode->buf, acode->len);
 		} else {
 			int b = acode->len;
-			if (bits==1) {
-				int bytes = (b/8)+1;
-				for (i=0; i<bytes; i++)
-					for (j=0; j<8 && b--; j++)
-						printf ("%c", (acode->buf[i] & (1<<j))?'1':'0');
+			if (bits == 1) {
+				int bytes = (b / 8) + 1;
+				for (i = 0; i < bytes; i++)
+					for (j = 0; j < 8 && b--; j++)
+						printf ("%c", (acode->buf[i] & (1 << j)) ? '1' : '0');
 				printf ("\n");
 			} else print_buf (acode->buf_hex);
 		}
@@ -298,11 +298,11 @@ int main(int argc, char *argv[]) {
 	unsigned char buf[R_ASM_BUFSIZE];
 	char *arch = NULL, *file = NULL, *filters = NULL, *kernel = NULL, *cpu = NULL, *tmp;
 	ut64 offset = 0;
-	int fd =-1, dis = 0, ascii = 0, bin = 0, ret = 0, bits = 32, c, whatsop = 0;
+	int fd = -1, dis = 0, ascii = 0, bin = 0, ret = 0, bits = 32, c, whatsop = 0;
 	ut64 len = 0, idx = 0, skip = 0;
 	bool analinfo = false;
 
-	if (argc<2)
+	if (argc < 2)
 		return rasm_show_help (0);
 
 	a = r_asm_new ();
@@ -415,6 +415,9 @@ int main(int argc, char *argv[]) {
 		case 'w':
 			whatsop = true;
 			break;
+		default:
+			ret = rasm_show_help (0);
+			goto beach;
 		}
 	}
 
@@ -439,8 +442,8 @@ int main(int argc, char *argv[]) {
 		goto beach;
 	}
 	r_asm_set_cpu (a, cpu);
-	r_asm_set_bits (a, (env_bits && *env_bits)? atoi (env_bits): bits);
-	r_anal_set_bits (anal, (env_bits && *env_bits)? atoi (env_bits): bits);
+	r_asm_set_bits (a, (env_bits && *env_bits) ? atoi (env_bits) : bits);
+	r_anal_set_bits (anal, (env_bits && *env_bits) ? atoi (env_bits) : bits);
 	a->syscall = r_syscall_new ();
 	r_syscall_setup (a->syscall, arch, kernel, bits);
 
@@ -459,7 +462,7 @@ int main(int argc, char *argv[]) {
 		if (p) {
 			*p = 0;
 			if (*filters) r_asm_filter_input (a, filters);
-			if (p[1]) r_asm_filter_output (a, p+1);
+			if (p[1]) r_asm_filter_output (a, p + 1);
 			*p = ':';
 		} else {
 			if (dis) r_asm_filter_output (a, filters);
@@ -471,16 +474,16 @@ int main(int argc, char *argv[]) {
 		char *content;
 		int length = 0;
 		if (!strcmp (file, "-")) {
-			ret = read (0, buf, sizeof (buf)-1);
+			ret = read (0, buf, sizeof (buf) - 1);
 			if (ret == R_ASM_BUFSIZE)
 				eprintf ("rasm2: Cannot slurp all stdin data\n");
 			if (ret >= 0) // only for text
 				buf[ret] = '\0';
 			len = ret;
 			if (dis) {
-				if (skip && length>skip) {
+				if (skip && length > skip) {
 					if (bin) {
-						memmove (buf, buf+skip, length-skip);
+						memmove (buf, buf + skip, length - skip);
 						length -= skip;
 					}
 				}
@@ -494,12 +497,12 @@ int main(int argc, char *argv[]) {
 		} else {
 			content = r_file_slurp (file, &length);
 			if (content) {
-				if (len && len>0 && len<length)
+				if (len && len > 0 && len < length)
 					length = len;
 				content[length] = '\0';
-				if (skip && length>skip) {
+				if (skip && length > skip) {
 					if (bin) {
-						memmove (content, content+skip, length-skip);
+						memmove (content, content + skip, length - skip);
 						length -= skip;
 					}
 				}
@@ -522,23 +525,23 @@ int main(int argc, char *argv[]) {
 		if (!strcmp (argv[optind], "-")) {
 			int length;
 			do {
-				length = read (0, buf, sizeof (buf)-1);
-				if (length<1) break;
-				if (len>0 && len < length)
+				length = read (0, buf, sizeof (buf) - 1);
+				if (length < 1) break;
+				if (len > 0 && len < length)
 					length = len;
 				buf[length] = 0;
 				if ((!bin || !dis) && feof (stdin))
 					break;
-				if (skip && length>skip) {
+				if (skip && length > skip) {
 					if (bin) {
-						memmove (buf, buf+skip, length-skip+1);
+						memmove (buf, buf + skip, length - skip + 1);
 						length -= skip;
 					}
 				}
 				if (!bin || !dis) {
 					int buflen = strlen ((const char *)buf);
-					if (buf[buflen]=='\n')
-						buf[buflen-1]='\0';
+					if (buf[buflen] == '\n')
+						buf[buflen - 1]='\0';
 				}
 				if (dis) {
 					ret = rasm_disasm ((char *)buf, offset, length, a->bits, ascii, bin, dis - 1);
@@ -548,17 +551,17 @@ int main(int argc, char *argv[]) {
 				idx += ret;
 				offset += ret;
 				if (!ret) goto beach;
-			} while (!len || idx<length);
+			} while (!len || idx < length);
 			ret = idx;
 			goto beach;
 		}
 		if (dis) {
 			char *buf = argv[optind];
 			len = strlen (buf);
-			if (skip && len>skip) {
+			if (skip && len > skip) {
 				skip *= 2;
 				//eprintf ("SKIP (%s) (%lld)\n", buf, skip);
-				memmove (buf, buf+skip, len-skip);
+				memmove (buf, buf + skip, len - skip);
 				len -= skip;
 				buf[len] = 0;
 			}

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -15,7 +15,7 @@ static int rax (char *str, int len, int last);
 
 static int format_output (char mode, const char *s) {
 	ut64 n = r_num_math (num, s);
-	const char *str = (char*) &n;
+	const char *str = (char*)&n;
 	char strbits[65];
 
 	if (force_mode)
@@ -23,16 +23,16 @@ static int format_output (char mode, const char *s) {
 
 	if (flags & 2) {
 		/* swap endian */
-		ut32 n2 = (n>>32)? 8:4;
-		r_mem_copyendian ((ut8*) str, (ut8*) str, n2, 0);
+		ut32 n2 = (n >> 32) ? 8 : 4;
+		r_mem_copyendian ((ut8*)str, (ut8*)str, n2, 0);
 	}
 	switch (mode) {
 	case 'I': printf ("%"PFMT64d"\n", n); break;
 	case '0': {
-		int len = strlen(s);
-		if (len > 0 && s[len-1]=='f') {
-			R_STATIC_ASSERT(sizeof(float) == 4)
-			float f = (float) num->fvalue;
+		int len = strlen (s);
+		if (len > 0 && s[len - 1] == 'f') {
+			R_STATIC_ASSERT(sizeof (float) == 4)
+			float f = (float)num->fvalue;
 			ut8 *p = (ut8*)&f;
 			printf ("Fx%02x%02x%02x%02x\n", p[3], p[2], p[1], p[0]);
 		} else printf ("0x%"PFMT64x"\n", n);
@@ -106,13 +106,13 @@ static int help () {
 static int rax (char *str, int len, int last) {
 	float f;
 	ut8 *buf;
-	char *p, out_mode = (flags & 128)? 'I': '0';
+	char *p, out_mode = (flags & 128) ? 'I' : '0';
 	int i;
 	if (!(flags & 4) || !len)
 		len = strlen (str);
 	if ((flags & 4))
 		goto dotherax;
-	if (*str=='=') {
+	if (*str == '=') {
 		switch (atoi (str+1)) {
 		case 2: force_mode = 'B'; break;
 		case 3: force_mode = 'T'; break;
@@ -123,32 +123,32 @@ static int rax (char *str, int len, int last) {
 		}
 		return true;
 	}
-	if (*str=='-') {
-		while (str[1] && str[1]!=' ') {
+	if (*str == '-') {
+		while (str[1] && str[1] != ' ') {
 			switch (str[1]) {
 			case 's': flags ^= 1; break;
-			case 'e': flags ^= 1<<1; break;
-			case 'S': flags ^= 1<<2; break;
-			case 'b': flags ^= 1<<3; break;
-			case 'x': flags ^= 1<<4; break;
-			case 'B': flags ^= 1<<5; break;
-			case 'f': flags ^= 1<<6; break;
-			case 'd': flags ^= 1<<7; break;
-			case 'k': flags ^= 1<<8; break;
-			case 'n': flags ^= 1<<9; break;
-			case 'u': flags ^= 1<<10; break;
-			case 't': flags ^= 1<<11; break;
-			case 'E': flags ^= 1<<12; break;
-			case 'D': flags ^= 1<<13; break;
-			case 'F': flags ^= 1<<14; break;
-			case 'N': flags ^= 1<<15; break;
-			case 'w': flags ^= 1<<16; break;
+			case 'e': flags ^= 1 << 1; break;
+			case 'S': flags ^= 1 << 2; break;
+			case 'b': flags ^= 1 << 3; break;
+			case 'x': flags ^= 1 << 4; break;
+			case 'B': flags ^= 1 << 5; break;
+			case 'f': flags ^= 1 << 6; break;
+			case 'd': flags ^= 1 << 7; break;
+			case 'k': flags ^= 1 << 8; break;
+			case 'n': flags ^= 1 << 9; break;
+			case 'u': flags ^= 1 << 10; break;
+			case 't': flags ^= 1 << 11; break;
+			case 'E': flags ^= 1 << 12; break;
+			case 'D': flags ^= 1 << 13; break;
+			case 'F': flags ^= 1 << 14; break;
+			case 'N': flags ^= 1 << 15; break;
+			case 'w': flags ^= 1 << 16; break;
 			case 'v': blob_version ("rax2"); return 0;
 			case '\0': return !use_stdin ();
 			default:
-				out_mode = (flags^32)? '0': 'I';
-				if (str[1]>='0' && str[1]<='9') {
-					if (str[2]=='x') out_mode = 'I';
+				out_mode = (flags ^ 32) ? '0' : 'I';
+				if (str[1] >= '0' && str[1] <= '9') {
+					if (str[2] == 'x') out_mode = 'I';
 					return format_output (out_mode, str);
 				}
 				printf ("Usage: rax2 [options] [expr ...]\n");
@@ -161,20 +161,20 @@ static int rax (char *str, int len, int last) {
 		return true;
 	}
 	if (!flags) {
-		if (*str=='q')
+		if (*str == 'q')
 			return false;
-		if (*str=='h' || *str=='?')
+		if (*str == 'h' || *str == '?')
 			return help ();
 	}
 	dotherax:
 	
 	if (flags & 1) { // -s
-		int n = ((strlen (str))>>1)+1;
+		int n = ((strlen (str)) >> 1) + 1;
 		buf = malloc (n);
 		if (buf) {
 			memset (buf, '\0', n);
 			n = r_hex_str2bin (str, (ut8*)buf);
-			if (n>0) fwrite (buf, n, 1, stdout);
+			if (n > 0) fwrite (buf, n, 1, stdout);
 #if __EMSCRIPTEN__
 			puts ("");
 #endif
@@ -184,7 +184,7 @@ static int rax (char *str, int len, int last) {
 		return true;
 	}
 	if (flags & 4) { // -S
-		for (i=0; i<len; i++)
+		for (i = 0; i < len; i++)
 			printf ("%02x", (ut8)str[i]);
 		printf ("\n");
 		return true;
@@ -192,7 +192,7 @@ static int rax (char *str, int len, int last) {
 		int i, len;
 		ut8 buf[4096];
 		len = r_str_binstr2bin (str, buf, sizeof (buf));
-		for (i=0; i<len; i++)
+		for (i = 0; i < len; i++)
 			printf ("%c", buf[i]);
 		return true;
 	} else if (flags & 16) {
@@ -204,7 +204,7 @@ static int rax (char *str, int len, int last) {
 	} else if (flags & 64) {
 		out_mode = 'f';
 	} else if (flags & 256) { // -k
-		int n = ((strlen (str))>>1)+1;
+		int n = ((strlen (str)) >> 1) + 1;
 		char *s = NULL;
 		ut32 *m;
 		buf = (ut8*) malloc (n);
@@ -226,9 +226,9 @@ static int rax (char *str, int len, int last) {
 		}
 		free (m);
 		return true;
-	} else if (flags & (1<<9)) { // -n
+	} else if (flags & (1 << 9)) { // -n
 		ut64 n = r_num_math (num, str);
-		if (n>>32) {
+		if (n >> 32) {
 			/* is 64 bit value */
 			ut8 *np = (ut8*)&n;
 			if (flags & 1) fwrite (&n, sizeof (n), 1, stdout);
@@ -237,7 +237,7 @@ static int rax (char *str, int len, int last) {
 				np[4], np[5], np[6], np[7]);
 		} else {
 			/* is 32 bit value */
-			ut32 n32 = (ut32)(n&UT32_MAX);
+			ut32 n32 = (ut32)(n & UT32_MAX);
 			ut8 *np = (ut8*)&n32;
 			if (flags & 1) fwrite (&n32, sizeof (n32), 1, stdout);
 			else printf ("%02x%02x%02x%02x\n",
@@ -245,22 +245,22 @@ static int rax (char *str, int len, int last) {
 		}
 		fflush (stdout);
 		return true;
-	} else if (flags & (1<<16)) { // -w
+	} else if (flags & (1 << 16)) { // -w
 		ut64 n = r_num_math (num, str);
 		if (n >> 31) {
 			// is >32bit
 			n = (st64)(st32)n;
-		} else if (n>>14) {
+		} else if (n >> 14) {
 			n = (st64)(st16)n;
-		} else if (n>>7) {
+		} else if (n >> 7) {
 			n = (st64)(st8)n;
 		}
 		printf ("%"PFMT64d"\n", n);
 		fflush (stdout);
 		return true;
-	} else if (flags & (1<<15)) { // -N
+	} else if (flags & (1 << 15)) { // -N
 		ut64 n = r_num_math (num, str);
-		if (n>>32) {
+		if (n >> 32) {
 			/* is 64 bit value */
 			ut8 *np = (ut8*)&n;
 			if (flags & 1) fwrite (&n, sizeof (n), 1, stdout);
@@ -303,7 +303,7 @@ static int rax (char *str, int len, int last) {
 	} else if (flags & 8192) { // -D
 		const int len = strlen (str);
 		/* http://stackoverflow.com/questions/4715415/base64-what-is-the-worst-possible-increase-in-space-usage */
-		ut8* out = calloc (sizeof(ut8), ((len+2)/3)*4);
+		ut8* out = calloc (sizeof (ut8), ((len + 2) / 3) * 4);
 		if (out) {
 			r_base64_decode (out, str, len);
 			printf ("%s\n", out);
@@ -311,7 +311,7 @@ static int rax (char *str, int len, int last) {
 			free (out);
 		}
 		return true;
-	} else if (flags & 1<<14) { // -F
+	} else if (flags & 1 << 14) { // -F
 		char *str = r_stdin_slurp (NULL);
 		if (str) {
 			char *res = r_hex_from_c (str);
@@ -327,31 +327,31 @@ static int rax (char *str, int len, int last) {
 		return false;
 	}
 
-	if (str[0]=='0' && str[1]=='x') {
-		out_mode = (flags&32)? '0': 'I';
-	} else if (str[0]=='b') {
+	if (str[0] == '0' && str[1] == 'x') {
+		out_mode = (flags & 32) ? '0' : 'I';
+	} else if (str[0] == 'b') {
 		out_mode = 'B';
 		str++;
-	} else if (str[0]=='t') {
+	} else if (str[0] == 't') {
 		out_mode = 'T';
 		str++;
-	} else if (str[0]=='F' && str[1]=='x') {
+	} else if (str[0] == 'F' && str[1] == 'x') {
 		out_mode = 'F';
 		*str = '0';
-	} else if (str[0]=='B' && str[1]=='x') {
+	} else if (str[0] == 'B' && str[1] == 'x') {
 		out_mode = 'B';
 		*str = '0';
-	} else if (str[0]=='T' && str[1]=='x') {
+	} else if (str[0] == 'T' && str[1] == 'x') {
 		out_mode = 'T';
 		*str = '0';
-	} else if (str[0]=='O' && str[1]=='x') {
+	} else if (str[0] == 'O' && str[1] == 'x') {
 		out_mode = 'O';
 		*str = '0';
-	} else if (str[strlen (str)-1]=='d') {
+	} else if (str[strlen (str)-1] == 'd') {
 		out_mode = 'I';
 		str[strlen (str)-1] = 'b';
 	//TODO: Move print into format_output
-	} else if (str[strlen (str)-1]=='f') {
+	} else if (str[strlen (str)-1] == 'f') {
 		ut8 *p = (ut8*)&f;
 		sscanf (str, "%f", &f);
 		printf ("Fx%02x%02x%02x%02x\n", p[3], p[2], p[1], p[0]);
@@ -360,7 +360,7 @@ static int rax (char *str, int len, int last) {
 	while ((p = strchr (str, ' '))) {
 		*p = 0;
 		format_output (out_mode, str);
-		str = p+1;
+		str = p + 1;
 	}
 	if (*str)
 		format_output (out_mode, str);
@@ -370,26 +370,26 @@ static int rax (char *str, int len, int last) {
 static int use_stdin () {
 	char * buf = malloc (STDIN_BUFFER_SIZE);
 	int l, sflag = (flags & 5);
-	if (! (flags & 16384)) {
-		for (l=0; l>=0; l++) {
-			int n = read (0, buf+l, STDIN_BUFFER_SIZE-1);
-			if (n<1) break;
-			l+= n;
-			if (buf[l-1]==0) {
+	if (!(flags & 16384)) {
+		for (l = 0; l >= 0; l++) {
+			int n = read (0, buf + l, STDIN_BUFFER_SIZE - 1);
+			if (n < 1) break;
+			l += n;
+			if (buf[l - 1] == 0) {
 				l--;
 				continue;
 			}
 			buf[n] = 0;
 			if (sflag && strlen (buf) < STDIN_BUFFER_SIZE) // -S
 				buf[strlen (buf)] = '\0';
-			else buf[strlen (buf)-1] = '\0';
+			else buf[strlen (buf) - 1] = '\0';
 			if (!rax (buf, l, 0)) break;
 			l = -1;
 		}
 	} else {
 		l = 1;
 	}
-	if (l>0)
+	if (l > 0)
 		rax (buf, l, 0);
 	free (buf);
 	return 0;
@@ -401,8 +401,8 @@ int main (int argc, char **argv) {
 	if (argc == 1) {
 		use_stdin ();
 	} else {
-		for (i=1; i<argc; i++) {
-			rax (argv[i], 0, i==argc-1);
+		for (i = 1; i < argc; i++) {
+			rax (argv[i], 0, i == argc - 1);
 		}
 	}
 	r_num_free (num);


### PR DESCRIPTION
While reading the source code of r2 binaries I found some inconsistencies in the coding style.
I also patched some *getopt* loops to print usage when there is an unknown option or a missing argument.
Changes are listed below.

# r2agent
* Fix the usage to match other r2 binaries.
* Remove trailing whitespace.
* Remove addressed TODO.
* Add a default case to display usage and exit if -p option was used without argument.
* Return 1 instead of 0 if too much arguments are provided.
* Small coding style fixes.

# radiff2
* Small coding style fixes.

# rafind2
* Add a default case to display usage and exit if an option have a missing argument or getopt does not recognize an option character.
* Small coding style fixes.

# ragg2
* Small coding style fixes.

# rahash2
* Remove useless optarg check.
* Missing arguments and unknown options now display usage and exit.
* Small coding style fixes.

# rarun2
* Small coding style fixes.

# rasm2
* Small coding style fixes.
* Missing arguments and unknown options now display usage and exit.

# rax2
* Small coding style fixes.

# radare2
* Missing arguments and unknown options now display usage and exit.
* Small coding style fixes.