### PR TITLE
Sort afl output by offset

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1193,6 +1193,11 @@ R_API int r_core_anal_fcn_list_size(RCore *core) {
 	return total;
 }
 
+static int cmpfcn(const void *_a, const void *_b) {
+	const RAnalFunction *_fcn1 = _a, *_fcn2 = _b;
+	return (_fcn1->addr > _fcn2->addr);
+}
+
 R_API int r_core_anal_fcn_list(RCore *core, const char *input, int rad) {
 	ut64 addr;
 	RListIter *iter, *iter2;
@@ -1232,6 +1237,7 @@ R_API int r_core_anal_fcn_list(RCore *core, const char *input, int rad) {
 	} else if (rad == 'j')  {
 		r_cons_printf ("[");
 	}
+	r_list_sort (core->anal->fcns, &cmpfcn);
 	r_list_foreach (core->anal->fcns, iter, fcn) {
 		int showFunc = 0;
 		if (input) {


### PR DESCRIPTION
I was looking to add the "sorted" boolean member to the RList structure as suggested, but then I realized that it's not a good idea. Indeed, it is possible to order a list using different Comparators, so it's impossible to know if a list is ordered according to the given one without checking. If efficiency is a concern, maybe I can try to improve the sorting algorithm with something that is O(n) on an already sorted list. (This should be done in a different pull request)

Just to be clear, this pull request is a prosecution of https://github.com/radare/radare2/pull/4250 so it is not a duplicate of https://github.com/radare/radare2/pull/4252