### PR TITLE
Implement cmd PS. Fix ax{*,j}

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -155,7 +155,7 @@ R_API int r_anal_xrefs_init (RAnal *anal) {
 static int xrefs_list_cb_rad(RAnal *anal, const char *k, const char *v) {
 	ut64 dst, src = r_num_get (NULL, v);
 	if (!strncmp (k, "ref.", 4)) {
-		char *p = strrchr (k, '.');
+		const char *p = r_str_rchr (k, NULL, '.');
 		if (p) {
 			dst = r_num_get (NULL, p+1);
 			anal->cb_printf ("ax 0x%"PFMT64x" 0x%"PFMT64x"\n", src, dst);
@@ -167,7 +167,7 @@ static int xrefs_list_cb_rad(RAnal *anal, const char *k, const char *v) {
 static int xrefs_list_cb_json(RAnal *anal, const char *k, const char *v) {
 	ut64 dst, src = r_num_get (NULL, v);
 	if (!strncmp (k, "ref.", 4) && (strlen (k)>8)) {
-		char *p = strrchr (k, '.');
+		const char *p = r_str_rchr (k, NULL, '.');
 		if (p) {
 			dst = r_num_get (NULL, p+1);
 			sscanf (p+1, "0x%"PFMT64x, &dst);

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -62,6 +62,7 @@ R_API int r_anal_xrefs_load(RAnal *anal, const char *prjfile) {
 
 R_API void r_anal_xrefs_save(RAnal *anal, const char *prjfile) {
 	sdb_sync (anal->sdb_xrefs);
+	sdb_file (anal->sdb_xrefs, prjfile);
 }
 
 R_API int r_anal_xrefs_set (RAnal *anal, const RAnalRefType type,
@@ -154,7 +155,7 @@ R_API int r_anal_xrefs_init (RAnal *anal) {
 static int xrefs_list_cb_rad(RAnal *anal, const char *k, const char *v) {
 	ut64 dst, src = r_num_get (NULL, v);
 	if (!strncmp (k, "ref.", 4)) {
-		char *p = strchr (k+4, '.');
+		char *p = strrchr (k, '.');
 		if (p) {
 			dst = r_num_get (NULL, p+1);
 			anal->cb_printf ("ax 0x%"PFMT64x" 0x%"PFMT64x"\n", src, dst);
@@ -166,7 +167,7 @@ static int xrefs_list_cb_rad(RAnal *anal, const char *k, const char *v) {
 static int xrefs_list_cb_json(RAnal *anal, const char *k, const char *v) {
 	ut64 dst, src = r_num_get (NULL, v);
 	if (!strncmp (k, "ref.", 4) && (strlen (k)>8)) {
-		char *p = strchr (k+4, '.');
+		char *p = strrchr (k, '.');
 		if (p) {
 			dst = r_num_get (NULL, p+1);
 			sscanf (p+1, "0x%"PFMT64x, &dst);

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -39,6 +39,11 @@ static int cmd_project(void *data, const char *input) {
 			r_cons_printf ("%s\n", file);
 		}
 		break;
+	case 'S':
+		if (input[1]==' ') {
+			r_core_project_save_rdb (core, input+2, R_CORE_PRJ_ALL);
+		} else eprintf ("Usage: PS [file]\n");
+		break;
 	case 'n':
 		if (!fileproject || !*fileproject) {
 			eprintf ("No project\n");
@@ -172,6 +177,7 @@ static int cmd_project(void *data, const char *input) {
 		"Pn", " -", "edit notes with cfg.editor",
 		"Po", " [file]", "open project",
 		"Ps", " [file]", "save project",
+		"PS", " [file]", "save script file",
 		"NOTE:", "", "See 'e file.project'",
 		"NOTE:", "", "project files are stored in ~/.config/radare2/projects",
 		NULL};

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -40,7 +40,7 @@ static int cmd_project(void *data, const char *input) {
 		}
 		break;
 	case 'S':
-		if (input[1]==' ') {
+		if (input[1] == ' ') {
 			r_core_project_save_rdb (core, input+2, R_CORE_PRJ_ALL);
 		} else eprintf ("Usage: PS [file]\n");
 		break;

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -272,9 +272,93 @@ R_API char *r_core_project_info(RCore *core, const char *prjfile) {
 	return file;
 }
 
+R_API int r_core_project_save_rdb(RCore *core, const char *file, int opts) {
+	char *filename;
+	int fd, fdold, tmp;
+
+	if (file == NULL || *file == '\0')
+		return false;
+
+	filename = r_str_word_get_first (file);
+	fd = r_sandbox_open (file, O_BINARY|O_RDWR|O_CREAT|O_TRUNC, 0644);
+	if (fd == -1) {
+		free (filename);
+		return false;
+	}
+
+	fdold = r_cons_singleton ()->fdout;
+	r_cons_singleton ()->fdout = fd;
+	r_cons_singleton ()->is_interactive = false;
+
+	r_str_write (fd, "# r2 rdb project file\n");
+
+	if (opts&R_CORE_PRJ_FLAGS) {
+		r_str_write (fd, "# flags\n");
+		tmp = core->flags->space_idx;
+		core->flags->space_idx = -1;
+		r_flag_list (core->flags, true, NULL);
+		core->flags->space_idx = tmp;
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_EVAL) {
+		r_str_write (fd, "# eval\n");
+		r_config_list (core->config, NULL, true);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_IO_MAPS) {
+		r_core_cmd (core, "om*", 0);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_SECTIONS) {
+		r_str_write (fd, "# sections\n");
+		r_io_section_list (core->io, core->offset, 1);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_META) {
+		r_str_write (fd, "# meta\n");
+		r_meta_list (core->anal, R_META_TYPE_ANY, 1);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_XREFS) {
+		r_core_cmd (core, "ax*", 0);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_FCNS) {
+		r_core_cmd (core, "afl*", 0);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_ANAL_HINTS) {
+		r_core_cmd (core, "ah*", 0);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_ANAL_TYPES) {
+		r_str_write (fd, "# types\n");
+		r_core_cmd (core, "t*", 0);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_ANAL_MACROS) {
+		r_str_write (fd, "# macros\n");
+		r_core_cmd (core, "(*", 0);
+		r_cons_flush ();
+	}
+	if (opts&R_CORE_PRJ_ANAL_SEEK) {
+		r_cons_printf ("# seek\n"
+			"s 0x%08"PFMT64x"\n", core->offset);
+		r_cons_flush ();
+	}
+
+	r_cons_singleton ()->fdout = fdold;
+	r_cons_singleton ()->is_interactive = true;
+
+	close (fd);
+	free (filename);
+
+	return true;
+}
+
 R_API int r_core_project_save(RCore *core, const char *file) {
-	int fd, fdold, tmp, ret = true;
-	char *prj;
+	int ret = true;
+	char *prj, buf[1024];
 
 	if (file == NULL || *file == '\0')
 		return false;
@@ -289,64 +373,17 @@ R_API int r_core_project_save(RCore *core, const char *file) {
 		free (prj);
 		return false;
 	}
+
 	r_core_project_init (core);
-	r_anal_project_save (core->anal, prj);
-	fd = r_sandbox_open (prj, O_BINARY|O_RDWR|O_CREAT|O_TRUNC, 0644);
-	if (fd != -1) {
-		fdold = r_cons_singleton ()->fdout;
-		r_cons_singleton ()->fdout = fd;
-		r_cons_singleton ()->is_interactive = false;
-		r_str_write (fd, "# r2 rdb project file\n");
-		r_str_write (fd, "# flags\n");
-		tmp = core->flags->space_idx;
-		core->flags->space_idx = -1;
-		r_flag_list (core->flags, true, NULL);
-		core->flags->space_idx = tmp;
-		r_cons_flush ();
-		r_str_write (fd, "# eval\n");
-		// TODO: r_str_writef (fd, "e asm.arch=%s", r_config_get ("asm.arch"));
-		r_config_list (core->config, NULL, true);
-		r_cons_flush ();
-		r_core_cmd (core, "om*", 0);
-		r_cons_flush ();
-		r_str_write (fd, "# sections\n");
-		r_io_section_list (core->io, core->offset, 1);
-		r_cons_flush ();
-		r_str_write (fd, "# meta\n");
-		r_meta_list (core->anal, R_META_TYPE_ANY, 1);
-		r_cons_flush ();
-		{
-			char buf[1024];
-			snprintf (buf, sizeof (buf), "%s.d"R_SYS_DIR"xrefs", prj);
-			sdb_file (core->anal->sdb_xrefs, buf);
-			sdb_sync (core->anal->sdb_xrefs);
-		}
-		r_core_cmd (core, "S*", 0);
-		r_cons_flush ();
-		r_core_cmd (core, "fV*", 0);
-		r_cons_flush ();
-		//r_core_cmd (core, "ax*", 0); // Not needed, xrefs are loaded from a DB file
-		//r_cons_flush ();
-		r_core_cmd (core, "afl*", 0);
-		r_cons_flush ();
-		r_core_cmd (core, "ah*", 0);
-		r_cons_flush ();
-		r_str_write (fd, "# types\n");
-		r_core_cmd (core, "t*", 0);
-		r_cons_flush ();
-		r_str_write (fd, "# macros\n");
-		r_core_cmd (core, "(*", 0);
-		r_cons_flush ();
-		r_cons_printf ("# seek\n"
-			"s 0x%08"PFMT64x"\n", core->offset);
-		r_cons_flush ();
-		close (fd);
-		r_cons_singleton ()->fdout = fdold;
-		r_cons_singleton ()->is_interactive = true;
-	} else {
+
+	snprintf (buf, sizeof (buf), "%s.d"R_SYS_DIR"xrefs", prj);
+	r_anal_project_save (core->anal, buf);
+
+	if (!r_core_project_save_rdb (core, prj, R_CORE_PRJ_ALL^R_CORE_PRJ_XREFS)) {
 		eprintf ("Cannot open '%s' for writing\n", prj);
 		ret = false;
 	}
+
 	free (prj);
 	return ret;
 }

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -272,7 +272,7 @@ R_API char *r_core_project_info(RCore *core, const char *prjfile) {
 	return file;
 }
 
-R_API int r_core_project_save_rdb(RCore *core, const char *file, int opts) {
+R_API bool r_core_project_save_rdb(RCore *core, const char *file, int opts) {
 	char *filename;
 	int fd, fdold, tmp;
 
@@ -292,7 +292,7 @@ R_API int r_core_project_save_rdb(RCore *core, const char *file, int opts) {
 
 	r_str_write (fd, "# r2 rdb project file\n");
 
-	if (opts&R_CORE_PRJ_FLAGS) {
+	if (opts & R_CORE_PRJ_FLAGS) {
 		r_str_write (fd, "# flags\n");
 		tmp = core->flags->space_idx;
 		core->flags->space_idx = -1;
@@ -300,48 +300,48 @@ R_API int r_core_project_save_rdb(RCore *core, const char *file, int opts) {
 		core->flags->space_idx = tmp;
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_EVAL) {
+	if (opts & R_CORE_PRJ_EVAL) {
 		r_str_write (fd, "# eval\n");
 		r_config_list (core->config, NULL, true);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_IO_MAPS) {
+	if (opts & R_CORE_PRJ_IO_MAPS) {
 		r_core_cmd (core, "om*", 0);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_SECTIONS) {
+	if (opts & R_CORE_PRJ_SECTIONS) {
 		r_str_write (fd, "# sections\n");
 		r_io_section_list (core->io, core->offset, 1);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_META) {
+	if (opts & R_CORE_PRJ_META) {
 		r_str_write (fd, "# meta\n");
 		r_meta_list (core->anal, R_META_TYPE_ANY, 1);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_XREFS) {
+	if (opts & R_CORE_PRJ_XREFS) {
 		r_core_cmd (core, "ax*", 0);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_FCNS) {
+	if (opts & R_CORE_PRJ_FCNS) {
 		r_core_cmd (core, "afl*", 0);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_ANAL_HINTS) {
+	if (opts & R_CORE_PRJ_ANAL_HINTS) {
 		r_core_cmd (core, "ah*", 0);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_ANAL_TYPES) {
+	if (opts & R_CORE_PRJ_ANAL_TYPES) {
 		r_str_write (fd, "# types\n");
 		r_core_cmd (core, "t*", 0);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_ANAL_MACROS) {
+	if (opts & R_CORE_PRJ_ANAL_MACROS) {
 		r_str_write (fd, "# macros\n");
 		r_core_cmd (core, "(*", 0);
 		r_cons_flush ();
 	}
-	if (opts&R_CORE_PRJ_ANAL_SEEK) {
+	if (opts & R_CORE_PRJ_ANAL_SEEK) {
 		r_cons_printf ("# seek\n"
 			"s 0x%08"PFMT64x"\n", core->offset);
 		r_cons_flush ();
@@ -356,8 +356,8 @@ R_API int r_core_project_save_rdb(RCore *core, const char *file, int opts) {
 	return true;
 }
 
-R_API int r_core_project_save(RCore *core, const char *file) {
-	int ret = true;
+R_API bool r_core_project_save(RCore *core, const char *file) {
+	bool ret = true;
 	char *prj, buf[1024];
 
 	if (file == NULL || *file == '\0')
@@ -376,7 +376,7 @@ R_API int r_core_project_save(RCore *core, const char *file) {
 
 	r_core_project_init (core);
 
-	snprintf (buf, sizeof (buf), "%s.d"R_SYS_DIR"xrefs", prj);
+	snprintf (buf, sizeof (buf), "%s.d" R_SYS_DIR "xrefs", prj);
 	r_anal_project_save (core->anal, buf);
 
 	if (!r_core_project_save_rdb (core, prj, R_CORE_PRJ_ALL^R_CORE_PRJ_XREFS)) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -403,6 +403,7 @@ R_API int r_core_project_open(RCore *core, const char *file);
 R_API int r_core_project_cat(RCore *core, const char *name);
 R_API int r_core_project_delete(RCore *core, const char *prjfile);
 R_API int r_core_project_list(RCore *core, int mode);
+R_API int r_core_project_save_rdb(RCore *core, const char *file, int opts);
 R_API int r_core_project_save(RCore *core, const char *file);
 R_API char *r_core_project_info(RCore *core, const char *file);
 R_API char *r_core_project_notes_file (RCore *core, const char *file);
@@ -437,6 +438,19 @@ R_API void r_core_sysenv_help(const RCore* core);
 #define R_CORE_BIN_ACC_EXPORTS  0x8000
 #define R_CORE_BIN_ACC_VERSIONINFO 0x10000
 #define R_CORE_BIN_ACC_ALL	0x4FFF
+
+#define R_CORE_PRJ_FLAGS	0x0001
+#define R_CORE_PRJ_EVAL		0x0002
+#define R_CORE_PRJ_IO_MAPS	0x0004
+#define R_CORE_PRJ_SECTIONS	0x0008
+#define R_CORE_PRJ_META		0x0010
+#define R_CORE_PRJ_XREFS	0x0020
+#define R_CORE_PRJ_FCNS		0x0040
+#define R_CORE_PRJ_ANAL_HINTS	0x0080
+#define R_CORE_PRJ_ANAL_TYPES	0x0100
+#define R_CORE_PRJ_ANAL_MACROS	0x0200
+#define R_CORE_PRJ_ANAL_SEEK	0x0400
+#define R_CORE_PRJ_ALL		0xFFFF
 
 typedef struct r_core_bin_filter_t {
 	ut64 offset;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -403,8 +403,8 @@ R_API int r_core_project_open(RCore *core, const char *file);
 R_API int r_core_project_cat(RCore *core, const char *name);
 R_API int r_core_project_delete(RCore *core, const char *prjfile);
 R_API int r_core_project_list(RCore *core, int mode);
-R_API int r_core_project_save_rdb(RCore *core, const char *file, int opts);
-R_API int r_core_project_save(RCore *core, const char *file);
+R_API bool r_core_project_save_rdb(RCore *core, const char *file, int opts);
+R_API bool r_core_project_save(RCore *core, const char *file);
 R_API char *r_core_project_info(RCore *core, const char *file);
 R_API char *r_core_project_notes_file (RCore *core, const char *file);
 


### PR DESCRIPTION
- Add r_core_project_save_rdb for selective project dump
- Implement command PS and Ps using r_core_project_save_rdb
- Fix commands ax* and axj
- Fix r_anal_xrefs_save (it didn't save DB to project file)