### PR TITLE
list all encoders/decoders supported by woE/woD and rahash2 -E/-D

### DIFF
--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -268,11 +268,20 @@ static int do_help(int line) {
 static void algolist() {
 	ut64 bits;
 	int i;
+	eprintf ("Available Hashes: \n");
 	for (i = 0; ; i++) {
 		bits = ((ut64)1) << i;
 		const char *name = r_hash_name (bits);
 		if (!name || !*name) break;
-		printf ("%s\n", name);
+		printf ("  %s\n", name);
+	}
+	eprintf ("\n");
+	eprintf ("Available Crypto Algos: \n");
+	for (i = 0; ; i++) {
+		bits = ((ut64)1) << i;
+		const char *name = r_crypto_name (bits);
+		if (!name || !*name) break;
+		printf ("  %s\n", name);
 	}
 }
 

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -198,8 +198,22 @@ static void cmd_write_op (RCore *core, const char *input) {
 				encrypt_or_decrypt_block (core, algo, key, direction, iv);
 			} else {
 				eprintf ("Usage: wo%c [algo] [key] [IV]\n", ((!direction)?'E':'D'));
-				eprintf ("TODO: list currently supported crypto algorithms\n");
-				eprintf ("  rc2, rc4, xor, blowfish, aes, rot, ror, rol\n");
+				eprintf ("Currently supported hashes:\n");
+				ut64 bits;
+				int i;
+				for (i = 0; ; i++) {
+					bits = ((ut64)1) << i;
+					const char *name = r_hash_name (bits);
+					if (!name || !*name) break;
+						printf ("  %s\n", name);
+				}
+				eprintf ("Currently supported crypto algos:\n");
+				for (i = 0; ; i++) {
+					bits = ((ut64)1) << i;
+					const char *name = r_crypto_name (bits);
+					if (!name || !*name) break;
+						printf ("  %s\n", name);
+				}
 			}
 			free (args);
 		}

--- a/libr/crypto/crypto.c
+++ b/libr/crypto/crypto.c
@@ -5,6 +5,29 @@
 
 R_LIB_VERSION (r_crypto);
 
+struct { const char *name; ut64 bit; }
+static const crypto_name_bytes[] = {
+	{"all", UT64_MAX},
+	{"rc2", R_CRYPTO_RC2},
+	{"rc4", R_CRYPTO_RC4},
+	{"rc6", R_CRYPTO_RC6},
+	{"aes-ecb", R_CRYPTO_AES_ECB},
+	{"aes-cbc", R_CRYPTO_AES_CBC},
+	{"ror", R_CRYPTO_ROR},
+	{"rol", R_CRYPTO_ROL},
+	{"rot", R_CRYPTO_ROT},
+	{"blowfish", R_CRYPTO_BLOWFISH},
+	{NULL, 0}
+};
+
+R_API const char *r_crypto_name(ut64 bit) {
+	int i;
+	for (i=1; crypto_name_bytes[i].bit; i++)
+		if (bit & crypto_name_bytes[i].bit)
+			return crypto_name_bytes[i].name;
+	return "";
+}
+
 static RCryptoPlugin *crypto_static_plugins[] = {
 	R_CRYPTO_STATIC_PLUGINS
 };

--- a/libr/hash/hash.c
+++ b/libr/hash/hash.c
@@ -25,6 +25,9 @@ static const hash_name_bytes[] = {
 	 {"hamdist", R_HASH_HAMDIST},
 	 {"pcprint", R_HASH_PCPRINT},
 	 {"mod255", R_HASH_MOD255},
+	 {"base64",R_HASH_BASE64},
+	 {"base91",R_HASH_BASE91},
+	 {"punycode",R_HASH_PUNYCODE},
 	 {NULL, 0}
 };
 

--- a/libr/include/r_crypto.h
+++ b/libr/include/r_crypto.h
@@ -58,6 +58,7 @@ R_API int r_crypto_update(RCrypto *cry, const ut8 *buf, int len);
 R_API int r_crypto_final(RCrypto *cry, const ut8 *buf, int len);
 R_API int r_crypto_append(RCrypto *cry, const ut8 *buf, int len);
 R_API ut8 *r_crypto_get_output(RCrypto *cry, int *size);
+R_API const char *r_crypto_name(ut64 bit);
 #endif
 
 /* plugin pointers */
@@ -74,6 +75,18 @@ extern RCryptoPlugin r_crypto_plugin_base91;
 extern RCryptoPlugin r_crypto_plugin_aes_cbc;
 extern RCryptoPlugin r_crypto_plugin_punycode;
 extern RCryptoPlugin r_crypto_plugin_rc6;
+
+#define R_CRYPTO_NONE 0
+#define R_CRYPTO_RC2 1
+#define R_CRYPTO_RC4 2
+#define R_CRYPTO_RC6 4
+#define R_CRYPTO_AES_ECB 8
+#define R_CRYPTO_AES_CBC 16
+#define R_CRYPTO_ROR 32
+#define R_CRYPTO_ROL 64
+#define R_CRYPTO_ROT 128
+#define R_CRYPTO_BLOWFISH 256
+#define R_CRYPTO_ALL 0xFFFF
 
 #ifdef __cplusplus
 }

--- a/libr/include/r_hash.h
+++ b/libr/include/r_hash.h
@@ -97,7 +97,10 @@ typedef struct r_hash_seed_t {
 #define R_HASH_MOD255 16384
 #define R_HASH_XXHASH 32768
 #define R_HASH_ADLER32 65536
-#define R_HASH_ALL 0xFFFF
+#define R_HASH_BASE64 131072
+#define R_HASH_BASE91 262144
+#define R_HASH_PUNYCODE 524288
+#define R_HASH_ALL 0xFFFFF
 
 #ifdef R_API
 /* OO */

--- a/man/rahash2.1
+++ b/man/rahash2.1
@@ -37,11 +37,11 @@ Define the block size
 .It Fl c Ar hash
 Compare the computed hash with this one. Allowed only when a single hash is computed.
 .It Fl D Ar algo
-Decrypt instead of hash using the given algorithm (base64, base91, rc4, aes, xor, blowfish, rot)
+Decrypt instead of hash using the given algorithm (base64, base91, rc4, aes, xor, blowfish, rot, rol, ror, rc2, rc6, punycode)
 .It Fl e
 Use little endian to display checksums
 .It Fl E Ar algo
-Encrypt instead of hash using the given algorithm ( base64, base91, rc4, aes, xor, blowfish, rot)
+Encrypt instead of hash using the given algorithm (base64, base91, rc4, aes, xor, blowfish, rot, rol, ror, rc2, rc6, punycode)
 .It Fl i Ar iters
 Apply the hash Iters times to itself+seed
 .It Fl I Ar [^]s:string|hexstr


### PR DESCRIPTION
fix https://github.com/radare/radare2/issues/4838.
The PR is somewhat incomplete. Not sure what the sizes at https://github.com/radare/radare2/blob/master/libr/include/r_hash.h#L63-L80 doing. I will update the PR after fixing it.