### PR TITLE
Fix checking `/proc/%d/task` for existence.

### DIFF
--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -132,7 +132,7 @@ RList *linux_thread_list (int pid, RList *list) {
 	/* LOL! linux hides threads from /proc, but they are accessible!! HAHAHA */
 	//while ((de = readdir (dh))) {
 	snprintf (cmdline, sizeof(cmdline), "/proc/%d/task", pid);
-	if (r_file_exists (cmdline)) {
+	if (r_file_is_directory (cmdline)) {
 		struct dirent *de;
 		DIR *dh = opendir (cmdline);
 		while ((de = readdir (dh))) {


### PR DESCRIPTION
#4669

Since `/proc/%d/task` is directory, it make sense to use appropriate
check function. Therefore,`r_file_exists` function is not suitable
here, because it checks for existence of regular file.