### PR TITLE
z80_cr asm: fix 'ed' opcode range resulted in overflow

### DIFF
--- a/libr/asm/arch/z80_cr/z80_cr.c
+++ b/libr/asm/arch/z80_cr/z80_cr.c
@@ -127,7 +127,7 @@ static ut8 z80_fddd_branch_index_res (ut8 hex)
 }
 
 static ut8 z80_ed_branch_index_res (ut8 hex) {
-	if (hex > 0x39 && 0x4c > hex)
+	if (hex > 0x3f && 0x4c > hex)
 		return hex-0x40;
 	if (hex == 0x4d)
 		return 0xc;


### PR DESCRIPTION
Parsing ``0xed`` prefixed opcode in range ``0x3a`` to ``0x3f`` results in overflow while looking up ``ed[]`` array (from ``libr/asm/arch/z80_cr/z80_tab.h``). This range belongs to unknown opcodes (``0x3b`` in ``ed[]``).

This range should be:
```
40 41 .. 4a 4b
   maps to
00 01 .. 0a 0b
```
Was:
```
3a 3b 3c 3d 3e 3f 40 41 .. 4a 4b
            maps to
fa fb fc fd fe ff 00 01 .. 0a 0b
```

This probably not causes segfault (unless built with something like address sanitizer) so I didn't create tests for it, tests will probably not detect this bug.