### PR TITLE
adding extra pass for find function argument

### DIFF
--- a/libr/anal/cc.c
+++ b/libr/anal/cc.c
@@ -22,7 +22,6 @@ R_API void r_anal_cc_init (RAnalCC *cc) {
 }
 
 R_API int r_anal_cc_str2type (const char *str) {
-	if (!strcmp (str, "none")) return R_ANAL_CC_TYPE_NONE;
 	if (!strcmp (str, "cdecl")) return R_ANAL_CC_TYPE_CDECL;
 	if (!strcmp (str, "stdcall")) return R_ANAL_CC_TYPE_STDCALL;
 	if (!strcmp (str, "fastcall")) return R_ANAL_CC_TYPE_FASTCALL;
@@ -40,7 +39,6 @@ R_API int r_anal_cc_str2type (const char *str) {
 
 R_API const char *r_anal_cc_type2str(int type) {
 	switch (type) {
-	case R_ANAL_CC_TYPE_NONE: return "none";
 	case R_ANAL_CC_TYPE_CDECL: return "cdecl";
 	case R_ANAL_CC_TYPE_STDCALL: return "stdcall";
 	case R_ANAL_CC_TYPE_FASTCALL: return "fastcall";

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -75,7 +75,7 @@ R_API RAnalFunction *r_anal_fcn_new() {
 	/* Function qualifier: static/volatile/inline/naked/virtual */
 	fcn->fmod = R_ANAL_FQUALIFIER_NONE;
 	/* Function calling convention: cdecl/stdcall/fastcall/etc */
-	fcn->call = R_ANAL_CC_TYPE_NONE;
+	fcn->call = R_ANAL_CC_TYPE_CDECL;
 	/* Function attributes: weak/noreturn/format/etc */
 	fcn->addr = UT64_MAX;
 	fcn->bits = 0;
@@ -265,6 +265,69 @@ static ut64 search_reg_val(RAnal *anal, ut8 *buf, ut64 len, ut64 addr, char *reg
 
 #define gotoBeach(x) ret=x;goto beach;
 #define gotoBeachRet() goto beach;
+
+R_API void fill_args (RAnal *anal, RAnalFunction *fcn, RAnalOp *op) {
+	char* varname;
+	switch (op->stackop) {
+	case R_ANAL_STACK_NULL:
+	case R_ANAL_STACK_NOP:
+	case R_ANAL_STACK_ALIGN:
+	case R_ANAL_STACK_INC: {
+		char *esil_buf, *ptr_end, *addr, *op_esil;
+		st64 ptr;
+		op_esil = r_strbuf_get (&op->esil);
+		if (!op_esil) {
+			return;
+		}
+		esil_buf = strdup (op_esil);
+		ptr_end = strstr (esil_buf, ",ebp,+,[4],");
+		if (!ptr_end) {
+			free (esil_buf);
+			break;
+		}
+		*ptr_end = 0;
+		addr = ptr_end;
+		while ((*addr != '0' || *(addr+1) != 'x') &&
+			addr >= esil_buf && *addr != ',' ) {
+			addr--;
+		}
+		if (strncmp(addr, "0x", 2)) {
+			free (esil_buf);
+			break;
+		}
+		ptr = (st64)r_num_get (NULL, addr);
+		varname = get_varname (anal, ARGPREFIX, R_ABS (ptr));
+		r_anal_var_add (anal, fcn->addr, 1, ptr, fcn->call, NULL, anal->bits/8, varname);
+		r_anal_var_access (anal, fcn->addr, fcn->call, 1, ptr, 0, op->addr);
+		free (esil_buf);
+		} break;
+	case R_ANAL_STACK_GET:
+		if (((int) op->ptr) > 0) {
+			varname = get_varname (anal, ARGPREFIX, R_ABS (op->ptr));
+			r_anal_var_add (anal, fcn->addr, 1, op->ptr, fcn->call, NULL, anal->bits/8, varname);
+			r_anal_var_access (anal, fcn->addr, 'a', 1, op->ptr, 0, op->addr);
+		} else {
+			varname = get_varname (anal, VARPREFIX, R_ABS (op->ptr));
+			r_anal_var_add (anal, fcn->addr, 1, -op->ptr, 'v', NULL, anal->bits/8, varname);
+			r_anal_var_access (anal, fcn->addr, 'v', 1, -op->ptr, 0, op->addr);
+		}
+		free (varname);
+		break;
+	case R_ANAL_STACK_SET:
+		if ((int)op->ptr > 0) {
+			varname = get_varname (anal, ARGPREFIX, R_ABS (op->ptr));
+			r_anal_var_add (anal, fcn->addr, 1, op->ptr,fcn->call, NULL, anal->bits/8, varname);
+			r_anal_var_access (anal, fcn->addr, fcn->call, 1, op->ptr, 1, op->addr);
+		} else {
+			varname = get_varname (anal, VARPREFIX, R_ABS (op->ptr));
+			r_anal_var_add (anal, fcn->addr, 1, -op->ptr,'v', NULL, anal->bits/8, varname);
+			r_anal_var_access (anal, fcn->addr, 'v', 1, -op->ptr, 1, op->addr);
+		}
+		free (varname);
+		break;
+	}
+}
+
 static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 len, int depth) {
 	int continue_after_jump = anal->opt.afterjmp;
 	RAnalBlock *bb = NULL;
@@ -795,7 +858,6 @@ R_API void r_anal_trim_jmprefs(RAnalFunction *fcn) {
 		}
 	}
 }
-
 R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 len, int reftype) {
 	int ret;
 	fcn->size = 0;

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1193,7 +1193,7 @@ R_API void r_core_anal_coderefs(RCore *core, ut64 addr, int fmt) {
 	RAnalFunction *fcni;
 	RAnalRef *fcnr;
 
-	if (fmt == 2) 
+	if (fmt == 2)
 		r_cons_printf ("[");
 	first = 0;
 	r_list_foreach (core->anal->fcns, iter, fcni) {
@@ -1263,7 +1263,7 @@ R_API void r_core_anal_coderefs(RCore *core, ut64 addr, int fmt) {
 					if (!hideempty || (hideempty && r_list_length (fr->refs)>0)) {
 						if (usenames)
 							r_cons_printf ("%s\"%s\"", first2?",":"", fr->name);
-						else 
+						else
 							r_cons_printf ("%s\"0x%08"PFMT64x"\"", first2?",":"", fr->addr);
 						first2 = 1;
 					}
@@ -1276,7 +1276,7 @@ R_API void r_core_anal_coderefs(RCore *core, ut64 addr, int fmt) {
 	}
 	if (showhdr && fmt==1)
 		r_cons_printf ("}\n");
-	if (fmt == 2) 
+	if (fmt == 2)
 		r_cons_printf ("]\n");
 }
 
@@ -1475,9 +1475,8 @@ R_API int r_core_anal_fcn_list(RCore *core, const char *input, int rad) {
 						fcn->type==R_ANAL_FCN_TYPE_IMP?'i':'f',
 						fcn->diff->type==R_ANAL_DIFF_TYPE_MATCH?'m':
 						fcn->diff->type==R_ANAL_DIFF_TYPE_UNMATCH?'u':'n');
-				if (fcn->call != R_ANAL_CC_TYPE_NONE)
-					r_cons_printf ("afC %s @ 0x%08"PFMT64x"\n",
-							r_anal_cc_type2str (fcn->call), fcn->addr);
+				r_cons_printf ("afC %s @ 0x%08"PFMT64x"\n",
+					r_anal_cc_type2str (fcn->call), fcn->addr);
 				if (fcn->folded)
 					r_cons_printf ("afF @ 0x%08"PFMT64x"\n", fcn->addr);
 				fcn_list_bbs (fcn);
@@ -1574,6 +1573,35 @@ static RList *recurse(RCore *core, RAnalBlock *from, RAnalBlock *dest) {
 	/* same for all calls */
 	// TODO: RAnalBlock must contain a linked list of calls
 	return NULL;
+}
+
+R_API void fcn_callconv (RCore *core, RAnalFunction *fcn) {
+	ut8 *buf = calloc(1,core->anal->opt.bb_max_size);
+	RListIter *tmp = NULL;
+	RAnalBlock *bb = NULL;
+	int i;
+	if(!core || !fcn || !buf){
+		return;
+	}
+	r_list_foreach (fcn->bbs, tmp, bb) {
+		if (r_io_read_at (core->io, bb->addr, buf, bb->size) != bb->size) {
+			eprintf ("read error\n");
+			free(buf);
+			return;
+		}
+		for (i = 0 ; i < bb->n_op_pos ; i++) {
+			RAnalOp op = {0};
+			r_anal_op (core->anal, &op, 0, buf + bb->op_pos[i], bb->size - bb->op_pos[i]);
+			op.addr = bb->addr + bb->op_pos[i];
+			fill_args (core->anal, fcn, &op);
+		}
+	}
+	if (fcn->call == R_ANAL_CC_TYPE_FASTCALL) {
+		r_anal_var_add (core->anal, fcn->addr, 1, 0,'A', "int", 4,"arg_ecx");
+		r_anal_var_add (core->anal, fcn->addr, 1, 1,'A', "int", 4,"arg_edx");
+	}
+	free (buf);
+	return;
 }
 
 R_API RList* r_core_anal_graph_to(RCore *core, ut64 addr, int n) {
@@ -1947,7 +1975,6 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 				}
 				// Add to SDB
 				r_anal_xrefs_set (core->anal, type, xref_from, xref_to);
-				
 			} else if (rad == 'j') {
 				// Output JSON
 				if (count > 0) r_cons_printf (",");

--- a/libr/debug/arg.c
+++ b/libr/debug/arg.c
@@ -7,7 +7,6 @@ R_API ut64 r_debug_arg_get (RDebug *dbg, int cctype, int num) {
 	ut64 n64, sp;
 	char reg[32];
 	switch (cctype) {
-	case R_ANAL_CC_TYPE_NONE:
 	case R_ANAL_CC_TYPE_SYSV:
 	case R_ANAL_CC_TYPE_FASTCALL:
 		snprintf (reg, 30, "SP%d", num);
@@ -38,7 +37,6 @@ R_API bool r_debug_arg_set (RDebug *dbg, int cctype, int num, ut64 val) {
 	// TODO
 	char reg[32];
 	switch (cctype) {
-	case R_ANAL_CC_TYPE_NONE:
 	case R_ANAL_CC_TYPE_SYSV:
 	case R_ANAL_CC_TYPE_FASTCALL:
 		snprintf (reg, 30, "A%d", num);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -177,17 +177,16 @@ enum {
 	R_ANAL_FQUALIFIER_VIRTUAL = 5,
 };
 
-enum {
-	R_ANAL_CC_TYPE_NONE,
-	R_ANAL_CC_TYPE_CDECL,
-	R_ANAL_CC_TYPE_STDCALL,
-	R_ANAL_CC_TYPE_FASTCALL,
-	R_ANAL_CC_TYPE_PASCAL,
-	R_ANAL_CC_TYPE_WINAPI, // Microsoft's pascal call clone
-	R_ANAL_CC_TYPE_MSFASTCALL, // microsoft fastcall
-	R_ANAL_CC_TYPE_BOFASTCALL, // borland fastcall
-	R_ANAL_CC_TYPE_WAFASTCALL, // wacom fastcall
-	R_ANAL_CC_TYPE_CLARION, // TopSpeed/Clarion/JPI
+/*--------------------Function Convnetions-----------*/
+#define	R_ANAL_CC_TYPE_CDECL 'a'
+#define	R_ANAL_CC_TYPE_STDCALL 0
+#define R_ANAL_CC_TYPE_FASTCALL 'A'
+#define	R_ANAL_CC_TYPE_PASCAL 1
+#define R_ANAL_CC_TYPE_WINAPI 2 // Microsoft's pascal call clone
+#define R_ANAL_CC_TYPE_MSFASTCALL 3 // microsoft fastcall
+#define R_ANAL_CC_TYPE_BOFASTCALL 4 // borland fastcall
+#define R_ANAL_CC_TYPE_WAFASTCALL 5 // wacom fastcall
+#define R_ANAL_CC_TYPE_CLARION 6 // TopSpeed/Clarion/JPI
 	/* Clarion:
 	 *	first four integer parameters are passed in registers:
 	 *	eax, ebx, ecx, edx. Floating point parameters are passed
@@ -198,10 +197,9 @@ enum {
 	 *	Integer values are returned in eax, pointers in edx
 	 *	and floating point types in st0.
 	 */
-	R_ANAL_CC_TYPE_SAFECALL, // Delphi and Free Pascal on Windows
-	R_ANAL_CC_TYPE_SYSV,
-	R_ANAL_CC_TYPE_THISCALL,
-};
+#define R_ANAL_CC_TYPE_SAFECALL 7 // Delphi and Free Pascal on Windows
+#define R_ANAL_CC_TYPE_SYSV 8
+#define R_ANAL_CC_TYPE_THISCALL 9
 
 #define R_ANAL_CC_ARGS 16
 
@@ -1248,6 +1246,7 @@ R_API RAnalFunction *r_anal_fcn_find_name(RAnal *anal, const char *name);
 R_API RList *r_anal_fcn_list_new(void);
 R_API int r_anal_fcn_insert(RAnal *anal, RAnalFunction *fcn);
 R_API void r_anal_fcn_free(void *fcn);
+R_API void fill_args (RAnal *anal, RAnalFunction *fcn, RAnalOp *op);
 R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr,
 		ut8 *buf, ut64 len, int reftype);
 R_API int r_anal_fcn_add(RAnal *anal, ut64 addr, ut64 size,

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -412,6 +412,7 @@ R_API char *r_core_sysenv_begin(RCore *core, const char *cmd);
 R_API void r_core_sysenv_end(RCore *core, const char *cmd);
 R_API void r_core_sysenv_help(const RCore* core);
 
+R_API void fcn_callconv (RCore *core, RAnalFunction *fcn);
 /* bin.c */
 #define R_CORE_BIN_PRINT	0x000
 #define R_CORE_BIN_RADARE	0x001


### PR DESCRIPTION
known issue .. 
the variables doesn't update in case of fastcall
![untitled](https://cloud.githubusercontent.com/assets/10424605/14723005/7395f586-0817-11e6-8944-839c56dbacbc.png)
note :- I used ESIL like no one ever did :P but after all it is fast and working which is cool 
the binary file used is found in r2r/bin/elf/fast