### PR TITLE
qnx debugger: fix segfault on macos

### DIFF
--- a/shlr/qnx/src/core.c
+++ b/shlr/qnx/src/core.c
@@ -148,7 +148,8 @@ int qnxr_connect (libqnxr_t *g, const char *host, int port) {
 	g->connected = 0;
 	g->mid = 0;
 
-	strncpy (g->host, host, sizeof (g->host));
+	if (g->host != host)
+		strncpy (g->host, host, sizeof (g->host));
 	g->port = port;
 
 	ret = snprintf (tmp, sizeof (tmp) - 1, "%d", port);

--- a/shlr/qnx/src/core.c
+++ b/shlr/qnx/src/core.c
@@ -148,8 +148,8 @@ int qnxr_connect (libqnxr_t *g, const char *host, int port) {
 	g->connected = 0;
 	g->mid = 0;
 
-	if (g->host != host)
-		strncpy (g->host, host, sizeof (g->host));
+
+	memmove (g->host, host, strlen (host) + 1);
 	g->port = port;
 
 	ret = snprintf (tmp, sizeof (tmp) - 1, "%d", port);


### PR DESCRIPTION
This fixes QNX debugger segfault on Mac OS X (due to MacOS doesn't allow `src` and `dst` of `strncpy` to overlap)