### PR TITLE
* BugFix: pxA did not display the last line of its output

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1359,6 +1359,7 @@ static int cmd_print_pxA(RCore *core, int len, const char *data) {
 		}
 		i += opsz;
 	}
+	r_cons_printf ("  %d\n", i-oi);
 	if (bgcolor_in_heap) free (bgcolor);
 
 	return true;


### PR DESCRIPTION
Fix a small bug in pxA. The last line of the output was not properly terminated with a "new line" and
so it was not displayed.
For instance:

    [0x00401410]> pxA
    0x00401410  mv->--==mvcJ<-_Rmv==cJ<-mv_J..mv->--  ..J..==cJ->mv_C<-mv_R..==cJmv==  162

    [0x00401410]> pxA 170
    0x00401410  mv->--==mvcJ<-_Rmv==cJ<-mv_J..mv->--  ..J..==cJ->mv_C<-mv_R..==cJmv==  162

    [0x00401410]> pxA 90
    [0x00401410]> 

After the fix:

    [0x00401410]> pxA
    0x00401410  mv->--==mvcJ<-_Rmv==cJ<-mv_J..mv->--  ..J..==cJ->mv_C<-mv_R..==cJmv==  162
    0x004014b2  cJ->mvmv_C<-_J.._J..->mvmvmv_^->--mv_Cmvmv_^mvmv_C_^mv    ==  94

    [0x00401410]> pxA 90
    0x00401410  mv->--==mvcJ<-_Rmv==cJ<-mv_J..mv->--  mvmv>>++  cJ<-_Rmv    90
