### PR TITLE
Add "-m32" and "-m64" flags for cross compilation with ragg2-cc

### DIFF
--- a/binr/ragg2/ragg2-cc
+++ b/binr/ragg2/ragg2-cc
@@ -153,8 +153,6 @@ if [ "`uname`" = Darwin ]; then
 jmp _main"
 else
 	OBJCOPY=objcopy
-	CFLAGS="-fPIC -fPIE -pie -fpic"
-	LDFLAGS="-fPIC -fPIE -pie -fpic"
 	SHDR="
 .section .text
 .globl  main
@@ -163,9 +161,13 @@ jmp main
 "
 	case "$B" in
 	64)
+	        CFLAGS="-fPIC -fPIE -pie -fpic -m64"
+	        LDFLAGS="-fPIC -fPIE -pie -fpic -m64"
 		ARCH=linux-x86-64
 		;;
 	*) 
+	        CFLAGS="-fPIC -fPIE -pie -fpic -m32"
+	        LDFLAGS="-fPIC -fPIE -pie -fpic -m32"
 		ARCH=linux-x86-32
 		;;
 	esac


### PR DESCRIPTION
Cross compiling 32 bit on a 64 bit Linux system fails since ragg2-cc doesn't include the "-m32" flag. This change should also help support cross compiling 64 bit on 32 bit systems by adding the "-m64" flag.