### PR TITLE
Fix for MSP430 disassembly of Emulated Instructions

### DIFF
--- a/libr/asm/arch/msp430/msp430_disas.c
+++ b/libr/asm/arch/msp430/msp430_disas.c
@@ -118,16 +118,16 @@ static int decode_emulation(ut16 instr, ut16 op1, struct msp430_cmd *cmd)
 	} else if (opcode == MSP430_MOV && ad == 0 && dst == MSP430_PC) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "%s", "br");
 		remove_second_operand(cmd);
-	} else if (opcode == MSP430_BIC && as == 2 && src == MSP430_SR && dst == MSP430_SR) {
+	} else if (opcode == MSP430_BIC && as == 2 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "%s", "clrn");
 		cmd->operands[0] = '\0';
-	} else if (opcode == MSP430_BIC && as == 2 && src == MSP430_R3 && dst == MSP430_SR) {
+	} else if (opcode == MSP430_BIC && as == 2 && src == MSP430_R3 && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "%s", "clrz");
 		cmd->operands[0] = '\0';
-	} else if (opcode == MSP430_BIC && as == 3 && src == MSP430_SR && dst == MSP430_SR) {
+	} else if (opcode == MSP430_BIC && as == 3 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "%s", "dint");
 		cmd->operands[0] = '\0';
-	} else if (opcode == MSP430_BIS && as == 3 && src == MSP430_SR && dst == MSP430_SR) {
+	} else if (opcode == MSP430_BIS && as == 3 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "%s", "eint");
 		cmd->operands[0] = '\0';
 	} else if (opcode == MSP430_DADD && as == 0 && src == MSP430_R3) {
@@ -157,13 +157,13 @@ static int decode_emulation(ut16 instr, ut16 op1, struct msp430_cmd *cmd)
 	} else if (opcode == MSP430_SUBC && as == 0 && src == MSP430_R3) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "%s", bw ? "sbc.b" : "sbc");
 		remove_first_operand(cmd);
-	} else if (opcode == MSP430_BIS && as == 1 && src == MSP430_R3) {
+	} else if (opcode == MSP430_BIS && as == 1 && src == MSP430_R3 && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "setc");
 		cmd->operands[0] = '\0';
-	} else if (opcode == MSP430_BIS && as == 2 && src == MSP430_SR) {
+	} else if (opcode == MSP430_BIS && as == 2 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "setn");
 		cmd->operands[0] = '\0';
-	} else if (opcode == MSP430_BIS && as == 2 && src == MSP430_R3) {
+	} else if (opcode == MSP430_BIS && as == 2 && src == MSP430_R3 && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, MSP430_INSTR_MAXLEN - 1, "setz");
 		cmd->operands[0] = '\0';
 	} else if (opcode == MSP430_CMP && as == 0 && src == MSP430_R3) {


### PR DESCRIPTION
Howdy y'all,

**Background**

The MSP430 instruction contains native instructions (which have real opcodes) and emulated instructions, which are really just shorthand for longer, real instructions.  For example, in MSP430 assembly one might use `SETZ` instead of `BIC #2, SR` to clear the Zero bit of the Status Register; these two have the exact same machine code, they are just written differently in assembly.

Radare2's disassembler has a few bugs in detection for these emulated instructions, causing instructions to be incorrectly interpreted.  In particular, it seems that all instructions which clear bit or set a bit in an absolute address using the constant generator are misinterpreted.

**Patch**

This pull request prevents instructions from being mistaken as CLRN, CLRZ, DINT, EINT, SETC, SETN, and SETZ by adding checks for the addressing mode and destination register.  These mistakes happened rather often in reverse engineering I/O routines, and this pull request is rather important for using R2 with the MSP430.

**Specific Example of the Fixed Bug**

The following three instructions are mistakenly interpreted as SETZ, CLRZ, and CLRN, when they are actually BIC.B and BIS.B, as shown in the comments.

```
debian8% rax2 -s e2d32100 e2c32600 e2c22e00 >foo
debian8% r2 -a msp430 foo
[0x00000000]> pdx 3
            0x00000000      e2d32100       setz          ; Should be bis.b #2, &0x0021
            0x00000004      e2c32600       clrz          ; Should be bic.b #2, &0x0026
            0x00000008      e2c22e00       clrn          ; Should be bic.b #4, &0x002e
[0x00000000]> 
```

As the SETZ, CLRZ, and CLRN instructions are all emulated by BITS or BITC on the Status Register, it turns out that the bug comes from missing checks in the part of `msp430_disas.c` that identifies emulated instructions.

In the case of SETZ, the current master of R2 only checks that the opcode is BIS, that the AS flags are 0b10, and that the source register is R3, used as a constant generator.  But it does not check that the AD flag is clear, so writes to an immediate destination address are mistakenly disassembled!

Cheers from Pizza Rat City,
--Travis

