### PR TITLE
Add EBC 'not' instruction decoding

### DIFF
--- a/libr/asm/arch/ebc/ebc_disas.c
+++ b/libr/asm/arch/ebc/ebc_disas.c
@@ -309,18 +309,13 @@ static int decode_cmpugte(const ut8 *bytes, ebc_command_t *cmd) {
 }
 
 static int decode_not(const ut8 *bytes, ebc_command_t *cmd) {
-	// TODO
-	return TEST_BIT (bytes[0], 7)? 4: 2;
-}
-
-static int decode_neg(const ut8 *bytes, ebc_command_t *cmd) {
 	int ret = 2;
 	unsigned bits = TEST_BIT (bytes[0], 6)? 64: 32;
 	unsigned op1, op2;
 	char index[32] = {0};
 	ut16 immed;
 
-	snprintf(cmd->instr, EBC_INSTR_MAXLEN, "%s%u", instr_names[EBC_NEG],
+	snprintf(cmd->instr, EBC_INSTR_MAXLEN, "%s%u", instr_names[EBC_NOT],
 			bits);
 
 	op1 = bytes[1] & 0x07;
@@ -344,6 +339,13 @@ static int decode_neg(const ut8 *bytes, ebc_command_t *cmd) {
 	snprintf (cmd->operands, EBC_OPERANDS_MAXLEN, "%sr%d, %sr%d%s",
 			TEST_BIT(bytes[1], 3) ? "@" : "", op1,
 			TEST_BIT(bytes[1], 7) ? "@" : "", op2, index);
+	return ret;
+}
+
+static int decode_neg(const ut8 *bytes, ebc_command_t *cmd) {
+	int ret = decode_not(bytes, cmd);
+	cmd->instr[1] = 'e';
+	cmd->instr[2] = 'g';
 	return ret;
 }
 


### PR DESCRIPTION
Test has been PR-ed at https://github.com/radare/radare2-regressions/pull/351

Otherwise, I'm not sure whether this way of writing the code is considered good practice (actually I'm almost sure it is not), but I didn't find a better way without either deeper refactoring of the code or almost complete code duplication between neg* and not*. Should I go with the deep refactoring?

EDIT: Hmmm, it seems the tests fail on, like, *all* test cases? On my computer radare2 seems to work pretty well with this patch...