### PR TITLE
m68k 

### DIFF
--- a/libr/anal/p/anal_m68k.c
+++ b/libr/anal/p/anal_m68k.c
@@ -88,8 +88,7 @@ static int m68k_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
 			break;
 		}
 		if (b[1]==0xF8 || b[1]==0xF9 || b[1]==0xB8 || b[1]==0xB9){
-			op->type = R_ANAL_OP_TYPE_JMP;
-			//op->type = R_ANAL_OP_TYPE_CALL;
+			op->type = (b[1]&0xf0) == 0xf0 ? R_ANAL_OP_TYPE_JMP : R_ANAL_OP_TYPE_CALL;
 
 			int off = 0;
 			if (op->size == 4)

--- a/libr/anal/p/anal_m68k.c
+++ b/libr/anal/p/anal_m68k.c
@@ -166,6 +166,21 @@ static int m68k_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
 	return op->size;
 }
 
+static int archinfo(RAnal *anal, int query) {
+	switch (query) {
+	case R_ANAL_ARCHINFO_MIN_OP_SIZE:
+		/* all ops are at least 1 word long */
+		return 2;
+	case R_ANAL_ARCHINFO_MAX_OP_SIZE:
+		/* judging by the M68000 PROGRAMMER'S REFERENCE MANUAL the
+		 * cpTRAPcc opcode is the longest at 5 words */
+		return 10;
+	default:
+		return -1;
+	}
+
+}
+
 RAnalPlugin r_anal_plugin_m68k = {
 	.name = "m68k",
 	.desc = "Motorola 68000",
@@ -173,6 +188,7 @@ RAnalPlugin r_anal_plugin_m68k = {
 	.arch = "m68k",
 	.bits = 16|32,
 	.op = &m68k_op,
+	.archinfo = archinfo,
 };
 
 #ifndef CORELIB

--- a/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.c
+++ b/libr/asm/arch/m68k/m68k_disasm/m68k_disasm.c
@@ -913,22 +913,19 @@ static void opcode_branch(dis_buffer_t *dbuf, ut16 opc)
       make_cond(dbuf,11,"b");
 
   addchar('.');
-  disp = BITFIELD(opc,7,0);
+  disp = (st8)BITFIELD(opc,7,0);
   if (disp == 0) {
     /* 16-bit signed displacement */
-    disp = read16(dbuf->val + 1);
+    disp = (st16)read16(dbuf->val + 1);
     dbuf->used++;
     addchar('w');
-  } else if (disp == 0xff) {
+  } else if (disp == -1) {
     /* 32-bit signed displacement */
-    disp = read32(dbuf->val + 1);
+    disp = (st32)read32(dbuf->val + 1);
     dbuf->used += 2;
     addchar('l');
   } else {
-    /* 8-bit signed displacement in opcode. */
-    /* Needs to be sign-extended... */
-    if (ISBITSET(disp,7))
-      disp -= 256;
+    /* 8-bit signed displacement */
     addchar('b');
   }
   addchar('\t');


### PR DESCRIPTION
A couple of m68k bugs I've fixed:

 - jsr (subroutine call) no longer terminates function analysis (was previously interpretted as a jump, not a call)
 - 16bit branches with negative displacement were disassembled as unsigned
 - adding simple archinfo so that backwards seek works in visual mode

Regression tests coming up...