### PR TITLE
Fixed 59d614edf16af3066762dc2016efd3b24a807678 commit

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -230,7 +230,7 @@ R_API ut64 r_debug_execute(RDebug *dbg, const ut8 *buf, int len, int restore) {
 		ri = r_reg_get (dbg->reg, dbg->reg->name[R_REG_NAME_A0], R_REG_TYPE_GPR);
 		ra0 = r_reg_get_value (dbg->reg, ri);
 		if (restore) {
-			r_reg_set_bytes (dbg->reg, -1, orig, orig_sz);
+			r_reg_read_regs (dbg->reg, orig, orig_sz);
 		} else {
 			r_reg_set_value (dbg->reg, ripc, rpc);
 		}

--- a/libr/debug/p/debug_wind.c
+++ b/libr/debug/p/debug_wind.c
@@ -29,7 +29,7 @@ static int r_debug_wind_reg_read (RDebug *dbg, int type, ut8 *buf, int size) {
 	int ret = wind_read_reg(wctx, buf, size);
 	if (!ret || size != ret)
 		return -1;
-	r_reg_set_bytes (dbg->reg, R_REG_TYPE_ALL, buf, ret);
+	r_reg_read_regs (dbg->reg, buf, ret);
 	// Report as if no register has been written as we've already updated the arena here
 	return 0;
 }

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -73,13 +73,12 @@ R_API bool r_reg_set_bytes(RReg *reg, int type, const ut8 *buf, const int len) {
 	int maxsz, ret = false;
 	struct r_reg_set_t *regset;
 	RRegArena *arena;
-	if (len < 0 || !buf)
+	if (len < 1 || !buf)
 		return false;
 	if (type < 0 || type >= R_REG_TYPE_LAST) return false;
 	regset = &reg->regset[type];
 	arena = regset->arena;
 	maxsz = R_MAX (arena->size, len);
-	if (len < 1) return false;
 	if ((arena->size != len) || (arena->bytes == NULL)) {
 		arena->bytes = calloc (1, maxsz);
 		if (!arena->bytes) {

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -237,22 +237,21 @@ R_API void r_reg_arena_poke(RReg *reg, const ut8 *ret) {
 }
 
 
-R_API int r_reg_arena_set_bytes(RReg *reg, const char* str)
-{
+R_API int r_reg_arena_set_bytes(RReg *reg, const char* str) {
 	while (*str == ' ') str++;
 
-	int len = r_hex_str_is_valid(str);
+	int len = r_hex_str_is_valid (str);
 	if (len == -1) {
 		eprintf("Invalid input\n");
 		return -1;
 	}
 	int bin_str_len = (len + 1) / 2; //2 hex chrs for 1 byte
-	ut8* bin_str = malloc(bin_str_len);
+	ut8* bin_str = malloc (bin_str_len);
 	if (bin_str == NULL) {
-		eprintf("Failed to decode hex str.\n");
+		eprintf ("Failed to decode hex str.\n");
 		return -1;
 	}
-	r_hex_str2bin(str, bin_str);
+	r_hex_str2bin (str, bin_str);
 
 	int i, n = 0; //n - cumulative sum of arena's sizes
 	for (i = 0; i < R_REG_TYPE_LAST; ++i) {
@@ -260,12 +259,12 @@ R_API int r_reg_arena_set_bytes(RReg *reg, const char* str)
 		int bl = bin_str_len - n; //bytes left
 		if (bl - n < sz) {
 			//r_reg_set_bytes checks if bl-n==0 :p
-			r_reg_set_bytes(reg, i, bin_str + n, bl - n);
+			r_reg_set_bytes (reg, i, bin_str + n, bl - n);
 			break;
 		}
-		r_reg_set_bytes(reg, i, bin_str + n, bin_str_len - n);
+		r_reg_set_bytes (reg, i, bin_str + n, bin_str_len - n);
 		n += sz;
 	}
-	free(bin_str);
+	free (bin_str);
 	return 0;
 }

--- a/libr/reg/t/test.c
+++ b/libr/reg/t/test.c
@@ -41,7 +41,7 @@ int main() {
 
 	reg = r_reg_new ();
 	r_reg_set_profile (reg, "./test.regs");
-	r_reg_set_bytes (reg, -1, (const ut8 *)foo, sizeof(foo));
+	r_reg_read_regs (reg, (const ut8 *)foo, sizeof(foo));
 {
 	ut64 a;
 	RRegItem *item;


### PR DESCRIPTION
r_reg_set_bytes (reg, type, buf, sz) when type==-1 was a call which didnt actually set bytes, it read them into buffer, so I made a function r_reg_read_regs for it but didnt replace previous calls for them.
also PR had some code style issues

also there's an issue with r_reg_get_bytes. when type==-1 it reads all registers into buffer, just like r_reg_set_bytes with type==-1 did earlier. might be troublesome, should make it clearer