### PR TITLE
Fix spurious reloc

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -35,7 +35,9 @@ static int format_output (char mode, const char *s) {
 			float f = (float)num->fvalue;
 			ut8 *p = (ut8*)&f;
 			printf ("Fx%02x%02x%02x%02x\n", p[3], p[2], p[1], p[0]);
-		} else printf ("0x%"PFMT64x"\n", n);
+		} else {
+			printf ("0x%"PFMT64x"\n", n);
+		}
 		} break;
 	case 'F': {
 		  float *f = (float*)&n;

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -21,6 +21,8 @@ typedef struct r_bin_elf_section_t {
 	ut64 size;
 	ut64 align;
 	ut32 flags;
+	ut32 link;
+	ut32 info;
 	char name[ELF_STRING_LENGTH];
 	int last;
 } RBinElfSection;
@@ -82,6 +84,7 @@ struct Elf_(r_bin_elf_obj_t) {
 	Elf_(Dyn) *dyn_buf;
 	int dyn_entries;
 	int is_rela;
+	ut32 reloc_num;
 
 	ut64 version_info[DT_VERSIONTAGNUM];
 

--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -133,6 +133,7 @@ RBinPlugin r_bin_plugin_elf64 = {
 	.size = &size,
 	.libs = &libs,
 	.relocs = &relocs,
+	.patch_relocs = &patch_relocs,
 	.dbginfo = &r_bin_dbginfo_elf64,
 	.create = &create,
 	.write = &r_bin_write_elf64,

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -140,7 +140,7 @@ typedef struct r_bin_object_t {
 	RList/*<??>*/ *entries;
 	RList/*<??>*/ *fields;
 	RList/*<??>*/ *libs;
-	RList/*<??>*/ *relocs;
+	RList/*<RBinReloc>*/ *relocs;
 	RList/*<??>*/ *strings;
 	RList/*<RBinClass>*/ *classes;
 	RList/*<RBinDwarfRow>*/ *lines;
@@ -267,6 +267,7 @@ typedef struct r_bin_plugin_t {
 	RList* (*relocs)(RBinFile *arch);
 	RList* (*classes)(RBinFile *arch);
 	RList* (*mem)(RBinFile *arch);
+	RList* (*patch_relocs)(RBin *bin);
 	int (*demangle_type)(const char *str);
 	struct r_bin_dbginfo_t *dbginfo;
 	struct r_bin_write_t *write;
@@ -466,6 +467,7 @@ R_API RList* r_bin_get_imports(RBin *bin);
 R_API RBinInfo* r_bin_get_info(RBin *bin);
 R_API RList* r_bin_get_libs(RBin *bin);
 R_API ut64 r_bin_get_size (RBin *bin);
+R_API RList* r_bin_patch_relocs(RBin *bin);
 R_API RList* r_bin_get_relocs(RBin *bin);
 R_API RList* r_bin_get_sections(RBin *bin);
 R_API RList* /*<RBinClass>*/r_bin_get_classes(RBin *bin);

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -742,6 +742,14 @@ R_API const ut8 *r_uleb128 (const ut8 *data, int datalen, ut64 *v);
 R_API const ut8 *r_uleb128_decode (const ut8 *data, int *datalen, ut64 *v);
 R_API const ut8 *r_uleb128_encode (const ut64 s, int *len);
 R_API const ut8 *r_leb128 (const ut8 *data, st64 *v);
+
+/*swap*/ //inline?
+R_API ut16 r_swap_ut16(ut16 val);
+R_API st16 r_swap_st16(st16 val);
+R_API ut32 r_swap_ut32(ut32 val);
+R_API st32 r_swap_st32(st32 val);
+R_API ut64 r_swap_ut64(ut64 val);
+R_API st64 r_swap_st64(st64 val);
 #endif
 
 /* constr */

--- a/libr/io/cache.c
+++ b/libr/io/cache.c
@@ -33,7 +33,8 @@ R_API void r_io_cache_commit(RIO *io, ut64 from, ut64 to) {
 		if (c->from >= from && c->to <= to) {
 			if (!r_io_write_at (io, c->from, c->data, c->size))
 				eprintf ("Error writing change at 0x%08"PFMT64x"\n", c->from);
-			else c->written = true;
+			else 
+				c->written = true;
 			break;
 		}
 	}

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -783,7 +783,8 @@ R_API ut64 r_io_seek(RIO *io, ut64 offset, int whence) {
 		if (io->plugin && io->plugin->lseek)
 			ret = io->plugin->lseek (io, io->desc, offset, whence);
 		// XXX can be problematic on w32..so no 64 bit offset?
-		else ret = (ut64)lseek (io->desc->fd, offset, posix_whence);
+		else 	
+			ret = (ut64)lseek (io->desc->fd, offset, posix_whence);
 		if (ret != UT64_MAX) {
 			if (whence == R_IO_SEEK_SET)
 				io->off = offset; // FIX linux-arm-32-bs at 0x10000

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -292,7 +292,8 @@ static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int wh
 }
 
 static ut64 r_io_def_mmap_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
-	if (!fd || !fd->data) return UT64_MAX;
+	if (!fd || !fd->data) 
+		return UT64_MAX;
 	return r_io_def_mmap_seek (io, (RIOMMapFileObj *)fd->data, offset, whence);
 }
 

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -56,10 +56,11 @@ static RIOSection *findMatching (RIO *io, ut64 paddr, ut64 vaddr, ut64 size, ut6
 R_API RIOSection *r_io_section_add(RIO *io, ut64 offset, ut64 vaddr, ut64 size, ut64 vsize, int rwx, const char *name, ut32 bin_id, int fd) {
 	int update = 0;
 	RIOSection *s;
-	if (size==0 || size>0xf0000000) {
-		if (size>0 && size != UT64_MAX && size != UT32_MAX)
-			eprintf ("Invalid size (0x%08"PFMT64x") for section '%s' at 0x%08"PFMT64x"\n",
-			size, name, vaddr);
+	if (size == 0 || size > 0xf0000000) {
+		if (size > 0 && size != UT64_MAX && size != UT32_MAX)
+			eprintf ("Invalid size (0x%08" PFMT64x
+				 ") for section '%s' at 0x%08" PFMT64x "\n",
+				 size, name, vaddr);
 		return NULL;
 	}
 	s = findMatching (io, offset, vaddr, size, vsize, rwx, name);
@@ -70,7 +71,9 @@ R_API RIOSection *r_io_section_add(RIO *io, ut64 offset, ut64 vaddr, ut64 size, 
 	if (s == NULL) {
 		s = R_NEW0 (RIOSection);
 		s->id = io->next_section_id++;
-	} else update = 1;
+	} else {
+		update = 1;
+	}
 	s->offset = offset;
 	s->vaddr = vaddr;
 	s->size = size;

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -12,6 +12,7 @@ OBJS+=strpool.o bitmap.o strht.o p_date.o p_format.o print.o
 OBJS+=p_seven.o slist.o randomart.o log.o zip.o debruijn.o
 OBJS+=utf8.o strbuf.o lib.o name.o spaces.o
 OBJS+=diff.o bdiff.o stack.o queue.o tree.o des.o
+OBJS+=swap.o
 
 # DO NOT BUILD r_big api (not yet used and its buggy)
 ifeq (1,0)

--- a/libr/util/swap.c
+++ b/libr/util/swap.c
@@ -1,0 +1,35 @@
+#include <r_util.h>
+
+
+R_API ut16 r_swap_ut16(ut16 val) {
+    return (val << 8) | (val >> 8 );
+}
+
+R_API st16 r_swap_st16(st16 val) {
+    val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
+    return (val << 16) | (val >> 16);
+}
+
+R_API ut32 r_swap_ut32(ut32 val) {
+    val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
+    return (val << 16) | (val >> 16);
+}
+
+R_API st32 r_swap_st32(st32 val) {
+    val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF );
+    return (val << 16) | ((val >> 16) & 0xFFFF);
+}
+
+
+R_API ut64 r_swap_ut64(ut64 val) {
+    val = ((val << 8) & 0xFF00FF00FF00FF00ULL ) | ((val >> 8) & 0x00FF00FF00FF00FFULL );
+    val = ((val << 16) & 0xFFFF0000FFFF0000ULL ) | ((val >> 16) & 0x0000FFFF0000FFFFULL );
+    return (val << 32) | (val >> 32);
+}
+
+R_API st64 r_swap_st64(st64 val) {
+    val = ((val << 8) & 0xFF00FF00FF00FF00ULL ) | ((val >> 8) & 0x00FF00FF00FF00FFULL );
+    val = ((val << 16) & 0xFFFF0000FFFF0000ULL ) | ((val >> 16) & 0x0000FFFF0000FFFFULL );
+    return (val << 32) | ((val >> 32) & 0xFFFFFFFFULL);
+}
+


### PR DESCRIPTION
we weren't taking into account this

For a relocatable file, the value is the byte offset from the beginning of the section to the storage unit affected by the relocation. For an executable file or a shared object, the value is the virtual address of the storage unit affected by the relocation.

but anyway still fails the mapping thing. baby steps ;) 

@codido take a look at this you shouldn't see those spurious reloc anymore