### PR TITLE
Explicitly document address offset for print commands.

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3447,7 +3447,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	default: {
 		 const char* help_msg[] = {
-			 "Usage:", "p[=68abcdDfiImrstuxz] [arg|len]", "",
+			 "Usage:", "p[=68abcdDfiImrstuxz] [arg|len] [@addr]", "",
 			 "p=","[bep?] [blks] [len] [blk]","show entropy/printable chars/chars bars",
 			 "p2"," [len]","8x8 2bpp-tiles",
 			 "p3"," [file]","print stereogram (3D)",


### PR DESCRIPTION
This confused me a lot. Apparently, `@` is a general thing that can be used for many other commands too though.

Either way, I figured it doesn't hurt to mention it explicitly when reading the print documentation. Feel free to disagree, though ;)