### PR TITLE
ESIL: add floating point instructions

### DIFF
--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -877,6 +877,7 @@ enum {
 	R_ANAL_ESIL_PARM_INTERNAL,
 	R_ANAL_ESIL_PARM_REG,
 	R_ANAL_ESIL_PARM_NUM,
+	R_ANAL_ESIL_PARM_FLOAT,
 };
 
 /* Constructs to convert from ESIL to REIL */
@@ -995,6 +996,7 @@ typedef struct r_anal_esil_t {
 	ut64 old;	//used for carry-flagging and borrow-flagging
 	ut64 cur;	//used for carry-flagging and borrow-flagging
 	ut8 lastsz;	//in bits //used for signature-flag
+	int curtype;	//used for detecting type of flags (double / ut64)
 	/* native ops and custom ops */
 	Sdb *ops;
 	Sdb *interrupts;

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -370,6 +370,7 @@ R_API const char *r_num_calc_index (RNum *num, const char *p);
 R_API ut64 r_num_chs (int cylinder, int head, int sector, int sectorsize);
 R_API int r_num_is_valid_input(RNum *num, const char *input_value);
 R_API ut64 r_num_get_input_value(RNum *num, const char *input_value);
+R_API double r_num_get_float (RNum *num, const char *str);
 R_API char* r_num_as_string(RNum *___, ut64 n);
 R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex);
 

--- a/libr/util/num.c
+++ b/libr/util/num.c
@@ -1,9 +1,7 @@
 /* radare - LGPL - Copyright 2007-2015 - pancake */
 
-#if __WINDOWS__ && MINGW32 && !__CYGWIN__
 #include <stdlib.h>
-#endif
-
+#include <r_types.h>
 #include <r_util.h>
 #define R_NUM_USE_CALC 1
 
@@ -279,15 +277,19 @@ R_API ut64 r_num_math(RNum *num, const char *str) {
 #endif
 }
 
-R_API int r_num_is_float(struct r_num_t *num, const char *str) {
+R_API int r_num_is_float (struct r_num_t *num, const char *str) {
 	// TODO: also support 'f' terminated strings
 	return (strchr (str, '.') != NULL)? R_TRUE:R_FALSE;
 }
 
-R_API double r_num_get_float(struct r_num_t *num, const char *str) {
-	double d = 0.0f;
-	sscanf (str, "%lf", &d);
-	return d;
+R_API double r_num_get_float (RNum *num, const char *str) {
+	typedef union {
+		ut64 n;
+		double d;
+	} dualtype;
+	dualtype dual;
+	dual.n = (ut64)r_num_get (NULL, str);
+	return (double)dual.d;
 }
 
 R_API int r_num_to_bits (char *out, ut64 num) {


### PR DESCRIPTION
Adds mul, div, add, sub and eq variants.

Signed-off-by: Damien Zammit <damien@zamaudio.com>