### PR TITLE
add aes-cbc encryption to rahash2

### DIFF
--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -289,7 +289,7 @@ int is_power_of_two(const ut64 x) {
 }
 
 //direction: 0 => encrypt, 1 => decrypt
-int encrypt_or_decrypt(const char *algo, int direction, const char *hashstr, int hashstr_len) {
+int encrypt_or_decrypt(const char *algo, int direction, const char *hashstr, int hashstr_len, const char *iv, int ivlen, int mode) {
 	bool no_key_mode = !strcmp ("base64", algo) || !strcmp ("base91", algo); //TODO: generalise this for all non key encoding/decoding.
 	if (no_key_mode || s.len > 0) {
 		RCrypto *cry = r_crypto_new ();
@@ -297,6 +297,11 @@ int encrypt_or_decrypt(const char *algo, int direction, const char *hashstr, int
 			if (r_crypto_set_key (cry, s.buf, s.len, 0, direction)) {
 				const char *buf = hashstr;
 				int buflen = hashstr_len;
+
+				if (iv && !r_crypto_set_iv (cry, iv, ivlen)) {
+					eprintf ("Invalid IV length.\n");
+					return 0;
+				}
 
 				r_crypto_update (cry, (const ut8*)buf, buflen);
 				r_crypto_final (cry, NULL, 0);
@@ -321,7 +326,7 @@ int encrypt_or_decrypt(const char *algo, int direction, const char *hashstr, int
 	return 1;
 }
 
-int encrypt_or_decrypt_file (const char *algo, int direction, char *filename) {
+int encrypt_or_decrypt_file (const char *algo, int direction, char *filename, const char *iv, int ivlen, int mode) {
 	bool no_key_mode = !strcmp ("base64", algo) || !strcmp ("base91", algo); //TODO: generalise this for all non key encoding/decoding.
 	if (no_key_mode || s.len > 0) {
 		RCrypto *cry = r_crypto_new ();
@@ -365,6 +370,9 @@ int main(int argc, char **argv) {
 	const char *decrypt = NULL;
 	const char *encrypt = NULL;
 	char *hashstr = NULL;
+	char *iv = NULL;
+	int ivlen = -1;
+	char *ivseed = NULL;
 	const char *compareStr = NULL;
 	ut8 *compareBin = NULL;
 	int hashstr_len = -1;
@@ -374,7 +382,7 @@ int main(int argc, char **argv) {
 	RHash *ctx;
 	RIO *io;
 
-	while ((c = getopt (argc, argv, "jD:rveE:a:i:S:s:x:b:nBhf:t:kLqc:")) != -1) {
+	while ((c = getopt (argc, argv, "jD:rveE:a:i:I:S:s:x:b:nBhf:t:kLqc:")) != -1) {
 		switch (c) {
 		case 'q': quiet ++; break;
 		case 'i':
@@ -386,6 +394,7 @@ int main(int argc, char **argv) {
 			break;
 		case 'j': rad = 'j'; break;
 		case 'S': seed = optarg; break;
+		case 'I': ivseed = optarg; break;
 		case 'n': numblocks = 1; break;
 		case 'D': decrypt = optarg; break;
 		case 'E': encrypt = optarg; break;
@@ -459,6 +468,20 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 	}
+	 // convert iv to hex or string.
+	if (ivseed) {
+		iv = (ut8*)malloc (strlen (ivseed) + 128);
+		if (!strncmp (ivseed, "s:", 2)) {
+			strcpy ((char*)iv, ivseed + 2);
+			ivlen = strlen (ivseed + 2);
+		} else {
+			ivlen = r_hex_str2bin (ivseed, iv);
+			if (ivlen < 1) {
+				strcpy ((char*)iv, ivseed);
+				ivlen = strlen (ivseed);
+			}
+		}
+	}
 	do_hash_seed (seed);
 	if (hashstr) {
 #define INSIZE 32768
@@ -508,9 +531,9 @@ int main(int argc, char **argv) {
 			hashstr_len = r_str_unescape (hashstr);
 		}
 		if (encrypt) {
-			return encrypt_or_decrypt (encrypt, 0, hashstr, hashstr_len);
+			return encrypt_or_decrypt (encrypt, 0, hashstr, hashstr_len, iv, ivlen, 0);
 		} else if (decrypt) {
-			return encrypt_or_decrypt (decrypt, 1, hashstr, hashstr_len);
+			return encrypt_or_decrypt (decrypt, 1, hashstr, hashstr_len, iv, ivlen, 0);
 		} else {
 			char *str = (char *)hashstr;
 			int strsz = hashstr_len;
@@ -560,11 +583,11 @@ int main(int argc, char **argv) {
 	io = r_io_new ();
 	for (ret = 0, i = optind; i < argc; i++) {
 		if (encrypt) {//for encrytion when files are provided 
-			int rt = encrypt_or_decrypt_file (encrypt, 0, argv[i]);
+			int rt = encrypt_or_decrypt_file (encrypt, 0, argv[i], iv, ivlen, 0);
 			if (rt == -1) continue;
 			else return rt;
 		} else if (decrypt) {
-			int rt = encrypt_or_decrypt_file (decrypt, 1, argv[i]);
+			int rt = encrypt_or_decrypt_file (decrypt, 1, argv[i], iv, ivlen, 0);
 			if (rt == -1) continue;
 			else return rt;
 		} else {

--- a/libr/crypto/Jamroot
+++ b/libr/crypto/Jamroot
@@ -1,4 +1,4 @@
 OBJS = crypto.c ;
-OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c p/crypto_rot.c p/crypto_rol.c p/crypto_ror.c p/crypto_base64.c p/crypto_base91.c;
+OBJS += p/crypto_aes.c p/crypto_aes_algo.c p/crypto_xor.c p/crypto_blowfish.c p/crypto_rc2.c p/crypto_rot.c p/crypto_rol.c p/crypto_ror.c p/crypto_base64.c p/crypto_base91.c p/crypto_aes_cbc.c;
 
 lib r_crypto : $(OBJS) : <include>../include <library>../util ;

--- a/libr/crypto/crypto.c
+++ b/libr/crypto/crypto.c
@@ -92,9 +92,9 @@ R_API int r_crypto_get_key_size(RCrypto *cry) {
 		cry->h->get_key_size (cry): 0;
 }
 
-R_API int r_crypto_set_iv(RCrypto *cry, const ut8 *iv) {
+R_API int r_crypto_set_iv(RCrypto *cry, const ut8 *iv, int ivlen) {
 	return (cry && cry->h && cry->h->set_iv)?
-		cry->h->set_iv(cry, iv): 0;
+		cry->h->set_iv(cry, iv, ivlen): 0;
 }
 
 // return the number of bytes written in the output buffer

--- a/libr/crypto/p/Makefile
+++ b/libr/crypto/p/Makefile
@@ -10,7 +10,7 @@ caca:
 foo: all
 
 ALL_TARGETS=
-ALGOS=aes.mk
+ALGOS=aes.mk aes_cbc.mk
 include $(ALGOS)
 
 all: ${ALL_TARGETS}

--- a/libr/crypto/p/aes_cbc.mk
+++ b/libr/crypto/p/aes_cbc.mk
@@ -1,0 +1,9 @@
+OBJ_AES_CBC=crypto_aes_cbc.o
+
+STATIC_OBJ+=${OBJ_AES_CBC}
+TARGET_AES_CBC=crypto_aes_cbc.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_AES_CBC}
+
+${TARGET_AES_CBC}: ${OBJ_AES_CBC}
+	${CC} $(call libname,crypto_aes_cbc) -L.. -lr_crypto ${LDFLAGS} ${CFLAGS} -o ${TARGET_AES_CBC} ${OBJ_AES_CBC}

--- a/libr/crypto/p/crypto_aes.c
+++ b/libr/crypto/p/crypto_aes.c
@@ -40,7 +40,7 @@ static int update (RCrypto *cry, const ut8 *buf, int len) {
 	// Pad to the block size, do not append dummy block
 	const int diff = (BLOCK_SIZE - (len % BLOCK_SIZE)) % BLOCK_SIZE;
 	const int size = len + diff;
-	const int blocks = size / st.key_size;
+	const int blocks = size / BLOCK_SIZE;
 
 	ut8 *const obuf = calloc (1, size);
 	if (!obuf) return false;

--- a/libr/crypto/p/crypto_aes_cbc.c
+++ b/libr/crypto/p/crypto_aes_cbc.c
@@ -1,0 +1,111 @@
+#include <r_lib.h>
+#include <r_crypto.h>
+#include "crypto_aes_algo.h"
+
+#define BLOCK_SIZE 16
+
+static struct aes_state st;
+int flag = 0;
+bool iv_set = 0;
+ut8 iv[32];
+
+static int aes_cbc_set_key(RCrypto *cry, const ut8 *key, int keylen, int mode, int direction) {
+	if (!(keylen == 128 / 8 || keylen == 192 / 8 || keylen == 256 / 8)) {
+		return false;
+	}
+	st.key_size = keylen;
+	st.rounds = 6 + (int)(keylen / 4);
+	st.columns = (int)(keylen / 4);
+	memcpy (st.key, key, keylen);
+	flag = direction;
+	return true;
+}
+
+static int aes_cbc_get_key_size(RCrypto *cry) {
+	return st.key_size;
+}
+
+static int aes_cbc_set_iv(RCrypto *cry, const ut8 *iv_src, int ivlen) {
+	if (ivlen != BLOCK_SIZE) {
+		return false;
+	}
+	memcpy (iv, iv_src, BLOCK_SIZE);
+	iv_set = 1;
+	return true;
+}
+
+static bool aes_cbc_use(const char *algo) {
+	return !strcmp (algo, "aes-cbc");
+}
+
+static int update(RCrypto *cry, const ut8 *buf, int len) {
+	if (!iv_set) {
+		eprintf ("IV not set. Use -I [iv]\n");
+		return false;
+	}
+	const int diff = (BLOCK_SIZE - (len % BLOCK_SIZE)) % BLOCK_SIZE;
+	const int size = len + diff;
+	const int blocks = size / BLOCK_SIZE;
+
+	ut8 *const obuf = calloc (1, size);
+	if (!obuf) return false;
+
+	ut8 *const ibuf = calloc (1, size);
+	if (!ibuf) {
+		free (obuf);
+		return false;
+	}
+
+	memset (ibuf, 0, size);
+	memcpy (ibuf, buf, len);
+
+	if (diff) {
+		ibuf[len] = 0b1000;
+	}
+
+	int i, j;
+	if (flag == 0) {
+		for (i = 0; i < blocks; i++) {
+			for (j = 0; j < BLOCK_SIZE; j++) {
+				ibuf[i * BLOCK_SIZE + j] ^= iv[j];
+			}
+			aes_encrypt (&st, ibuf + BLOCK_SIZE * i, obuf + BLOCK_SIZE * i);
+			memcpy (iv, obuf + BLOCK_SIZE * i, BLOCK_SIZE);
+		}
+	} else if (flag == 1) {
+		for (i = 0; i < blocks; i++) {
+			aes_decrypt (&st, ibuf + BLOCK_SIZE * i, obuf + BLOCK_SIZE * i);
+			for (j = 0; j < BLOCK_SIZE; j++) {
+				obuf[i * BLOCK_SIZE + j] ^= iv[j];
+			}
+			memcpy(iv, buf + BLOCK_SIZE * i, BLOCK_SIZE);
+		}
+	}
+
+	r_crypto_append (cry, obuf, size);
+	free (obuf);
+	free (ibuf);
+	return 0;
+}
+
+static int final(RCrypto *cry, const ut8 *buf, int len) {
+	return update (cry, buf, len);
+}
+
+RCryptoPlugin r_crypto_plugin_aes_cbc = {
+	.name = "aes-cbc",
+	.set_key = aes_cbc_set_key,
+	.get_key_size = aes_cbc_get_key_size,
+	.set_iv = aes_cbc_set_iv,
+	.use = aes_cbc_use,
+	.update = update,
+	.final = final
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_CRYPTO,
+	.data = &r_crypto_plugin_aes_cbc,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/include/r_crypto.h
+++ b/libr/include/r_crypto.h
@@ -37,7 +37,7 @@ typedef struct r_crypto_t {
 typedef struct r_crypto_plugin_t {
 	const char *name;
 	int (*get_key_size)(RCrypto *cry);
-	int (*set_iv)(RCrypto *cry, const ut8 *iv);
+	int (*set_iv)(RCrypto *cry, const ut8 *iv, int ivlen);
 	int (*set_key)(RCrypto *cry, const ut8 *key, int keylen, int mode, int direction);
 	int (*update)(RCrypto *cry, const ut8 *buf, int len);
 	int (*final)(RCrypto *cry, const ut8 *buf, int len);
@@ -53,7 +53,7 @@ R_API RCrypto *r_crypto_new(void);
 R_API RCrypto *r_crypto_free(RCrypto *cry);
 R_API bool r_crypto_use(RCrypto *cry, const char *algo);
 R_API int r_crypto_set_key(RCrypto *cry, const ut8* key, int keylen, int mode, int direction);
-R_API int r_crypto_set_iv(RCrypto *cry, const ut8 *iv);
+R_API int r_crypto_set_iv(RCrypto *cry, const ut8 *iv, int ivlen);
 R_API int r_crypto_update(RCrypto *cry, const ut8 *buf, int len);
 R_API int r_crypto_final(RCrypto *cry, const ut8 *buf, int len);
 R_API int r_crypto_append(RCrypto *cry, const ut8 *buf, int len);
@@ -71,6 +71,7 @@ extern RCryptoPlugin r_crypto_plugin_rol;
 extern RCryptoPlugin r_crypto_plugin_ror;
 extern RCryptoPlugin r_crypto_plugin_base64;
 extern RCryptoPlugin r_crypto_plugin_base91;
+extern RCryptoPlugin r_crypto_plugin_aes_cbc;
 
 #ifdef __cplusplus
 }

--- a/man/rahash2.1
+++ b/man/rahash2.1
@@ -12,6 +12,7 @@
 .Op Fl E Ar algo
 .Op Fl s Ar string
 .Op Fl i Ar iterations
+.Op Fl I Ar IV
 .Op Fl S Ar seed
 .Op Fl f Ar from
 .Op Fl x Ar hexstr
@@ -43,6 +44,8 @@ Use little endian to display checksums
 Encrypt instead of hash using the given algorithm ( base64, base91, rc4, aes, xor, blowfish, rot)
 .It Fl i Ar iters
 Apply the hash Iters times to itself+seed
+.It Fl I Ar [^]s:string|hexstr
+Set initialization vector (IV) for the cryptographic functions.
 .It Fl j
 Show output in JSON (see -r)
 .It Fl B

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -158,6 +158,7 @@ crypto.rol
 crypto.ror
 crypto.base64
 crypto.base91
+crypto.aes_cbc
 debug.bf
 debug.esil
 debug.gdb


### PR DESCRIPTION
Add AES-CBC mode and fix AES-ECB .  Support for getting IV is added with `-I` option in rahash2.