### PR TITLE
Cleanup

### DIFF
--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -11,7 +11,6 @@
 #include <r_flist.h> // radare fixed pointer array iterators
 #include <list.h> // kernel linked list
 #include <r_th.h>
-#include <r_lib.h>
 #include <dirent.h>
 #include <sys/time.h>
 #if __UNIX__

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <r_util.h>
 #include <r_socket.h>
+#include <r_lib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #if __APPLE__

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -13,6 +13,7 @@
 #include <dirent.h>
 #include <r_types.h>
 #include <r_util.h>
+#include <r_lib.h>
 #if (__linux__ && __GNU_LIBRARY__) || defined(NETBSD_WITH_BACKTRACE)
 # include <execinfo.h>
 #endif


### PR DESCRIPTION
We clean up a r_lib dependency of r_util both because it's not necessary and in preparation of removing r_lib from util