### PR TITLE
adding support for esp register in afCa afCa 

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -997,7 +997,7 @@ static void handle_show_functions(RCore *core, RDisasmState *ds) {
 				}
 				break;
 			case 'e':
-				r_cons_printf ("var %s %s @ %s+0x%x\n",
+				r_cons_printf ("var %s %s @ %s+0x%x",
 					var->type, var->name,
 					core->anal->reg->name[R_REG_NAME_SP],
 					var->delta);


### PR DESCRIPTION
test case
```
r2 - 
wx 83ec108b44241899f77c241c8b44241401d08944240c8b44242099f77c24288b44240c01d0894424088b5424148b44240c8d0c028b44242c99f7f98b44240801d0894424048b54240c8b44240801c28b44240401d083c410c38d4c240483e4f0ff71fc5589e55183ec046a076a066a056a046a036a026a01e883ffffff83c41c83ec08506844850408e847feffff83c410b8000000008b4dfcc98d61fcc36690669066909055575653e887feffff81c3371b000083ec0c8b6c24208db30cffffffe8d3fdffff8d8308ffffff29c6c1fe0285f6742531ff8db60000000083ec04ff74242cff74242c55ff94bb08ffffff83c70183c41039f775e383c40c5b5e5f
aa
afCa
pdf
```
this should output all esp args detected and autorenamed named 