### PR TITLE
fix POP and POPF

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -681,8 +681,6 @@ Sets the byte in the operand to 1 if the Sign Flag is not equal
 		esilprintf (op, "%s,%s,=,%s,[%d],%s,=,%d,%s,+=",
 			bp, sp, sp, rs, bp, rs, sp);
 		break;
-	case X86_INS_POP:
-	case X86_INS_POPF:
 	case X86_INS_POPAW:
 	case X86_INS_POPAL:
 		{
@@ -708,6 +706,8 @@ Sets the byte in the operand to 1 if the Sign Flag is not equal
 				);
 		}
 		break;
+	case X86_INS_POP:
+	case X86_INS_POPF:
 	case X86_INS_POPCNT:
 		{
 			char *dst = getarg (&gop, 0, 0, NULL);


### PR DESCRIPTION
POP and POPF (though not implemented properly yet) did same as POPAL and POPAW.

Also I feel the need to update 
https://github.com/P4N74/radare2/blob/0c21b433f0f81e520f604de9b0a51c9128708dbc/libr/anal/p/anal_x86_cs.c#L1691-L1699 and have it handled at:
```
	case X86_INS_POPAW:
	case X86_INS_POPAL:
		op->type = R_ANAL_OP_TYPE_POP;
		op->stackop = R_ANAL_STACK_INC;
		op->stackptr = -regsz * 8;
		break;
```
But I am not sure if this would be required or not. Also are any other changes required?