### PR TITLE
Colour current graphviz nodes

### DIFF
--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -66,9 +66,12 @@ R_API void r_cons_pal_init (const char *foo) {
 	cons->pal.graph_box = Color_RESET;
 	cons->pal.graph_box2 = Color_BLUE;
 	cons->pal.graph_box3 = Color_MAGENTA;
+	cons->pal.graph_box4 = Color_GRAY;
 	cons->pal.graph_true = Color_GREEN;
 	cons->pal.graph_false = Color_RED;
 	cons->pal.graph_trufae = Color_BLUE; // single jump
+	cons->pal.graph_traced = Color_YELLOW;
+	cons->pal.graph_current = Color_BLUE;
 
 	r_cons_pal_free ();
 	cons->pal.list[0] = strdup (Color_RED);
@@ -254,9 +257,12 @@ static struct {
 	{ "graph.box", r_offsetof (RConsPalette, graph_box) },
 	{ "graph.box2", r_offsetof (RConsPalette, graph_box2) },
 	{ "graph.box3", r_offsetof (RConsPalette, graph_box3) },
+	{ "graph.box4", r_offsetof (RConsPalette, graph_box4) },
 	{ "graph.true", r_offsetof (RConsPalette, graph_true) },
 	{ "graph.false", r_offsetof (RConsPalette, graph_false) },
 	{ "graph.trufae", r_offsetof (RConsPalette, graph_trufae) },
+	{ "graph.current", r_offsetof (RConsPalette, graph_current) },
+	{ "graph.traced", r_offsetof (RConsPalette, graph_traced) },
 
 	{ "gui.cflow", r_offsetof (RConsPalette, gui_cflow) },
 	{ "gui.dataoffset", r_offsetof (RConsPalette, gui_dataoffset) },

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -753,6 +753,9 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 	char *pal_jump = palColorFor ("graph.true");
 	char *pal_fail = palColorFor ("graph.false");
 	char *pal_trfa = palColorFor ("graph.trufae");
+	char *pal_curr = palColorFor ("graph.current");
+	char *pal_traced = palColorFor ("graph.traced");
+	char *pal_box4 = palColorFor ("graph.box4");
 	bool color_current = r_config_get_i (core->config, "graph.gv.current");
 
 	if (is_keva) {
@@ -939,8 +942,9 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 					r_cons_printf ("\t\"0x%08"PFMT64x"\" ["
 						"URL=\"%s/0x%08"PFMT64x"\", color=\"%s\", label=\"%s\"]\n",
 						bbi->addr, fcn->name, bbi->addr,
-						bbi->traced?"yellow":(
-							(color_current && r_anal_bb_is_in_offset (bbi, core->offset))?"lightblue":"lightgray"),
+						bbi->traced?pal_traced:(
+							(color_current &&
+							 r_anal_bb_is_in_offset (bbi, core->offset))?pal_curr:pal_box4),
 						str);
 				}
 			}
@@ -1242,7 +1246,7 @@ R_API void r_core_anal_coderefs(RCore *core, ut64 addr, int fmt) {
 					if (!gv_edge || !*gv_edge)
 						gv_edge = "arrowhead=\"vee\"";
 					if (!gv_node || !*gv_node)
-						gv_node = "color=lightgray, style=filled shape=box";
+						gv_node = "color=gray, style=filled shape=box";
 					if (!gv_grph || !*gv_grph)
 						gv_grph = "bgcolor=white";
 					r_cons_printf ("digraph code {\n"
@@ -1680,7 +1684,7 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 		if (!gv_edge || !*gv_edge)
 			gv_edge = "arrowhead=\"vee\"";
 		if (!gv_node || !*gv_node) {
-			gv_node = "color=lightgray, style=filled shape=box";
+			gv_node = "color=gray, style=filled shape=box";
 		}
 		r_cons_printf ("digraph code {\n"
 			"\tgraph [bgcolor=white fontsize=8 fontname=\"%s\"];\n"

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -753,6 +753,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 	char *pal_jump = palColorFor ("graph.true");
 	char *pal_fail = palColorFor ("graph.false");
 	char *pal_trfa = palColorFor ("graph.trufae");
+	bool color_current = r_config_get_i(core->config, "graph.gv.current");
 
 	if (is_keva) {
 		char ns[64];
@@ -935,10 +936,12 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 					//	fcn->addr, bbi->addr,
 					//	fcn->name, bbi->addr,
 					//	bbi->traced?"yellow":"lightgray", str);
-					r_cons_printf (" \"0x%08"PFMT64x"\" ["
+					r_cons_printf ("\t\"0x%08"PFMT64x"\" ["
 						"URL=\"%s/0x%08"PFMT64x"\", color=\"%s\", label=\"%s\"]\n",
 						bbi->addr, fcn->name, bbi->addr,
-						bbi->traced?"yellow":"lightgray", str);
+						bbi->traced?"yellow":(
+							(color_current && r_anal_bb_is_in_offset(bbi, core->offset))?"lightblue":"lightgray"),
+						str);
 				}
 			}
 			free (str);
@@ -1260,7 +1263,8 @@ R_API void r_core_anal_coderefs(RCore *core, ut64 addr, int fmt) {
 						 fcnr->type==R_ANAL_REF_TYPE_CALL)?"green":"red",
 						flag->name, fcnr->addr);
 					r_cons_printf ("\t\"0x%08"PFMT64x"\" "
-						"[label=\"%s\" URL=\"%s/0x%08"PFMT64x"\"];\n",
+						"[label=\"%s\""
+						" URL=\"%s/0x%08"PFMT64x"\"];\n",
 						fcnr->addr, flag->name,
 						flag->name, fcnr->addr);
 				}

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -753,7 +753,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 	char *pal_jump = palColorFor ("graph.true");
 	char *pal_fail = palColorFor ("graph.false");
 	char *pal_trfa = palColorFor ("graph.trufae");
-	bool color_current = r_config_get_i(core->config, "graph.gv.current");
+	bool color_current = r_config_get_i (core->config, "graph.gv.current");
 
 	if (is_keva) {
 		char ns[64];
@@ -940,7 +940,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 						"URL=\"%s/0x%08"PFMT64x"\", color=\"%s\", label=\"%s\"]\n",
 						bbi->addr, fcn->name, bbi->addr,
 						bbi->traced?"yellow":(
-							(color_current && r_anal_bb_is_in_offset(bbi, core->offset))?"lightblue":"lightgray"),
+							(color_current && r_anal_bb_is_in_offset (bbi, core->offset))?"lightblue":"lightgray"),
 						str);
 				}
 			}

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1719,7 +1719,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("graph.gv.node", "", "Custom graphviz node style for aga, agc, ...");
 	SETPREF("graph.gv.edge", "", "Custom graphviz edge style for aga, agc, ...");
 	SETPREF("graph.gv.graph", "", "Custom graphviz graph style for aga, agc, ...");
-
+	SETPREF("graph.gv.current", "false", "Color current node differently.");
 	/* hud */
 	SETPREF("hud.path", "", "Set a custom path for the HUD file");
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -110,9 +110,13 @@ typedef struct r_cons_palette_t {
 	char *graph_box;
 	char *graph_box2;
 	char *graph_box3;
+	char *graph_box4;
 	char *graph_true;
 	char *graph_false;
 	char *graph_trufae;
+	char *graph_traced;
+	char *graph_current;
+	
 
 #define R_CONS_PALETTE_LIST_SIZE 8
 	char *list[R_CONS_PALETTE_LIST_SIZE];
@@ -270,6 +274,7 @@ typedef struct r_cons_t {
 #define Color_BCYAN     "\x1b[1;36m"
 #define Color_BBLUE     "\x1b[1;34m"
 #define Color_BGRAY     "\x1b[1;38m"
+
 
 #define Colors_PLAIN { \
 	Color_BLACK, Color_RED, Color_WHITE, \


### PR DESCRIPTION
Colours current node in Graphviz output (`ag` command) 'lightblue'.

Add `graph.gv.current` option to config with default to `false`