### PR TITLE
Add `rahash2 -D` option, `woD` in r2, base64 and base91 plugin

### DIFF
--- a/libr/crypto/Jamroot
+++ b/libr/crypto/Jamroot
@@ -1,4 +1,4 @@
 OBJS = crypto.c ;
-OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c p/crypto_rot.c p/crypto_rol.c p/crypto_ror.c;
+OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c p/crypto_rot.c p/crypto_rol.c p/crypto_ror.c p/crypto_base64.c p/crypto_base91.c;
 
 lib r_crypto : $(OBJS) : <include>../include <library>../util ;

--- a/libr/crypto/crypto.c
+++ b/libr/crypto/crypto.c
@@ -72,9 +72,11 @@ R_API bool r_crypto_use(RCrypto *cry, const char *algo) {
 	r_list_foreach (cry->plugins, iter, h) {
 		if (h && h->use && h->use (algo)) {
 			cry->h = h;
-			cry->key_len = h->get_key_size (cry);
-			cry->key = calloc (1, cry->key_len);
-			return cry->key != NULL;
+			if (h->get_key_size) {	//should i change this or make base64/base91 return 0 for get_key_size?
+				cry->key_len = h->get_key_size (cry);
+				cry->key = calloc (1, cry->key_len);
+			}
+			return (h->get_key_size) ? (cry->key != NULL) : true;
 		}
 	}
 	return false;
@@ -137,4 +139,3 @@ R_API ut8 *r_crypto_get_output(RCrypto *cry, int *size) {
 	}
 	return buf;
 }
-

--- a/libr/crypto/crypto.c
+++ b/libr/crypto/crypto.c
@@ -98,14 +98,14 @@ R_API int r_crypto_set_iv(RCrypto *cry, const ut8 *iv) {
 }
 
 // return the number of bytes written in the output buffer
-R_API int r_crypto_update(RCrypto *cry, const ut8 *buf, int len) {
+R_API int r_crypto_update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	return (cry && cry->h && cry->h->update)?
-		cry->h->update (cry, buf, len): 0;
+		cry->h->update (cry, buf, len, to_encrypt): 0;
 }
 
-R_API int r_crypto_final(RCrypto *cry, const ut8 *buf, int len) {
+R_API int r_crypto_final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	return (cry && cry->h && cry->h->final)?
-		cry->h->final (cry, buf, len): 0;
+		cry->h->final (cry, buf, len, to_encrypt): 0;
 }
 
 // TODO: internal api?? used from plugins? TODO: use r_buf here

--- a/libr/crypto/p/base64.mk
+++ b/libr/crypto/p/base64.mk
@@ -1,0 +1,9 @@
+OBJ_B64=crypto_base64.o
+
+STATIC_OBJ+=${OBJ_B64}
+TARGET_B64=crypto_base64.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_B64}
+
+${TARGET_B64}: ${OBJ_B64}
+	${CC} $(call libname,crypto_base64) ${LDFLAGS} ${CFLAGS} -o ${TARGET_B64} ${OBJ_B64}

--- a/libr/crypto/p/base91.mk
+++ b/libr/crypto/p/base91.mk
@@ -1,0 +1,9 @@
+OBJ_B91=crypto_base91.o
+
+STATIC_OBJ+=${OBJ_B91}
+TARGET_B91=crypto_base91.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_B91}
+
+${TARGET_B91}: ${OBJ_B91}
+	${CC} $(call libname,crypto_base91) ${LDFLAGS} ${CFLAGS} -o ${TARGET_B91} ${OBJ_B91}

--- a/libr/crypto/p/crypto_aes.c
+++ b/libr/crypto/p/crypto_aes.c
@@ -34,7 +34,7 @@ static bool aes_use (const char *algo) {
 
 #define BLOCK_SIZE 16
 
-static int update (RCrypto *cry, const ut8 *buf, int len) {
+static int update (RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	// Pad to the block size, do not append dummy block
 	const int diff = (BLOCK_SIZE - (len % BLOCK_SIZE)) % BLOCK_SIZE;
 	const int size = len + diff;
@@ -62,10 +62,16 @@ static int update (RCrypto *cry, const ut8 *buf, int len) {
 	//         columns: %d\n \
 	//         rounds: %d\n", st.key, st.key_size, st.columns, st.rounds);
 	int i;
-	for (i = 0; i < blocks; i++) {
-		// printf("Block: %d\n", i);
-		aes_encrypt (&st, ibuf + BLOCK_SIZE * i, obuf + BLOCK_SIZE * i);
-		// printf("Block finished: %d\n", i);
+	if (to_encrypt) {
+		for (i = 0; i < blocks; i++) {
+			// printf("Block: %d\n", i);
+			aes_encrypt (&st, ibuf + BLOCK_SIZE * i, obuf + BLOCK_SIZE * i);
+			// printf("Block finished: %d\n", i);
+		}
+	} else {
+		for (i = 0; i < blocks; i++) {
+			aes_decrypt (&st, ibuf + BLOCK_SIZE * i, obuf + BLOCK_SIZE * i);
+		}
 	}
 
 	// printf("%128s\n", obuf);
@@ -76,8 +82,8 @@ static int update (RCrypto *cry, const ut8 *buf, int len) {
 	return 0;
 }
 
-static int final (RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final (RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_aes = { 

--- a/libr/crypto/p/crypto_base64.c
+++ b/libr/crypto/p/crypto_base64.c
@@ -1,0 +1,45 @@
+#include <r_lib.h>
+#include <r_crypto.h>
+#include <r_util.h>
+
+static bool base64_use(const char *algo) {
+	return !strcmp (algo, "base64");
+}
+
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encode) {
+	int olen;
+	ut8 *obuf;
+	if (to_encode) {
+		olen = ((len + 2) / 3 ) * 4;
+		obuf = malloc (olen + 1);
+		r_base64_encode (obuf, buf, len);
+	} else {
+		olen = (len / 4) * 3;
+		if (len > 0)					//to prevent invalid access of memory
+			olen -= (buf[len-1] == '=') ? ((buf[len-2] == '=') ? 2 : 1) : 0;
+		obuf = malloc (olen + 1);
+		olen = r_base64_decode (obuf, buf, len);
+	}
+	r_crypto_append (cry, obuf, olen);
+	free (obuf);
+	return 0;
+}
+
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encode) {
+	return update (cry, buf, len, to_encode);
+}
+
+RCryptoPlugin r_crypto_plugin_base64 = {
+	.name = "base64",
+	.use = base64_use,
+	.update = update,
+	.final = final
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_CRYPTO,
+	.data = &r_crypto_plugin_base64,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/crypto/p/crypto_base91.c
+++ b/libr/crypto/p/crypto_base91.c
@@ -1,0 +1,41 @@
+#include <r_lib.h>
+#include <r_crypto.h>
+#include <r_util.h>
+
+#define INSIZE 32768
+
+static bool base91_use(const char *algo) {
+	return !strcmp (algo, "base91");
+}
+
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encode) {
+	int olen = INSIZE; //a way to optimise memory allocation.
+	ut8 *obuf = malloc (olen);
+	if (to_encode) {
+		olen = r_base91_encode (obuf, buf, len);
+	} else {
+		olen = r_base91_decode (obuf, buf, len);
+	}
+	r_crypto_append (cry, obuf, olen);
+	free (obuf);
+	return 0;
+}
+
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encode) {
+	return update (cry, buf, len, to_encode);
+}
+
+RCryptoPlugin r_crypto_plugin_base91 = {
+	.name = "base91",
+	.use = base91_use,
+	.update = update,
+	.final = final
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_CRYPTO,
+	.data = &r_crypto_plugin_base91,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/crypto/p/crypto_blowfish.c
+++ b/libr/crypto/p/crypto_blowfish.c
@@ -301,17 +301,21 @@ static bool blowfish_use(const char *algo) {
 	return !strcmp (algo, "blowfish");
 }
 
-static int update(RCrypto *cry, const ut8 *buf, int len) {
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	ut8 *obuf = calloc (1, len);
 	if (!obuf) return false;
-	blowfish_crypt (&st, buf, obuf, len);
+	if (to_encrypt) {
+		blowfish_crypt (&st, buf, obuf, len);
+	} else {
+		blowfish_decrypt (&st, buf, obuf, len);
+	}
 	r_crypto_append (cry, obuf, len);
 	free (obuf);
 	return 0;
 }
 
-static int final(RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_blowfish = {

--- a/libr/crypto/p/crypto_rc2.c
+++ b/libr/crypto/p/crypto_rc2.c
@@ -208,17 +208,21 @@ static bool rc2_use(const char *algo) {
 	return !strcmp (algo, "rc2");
 }
 
-static int update(RCrypto *cry, const ut8 *buf, int len) {
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	ut8 *obuf = calloc (1, len);
 	if (!obuf) return false;
-	rc2_crypt(&state, buf, obuf, len);
+	if (to_encrypt) {
+		rc2_crypt (&state, buf, obuf, len);
+	} else {
+		rc2_dcrypt (&state, buf, obuf, len);
+	}
 	r_crypto_append(cry, obuf, len);
 	free (obuf);
 	return 0;
 }
 
-static int final(RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_rc2 = {

--- a/libr/crypto/p/crypto_rc4.c
+++ b/libr/crypto/p/crypto_rc4.c
@@ -85,7 +85,7 @@ static bool rc4_use(const char *algo) {
 	return !strcmp (algo, "rc4");
 }
 
-static int update(RCrypto *cry, const ut8 *buf, int len) {
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	ut8 *obuf = calloc (1, len);
 	if (!obuf) return false;
 	rc4_crypt (&st, buf, obuf, len);
@@ -94,8 +94,8 @@ static int update(RCrypto *cry, const ut8 *buf, int len) {
 	return 0;
 }
 
-static int final(RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_rc4 = {

--- a/libr/crypto/p/crypto_rol.c
+++ b/libr/crypto/p/crypto_rol.c
@@ -41,7 +41,11 @@ static bool rol_use(const char *algo) {
 	return !strcmp (algo, "rol");
 }
 
-static int update(RCrypto *cry, const ut8 *buf, int len) {
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	if (!to_encrypt) {
+		eprintf ("Use ROR\n");
+		return false;
+	}
 	ut8 *obuf = calloc (1, len);
 	if (!obuf) return false;
 	rol_crypt (&st, buf, obuf, len);
@@ -50,8 +54,8 @@ static int update(RCrypto *cry, const ut8 *buf, int len) {
 	return 0;
 }
 
-static int final(RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_rol = {

--- a/libr/crypto/p/crypto_ror.c
+++ b/libr/crypto/p/crypto_ror.c
@@ -41,7 +41,11 @@ static bool ror_use(const char *algo) {
 	return !strcmp (algo, "ror");
 }
 
-static int update(RCrypto *cry, const ut8 *buf, int len) {
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	if (!to_encrypt) {
+		eprintf ("USE ROL\n");
+		return false;
+	}
 	ut8 *obuf = calloc (1, len);
 	if (!obuf) return false;
 	ror_crypt (&st, buf, obuf, len);
@@ -50,8 +54,8 @@ static int update(RCrypto *cry, const ut8 *buf, int len) {
 	return 0;
 }
 
-static int final(RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_ror = {

--- a/libr/crypto/p/crypto_rot.c
+++ b/libr/crypto/p/crypto_rot.c
@@ -32,7 +32,22 @@ static void rot_crypt(ut8 key, const ut8 *inbuf, ut8 *outbuf, int buflen) {
 		outbuf[i] -= (inbuf[i] >= 'a' && inbuf[i] <= 'z') ? 'a' : 'A';
 		outbuf[i] = mod (outbuf[i], 26);
 		outbuf[i] += (inbuf[i] >= 'a' && inbuf[i] <= 'z') ? 'a' : 'A';
-    }   
+	}
+}
+
+static void rot_decrypt(ut8 key, const ut8 *inbuf, ut8 *outbuf, int buflen) {
+	int i;
+	for (i = 0; i < buflen; i++) {
+		outbuf[i] = inbuf[i];
+		if ((inbuf[i] < 'a' || inbuf[i] > 'z') && (inbuf[i] < 'A' || inbuf[i] > 'Z')) {
+			continue;
+		}
+		outbuf[i] += 26;	//adding so that subtracting does not make it negative
+		outbuf[i] -= key;
+		outbuf[i] -= (inbuf[i] >= 'a' && inbuf[i] <= 'z') ? 'a' : 'A';
+		outbuf[i] = mod (outbuf[i], 26);
+		outbuf[i] += (inbuf[i] >= 'a' && inbuf[i] <= 'z') ? 'a' : 'A';
+	}
 }
 
 static ut8 rot_key;
@@ -50,17 +65,21 @@ static bool rot_use(const char *algo) {
 	return !strcmp (algo, "rot");
 }
 
-static int update(RCrypto *cry, const ut8 *buf, int len) {
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	ut8 *obuf = calloc (1, len);
 	if (!obuf) return false;
-	rot_crypt (rot_key, buf, obuf, len);
+	if (to_encrypt) {
+		rot_crypt (rot_key, buf, obuf, len);
+	} else {
+		rot_decrypt (rot_key, buf, obuf, len);
+	}
 	r_crypto_append (cry, obuf, len);
 	free (obuf);
 	return 0;
 }
 
-static int final(RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_rot = {

--- a/libr/crypto/p/crypto_xor.c
+++ b/libr/crypto/p/crypto_xor.c
@@ -47,7 +47,7 @@ static bool xor_use(const char *algo) {
 	return !strcmp (algo, "xor");
 }
 
-static int update(RCrypto *cry, const ut8 *buf, int len) {
+static int update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
 	ut8 *obuf = calloc (1, len);
 	if (!obuf) return false;
 	xor_crypt (&st, buf, obuf, len);
@@ -56,8 +56,8 @@ static int update(RCrypto *cry, const ut8 *buf, int len) {
 	return 0;
 }
 
-static int final(RCrypto *cry, const ut8 *buf, int len) {
-	return update (cry, buf, len);
+static int final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt) {
+	return update (cry, buf, len, to_encrypt);
 }
 
 RCryptoPlugin r_crypto_plugin_xor = {

--- a/libr/include/r_crypto.h
+++ b/libr/include/r_crypto.h
@@ -39,8 +39,8 @@ typedef struct r_crypto_plugin_t {
 	int (*get_key_size)(RCrypto *cry);
 	int (*set_iv)(RCrypto *cry, const ut8 *iv);
 	int (*set_key)(RCrypto *cry, const ut8 *key, int keylen, int mode, int direction);
-	int (*update)(RCrypto *cry, const ut8 *buf, int len);
-	int (*final)(RCrypto *cry, const ut8 *buf, int len);
+	int (*update)(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt);
+	int (*final)(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt);
 	bool (*use)(const char *algo);
 	int (*fini)(RCrypto *cry);
 } RCryptoPlugin;
@@ -54,8 +54,8 @@ R_API RCrypto *r_crypto_free(RCrypto *cry);
 R_API bool r_crypto_use(RCrypto *cry, const char *algo);
 R_API int r_crypto_set_key(RCrypto *cry, const ut8* key, int keylen, int mode, int direction);
 R_API int r_crypto_set_iv(RCrypto *cry, const ut8 *iv);
-R_API int r_crypto_update(RCrypto *cry, const ut8 *buf, int len);
-R_API int r_crypto_final(RCrypto *cry, const ut8 *buf, int len);
+R_API int r_crypto_update(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt);
+R_API int r_crypto_final(RCrypto *cry, const ut8 *buf, int len, bool to_encrypt);
 R_API int r_crypto_append(RCrypto *cry, const ut8 *buf, int len);
 R_API ut8 *r_crypto_get_output(RCrypto *cry, int *size);
 #endif

--- a/libr/include/r_crypto.h
+++ b/libr/include/r_crypto.h
@@ -69,6 +69,8 @@ extern RCryptoPlugin r_crypto_plugin_rc2;
 extern RCryptoPlugin r_crypto_plugin_rot;
 extern RCryptoPlugin r_crypto_plugin_rol;
 extern RCryptoPlugin r_crypto_plugin_ror;
+extern RCryptoPlugin r_crypto_plugin_base64;
+extern RCryptoPlugin r_crypto_plugin_base91;
 
 #ifdef __cplusplus
 }

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -479,6 +479,9 @@ R_API int r_base64_decode(ut8 *bout, const char *bin, int len);
 R_API ut8 *r_base64_decode_dyn(const char *in, int len);
 R_API char *r_base64_encode_dyn(const char *str, int len);
 
+R_API int r_base91_encode(char *bout, const ut8 *bin, int len);
+R_API int r_base91_decode(ut8 *bout, const char *bin, int len);
+
 /* strings */
 static inline void r_str_rmch (char *s, char ch) {
 	for (;*s; s++) {

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -4,7 +4,7 @@ NAME=r_util
 DEPS=
 
 OBJS=mem.o pool.o num.o str.o hex.o file.o range.o
-OBJS+=prof.o cache.o sys.o buf.o w32-sys.o base64.o base85.o
+OBJS+=prof.o cache.o sys.o buf.o w32-sys.o base64.o base85.o base91.o
 OBJS+=list.o flist.o ht.o ht64.o mixed.o btree.o chmod.o graph.o
 OBJS+=regex/regcomp.o regex/regerror.o regex/regexec.o uleb128.o
 OBJS+=sandbox.o calc.o thread.o thread_lock.o thread_msg.o

--- a/libr/util/base91.c
+++ b/libr/util/base91.c
@@ -1,0 +1,93 @@
+#include <string.h>
+
+#include <r_util.h>
+
+static const char b91[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+							'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+							'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+							'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+							'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
+							'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',
+							'8', '9', '!', '#', '$', '%', '&', '(', ')', '*',
+							'+', ',', '.', '/', ':', ';', '<', '=', '>', '?',
+							'@', '[', ']', '^', '_', '`', '{', '|', '}', '~', '"'};
+
+int get_char_index(const char c) {
+	int i;
+	for (i = 0; i < 91; i++ ) {
+		if (b91[i] == c)
+			return i;
+	}
+	return -1;
+}
+
+R_API int r_base91_decode(ut8* bout, const char *bin, int len) {
+	int in, out;
+	int v = -1;
+	int b = 0;
+	int n = 0;
+	int c;
+	if (len < 0)
+		len = strlen (bin);
+	for (in = out = 0; in < len; in++) {
+		c = get_char_index(bin[in]);
+		if (c == -1)
+			continue;
+		if (v < 0) {
+			v = c;
+		} else {
+			v += c * 91;
+			b |= (v << n);
+			if ((v&8191) > 88) {
+				n += 13;
+			} else {
+				n += 14;
+			}
+			while (true) {
+				bout[out++] = b & 255;
+				b >>= 8;
+				n -= 8;
+				if (n <= 7)
+					break;
+			}
+			v = -1;
+		}
+	}
+	if (v+1) {
+		bout[out++] = (b | v << n) & 255;
+	}
+	return out;
+}
+
+R_API int r_base91_encode(char *bout, const ut8 *bin, int len) {
+	int in, out;
+	int v = 0;
+	int b = 0;
+	int n = 0;
+	if (len < 0)
+		len = strlen ((const char *)bin);
+	for (in = out = 0; in < len; in++) {
+		b |= (bin[in] << n);
+		n += 8;
+		if (n > 13) {
+			v = b & 8191;
+			if (v > 88) {
+				b >>= 13;
+				n -= 13;
+			} else {
+				v = b & 16383;
+				b >>= 14;
+				n -= 14;
+			}
+			bout[out++] = b91[v % 91];
+			bout[out++] = b91[v / 91];
+		}
+	}
+	if (n) {
+		bout[out++] = b91[b % 91];
+		if (n > 7 || b > 90) {
+			bout[out++] = b91[b / 91];
+		}
+	}
+	return out;
+}

--- a/man/rahash2.1
+++ b/man/rahash2.1
@@ -8,6 +8,7 @@
 .Op Fl BdDehjrkvq
 .Op Fl a Ar algorithm
 .Op Fl b Ar size
+.Op Fl D Ar algo
 .Op Fl E Ar algo
 .Op Fl s Ar string
 .Op Fl i Ar iterations
@@ -34,14 +35,12 @@ Select an algorithm for the hashing. Valid values are listed in: rahash2 -L
 Define the block size
 .It Fl c Ar hash
 Compare the computed hash with this one. Allowed only when a single hash is computed.
-.It Fl d
-encoDe base64 string or file
-.It Fl D
-Decode base64 string or file
+.It Fl D Ar algo
+Decrypt instead of hash using the given algorithm (base64, base91, rc4, aes, xor, blowfish, rot)
 .It Fl e
 Use little endian to display checksums
 .It Fl E Ar algo
-Encrypt instead of hash using the given algorithm (rc4, aes, xor, blowfish, rot)
+Encrypt instead of hash using the given algorithm ( base64, base91, rc4, aes, xor, blowfish, rot)
 .It Fl i Ar iters
 Apply the hash Iters times to itself+seed
 .It Fl j

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -156,6 +156,8 @@ crypto.rc2
 crypto.rot
 crypto.rol
 crypto.ror
+crypto.base64
+crypto.base91
 debug.bf
 debug.esil
 debug.gdb


### PR DESCRIPTION
Complete the issue https://github.com/radare/radare2/issues/4595, regarding adding option `-D` in rahash2 and removing `-d` by merging it with `-E b64`. The support for `woD b64` or `woE b64` is not added since it is already present in `r2` as `w6[de]`