### PR TITLE
z80 analysis improvements, removed dependency to old z80

### DIFF
--- a/libr/anal/p/anal_z80.c
+++ b/libr/anal/p/anal_z80.c
@@ -168,35 +168,35 @@ static int z80_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len)
 
 	case 0xc7:				//rst 0
 		op->jump = 0x00;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
 	case 0xcf:				//rst 8
 		op->jump = 0x08;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
 	case 0xd7:				//rst 16
 		op->jump = 0x10;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
 	case 0xdf:				//rst 24
 		op->jump = 0x18;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
 	case 0xe7:				//rst 32
 		op->jump = 0x20;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
 	case 0xef:				//rst 40
 		op->jump = 0x28;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
 	case 0xf7:				//rst 48
 		op->jump = 0x30;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
 	case 0xff:				//rst 56
 		op->jump = 0x38;
-		op->type = R_ANAL_OP_TYPE_CALL;
+		op->type = R_ANAL_OP_TYPE_SWI;
 		break;				// condret: i think that foo resets some regs, but i'm not sure
 
 	// conditional call

--- a/libr/anal/p/anal_z80.c
+++ b/libr/anal/p/anal_z80.c
@@ -113,16 +113,17 @@ static int z80_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len)
 	case 0xf1:
 		op->type = R_ANAL_OP_TYPE_POP;
 		break;
+	// ld from register to register
 	case 0x40:
 	case 0x49:
 	case 0x52:
 	case 0x5b:
 	case 0x64:
 	case 0x6d:
-	case 0x76:
 	case 0x7f:
+		break;
+	case 0x76:
 		op->type = R_ANAL_OP_TYPE_TRAP; // HALT
-		op->eob = true;
 		break;
 
 	case 0x10: // djnz


### PR DESCRIPTION
- Changed dependency from old ``z80`` asm plugin to ``z80_cr`` #3287 
- Handle opcodes with memory address argument, extract address and mark as ``R_ANAL_OP_TYPE_LOAD`` or ``R_ANAL_OP_TYPE_STORE``
- Calculate opcode argument length
- ``rst``: syscall instead of regular call

Related to #2119