### PR TITLE
fix mips forward assembler when using negative offset

### DIFF
--- a/libr/asm/arch/mips/mipsasm.c
+++ b/libr/asm/arch/mips/mipsasm.c
@@ -106,21 +106,31 @@ static int mips_j (ut8 *b, int op, int addr) {
 
 static int getreg (const char *p) {
 	int n;
+	char **tmp;
+
 	if (!p || !*p) {
 		eprintf ("Missing argument\n");
 		return -1;
 	}
-	n = (int) r_num_get (NULL, p);
-	if (n != 0) {
+	/* check if it's a register */
+	for (n=0; regs[n]; n++) {
+		if (!strcmp (p, regs[n]))
+			return n;
+	}
+
+	/* try to convert it into a number */
+	if (p[0] == '-') {
+		n = (int) r_num_get (NULL, &p[1]);
+		n = -n;
+	} else {
+		n = (int) r_num_get (NULL, p);
+	}
+
+	if (n != 0 || p[0] == '0') {
 		return n;
 	}
-	if (strcmp (p, "0")) {
-		for (n=0; regs[n]; n++) {
-			if (!strcmp (p, regs[n]))
-				return n;
-		}
-		eprintf ("Invalid reg name (%s)\n", p);
-	}
+
+	eprintf ("Invalid reg name (%s) at pos %d\n", p, n);
 	return -1;
 }
 


### PR DESCRIPTION
Fix 'Invalid reg name (-0x5c60)' when try to assemble
'lw t9, -0x5c60(gp)'