### PR TITLE
Reduce OMF format false positives

### DIFF
--- a/libr/bin/format/omf/omf.c
+++ b/libr/bin/format/omf/omf.c
@@ -31,7 +31,7 @@ int r_bin_checksum_omf_ok(const char *buf, ut64 buf_size) {
 		eprintf ("Invalid record (too short)\n");
 		return false;
 	}
-	size = *((ut16 *)(buf + 1));
+	size = ut8p_bw (buf + 1);
 	if (buf_size < size + 3) {
 		eprintf ("Invalid record (too short)\n");
 		return false;


### PR DESCRIPTION
While developing the SNES bin plugin, I noticed some SNES ROMs were wrongly
detected as OMF.

This commit adds two additional checks to check_bytes:

* Check that record size and string size in the first record agree with each other
* Check that the string in the first record is valid ASCII

Regression tests still pass.

This commit also fixes an assumption that the host is little endian.