### PR TITLE
fix r_socket_read, don't lose sent data on r_socket_close (mingw32)

### DIFF
--- a/libr/include/r_socket.h
+++ b/libr/include/r_socket.h
@@ -32,6 +32,11 @@ R_LIB_VERSION_HEADER(r_socket);
 #ifndef MSG_DONTWAIT
 #define MSG_DONTWAIT 0
 #endif
+#ifndef SD_BOTH
+#define SD_RECEIVE  0
+#define SD_SEND 1
+#define SD_BOTH 2
+#endif
 
 typedef struct {
 	int magic;

--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -259,12 +259,22 @@ R_API int r_socket_close_fd (RSocket *s) {
 /* shutdown the socket and close the file descriptor */
 R_API int r_socket_close (RSocket *s) {
 	int ret = false;
+	char buf;
 	if (!s) return false;
 	if (s->fd != -1) {
 #if __UNIX__ || defined(__CYGWIN__)
 		shutdown (s->fd, SHUT_RDWR);
 #endif
+#if __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms740481(v=vs.85).aspx
+		shutdown (s->fd, SD_SEND);
+		do {
+			ret = recv (s->fd, &buf, 1, 0); 
+		} while (ret != 0 && ret != SOCKET_ERROR);
+		ret = closesocket (s->fd);
+#else
 		ret = close (s->fd);
+#endif
 	}
 #if HAVE_LIB_SSL
 	if (s->is_ssl && s->sfd) {
@@ -447,7 +457,7 @@ R_API int r_socket_flush(RSocket *s) {
 }
 
 // XXX: rewrite it to use select //
-/* waits secs until new data is received.     */
+/* waits secs until new data is received.	  */
 /* returns -1 on error, 0 is false, 1 is true */
 R_API int r_socket_ready(RSocket *s, int secs, int usecs) {
 #if __UNIX__ || defined(__CYGWIN__)
@@ -561,8 +571,8 @@ R_API int r_socket_read(RSocket *s, unsigned char *buf, int len) {
 rep:
 	{
 	int ret = recv (s->fd, (void *)buf, len, 0);
-	if (ret != len)
-		return 0;
+	//if (ret != len)
+	//	return 0;
 	//r_sys_perror ("recv");
 	if (ret == -1) goto rep;
 	return ret;
@@ -583,7 +593,7 @@ R_API int r_socket_read_block(RSocket *s, unsigned char *buf, int len) {
 	return ret;
 }
 
-R_API int r_socket_gets(RSocket *s, char *buf,  int size) {
+R_API int r_socket_gets(RSocket *s, char *buf,	int size) {
 	int i = 0;
 	int ret = 0;
 


### PR DESCRIPTION
1) `r_socket_read()`: was broken on mingw32, a zero length was returned if `ret != len`
2) `r_socket_close()`: fixed closing of socket on mingw32, incl. waiting for last outgoing data to be sent to the wire. This also makes the HTTP server stable (before the fix the connection was sometimes randomly closed before the web browser received all content from the server, leading to ERR_CONNECTION_RESET error in Chrome).