### PR TITLE
 Fix #4523 - Fix asm.emu + pd leaks

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -810,6 +810,7 @@ static int esil_if(RAnalEsil *esil) {
 		(void)r_anal_esil_get_parm (esil, src, &num);
 		// condition not matching, skipping until }
 		if (!num) esil->skip = true;
+		free (src);
 		return true;
 	}
 	return false;
@@ -1398,6 +1399,8 @@ static int esil_poke_n(RAnalEsil *esil, int bits) {
 			ret = r_anal_esil_mem_write (esil, addr, (const ut8 *)&n, bytes);
 		}
 	}
+	free (src);
+	free (dst);
 	return ret;
 }
 
@@ -1989,8 +1992,10 @@ static int esil_num(RAnalEsil *esil) {
 		return false;
 	if (!(dup_me = r_anal_esil_pop (esil)))
 		return false;
-	if (!r_anal_esil_get_parm (esil, dup_me, &dup))
+	if (!r_anal_esil_get_parm (esil, dup_me, &dup)) {
+		free (dup_me);
 		return false;
+	}
 	free (dup_me);
 	return r_anal_esil_pushnum (esil, dup);
 }

--- a/libr/anal/esil2reil.c
+++ b/libr/anal/esil2reil.c
@@ -80,11 +80,13 @@ RAnalReilArg *reil_pop_arg(RAnalEsil *esil) {
 		} else if (op->type == ARG_CONST) {
 			op->size = esil->anal->bits;
 		}
+		free(buf);
 		return op;
 	}
 
 	op->size = strtoll(tmp_buf, NULL, 10);
 	op->type = reil_get_arg_type(esil, op->name);
+	free(buf);
 	return op;
 }
 

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -196,6 +196,7 @@ static int process_input(RCore *core, const char *input, ut64* blocksize, char *
 		}
 		result = true;
 	}
+	free (str_clone);
 	return result;
 }
 

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1294,8 +1294,10 @@ static void do_esil_search(RCore *core, struct search_parameters *param, const c
 			res = r_anal_esil_pop (core->anal->esil);
 			if (r_anal_esil_get_parm (core->anal->esil, res, &nres)) {
 				if (nres) {
-					if (!__cb_hit (&kw, core, addr))
+					if (!__cb_hit (&kw, core, addr)){
+						free (res);
 						break;
+					}
 					//eprintf (" HIT AT 0x%"PFMT64x"\n", addr);
 					kw.type = 0; //R_SEARCH_TYPE_ESIL;
 					kw.kwidx = kwidx;

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -21,8 +21,7 @@ R_API int r_core_gdiff_fcn(RCore *c, ut64 addr, ut64 addr2) {
 	return false;
 }
 
-/* Fingerprint functions and blocks, then diff.
- * If `anal_all` is 1 analyse all the symbols, if its 2 runs `aac` */
+/* Fingerprint functions and blocks, then diff. */
 R_API int r_core_gdiff(RCore *c, RCore *c2) {
 	RCore *cores[2] = {c, c2};
 	RAnalFunction *fcn;


### PR DESCRIPTION
All the memory allocations made by function `r_anal_esil_push` are freed while using `r_anal_esil_pop`