### PR TITLE
Expand on error message for unsigned OSX binary

### DIFF
--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -384,6 +384,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 			break;
 		case EINVAL:
 			perror ("ptrace: Cannot attach");
+			eprintf ("Possibly unsigned r2. Please see doc/osx.md\n");
 			eprintf ("ERRNO: %d (EINVAL)\n", errno);
 			break;
 		default:


### PR DESCRIPTION
If r2 is unsigned the message the user gets when trying to debug with it isn't clear as to what the problem is. Add a line to suggest most likely issue and go see the docs to get a cert.