### PR TITLE
Count hex digits as numbers in parse filter

### DIFF
--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -466,7 +466,7 @@ R_API ut64 r_get_input_num_value(RNum *num, const char *input_value);
 #define isseparator(x) ((x)==' '||(x)=='\t'||(x)=='\n'||(x)=='\r'||(x)==' '|| \
 		(x)==','||(x)==';'||(x)==':'||(x)=='['||(x)==']'|| \
 		(x)=='('||(x)==')'||(x)=='{'||(x)=='}')
-#define ishexchar(x) ((x>='0'&&x<='9') ||  (x>='a'&&x<='f') ||  (x>='A'&&x<='F')) {
+#define ishexchar(x) ((x>='0'&&x<='9') ||  (x>='a'&&x<='f') ||  (x>='A'&&x<='F'))
 
 R_API int r_name_check(const char *name);
 R_API int r_name_filter(char *name, int len);

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -195,11 +195,16 @@ static int filter(RParse *p, RFlag *f, char *data, char *str, int len) {
 			int pnumleft, immbase = p->hint->immbase;
 			bool big_endian = false;
 			char num[256], *pnum;
+			bool is_hex = false;
 			strncpy (num, ptr, sizeof (num)-2);
-			for (pnum = num; *pnum; pnum++) {
-				if (IS_NUMBER (*pnum))
+			pnum = num;
+			if (*pnum == '0' && *(pnum+1) == 'x') {
+				is_hex = true;
+				pnum += 2;
+			}
+			for (; *pnum; pnum++) {
+				if ((is_hex && ishexchar(*pnum)) || IS_NUMBER(*pnum))
 					continue;
-				if (*pnum=='x') continue;
 				break;
 			}
 			*pnum = 0;


### PR DESCRIPTION
Without this we chop off number operands as soon as a hex digit is seen.

Also fix and use a previously unused macro.