### PR TITLE
Basic analysis for z80

### DIFF
--- a/libr/anal/p/anal_z80.c
+++ b/libr/anal/p/anal_z80.c
@@ -132,7 +132,6 @@ static int z80_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len)
 		break;
 	case 0x18: // jr xx
 		op->type = R_ANAL_OP_TYPE_JMP;
-		op->eob = true;
 		op->jump = addr + (st8)data[1] + ilen;
 		break;
 	// jr cond, xx
@@ -160,12 +159,10 @@ static int z80_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len)
 		break;
 	case 0xc3: // jp xx
 		op->type = R_ANAL_OP_TYPE_JMP;
-		op->eob = true;
 		op->jump = data[1] | data[2] << 8;
 		break;
 	case 0xe9: // jp (HL)
 		op->type = R_ANAL_OP_TYPE_UJMP;
-		op->eob = true;
 		break;
 
 	case 0xc7:				//rst 0


### PR DESCRIPTION
Trying to make z80 analysis work. It was in almost stub state, at least now it detects conditional and unconditional jumps and returns.

I'm not sure if it works correctly, I need to get used to analysis in Radare.

What can I do to improve it further? Will esil be used by analyzer or it's intended only to be human-readable? Are all fields such as ``stackop``, ``ptr`` and op types such as ``R_ANAL_OP_TYPE_DIV`` useful or they're superseded by esil?