### PR TITLE
Add support for dword offsets

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1097,7 +1097,7 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 					} else data[l++] = getreg (arg)<<3 | r | mask;
 
 					data[l++] = d;
-					if ((ST8_MIN > d) && (d > ST8_MAX)) {:
+					if ((ST8_MIN > d) && (d > ST8_MAX)) {
 						data[l++] = d>>8;
 						data[l++] = d>>16;
 						data[l++] = d>>24;

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1039,6 +1039,7 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 				delta = strchr (arg, '+');
 				//if (!delta) delta = strchr (arg, '-'); // XXX: TODO: handle negative off
 				if (delta) {
+					eprintf("1 handle + \n");
 					*delta++ = 0;
 				} else {
 					delta = strchr (arg, '-');
@@ -1081,15 +1082,28 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 					}
 				}
 				data[l++] = 0x8b;
-				if (delta) {
+				if (delta) {					
+					ut8 mask = 0x40;
+					ut32 d = r_num_math (NULL, delta) * N;
+					// Check if delta is short or dword
+					if (d>>8 > 0) {
+						mask = 0x80;
+					}
 					int r = getreg (arg2);
 					if (r==4) { //ESP
-						data[l++] = getreg (arg)<<3 | r | 0x40;
+						data[l++] = getreg (arg)<<3 | r | mask;
 						data[l++] = 0x24;
 					} else if (r==5) { // EBP
-						data[l++] = getreg (arg)<<3 | r | 0x40;
-					} else data[l++] = getreg (arg)<<3 | r | 0x40;
-					data[l++] = r_num_math (NULL, delta) * N;
+						data[l++] = getreg (arg)<<3 | r | mask;
+					} else data[l++] = getreg (arg)<<3 | r | mask;					
+					
+					data[l++] = d;
+					if (d>>8 > 0) {
+						// Split...						
+						data[l++] = d>>8;
+						data[l++] = d>>16;
+						data[l++] = d>>24;
+					}
 				} else {
 					int r = getreg (arg2);
 					if (r==4) { //ESP

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1039,7 +1039,6 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 				delta = strchr (arg, '+');
 				//if (!delta) delta = strchr (arg, '-'); // XXX: TODO: handle negative off
 				if (delta) {
-					eprintf("1 handle + \n");
 					*delta++ = 0;
 				} else {
 					delta = strchr (arg, '-');
@@ -1082,7 +1081,7 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 					}
 				}
 				data[l++] = 0x8b;
-				if (delta) {					
+				if (delta) {
 					ut8 mask = 0x40;
 					ut32 d = r_num_math (NULL, delta) * N;
 					// Check if delta is short or dword
@@ -1095,11 +1094,10 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 						data[l++] = 0x24;
 					} else if (r==5) { // EBP
 						data[l++] = getreg (arg)<<3 | r | mask;
-					} else data[l++] = getreg (arg)<<3 | r | mask;					
-					
+					} else data[l++] = getreg (arg)<<3 | r | mask;
+
 					data[l++] = d;
-					if ((ST8_MIN > d) && (d > ST8_MAX)) {
-						// Split...						
+					if ((ST8_MIN > d) && (d > ST8_MAX)) {:
 						data[l++] = d>>8;
 						data[l++] = d>>16;
 						data[l++] = d>>24;

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1086,7 +1086,7 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 					ut8 mask = 0x40;
 					ut32 d = r_num_math (NULL, delta) * N;
 					// Check if delta is short or dword
-					if (d>>8 > 0) {
+					if ((ST8_MIN > d) && (d > ST8_MAX)) {
 						mask = 0x80;
 					}
 					int r = getreg (arg2);
@@ -1098,7 +1098,7 @@ SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
 					} else data[l++] = getreg (arg)<<3 | r | mask;					
 					
 					data[l++] = d;
-					if (d>>8 > 0) {
+					if ((ST8_MIN > d) && (d > ST8_MAX)) {
 						// Split...						
 						data[l++] = d>>8;
 						data[l++] = d>>16;


### PR DESCRIPTION
`nz` assembler now handles dword size offsets aswell as negative offsets. 

Tests added to regression tests with PR radare/radare2-regressions#388