### PR TITLE
fix wait in bochs for linux

### DIFF
--- a/libr/io/p/io_bochs.c
+++ b/libr/io/p/io_bochs.c
@@ -27,7 +27,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 	if (!__plugin_open (io, file, 0)) {
 		return NULL;
 	}
-	if (!r_sandbox_enable (false)) {
+	if (r_sandbox_enable (false)) {
 		eprintf ("sandbox exit\n");
 		return NULL;
 	}

--- a/shlr/bochs/src/libbochs.c
+++ b/shlr/bochs/src/libbochs.c
@@ -94,14 +94,15 @@ bool bochs_wait(libbochs_t *b) {
 	n = fcntl (b->hReadPipeIn, (flags | O_NONBLOCK));
 	while (1) {
 		n = read (b->hReadPipeIn, lpTmpBuffer, SIZE_BUF - 1);
-		if (n < 1) break;
-		lpTmpBuffer[n] = 0;
-		if (b->punteroBuffer + n >= SIZE_BUF - 1)
-			bochs_reset_buffer(b);
-		memcpy (&b->data[b->punteroBuffer], lpTmpBuffer, n + 1);
-		b->punteroBuffer += n;
-		if (strstr (&b->data[0], "<bochs:")) {
-			break;
+		if (n >0) {
+			lpTmpBuffer[n] = 0;
+			if (b->punteroBuffer + n >= SIZE_BUF - 1)
+				bochs_reset_buffer(b);
+			memcpy (&b->data[b->punteroBuffer], lpTmpBuffer, n + 1);
+			b->punteroBuffer += n;
+			if (strstr (&b->data[0], "<bochs:")) {
+				break;
+			}
 		}
 	}
 	n = fcntl (b->hReadPipeIn, (flags | ~O_NONBLOCK));


### PR DESCRIPTION
Fixed bochs_wait()

Tested using: r2 -D bochs bochs:// ,all working.
Problems using: r2 -d bochs:// ,use te above command syntax.