### PR TITLE
Add crypto ROT, ROL and ROR

### DIFF
--- a/libr/crypto/Jamroot
+++ b/libr/crypto/Jamroot
@@ -1,4 +1,4 @@
 OBJS = crypto.c ;
-OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c p/crypto_rot.c;
+OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c p/crypto_rot.c p/crypto_rol.c p/crypto_ror.c;
 
 lib r_crypto : $(OBJS) : <include>../include <library>../util ;

--- a/libr/crypto/Jamroot
+++ b/libr/crypto/Jamroot
@@ -1,4 +1,4 @@
 OBJS = crypto.c ;
-OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c;
+OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c p/crypto_rot.c;
 
 lib r_crypto : $(OBJS) : <include>../include <library>../util ;

--- a/libr/crypto/p/crypto_rol.c
+++ b/libr/crypto/p/crypto_rol.c
@@ -1,0 +1,72 @@
+#include <r_lib.h>
+#include <r_crypto.h>
+
+#define MAX_rol_KEY_SIZE 32768
+
+struct rol_state {
+	ut8 key[MAX_rol_KEY_SIZE];
+	int key_size;
+};
+
+static bool rol_init(struct rol_state *const state, const ut8 *key, int keylen) {
+	if (!state || !key || keylen < 1 || keylen > MAX_rol_KEY_SIZE) {
+		return false;
+	}
+	int i;
+	state->key_size = keylen;
+	for (i = 0; i < keylen; i++) {
+		state->key[i] = key[i];
+	}
+	return true;
+}
+
+static void rol_crypt(struct rol_state *const state, const ut8 *inbuf, ut8 *outbuf, int buflen) {
+	int i;
+	for (i = 0; i < buflen; i++) {
+		outbuf[i] = inbuf[i] << state->key[i%state->key_size];
+	}
+}
+
+static struct rol_state st;
+
+static int rol_set_key(RCrypto *cry, const ut8 *key, int keylen, int mode, int direction) {
+	return rol_init (&st, key, keylen);
+}
+
+static int rol_get_key_size(RCrypto *cry) {
+	return st.key_size;
+}
+
+static bool rol_use(const char *algo) {
+	return !strcmp (algo, "rol");
+}
+
+static int update(RCrypto *cry, const ut8 *buf, int len) {
+	ut8 *obuf = calloc (1, len);
+	if (!obuf) return false;
+	rol_crypt (&st, buf, obuf, len);
+	r_crypto_append (cry, obuf, len);
+	free (obuf);
+	return 0;
+}
+
+static int final(RCrypto *cry, const ut8 *buf, int len) {
+	return update (cry, buf, len);
+}
+
+RCryptoPlugin r_crypto_plugin_rol = {
+	.name = "rol",
+	.set_key = rol_set_key,
+	.get_key_size = rol_get_key_size,
+	.use = rol_use,
+	.update = update,
+	.final = final
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_CRYPTO,
+	.data = &r_crypto_plugin_rol,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/crypto/p/crypto_ror.c
+++ b/libr/crypto/p/crypto_ror.c
@@ -1,0 +1,72 @@
+#include <r_lib.h>
+#include <r_crypto.h>
+
+#define MAX_ror_KEY_SIZE 32768
+
+struct ror_state {
+	ut8 key[MAX_ror_KEY_SIZE];
+	int key_size;
+};
+
+static bool ror_init(struct ror_state *const state, const ut8 *key, int keylen) {
+	if (!state || !key || keylen < 1 || keylen > MAX_ror_KEY_SIZE) {
+		return false;
+	}
+	int i;
+	state->key_size = keylen;
+	for (i = 0; i < keylen; i++) {
+		state->key[i] = key[i];
+	}
+	return true;
+}
+
+static void ror_crypt(struct ror_state *const state, const ut8 *inbuf, ut8 *outbuf, int buflen) {
+	int i;
+	for (i = 0; i < buflen; i++) {
+		outbuf[i] = inbuf[i] >> state->key[i%state->key_size];
+	}
+}
+
+static struct ror_state st;
+
+static int ror_set_key(RCrypto *cry, const ut8 *key, int keylen, int mode, int direction) {
+	return ror_init (&st, key, keylen);
+}
+
+static int ror_get_key_size(RCrypto *cry) {
+	return st.key_size;
+}
+
+static bool ror_use(const char *algo) {
+	return !strcmp (algo, "ror");
+}
+
+static int update(RCrypto *cry, const ut8 *buf, int len) {
+	ut8 *obuf = calloc (1, len);
+	if (!obuf) return false;
+	ror_crypt (&st, buf, obuf, len);
+	r_crypto_append (cry, obuf, len);
+	free (obuf);
+	return 0;
+}
+
+static int final(RCrypto *cry, const ut8 *buf, int len) {
+	return update (cry, buf, len);
+}
+
+RCryptoPlugin r_crypto_plugin_ror = {
+	.name = "ror",
+	.set_key = ror_set_key,
+	.get_key_size = ror_get_key_size,
+	.use = ror_use,
+	.update = update,
+	.final = final
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_CRYPTO,
+	.data = &r_crypto_plugin_ror,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/crypto/p/crypto_rot.c
+++ b/libr/crypto/p/crypto_rot.c
@@ -1,0 +1,82 @@
+#include <r_lib.h>
+#include <r_crypto.h>
+
+int mod(int a, int b) {
+	if (b < 0) {
+		return mod (-a, -b);
+	}   
+	int ret = a % b;
+	if (ret < 0) {
+		ret += b;
+	}   
+	return ret;
+}
+
+static bool rot_init(ut8 *rotkey, const ut8 *key, int keylen) {
+	if (!rotkey || !key) {
+		return false;
+	}   
+	int i = atoi(key);
+	*rotkey = (ut8)mod(i, 26);
+	return true;
+}
+
+static void rot_crypt(ut8 key, const ut8 *inbuf, ut8 *outbuf, int buflen) {
+	int i;
+	for (i = 0; i < buflen; i++) {
+		outbuf[i] = inbuf[i];
+		if ((inbuf[i] < 'a' || inbuf[i] > 'z') && (inbuf[i] < 'A' || inbuf[i] > 'Z')) {
+			continue;
+		}
+		outbuf[i] += key;
+		outbuf[i] -= (inbuf[i] >= 'a' && inbuf[i] <= 'z') ? 'a' : 'A';
+		outbuf[i] = mod (outbuf[i], 26);
+		outbuf[i] += (inbuf[i] >= 'a' && inbuf[i] <= 'z') ? 'a' : 'A';
+    }   
+}
+
+static ut8 rot_key;
+
+static int rot_set_key(RCrypto *cry, const ut8 *key, int keylen, int mode, int direction) {
+	return rot_init (&rot_key, key, keylen);
+}
+
+static int rot_get_key_size(RCrypto *cry) {
+	//Returning number of bytes occupied by ut8
+	return 1;
+}
+
+static bool rot_use(const char *algo) {
+	return !strcmp (algo, "rot");
+}
+
+static int update(RCrypto *cry, const ut8 *buf, int len) {
+	ut8 *obuf = calloc (1, len);
+	if (!obuf) return false;
+	rot_crypt (rot_key, buf, obuf, len);
+	r_crypto_append (cry, obuf, len);
+	free (obuf);
+	return 0;
+}
+
+static int final(RCrypto *cry, const ut8 *buf, int len) {
+	return update (cry, buf, len);
+}
+
+RCryptoPlugin r_crypto_plugin_rot = {
+	.name = "rot",
+	.set_key = rot_set_key,
+	.get_key_size = rot_get_key_size,
+	.use = rot_use,
+	.update = update,
+	.final = final
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_CRYPTO,
+	.data = &r_crypto_plugin_rot,
+	.version = R2_VERSION
+};
+#endif
+

--- a/libr/crypto/p/rol.mk
+++ b/libr/crypto/p/rol.mk
@@ -1,0 +1,9 @@
+OBJ_ROL=crypto_rol.o
+
+STATIC_OBJ+=${OBJ_ROL}
+TARGET_ROL=crypto_rol.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_ROL}
+
+${TARGET_ROL}: ${OBJ_ROL}
+	${CC} $(call libname,crypto_rol) ${LDFLAGS} ${CFLAGS} -o ${TARGET_ROL} ${OBJ_ROL}

--- a/libr/crypto/p/ror.mk
+++ b/libr/crypto/p/ror.mk
@@ -1,0 +1,9 @@
+OBJ_ROR=crypto_ror.o
+
+STATIC_OBJ+=${OBJ_ROR}
+TARGET_ROR=crypto_ror.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_ROR}
+
+${TARGET_ROR}: ${OBJ_ROR}
+	${CC} $(call libname,crypto_ror) ${LDFLAGS} ${CFLAGS} -o ${TARGET_ROR} ${OBJ_ROR}

--- a/libr/crypto/p/rot.mk
+++ b/libr/crypto/p/rot.mk
@@ -1,0 +1,9 @@
+OBJ_ROT=crypto_rot.o
+
+STATIC_OBJ+=${OBJ_ROT}
+TARGET_ROT=crypto_rot.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_ROT}
+
+${TARGET_ROT}: ${OBJ_ROT}
+	${CC} $(call libname,crypto_rot) ${LDFLAGS} ${CFLAGS} -o ${TARGET_ROT} ${OBJ_ROT}

--- a/libr/include/r_crypto.h
+++ b/libr/include/r_crypto.h
@@ -66,6 +66,7 @@ extern RCryptoPlugin r_crypto_plugin_rc4;
 extern RCryptoPlugin r_crypto_plugin_xor;
 extern RCryptoPlugin r_crypto_plugin_blowfish;
 extern RCryptoPlugin r_crypto_plugin_rc2;
+extern RCryptoPlugin r_crypto_plugin_rot;
 
 #ifdef __cplusplus
 }

--- a/libr/include/r_crypto.h
+++ b/libr/include/r_crypto.h
@@ -67,6 +67,8 @@ extern RCryptoPlugin r_crypto_plugin_xor;
 extern RCryptoPlugin r_crypto_plugin_blowfish;
 extern RCryptoPlugin r_crypto_plugin_rc2;
 extern RCryptoPlugin r_crypto_plugin_rot;
+extern RCryptoPlugin r_crypto_plugin_rol;
+extern RCryptoPlugin r_crypto_plugin_ror;
 
 #ifdef __cplusplus
 }

--- a/man/rahash2.1
+++ b/man/rahash2.1
@@ -41,7 +41,7 @@ Decode base64 string or file
 .It Fl e
 Use little endian to display checksums
 .It Fl E Ar algo
-Encrypt instead of hash using the given algorithm (rc4, aes, xor, blowfish)
+Encrypt instead of hash using the given algorithm (rc4, aes, xor, blowfish, rot)
 .It Fl i Ar iters
 Apply the hash Iters times to itself+seed
 .It Fl j

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -154,6 +154,8 @@ crypto.xor
 crypto.blowfish
 crypto.rc2
 crypto.rot
+crypto.rol
+crypto.ror
 debug.bf
 debug.esil
 debug.gdb

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -153,6 +153,7 @@ crypto.rc4
 crypto.xor
 crypto.blowfish
 crypto.rc2
+crypto.rot
 debug.bf
 debug.esil
 debug.gdb


### PR DESCRIPTION
Implementing ROTn instead of ROT13 as specified in https://github.com/radare/radare2/issues/4254. Also `rahash2 -S` used to convert the seed to hex even though `s:` was given in the seed string, hence it is corrected and recalculation of `seed` is removed.