### PR TITLE
Debug plugin for QNX Neutrino pdebug interface

### DIFF
--- a/libr/debug/p/Makefile
+++ b/libr/debug/p/Makefile
@@ -6,7 +6,7 @@ CFLAGS+=-I../../include -Wall ${PIC_FLAGS} ${LDFLAGS_LIB} ${LDFLAGS_LINKPATH}.. 
 foo: all
 
 ALL_TARGETS=
-DEBUGS=native.mk gdb.mk wind.mk bochs.mk
+DEBUGS=native.mk gdb.mk qnx.mk wind.mk bochs.mk
 include $(DEBUGS)
 
 all: ${ALL_TARGETS}

--- a/libr/debug/p/debug_qnx.c
+++ b/libr/debug/p/debug_qnx.c
@@ -1,0 +1,337 @@
+/* radare - LGPL - Copyright 2009-2016 - pancake, defragger, madprogrammer */
+
+#include <r_asm.h>
+#include <r_debug.h>
+#include <libqnxr.h>
+
+typedef struct {
+	libqnxr_t desc;
+} RIOQnx;
+
+static libqnxr_t *desc = NULL;
+static ut8 *reg_buf = NULL;
+static int buf_size = 0;
+
+static void pidlist_cb (void *ctx, pid_t pid, char *name) {
+	RList *list = ctx;
+	r_list_append (list, r_debug_pid_new (name, pid, 's', 0));
+}
+
+static int r_debug_qnx_select (int pid, int tid) {
+	return qnxr_select (desc, pid, tid);
+}
+
+static RList *r_debug_qnx_tids (int pid) {
+	eprintf ("%s: TODO: Threads\n", __func__);
+	return NULL;
+}
+
+static RList *r_debug_qnx_pids (int pid) {
+	RList *list = r_list_new ();
+	list->free = (RListFree)&r_debug_pid_free;
+
+	/* TODO */
+	if (pid) {
+		r_list_append (list, r_debug_pid_new ("(current)", pid, 's', 0));
+	} else {
+		qnxr_pidlist (desc, list, &pidlist_cb);
+	}
+
+	return list;
+}
+
+static int r_debug_qnx_reg_read (RDebug *dbg, int type, ut8 *buf, int size) {
+	int copy_size;
+	int buflen = 0;
+	if (!desc) {
+		return -1;
+	}
+	int len = qnxr_read_registers (desc);
+	if (len <= 0) return -1;
+	// read the len of the current area
+	free (r_reg_get_bytes (dbg->reg, type, &buflen));
+	if (size < len) {
+		eprintf ("r_debug_qnx_reg_read: small buffer %d vs %d\n",
+			 (int)size, (int)len);
+	}
+	copy_size = R_MIN (len, size);
+	buflen = R_MAX (len, buflen);
+	if (reg_buf) {
+		if (buf_size < copy_size) {
+			ut8 *new_buf = realloc (reg_buf, copy_size);
+			if (!new_buf)
+				return -1;
+			reg_buf = new_buf;
+			buflen = copy_size;
+			buf_size = len;
+		}
+	} else {
+		reg_buf = calloc (buflen, 1);
+		if (!reg_buf)
+			return -1;
+		buf_size = buflen;
+	}
+	memset ((void *)(volatile void *) buf, 0, size);
+	memcpy ((void *)(volatile void *) buf, desc->recv.data, copy_size);
+	memset ((void *)(volatile void *) reg_buf, 0, buflen);
+	memcpy ((void *)(volatile void *) reg_buf, desc->recv.data, copy_size);
+
+	return len;
+}
+
+static RList *r_debug_qnx_map_get (RDebug *dbg) {
+	return NULL;
+}
+
+static int r_debug_qnx_reg_write (RDebug *dbg, int type, const ut8 *buf, int size) {
+	if (!reg_buf) {
+		// we cannot write registers before we once read them
+		return -1;
+	}
+	int buflen = 0;
+	int bits = dbg->anal->bits;
+	const char *pcname = r_reg_get_name (dbg->anal->reg, R_REG_NAME_PC);
+	RRegItem *reg = r_reg_get (dbg->anal->reg, pcname, 0);
+	if (reg) {
+		if (dbg->anal->bits != reg->size)
+			bits = reg->size;
+	}
+	free (r_reg_get_bytes (dbg->reg, type, &buflen));
+	// some implementations of the gdb protocol are acting weird.
+	// so winedbg is not able to write registers through the <G> packet
+	// and also it does not return the whole gdb register profile after
+	// calling <g>
+	// so this workaround resizes the small register profile buffer
+	// to the whole set and fills the rest with 0
+	if (buf_size < buflen) {
+		ut8 *new_buf = realloc (reg_buf, buflen * sizeof(ut8));
+		if (!new_buf) {
+			return -1;
+		}
+		reg_buf = new_buf;
+		memset (new_buf + buf_size, 0, buflen - buf_size);
+	}
+
+	RRegItem *current = NULL;
+	for (;;) {
+		current = r_reg_next_diff (dbg->reg, type, reg_buf, buflen, current, bits);
+		if (!current) break;
+		ut64 val = r_reg_get_value (dbg->reg, current);
+		int bytes = bits / 8;
+		qnxr_write_reg (desc, current->name, (char *)&val, bytes);
+	}
+	return true;
+}
+
+static int r_debug_qnx_continue (RDebug *dbg, int pid, int tid, int sig) {
+	qnxr_continue (desc, -1);
+	return true;
+}
+
+static int r_debug_qnx_step (RDebug *dbg) {
+	qnxr_step (desc, -1);
+	return true;
+}
+
+static int r_debug_qnx_wait (RDebug *dbg, int pid) {
+	ptid_t ptid = qnxr_wait (desc, pid);
+	if (!ptid_equal (ptid, null_ptid)) {
+		dbg->reason.signum = desc->signal;
+		return desc->notify_type;
+	}
+	return 0;
+}
+
+static int r_debug_qnx_stop (RDebug *dbg) {
+	qnxr_stop (desc);
+	return true;
+}
+
+static int r_debug_qnx_attach (RDebug *dbg, int pid) {
+	RIODesc *d = dbg->iob.io->desc;
+	dbg->swstep = false;
+
+	if (d && d->plugin && d->plugin->name && d->data) {
+		if (!strcmp ("qnx", d->plugin->name)) {
+			RIOQnx *g = d->data;
+			int arch = r_sys_arch_id (dbg->arch);
+			int bits = dbg->anal->bits;
+			if ((desc = &g->desc))
+				switch (arch) {
+				case R_SYS_ARCH_X86:
+					if (bits == 16 || bits == 32) {
+						qnxr_set_architecture (&g->desc, X86_32);
+					} else {
+						eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+						return false;
+					}
+					break;
+				case R_SYS_ARCH_ARM:
+					if (bits == 16 || bits == 32) {
+						qnxr_set_architecture (&g->desc, ARM_32);
+					} else {
+						eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+						return false;
+					}
+					break;
+				}
+			if (pid)
+				qnxr_attach (desc, pid);
+		} else {
+			eprintf ("%s: error: underlying IO descriptor isn't a QNX one\n", __func__);
+			return false;
+		}
+	}
+
+	dbg->pid = 0;
+	return true;
+}
+
+static int r_debug_qnx_detach (RDebug *dbg, int pid) {
+	qnxr_disconnect (desc);
+	free (reg_buf);
+	return true;
+}
+
+static const char *r_debug_qnx_reg_profile (RDebug *dbg) {
+	int arch = r_sys_arch_id (dbg->arch);
+	int bits = dbg->anal->bits;
+	switch (arch) {
+	case R_SYS_ARCH_X86:
+		return strdup (
+			"=PC	eip\n"
+			"=SP	esp\n"
+			"=BP	ebp\n"
+			"=A0	eax\n"
+			"=A1	ebx\n"
+			"=A2	ecx\n"
+			"=A3	edi\n"
+			"gpr	eax	.32	0	0\n"
+			"gpr	ecx	.32	4	0\n"
+			"gpr	edx	.32	8	0\n"
+			"gpr	ebx	.32	12	0\n"
+			"gpr	esp	.32	16	0\n"
+			"gpr	ebp	.32	20	0\n"
+			"gpr	esi	.32	24	0\n"
+			"gpr	edi	.32	28	0\n"
+			"gpr	eip	.32	32	0\n"
+			"gpr	eflags	.32	36	0\n"
+			"seg	cs	.32	40	0\n"
+			"seg	ss	.32	44	0\n"
+#if 0
+			"seg	ds	.32	48	0\n"
+			"seg	es	.32	52	0\n"
+			"seg	fs	.32	56	0\n"
+			"seg	gs	.32	60	0\n"
+#endif
+			);
+	case R_SYS_ARCH_ARM:
+		if (bits == 32)
+			return strdup (
+				"=PC	r15\n"
+				"=SP	r14\n" // XXX
+				"=A0	r0\n"
+				"=A1	r1\n"
+				"=A2	r2\n"
+				"=A3	r3\n"
+				"gpr	r0	.32	0	0\n"
+				"gpr	r1	.32	4	0\n"
+				"gpr	r2	.32	8	0\n"
+				"gpr	r3	.32	12	0\n"
+				"gpr	r4	.32	16	0\n"
+				"gpr	r5	.32	20	0\n"
+				"gpr	r6	.32	24	0\n"
+				"gpr	r7	.32	28	0\n"
+				"gpr	r8	.32	32	0\n"
+				"gpr	r9	.32	36	0\n"
+				"gpr	r10	.32	40	0\n"
+				"gpr	r11	.32	44	0\n"
+				"gpr	r12	.32	48	0\n"
+				"gpr	sp	.32	52	0\n" // r13
+				"gpr	lr	.32	56	0\n" // r14
+				"gpr	pc	.32	60	0\n" // r15
+				"gpr	r13	.32	52	0\n"
+				"gpr	r14	.32	56	0\n"
+				"gpr	r15	.32	60	0\n"
+				"gpr	cpsr	.96	64	0\n"
+				"mmx	d0	.64	68	0\n" // neon
+				"mmx	d1	.64	76	0\n" // neon
+				"mmx	d2	.64	84	0\n" // neon
+				"mmx	d3	.64	92	0\n" // neon
+				"mmx	d4	.64	100	0\n" // neon
+				"mmx	d5	.64	108	0\n" // neon
+				"mmx	d6	.64	116	0\n" // neon
+				"mmx	d7	.64	124	0\n" // neon
+				"mmx	d8	.64	132	0\n" // neon
+				"mmx	d9	.64	140	0\n" // neon
+				"mmx	d10	.64	148	0\n" // neon
+				"mmx	d11	.64	156	0\n" // neon
+				"mmx	d12	.64	164	0\n" // neon
+				"mmx	d13	.64	172	0\n" // neon
+				"mmx	d14	.64	180	0\n" // neon
+				"mmx	d15	.64	188	0\n" // neon
+				"mmx	d16	.64	196	0\n" // neon
+				"mmx	d17	.64	204	0\n" // neon
+				"mmx	d18	.64	212	0\n" // neon
+				"mmx	d19	.64	220	0\n" // neon
+				"mmx	d20	.64	228	0\n" // neon
+				"mmx	d21	.64	236	0\n" // neon
+				"mmx	d22	.64	244	0\n" // neon
+				"mmx	d23	.64	252	0\n" // neon
+				"mmx	d24	.64	260	0\n" // neon
+				"mmx	d25	.64	268	0\n" // neon
+				"mmx	d26	.64	276	0\n" // neon
+				"mmx	d27	.64	284	0\n" // neon
+				"mmx	d28	.64	292	0\n" // neon
+				"mmx	d29	.64	300	0\n" // neon
+				"mmx	d30	.64	308	0\n" // neon
+				"mmx	d31	.64	316	0\n" // neon
+				"mmx	fpscr	.32	324	0\n" // neon
+				);
+	}
+	return NULL;
+}
+
+static int r_debug_qnx_breakpoint (RBreakpointItem *bp, int set, void *user) {
+	int ret;
+	if (!bp)
+		return false;
+	if (set)
+		ret = bp->hw ?
+			      qnxr_set_hwbp (desc, bp->addr, "") :
+			      qnxr_set_bp (desc, bp->addr, "");
+	else
+		ret = bp->hw ?
+			      qnxr_remove_hwbp (desc, bp->addr) :
+			      qnxr_remove_bp (desc, bp->addr);
+	return !ret;
+}
+
+struct r_debug_plugin_t r_debug_plugin_qnx = {
+	.name = "qnx",
+	.license = "LGPL3",
+	.arch = "x86,arm",
+	.bits = R_SYS_BITS_32,
+	.step = r_debug_qnx_step,
+	.cont = r_debug_qnx_continue,
+	.attach = &r_debug_qnx_attach,
+	.detach = &r_debug_qnx_detach,
+	.pids = &r_debug_qnx_pids,
+	.tids = &r_debug_qnx_tids,
+	.select = &r_debug_qnx_select,
+	.stop = &r_debug_qnx_stop,
+	.canstep = 1,
+	.wait = &r_debug_qnx_wait,
+	.map_get = r_debug_qnx_map_get,
+	.breakpoint = &r_debug_qnx_breakpoint,
+	.reg_read = &r_debug_qnx_reg_read,
+	.reg_write = &r_debug_qnx_reg_write,
+	.reg_profile = (void *)r_debug_qnx_reg_profile,
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_DBG,
+	.data = &r_debug_plugin_qnx,
+	.version = R2_VERSION};
+#endif

--- a/libr/debug/p/qnx.mk
+++ b/libr/debug/p/qnx.mk
@@ -1,0 +1,32 @@
+#include ../../config.mk
+#BINDEPS=r_reg r_bp r_util r_io r_anal
+
+CFLAGS+=-I$(SHLR)/qnx/include/
+LIB_PATH=$(SHRL)/qnx/
+
+ifeq (${OSTYPE},windows)
+LDFLAGS+=-lwsock32
+endif
+ifeq (${OSTYPE},solaris)
+LDFLAGS+=-lsocket
+endif
+
+-include ../../global.mk
+-include ../../../global.mk
+LDFLAGS+=-L$(LTOP)/util -lr_util
+LDFLAGS+=-L$(LTOP)/cons -lr_cons
+LDFLAGS+=-L$(LTOP)/parse -lr_parse
+LDFLAGS+=-L$(LTOP)/anal -lr_anal
+LDFLAGS+=-L$(LTOP)/reg -lr_reg
+LDFLAGS+=-L$(LTOP)/bp -lr_bp
+LDFLAGS+=-L$(LTOP)/io -lr_io
+
+OBJ_QNX=debug_qnx.o 
+
+STATIC_OBJ+=${OBJ_QNX}
+TARGET_QNX=debug_qnx.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_QNX}
+
+${TARGET_QNX}: ${OBJ_QNX}
+	${CC_LIB} $(call libname,debug_qnx) ${OBJ_QNX} ${CFLAGS} ${LDFLAGS}

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -443,6 +443,7 @@ extern RDebugPlugin r_debug_plugin_gdb;
 extern RDebugPlugin r_debug_plugin_bf;
 extern RDebugPlugin r_debug_plugin_wind;
 extern RDebugPlugin r_debug_plugin_bochs;
+extern RDebugPlugin r_debug_plugin_qnx;
 #endif
 
 #ifdef __cplusplus

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -473,6 +473,7 @@ extern RIOPlugin r_io_plugin_mach;
 extern RIOPlugin r_io_plugin_debug;
 extern RIOPlugin r_io_plugin_shm;
 extern RIOPlugin r_io_plugin_gdb;
+extern RIOPlugin r_io_plugin_qnx;
 extern RIOPlugin r_io_plugin_rap;
 extern RIOPlugin r_io_plugin_http;
 extern RIOPlugin r_io_plugin_bfdbg;

--- a/libr/io/Jamroot
+++ b/libr/io/Jamroot
@@ -6,8 +6,9 @@ IO_OBJS += map.c plugin.c section.c undo.c ;
 IO_OBJS +=
     p/io_bfdbg.c
     p/io_debug.c
- p/io_ewf.c
+    p/io_ewf.c
     p/io_gdb.c
+    p/io_qnx.c
     p/io_http.c
     p/io_ihex.c
     p/io_mach.c

--- a/libr/io/Makefile
+++ b/libr/io/Makefile
@@ -13,6 +13,7 @@ CFLAGS+=-Wall -DCORELIB
 include ../socket/deps.mk
 include $(SHLR)/zip/deps.mk
 include $(SHLR)/gdb/deps.mk
+include $(SHLR)/qnx/deps.mk
 
 .PHONY: pre
 pre: libr_io.${EXT_SO} libr_io.${EXT_AR}

--- a/libr/io/p/Makefile
+++ b/libr/io/p/Makefile
@@ -15,7 +15,7 @@ endif
 foo: all
 
 ALL_TARGETS=
-PLUGINS=ptrace.mk debug.mk gdb.mk malloc.mk shm.mk mach.mk w32dbg.mk procpid.mk windbg.mk bochs.mk
+PLUGINS=ptrace.mk debug.mk gdb.mk malloc.mk shm.mk mach.mk w32dbg.mk procpid.mk windbg.mk bochs.mk qnx.mk
 #zip.mk
 #PLUGINS=ptrace.mk debug.mk gdb.mk malloc.mk mach.mk w32dbg.mk procpid.mk
 include ${PLUGINS}

--- a/libr/io/p/io_qnx.c
+++ b/libr/io/p/io_qnx.c
@@ -1,0 +1,164 @@
+/* radare - LGPL - Copyright 2010-2016 pancake */
+
+#include <r_io.h>
+#include <r_lib.h>
+#include <r_socket.h>
+#include <r_util.h>
+#define IRAPI static inline
+#include <libqnxr.h>
+
+typedef struct {
+	libqnxr_t desc;
+} RIOQnx;
+
+static libqnxr_t *desc = NULL;
+static RIODesc *rioqnx = NULL;
+
+static int __plugin_open (RIO *io, const char *file, ut8 many) {
+	return (!strncmp (file, "qnx://", 6));
+}
+
+/* hacky cache to speedup io a bit */
+/* reading in a different place clears the previous cache */
+static ut64 c_addr = UT64_MAX;
+static ut32 c_size = UT32_MAX;
+static ut8 *c_buff = NULL;
+#define SILLY_CACHE 0
+
+static int debug_qnx_read_at (ut8 *buf, int sz, ut64 addr) {
+	ut32 size_max = 500;
+	ut32 packets = sz / size_max;
+	ut32 last = sz % size_max;
+	ut32 x;
+	if (c_buff && addr != UT64_MAX && addr == c_addr) {
+		memcpy (buf, c_buff, sz);
+		return sz;
+	}
+	if (sz < 1 || addr >= UT64_MAX) return -1;
+	for (x = 0; x < packets; x++) {
+		qnxr_read_memory (desc, addr + x * size_max, (buf + x * size_max), size_max);
+	}
+	if (last) {
+		qnxr_read_memory (desc, addr + x * size_max, (buf + x * size_max), last);
+	}
+	c_addr = addr;
+	c_size = sz;
+#if SILLY_CACHE
+	free (c_buff);
+	c_buff = r_mem_dup (buf, sz);
+#endif
+	return sz;
+}
+
+static int debug_qnx_write_at (const ut8 *buf, int sz, ut64 addr) {
+	ut32 x, size_max = 500;
+	ut32 packets = sz / size_max;
+	ut32 last = sz % size_max;
+
+	if (sz < 1 || addr >= UT64_MAX) {
+		return -1;
+	}
+	if (c_addr != UT64_MAX && addr >= c_addr && c_addr + sz < (c_addr + c_size)) {
+		R_FREE (c_buff);
+		c_addr = UT64_MAX;
+	}
+	for (x = 0; x < packets; x++) {
+		qnxr_write_memory (desc, addr + x * size_max,
+				   (const uint8_t *)(buf + x * size_max), size_max);
+	}
+	if (last) {
+		qnxr_write_memory (desc, addr + x * size_max,
+				   (buf + x * size_max), last);
+	}
+
+	return sz;
+}
+
+static RIODesc *__open (RIO *io, const char *file, int rw, int mode) {
+	RIOQnx *rioq;
+	char host[128], *port, *p;
+
+	if (!__plugin_open (io, file, 0))
+		return NULL;
+	if (rioqnx) {
+		// FIX: Don't allocate more than one RIODesc
+		return rioqnx;
+	}
+	strncpy (host, file + 6, sizeof(host) - 1);
+	host[sizeof(host) - 1] = '\0';
+	port = strchr (host, ':');
+	if (!port) {
+		eprintf ("Port not specified. Please use qnx://[host]:[port]\n");
+		return NULL;
+	}
+	*port = '\0';
+	port++;
+	p = strchr (port, '/');
+	if (p) *p = 0;
+
+	if (r_sandbox_enable (0)) {
+		eprintf ("sandbox: Cannot use network\n");
+		return NULL;
+	}
+	rioq = R_NEW0 (RIOQnx);
+	qnxr_init (&rioq->desc);
+	int i_port = atoi (port);
+	if (qnxr_connect (&rioq->desc, host, i_port) == 0) {
+		desc = &rioq->desc;
+		rioqnx = r_io_desc_new (&r_io_plugin_qnx, rioq->desc.sock->fd, file, rw, mode, rioq);
+		return rioqnx;
+	}
+	eprintf ("qnx.io.open: Cannot connect to host.\n");
+	free (rioq);
+	return NULL;
+}
+
+static int __write (RIO *io, RIODesc *fd, const ut8 *buf, int count) {
+	ut64 addr = io->off;
+	if (!desc) return -1;
+	return debug_qnx_write_at (buf, count, addr);
+}
+
+static ut64 __lseek (RIO *io, RIODesc *fd, ut64 offset, int whence) {
+	return offset;
+}
+
+static int __read (RIO *io, RIODesc *fd, ut8 *buf, int count) {
+	memset (buf, 0xff, count);
+	ut64 addr = io->off;
+	if (!desc) return -1;
+	return debug_qnx_read_at (buf, count, addr);
+}
+
+static int __close (RIODesc *fd) {
+	// TODO
+	return -1;
+}
+
+static int __system (RIO *io, RIODesc *fd, const char *cmd) {
+	//printf("ptrace io command (%s)\n", cmd);
+	/* XXX ugly hack for testing purposes */
+	if (!strcmp (cmd, "help")) {
+		eprintf ("Usage: =!cmd args\n"
+			 " =!pid      - show targeted pid\n");
+	} else if (!strncmp (cmd, "pid", 3)) {
+		int pid = 1234;
+		io->cb_printf ("%d\n", pid);
+		return pid;
+	} else
+		eprintf ("Try: '=!pid'\n");
+	return true;
+}
+
+RIOPlugin r_io_plugin_qnx = {
+	.name = "qnx",
+	.license = "LGPL3",
+	.desc = "Attach to QNX pdebug instance, qnx://host:1234",
+	.open = __open,
+	.close = __close,
+	.read = __read,
+	.write = __write,
+	.plugin_open = __plugin_open,
+	.lseek = __lseek,
+	.system = __system,
+	.isdbg = true};

--- a/libr/io/p/qnx.mk
+++ b/libr/io/p/qnx.mk
@@ -1,0 +1,29 @@
+OBJ_QNX=io_qnx.o
+
+STATIC_OBJ+=${OBJ_QNX}
+TARGET_QNX=io_qnx.${EXT_SO}
+ALL_TARGETS+=${TARGET_QNX}
+
+LIB_PATH=$(SHLR)/qnx/
+CFLAGS+=-I$(SHLR)/qnx/include/
+LDFLAGS+=$(SHLR)/qnx/lib/libqnxr.a
+
+include $(LIBR)/socket/deps.mk
+
+ifeq (${WITHPIC},0)
+LINKFLAGS=../../socket/libr_socket.a
+LINKFLAGS+=../../util/libr_util.a
+LINKFLAGS+=../../io/libr_io.a
+else
+LINKFLAGS=-L../../socket -lr_socket
+LINKFLAGS+=-L../../util -lr_util
+LINKFLAGS+=-L.. -lr_io
+endif
+ifeq (${HAVE_LIB_SSL},1)
+CFLAGS+=${SSL_CFLAGS}
+LINKFLAGS+=${SSL_LDFLAGS}
+endif
+
+${TARGET_QNX}: ${OBJ_QNX}
+	${CC} $(call libname,io_qnx) ${OBJ_QNX} ${CFLAGS} \
+		${LINKFLAGS} ${LDFLAGS_LIB} $(LDFLAGS)

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -162,6 +162,7 @@ crypto.aes_cbc
 debug.bf
 debug.esil
 debug.gdb
+debug.qnx
 debug.native
 debug.rap
 debug.wind
@@ -191,6 +192,7 @@ io.bochs
 io.debug
 io.default
 io.gdb
+io.qnx
 io.r2pipe
 io.gzip
 io.http

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -39,6 +39,7 @@ ifeq (1,$(WITH_GPL))
 MODS+=grub
 endif
 MODS+=gdb
+MODS+=qnx
 SDB_URL=git://github.com/radare/sdb
 #SDB_URL=/Users/pancake/prg/sdb
 PWD=$(shell pwd)

--- a/shlr/qnx/Jamroot
+++ b/shlr/qnx/Jamroot
@@ -1,0 +1,10 @@
+OBJS = 
+src/core.c
+src/libgdbr.c
+src/messages.c
+src/packet.c
+src/utils.c
+;
+
+lib zip : $(OBJS) : <link>static <include>include <cflags>-fPIC 
+  <include>../../libr/include ;

--- a/shlr/qnx/Makefile
+++ b/shlr/qnx/Makefile
@@ -1,0 +1,83 @@
+include ../../libr/config.mk
+include ../../mk/platform.mk
+include ../../shlr/zip/deps.mk
+EDITOR?=vim
+CC?=gcc
+AR?=ar
+RANLIB?=ranlib
+LIBNAME=libqnxr
+LIBFILE=$(LIBNAME).$(EXT_SO)
+CFLAGS+=-I$(LIBR)/include $(PIC_CFLAGS)
+CFLAGS+=-Iinclude -I${LIBR}/include
+MAJOR=0
+MINOR=1
+#CFLAGS=-Wall -g -O0 -ggdb # -std=gnu11
+LD=$(CC)
+LDFLAGS+=-L${LIBR}/socket -lr_socket
+LDFLAGS+=-L${LIBR}/util -lr_util
+#OSTYPE=windows
+include ../../libr/socket/deps.mk
+
+# Test variables
+TEST_D= $(PWD)/test
+BIN=$(PWD)/bin
+UNIT_TEST=$(TEST_D)/unit.c
+CLIENT=$(TEST_D)/client.c
+
+PWD=$(shell pwd)
+TEST=test
+LIB=lib
+
+TEST_INCLUDES += $(INCLUDES) -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include
+
+SRC_D=src
+SRC_C=$(wildcard $(SRC_D)/*.c)
+SRC_O=$(SRC_C:.c=.o)
+
+TEST_C=$(wildcard $(TEST_D)/*.c)
+TEST_O=$(TEST_C:.c=.o)
+
+all: $(LIB)/$(LIBNAME).a
+#	make
+
+default: make
+
+prepare:
+	mkdir -p $(LIB)
+
+#$(LD) -shared -Wl,-soname,$(LIBNAME).so -o $(LIB)/$(LIBNAME).so $(SRC_O)
+$(LIB):
+	mkdir -p $(LIB)
+
+$(LIB)/$(LIBNAME).a: $(LIB) $(SRC_O)
+	$(LD) $(PIC_CFLAGS) -shared -o $(LIB)/$(LIBFILE) $(CFLAGS) $(SRC_O) $(LDFLAGS) $(LINK)
+	$(AR) rvs $(LIB)/$(LIBNAME).a $(SRC_O)
+	# required for solaris and w32
+	$(RANLIB) $(LIB)/$(LIBNAME).a
+
+clean:
+	-rm -f $(SRC_O)
+	-rm -rf lib
+
+unit: lib 
+	$(CC) $(CFLAGS) $(TEST_INCLUDES) -c $(UNIT_TEST) -o $(TEST_D)/unit.o
+	$(LD) $(TEST_D)/unit.o -o $(TEST_D)/unit -L$(LIB) -lqnxr -lglib-2.0
+
+run_unit: unit
+	LD_LIBRARY_PATH=./lib ./test/unit
+
+client: lib
+	$(CC) $(CFLAGS) $(INCLUDES) -c $(CLIENT) -o $(TEST_D)/client.o
+	$(LD) $(TEST_D)/client.o -o $(TEST_D)/client -L$(LIB) -lqnxr
+
+run_test: client
+	rarun2 libpath=./lib program=./test/client
+
+gdb_test: client
+	rarun2 libpath=./lib system="gdb ./test/client"
+
+valgrind_test: client
+	rarun2 libpath=./lib system="valgrind --track-origins=yes -v --leak-check=full ./test/client"
+
+edit:
+	$(EDITOR) -c "args **/*.h **/*.c"

--- a/shlr/qnx/deps.mk
+++ b/shlr/qnx/deps.mk
@@ -1,0 +1,1 @@
+LINK+=../../shlr/qnx/lib/libqnxr.a

--- a/shlr/qnx/include/arch.h
+++ b/shlr/qnx/include/arch.h
@@ -1,0 +1,20 @@
+/*! \file */
+#ifndef ARCH_H
+#define ARCH_H
+
+#define ARCH_X86_64 0
+#define ARCH_X86_32 1
+#define ARCH_ARM_32 2
+#define ARCH_ARM_64 3
+
+/*!
+ * This struct defines a generic
+ * register view
+ */
+typedef struct registers_t {
+	char name[32]; /*! The Name of the current register */
+	uint64_t offset; /*! Offset in the data block */
+	uint64_t size;	/*! Size of the register */
+} registers_t;
+
+#endif

--- a/shlr/qnx/include/core.h
+++ b/shlr/qnx/include/core.h
@@ -1,0 +1,35 @@
+/*! \file */
+#ifndef QNX_CORE_H
+#define QNX_CORE_H
+
+#include "r_types.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#include "libqnxr.h"
+#include "utils.h"
+#include "arch.h"
+
+#ifndef offsetof
+#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#endif
+
+enum Breakpoint {
+	BREAKPOINT,
+	HARDWARE_BREAKPOINT,
+	WRITE_WATCHPOINT,
+	READ_WATCHPOINT,
+	ACCESS_WATCHPOINT
+};
+
+int qnxr_send_vcont(libqnxr_t* g, int step, int thread_id);
+
+int _qnxr_set_bp(libqnxr_t* g, ut64 address, const char* conditions, enum Breakpoint type);
+
+int _qnxr_remove_bp(libqnxr_t* g, ut64 address, enum Breakpoint type);
+
+#endif

--- a/shlr/qnx/include/dsmsgs.h
+++ b/shlr/qnx/include/dsmsgs.h
@@ -1,0 +1,754 @@
+/*
+ * $QNXtpLicenseC:  
+ * Copyright 2005, QNX Software Systems. All Rights Reserved.
+ *
+ * This source code may contain confidential information of QNX Software 
+ * Systems (QSS) and its licensors.  Any use, reproduction, modification, 
+ * disclosure, distribution or transfer of this software, or any software 
+ * that includes or is based upon any of this code, is prohibited unless 
+ * expressly authorized by QSS by written agreement.  For more information 
+ * (including whether this source code file has been published) please
+ * email licensing@qnx.com. $
+*/
+
+/*
+
+   Copyright 2003 Free Software Foundation, Inc.
+
+   Contributed by QNX Software Systems Ltd.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place - Suite 330,
+   Boston, MA 02111-1307, USA.  */
+
+#ifndef __DSMSGS_H__
+#define __DSMSGS_H__
+
+/* These are the protocol versioning numbers.
+   Update them with changes that introduce potential 
+   compatibility issues.  */
+#define PDEBUG_PROTOVER_MAJOR				0x00000000
+#define PDEBUG_PROTOVER_MINOR				0x00000003
+
+#include <stddef.h>
+
+/* These are pdebug specific errors, sent sometimes with the errno after
+   an action failed.  Simply provides additional info on the reason for the 
+   error.  Sent in the DSrMsg_err_t.hdr.subcmd byte.  */
+
+#define PDEBUG_ENOERR		0	/* No error.  */
+#define PDEBUG_ENOPTY		1	/* No Pseudo Terminals found.  */
+#define PDEBUG_ETHREAD		2	/* Thread Create error.  */
+#define PDEBUG_ECONINV		3	/* Invalid Console number.  */
+#define PDEBUG_ESPAWN		4	/* Spawn error.  */
+#define PDEBUG_EPROCFS		5	/* NTO Proc File System error.  */
+#define PDEBUG_EPROCSTOP	6	/* NTO Process Stop error.  */
+#define PDEBUG_EQPSINFO		7	/* QNX4 PSINFO error.  */
+#define PDEBUG_EQMEMMODEL	8	/* QNX4 - Flat Memory Model only supported.  */
+#define PDEBUG_EQPROXY		9	/* QNX4 Proxy error.  */
+#define PDEBUG_EQDBG		10	/* QNX4 qnx_debug_* error.  */
+
+/* There is room for pdebugerrnos up to sizeof(unsigned char).
+
+   We are moving away from the channel commands - only the RESET
+   and NAK are required.  The DEBUG and TEXT channels are now part
+   of the DShdr and TShdr structs, 4th byte.  GP June 1 1999.
+   They are still supported, but not required. 
+
+   A packet containg a single byte is a set channel command. 
+   IE:  7e xx chksum 7e 
+
+   After a set channel all following packets are in the format
+   for the specified channel.  Currently three channels are defined.
+   The raw channel has no structure.  The other channels are all framed.
+   The contents of each channel is defined by structures below. 
+  
+   0 - Reset channel. Used when either end starts.
+  
+   1 - Debug channel with the structure which follows below.
+       Uses DS (Debug Services) prefix.
+  
+   2 - Text channel with the structure which follows below.
+       Uses TS (Text Services) prefix.
+  
+   0xff - Negative acknowledgment of a packet transmission.  */
+
+#define SET_CHANNEL_RESET				0
+#define SET_CHANNEL_DEBUG				1
+#define SET_CHANNEL_TEXT				2
+#define SET_CHANNEL_NAK					0xff
+
+
+/* Debug channel Messages:   DS - Debug services.  */
+
+/* Defines and structures for the debug channel.  */
+
+#define DS_DATA_MAX_SIZE				1024
+#define DS_DATA_RCV_SIZE(msg, total)	((total) - (sizeof(*(msg)) - DS_DATA_MAX_SIZE))
+#define DS_MSG_OKSTATUS_FLAG			0x20000000
+#define DS_MSG_OKDATA_FLAG				0x40000000
+#define DS_MSG_NO_RESPONSE				0x80000000
+
+#define QNXNTO_NSIG			57	/* From signals.h NSIG.  */
+
+/* Common message header. It must be 32 or 64 bit aligned.
+   The top bit of cmd is 1 for BIG endian data format.  */
+#define DSHDR_MSG_BIG_ENDIAN	0x80
+struct DShdr
+{
+  unsigned char cmd;
+  unsigned char subcmd;
+  unsigned char mid;
+  unsigned char channel;
+};
+
+/* Command types.  */
+enum
+{
+  DStMsg_connect,		/*  0  0x0 */
+  DStMsg_disconnect,		/*  1  0x1 */
+  DStMsg_select,		/*  2  0x2 */
+  DStMsg_mapinfo,		/*  3  0x3 */
+  DStMsg_load,			/*  4  0x4 */
+  DStMsg_attach,		/*  5  0x5 */
+  DStMsg_detach,		/*  6  0x6 */
+  DStMsg_kill,			/*  7  0x7 */
+  DStMsg_stop,			/*  8  0x8 */
+  DStMsg_memrd,			/*  9  0x9 */
+  DStMsg_memwr,			/* 10  0xA */
+  DStMsg_regrd,			/* 11  0xB */
+  DStMsg_regwr,			/* 12  0xC */
+  DStMsg_run,			/* 13  0xD */
+  DStMsg_brk,			/* 14  0xE */
+  DStMsg_fileopen,		/* 15  0xF */
+  DStMsg_filerd,		/* 16  0x10 */
+  DStMsg_filewr,		/* 17  0x11 */
+  DStMsg_fileclose,		/* 18  0x12 */
+  DStMsg_pidlist,		/* 19  0x13 */
+  DStMsg_cwd,			/* 20  0x14 */
+  DStMsg_env,			/* 21  0x15 */
+  DStMsg_base_address,		/* 22  0x16 */
+  DStMsg_protover,		/* 23  0x17 */
+  DStMsg_handlesig,		/* 24  0x18 */
+  DStMsg_cpuinfo,		/* 25  0x19 */
+  DStMsg_tidnames,		/* 26  0x1A */
+  DStMsg_procfsinfo,		/* 27  0x1B */
+  /* Room for new codes here.  */
+  DSrMsg_err = 32,		/* 32  0x20 */
+  DSrMsg_ok,			/* 33  0x21 */
+  DSrMsg_okstatus,		/* 34  0x22 */
+  DSrMsg_okdata,		/* 35  0x23 */
+  /* Room for new codes here.  */
+  DShMsg_notify = 64		/* 64  0x40 */
+};
+
+
+/* Subcommand types.  */
+enum
+{
+  DSMSG_LOAD_DEBUG,
+  DSMSG_LOAD_RUN,
+  DSMSG_LOAD_RUN_PERSIST,
+  DSMSG_LOAD_INHERIT_ENV = 0x80
+};
+
+enum
+{
+  DSMSG_ENV_CLEARARGV,
+  DSMSG_ENV_ADDARG,
+  DSMSG_ENV_CLEARENV,
+  DSMSG_ENV_SETENV,
+  DSMSG_ENV_SETENV_MORE
+};
+
+enum
+{
+  DSMSG_STOP_PID,
+  DSMSG_STOP_PIDS
+};
+
+enum
+{
+  DSMSG_SELECT_SET,
+  DSMSG_SELECT_QUERY
+};
+
+enum
+{
+  DSMSG_KILL_PIDTID,
+  DSMSG_KILL_PID,
+  DSMSG_KILL_PIDS
+};
+
+enum
+{
+  DSMSG_MEM_VIRTUAL,
+  DSMSG_MEM_PHYSICAL,
+  DSMSG_MEM_IO,
+  DSMSG_MEM_BASEREL
+};
+
+enum
+{
+  DSMSG_REG_GENERAL,
+  DSMSG_REG_FLOAT,
+  DSMSG_REG_SYSTEM,
+  DSMSG_REG_ALT,
+  DSMSG_REG_END
+};
+
+enum
+{
+  DSMSG_RUN,
+  DSMSG_RUN_COUNT,
+  DSMSG_RUN_RANGE,
+};
+
+enum
+{
+  DSMSG_PIDLIST_BEGIN,
+  DSMSG_PIDLIST_NEXT,
+  DSMSG_PIDLIST_SPECIFIC,
+  DSMSG_PIDLIST_SPECIFIC_TID,	/* *_TID - send starting tid for the request, */
+};				/* and the response will have total to be sent.  */
+
+enum
+{
+  DSMSG_CWD_QUERY,
+  DSMSG_CWD_SET,
+};
+
+enum
+{
+  DSMSG_MAPINFO_BEGIN = 0x01,
+  DSMSG_MAPINFO_NEXT = 0x02,
+  DSMSG_MAPINFO_SPECIFIC = 0x04,
+  DSMSG_MAPINFO_ELF = 0x80,
+};
+
+enum
+{
+  DSMSG_PROTOVER_MINOR = 0x000000FF,	/* bit field (status & DSMSG_PROTOVER_MAJOR) */
+  DSMSG_PROTOVER_MAJOR = 0x0000FF00,	/* bit field (status & DSMSG_PROTOVER_MINOR) */
+};
+
+enum
+{
+  DSMSG_BRK_EXEC = 0x0001,	/* Execution breakpoint.  */
+  DSMSG_BRK_RD = 0x0002,	/* Read access (fail if not supported).  */
+  DSMSG_BRK_WR = 0x0004,	/* Write access (fail if not supported).  */
+  DSMSG_BRK_RW = 0x0006,	/* Read or write access (fail if not supported).  */
+  DSMSG_BRK_MODIFY = 0x0008,	/* Memory modified.  */
+  DSMSG_BRK_RDM = 0x000a,	/* Read access if suported otherwise modified.  */
+  DSMSG_BRK_WRM = 0x000c,	/* Write access if suported otherwise modified.  */
+  DSMSG_BRK_RWM = 0x000e,	/* Read or write access if suported otherwise modified.  */
+  DSMSG_BRK_HW = 0x0010,	/* Only use hardware debugging (i.e. no singlestep).  */
+};
+
+enum
+{
+  DSMSG_NOTIFY_PIDLOAD,		/* 0 */
+  DSMSG_NOTIFY_TIDLOAD,		/* 1 */
+  DSMSG_NOTIFY_DLLLOAD,		/* 2 */
+  DSMSG_NOTIFY_PIDUNLOAD,	/* 3 */
+  DSMSG_NOTIFY_TIDUNLOAD,	/* 4 */
+  DSMSG_NOTIFY_DLLUNLOAD,	/* 5 */
+  DSMSG_NOTIFY_BRK,		/* 6 */
+  DSMSG_NOTIFY_STEP,		/* 7 */
+  DSMSG_NOTIFY_SIGEV,		/* 8 */
+  DSMSG_NOTIFY_STOPPED		/* 9 */
+};
+
+
+
+/* Messages sent to the target. DStMsg_* (t - for target messages).  */
+
+/* Connect to the agent running on the target.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned char major;
+  unsigned char minor;
+  unsigned char spare[2];
+} DStMsg_connect_t;
+
+
+/* Disconnect from the agent running on the target. */
+typedef struct
+{
+  struct DShdr hdr;
+} DStMsg_disconnect_t;
+
+
+/* Select a pid, tid for subsequent messages or query their validity.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int pid;
+  int tid;
+} DStMsg_select_t;
+
+
+/* Return information on what is at the specified virtual address.
+   If nothing is there we return info on the next thing in the address.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int pid;
+  int addr;
+} DStMsg_mapinfo_t;
+
+
+/* Load a new process into memory for a filesystem. */
+typedef struct
+{
+  struct DShdr hdr;
+  int argc;
+  int envc;
+  char cmdline[DS_DATA_MAX_SIZE];
+} DStMsg_load_t;
+
+
+/* Attach to an already running process.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int pid;
+} DStMsg_attach_t;
+
+typedef DStMsg_attach_t DStMsg_procfsinfo_t;
+
+/* Detach from a running process which was attached to or loaded.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int pid;
+} DStMsg_detach_t;
+
+
+/* Set a signal on a process.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int signo;
+} DStMsg_kill_t;
+
+
+/* Stop one or more processes/threads.  */
+typedef struct
+{
+  struct DShdr hdr;
+} DStMsg_stop_t;
+
+
+/* Memory read request.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned spare0;
+  unsigned long long addr;
+  unsigned short size;
+} DStMsg_memrd_t;
+
+
+/* Memory write request.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned spare0;
+  unsigned long long addr;
+  unsigned char data[DS_DATA_MAX_SIZE];
+} DStMsg_memwr_t;
+
+
+/* Register read request.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned short offset;
+  unsigned short size;
+} DStMsg_regrd_t;
+
+
+/* Register write request.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned short offset;
+  unsigned char data[DS_DATA_MAX_SIZE];
+} DStMsg_regwr_t;
+
+
+/* Run.  */
+typedef struct
+{
+  struct DShdr hdr;
+  union
+  {
+    unsigned count;
+    unsigned addr[2];
+  } step;
+} DStMsg_run_t;
+
+
+/* Break.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned addr;
+  unsigned size;
+} DStMsg_brk_t;
+
+
+/* Open a file on the target.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int mode;
+  int perms;
+  char pathname[DS_DATA_MAX_SIZE];
+} DStMsg_fileopen_t;
+
+
+/* Read a file on the target.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned short size;
+} DStMsg_filerd_t;
+
+
+/* Write a file on the target.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned char data[DS_DATA_MAX_SIZE];
+} DStMsg_filewr_t;
+
+
+/* Close a file on the target.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int mtime;
+} DStMsg_fileclose_t;
+
+
+/* Get pids and process names in the system.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int pid;			/* Only valid for type subtype SPECIFIC.  */
+  int tid;			/* Tid to start reading from.  */
+} DStMsg_pidlist_t;
+
+
+/* Set current working directory of process.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned char path[DS_DATA_MAX_SIZE];
+} DStMsg_cwd_t;
+
+
+/* Clear, set, get environment for new process.  */
+typedef struct
+{
+  struct DShdr hdr;
+  char data[DS_DATA_MAX_SIZE];
+} DStMsg_env_t;
+
+
+/* Get the base address of a process.  */
+typedef struct
+{
+  struct DShdr hdr;
+} DStMsg_baseaddr_t;
+
+
+/* Send pdebug protocol version info, get the same in response_ok_status.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned char major;
+  unsigned char minor;
+} DStMsg_protover_t;
+
+
+/* Handle signal message.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned char signals[QNXNTO_NSIG];
+  unsigned sig_to_pass;
+} DStMsg_handlesig_t;
+
+
+/* Get some cpu info.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned spare;
+} DStMsg_cpuinfo_t;
+
+/* Get the names of the threads */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned spare;
+} DStMsg_tidnames_t;
+
+/* Messages sent to the host. DStMsg_* (h - for host messages).  */
+
+/* Notify host that something happened it needs to know about.  */
+#define NOTIFY_HDR_SIZE				offsetof(DShMsg_notify_t, un)
+#define NOTIFY_MEMBER_SIZE(member)	sizeof(member)
+
+typedef struct
+{
+  struct DShdr hdr;
+  int pid;
+  int tid;
+  union
+  {
+    struct
+    {
+      unsigned codeoff;
+      unsigned dataoff;
+      unsigned short ostype;
+      unsigned short cputype;
+      unsigned cpuid;		/* CPU dependant value.  */
+      char name[DS_DATA_MAX_SIZE];
+    } pidload;
+    struct
+    {
+      int status;
+    } pidunload;
+    struct
+    {
+      int status;
+      unsigned char faulted;
+      unsigned char reserved[3];
+    } pidunload_v3;
+    struct
+    {
+      unsigned ip;
+      unsigned dp;
+      unsigned flags;		/* Defined in <sys/debug.h>. */
+    } brk;
+    struct
+    {
+      unsigned ip;
+      unsigned lastip;
+    } step;
+    struct
+    {
+      int signo;
+      int code;
+      int value;
+    } sigev;
+  } un;
+} DShMsg_notify_t;
+
+
+
+/* Responses to a message. DSrMsg_* (r - for response messages).  */
+
+/* Error response packet.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int err;
+} DSrMsg_err_t;
+
+/* Simple OK response.  */
+typedef struct
+{
+  struct DShdr hdr;
+} DSrMsg_ok_t;
+
+
+/* Simple OK response with a result.  Used where limited data needs
+   to be returned.  For example, if the number of bytes which were
+   successfully written was less than requested on any write cmd the
+   status will be the number actually written.
+   The 'subcmd' will always be zero.  */
+typedef struct
+{
+  struct DShdr hdr;
+  int status;
+} DSrMsg_okstatus_t;
+
+
+/* The following structures overlay data[..] on a DSrMsg_okdata_t.  */
+struct dslinkmap
+{
+  unsigned addr;
+  unsigned size;
+  unsigned flags;
+  unsigned debug_vaddr;
+  unsigned long long offset;
+};
+
+struct dsmapinfo
+{
+  struct dsmapinfo *next;
+  unsigned spare0;
+  unsigned long long ino;
+  unsigned dev;
+  unsigned spare1;
+  struct dslinkmap text;
+  struct dslinkmap data;
+  char name[256];
+};
+
+struct dspidlist
+{
+  int pid;
+  int num_tids;			/* Num of threads this pid has.  */
+  int spare[6];
+  struct tidinfo
+  {
+    short tid;
+    unsigned char state;
+    unsigned char flags;
+  } tids[1];			/* Variable length terminated by tid==0.  */
+  char name[1];			/* Variable length terminated by \0.  */
+};
+
+struct dscpuinfo
+{
+  unsigned cpuflags;
+  unsigned spare1;
+  unsigned spare2;
+  unsigned spare3;
+};
+
+struct dstidnames
+{
+  unsigned	numtids;
+  unsigned	numleft;
+  unsigned	spare1;
+  unsigned	spare2;
+  char		data[1]; /* A bunch of string data tidNULLnameNULL... */
+};
+
+/* Long OK response with 0..DS_DATA_MAX_SIZE data.
+   The 'subcmd' will always be zero.  */
+typedef struct
+{
+  struct DShdr hdr;
+  unsigned char data[DS_DATA_MAX_SIZE];
+} DSrMsg_okdata_t;
+
+
+/* A union of all possible messages and responses.  */
+typedef union
+{
+  struct DShdr hdr;
+  DStMsg_connect_t connect;
+  DStMsg_disconnect_t disconnect;
+  DStMsg_select_t select;
+  DStMsg_load_t load;
+  DStMsg_attach_t attach;
+  DStMsg_procfsinfo_t procfsinfo;
+  DStMsg_detach_t detach;
+  DStMsg_kill_t kill;
+  DStMsg_stop_t stop;
+  DStMsg_memrd_t memrd;
+  DStMsg_memwr_t memwr;
+  DStMsg_regrd_t regrd;
+  DStMsg_regwr_t regwr;
+  DStMsg_run_t run;
+  DStMsg_brk_t brk;
+  DStMsg_fileopen_t fileopen;
+  DStMsg_filerd_t filerd;
+  DStMsg_filewr_t filewr;
+  DStMsg_fileclose_t fileclose;
+  DStMsg_pidlist_t pidlist;
+  DStMsg_mapinfo_t mapinfo;
+  DStMsg_cwd_t cwd;
+  DStMsg_env_t env;
+  DStMsg_baseaddr_t baseaddr;
+  DStMsg_protover_t protover;
+  DStMsg_handlesig_t handlesig;
+  DStMsg_cpuinfo_t cpuinfo;
+  DStMsg_tidnames_t tidnames;
+  DShMsg_notify_t notify;
+  DSrMsg_err_t err;
+  DSrMsg_ok_t ok;
+  DSrMsg_okstatus_t okstatus;
+  DSrMsg_okdata_t okdata;
+} DSMsg_union_t;
+
+
+
+
+
+/* Text channel Messages:   TS - Text services.  */
+#define TS_TEXT_MAX_SIZE	100
+
+/* Command types.  */
+enum
+{
+  TSMsg_text,			/* 0 */
+  TSMsg_done,			/* 1 */
+  TSMsg_start,			/* 2 */
+  TSMsg_stop,			/* 3 */
+  TSMsg_ack,			/* 4 */
+};
+
+
+struct TShdr
+{
+  unsigned char cmd;
+  unsigned char console;
+  unsigned char spare1;
+  unsigned char channel;
+};
+
+
+/* Deliver text.  This message can be sent by either side.
+   The debugger displays it in a window.  The agent gives it to a pty
+   which a program may be listening on.  */
+typedef struct
+{
+  struct TShdr hdr;
+  char text[TS_TEXT_MAX_SIZE];
+} TSMsg_text_t;
+
+
+/* There is no longer a program connected to this console.  */
+typedef struct
+{
+  struct TShdr hdr;
+} TSMsg_done_t;
+
+
+/* TextStart or TextStop flow controlÿ.  */
+typedef struct
+{
+  struct TShdr hdr;
+} TSMsg_flowctl_t;
+
+
+/* Ack a flowctl message.  */
+typedef struct
+{
+  struct TShdr hdr;
+} TSMsg_ack_t;
+
+#endif

--- a/shlr/qnx/include/gdb_signals.h
+++ b/shlr/qnx/include/gdb_signals.h
@@ -1,0 +1,234 @@
+/* Target signal numbers for GDB and the GDB remote protocol.
+   Copyright 1986, 1988, 1989, 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997,
+   1998, 1999, 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef GDB_SIGNALS_H
+#define GDB_SIGNALS_H
+
+/* The numbering of these signals is chosen to match traditional unix
+   signals (insofar as various unices use the same numbers, anyway).
+   It is also the numbering of the GDB remote protocol.  Other remote
+   protocols, if they use a different numbering, should make sure to
+   translate appropriately.
+
+   Since these numbers have actually made it out into other software
+   (stubs, etc.), you mustn't disturb the assigned numbering.  If you
+   need to add new signals here, add them to the end of the explicitly
+   numbered signals, at the comment marker.  Add them unconditionally,
+   not within any #if or #ifdef.
+
+   This is based strongly on Unix/POSIX signals for several reasons:
+   (1) This set of signals represents a widely-accepted attempt to
+   represent events of this sort in a portable fashion, (2) we want a
+   signal to make it from wait to child_wait to the user intact, (3) many
+   remote protocols use a similar encoding.  However, it is
+   recognized that this set of signals has limitations (such as not
+   distinguishing between various kinds of SIGSEGV, or not
+   distinguishing hitting a breakpoint from finishing a single step).
+   So in the future we may get around this either by adding additional
+   signals for breakpoint, single-step, etc., or by adding signal
+   codes; the latter seems more in the spirit of what BSD, System V,
+   etc. are doing to address these issues.  */
+
+/* For an explanation of what each signal means, see
+   target_signal_to_string.  */
+
+enum target_signal
+  {
+    /* Used some places (e.g. stop_signal) to record the concept that
+       there is no signal.  */
+    TARGET_SIGNAL_0 = 0,
+    TARGET_SIGNAL_FIRST = 0,
+    TARGET_SIGNAL_HUP = 1,
+    TARGET_SIGNAL_INT = 2,
+    TARGET_SIGNAL_QUIT = 3,
+    TARGET_SIGNAL_ILL = 4,
+    TARGET_SIGNAL_TRAP = 5,
+    TARGET_SIGNAL_ABRT = 6,
+    TARGET_SIGNAL_EMT = 7,
+    TARGET_SIGNAL_FPE = 8,
+    TARGET_SIGNAL_KILL = 9,
+    TARGET_SIGNAL_BUS = 10,
+    TARGET_SIGNAL_SEGV = 11,
+    TARGET_SIGNAL_SYS = 12,
+    TARGET_SIGNAL_PIPE = 13,
+    TARGET_SIGNAL_ALRM = 14,
+    TARGET_SIGNAL_TERM = 15,
+    TARGET_SIGNAL_URG = 16,
+    TARGET_SIGNAL_STOP = 17,
+    TARGET_SIGNAL_TSTP = 18,
+    TARGET_SIGNAL_CONT = 19,
+    TARGET_SIGNAL_CHLD = 20,
+    TARGET_SIGNAL_TTIN = 21,
+    TARGET_SIGNAL_TTOU = 22,
+    TARGET_SIGNAL_IO = 23,
+    TARGET_SIGNAL_XCPU = 24,
+    TARGET_SIGNAL_XFSZ = 25,
+    TARGET_SIGNAL_VTALRM = 26,
+    TARGET_SIGNAL_PROF = 27,
+    TARGET_SIGNAL_WINCH = 28,
+    TARGET_SIGNAL_LOST = 29,
+    TARGET_SIGNAL_USR1 = 30,
+    TARGET_SIGNAL_USR2 = 31,
+    TARGET_SIGNAL_PWR = 32,
+    /* Similar to SIGIO.  Perhaps they should have the same number.  */
+    TARGET_SIGNAL_POLL = 33,
+    TARGET_SIGNAL_WIND = 34,
+    TARGET_SIGNAL_PHONE = 35,
+    TARGET_SIGNAL_WAITING = 36,
+    TARGET_SIGNAL_LWP = 37,
+    TARGET_SIGNAL_DANGER = 38,
+    TARGET_SIGNAL_GRANT = 39,
+    TARGET_SIGNAL_RETRACT = 40,
+    TARGET_SIGNAL_MSG = 41,
+    TARGET_SIGNAL_SOUND = 42,
+    TARGET_SIGNAL_SAK = 43,
+    TARGET_SIGNAL_PRIO = 44,
+    TARGET_SIGNAL_REALTIME_33 = 45,
+    TARGET_SIGNAL_REALTIME_34 = 46,
+    TARGET_SIGNAL_REALTIME_35 = 47,
+    TARGET_SIGNAL_REALTIME_36 = 48,
+    TARGET_SIGNAL_REALTIME_37 = 49,
+    TARGET_SIGNAL_REALTIME_38 = 50,
+    TARGET_SIGNAL_REALTIME_39 = 51,
+    TARGET_SIGNAL_REALTIME_40 = 52,
+    TARGET_SIGNAL_REALTIME_41 = 53,
+    TARGET_SIGNAL_REALTIME_42 = 54,
+    TARGET_SIGNAL_REALTIME_43 = 55,
+    TARGET_SIGNAL_REALTIME_44 = 56,
+    TARGET_SIGNAL_REALTIME_45 = 57,
+    TARGET_SIGNAL_REALTIME_46 = 58,
+    TARGET_SIGNAL_REALTIME_47 = 59,
+    TARGET_SIGNAL_REALTIME_48 = 60,
+    TARGET_SIGNAL_REALTIME_49 = 61,
+    TARGET_SIGNAL_REALTIME_50 = 62,
+    TARGET_SIGNAL_REALTIME_51 = 63,
+    TARGET_SIGNAL_REALTIME_52 = 64,
+    TARGET_SIGNAL_REALTIME_53 = 65,
+    TARGET_SIGNAL_REALTIME_54 = 66,
+    TARGET_SIGNAL_REALTIME_55 = 67,
+    TARGET_SIGNAL_REALTIME_56 = 68,
+    TARGET_SIGNAL_REALTIME_57 = 69,
+    TARGET_SIGNAL_REALTIME_58 = 70,
+    TARGET_SIGNAL_REALTIME_59 = 71,
+    TARGET_SIGNAL_REALTIME_60 = 72,
+    TARGET_SIGNAL_REALTIME_61 = 73,
+    TARGET_SIGNAL_REALTIME_62 = 74,
+    TARGET_SIGNAL_REALTIME_63 = 75,
+
+    /* Used internally by Solaris threads.  See signal(5) on Solaris.  */
+    TARGET_SIGNAL_CANCEL = 76,
+
+    /* Yes, this pains me, too.  But LynxOS didn't have SIG32, and now
+       GNU/Linux does, and we can't disturb the numbering, since it's
+       part of the remote protocol.  Note that in some GDB's
+       TARGET_SIGNAL_REALTIME_32 is number 76.  */
+    TARGET_SIGNAL_REALTIME_32,
+    /* Yet another pain, IRIX 6 has SIG64. */
+    TARGET_SIGNAL_REALTIME_64,
+    /* Yet another pain, GNU/Linux MIPS might go up to 128. */
+    TARGET_SIGNAL_REALTIME_65,
+    TARGET_SIGNAL_REALTIME_66,
+    TARGET_SIGNAL_REALTIME_67,
+    TARGET_SIGNAL_REALTIME_68,
+    TARGET_SIGNAL_REALTIME_69,
+    TARGET_SIGNAL_REALTIME_70,
+    TARGET_SIGNAL_REALTIME_71,
+    TARGET_SIGNAL_REALTIME_72,
+    TARGET_SIGNAL_REALTIME_73,
+    TARGET_SIGNAL_REALTIME_74,
+    TARGET_SIGNAL_REALTIME_75,
+    TARGET_SIGNAL_REALTIME_76,
+    TARGET_SIGNAL_REALTIME_77,
+    TARGET_SIGNAL_REALTIME_78,
+    TARGET_SIGNAL_REALTIME_79,
+    TARGET_SIGNAL_REALTIME_80,
+    TARGET_SIGNAL_REALTIME_81,
+    TARGET_SIGNAL_REALTIME_82,
+    TARGET_SIGNAL_REALTIME_83,
+    TARGET_SIGNAL_REALTIME_84,
+    TARGET_SIGNAL_REALTIME_85,
+    TARGET_SIGNAL_REALTIME_86,
+    TARGET_SIGNAL_REALTIME_87,
+    TARGET_SIGNAL_REALTIME_88,
+    TARGET_SIGNAL_REALTIME_89,
+    TARGET_SIGNAL_REALTIME_90,
+    TARGET_SIGNAL_REALTIME_91,
+    TARGET_SIGNAL_REALTIME_92,
+    TARGET_SIGNAL_REALTIME_93,
+    TARGET_SIGNAL_REALTIME_94,
+    TARGET_SIGNAL_REALTIME_95,
+    TARGET_SIGNAL_REALTIME_96,
+    TARGET_SIGNAL_REALTIME_97,
+    TARGET_SIGNAL_REALTIME_98,
+    TARGET_SIGNAL_REALTIME_99,
+    TARGET_SIGNAL_REALTIME_100,
+    TARGET_SIGNAL_REALTIME_101,
+    TARGET_SIGNAL_REALTIME_102,
+    TARGET_SIGNAL_REALTIME_103,
+    TARGET_SIGNAL_REALTIME_104,
+    TARGET_SIGNAL_REALTIME_105,
+    TARGET_SIGNAL_REALTIME_106,
+    TARGET_SIGNAL_REALTIME_107,
+    TARGET_SIGNAL_REALTIME_108,
+    TARGET_SIGNAL_REALTIME_109,
+    TARGET_SIGNAL_REALTIME_110,
+    TARGET_SIGNAL_REALTIME_111,
+    TARGET_SIGNAL_REALTIME_112,
+    TARGET_SIGNAL_REALTIME_113,
+    TARGET_SIGNAL_REALTIME_114,
+    TARGET_SIGNAL_REALTIME_115,
+    TARGET_SIGNAL_REALTIME_116,
+    TARGET_SIGNAL_REALTIME_117,
+    TARGET_SIGNAL_REALTIME_118,
+    TARGET_SIGNAL_REALTIME_119,
+    TARGET_SIGNAL_REALTIME_120,
+    TARGET_SIGNAL_REALTIME_121,
+    TARGET_SIGNAL_REALTIME_122,
+    TARGET_SIGNAL_REALTIME_123,
+    TARGET_SIGNAL_REALTIME_124,
+    TARGET_SIGNAL_REALTIME_125,
+    TARGET_SIGNAL_REALTIME_126,
+    TARGET_SIGNAL_REALTIME_127,
+
+    TARGET_SIGNAL_INFO,
+
+    /* Some signal we don't know about.  */
+    TARGET_SIGNAL_UNKNOWN,
+
+    /* Use whatever signal we use when one is not specifically specified
+       (for passing to proceed and so on).  */
+    TARGET_SIGNAL_DEFAULT,
+
+    /* Mach exceptions.  In versions of GDB before 5.2, these were just before
+       TARGET_SIGNAL_INFO if you were compiling on a Mach host (and missing
+       otherwise).  */
+    TARGET_EXC_BAD_ACCESS,
+    TARGET_EXC_BAD_INSTRUCTION,
+    TARGET_EXC_ARITHMETIC,
+    TARGET_EXC_EMULATION,
+    TARGET_EXC_SOFTWARE,
+    TARGET_EXC_BREAKPOINT,
+
+    /* If you are adding a new signal, add it just above this comment.  */
+
+    /* Last and unused enum value, for sizing arrays, etc.  */
+    TARGET_SIGNAL_LAST
+  };
+
+#endif /* #ifndef GDB_SIGNALS_H */

--- a/shlr/qnx/include/libqnxr.h
+++ b/shlr/qnx/include/libqnxr.h
@@ -1,0 +1,95 @@
+/*! \file */
+#ifndef LIBQNXR_H
+#define LIBQNXR_H
+
+#include <stdint.h>
+#include <unistd.h>
+
+#include "arch.h"
+#include "r_types_base.h"
+#include "r_socket.h"
+#include "dsmsgs.h"
+
+#define MSG_OK 0
+#define MSG_NOT_SUPPORTED -1
+#define MSG_ERROR_1 -2
+
+#define X86_64 ARCH_X86_64
+#define X86_32 ARCH_X86_32
+#define ARM_32 ARCH_ARM_32
+#define ARM_64 ARCH_ARM_64
+
+typedef struct
+	{
+	int pid;
+	long tid;
+} ptid_t;
+
+/*! 
+ * Core "object" that saves
+ * the instance of the lib
+ */
+typedef struct libqnxr_t {
+	char *read_buff;
+	char *send_buff;
+	ssize_t send_len;
+	ssize_t read_len;
+	ssize_t read_ptr;
+	RSocket *sock;
+	char host[256];
+	int port;
+	int connected;
+	uint8_t mid;
+	union {
+		uint8_t data[DS_DATA_MAX_SIZE];
+		DSMsg_union_t pkt;
+	} tran, recv;
+	ssize_t data_len;
+	uint8_t architecture;
+	registers_t *registers;
+	int channelrd;
+	int channelwr;
+	int target_proto_minor;
+	int target_proto_major;
+	int stop_flags;
+	uint8_t notify_type;
+	uint32_t stop_pc;
+	int signal;
+	ptid_t inferior_ptid;
+	int waiting_for_stop;
+} libqnxr_t;
+
+typedef void(pidlist_cb_t)(void *ctx, pid_t pid, char *name);
+
+int qnxr_init (libqnxr_t *g);
+int qnxr_set_architecture (libqnxr_t *g, uint8_t architecture);
+int qnxr_cleanup (libqnxr_t *g);
+int qnxr_connect (libqnxr_t *g, const char *server, int port);
+int qnxr_disconnect (libqnxr_t *g);
+void qnxr_pidlist (libqnxr_t *g, void *ctx, pidlist_cb_t *cb);
+int qnxr_select (libqnxr_t *g, pid_t pid, int tid);
+ptid_t qnxr_run (libqnxr_t *g, const char *file, char **args, char **env);
+ptid_t qnxr_attach (libqnxr_t *g, pid_t pid);
+ptid_t qnxr_wait (libqnxr_t *g, pid_t pid);
+int qnxr_stop (libqnxr_t *g);
+
+// Commands
+int qnxr_continue (libqnxr_t *g, int thread_id);
+int qnxr_step (libqnxr_t *g, int thread_id);
+int qnxr_read_registers (libqnxr_t *g);
+
+int qnxr_write_reg (libqnxr_t *g, const char *name, char *value, int len);
+int qnxr_write_register (libqnxr_t *g, int index, char *value, int len);
+int qnxr_read_memory (libqnxr_t *g, ut64 address, uint8_t *data, ut64 len);
+int qnxr_write_memory (libqnxr_t *g, ut64 address, const uint8_t *data, ut64 len);
+
+int qnxr_set_bp (libqnxr_t *g, ut64 address, const char *conditions);
+int qnxr_set_hwbp (libqnxr_t *g, ut64 address, const char *conditions);
+int qnxr_remove_bp (libqnxr_t *g, ut64 address);
+int qnxr_remove_hwbp (libqnxr_t *g, ut64 address);
+
+// ptid
+extern ptid_t null_ptid;
+int ptid_equal (ptid_t ptid1, ptid_t ptid2);
+
+#endif

--- a/shlr/qnx/include/packet.h
+++ b/shlr/qnx/include/packet.h
@@ -1,0 +1,37 @@
+/*! \file */
+#ifndef PACKET_H
+#define PACKET_H
+
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include "libqnxr.h"
+#include <stdio.h>
+#if __WINDOWS__
+#include <windows.h>
+#if !__CYGWIN__
+#include <winsock.h>
+#endif
+#endif
+
+int qnxr_send_nak(libqnxr_t* instance);
+int qnxr_send_ch_reset(libqnxr_t* instance);
+int qnxr_send_ch_debug(libqnxr_t* instance);
+int qnxr_send_ch_text(libqnxr_t* instance);
+
+/*!
+ * \brief sends a packet sends a packet to the established connection
+ * \param instance the "instance" of the current libqnxr session
+ * \returns a failure code (currently -1) or 0 if call successfully
+ */
+int qnxr_send_packet(libqnxr_t* instance);
+
+/*!
+ * \brief Function reads data from the established connection
+ * \param instance the "instance" of the current libqnxr session
+ * \returns a failure code (currently -1) or 0 if call successfully
+ */
+int qnxr_read_packet(libqnxr_t* instance);
+
+#endif

--- a/shlr/qnx/include/sigutil.h
+++ b/shlr/qnx/include/sigutil.h
@@ -1,0 +1,6 @@
+#ifndef SIGNAL_H
+#define SIGNAL_H
+
+int host_signal_from_nto (int sig);
+
+#endif

--- a/shlr/qnx/include/utils.h
+++ b/shlr/qnx/include/utils.h
@@ -1,0 +1,36 @@
+/*! \file */
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include "libqnxr.h"
+
+#define LONGEST long long
+#define ULONGEST unsigned long long
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a) (sizeof (a) / sizeof ((a)[0]))
+#endif
+
+#define EXTRACT_SIGNED_INTEGER(addr, len) \
+    extract_signed_integer((const uint8_t*)addr, len, 0)
+#define EXTRACT_UNSIGNED_INTEGER(addr, len) \
+    extract_unsigned_integer((const uint8_t*)addr, len, 0)
+
+#if defined(__linux__) || defined (__CYGWIN__) || defined (__MINGW32__)
+int errnoconvert(int x);
+#endif
+
+enum target_signal target_signal_from_nto(int sig);
+
+LONGEST extract_signed_integer (const uint8_t *addr, int len, int be);
+ULONGEST extract_unsigned_integer (const uint8_t *addr, int len, int be);
+
+int i386nto_regset_id (int regno);
+int i386nto_reg_offset (int regnum);
+int i386nto_register_area (int regno, int regset, unsigned *off);
+
+ptid_t ptid_build(int pid, long tid);
+
+#endif

--- a/shlr/qnx/src/core.c
+++ b/shlr/qnx/src/core.c
@@ -1,0 +1,789 @@
+/* libqnxr - GPL - Copyright 2016 - defragger, madprogrammer, FSF Inc */
+
+#include <errno.h>
+#include <r_debug.h>
+#include "libqnxr.h"
+#include "core.h"
+#include "signal.h"
+#include "packet.h"
+
+#define MAX_TRAN_TRIES 3
+#define HOST_QNX_PROTOVER_MAJOR 0
+#define HOST_QNX_PROTOVER_MINOR 3
+
+ptid_t null_ptid = {0, 0};
+
+void nto_send_init (libqnxr_t *g, unsigned cmd, unsigned subcmd, unsigned chan);
+
+ptid_t nto_parse_notify (libqnxr_t *g);
+int nto_send_env (libqnxr_t *g, const char *env);
+int nto_send_arg (libqnxr_t *g, const char *arg);
+int nto_send (libqnxr_t *g, unsigned len, int report_errors);
+
+static registers_t x86_32[] = {
+	{"eax", 0, 4},
+	{"ecx", 4, 4},
+	{"edx", 8, 4},
+	{"ebx", 12, 4},
+	{"esp", 16, 4},
+	{"ebp", 20, 4},
+	{"esi", 24, 4},
+	{"edi", 28, 4},
+	{"eip", 32, 4},
+	{"eflags", 36, 4},
+	{"cs", 40, 4},
+	{"ss", 44, 4},
+#if 0
+	{"ds",	48,	4},
+	{"es",	52,	4},
+	{"fs",	56,	4},
+	{"gs",	60,	4},
+	{"st0",	64,	10},
+	{"st1",	74,	10},
+	{"st2",	84,	10},
+	{"st3",	94,	10},
+	{"st4",	104,	10},
+	{"st5",	114,	10},
+	{"st6",	124,	10},
+	{"st7",	134,	10},
+	{"fctrl",	144,	4},
+	{"fstat",	148,	4},
+	{"ftag",	152,	4},
+	{"fiseg",	156,	4},
+	{"fioff",	160,	4},
+	{"foseg",	164,	4},
+	{"fooff",	168,	4},
+	{"fop",	172,	4},
+	{"xmm0",	176,	16},
+	{"xmm1",	192,	16},
+	{"xmm2",	208,	16},
+	{"xmm3",	224,	16},
+	{"xmm4",	240,	16},
+	{"xmm5",	256,	16},
+	{"xmm6",	272,	16},
+	{"xmm7",	288,	16},
+	{"mxcsr",	304,	4},
+#endif
+	{"", 0, 0}};
+
+static registers_t arm32[] = {
+	{"r0", 0, 4},
+	{"r1", 4, 4},
+	{"r2", 8, 4},
+	{"r3", 12, 4},
+	{"r4", 16, 4},
+	{"r5", 20, 4},
+	{"r6", 24, 4},
+	{"r7", 28, 4},
+	{"r8", 32, 4},
+	{"r9", 36, 4},
+	{"r10", 40, 4},
+	{"r11", 44, 4},
+	{"r12", 48, 4},
+	{"sp", 52, 4},
+	{"lr", 56, 4},
+	{"pc", 60, 4},
+	{"f0", 64, 12},
+	{"f1", 76, 12},
+	{"f2", 88, 12},
+	{"f3", 100, 12},
+	{"f4", 112, 12},
+	{"f5", 124, 12},
+	{"f6", 136, 12},
+	{"f7", 148, 12},
+	{"fps", 160, 12},
+	{"cpsr", 172, 4},
+	{"", 0, 0}};
+
+int qnxr_init (libqnxr_t *g) {
+	if (!g) return -1;
+	memset (g, 0, sizeof(libqnxr_t));
+	g->send_len = 0;
+	g->send_buff = (char *)calloc (DS_DATA_MAX_SIZE * 2, 1);
+	if (!g->send_buff)
+		return -1;
+	g->read_buff = (char *)calloc (DS_DATA_MAX_SIZE * 2, 1);
+	if (!g->read_buff) {
+		R_FREE (g->send_buff);
+		return -1;
+	}
+	g->registers = x86_32;
+	return 0;
+}
+
+int qnxr_set_architecture (libqnxr_t *g, uint8_t architecture) {
+	if (!g) return -1;
+	g->architecture = architecture;
+	switch (architecture) {
+	case ARCH_X86_32:
+		g->registers = x86_32;
+		break;
+	case ARCH_ARM_32:
+		g->registers = arm32;
+		break;
+	default:
+		eprintf ("Error unknown architecture set\n");
+	}
+	return 0;
+}
+
+int qnxr_cleanup (libqnxr_t *g) {
+	if (!g) return -1;
+	free (g->send_buff);
+	g->send_len = 0;
+	free (g->read_buff);
+	return 0;
+}
+
+int qnxr_connect (libqnxr_t *g, const char *host, int port) {
+	char tmp[255];
+	int ret;
+	if (!g || !host || g->connected) return -1;
+
+	g->data_len = 0;
+	g->read_len = 0;
+	g->read_ptr = 0;
+	g->sock = r_socket_new (0);
+	g->connected = 0;
+	g->mid = 0;
+
+	strncpy (g->host, host, sizeof(g->host));
+	g->port = port;
+
+	ret = snprintf (tmp, sizeof(tmp) - 1, "%d", port);
+	if (!ret) return -1;
+	ret = r_socket_connect_tcp (g->sock, host, tmp, 200);
+	if (!ret) return -1;
+	g->connected = 1;
+
+	qnxr_send_ch_reset (g);
+	nto_send_init (g, DStMsg_connect, 0, SET_CHANNEL_DEBUG);
+	g->tran.pkt.connect.major = HOST_QNX_PROTOVER_MAJOR;
+	g->tran.pkt.connect.minor = HOST_QNX_PROTOVER_MINOR;
+	nto_send (g, sizeof(g->tran.pkt.connect), 0);
+
+	if (g->recv.pkt.hdr.cmd == DSrMsg_err) {
+		eprintf ("%s: connection failed: %lld\n", __func__,
+			 EXTRACT_SIGNED_INTEGER (&g->recv.pkt.err.err, 4));
+		return -1;
+	}
+
+	/* Try to query pdebug for their version of the protocol */
+	nto_send_init (g, DStMsg_protover, 0, SET_CHANNEL_DEBUG);
+	g->tran.pkt.protover.major = HOST_QNX_PROTOVER_MAJOR;
+	g->tran.pkt.protover.minor = HOST_QNX_PROTOVER_MINOR;
+	nto_send (g, sizeof(g->tran.pkt.protover), 0);
+
+	if ((g->recv.pkt.hdr.cmd == DSrMsg_err) && (EXTRACT_SIGNED_INTEGER (&g->recv.pkt.err.err, 4) == EINVAL)) {
+		g->target_proto_major = 0;
+		g->target_proto_minor = 0;
+	} else if (g->recv.pkt.hdr.cmd == DSrMsg_okstatus) {
+		g->target_proto_major = EXTRACT_SIGNED_INTEGER (&g->recv.pkt.okstatus.status, 4);
+		g->target_proto_minor = EXTRACT_SIGNED_INTEGER (&g->recv.pkt.okstatus.status, 4);
+		g->target_proto_major = (g->target_proto_major >> 8) & DSMSG_PROTOVER_MAJOR;
+		g->target_proto_minor = g->target_proto_minor & DSMSG_PROTOVER_MINOR;
+	} else {
+		eprintf ("Connection failed (Protocol Version Query): %lld\n",
+			 EXTRACT_SIGNED_INTEGER (&g->recv.pkt.err.err, 4));
+		return -1;
+	}
+
+	return 0;
+}
+
+int qnxr_disconnect (libqnxr_t *g) {
+	if (!g) return -1;
+
+	if (g->connected) {
+		nto_send_init (g, DStMsg_disconnect, 0, SET_CHANNEL_DEBUG);
+		nto_send (g, sizeof(g->tran.pkt.disconnect), 0);
+		g->connected = 0;
+		g->inferior_ptid = null_ptid;
+
+		if (!r_socket_close (g->sock))
+			return -1;
+	}
+
+	return 0;
+}
+
+ptid_t qnxr_attach (libqnxr_t *g, pid_t pid) {
+
+	if (g->inferior_ptid.pid != pid) {
+		qnxr_disconnect (g);
+		sleep (1);
+		qnxr_connect (g, g->host, g->port);
+	}
+
+	nto_send_init (g, DStMsg_attach, 0, SET_CHANNEL_DEBUG);
+	g->tran.pkt.attach.pid = pid;
+	g->tran.pkt.attach.pid = EXTRACT_SIGNED_INTEGER (&g->tran.pkt.attach.pid, 4);
+
+	nto_send (g, sizeof(g->tran.pkt.attach), 0);
+	if (g->recv.pkt.hdr.cmd != DSrMsg_okdata) {
+		eprintf ("%s: failed to attach to %d\n", __func__, pid);
+		return null_ptid;
+	}
+
+	g->inferior_ptid = ptid_build (
+		EXTRACT_SIGNED_INTEGER (&g->recv.pkt.notify.pid, 4),
+		EXTRACT_SIGNED_INTEGER (&g->recv.pkt.notify.tid, 4));
+
+	return g->inferior_ptid;
+}
+
+ptid_t qnxr_run (libqnxr_t *g, const char *file, char **args, char **env) {
+	unsigned argc, envc;
+	char **argv, *p;
+	int errors = 0;
+
+	nto_send_init (g, DStMsg_env, DSMSG_ENV_CLEARENV, SET_CHANNEL_DEBUG);
+	nto_send (g, sizeof(DStMsg_env_t), 1);
+
+	for (envc = 0; *env; env++, envc++)
+		errors += !nto_send_env (g, *env);
+
+	if (errors) {
+		eprintf ("%s: error(s) occured while sending environment\n", __func__);
+	}
+
+	nto_send_init (g, DStMsg_env, DSMSG_ENV_CLEARARGV, SET_CHANNEL_DEBUG);
+	nto_send (g, sizeof(DStMsg_env_t), 1);
+
+	if (file != NULL) {
+		errors = !nto_send_arg (g, file);
+		if (!errors)
+			errors = !nto_send_arg (g, file);
+
+		if (errors) {
+			eprintf ("%s: failed to send executable file name\n", __func__);
+			return null_ptid;
+		}
+
+		errors = 0;
+		for (argv = args; *argv && **argv; argv++, argc++)
+			errors |= !nto_send_arg (g, *argv);
+
+		if (errors) {
+			eprintf ("%s: error(s) occured while sending args\n", __func__);
+		}
+	}
+
+	if (errors) return null_ptid;
+
+	nto_send_init (g, DStMsg_load, DSMSG_LOAD_DEBUG, SET_CHANNEL_DEBUG);
+	p = g->tran.pkt.load.cmdline;
+
+	g->tran.pkt.load.envc = 0;
+	g->tran.pkt.load.argc = 0;
+
+	strcpy (p, file);
+	p += strlen (p);
+	*p++ = '\0';
+
+	*p++ = '\0'; // stdin
+	*p++ = '\0'; // stdout
+	*p++ = '\0'; // stderr
+
+	nto_send (g, offsetof (DStMsg_load_t, cmdline) + p - g->tran.pkt.load.cmdline + 1, 1);
+
+	if (g->recv.pkt.hdr.cmd == DSrMsg_okdata) {
+		ptid_t ptid = nto_parse_notify (g);
+		eprintf ("%s: inferior pid: %d\n", __func__, ptid.pid);
+		g->inferior_ptid = ptid;
+
+		return ptid;
+	}
+
+	return null_ptid;
+}
+
+int qnxr_read_registers (libqnxr_t *g) {
+	if (!g) return -1;
+	int i = 0;
+	int len, rlen, regset;
+	int n = 0;
+	unsigned off;
+	char buf[DS_DATA_MAX_SIZE];
+
+	while (g->registers[i].size > 0) {
+		regset = i386nto_regset_id (i);
+		len = i386nto_register_area (i, regset, &off);
+		if (len < 1) {
+			eprintf ("%s: unknown register %d\n", __func__, i);
+			len = g->registers[i].size;
+		}
+		nto_send_init (g, DStMsg_regrd, regset, SET_CHANNEL_DEBUG);
+		g->tran.pkt.regrd.offset = EXTRACT_SIGNED_INTEGER (&off, 2);
+		g->tran.pkt.regrd.size = EXTRACT_SIGNED_INTEGER (&len, 2);
+		rlen = nto_send (g, sizeof(g->tran.pkt.regrd), 1);
+
+		if (rlen > 0) {
+			if (g->recv.pkt.hdr.cmd == DSrMsg_okdata) {
+				memcpy (buf + g->registers[i].offset,
+					g->recv.pkt.okdata.data, len);
+				n += len;
+			} else {
+				memset (buf + g->registers[i].offset,
+					0, len);
+			}
+		} else {
+			eprintf ("%s: couldn't read register %d\n", __func__, i);
+			return -1;
+		}
+		i++;
+	}
+
+	memcpy (g->recv.data, buf, n);
+	return n;
+}
+
+int qnxr_read_memory (libqnxr_t *g, ut64 address, uint8_t *data, ut64 len) {
+	if (!g || !data) return -1;
+	int rcv_len, tot_len, ask_len;
+	ut64 addr;
+
+	tot_len = rcv_len = ask_len = 0;
+
+	do {
+		nto_send_init (g, DStMsg_memrd, 0, SET_CHANNEL_DEBUG);
+		addr = address + tot_len;
+		g->tran.pkt.memrd.addr = EXTRACT_UNSIGNED_INTEGER (&addr, 8);
+		ask_len = ((len - tot_len) > DS_DATA_MAX_SIZE) ?
+				  DS_DATA_MAX_SIZE :
+				  (len - tot_len);
+
+		g->tran.pkt.memrd.size = EXTRACT_SIGNED_INTEGER (&ask_len, 2);
+		rcv_len = nto_send (g, sizeof(g->tran.pkt.memrd), 0) -
+			  sizeof(g->recv.pkt.hdr);
+		if (rcv_len <= 0) break;
+		if (g->recv.pkt.hdr.cmd == DSrMsg_okdata) {
+			memcpy (data + tot_len, g->recv.pkt.okdata.data, rcv_len);
+			tot_len += rcv_len;
+		} else
+			break;
+	} while (tot_len != len);
+
+	return tot_len;
+}
+
+int qnxr_write_memory (libqnxr_t *g, ut64 address, const uint8_t *data, ut64 len) {
+	if (!g || !data) return -1;
+	ut64 addr;
+
+	nto_send_init (g, DStMsg_memwr, 0, SET_CHANNEL_DEBUG);
+	addr = address;
+	g->tran.pkt.memwr.addr = EXTRACT_UNSIGNED_INTEGER (&addr, 8);
+	memcpy (g->tran.pkt.memwr.data, data, len);
+	nto_send (g, offsetof (DStMsg_memwr_t, data) + len, 0);
+
+	switch (g->recv.pkt.hdr.cmd) {
+	case DSrMsg_ok:
+		return len;
+	case DSrMsg_okstatus:
+		return EXTRACT_SIGNED_INTEGER (&g->recv.pkt.okstatus.status, 4);
+	}
+
+	return 0;
+}
+
+void qnxr_pidlist (libqnxr_t *g, void *ctx, pidlist_cb_t *cb) {
+	if (!g) return;
+
+	struct dspidlist *pidlist = (void *)g->recv.pkt.okdata.data;
+	pid_t pid, start_tid;
+	char subcmd;
+
+	start_tid = 1;
+	pid = 1;
+	subcmd = DSMSG_PIDLIST_BEGIN;
+
+	while (1) {
+		nto_send_init (g, DStMsg_pidlist, subcmd, SET_CHANNEL_DEBUG);
+		g->tran.pkt.pidlist.pid = EXTRACT_SIGNED_INTEGER (&pid, 4);
+		g->tran.pkt.pidlist.tid = EXTRACT_SIGNED_INTEGER (&start_tid, 4);
+		nto_send (g, sizeof(g->tran.pkt.pidlist), 0);
+
+		if (g->recv.pkt.hdr.cmd == DSrMsg_err || g->recv.pkt.hdr.cmd != DSrMsg_okdata)
+			return;
+
+		pid = EXTRACT_SIGNED_INTEGER (&pidlist->pid, 4);
+		if (cb != NULL)
+			cb (ctx, pid, pidlist->name);
+		subcmd = DSMSG_PIDLIST_NEXT;
+	}
+}
+
+int qnxr_select (libqnxr_t *g, pid_t pid, int tid) {
+	if (!g) return 0;
+
+	/* TODO */
+	tid = 1;
+
+	nto_send_init (g, DStMsg_select, DSMSG_SELECT_SET, SET_CHANNEL_DEBUG);
+	g->tran.pkt.select.pid = pid;
+	g->tran.pkt.select.pid = EXTRACT_SIGNED_INTEGER (&g->tran.pkt.select.pid, 4);
+	g->tran.pkt.select.tid = EXTRACT_SIGNED_INTEGER (&tid, 4);
+	nto_send (g, sizeof(g->tran.pkt.select), 1);
+
+	if (g->recv.pkt.hdr.cmd == DSrMsg_err) {
+		eprintf ("%s: failed to select %d\n", __func__, pid);
+		return 0;
+	}
+
+	return 1;
+}
+
+int qnxr_step (libqnxr_t *g, int thread_id) {
+	return qnxr_send_vcont (g, 1, thread_id);
+}
+
+int qnxr_continue (libqnxr_t *g, int thread_id) {
+	return qnxr_send_vcont (g, 0, thread_id);
+}
+
+int qnxr_write_register (libqnxr_t *g, int index, char *value, int len) {
+	int tdep_len, regset;
+	unsigned off;
+
+	regset = i386nto_regset_id (index);
+	tdep_len = i386nto_register_area (index, regset, &off);
+	if (len < 0 || tdep_len != len) {
+		eprintf ("%s: invalid length\n", __func__);
+		return -1;
+	}
+
+	nto_send_init (g, DStMsg_regwr, regset, SET_CHANNEL_DEBUG);
+	g->tran.pkt.regwr.offset = EXTRACT_SIGNED_INTEGER (&off, 2);
+	memcpy (g->tran.pkt.regwr.data, value, len);
+	nto_send (g, offsetof (DStMsg_regwr_t, data) + len, 1);
+
+	return 0;
+}
+
+int qnxr_write_reg (libqnxr_t *g, const char *name, char *value, int len) {
+	int i = 0;
+	if (!g) return -1;
+
+	while (g->registers[i].size > 0) {
+		if (!strcmp (g->registers[i].name, name)) {
+			break;
+		}
+		i++;
+	}
+	if (g->registers[i].size == 0) {
+		eprintf ("Error registername <%s> not found in profile\n", name);
+		return -1;
+	}
+	qnxr_write_register (g, i, value, len);
+
+	return 0;
+}
+
+int qnxr_send_vcont (libqnxr_t *g, int step, int thread_id) {
+	if (!g) return -1;
+
+	nto_send_init (g, DStMsg_run, step ? DSMSG_RUN_COUNT : DSMSG_RUN,
+		       SET_CHANNEL_DEBUG);
+	g->tran.pkt.run.step.count = 1;
+	nto_send (g, sizeof(g->tran.pkt.run), 1);
+	return 0;
+}
+
+int qnxr_stop (libqnxr_t *g) {
+	if (!g) return 0;
+
+	eprintf ("%s: waiting for stop\n", __func__);
+	g->waiting_for_stop = 1;
+	nto_send_init (g, DStMsg_stop, DSMSG_STOP_PIDS, SET_CHANNEL_DEBUG);
+
+	g->send_len = sizeof(g->tran.pkt.stop);
+	qnxr_send_packet (g);
+
+	return 1;
+}
+
+ptid_t qnxr_wait (libqnxr_t *g, pid_t pid) {
+	if (!g) return null_ptid;
+
+	ptid_t returned_ptid = g->inferior_ptid;
+
+	if (g->inferior_ptid.pid != pid)
+		return null_ptid;
+
+	if (g->recv.pkt.hdr.cmd != DShMsg_notify) {
+		int rlen;
+		char waiting_for_notify = 1;
+
+		eprintf ("%s: waiting for inferior\n", __func__);
+
+		while (1) {
+			rlen = qnxr_read_packet (g);
+			if (rlen == -1) {
+				if (g->waiting_for_stop) {
+					eprintf ("%s: read eror while waiting for stop\n",
+						 __func__);
+					continue;
+				} else {
+					eprintf ("%s: read packet error or NAK\n", __func__);
+					return null_ptid;
+				}
+			}
+			if (g->channelrd == SET_CHANNEL_TEXT) {
+				// TODO nto_incoming_text
+			} else {
+				g->recv.pkt.hdr.cmd &= ~DSHDR_MSG_BIG_ENDIAN;
+				if (g->waiting_for_stop && g->recv.pkt.hdr.cmd == DSrMsg_ok) {
+					g->waiting_for_stop = 0;
+					eprintf ("%s: got stop response\n", __func__);
+					if (!waiting_for_notify)
+						break;
+				} else if (g->recv.pkt.hdr.cmd == DShMsg_notify) {
+					// acknowledge the notify
+					g->tran.pkt.hdr.cmd = DSrMsg_ok;
+					g->tran.pkt.hdr.channel = SET_CHANNEL_DEBUG;
+					g->tran.pkt.hdr.mid = g->recv.pkt.hdr.mid;
+					qnxr_send_ch_debug (g);
+
+					g->send_len = sizeof(g->tran.pkt.ok);
+					qnxr_send_packet (g);
+
+					returned_ptid = nto_parse_notify (g);
+					break;
+				}
+			}
+		}
+	}
+
+	/* to make us wait the next time */
+	g->recv.pkt.hdr.cmd = DSrMsg_ok;
+	return returned_ptid;
+}
+
+int qnxr_set_bp (libqnxr_t *g, ut64 address, const char *conditions) {
+	return _qnxr_set_bp (g, address, conditions, BREAKPOINT);
+}
+
+int qnxr_set_hwbp (libqnxr_t *g, ut64 address, const char *conditions) {
+	return _qnxr_set_bp (g, address, conditions, HARDWARE_BREAKPOINT);
+}
+
+int qnxr_remove_bp (libqnxr_t *g, ut64 address) {
+	return _qnxr_remove_bp (g, address, BREAKPOINT);
+}
+
+int qnxr_remove_hwbp (libqnxr_t *g, ut64 address) {
+	return _qnxr_remove_bp (g, address, HARDWARE_BREAKPOINT);
+}
+
+int _qnxr_set_bp (libqnxr_t *g, ut64 address, const char *conditions, enum Breakpoint type) {
+	if (!g) return -1;
+
+	nto_send_init (g, DStMsg_brk, DSMSG_BRK_EXEC, SET_CHANNEL_DEBUG);
+	g->tran.pkt.brk.addr = EXTRACT_UNSIGNED_INTEGER (&address, 4);
+	g->tran.pkt.brk.size = 0;
+	nto_send (g, sizeof(g->tran.pkt.brk), 0);
+
+	if (g->recv.pkt.hdr.cmd == DSrMsg_err)
+		return -1;
+	return 0;
+}
+
+int _qnxr_remove_bp (libqnxr_t *g, ut64 address, enum Breakpoint type) {
+	if (!g) return -1;
+
+	nto_send_init (g, DStMsg_brk, DSMSG_BRK_EXEC, SET_CHANNEL_DEBUG);
+	g->tran.pkt.brk.addr = EXTRACT_UNSIGNED_INTEGER (&address, 4);
+	g->tran.pkt.brk.size = -1;
+	nto_send (g, sizeof(g->tran.pkt.brk), 0);
+
+	if (g->recv.pkt.hdr.cmd == DSrMsg_err)
+		return -1;
+	return 0;
+}
+
+void nto_send_init (libqnxr_t *g, unsigned cmd, unsigned subcmd, unsigned chan) {
+	g->tran.pkt.hdr.cmd = cmd;
+	g->tran.pkt.hdr.subcmd = subcmd;
+	g->tran.pkt.hdr.mid = ((chan == SET_CHANNEL_DEBUG) ? g->mid++ : 0);
+	g->tran.pkt.hdr.channel = chan;
+}
+
+ptid_t nto_parse_notify (libqnxr_t *g) {
+	pid_t pid, tid;
+
+	pid = EXTRACT_SIGNED_INTEGER (&g->recv.pkt.notify.pid, 4);
+	tid = EXTRACT_SIGNED_INTEGER (&g->recv.pkt.notify.tid, 4);
+
+	if (tid == 0) tid = 1;
+	eprintf ("%s: parse notify %d\n", __func__, g->recv.pkt.hdr.subcmd);
+
+	switch (g->recv.pkt.hdr.subcmd) {
+	case DSMSG_NOTIFY_PIDUNLOAD:
+		g->notify_type = R_DEBUG_REASON_DEAD;
+		break;
+	case DSMSG_NOTIFY_BRK:
+		g->stop_flags = EXTRACT_UNSIGNED_INTEGER (&g->recv.pkt.notify.un.brk.flags, 4);
+		g->stop_pc = EXTRACT_UNSIGNED_INTEGER (&g->recv.pkt.notify.un.brk.ip, 4);
+		g->notify_type = R_DEBUG_REASON_BREAKPOINT;
+		break;
+	case DSMSG_NOTIFY_STEP:
+		g->notify_type = R_DEBUG_REASON_STEP;
+		break;
+	case DSMSG_NOTIFY_SIGEV:
+		g->notify_type = R_DEBUG_REASON_SIGNAL;
+		g->signal = host_signal_from_nto (EXTRACT_SIGNED_INTEGER (&g->recv.pkt.notify.un.sigev.signo, 4));
+		break;
+	case DSMSG_NOTIFY_PIDLOAD:
+		eprintf ("%s: notify type DSMSG_NOTIFY_PIDLOAD\n", __func__);
+		g->notify_type = R_DEBUG_REASON_UNKNOWN;
+		break;
+	case DSMSG_NOTIFY_DLLLOAD:
+	case DSMSG_NOTIFY_TIDLOAD:
+	case DSMSG_NOTIFY_TIDUNLOAD:
+	case DSMSG_NOTIFY_DLLUNLOAD:
+		eprintf ("%s: notify type DSMSG_NOTIFY_DLLTID\n", __func__);
+		g->notify_type = R_DEBUG_REASON_UNKNOWN;
+		break;
+	case DSMSG_NOTIFY_STOPPED:
+		g->notify_type = R_DEBUG_REASON_SWI;
+		break;
+	default:
+		eprintf ("%s: Unexpected notify type %d\n", __func__,
+			 g->recv.pkt.hdr.subcmd);
+		g->notify_type = R_DEBUG_REASON_UNKNOWN;
+	}
+
+	return ptid_build (pid, tid);
+}
+
+int nto_send_env (libqnxr_t *g, const char *env) {
+	int len; /* Length including zero terminating char.  */
+	int totlen = 0;
+	len = strlen (env) + 1;
+	if (g->target_proto_minor >= 2) {
+		while (len > DS_DATA_MAX_SIZE) {
+			nto_send_init (g, DStMsg_env, DSMSG_ENV_SETENV_MORE,
+				       SET_CHANNEL_DEBUG);
+			memcpy (g->tran.pkt.env.data, env + totlen,
+				DS_DATA_MAX_SIZE);
+			if (!nto_send (g, offsetof (DStMsg_env_t, data) +
+						  DS_DATA_MAX_SIZE,
+				       1)) {
+				/* An error occured.  */
+				return 0;
+			}
+			len -= DS_DATA_MAX_SIZE;
+			totlen += DS_DATA_MAX_SIZE;
+		}
+	} else if (len > DS_DATA_MAX_SIZE) {
+		/* Not supported by this protocol version.  */
+		eprintf ("Protovers < 0.2 do not handle env vars longer than %d\n",
+			 DS_DATA_MAX_SIZE - 1);
+		return 0;
+	}
+	nto_send_init (g, DStMsg_env, DSMSG_ENV_SETENV, SET_CHANNEL_DEBUG);
+	memcpy (g->tran.pkt.env.data, env + totlen, len);
+	return nto_send (g, offsetof (DStMsg_env_t, data) + len, 1);
+}
+
+int nto_send_arg (libqnxr_t *g, const char *arg) {
+	int len;
+
+	len = strlen (arg) + 1;
+	if (len > DS_DATA_MAX_SIZE) {
+		eprintf ("Argument too long: %.40s...\n", arg);
+		return 0;
+	}
+	nto_send_init (g, DStMsg_env, DSMSG_ENV_ADDARG, SET_CHANNEL_DEBUG);
+	memcpy (g->tran.pkt.env.data, arg, len);
+	return nto_send (g, offsetof (DStMsg_env_t, data) + len, 1);
+}
+
+int nto_send (libqnxr_t *g, unsigned len, int report_errors) {
+	int rlen;
+	uint8_t tries = 0;
+	g->send_len = len;
+
+	if (g->connected == 0) return -1;
+
+	for (tries = 0;; tries++) {
+		if (tries >= MAX_TRAN_TRIES) {
+			eprintf ("%s: Remote exhausted %d retries.\n", __func__, tries);
+			return -1;
+		}
+		qnxr_send_packet (g);
+		for (;;) {
+			rlen = qnxr_read_packet (g);
+			if ((g->channelrd != SET_CHANNEL_TEXT) || (rlen == -1))
+				break;
+			//nto_incoming_text (rlen); TODO
+		}
+		if (rlen == -1) {
+			eprintf ("%s: NAK received - resending\n", __func__);
+			continue;
+		}
+		if ((rlen >= 0) && (g->recv.pkt.hdr.mid == g->tran.pkt.hdr.mid))
+			break;
+		eprintf ("%s: mid mismatch: %d/%d\n", __func__, g->recv.pkt.hdr.mid,
+			 g->tran.pkt.hdr.mid);
+	}
+
+	switch (g->channelrd) {
+	case SET_CHANNEL_DEBUG:
+		if (((g->recv.pkt.hdr.cmd & DSHDR_MSG_BIG_ENDIAN) != 0)) {
+			// TODO
+		} else {
+			// TODO
+		}
+		g->recv.pkt.hdr.cmd &= ~DSHDR_MSG_BIG_ENDIAN;
+		if (g->recv.pkt.hdr.cmd == DSrMsg_err) {
+			if (report_errors) {
+				int nerrno = errnoconvert (
+					EXTRACT_SIGNED_INTEGER (&g->recv.pkt.err.err, 4));
+				switch (g->recv.pkt.hdr.subcmd) {
+				case PDEBUG_ENOERR:
+					eprintf ("remote: error packet with errno %d\n", nerrno);
+					break;
+				case PDEBUG_ENOPTY:
+					eprintf ("remote: no ptys available\n");
+					break;
+				case PDEBUG_ETHREAD:
+					eprintf ("remote: thread start error\n");
+					break;
+				case PDEBUG_ECONINV:
+					eprintf ("remote: invalid console number\n");
+					break;
+				case PDEBUG_ESPAWN:
+					eprintf ("Remote (spawn error)\n");
+					break;
+				case PDEBUG_EPROCFS:
+					eprintf ("Remote (procfs [/proc] error)\n");
+					break;
+				case PDEBUG_EPROCSTOP:
+					eprintf ("Remote (devctl PROC_STOP error)\n");
+					break;
+				case PDEBUG_EQPSINFO:
+					eprintf ("Remote (psinfo error)\n");
+					break;
+				case PDEBUG_EQMEMMODEL:
+					eprintf ("Remote (invalid memory model [not flat])\n");
+					break;
+				case PDEBUG_EQPROXY:
+					eprintf ("Remote (proxy error)\n");
+					break;
+				case PDEBUG_EQDBG:
+					eprintf ("Remote (__nto_debug_* error)\n");
+					break;
+				default:
+					eprintf ("Remote error\n");
+				}
+			}
+		}
+		break;
+	case SET_CHANNEL_TEXT:
+	case SET_CHANNEL_RESET:
+		break;
+	}
+	return rlen;
+}

--- a/shlr/qnx/src/core.c
+++ b/shlr/qnx/src/core.c
@@ -211,7 +211,7 @@ ptid_t qnxr_attach (libqnxr_t *g, pid_t pid) {
 
 	if (g->inferior_ptid.pid != pid) {
 		qnxr_disconnect (g);
-		sleep (1);
+		r_sys_sleep (1);
 		qnxr_connect (g, g->host, g->port);
 	}
 

--- a/shlr/qnx/src/libqnxr.c
+++ b/shlr/qnx/src/libqnxr.c
@@ -1,0 +1,7 @@
+/* libqnxr - LGPL - Copyright 2016 - madprogrammer */
+
+#include "libqnxr.h"
+#include "core.h"
+
+#include <stdio.h>
+

--- a/shlr/qnx/src/packet.c
+++ b/shlr/qnx/src/packet.c
@@ -1,0 +1,196 @@
+/* libqnxr - GPL - Copyright 2014-2016 - defragger, madprogrammer */
+
+#include <errno.h>
+#include "packet.h"
+#include "utils.h"
+#include "dsmsgs.h"
+
+#define READ_TIMEOUT (300 * 1000 * 1000)
+#define FRAME_CHAR 0x7e
+#define ESC_CHAR 0x7d
+
+#define SET_CHANNEL_RESET 0
+#define SET_CHANNEL_DEBUG 1
+#define SET_CHANNEL_TEXT 2
+#define SET_CHANNEL_NAK 0xff
+
+static uint8_t nak_packet[] =
+	{FRAME_CHAR, SET_CHANNEL_NAK, 0, FRAME_CHAR};
+static uint8_t ch_reset_packet[] =
+	{FRAME_CHAR, SET_CHANNEL_RESET, 0xff, FRAME_CHAR};
+static uint8_t ch_debug_packet[] =
+	{FRAME_CHAR, SET_CHANNEL_DEBUG, 0xfe, FRAME_CHAR};
+static uint8_t ch_text_packet[] =
+	{FRAME_CHAR, SET_CHANNEL_TEXT, 0xfd, FRAME_CHAR};
+
+static int append (libqnxr_t *g, char ch) {
+	if (g->data_len == DS_DATA_MAX_SIZE + 16) {
+		eprintf ("%s: data too long\n", __func__);
+		return -1;
+	}
+
+	g->recv.data[g->data_len++] = ch;
+	return 0;
+}
+
+static int unpack (libqnxr_t *g) {
+	unsigned char modifier = 0;
+	unsigned char sum = 0xff;
+
+	for (; g->read_ptr < g->read_len; g->read_ptr++) {
+		char cur = g->read_buff[g->read_ptr];
+		switch (cur) {
+		case ESC_CHAR:
+			modifier = 0x20;
+			continue;
+		case FRAME_CHAR:
+			/* Ignore multiple start frames */
+			if (g->data_len == 0)
+				continue;
+			if (sum != 0x00) {
+				eprintf ("%s: Checksum error\n", __func__);
+				return -1;
+			}
+			g->read_ptr++;
+			return 0;
+		default:
+			cur ^= modifier;
+			sum -= cur;
+			append (g, cur);
+		}
+		modifier = 0;
+	}
+
+	return 1;
+}
+
+int qnxr_read_packet (libqnxr_t *g) {
+	int ret;
+	g->data_len = 0;
+
+	if (!g) {
+		eprintf ("Initialize libqnxr_t first\n");
+		return -1;
+	}
+
+	// read from network if we've exhausted our buffer
+	// or the buffer is empty
+	if (g->read_len == 0 || g->read_ptr == g->read_len) {
+		while (true) {
+			int ret = r_socket_ready (g->sock, 0, READ_TIMEOUT);
+			if (ret < 0) {
+				if (errno == EINTR)
+					continue;
+				else
+					return -1;
+			}
+
+			g->read_ptr = 0;
+			g->read_len = r_socket_read (g->sock, (void *)g->read_buff,
+
+						     DS_DATA_MAX_SIZE * 2);
+			if (g->read_len <= 0) {
+				g->read_len = 0;
+				eprintf ("%s: read failed\n", __func__);
+				return -1;
+			}
+
+			break;
+		}
+	}
+
+	ret = unpack (g);
+	if (ret < 0) {
+		eprintf ("%s: unpack failed\n", __func__);
+		return -1;
+	}
+
+	if (g->data_len >= sizeof(struct DShdr)) {
+		if (g->recv.pkt.hdr.channel)
+			g->channelrd = g->recv.pkt.hdr.channel;
+	} else if (g->data_len >= 1) {
+		if (g->recv.data[0] == SET_CHANNEL_NAK) {
+			eprintf ("%s: NAK received\n", __func__);
+			g->channelrd = SET_CHANNEL_NAK;
+			return -1;
+		}
+		if (g->recv.data[0] <= SET_CHANNEL_TEXT)
+			g->channelrd = g->recv.data[0];
+	}
+
+	if (!ret) {
+		// Skip the checksum
+		return g->data_len - 1;
+	}
+
+	return -1;
+}
+
+int qnxr_send_nak (libqnxr_t *g) {
+	return r_socket_write (g->sock, nak_packet, sizeof(nak_packet));
+}
+
+int qnxr_send_ch_reset (libqnxr_t *g) {
+	return r_socket_write (g->sock, ch_reset_packet, sizeof(ch_reset_packet));
+}
+
+int qnxr_send_ch_debug (libqnxr_t *g) {
+	return r_socket_write (g->sock, ch_debug_packet, sizeof(ch_debug_packet));
+}
+
+int qnxr_send_ch_text (libqnxr_t *g) {
+	return r_socket_write (g->sock, ch_text_packet, sizeof(ch_text_packet));
+}
+
+int qnxr_send_packet (libqnxr_t *g) {
+	if (!g) {
+		eprintf ("Initialize libqnxr_t first\n");
+		return -1;
+	}
+
+	int i;
+	uint8_t csum = 0;
+	char *p;
+
+	p = g->send_buff;
+	*p++ = FRAME_CHAR;
+
+	for (i = 0; i < g->send_len; i++) {
+		uint8_t c = g->tran.data[i];
+		csum += c;
+
+		switch (c) {
+		case FRAME_CHAR:
+		case ESC_CHAR:
+			*p++ = ESC_CHAR;
+			c ^= 0x20;
+			break;
+		}
+		*p++ = c;
+	}
+
+	csum ^= 0xff;
+	switch (csum) {
+	case FRAME_CHAR:
+	case ESC_CHAR:
+		*p++ = ESC_CHAR;
+		csum ^= 0x20;
+		break;
+	}
+	*p++ = csum;
+	*p++ = FRAME_CHAR;
+
+	if (g->channelwr != g->tran.pkt.hdr.channel) {
+		switch (g->tran.pkt.hdr.channel) {
+		case SET_CHANNEL_TEXT:
+			qnxr_send_ch_text (g);
+			break;
+		case SET_CHANNEL_DEBUG:
+			qnxr_send_ch_debug (g);
+			break;
+		}
+		g->channelwr = g->tran.pkt.hdr.channel;
+	}
+
+	return r_socket_write (g->sock, g->send_buff, p - g->send_buff);
+}

--- a/shlr/qnx/src/sigutil.c
+++ b/shlr/qnx/src/sigutil.c
@@ -1,0 +1,611 @@
+#include <signal.h>
+#include "gdb_signals.h"
+#include "sigutil.h"
+#include "utils.h"
+
+#define NTO_SIGHUP 1    /* hangup */
+#define NTO_SIGINT 2    /* interrupt */
+#define NTO_SIGQUIT 3   /* quit */
+#define NTO_SIGILL 4    /* illegal instruction (not reset when caught) */
+#define NTO_SIGTRAP 5   /* trace trap (not reset when caught) */
+#define NTO_SIGIOT 6    /* IOT instruction */
+#define NTO_SIGABRT 6   /* used by abort */
+#define NTO_SIGEMT 7    /* EMT instruction */
+#define NTO_SIGDEADLK 7 /* Mutex deadlock */
+#define NTO_SIGFPE 8    /* floating point exception */
+#define NTO_SIGKILL 9   /* kill (cannot be caught or ignored) */
+#define NTO_SIGBUS 10   /* bus error */
+#define NTO_SIGSEGV 11  /* segmentation violation */
+#define NTO_SIGSYS 12   /* bad argument to system call */
+#define NTO_SIGPIPE 13  /* write on pipe with no reader */
+#define NTO_SIGALRM 14  /* real-time alarm clock */
+#define NTO_SIGTERM 15  /* software termination signal from kill */
+#define NTO_SIGUSR1 16  /* user defined signal 1 */
+#define NTO_SIGUSR2 17  /* user defined signal 2 */
+#define NTO_SIGCHLD 18  /* death of child */
+#define NTO_SIGPWR 19   /* power-fail restart */
+#define NTO_SIGWINCH 20 /* window change */
+#define NTO_SIGURG 21   /* urgent condition on I/O channel */
+#define NTO_SIGPOLL 22  /* System V name for NTO_SIGIO */
+#define NTO_SIGIO NTO_SIGPOLL
+#define NTO_SIGSTOP 23   /* sendable stop signal not from tty */
+#define NTO_SIGTSTP 24   /* stop signal from tty */
+#define NTO_SIGCONT 25   /* continue a stopped process */
+#define NTO_SIGTTIN 26   /* attempted background tty read */
+#define NTO_SIGTTOU 27   /* attempted background tty write */
+#define NTO_SIGVTALRM 28 /* virtual timer expired */
+#define NTO_SIGPROF 29   /* profileing timer expired */
+#define NTO_SIGXCPU 30   /* exceded cpu limit */
+#define NTO_SIGXFSZ 31   /* exceded file size limit */
+#define NTO_SIGRTMIN 41  /* Realtime signal 41 (SIGRTMIN) */
+#define NTO_SIGRTMAX 56  /* Realtime signal 56 (SIGRTMAX) */
+#define NTO_SIGSELECT (NTO_SIGRTMAX + 1)
+#define NTO_SIGPHOTON (NTO_SIGRTMAX + 2)
+
+static struct
+	{
+	int nto_sig;
+	enum target_signal gdb_sig;
+} sig_map[] =
+	  {
+	   {NTO_SIGHUP, TARGET_SIGNAL_HUP},
+	   {NTO_SIGINT, TARGET_SIGNAL_INT},
+	   {NTO_SIGQUIT, TARGET_SIGNAL_QUIT},
+	   {NTO_SIGILL, TARGET_SIGNAL_ILL},
+	   {NTO_SIGTRAP, TARGET_SIGNAL_TRAP},
+	   {NTO_SIGABRT, TARGET_SIGNAL_ABRT},
+	   {NTO_SIGEMT, TARGET_SIGNAL_EMT},
+	   {NTO_SIGFPE, TARGET_SIGNAL_FPE},
+	   {NTO_SIGKILL, TARGET_SIGNAL_KILL},
+	   {NTO_SIGBUS, TARGET_SIGNAL_BUS},
+	   {NTO_SIGSEGV, TARGET_SIGNAL_SEGV},
+	   {NTO_SIGSYS, TARGET_SIGNAL_SYS},
+	   {NTO_SIGPIPE, TARGET_SIGNAL_PIPE},
+	   {NTO_SIGALRM, TARGET_SIGNAL_ALRM},
+	   {NTO_SIGTERM, TARGET_SIGNAL_TERM},
+	   {NTO_SIGUSR1, TARGET_SIGNAL_USR1},
+	   {NTO_SIGUSR2, TARGET_SIGNAL_USR2},
+	   {NTO_SIGCHLD, TARGET_SIGNAL_CHLD},
+	   {NTO_SIGPWR, TARGET_SIGNAL_PWR},
+	   {NTO_SIGWINCH, TARGET_SIGNAL_WINCH},
+	   {NTO_SIGURG, TARGET_SIGNAL_URG},
+	   {NTO_SIGPOLL, TARGET_SIGNAL_POLL},
+	   {NTO_SIGSTOP, TARGET_SIGNAL_STOP},
+	   {NTO_SIGTSTP, TARGET_SIGNAL_TSTP},
+	   {NTO_SIGCONT, TARGET_SIGNAL_CONT},
+	   {NTO_SIGTTIN, TARGET_SIGNAL_TTIN},
+	   {NTO_SIGTTOU, TARGET_SIGNAL_TTOU},
+	   {NTO_SIGVTALRM, TARGET_SIGNAL_VTALRM},
+	   {NTO_SIGPROF, TARGET_SIGNAL_PROF},
+	   {NTO_SIGXCPU, TARGET_SIGNAL_XCPU},
+	   {NTO_SIGXFSZ, TARGET_SIGNAL_XFSZ}};
+
+/* Convert host signal to our signals.  */
+enum target_signal
+target_signal_from_host (int hostsig) {
+	/* A switch statement would make sense but would require special kludges
+     to deal with the cases where more than one signal has the same number.  */
+
+	if (hostsig == 0)
+		return TARGET_SIGNAL_0;
+
+#if defined(SIGHUP)
+	if (hostsig == SIGHUP)
+		return TARGET_SIGNAL_HUP;
+#endif
+#if defined(SIGINT)
+	if (hostsig == SIGINT)
+		return TARGET_SIGNAL_INT;
+#endif
+#if defined(SIGQUIT)
+	if (hostsig == SIGQUIT)
+		return TARGET_SIGNAL_QUIT;
+#endif
+#if defined(SIGILL)
+	if (hostsig == SIGILL)
+		return TARGET_SIGNAL_ILL;
+#endif
+#if defined(SIGTRAP)
+	if (hostsig == SIGTRAP)
+		return TARGET_SIGNAL_TRAP;
+#endif
+#if defined(SIGABRT)
+	if (hostsig == SIGABRT)
+		return TARGET_SIGNAL_ABRT;
+#endif
+#if defined(SIGEMT)
+	if (hostsig == SIGEMT)
+		return TARGET_SIGNAL_EMT;
+#endif
+#if defined(SIGFPE)
+	if (hostsig == SIGFPE)
+		return TARGET_SIGNAL_FPE;
+#endif
+#if defined(SIGKILL)
+	if (hostsig == SIGKILL)
+		return TARGET_SIGNAL_KILL;
+#endif
+#if defined(SIGBUS)
+	if (hostsig == SIGBUS)
+		return TARGET_SIGNAL_BUS;
+#endif
+#if defined(SIGSEGV)
+	if (hostsig == SIGSEGV)
+		return TARGET_SIGNAL_SEGV;
+#endif
+#if defined(SIGSYS)
+	if (hostsig == SIGSYS)
+		return TARGET_SIGNAL_SYS;
+#endif
+#if defined(SIGPIPE)
+	if (hostsig == SIGPIPE)
+		return TARGET_SIGNAL_PIPE;
+#endif
+#if defined(SIGALRM)
+	if (hostsig == SIGALRM)
+		return TARGET_SIGNAL_ALRM;
+#endif
+#if defined(SIGTERM)
+	if (hostsig == SIGTERM)
+		return TARGET_SIGNAL_TERM;
+#endif
+#if defined(SIGUSR1)
+	if (hostsig == SIGUSR1)
+		return TARGET_SIGNAL_USR1;
+#endif
+#if defined(SIGUSR2)
+	if (hostsig == SIGUSR2)
+		return TARGET_SIGNAL_USR2;
+#endif
+#if defined(SIGCLD)
+	if (hostsig == SIGCLD)
+		return TARGET_SIGNAL_CHLD;
+#endif
+#if defined(SIGCHLD)
+	if (hostsig == SIGCHLD)
+		return TARGET_SIGNAL_CHLD;
+#endif
+#if defined(SIGPWR)
+	if (hostsig == SIGPWR)
+		return TARGET_SIGNAL_PWR;
+#endif
+#if defined(SIGWINCH)
+	if (hostsig == SIGWINCH)
+		return TARGET_SIGNAL_WINCH;
+#endif
+#if defined(SIGURG)
+	if (hostsig == SIGURG)
+		return TARGET_SIGNAL_URG;
+#endif
+#if defined(SIGIO)
+	if (hostsig == SIGIO)
+		return TARGET_SIGNAL_IO;
+#endif
+#if defined(SIGPOLL)
+	if (hostsig == SIGPOLL)
+		return TARGET_SIGNAL_POLL;
+#endif
+#if defined(SIGSTOP)
+	if (hostsig == SIGSTOP)
+		return TARGET_SIGNAL_STOP;
+#endif
+#if defined(SIGTSTP)
+	if (hostsig == SIGTSTP)
+		return TARGET_SIGNAL_TSTP;
+#endif
+#if defined(SIGCONT)
+	if (hostsig == SIGCONT)
+		return TARGET_SIGNAL_CONT;
+#endif
+#if defined(SIGTTIN)
+	if (hostsig == SIGTTIN)
+		return TARGET_SIGNAL_TTIN;
+#endif
+#if defined(SIGTTOU)
+	if (hostsig == SIGTTOU)
+		return TARGET_SIGNAL_TTOU;
+#endif
+#if defined(SIGVTALRM)
+	if (hostsig == SIGVTALRM)
+		return TARGET_SIGNAL_VTALRM;
+#endif
+#if defined(SIGPROF)
+	if (hostsig == SIGPROF)
+		return TARGET_SIGNAL_PROF;
+#endif
+#if defined(SIGXCPU)
+	if (hostsig == SIGXCPU)
+		return TARGET_SIGNAL_XCPU;
+#endif
+#if defined(SIGXFSZ)
+	if (hostsig == SIGXFSZ)
+		return TARGET_SIGNAL_XFSZ;
+#endif
+#if defined(SIGWIND)
+	if (hostsig == SIGWIND)
+		return TARGET_SIGNAL_WIND;
+#endif
+#if defined(SIGPHONE)
+	if (hostsig == SIGPHONE)
+		return TARGET_SIGNAL_PHONE;
+#endif
+#if defined(SIGLOST)
+	if (hostsig == SIGLOST)
+		return TARGET_SIGNAL_LOST;
+#endif
+#if defined(SIGWAITING)
+	if (hostsig == SIGWAITING)
+		return TARGET_SIGNAL_WAITING;
+#endif
+#if defined(SIGCANCEL)
+	if (hostsig == SIGCANCEL)
+		return TARGET_SIGNAL_CANCEL;
+#endif
+#if defined(SIGLWP)
+	if (hostsig == SIGLWP)
+		return TARGET_SIGNAL_LWP;
+#endif
+#if defined(SIGDANGER)
+	if (hostsig == SIGDANGER)
+		return TARGET_SIGNAL_DANGER;
+#endif
+#if defined(SIGGRANT)
+	if (hostsig == SIGGRANT)
+		return TARGET_SIGNAL_GRANT;
+#endif
+#if defined(SIGRETRACT)
+	if (hostsig == SIGRETRACT)
+		return TARGET_SIGNAL_RETRACT;
+#endif
+#if defined(SIGMSG)
+	if (hostsig == SIGMSG)
+		return TARGET_SIGNAL_MSG;
+#endif
+#if defined(SIGSOUND)
+	if (hostsig == SIGSOUND)
+		return TARGET_SIGNAL_SOUND;
+#endif
+#if defined(SIGSAK)
+	if (hostsig == SIGSAK)
+		return TARGET_SIGNAL_SAK;
+#endif
+#if defined(SIGPRIO)
+	if (hostsig == SIGPRIO)
+		return TARGET_SIGNAL_PRIO;
+#endif
+
+/* Mach exceptions.  Assumes that the values for EXC_ are positive! */
+#if defined(EXC_BAD_ACCESS) && defined(_NSIG)
+	if (hostsig == _NSIG + EXC_BAD_ACCESS)
+		return TARGET_EXC_BAD_ACCESS;
+#endif
+#if defined(EXC_BAD_INSTRUCTION) && defined(_NSIG)
+	if (hostsig == _NSIG + EXC_BAD_INSTRUCTION)
+		return TARGET_EXC_BAD_INSTRUCTION;
+#endif
+#if defined(EXC_ARITHMETIC) && defined(_NSIG)
+	if (hostsig == _NSIG + EXC_ARITHMETIC)
+		return TARGET_EXC_ARITHMETIC;
+#endif
+#if defined(EXC_EMULATION) && defined(_NSIG)
+	if (hostsig == _NSIG + EXC_EMULATION)
+		return TARGET_EXC_EMULATION;
+#endif
+#if defined(EXC_SOFTWARE) && defined(_NSIG)
+	if (hostsig == _NSIG + EXC_SOFTWARE)
+		return TARGET_EXC_SOFTWARE;
+#endif
+#if defined(EXC_BREAKPOINT) && defined(_NSIG)
+	if (hostsig == _NSIG + EXC_BREAKPOINT)
+		return TARGET_EXC_BREAKPOINT;
+#endif
+
+#if defined(SIGINFO)
+	if (hostsig == SIGINFO)
+		return TARGET_SIGNAL_INFO;
+#endif
+
+#if defined(REALTIME_LO)
+	if (hostsig >= REALTIME_LO && hostsig < REALTIME_HI) {
+		/* This block of TARGET_SIGNAL_REALTIME value is in order.  */
+		if (33 <= hostsig && hostsig <= 63)
+			return (enum target_signal)(hostsig - 33 + (int)TARGET_SIGNAL_REALTIME_33);
+		else if (hostsig == 32)
+			return TARGET_SIGNAL_REALTIME_32;
+		else if (64 <= hostsig && hostsig <= 127)
+			return (enum target_signal)(hostsig - 64 + (int)TARGET_SIGNAL_REALTIME_64);
+		else
+			error ("GDB bug: target.c (target_signal_from_host): unrecognized real-time signal");
+	}
+#endif
+
+	return TARGET_SIGNAL_UNKNOWN;
+}
+
+static int
+do_target_signal_to_host (enum target_signal oursig,
+			  int *oursig_ok) {
+	int retsig;
+	/* Silence the 'not used' warning, for targets that
+     do not support signals.  */
+	(void)retsig;
+
+	*oursig_ok = 1;
+	switch (oursig) {
+	case TARGET_SIGNAL_0:
+		return 0;
+
+#if defined(SIGHUP)
+	case TARGET_SIGNAL_HUP:
+		return SIGHUP;
+#endif
+#if defined(SIGINT)
+	case TARGET_SIGNAL_INT:
+		return SIGINT;
+#endif
+#if defined(SIGQUIT)
+	case TARGET_SIGNAL_QUIT:
+		return SIGQUIT;
+#endif
+#if defined(SIGILL)
+	case TARGET_SIGNAL_ILL:
+		return SIGILL;
+#endif
+#if defined(SIGTRAP)
+	case TARGET_SIGNAL_TRAP:
+		return SIGTRAP;
+#endif
+#if defined(SIGABRT)
+	case TARGET_SIGNAL_ABRT:
+		return SIGABRT;
+#endif
+#if defined(SIGEMT)
+	case TARGET_SIGNAL_EMT:
+		return SIGEMT;
+#endif
+#if defined(SIGFPE)
+	case TARGET_SIGNAL_FPE:
+		return SIGFPE;
+#endif
+#if defined(SIGKILL)
+	case TARGET_SIGNAL_KILL:
+		return SIGKILL;
+#endif
+#if defined(SIGBUS)
+	case TARGET_SIGNAL_BUS:
+		return SIGBUS;
+#endif
+#if defined(SIGSEGV)
+	case TARGET_SIGNAL_SEGV:
+		return SIGSEGV;
+#endif
+#if defined(SIGSYS)
+	case TARGET_SIGNAL_SYS:
+		return SIGSYS;
+#endif
+#if defined(SIGPIPE)
+	case TARGET_SIGNAL_PIPE:
+		return SIGPIPE;
+#endif
+#if defined(SIGALRM)
+	case TARGET_SIGNAL_ALRM:
+		return SIGALRM;
+#endif
+#if defined(SIGTERM)
+	case TARGET_SIGNAL_TERM:
+		return SIGTERM;
+#endif
+#if defined(SIGUSR1)
+	case TARGET_SIGNAL_USR1:
+		return SIGUSR1;
+#endif
+#if defined(SIGUSR2)
+	case TARGET_SIGNAL_USR2:
+		return SIGUSR2;
+#endif
+#if defined(SIGCHLD) || defined(SIGCLD)
+	case TARGET_SIGNAL_CHLD:
+#if defined(SIGCHLD)
+		return SIGCHLD;
+#else
+		return SIGCLD;
+#endif
+#endif /* SIGCLD or SIGCHLD */
+#if defined(SIGPWR)
+	case TARGET_SIGNAL_PWR:
+		return SIGPWR;
+#endif
+#if defined(SIGWINCH)
+	case TARGET_SIGNAL_WINCH:
+		return SIGWINCH;
+#endif
+#if defined(SIGURG)
+	case TARGET_SIGNAL_URG:
+		return SIGURG;
+#endif
+#if defined(SIGIO)
+	case TARGET_SIGNAL_IO:
+		return SIGIO;
+#endif
+#if defined(SIGPOLL)
+	case TARGET_SIGNAL_POLL:
+		return SIGPOLL;
+#endif
+#if defined(SIGSTOP)
+	case TARGET_SIGNAL_STOP:
+		return SIGSTOP;
+#endif
+#if defined(SIGTSTP)
+	case TARGET_SIGNAL_TSTP:
+		return SIGTSTP;
+#endif
+#if defined(SIGCONT)
+	case TARGET_SIGNAL_CONT:
+		return SIGCONT;
+#endif
+#if defined(SIGTTIN)
+	case TARGET_SIGNAL_TTIN:
+		return SIGTTIN;
+#endif
+#if defined(SIGTTOU)
+	case TARGET_SIGNAL_TTOU:
+		return SIGTTOU;
+#endif
+#if defined(SIGVTALRM)
+	case TARGET_SIGNAL_VTALRM:
+		return SIGVTALRM;
+#endif
+#if defined(SIGPROF)
+	case TARGET_SIGNAL_PROF:
+		return SIGPROF;
+#endif
+#if defined(SIGXCPU)
+	case TARGET_SIGNAL_XCPU:
+		return SIGXCPU;
+#endif
+#if defined(SIGXFSZ)
+	case TARGET_SIGNAL_XFSZ:
+		return SIGXFSZ;
+#endif
+#if defined(SIGWIND)
+	case TARGET_SIGNAL_WIND:
+		return SIGWIND;
+#endif
+#if defined(SIGPHONE)
+	case TARGET_SIGNAL_PHONE:
+		return SIGPHONE;
+#endif
+#if defined(SIGLOST)
+	case TARGET_SIGNAL_LOST:
+		return SIGLOST;
+#endif
+#if defined(SIGWAITING)
+	case TARGET_SIGNAL_WAITING:
+		return SIGWAITING;
+#endif
+#if defined(SIGCANCEL)
+	case TARGET_SIGNAL_CANCEL:
+		return SIGCANCEL;
+#endif
+#if defined(SIGLWP)
+	case TARGET_SIGNAL_LWP:
+		return SIGLWP;
+#endif
+#if defined(SIGDANGER)
+	case TARGET_SIGNAL_DANGER:
+		return SIGDANGER;
+#endif
+#if defined(SIGGRANT)
+	case TARGET_SIGNAL_GRANT:
+		return SIGGRANT;
+#endif
+#if defined(SIGRETRACT)
+	case TARGET_SIGNAL_RETRACT:
+		return SIGRETRACT;
+#endif
+#if defined(SIGMSG)
+	case TARGET_SIGNAL_MSG:
+		return SIGMSG;
+#endif
+#if defined(SIGSOUND)
+	case TARGET_SIGNAL_SOUND:
+		return SIGSOUND;
+#endif
+#if defined(SIGSAK)
+	case TARGET_SIGNAL_SAK:
+		return SIGSAK;
+#endif
+#if defined(SIGPRIO)
+	case TARGET_SIGNAL_PRIO:
+		return SIGPRIO;
+#endif
+
+/* Mach exceptions.  Assumes that the values for EXC_ are positive! */
+#if defined(EXC_BAD_ACCESS) && defined(_NSIG)
+	case TARGET_EXC_BAD_ACCESS:
+		return _NSIG + EXC_BAD_ACCESS;
+#endif
+#if defined(EXC_BAD_INSTRUCTION) && defined(_NSIG)
+	case TARGET_EXC_BAD_INSTRUCTION:
+		return _NSIG + EXC_BAD_INSTRUCTION;
+#endif
+#if defined(EXC_ARITHMETIC) && defined(_NSIG)
+	case TARGET_EXC_ARITHMETIC:
+		return _NSIG + EXC_ARITHMETIC;
+#endif
+#if defined(EXC_EMULATION) && defined(_NSIG)
+	case TARGET_EXC_EMULATION:
+		return _NSIG + EXC_EMULATION;
+#endif
+#if defined(EXC_SOFTWARE) && defined(_NSIG)
+	case TARGET_EXC_SOFTWARE:
+		return _NSIG + EXC_SOFTWARE;
+#endif
+#if defined(EXC_BREAKPOINT) && defined(_NSIG)
+	case TARGET_EXC_BREAKPOINT:
+		return _NSIG + EXC_BREAKPOINT;
+#endif
+
+#if defined(SIGINFO)
+	case TARGET_SIGNAL_INFO:
+		return SIGINFO;
+#endif
+
+	default:
+#if defined(REALTIME_LO)
+		retsig = 0;
+
+		if (oursig >= TARGET_SIGNAL_REALTIME_33 && oursig <= TARGET_SIGNAL_REALTIME_63) {
+			/* This block of signals is continuous, and
+             TARGET_SIGNAL_REALTIME_33 is 33 by definition.  */
+			retsig = (int)oursig - (int)TARGET_SIGNAL_REALTIME_33 + 33;
+		} else if (oursig == TARGET_SIGNAL_REALTIME_32) {
+			/* TARGET_SIGNAL_REALTIME_32 isn't contiguous with
+             TARGET_SIGNAL_REALTIME_33.  It is 32 by definition.  */
+			retsig = 32;
+		} else if (oursig >= TARGET_SIGNAL_REALTIME_64 && oursig <= TARGET_SIGNAL_REALTIME_127) {
+			/* This block of signals is continuous, and
+             TARGET_SIGNAL_REALTIME_64 is 64 by definition.  */
+			retsig = (int)oursig - (int)TARGET_SIGNAL_REALTIME_64 + 64;
+		}
+
+		if (retsig >= REALTIME_LO && retsig < REALTIME_HI)
+			return retsig;
+#endif
+
+		*oursig_ok = 0;
+		return 0;
+	}
+}
+
+int
+target_signal_to_host (enum target_signal oursig) {
+	int oursig_ok;
+	int targ_signo = do_target_signal_to_host (oursig, &oursig_ok);
+	if (!oursig_ok)
+		return 0;
+	else
+		return targ_signo;
+}
+
+/* Convert nto signal to gdb signal.  */
+enum target_signal
+target_signal_from_nto (int sig) {
+	int i;
+	if (sig == 0)
+		return 0;
+
+	for (i = 0; i != ARRAY_SIZE (sig_map); i++) {
+		if (sig_map[i].nto_sig == sig)
+			return sig_map[i].gdb_sig;
+	}
+
+	if (sig >= NTO_SIGRTMIN && sig <= NTO_SIGRTMAX)
+		return TARGET_SIGNAL_REALTIME_41 + sig - NTO_SIGRTMIN;
+	return target_signal_from_host (sig);
+}
+
+int
+host_signal_from_nto (int sig) {
+	return target_signal_to_host (target_signal_to_host (sig));
+}

--- a/shlr/qnx/src/utils.c
+++ b/shlr/qnx/src/utils.c
@@ -1,0 +1,315 @@
+#include <errno.h>
+#include <r_types.h>
+#include "utils.h"
+
+#define I386_NUM_GREGS 16
+#define I386_NUM_FREGS 16
+#define I386_NUM_XREGS 9
+
+#define NUM_GPREGS 13
+
+#define I386_SSE_NUM_REGS (I386_NUM_GREGS + I386_NUM_FREGS + I386_NUM_XREGS)
+
+#define I387_NUM_XMM_REGS 8
+#define I387_ST0_REGNUM I386_ST0_REGNUM
+#define I387_FCTRL_REGNUM (I387_ST0_REGNUM + 8)
+#define I387_FSTAT_REGNUM (I387_FCTRL_REGNUM + 1)
+#define I387_FTAG_REGNUM (I387_FCTRL_REGNUM + 2)
+#define I387_FISEG_REGNUM (I387_FCTRL_REGNUM + 3)
+#define I387_FIOFF_REGNUM (I387_FCTRL_REGNUM + 4)
+#define I387_FOSEG_REGNUM (I387_FCTRL_REGNUM + 5)
+#define I387_FOOFF_REGNUM (I387_FCTRL_REGNUM + 6)
+#define I387_FOP_REGNUM (I387_FCTRL_REGNUM + 7)
+#define I387_XMM0_REGNUM (I387_ST0_REGNUM + 16)
+#define I387_MXCSR_REGNUM (I387_XMM0_REGNUM + I387_NUM_XMM_REGS)
+
+/* These correspond to the DSMSG_* versions in dsmsgs.h. */
+enum {
+	NTO_REG_GENERAL,
+	NTO_REG_FLOAT,
+	NTO_REG_SYSTEM,
+	NTO_REG_ALT,
+	NTO_REG_END
+};
+
+enum i386_regnum {
+	I386_EAX_REGNUM,    /* %eax */
+	I386_ECX_REGNUM,    /* %ecx */
+	I386_EDX_REGNUM,    /* %edx */
+	I386_EBX_REGNUM,    /* %ebx */
+	I386_ESP_REGNUM,    /* %esp */
+	I386_EBP_REGNUM,    /* %ebp */
+	I386_ESI_REGNUM,    /* %esi */
+	I386_EDI_REGNUM,    /* %edi */
+	I386_EIP_REGNUM,    /* %eip */
+	I386_EFLAGS_REGNUM, /* %eflags */
+	I386_CS_REGNUM,     /* %cs */
+	I386_SS_REGNUM,     /* %ss */
+	I386_DS_REGNUM,     /* %ds */
+	I386_ES_REGNUM,     /* %es */
+	I386_FS_REGNUM,     /* %fs */
+	I386_GS_REGNUM,     /* %gs */
+	I386_ST0_REGNUM     /* %st(0) */
+};
+
+static int i386nto_gregset_reg_offset[] =
+	{
+	 7 * 4,  /* %eax */
+	 6 * 4,  /* %ecx */
+	 5 * 4,  /* %edx */
+	 4 * 4,  /* %ebx */
+	 11 * 4, /* %esp */
+	 2 * 4,  /* %epb */
+	 1 * 4,  /* %esi */
+	 0 * 4,  /* %edi */
+	 8 * 4,  /* %eip */
+	 10 * 4, /* %eflags */
+	 9 * 4,  /* %cs */
+	 12 * 4, /* %ss */
+	 -1      /* filler */
+};
+
+/* Pdebug returns errno values on Neutrino that do not correspond to right
+   errno values on host side.  */
+
+#define NTO_ENAMETOOLONG 78
+#define NTO_ELIBACC 83
+#define NTO_ELIBBAD 84
+#define NTO_ELIBSCN 85
+#define NTO_ELIBMAX 86
+#define NTO_ELIBEXEC 87
+#define NTO_EILSEQ 88
+#define NTO_ENOSYS 89
+
+#if defined(__QNXNTO__) || defined(__SOLARIS__)
+#define errnoconvert(x) x
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__MINGW32__)
+
+struct errnomap_t {
+	int nto;
+	int other;
+};
+
+int
+errnoconvert (int x) {
+	struct errnomap_t errnomap[] = {
+#if defined(__linux__)
+		{NTO_ENAMETOOLONG, ENAMETOOLONG},
+		{NTO_ELIBACC, ELIBACC},
+		{NTO_ELIBBAD, ELIBBAD},
+		{NTO_ELIBSCN, ELIBSCN},
+		{NTO_ELIBMAX, ELIBMAX},
+		{NTO_ELIBEXEC, ELIBEXEC},
+		{NTO_EILSEQ, EILSEQ},
+		{NTO_ENOSYS, ENOSYS}
+#elif defined(__CYGWIN__)
+		{NTO_ENAMETOOLONG, ENAMETOOLONG},
+		{NTO_ENOSYS, ENOSYS}
+#elif defined(__MINGW32__)
+		/* The closest mappings from mingw's errno.h.  */
+		{NTO_ENAMETOOLONG, ENAMETOOLONG},
+		{NTO_ELIBACC, ESRCH},
+		{NTO_ELIBBAD, ESRCH},
+		{NTO_ELIBSCN, ENOEXEC},
+		{NTO_ELIBMAX, EPERM},
+		{NTO_ELIBEXEC, ENOEXEC},
+		{NTO_EILSEQ, EILSEQ},
+		{NTO_ENOSYS, ENOSYS}
+#endif
+	};
+	int i;
+
+	for (i = 0; i < sizeof(errnomap) / sizeof(errnomap[0]); i++)
+		if (errnomap[i].nto == x) return errnomap[i].other;
+	return x;
+}
+
+#define errnoconvert(x) errnoconvert (x)
+#else
+#error errno mapping not setup for this host
+#endif /* __QNXNTO__ */
+
+LONGEST
+extract_signed_integer (const uint8_t *addr, int len, int be) {
+	LONGEST retval;
+	const unsigned char *p;
+	const unsigned char *startaddr = addr;
+	const unsigned char *endaddr = startaddr + len;
+
+	if (len > (int)sizeof(LONGEST))
+		eprintf ("This operation is not available on integers of more than %d bytes\n",
+			 (int)sizeof(LONGEST));
+
+	/* Start at the most significant end of the integer, and work towards
+       the least significant.  */
+	if (be) {
+		p = startaddr;
+		/* Do the sign extension once at the start.  */
+		retval = ((LONGEST)*p ^ 0x80) - 0x80;
+		for (++p; p < endaddr; ++p)
+			retval = (retval << 8) | *p;
+	} else {
+		p = endaddr - 1;
+		/* Do the sign extension once at the start.  */
+		retval = ((LONGEST)*p ^ 0x80) - 0x80;
+		for (--p; p >= startaddr; --p)
+			retval = (retval << 8) | *p;
+	}
+	return retval;
+}
+
+ULONGEST
+extract_unsigned_integer (const uint8_t *addr, int len, int be) {
+	ULONGEST retval;
+	const unsigned char *p;
+	const unsigned char *startaddr = addr;
+	const unsigned char *endaddr = startaddr + len;
+
+	if (len > (int)sizeof(LONGEST))
+		eprintf ("This operation is not available on integers of more than %d bytes\n",
+			 (int)sizeof(LONGEST));
+
+	/* Start at the most significant end of the integer, and work towards
+       the least significant.  */
+	retval = 0;
+	if (be) {
+		for (p = startaddr; p < endaddr; ++p)
+			retval = (retval << 8) | *p;
+	} else {
+		for (p = endaddr - 1; p >= startaddr; --p)
+			retval = (retval << 8) | *p;
+	}
+	return retval;
+}
+
+int
+i386nto_regset_id (int regno) {
+	if (regno == -1)
+		return NTO_REG_END;
+	else if (regno < I386_NUM_GREGS)
+		return NTO_REG_GENERAL;
+	else if (regno < I386_NUM_GREGS + I386_NUM_FREGS)
+		return NTO_REG_FLOAT;
+	else if (regno < I386_SSE_NUM_REGS)
+		return NTO_REG_FLOAT; /* We store xmm registers in fxsave_area.  */
+
+	return -1;
+}
+
+int
+i386nto_reg_offset (int regnum) {
+	if (regnum >= 0 && regnum < ARRAY_SIZE (i386nto_gregset_reg_offset))
+		return i386nto_gregset_reg_offset[regnum];
+
+	return -1;
+}
+
+int
+i386nto_register_area (int regno, int regset, unsigned *off) {
+	*off = 0;
+	if (regset == NTO_REG_GENERAL) {
+		if (regno == -1)
+			return NUM_GPREGS * 4;
+
+		*off = i386nto_reg_offset (regno);
+		if (*off == -1)
+			return 0;
+		return 4;
+	} else if (regset == NTO_REG_FLOAT) {
+		unsigned off_adjust, regsize, regset_size, regno_base;
+		/* The following are flags indicating number in our fxsave_area.  */
+		int first_four = (regno >= I387_FCTRL_REGNUM && regno <= I387_FISEG_REGNUM);
+		int second_four = (regno > I387_FISEG_REGNUM && regno <= I387_FOP_REGNUM);
+		int st_reg = (regno >= I387_ST0_REGNUM && regno < I387_ST0_REGNUM + 8);
+		int xmm_reg = (regno >= I387_XMM0_REGNUM && regno < I387_MXCSR_REGNUM);
+#if 0
+      if (nto_cpuinfo_valid && nto_cpuinfo_flags | X86_CPU_FXSR)
+	  {
+#endif
+		regset_size = 512;
+		/* fxsave_area structure.  */
+		if (first_four) {
+			/* fpu_control_word, fpu_status_word, fpu_tag_word, fpu_operand
+	         registers.  */
+			regsize = 2; /* Two bytes each.  */
+			off_adjust = 0;
+			regno_base = I387_FCTRL_REGNUM;
+		} else if (second_four) {
+			/* fpu_ip, fpu_cs, fpu_op, fpu_ds registers.  */
+			regsize = 4;
+			off_adjust = 8;
+			regno_base = I387_FISEG_REGNUM + 1;
+		} else if (st_reg) {
+			/* ST registers.  */
+			regsize = 16;
+			off_adjust = 32;
+			regno_base = I387_ST0_REGNUM;
+		} else if (xmm_reg) {
+			/* XMM registers.  */
+			regsize = 16;
+			off_adjust = 160;
+			regno_base = I387_XMM0_REGNUM;
+		} else if (regno == I387_MXCSR_REGNUM) {
+			regsize = 4;
+			off_adjust = 24;
+			regno_base = I387_MXCSR_REGNUM;
+		} else {
+			/* Whole regset.  */
+			off_adjust = 0;
+			regno_base = 0;
+			regsize = regset_size;
+		}
+#if 0
+	}
+      else
+	{
+	  regset_size = 108;
+	  /* fsave_area structure.  */
+	  if (first_four || second_four)
+	    {
+	      /* fpu_control_word, ... , fpu_ds registers.  */
+	      regsize = 4;
+	      off_adjust = 0;
+	      regno_base = I387_FCTRL_REGNUM;
+	    }
+	  else if (st_reg)
+	    {
+	      /* One of ST registers.  */
+	      regsize = 10;
+	      off_adjust = 7 * 4;
+	      regno_base = I387_ST0_REGNUM;
+	    }
+	  else
+	    {
+	      /* Whole regset.  */
+	      off_adjust = 0;
+	      regno_base = 0;
+	      regsize = regset_size;
+	    }
+	}
+#endif
+
+		if (regno != -1)
+			*off = off_adjust + (regno - regno_base) * regsize;
+		else
+			*off = 0;
+		return regsize;
+	}
+	return -1;
+}
+
+ptid_t
+ptid_build (int pid, long tid) {
+	ptid_t ptid;
+
+	ptid.pid = pid;
+	ptid.tid = tid;
+
+	return ptid;
+}
+
+int
+ptid_equal (ptid_t ptid1, ptid_t ptid2) {
+	return ptid1.pid == ptid2.pid &&
+	       ptid1.tid == ptid2.tid;
+}


### PR DESCRIPTION
I've made a debug plugin which connects to a QNX system, and allows to remotely debug programs via the QNX `pdebug` protocol (pulled from the QNX-modified version of GDB). The QNX OS itself can run on 32-bit Intel or 32-bit ARM architecture, but this plugin currently only supports Intel, though adding ARM support shouldn't be hard, but I didn't have a chance to test it with an ARM system yet.

Current workflow should be as follows:
  1. Run `r2 -D qnx -a x86 -b 32 qnx://1.2.3.4:8001`, where 8001 is the port you've ran `pdebug` on.
  2. Run `dp*` to list remote processes with their process IDs.
  3. Run `dpa <pid>` to attach to a PID of your choice.

Use `radare2` debugger commands (`dr`, `ds`, `dc`, `db` etc.) as usual.

**Known issues:**

At initial startup `radare2` tries to attach to a non-existent PID, which fails (`libr/core/io.c:16`):
```
pid = *p; // 1st element in debugger's struct must be int
```
Futher commands will return errros until radare is attached to a valid remote process.

ARM32 target architecture support not yet implemented.
Some code licensed under GPL due to the license of GDB.