### PR TITLE
fixing coverities

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2316,6 +2316,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			free (str2);
 		}
 		r_anal_op_fini (&aop);
+		free (old_arch);
 		}
 		break;
 	case '?':

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -354,7 +354,11 @@ static int cmd_type(void *data, const char *input) {
 	case 'p': {
 		const char *type = input + 2;
 		char *ptr = strchr (type, ' ');
-		*ptr++ = 0;
+		if (!ptr) {
+			eprintf ("see t?\n");
+			break;
+		}
+		*ptr++=0;
 		ut64 addr = r_num_math (core->num, ptr);
 		char *fmt = r_anal_type_format (core->anal, type);
 		if (fmt) {


### PR DESCRIPTION
libr/core/cmd_type
Incrementing a pointer which might be null: "ptr".

/libr/core/cmd_anal.c: 2319 in cmd_anal_esil()
Variable "old_arch" going out of scope leaks the storage it points to.