### PR TITLE
Temp rasm2 lib loading fix

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -457,16 +457,28 @@ int main(int argc, char **argv) {
 	bin = core.bin;
 
 	if (!(tmp = r_sys_getenv ("RABIN2_NOPLUGINS"))) {
-		tmp = r_str_home (R2_HOMEDIR"/plugins");
 		l = r_lib_new ("radare_plugin");
 		r_lib_add_handler (l, R_LIB_TYPE_BIN, "bin plugins",
 				   &__lib_bin_cb, &__lib_bin_dt, NULL);
 		r_lib_add_handler (l, R_LIB_TYPE_BIN_XTR, "bin xtr plugins",
 				   &__lib_bin_xtr_cb, &__lib_bin_xtr_dt, NULL);
 		/* load plugins everywhere */
-		r_lib_opendir (l, getenv ("LIBR_PLUGINS"));
-		r_lib_opendir (l, tmp);
-		r_lib_opendir (l, R2_LIBDIR"/radare2/"R2_VERSION);
+		
+		path = r_sys_getenv (R_LIB_ENV);
+		if (path && *path)
+			r_lib_opendir (l, path);
+		
+		if (1) {
+			char *homeplugindir = r_str_home (R2_HOMEDIR "/plugins");
+			// eprintf ("OPENDIR (%s)\n", homeplugindir);
+			r_lib_opendir (l, homeplugindir);
+			free (homeplugindir);
+		}
+		if (1) { //where & R_CORE_LOADLIBS_SYSTEM) {
+			r_lib_opendir (l, R2_LIBDIR "/radare2/" R2_VERSION);
+			r_lib_opendir (l, R2_LIBDIR "/radare2-extras/" R2_VERSION);
+			r_lib_opendir (l, R2_LIBDIR "/radare2-bindings/" R2_VERSION);
+		}
 	}
 	free (tmp);
 

--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -446,6 +446,7 @@ int main(int argc, char **argv) {
 	const char *forcebin = NULL;
 	const char *chksum = NULL;
 	const char *op = NULL;
+	const char *path = NULL;
 	RCoreBinFilter filter;
 	RCoreFile *cf = NULL;
 	int xtr_idx = 0; // load all files if extraction is necessary.

--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -390,7 +390,7 @@ int main (int argc, char *argv[]) {
 			break;
 		case 'B':
 			bin = 1;
-			ibreak;
+			break;
 		case 'c':
 			cpu = optarg;
 			break;

--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -358,13 +358,12 @@ int main (int argc, char *argv[]) {
 			r_lib_opendir (l, homeplugindir);
 			free (homeplugindir);
 		}
-		free (tmp);
 		if (1) { //where & R_CORE_LOADLIBS_SYSTEM) {
 			r_lib_opendir (l, R2_LIBDIR "/radare2/" R2_VERSION);
 			r_lib_opendir (l, R2_LIBDIR "/radare2-extras/" R2_VERSION);
 			r_lib_opendir (l, R2_LIBDIR "/radare2-bindings/" R2_VERSION);
 		}
-
+		free (tmp);
 	}
 
 	r_asm_use (a, R_SYS_ARCH);

--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -349,7 +349,7 @@ int main (int argc, char *argv[]) {
 		r_lib_add_handler (l, R_LIB_TYPE_ANAL, "analysis/emulation plugins",
 				&__lib_anal_cb, &__lib_anal_dt, NULL);
 		
-		path = r_sys_getenv ("LIBR_PLUGINS");
+		path = r_sys_getenv (R_LIB_ENV);
 		if (path && *path)
 			r_lib_opendir (l, path);
 		

--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -348,10 +348,11 @@ int main (int argc, char *argv[]) {
 				&__lib_asm_cb, &__lib_asm_dt, NULL);
 		r_lib_add_handler (l, R_LIB_TYPE_ANAL, "analysis/emulation plugins",
 				&__lib_anal_cb, &__lib_anal_dt, NULL);
+		
 		path = r_sys_getenv ("LIBR_PLUGINS");
-		if (!path || !*path)
-			path = R2_LIBDIR "/radare2/" R2_VERSION;
-		r_lib_opendir (l, path);
+		if (path && *path)
+			r_lib_opendir (l, path);
+		
 		if (1) {
 			char *homeplugindir = r_str_home (R2_HOMEDIR "/plugins");
 			// eprintf ("OPENDIR (%s)\n", homeplugindir);

--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -352,10 +352,6 @@ int main (int argc, char *argv[]) {
 		if (!path || !*path)
 			path = R2_LIBDIR "/radare2/" R2_VERSION;
 		r_lib_opendir (l, path);
-		if (1) { //where & R_CORE_LOADLIBS_SYSTEM) {
-			r_lib_opendir (l, R2_LIBDIR "/radare2-extras/" R2_VERSION);
-			r_lib_opendir (l, R2_LIBDIR "/radare2-bindings/" R2_VERSION);
-		}
 		if (1) {
 			char *homeplugindir = r_str_home (R2_HOMEDIR "/plugins");
 			// eprintf ("OPENDIR (%s)\n", homeplugindir);
@@ -363,6 +359,12 @@ int main (int argc, char *argv[]) {
 			free (homeplugindir);
 		}
 		free (tmp);
+		if (1) { //where & R_CORE_LOADLIBS_SYSTEM) {
+			r_lib_opendir (l, R2_LIBDIR "/radare2/" R2_VERSION);
+			r_lib_opendir (l, R2_LIBDIR "/radare2-extras/" R2_VERSION);
+			r_lib_opendir (l, R2_LIBDIR "/radare2-bindings/" R2_VERSION);
+		}
+
 	}
 
 	r_asm_use (a, R_SYS_ARCH);
@@ -388,7 +390,7 @@ int main (int argc, char *argv[]) {
 			break;
 		case 'B':
 			bin = 1;
-			break;
+			ibreak;
 		case 'c':
 			cpu = optarg;
 			break;

--- a/libr/core/libs.c
+++ b/libr/core/libs.c
@@ -61,7 +61,9 @@ R_API int r_core_loadlibs(RCore *core, int where, const char *path) {
 		r_lib_opendir (core->lib, r_config_get (core->config, "dir.plugins"));
 	}
 	if (where & R_CORE_LOADLIBS_ENV) {
-		r_lib_opendir (core->lib, getenv (R_LIB_ENV));
+		path = r_sys_getenv (R_LIB_ENV);
+		if (path && *path)
+			r_lib_opendir (l, path);
 	}
 	if (where & R_CORE_LOADLIBS_HOME) {
 		char *homeplugindir = r_str_home (R2_HOMEDIR"/plugins");

--- a/libr/core/libs.c
+++ b/libr/core/libs.c
@@ -63,7 +63,7 @@ R_API int r_core_loadlibs(RCore *core, int where, const char *path) {
 	if (where & R_CORE_LOADLIBS_ENV) {
 		path = r_sys_getenv (R_LIB_ENV);
 		if (path && *path)
-			r_lib_opendir (l, path);
+			r_lib_opendir (core->lib, path);
 	}
 	if (where & R_CORE_LOADLIBS_HOME) {
 		char *homeplugindir = r_str_home (R2_HOMEDIR"/plugins");

--- a/libr/reg/profile.c
+++ b/libr/reg/profile.c
@@ -2,6 +2,7 @@
 
 #include <r_reg.h>
 #include <r_util.h>
+#include <r_lib.h>
 
 static const char *parse_alias(RReg *reg, char **tok, const int n) {
 	if (n != 2) return "Invalid syntax";

--- a/libr/reg/profile.c
+++ b/libr/reg/profile.c
@@ -189,8 +189,7 @@ R_API int r_reg_set_profile(RReg *reg, const char *profile) {
 	char *base, *file;
 	char *str = r_file_slurp (profile, NULL);
 	if (!str) {
-		// XXX we must define this varname in r_lib.h /compiletime/
-		base = r_sys_getenv ("LIBR_PLUGINS");
+		base = r_sys_getenv (R_LIB_ENV);
 		if (base) {
 			file = r_str_concat (base, profile);
 			str = r_file_slurp (file, NULL);


### PR DESCRIPTION
So i made a preliminary fix for issue #4495 simply for 0.10.2, will be fixed better once i tackled issue #4513. Also adjusted rasm2's load order to match core/libs.c
Adjusted library loading by all the r*2 tools to work the same way as the core. Again, will be fixed better.