### PR TITLE
Prettier memory region printing

### DIFF
--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -1846,11 +1846,9 @@ static void bin_mem_print(RList *mems, int perms, int depth) {
 
 	r_list_foreach (mems, iter, mem) {
 		if (mem) {
-			for (i = 0; i < depth; i++) {
-				r_cons_printf (" ");
-			}
-			r_cons_printf ("%8s addr=0x%016"PFMT64x" size=%6d perms=[%s]\n",
-				mem->name, mem->addr, mem->size, r_str_rwx_i (mem->perms & perms));
+			r_cons_printf ("%*s%-*s addr=0x%016"PFMT64x" size=%6d perms=[%s]\n",
+				depth, "", 20-depth, mem->name, mem->addr,
+				mem->size, r_str_rwx_i (mem->perms & perms));
 			if (mem->mirrors) {
 				bin_mem_print (mem->mirrors, (mem->perms & perms), (depth + 1));	//sorry, but anything else would be inefficient
 			}


### PR DESCRIPTION
* Left-align the memory region names instead of right-aligning. This lets the
  indentation for mirroring show up properly.
* Allow 20 characters for the region name. This allows all NES regions to fit.
* Align columns even when there's indentation.

Before:
```
     RAM addr=0x0000000000000000 size=  2048 perms=[-rwx]
 RAM_MIRROR_2 addr=0x0000000000001000 size=  2048 perms=[-rwx]
 PPU_REG addr=0x0000000000002000 size=     8 perms=[-rwx]
 PPU_REG_MIRROR_1 addr=0x0000000000002008 size=     8 perms=[-rwx]
```

After:
```
RAM                  addr=0x0000000000000000 size=  2048 perms=[-rwx]
 RAM_MIRROR_2        addr=0x0000000000001000 size=  2048 perms=[-rwx]
PPU_REG              addr=0x0000000000002000 size=     8 perms=[-rwx]
 PPU_REG_MIRROR_1    addr=0x0000000000002008 size=     8 perms=[-rwx]
```