### PR TITLE
treating #error as if it was #warning in `to`

### DIFF
--- a/shlr/tcc/tccpp.c
+++ b/shlr/tcc/tccpp.c
@@ -1633,10 +1633,7 @@ include_done:
                 inp();
         }
         *q = '\0';
-        if (c == TOK_ERROR)
-            tcc_error("#error %s", buf);
-        else
-            tcc_warning("#warning %s", buf);
+	tcc_warning("#%s %s",c==TOK_ERROR?"error":"warning",buf);
         break;
     case TOK_PRAGMA:
         pragma_parse(s1);


### PR DESCRIPTION
added test https://github.com/radare/radare2-regressions/pull/335
the bug can be re generated by parsing header with a #error in there
the compile in the normal case will issue an error and terminate
but since no compilation is done we need to proceed parsign the file
and treating the errors as warning just to be able to get all the types
in the given file.