### PR TITLE
Compute index32 value for indirect EBC call32

### DIFF
--- a/libr/asm/arch/ebc/ebc_disas.c
+++ b/libr/asm/arch/ebc/ebc_disas.c
@@ -100,8 +100,7 @@ static int decode_index32(const ut8 *data, ebc_index_t *index) {
 	ut32 tmp = *(ut32*)data;
 	index->type = EBC_INDEX32;
 	index->sign = tmp & EBC_NTH_BIT(31) ? EBC_INDEX_PLUS : EBC_INDEX_MINUS;
-	//should be multiplied by 4 here but EbcDebugger does not do that
-	index->a_width = ((tmp >> 28) & EBC_N_BIT_MASK(2)) * 2;
+	index->a_width = ((tmp >> 28) & EBC_N_BIT_MASK(2)) * 4;
 	index->n = tmp & EBC_N_BIT_MASK(index->a_width);
 	index->c = (tmp >> index->a_width) & EBC_N_BIT_MASK(28 - index->a_width);
 	return 0;
@@ -111,7 +110,7 @@ static int decode_index64(const ut8 *data, ebc_index_t *index) {
 	ut64 tmp = *(ut64*)data;
 	index->type = EBC_INDEX64;
 	index->sign = tmp & EBC_NTH_BIT(63) ? EBC_INDEX_PLUS : EBC_INDEX_MINUS;
-	index->a_width = ((tmp >> 60) & EBC_N_BIT_MASK(2)) * 2;
+	index->a_width = ((tmp >> 60) & EBC_N_BIT_MASK(2)) * 8;
 	index->n = tmp & EBC_N_BIT_MASK(index->a_width);
 	index->c = (tmp >> index->a_width) & EBC_N_BIT_MASK(60- index->a_width);
 	return 0;

--- a/libr/asm/arch/ebc/ebc_disas.c
+++ b/libr/asm/arch/ebc/ebc_disas.c
@@ -185,6 +185,8 @@ static int decode_call(const ut8 *bytes, ebc_command_t *cmd) {
 	ut8 op1 = bytes[1] & 0x7;
 	ut32 i1;
 	unsigned long i2;
+	ebc_index_t idx32;
+	char sign;
 
 	if (!TEST_BIT (bytes[0], 6)) {
 		//CALL32
@@ -194,10 +196,12 @@ static int decode_call(const ut8 *bytes, ebc_command_t *cmd) {
 			//operand 1 indirect
 			if (TEST_BIT (bytes[0], 7)) {
 				// immediate data is present
-				i1 = *(ut32*)(bytes + 2);
-				// TODO: if operand is indirect immediate data is index
+				decode_index32(bytes + 2, &idx32);
+				sign = idx32.sign ? '+' : '-';
+
 				snprintf (cmd->operands, EBC_OPERANDS_MAXLEN,
-						"@r%d(0x%x)", op1, i1);
+						"@r%d(%c%u, %c%u)",
+						op1, sign, idx32.n, sign, idx32.c);
 				ret = 6;
 			} else {
 				snprintf (cmd->operands, EBC_OPERANDS_MAXLEN,

--- a/libr/asm/arch/ebc/ebc_disas.c
+++ b/libr/asm/arch/ebc/ebc_disas.c
@@ -228,8 +228,9 @@ static int decode_call(const ut8 *bytes, ebc_command_t *cmd) {
 		snprintf (cmd->operands, EBC_OPERANDS_MAXLEN,
 				"0x%lx", i2);
 	}
-	snprintf (cmd->instr, EBC_INSTR_MAXLEN, "%s%d%s",
+	snprintf (cmd->instr, EBC_INSTR_MAXLEN, "%s%d%s%s",
 			instr_names[EBC_CALL], bits,
+			TEST_BIT(bytes[1], 5) ? "ex" : "",
 			TEST_BIT(bytes[1], 4) ? "" : "a");
 	return ret;
 }


### PR DESCRIPTION
Besides, I'm wondering whether the fact that "EbcDebugger does not do that" is a good reason not to multiply by the right amount. Anyway, I've added a parameter to the function so that call32's are properly decompiled for my use case.

Hoping that helps,
Leo Gaspard / Ekleog