### PR TITLE
Fix incorrect assembly for x86 mov

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1088,7 +1088,7 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 						data[l++] = 0x24;
 					} else if (r==5) { // EBP
 						data[l++] = getreg (arg)<<3 | r | 0x40;
-					} else data[l++] = getreg (arg) | r | 0x40;
+					} else data[l++] = getreg (arg)<<3 | r | 0x40;
 					data[l++] = r_num_math (NULL, delta) * N;
 				} else {
 					int r = getreg (arg2);


### PR DESCRIPTION
Fixes issue #4745

The opcode for the dest was set incorrectly, missing the `<<3`

    $ rasm2 -a x86.nz -b 32 "mov esi, [esi + 8]"
    8b7608

Added a test case for this to radare2-regressions as a separate PR. radare/radare2-regressions#380