### PR TITLE
fixing 6502 analysis

### DIFF
--- a/libr/anal/p/anal_6502.c
+++ b/libr/anal/p/anal_6502.c
@@ -292,7 +292,7 @@ static int _6502_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	const int buffsize = sizeof(addrbuf)-1;
 
 	memset (op, '\0', sizeof (RAnalOp));
-	op->size = snes_op[data[0]].len;	//snes-arch is similiar to nes/6502
+	op->size = snes_op_get_size(8, &snes_op[data[0]]);	//snes-arch is similiar to nes/6502
 	op->addr = addr;
 	op->type = R_ANAL_OP_TYPE_UNK;
 	r_strbuf_init (&op->esil);

--- a/libr/anal/p/anal_snes.c
+++ b/libr/anal/p/anal_snes.c
@@ -9,7 +9,7 @@
 
 static int snes_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
 	memset (op, '\0', sizeof (RAnalOp));
-	op->size = snes_op[data[0]].len;
+	op->size = snes_op_get_size(anal->bits, &snes_op[data[0]]);
 	if (op->size > len)
 		return op->size = 0;
 	op->addr = addr;

--- a/libr/asm/arch/snes/snes_op_table.h
+++ b/libr/asm/arch/snes/snes_op_table.h
@@ -10,11 +10,19 @@ enum {
 	SNES_OP_IMM // 8- or 16-bit immediate depending on X or M flag
 };
 
+
 typedef struct {
 	const char *name;
 	ut8 len;
 } snes_op_t;
 
+static int snes_op_get_size(int bits, snes_op_t* op) {
+	if (op->len == SNES_OP_IMM) {
+		return bits == 8 ? SNES_OP_16BIT : SNES_OP_24BIT;
+	} else {
+		return op->len;
+	}
+}
 
 static snes_op_t snes_op[]={
 {"brk 0x%02x",		SNES_OP_16BIT},

--- a/libr/asm/arch/snes/snesdis.c
+++ b/libr/asm/arch/snes/snesdis.c
@@ -9,9 +9,7 @@
 
 static int snesDisass(int bits, RAsmOp *op, const ut8 *buf, int len){
 	snes_op_t *s_op = &snes_op[buf[0]];
-	int op_len = s_op->len;
-	if (op_len == SNES_OP_IMM)
-		op_len = bits == 8 ? SNES_OP_16BIT : SNES_OP_24BIT;
+	int op_len = snes_op_get_size(bits, s_op);
 	if (len < op_len)
 		return 0;
 	switch (s_op->len) {


### PR DESCRIPTION
36e42b33fe37e922f132e286508bd88ef9fb137d broke analysis by introducing a
new enum value. The analysis code didn't switch on the enum but rather
used it directly as an integer, so since the new `SNES_OP_IMM` has 5 as
its integer value the analysis code would think that the op was 5 bytes
in length.

I have only verified it fixes code analysis on 6502, not SNES. But this patch is fairly simple, and by the looks of it, it was broken on SNES too since it would still assume that `SNES_OP_IMM`'s were 5 bytes in length, not the correct 2 or 3 bytes.