### PR TITLE
Remove useless cast in anal_ppc_cs

### DIFF
--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -33,7 +33,7 @@ static char *getarg2(struct Getarg *gop, int n, const char *setstr) {
 		break;
 	case PPC_OP_IMM:
 		snprintf (words[n], sizeof (words[n]), 
-			"0x%"PFMT64x"%s", (ut64)(ut32)op.imm, setstr);
+			"0x%"PFMT64x"%s", (ut64)op.imm, setstr);
 		break;
 	case PPC_OP_MEM:
 		snprintf (words[n], sizeof (words[n]), 
@@ -283,14 +283,14 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		case PPC_INS_B:
 		case PPC_INS_BA:
 			op->type = R_ANAL_OP_TYPE_JMP;
-			op->jump = (ut64)(ut32)insn->detail->ppc.operands[0].imm;
+			op->jump = (ut64)insn->detail->ppc.operands[0].imm;
 			switch (insn->detail->ppc.operands[0].type) {
 			case PPC_OP_CRX:
 				op->type = R_ANAL_OP_TYPE_CJMP;
 				break;
 			case PPC_OP_REG:
 				op->type = R_ANAL_OP_TYPE_CJMP;
-				op->jump = (ut64)(ut32)insn->detail->ppc.operands[1].imm;
+				op->jump = (ut64)insn->detail->ppc.operands[1].imm;
 				op->fail = addr+4;
 				//op->type = R_ANAL_OP_TYPE_UJMP;
 			default:
@@ -316,7 +316,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		case PPC_INS_BL:
 		case PPC_INS_BLA:
 			op->type = R_ANAL_OP_TYPE_CALL;
-			op->jump = (ut64)(ut32)insn->detail->ppc.operands[0].imm;
+			op->jump = (ut64)insn->detail->ppc.operands[0].imm;
 			op->fail = addr+4;
 			esilprintf (op, "pc,lr,=,%s,pc,=", ARG(0));
 			break;


### PR DESCRIPTION
It was necessary when the PPC imm field (in capstone) was a i32. It is counterproductive, now that imm is a i64.