### PR TITLE
Fix #4393

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -891,8 +891,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			{
 			char *name = r_core_anal_fcn_autoname (core, core->offset, 0);
 			if (name) {
-				r_cons_printf ("afn %s 0x%08" PFMT64x "\n",
-					name, core->offset);
+				r_cons_printf ("afn %s 0x%08" PFMT64x "\n", name, core->offset);
 				free (name);
 			}
 			}
@@ -3584,7 +3583,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		"aac", " [len]", "analyze function calls (af @@ `pi len~call[1]`)",
 		"aae", " [len]", "analyze references with ESIL",
 		"aar", " [len]", "analyze len bytes of instructions for references",
-		"aan", "", "afna @@ fcn*",
+		"aan", "", "autoname functions that either start with fcn.* or sym.func.*",
 		"aas", " [len]", "analyze symbols (af @@= `isq~[0]`)",
 		"aat", " [len]", "analyze all consecutive functions in section",
 		"aap", "", "find and analyze function preludes",
@@ -3602,7 +3601,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		r_core_cmd0 (core, "af @@= `isq~[0]`");
 		r_core_cmd0 (core, "af @ entry0");
 		break;
-	case 'n': r_core_cmd0 (core, ".afna @@ fcn.*"); break;
+	case 'n': r_core_anal_autoname_all_fcns (core); break; //aan
 	case 'p': // "aap"
 		if (*input == '?') {
 			// TODO: accept parameters for ranges
@@ -3654,11 +3653,9 @@ static int cmd_anal_all(RCore *core, const char *input) {
 					eprintf ("[*] Use -AA or aaaa to perform additional experimental analysis.\n");
 				}
 				r_config_set_i (core->config, "anal.calls", c);
-				if (r_config_get_i (core->config, "anal.autoname")) {
-					rowlog (core, "Construct a function name for all fcn.* (.afna @@ fcn.*)");
-					r_core_cmd0 (core, ".afna @@ fcn.*");
-					rowlog_done (core);
-				}
+				rowlog (core, "Constructing a function name for fcn.* and sym.func.* functions");
+				r_core_anal_autoname_all_fcns (core);
+				rowlog_done (core);
 				if (core->cons->breaked)
 					goto jacuzzi;
 				r_core_cmd0 (core, "s-");

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -339,6 +339,7 @@ R_API ut64 r_core_anal_get_bbaddr(RCore *core, ut64 addr);
 R_API int r_core_anal_bb_seek(RCore *core, ut64 addr);
 R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth);
 R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump);
+R_API void r_core_anal_autoname_all_fcns(RCore *core);
 R_API int r_core_anal_fcn_list(RCore *core, const char *input, int rad);
 R_API int r_core_anal_fcn_list_size(RCore *core);
 R_API void r_core_anal_fcn_labels(RCore *core, RAnalFunction *fcn, int rad);


### PR DESCRIPTION
I've added `aau` to autoname all fcns. Maybe move this functionality into `aan` would be better instead of rely in the functions flag space since it doesn't work right now