### PR TITLE
Fix issues related to perror and r_sys_perror

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -125,7 +125,7 @@ const char *x##_version()
 #define R_LIB_VERSION(x) \
 const char *x##_version () { return "" R2_GITTAP; }
 
-#define TODO(x) eprintf(__FUNCTION__"  " x)
+#define TODO(x) eprintf(__func__"  " x)
 
 // TODO: FS or R_SYS_DIR ??
 #undef FS
@@ -217,6 +217,11 @@ typedef void (*PrintfCallback)(const char *str, ...);
 //#define R_BIT_CHK(x,y) ((((const ut8*)x)[y>>4] & (1<<(y&0xf))))
 #define R_BIT_CHK(x,y) (*(x) & (1<<(y)))
 
+/* try for C99, but provide backwards compatibility */
+#if defined(_MSC_VER) && (_MSC_VER <= 1800)
+#define __func__ __FUNCTION__
+#endif
+
 /* make error messages useful by prepending file, line, and function name */
 #define _perror(str,file,line,func) \
   { \
@@ -224,8 +229,8 @@ typedef void (*PrintfCallback)(const char *str, ...);
 	  snprintf(buf,sizeof(buf),"[%s:%d %s] %s",file,line,func,str); \
 	  r_sys_perror_str(buf); \
   }
-#define perror(x) _perror(x,__FILE__,__LINE__,__FUNCTION__)
-#define r_sys_perror(x) _perror(x,__FILE__,__LINE__,__FUNCTION__)
+#define perror(x) _perror(x,__FILE__,__LINE__,__func__)
+#define r_sys_perror(x) _perror(x,__FILE__,__LINE__,__func__)
 
 #if __UNIX__
 #include <sys/types.h>

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -217,6 +217,16 @@ typedef void (*PrintfCallback)(const char *str, ...);
 //#define R_BIT_CHK(x,y) ((((const ut8*)x)[y>>4] & (1<<(y&0xf))))
 #define R_BIT_CHK(x,y) (*(x) & (1<<(y)))
 
+/* make error messages useful by prepending file, line, and function name */
+#define _perror(str,file,line,func) \
+  { \
+	  char buf[256]; \
+	  snprintf(buf,sizeof(buf),"[%s:%d %s] %s",file,line,func,str); \
+	  r_sys_perror_str(buf); \
+  }
+#define perror(x) _perror(x,__FILE__,__LINE__,__FUNCTION__)
+#define r_sys_perror(x) _perror(x,__FILE__,__LINE__,__FUNCTION__)
+
 #if __UNIX__
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -224,11 +234,6 @@ typedef void (*PrintfCallback)(const char *str, ...);
 #include <dirent.h>
 #endif
 #include <unistd.h>
-
-/* TODO: Move outside */
-#define _perror(str,file,line) \
-  { char buf[128];snprintf(buf,sizeof(buf),"%s:%d %s",file,line,str);perror(buf); }
-#define perror(x) _perror(x,__FILE__,__LINE__)
 
 #ifndef HAVE_EPRINTF
 #define eprintf(x,y...) fprintf(stderr,x,##y)

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -649,7 +649,7 @@ R_API const char *r_sys_arch_str(int arch);
 R_API int r_sys_arch_id(const char *arch);
 R_API bool r_sys_arch_match(const char *archstr, const char *arch);
 R_API RList *r_sys_dir(const char *path);
-R_API void r_sys_perror(const char *fun);
+R_API void r_sys_perror_str(const char *fun);
 #if __WINDOWS__ && !defined(__CYGWIN__)
 #define r_sys_mkdir(x) (CreateDirectory(x,NULL)!=0)
 #define r_sys_mkdir_failed() (GetLastError () != ERROR_ALREADY_EXISTS)

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -550,7 +550,7 @@ R_API int r_file_mmap_read (const char *file, ut64 addr, ut8 *buf, int len) {
 		FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, 0);
 
 	if (fh == INVALID_HANDLE_VALUE) {
-		r_sys_perror ("r_file_mmap_read: CreateFile");
+		r_sys_perror ("CreateFile");
 		return -1;
 	}
 
@@ -564,7 +564,7 @@ R_API int r_file_mmap_read (const char *file, ut64 addr, ut8 *buf, int len) {
 		memcpy (obuf, buf, len);
 		UnmapViewOfFile (obuf);
 	} else {
-		r_sys_perror ("r_file_mmap_read: CreateFileMapping");
+		r_sys_perror ("CreateFileMapping");
 		CloseHandle (fh);
 		return -1;
 	}
@@ -608,7 +608,7 @@ static RMmap *r_file_mmap_windows (RMmap *m, const char *file) {
 		FILE_SHARE_READ|(m->rw?FILE_SHARE_WRITE:0), NULL,
 		OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);
 	if (m->fh == INVALID_HANDLE_VALUE) {
-		r_sys_perror ("r_file_mmap_windows: CreateFile");
+		r_sys_perror ("CreateFile");
 		free (m);
 		return NULL;
 	}
@@ -621,7 +621,7 @@ static RMmap *r_file_mmap_windows (RMmap *m, const char *file) {
 			FILE_MAP_COPY,
 			UT32_HI (m->base), UT32_LO (m->base), 0);
 	} else {
-		r_sys_perror ("r_file_mmap_windows: CreateFileMapping");
+		r_sys_perror ("CreateFileMapping");
 		CloseHandle (m->fh);
 		free (m);
 		m = NULL;

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -550,9 +550,12 @@ R_API bool r_sys_mkdirp(const char *dir) {
 	return ret;
 }
 
-R_API void r_sys_perror(const char *fun) {
+R_API void r_sys_perror_str(const char *fun) {
 #if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#pragma push_macro("perror")
+#undef perror
 	perror (fun);
+#pragma pop_macro("perror")
 #elif __WINDOWS__
 	char *lpMsgBuf;
 	LPVOID lpDisplayBuf;

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -9,7 +9,7 @@
 #endif
 
 #define BUFSIZE 1024
-void r_sys_perror(const char *fun);
+void r_sys_perror_str(const char *fun);
 
 #define ErrorExit(x) { r_sys_perror(x); return NULL; }
 static int CreateChildProcess(const char *szCmdline, HANDLE out);

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -3556,7 +3556,7 @@ R_API RBinJavaAttrInfo* r_bin_java_line_number_table_attr_new (ut8 *buffer, ut64
 		// XXX if (curpos + 8 >= sz) break;
 		lnattr = R_NEW0 (RBinJavaLineNumberAttribute);
 		if (!lnattr) {
-			perror ("r_bin_java_line_number_table_attr_new");
+			perror ("calloc");
 			break;
 		}
 		lnattr->start_pc = R_BIN_JAVA_USHORT (buffer, offset);


### PR DESCRIPTION
From what I can tell, r_sys_perror is meant to be a platform-independent version of printing an error message. The "perror" function has been replaced (before this PR) with a macro that adds file and line information. However, if r_sys_perror is used it will incorrectly put the file/line of r_sys_perror.

Instead, we rename r_sys_perror to r_sys_perror_str (any other name should be fine) and then create a macro for it as well. To avoid calling the macro, we use the "push_macro" and "pop_macro" pragama directives. Finally, change perror() to call r_sys_perror so that it will work on all platforms.

One down side I noticed so far is that the following won't compile anymore:

```
if (something() == -1)
   r_sys_perror("something");
else
   printf("it worked!\n");
```

But that pattern doesn't seem to be used in the code anywhere.