### PR TITLE
Include refactor

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake, maijin */
 
 #include "r_util.h"
+#include "r_core.h"
 
 static void find_refs(RCore *core, const char *glob) {
 	char cmd[128];
@@ -1575,6 +1576,7 @@ void cmd_anal_reg (RCore *core, const char *str) {
 		}
 		break;
 	case 'p': // drp
+		// XXX we have to break out .h for these cmd_xxx files.
 		cmd_reg_profile (core, str);
 		break;
 	case 't': // "drt"

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -1,5 +1,6 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
 
+#include "r_core.h"
 
 static void showhelp(RCore *core) {
 	const char* help_msg[] = {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1,5 +1,9 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake */
 
+#include "r_core.h"
+#include "r_util.h"
+#include "sdb/sdb.h"
+
 #define TN_KEY_LEN 32
 #define TN_KEY_FMT "%"PFMT64u
 

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -1,4 +1,7 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_egg.h"
 
 static void cmd_egg_option (REgg *egg, const char *key, const char *input) {
 	if (!*input) return;

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -1,4 +1,8 @@
 /* radare2 - LGPL - Copyright 2009-2016 - pancake */
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "r_core.h"
 
 static char *curtheme = NULL;
 static bool getNext = false;
@@ -155,6 +159,7 @@ static int cmd_eval(void *data, const char *input) {
 		}
 		return true;
 	case 'x': // exit
+		// XXX we need headers for the cmd_xxx files.
 		return cmd_quit (data, "");
 	case 'j':
 		r_config_list (core->config, NULL, 'j');
@@ -225,7 +230,7 @@ static int cmd_eval(void *data, const char *input) {
 			break;
 		case 's': r_cons_pal_show (); break; // "ecs"
 		case '*': r_cons_pal_list (1); break; // "ec*"
-		case 'h': // echo 
+		case 'h': // echo
 			if (( p = strchr (input, ' ') )) {
 				r_cons_strcat (p+1);
 				r_cons_newline ();

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -1,4 +1,8 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake */
+#include <stddef.h>
+
+#include "r_cons.h"
+#include "r_core.h"
 
 static void flagbars(RCore *core) {
 	int total = 0;

--- a/libr/core/cmd_hash.c
+++ b/libr/core/cmd_hash.c
@@ -1,4 +1,10 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake, nibble */
+#include <stddef.h>
+
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_hash.h"
+#include "r_types_base.h"
 
 typedef void (*HashHandler)(const ut8 *block, int len);
 

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -1,4 +1,9 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake */
+#include <stddef.h>
+
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_util.h"
 
 static const char* findBreakChar(const char *s) {
 	while (*s) {
@@ -146,6 +151,7 @@ static int cmd_help(void *data, const char *input) {
 	case 'd':
 		if (input[1]=='.'){
 			int cur = R_MAX(core->print->cur, 0);
+			// XXX: we need cmd_xxx.h (cmd_anal.h)
 			core_anal_bytes(core, core->block + cur, core->blocksize, 1, 'd');
 		} else if (input[1]==' '){
 			char *d = r_asm_describe (core->assembler, input+2);

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -1,4 +1,10 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake */
+#include <string.h>
+
+#include "r_bin.h"
+#include "r_config.h"
+#include "r_cons.h"
+#include "r_core.h"
 
 #define PAIR_WIDTH 9
 // TODO: reuse implementation in core/bin.c

--- a/libr/core/cmd_log.c
+++ b/libr/core/cmd_log.c
@@ -1,4 +1,9 @@
 /* radare - LGPL - Copyright 2009-2014 - pancake */
+#include <string.h>
+
+#include "r_config.h"
+#include "r_cons.h"
+#include "r_core.h"
 
 static int textlog_chat (RCore *core) {
 	char prompt[64];

--- a/libr/core/cmd_macro.c
+++ b/libr/core/cmd_macro.c
@@ -1,4 +1,6 @@
 /* radare - LGPL - Copyright 2009-2014 - pancake */
+#include "r_cmd.h"
+#include "r_core.h"
 
 static int cmd_macro(void *data, const char *input) {
 	char *buf = NULL;

--- a/libr/core/cmd_magic.c
+++ b/libr/core/cmd_magic.c
@@ -1,4 +1,11 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include <stddef.h>
+
+#include "r_config.h"
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_magic.h"
+#include "r_types.h"
 
 /* ugly global vars */
 static int magicdepth = 99; //XXX: do not use global var here

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -1,4 +1,11 @@
 /* radare2 - LGPL - Copyright 2009-2016 - pancake */
+#include "r_anal.h"
+#include "r_bin.h"
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_print.h"
+#include "r_types.h"
+#include "sdb/sdb.h"
 
 static int remove_meta_offset(RCore *core, ut64 offset) {
 	char aoffset[64];

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1,4 +1,9 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include "r_list.h"
+#include "r_config.h"
+#include "r_core.h"
+#include "r_print.h"
+#include "r_bin.h"
 
 
 static inline ut32 find_binfile_id_by_fd (RBin *bin, ut32 fd) {
@@ -261,6 +266,7 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 	r_config_set_i (core->config, "cfg.debug", true);
 	newfile = newfile2;
 
+	//XXX: need cmd_debug.h for r_debug_get_baddr
 	ut64 new_baddr = r_debug_get_baddr (core, newfile);
 	ut64 old_baddr = r_config_get_i (core->config, "bin.baddr");
 	if (old_baddr != new_baddr) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1,4 +1,10 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake */
+#include "r_asm.h"
+#include "r_core.h"
+#include "r_config.h"
+#include "r_print.h"
+#include "r_types.h"
+#include "r_util.h"
 
 #define R_CORE_MAX_DISASM (1024*1024*8)
 
@@ -2815,7 +2821,10 @@ static int cmd_print(void *data, const char *input) {
 				"| e dir.magic  # defaults to "R_MAGIC_PATH"\n"
 				"| /m           # search for magic signatures\n"
 				);
-		} else r_core_magic (core, input+1, true);
+		} else {
+			// XXX: need cmd_magic header for r_core_magic
+			r_core_magic (core, input+1, true);
+		}
 		break;
 	case 'u': //pu
 		if (input[1]=='?') {

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -1,4 +1,7 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include "r_config.h"
+#include "r_core.h"
+#include "r_print.h"
 
 static int cmd_project(void *data, const char *input) {
 	RCore *core = (RCore *)data;

--- a/libr/core/cmd_quit.c
+++ b/libr/core/cmd_quit.c
@@ -1,4 +1,5 @@
 /* radare - LGPL - Copyright 2009-2014 - pancake */
+#include "r_core.h"
 
 static int cmd_quit(void *data, const char *input) {
 	RCore *core = (RCore *)data;

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1,4 +1,10 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake */
+#include <stddef.h>
+
+#include "r_core.h"
+#include "r_io.h"
+#include "r_list.h"
+#include "r_types_base.h"
 
 static int preludecnt = 0;
 static int searchflags = 0;

--- a/libr/core/cmd_section.c
+++ b/libr/core/cmd_section.c
@@ -1,4 +1,8 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_types.h"
+#include "r_io.h"
 
 static int __dump_sections_to_disk(RCore *core) {
 	char file[128];

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -1,4 +1,10 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include "r_types.h"
+#include "r_config.h"
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_debug.h"
+#include "r_io.h"
 
 static void __init_seek_line (RCore *core) {
 	ut64 from, to;

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -1,4 +1,10 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake, oddcoder, Anton Kochkov, Jody Frankowski */
+#include <string.h>
+
+#include "r_anal.h"
+#include "r_cons.h"
+#include "r_core.h"
+#include "sdb/sdb.h"
 
 static void show_help(RCore *core) {
 	const char *help_message[] = {

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -1,4 +1,12 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include <stdbool.h>
+#include <string.h>
+
+#include "r_crypto.h"
+#include "r_config.h"
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_io.h"
 
 R_API int cmd_write_hexpair(RCore* core, const char* pairs) {
 	ut8 *buf = malloc (strlen (pairs) + 1);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1,4 +1,9 @@
 /* radare - LGPL - Copyright 2009-2015 - pancake */
+#include "r_anal.h"
+#include "r_cons.h"
+#include "r_core.h"
+#include "r_list.h"
+#include "r_sign.h"
 
 static int cmd_zign(void *data, const char *input) {
 	RCore *core = (RCore *)data;
@@ -92,8 +97,8 @@ static int cmd_zign(void *data, const char *input) {
 			if (ptr) {
 				*ptr = 0;
 				r_sign_add (core->sign, core->anal, (int)*input, input+2, ptr+1);
-			} 
-		}	
+			}
+		}
 		break;
 	case 'c':
 		item = r_sign_check (core->sign, core->block, core->blocksize);


### PR DESCRIPTION
refactor the includes so that automated tools such as youcompleteme will work with the r2 codebase.

all of the crossreference tools rely on the includes, so this will make them work much better.