### PR TITLE
fix relocations for object files

### DIFF
--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -128,7 +128,6 @@ static RList* sections(RBinFile *arch) {
 	ret->free = free;
 	if ((section = Elf_(r_bin_elf_get_sections) (obj))) {
 		for (i = 0; !section[i].last; i++) {
-			if (!section[i].size) continue;
 			if (!(ptr = R_NEW0 (RBinSection)))
 				break;
 			strncpy (ptr->name, (char*)section[i].name, R_BIN_SIZEOF_STRINGS);


### PR DESCRIPTION
This fix partially the issue #4155. now i extract the relative offset regarding the correct section instead of doing that ugly hack seeking `.text` section.

Still remains to fix the fdata-section issue but this is more related with mapping. The symbols in fdata-section go into COMMON section that is used to store undefined symbols. Reading on internet 

----
If a symbol's value refers to a specific location within a section, the symbols's section index member, st_shndx, holds an index into the section header table. As the section moves during relocation, the symbol's value changes as well. References to the symbol continue to point to the same location in the program. Some special section index values give other semantics.

...

SHN_COMMON, and SHN_AMD64_LCOMMON
.... The link-editor allocates the storage for the symbol at an address that is a multiple of st_value. The symbol's size tells how many bytes are required.

----

So in order to fix we need to map a new section (common symbols segment) and storage there each symbol with its size.

The same happens with global initialize variables that either go into .bss sections or .data sections.

```C
(gcc -m32 -x c - -c -fdata-sections -o foobar.o << EOF
int foo = 0;
int bar = 0;               
EOF
r2 -qc 'is' foobar.o)
```

```
idx=04 vaddr=0x00000000 paddr=0x00000034 sz=4 vsz=4 perm=--rw- name=.bss.foo
idx=05 vaddr=0x00000000 paddr=0x00000034 sz=4 vsz=4 perm=--rw- name=.bss.bar

[0x00000034]> S
[00] * 0x00000034 -rw- va=0x00000000 sz=0x0004 vsz=0x0004 .bss.bar
[01] * 0x00000034 ---- va=0x00000000 sz=0x0012 vsz=0x0012 .comment
[02] . 0x00000101 ---- va=0x00000000 sz=0x0057 vsz=0x0057 .shstrtab
[03] . 0x00000048 ---- va=0x00000000 sz=0x00b0 vsz=0x00b0 .symtab
[04] . 0x000000f8 ---- va=0x00000000 sz=0x0009 vsz=0x0009 .strtab
[05] * 0x00000000 -rwx va=0x00000000 sz=0x0310 vsz=0x0310 ehdr
```

To fix this i need time to read and understand the io/section code

@codido check this to see if ffunction-section and different tricks are handled correctly

This break tests since we weren't printing sections with size == 0 such as .bss