### PR TITLE
adding support for handling sp registers at parsing

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -272,22 +272,8 @@ static ut64 search_reg_val(RAnal *anal, ut8 *buf, ut64 len, ut64 addr, char *reg
 void extract_arg (RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg, const char *sign, char type) {
 	char *varname, *esil_buf, *ptr_end, *addr, *op_esil;
 	st64 ptr;
-	int len, lenmax=50;
-	char *sig = malloc (sizeof (char)*lenmax+1);
+	char *sig = r_str_newf (",%s,%s", reg, sign);
 	if(!sig) return;
-	strcpy(sig,",");
-	strncat (sig, reg, lenmax-1);
-	len = strlen(sig);
-	if (len > lenmax - 3) { /*<=============-i
-		1 for first colon		||
-		1 for the next colon		||
-		at least one for the sign	/|
-		total of 3 =====================_| */
-		return;
-	}
-	strncat (sig, ",", lenmax - len++);
-	strncat (sig, sign, lenmax - len);
-	//strcat (sig,",[4],");
 	op_esil = r_strbuf_get (&op->esil);
 	if (!op_esil) {
 		return;


### PR DESCRIPTION
```
r2 - 
wx 83ec108b44241899f77c241c8b44241401d08944240c8b44242099f77c24288b44240c01d0894424088b5424148b44240c8d0c028b44242c99f7f98b44240801d0894424048b54240c8b44240801c28b44240401d083c410c38d4c240483e4f0ff71fc5589e55183ec046a076a066a056a046a036a026a01e883ffffff83c41c83ec08506844850408e847feffff83c410b8000000008b4dfcc98d61fcc36690669066909055575653e887feffff81c3371b000083ec0c8b6c24208db30cffffffe8d3fdffff8d8308ffffff29c6c1fe0285f6742531ff8db60000000083ec04ff74242cff74242c55ff94bb08ffffff83c70183c41039f775e383c40c5b5e5f
aa
afCa
pdf
```
now it catches all the arguments/vars and rename them or at least should ( ͡° ͜ʖ ͡°)