### PR TITLE
fix tricore disasm buffer copy function.

### DIFF
--- a/libr/asm/p/asm_tricore.c
+++ b/libr/asm/p/asm_tricore.c
@@ -17,7 +17,7 @@ static char *buf_global = NULL;
 static unsigned char bytes[32];
 
 static int tricore_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
-	memcpy (myaddr, bytes, length);
+	memcpy (myaddr, &bytes[memaddr-Offset], length);
 	return 0;
 }
 


### PR DESCRIPTION
did not take `memaddr' argument into account, resulting in wrong disassembly.
compare "rasm2 -a tricore -d 200a", which should give "sub.a sp, 10", but gave "sub.a sp, 32" (interpreting the opcode as also the operand)