### PR TITLE
Fix #4560: Handle recoils well with swstep=true

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -97,8 +97,8 @@ R_API RBreakpointItem *r_bp_get_in(RBreakpoint *bp, ut64 addr, int rwx) {
 	r_list_foreach (bp->bps, iter, b) {
 		// eprintf ("---ataddr--- 0x%08"PFMT64x" %d %d %x\n", b->addr, b->size, b->recoil, b->rwx);
 		// Check addr within range and provided rwx matches (or null)
-		if (addr >= b->addr && addr <= (b->addr+b->size) && \
-			(!rwx || rwx&b->rwx))
+		if ((addr >= b->addr) && (addr < (b->addr+b->size))
+				&& (!rwx || rwx&b->rwx))
 			return b;
 	}
 	return NULL;

--- a/libr/bp/io.c
+++ b/libr/bp/io.c
@@ -9,10 +9,21 @@
  * reflect all r_bp stuff in the process using dbg->bp_write or ->breakpoint
  */
 R_API int r_bp_restore(RBreakpoint *bp, int set) {
+	return r_bp_restore_except (bp, set, 0);
+}
+
+/**
+ * reflect all r_bp stuff in the process using dbg->bp_write or ->breakpoint
+ *
+ * except the specified breakpoint...
+ */
+R_API int r_bp_restore_except(RBreakpoint *bp, int set, ut64 addr) {
 	RListIter *iter;
 	RBreakpointItem *b;
 
 	r_list_foreach (bp->bps, iter, b) {
+		if (addr && b->addr == addr)
+			continue;
 		if (bp->breakpoint && bp->breakpoint (b, set, bp->user))
 			continue;
 		/* write obytes from every breakpoint in r_bp if not handled by plugin */
@@ -39,7 +50,7 @@ R_API int r_bp_recoil(RBreakpoint *bp, ut64 addr) {
 		//eprintf("HIT AT ADDR 0x%"PFMT64x"\n", addr);
 		//eprintf("  recoil = %d\n", b->recoil);
 		//eprintf("  size = %d\n", b->size);
-		if (!b->hw && ((b->addr + b->size) == addr))
+		if (!b->hw && b->addr == addr)
 			return b->recoil;
 	}
 	return 0;

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -32,11 +32,12 @@ static int r_debug_recoil(RDebug *dbg) {
 	dbg->reason.bpi = NULL;
 	if (ri) {
 		ut64 addr = r_reg_get_value (dbg->reg, ri);
-		recoil = r_bp_recoil (dbg->bp, addr);
+		recoil = r_bp_recoil (dbg->bp, addr - dbg->bpsize);
 		//eprintf ("[R2] Breakpoint recoil at 0x%"PFMT64x" = %d\n", addr, recoil);
 		if (recoil < 1)
 			recoil = 0; // XXX Hack :D
 		if (recoil) {
+			dbg->in_recoil = true;
 			dbg->reason.type = R_DEBUG_REASON_BREAKPOINT;
 			dbg->reason.bpi = r_bp_get_at (dbg->bp, addr-recoil);
 			dbg->reason.addr = addr - recoil;
@@ -74,6 +75,7 @@ R_API RDebug *r_debug_new(int hard) {
 	dbg->tracenodes = sdb_new0 ();
 	dbg->swstep = 0;
 	dbg->newstate = 0;
+	dbg->in_recoil = false;
 	dbg->stop_all_threads = false;
 	dbg->trace = r_debug_trace_new ();
 	dbg->cb_printf = (void *)printf;
@@ -540,7 +542,15 @@ repeat:
 	if (r_debug_is_dead (dbg))
 		return false;
 	if (dbg->h && dbg->h->cont) {
-		r_bp_restore (dbg->bp, true); // set sw breakpoints
+		if (dbg->in_recoil) {
+			/* if we are recoiling, we should not set the breakpoint that
+			 * caused us to stop.
+			 */
+			dbg->in_recoil = false;
+			r_bp_restore_except (dbg->bp, true, dbg->reason.addr);
+		}
+		else
+			r_bp_restore (dbg->bp, true); // set sw breakpoints
 		ret = dbg->h->cont (dbg, dbg->pid, dbg->tid, sig);
 		dbg->reason.signum = 0;
 		retwait = r_debug_wait (dbg);

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -131,6 +131,7 @@ R_API int r_bp_add_fault(RBreakpoint *bp, ut64 addr, int size, int rwx);
 R_API RBreakpointItem *r_bp_add_sw(RBreakpoint *bp, ut64 addr, int size, int rwx);
 R_API RBreakpointItem *r_bp_add_hw(RBreakpoint *bp, ut64 addr, int size, int rwx);
 R_API int r_bp_restore(RBreakpoint *bp, int set);
+R_API int r_bp_restore_except(RBreakpoint *bp, int set, ut64 addr);
 R_API int r_bp_recoil(RBreakpoint *bp, ut64 addr);
 
 /* traptrace */

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -144,6 +144,7 @@ typedef struct r_debug_t {
 	int swstep; /* steps with software traps */
 	int steps;  /* counter of steps done */
 	int newstate;
+	bool in_recoil; 			/* are we stopped due to bp? */
 	RDebugReason reason; /* stop reason */
 	RDebugTrace *trace;
 	int stop_all_threads;


### PR DESCRIPTION
When resuming after (during) recoil from a breakpoint, the swstep
implementation would fail to advance. In short, the debugger would immediately
interrupt again because r_bp_restore was re-setting the original breakpoint
just before continue. The following changes fix this issue:

1. Modify r_bp_get_in to stop including the byte after a breakpoint. This was
causing r_bp_recoil to fail because it thought there was already a breakpoint
on the next instruction.

2. Pass the real breakpoint address (pc - dbg->bpsize) to r_bp_recoil so
that r_bp_get_in can work properly. Stop adding the b->size there to keep it
going too.

3. Add a state flag to core->dbg to track that we are in the midst of a recoil.

4. When continuing from recoil (in r_debug_continue_kill), restore all
breakpoints except the one we just hit (with the new r_bp_restore_except) to
avoid hitting it again. Once we move past this instruction, that breakpoint
will be set again.