### PR TITLE
Detect MSYS2 @ ./configure --with-ostype=windows

### DIFF
--- a/shlr/zip/zip/Makefile
+++ b/shlr/zip/zip/Makefile
@@ -10,7 +10,7 @@ SOVER=${EXT_SO}
 LDFLAGS+=-shared
 LDFLAGS_SHARED?=-shared
 else
-ifneq (,$(findstring mingw32,${OSTYPE})$(findstring mingw64,${OSTYPE})$(findstring msys,${OSTYPE}))
+ifneq (,$(findstring mingw32,${OSTYPE})$(findstring mingw64,${OSTYPE})$(findstring msys,${OSTYPE})$(findstring msys,${HOST_OS}))
 CFLAGS+=-DMINGW32=1
 EXT_SO=dll
 SOVER=${EXT_SO}


### PR DESCRIPTION
Fix build issues local to lib_zip when building r2 under MSYS2 and using `./configure --with-ostype=windows` (some broken defines at `shlr/zip/zip/zip_close.c` that are valid for MSVC but not for MSYS2 + some local lib_zip #ifdef _WIN32)
So, if config-user.mk has:
```
# ./configure --with-ostype=[linux,osx,solaris,windows] # TODO: rename to w32, w64?
OSTYPE=windows
BUILD_OS=msys_nt
HOST_OS=msys_nt
```
I assume that if `BUILD_OS` contains `'msys'`, then we are building r2 for MSYS or MSYS2, and therefore it is not a MSVC build (as implied by the local macro switches)