### PR TITLE
Correctly propogate file and line information for users of r_sys_perror

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -227,8 +227,9 @@ typedef void (*PrintfCallback)(const char *str, ...);
 
 /* TODO: Move outside */
 #define _perror(str,file,line) \
-  { char buf[128];snprintf(buf,sizeof(buf),"%s:%d %s",file,line,str);perror(buf); }
+  { char buf[128];snprintf(buf,sizeof(buf),"%s:%d %s",file,line,str);r_sys_perror_str(buf); }
 #define perror(x) _perror(x,__FILE__,__LINE__)
+#define r_sys_perror(x) _perror(x,__FILE__,__LINE__)
 
 #ifndef HAVE_EPRINTF
 #define eprintf(x,y...) fprintf(stderr,x,##y)

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -647,7 +647,7 @@ R_API const char *r_sys_arch_str(int arch);
 R_API int r_sys_arch_id(const char *arch);
 R_API bool r_sys_arch_match(const char *archstr, const char *arch);
 R_API RList *r_sys_dir(const char *path);
-R_API void r_sys_perror(const char *fun);
+R_API void r_sys_perror_str(const char *fun);
 #if __WINDOWS__ && !defined(__CYGWIN__)
 #define r_sys_mkdir(x) (CreateDirectory(x,NULL)!=0)
 #define r_sys_mkdir_failed() (GetLastError () != ERROR_ALREADY_EXISTS)

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -550,9 +550,12 @@ R_API bool r_sys_mkdirp(const char *dir) {
 	return ret;
 }
 
-R_API void r_sys_perror(const char *fun) {
+R_API void r_sys_perror_str(const char *fun) {
 #if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#pragma push_macro("perror")
+#undef perror
 	perror (fun);
+#pragma pop_macro("perror")
 #elif __WINDOWS__
 	char *lpMsgBuf;
 	LPVOID lpDisplayBuf;

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -9,7 +9,7 @@
 #endif
 
 #define BUFSIZE 1024
-void r_sys_perror(const char *fun);
+void r_sys_perror_str(const char *fun);
 
 #define ErrorExit(x) { r_sys_perror(x); return NULL; }
 static int CreateChildProcess(const char *szCmdline, HANDLE out);


### PR DESCRIPTION
From what I can tell, r_sys_perror is meant to be a platform-independent version of printing an error message. The "perror" function has been replaced (before this PR) with a macro that adds file and line information. However, if r_sys_perror is used it will incorrectly put the file/line of r_sys_perror.

Instead, we rename r_sys_perror to r_sys_perror_str (any other name should be fine) and then create a macro for it as well. To avoid calling the macro, we use the "push_macro" and "pop_macro" pragama directives. Finally, change perror() to call r_sys_perror so that it will work on all platforms.