### PR TITLE
util/print: use `screen_bounds` to store the first non visible address

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -967,3 +967,9 @@ R_API void r_cons_chop () {
 		I.buffer_len--;
 	}
 }
+
+R_API void r_cons_bind(RConsBind *bind) {
+	if (!bind) return;
+	bind->get_size = r_cons_get_size;
+	bind->get_cursor = r_cons_get_cursor;
+}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1177,7 +1177,6 @@ R_API int r_core_init(RCore *core) {
 	core->sdb = sdb_new (NULL, "r2kv.sdb", 0); // XXX: path must be in home?
 	core->lastsearch = NULL;
 	core->incomment = false;
-	core->screen_bounds = 0LL;
 	core->config = NULL;
 	core->http_up = false;
 	core->print = r_print_new ();
@@ -1233,6 +1232,7 @@ R_API int r_core_init(RCore *core) {
 		r_line_hist_load (R2_HOMEDIR"/history");
 	}
 	core->print->cons = core->cons;
+	r_cons_bind (&core->print->consbind);
 	core->cons->num = core->num;
 	core->lang = r_lang_new ();
 	core->lang->cmd_str = (char *(*)(void *, const char *))r_core_cmd_str;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1439,16 +1439,7 @@ static void handle_print_stackptr(RCore *core, RDisasmState *ds) {
 }
 
 static void handle_print_offset(RCore *core, RDisasmState *ds) {
-	if (core->screen_bounds) {
-		int r, rc;
-
-		(void)r_cons_get_size (&r);
-		(void)r_cons_get_cursor (&rc);
-
-		if (rc > r - 1 && core->screen_bounds == 1) {
-			core->screen_bounds = ds->at;
-		}
-	}
+	r_print_set_screenbounds (core->print, ds->at);
 	if (ds->show_offset) {
 		static RFlagItem sfi = {0};
 		RFlagItem *fi;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -8,7 +8,7 @@
 static int obs = 0;
 static int blocksize = 0;
 static int autoblocksize = 1;
-static void r_core_visual_refresh (RCore *core);
+static void visual_refresh(RCore *core);
 #define PIDX (R_ABS(core->printidx%NPF))
 
 #define debugfmt_default "?0;f tmp;sr SP;pxw 64;?1;dr=;?1;s-;s tmp;f-tmp;pd $r"
@@ -28,7 +28,7 @@ static int visual_repeat_thread(RThread *th) {
 	for (;;) {
 		if (core->cons->breaked)
 			break;
-		r_core_visual_refresh (core);
+		visual_refresh (core);
 		r_cons_flush ();
 		r_cons_gotoxy (0, 0);
 		r_cons_printf ("[@%d] ", i++);
@@ -995,10 +995,10 @@ static bool fix_cursor(RCore *core) {
 	bool res = false;
 
 	if (!core->print->cur_enabled) return false;
-	if (core->screen_bounds > 1) {
-		bool off_is_visible = core->offset < core->screen_bounds;
-		bool cur_is_visible = core->offset + p->cur < core->screen_bounds;
-		bool is_close = core->offset + p->cur < core->screen_bounds + 32;
+	if (core->print->screen_bounds > 1) {
+		bool off_is_visible = core->offset < core->print->screen_bounds;
+		bool cur_is_visible = core->offset + p->cur < core->print->screen_bounds;
+		bool is_close = core->offset + p->cur < core->print->screen_bounds + 32;
 
 		if (!cur_is_visible && !is_close) {
 			// when the cursor is not visible and it's far from the
@@ -1096,7 +1096,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 							op->type == R_ANAL_OP_TYPE_CCALL) {
 						if (core->print->cur_enabled) {
 							int delta = R_ABS ((st64)op->jump-(st64)offset);
-							if ( op->jump < core->offset || op->jump >= core->screen_bounds) {
+							if ( op->jump < core->offset || op->jump >= core->print->screen_bounds) {
 								r_io_sundo_push (core->io, offset);
 								r_core_visual_seek_animation (core, op->jump);
 								core->print->cur = 0;
@@ -1486,9 +1486,9 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 		if (core->print->cur_enabled) {
 			cursor_nextrow (core, true);
 		} else {
-			if (core->screen_bounds > 1 && core->screen_bounds >= core->offset) {
-				ut64 addr = core->screen_bounds;
-				if (core->screen_bounds == core->offset) {
+			if (core->print->screen_bounds > 1 && core->print->screen_bounds >= core->offset) {
+				ut64 addr = core->print->screen_bounds;
+				if (core->print->screen_bounds == core->offset) {
 					addr += r_asm_disassemble (core->assembler, &op, core->block, 32);
 				}
 				r_core_seek (core, addr, 1);
@@ -1527,8 +1527,8 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 		if (core->print->cur_enabled) {
 			cursor_prevrow (core, true);
 		} else {
-			if (core->screen_bounds > 1 && core->screen_bounds > core->offset) {
-				int delta = (core->screen_bounds - core->offset);
+			if (core->print->screen_bounds > 1 && core->print->screen_bounds > core->offset) {
+				int delta = (core->print->screen_bounds - core->offset);
 				if (core->offset >= delta)
 					r_core_seek (core, core->offset - delta, 1);
 				else
@@ -1875,10 +1875,10 @@ R_API void r_core_visual_title (RCore *core, int color) {
 	{
 		int bsize = core->cons->rows * 5;
 
-		if (core->screen_bounds > 1) {
+		if (core->print->screen_bounds > 1) {
 			// estimate new blocksize with the size of the last
 			// printed instructions
-			int new_sz = core->screen_bounds - core->offset + 32;
+			int new_sz = core->print->screen_bounds - core->offset + 32;
 			if (new_sz > bsize) bsize = new_sz;
 		}
 		r_core_block_size (core, bsize);
@@ -1951,7 +1951,7 @@ R_API void r_core_visual_title (RCore *core, int color) {
 	if (color) r_cons_strcat (Color_RESET);
 }
 
-static int r_core_visual_responsive (RCore *core) {
+static int visual_responsive(RCore *core) {
 	int h, w = r_cons_get_size (&h);
 	if (r_config_get_i (core->config, "scr.responsive")) {
 		if (w<110) {
@@ -1986,14 +1986,14 @@ static int r_core_visual_responsive (RCore *core) {
 	return w;
 }
 
-static void r_core_visual_refresh (RCore *core) {
+static void visual_refresh(RCore *core) {
 	int w;
 	const char *vi, *vcmd;
 	if (!core) return;
 	r_print_set_cursor (core->print, core->print->cur_enabled, core->print->ocur, core->print->cur);
 	core->cons->blankline = true;
 
-	w = r_core_visual_responsive (core);
+	w = visual_responsive (core);
 
 	if (autoblocksize) {
 		r_cons_gotoxy (0, 0);
@@ -2002,7 +2002,6 @@ static void r_core_visual_refresh (RCore *core) {
 	}
 	r_cons_flush ();
 	r_cons_print_clear ();
-	//core->curtab = 0;
 
 	vi = r_config_get (core->config, "cmd.cprompt");
 	if (vi && *vi) {
@@ -2036,15 +2035,15 @@ static void r_core_visual_refresh (RCore *core) {
 	if (vcmd && *vcmd) {
 		// disable screen bounds when it's a user-defined command
 		// because it can cause some issues
-		core->screen_bounds = 0;
+		core->print->screen_bounds = 0;
 		r_core_cmd (core, vcmd, 0);
 	} else {
-		core->screen_bounds = 1LL;
-		r_core_cmd0 (core, zoom? "pz": printfmt[PIDX]);
+		core->print->screen_bounds = 1LL;
+		r_core_cmd0 (core, zoom ? "pz" : printfmt[PIDX]);
 	}
-	if (core->screen_bounds != 1LL) {
+	if (core->print->screen_bounds != 1LL) {
 		r_cons_printf ("[0x%08"PFMT64x"..0x%08"PFMT64x"]\n",
-			core->offset, core->screen_bounds);
+			core->offset, core->print->screen_bounds);
 	}
 	blocksize = core->num->value? core->num->value : core->blocksize;
 
@@ -2130,7 +2129,7 @@ R_API int r_core_visual(RCore *core, const char *input) {
 		r_cons_show_cursor (false);
 		if (wheel) r_cons_enable_mouse (true);
 		core->cons->event_data = core;
-		core->cons->event_resize = (RConsEvent)r_core_visual_refresh;
+		core->cons->event_resize = (RConsEvent)visual_refresh;
 		flags = core->print->flags;
 		color = r_config_get_i (core->config, "scr.color");
 		if (color) flags |= R_PRINT_FLAGS_COLOR;
@@ -2150,7 +2149,7 @@ R_API int r_core_visual(RCore *core, const char *input) {
 			r_core_cmd (core, cmdprompt, 0);
 		}
 		core->print->vflush = !skip;
-		r_core_visual_refresh (core);
+		visual_refresh (core);
 		if (!skip) {
 			ch = r_cons_readchar ();
 			r_core_visual_show_char (core, ch);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -42,6 +42,14 @@ extern "C" {
 
 R_LIB_VERSION_HEADER(r_cons);
 
+typedef int (*RConsGetSize)(int *rows);
+typedef int (*RConsGetCursor)(int *rows);
+
+typedef struct r_cons_bind_t {
+	RConsGetSize get_size;
+	RConsGetCursor get_cursor;
+} RConsBind;
+
 typedef struct r_cons_grep_t {
 	char strings[R_CONS_GREP_WORDS][R_CONS_GREP_WORD_SIZE];
 	int nstrings;
@@ -116,7 +124,6 @@ typedef struct r_cons_palette_t {
 	char *graph_trufae;
 	char *graph_traced;
 	char *graph_current;
-	
 
 #define R_CONS_PALETTE_LIST_SIZE 8
 	char *list[R_CONS_PALETTE_LIST_SIZE];
@@ -462,6 +469,7 @@ R_API int r_cons_get_column (void);
 R_API char *r_cons_message(const char *msg);
 R_API void r_cons_set_title(const char *str);
 R_API int r_cons_enable_mouse(const int enable);
+R_API void r_cons_bind(RConsBind *bind);
 #endif
 
 /* r_line */

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -139,9 +139,6 @@ typedef struct r_core_t {
 	char *lastcmd;
 	int cmdrepeat;
 	ut64 inc;
-	// represents the first not-visible offset on the screen
-	// (only when in visual disasm mode)
-	ut64 screen_bounds;
 	int rtr_n;
 	RCoreRtrHost rtr_host[RTR_MAX_HOSTS];
 	int curasmstep;

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -69,6 +69,7 @@ typedef struct r_print_t {
 	RPrintColorFor hasrefs;
 	RStrHT *formats;
 	RCons *cons;
+	RConsBind consbind;
 	RNum *num;
 	RReg *reg;
 	RRegItem* (*get_register)(RReg *reg, const char *name, int type);
@@ -84,6 +85,9 @@ typedef struct r_print_t {
 	int row_offsets_sz;
 	// when true it makes visual mode flush the buffer to screen
 	bool vflush;
+	// represents the first not-visible offset on the screen
+	// (only when in visual disasm mode)
+	ut64 screen_bounds;
 } RPrint;
 
 #ifdef R_API
@@ -154,6 +158,7 @@ R_API int r_print_pack7bit(const char *src, char *dest);
 R_API char *r_print_stereogram_bytes(const ut8 *buf, int len);
 R_API char *r_print_stereogram(const char *bump, int w, int h);
 R_API void r_print_stereogram_print(RPrint *p, const char *buf);
+R_API void r_print_set_screenbounds(RPrint *p, ut64 addr);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
It fixes #4754.

Main things to notice:

* screen_bounds was moved from RCore to RPrint because otherwise it wasn't accessible from r_print_hexdump
* I added RConsBind to r_cons.h so that `r_cons_get_size` and `r_cons_get_cursor` would be accessible from print.c without having circular dependencies at compilation time.
* I added a new api, r_print_set_screenbounds.