### PR TITLE
RBin: improving versioninfo

### DIFF
--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -83,6 +83,10 @@ struct Elf_(r_bin_elf_obj_t) {
 	int dyn_entries;
 	int is_rela;
 
+	ut64 version_info[DT_VERSIONTAGNUM];
+
+	char *dynstr;
+
 	RBinImport **imports_by_ord;
 	size_t imports_by_ord_size;
 	RBinSymbol **symbols_by_ord;

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -453,7 +453,7 @@ static int cmd_info(void *data, const char *input) {
 				"ir|iR", "", "Relocs",
 				"is", "", "Symbols",
 				"iS ", "[entropy,sha1]", "Sections (choose which hash algorithm to use)",
-				"iV", "", "Display file version info)",
+				"iV", "", "Display file version info",
 				"iz", "", "Strings in data sections",
 				"izz", "", "Search for Strings in the whole binary",
 				NULL

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -573,6 +573,7 @@ R_API char *r_str_escape_dot(const char *buf);
 R_API void r_str_uri_decode(char *buf);
 R_API char *r_str_uri_encode (const char *buf);
 R_API char *r_str_utf16_decode (const ut8 *s, int len);
+R_API int r_str_utf16_to_utf8 (ut8 *dst, int len_dst, const ut8 *src, int len_src, int little_endian);
 R_API char *r_str_utf16_encode (const char *s, int len);
 R_API char *r_str_home(const char *str);
 R_API int r_str_nlen (const char *s, int n);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1547,6 +1547,74 @@ R_API char *r_str_uri_encode (const char *s) {
 	return realloc (od, strlen (od)+1); // FIT
 }
 
+R_API int r_str_utf16_to_utf8 (ut8 *dst, int len_dst, const ut8 *src, int len_src, int little_endian) {
+	ut8 *outstart = dst;
+	const ut8 *processed = src;
+	ut8 *outend = dst + len_dst;
+	ut16 *in = (ut16*)src;
+	ut16 *inend;
+	ut32 c, d, inlen;
+	ut8 *tmp;
+	int bits;
+
+	if ((len_src % 2) == 1)
+		len_src--;
+	inlen = len_src / 2;
+	inend = in + inlen;
+	while ((in < inend) && (dst - outstart + 5 < len_dst)) {
+		if (little_endian) {
+			c= *in++;
+		} else {
+			tmp = (ut8*) in;
+			c = *tmp++;
+			c = c | (((ut32)*tmp) << 8);
+			in++;
+		}
+		if ((c & 0xFC00) == 0xD800) {    /* surrogates */
+			if (in >= inend) {           /* (in > inend) shouldn't happens */
+				break;
+			}
+			if (little_endian) {
+				d = *in++;
+			} else {
+				tmp = (ut8*) in;
+				d = *tmp++;
+				d = d | (((ut32)*tmp) << 8);
+				in++;
+			}
+			if ((d & 0xFC00) == 0xDC00) {
+				c &= 0x03FF;
+				c <<= 10;
+				c |= d & 0x03FF;
+				c += 0x10000;
+			}
+			else {
+				len_dst = dst - outstart;
+				len_src = processed - src;
+				return -2;
+			}
+		}
+
+		/* assertion: c is a single UTF-4 value */
+		if (dst >= outend)
+			break;
+
+		if      (c <    0x80) { *dst++ =  c; bits= -6; }
+		else if (c <   0x800) { *dst++ = ((c >>  6) & 0x1F) | 0xC0; bits =  0; }
+		else if (c < 0x10000) { *dst++ = ((c >> 12) & 0x0F) | 0xE0; bits =  6; }
+		else                  { *dst++ = ((c >> 18) & 0x07) | 0xF0; bits = 12; }
+
+		for (; bits >= 0; bits-= 6) {
+			if (dst >= outend)
+				break;
+			*dst++ = ((c >> bits) & 0x3F) | 0x80;
+		}
+		processed = (const unsigned char*) in;
+	}
+	len_dst = dst - outstart;
+	return len_dst;
+}
+
 R_API char *r_str_utf16_decode (const ut8 *s, int len) {
 	int i = 0;
 	int j = 0;


### PR DESCRIPTION
- Store ELF versioninfo in sdb and display with iV
- Display VS_FIXEDFILEINFO for PE
- UTF-16 characters are now correctly displayed (they are converted to UTF-8)