### PR TITLE
libr/util/sys.c: Avoid malloc() calls in the signal handler

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -147,13 +147,10 @@ R_API char *r_sys_cmd_strf(const char *fmt, ...) {
 
 R_API void r_sys_backtrace(void) {
 #if (__linux__ && __GNU_LIBRARY__) || (__APPLE__ && APPLE_WITH_BACKTRACE) || defined(NETBSD_WITH_BACKTRACE)
-        void *array[10];
-        size_t i, size = backtrace (array, 10);
-        char **strings = (char **)(size_t)backtrace_symbols (array, size);
-        printf ("Backtrace %zd stack frames.\n", size);
-        for (i = 0; i < size; i++)
-                printf ("%s\n", strings[i]);
-        free (strings);
+	void *array[10];
+	size_t size = backtrace (array, 10);
+	printf ("Backtrace %zd stack frames.\n", size);
+	backtrace_symbols_fd (array, size, 2);
 #elif __APPLE__
 	void **fp = (void **) __builtin_frame_address (0);
 	void *saved_pc = __builtin_return_address (0);
@@ -236,13 +233,10 @@ static char *crash_handler_cmd = NULL;
 
 #if __UNIX__
 static void signal_handler(int signum) {
-	int len;
-	char *cmd;
+	char cmd[1024];
 	if (!crash_handler_cmd)
 		return;
-	len = strlen (crash_handler_cmd)+32;
-	cmd = malloc (len);
-	snprintf (cmd, len, crash_handler_cmd, getpid ());
+	snprintf (cmd, sizeof(cmd) - 1, crash_handler_cmd, getpid ());
 	r_sys_backtrace ();
 	exit (r_sys_cmd (cmd));
 }
@@ -262,8 +256,14 @@ static int checkcmd(const char *c) {
 R_API int r_sys_crash_handler(const char *cmd) {
 #if __UNIX__
 	struct sigaction sigact;
+	void *array[1];
+
 	if (!checkcmd (cmd))
 		return R_FALSE;
+
+	/* call this outside of the signal handler to init it safely */
+	backtrace (array, 1);
+
 	free (crash_handler_cmd);
 	crash_handler_cmd = strdup (cmd);
 	sigact.sa_handler = signal_handler;


### PR DESCRIPTION
Using functions like `malloc()` in async signal handlers is unsafe, and may result in deadlocks.

Turns out that `backtrace()` is not safe either because its initialization code uses `dlopen()` and `malloc()` and others, but this can be workarounded by calling it once outside of a signal handler.