### PR TITLE
anal/fcn: use getter/setter to access the size of a RAnalFunction

### DIFF
--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -165,8 +165,8 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 			if (fcn2->type != R_ANAL_FCN_TYPE_SYM || fcn2->name == NULL ||
 				strcmp (fcn->name, fcn2->name))
 				continue;
-			r_diff_buffers_distance (NULL, fcn->fingerprint, fcn->size,
-					fcn2->fingerprint, fcn2->size, NULL, &t);
+			r_diff_buffers_distance (NULL, fcn->fingerprint, r_anal_fcn_size (fcn),
+					fcn2->fingerprint, r_anal_fcn_size (fcn2), NULL, &t);
 #if 0
 			eprintf ("FCN NAME (NAME): %s - %s => %lli - %lli => %f\n", fcn->name, fcn2->name,
 					fcn->size, fcn2->size, t);
@@ -179,8 +179,8 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 			R_FREE (fcn2->fingerprint);
 			fcn->diff->addr = fcn2->addr;
 			fcn2->diff->addr = fcn->addr;
-			fcn->diff->size = fcn2->size;
-			fcn2->diff->size = fcn->size;
+			fcn->diff->size = r_anal_fcn_size (fcn2);
+			fcn2->diff->size = r_anal_fcn_size (fcn);
 			R_FREE (fcn->diff->name);
 			if (fcn2->name)
 				fcn->diff->name = strdup (fcn2->name);
@@ -199,18 +199,20 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 		ot = 0;
 		mfcn = mfcn2 = NULL;
 		r_list_foreach (fcns2, iter2, fcn2) {
-			if (fcn->size > fcn2->size) {
-				maxsize = fcn->size;
-				minsize = fcn2->size;
+			int fcn_size = r_anal_fcn_size (fcn);
+			int fcn2_size = r_anal_fcn_size (fcn2);
+			if (fcn_size > fcn2_size) {
+				maxsize = fcn_size;
+				minsize = fcn2_size;
 			} else {
-				maxsize = fcn2->size;
-				minsize = fcn->size;
+				maxsize = fcn2_size;
+				minsize = fcn_size;
 			}
 			if ((fcn2->type != R_ANAL_FCN_TYPE_FCN && fcn2->type != R_ANAL_FCN_TYPE_SYM) ||
 				fcn2->diff->type != R_ANAL_DIFF_TYPE_NULL || (maxsize * anal->diff_thfcn > minsize))
 				continue;
-			r_diff_buffers_distance (NULL, fcn->fingerprint, fcn->size,
-					fcn2->fingerprint, fcn2->size, NULL, &t);
+			r_diff_buffers_distance (NULL, fcn->fingerprint, fcn_size,
+					fcn2->fingerprint, fcn2_size, NULL, &t);
 			fcn->diff->dist = fcn2->diff->dist = t;
 #if 0
 			int i;
@@ -244,8 +246,8 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 			R_FREE (mfcn2->fingerprint);
 			mfcn->diff->addr = mfcn2->addr;
 			mfcn2->diff->addr = mfcn->addr;
-			mfcn->diff->size = mfcn2->size;
-			mfcn2->diff->size = mfcn->size;
+			mfcn->diff->size = r_anal_fcn_size (mfcn2);
+			mfcn2->diff->size = r_anal_fcn_size (mfcn);
 			R_FREE (mfcn->diff->name);
 			if (mfcn2->name)
 				mfcn->diff->name = strdup (mfcn2->name);

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -538,6 +538,7 @@ static int module_match_buffer (const RAnal *anal, const RFlirtModule *module,
 		if (next_module_function) {
 			char *name;
 			int name_offs = 0;
+			ut32 next_module_function_size;
 
 			// get function size from flirt signature
 			ut64 flirt_fcn_size = module->length - flirt_func->offset;
@@ -552,12 +553,13 @@ static int module_match_buffer (const RAnal *anal, const RFlirtModule *module,
 				next_flirt_func_it = next_flirt_func_it->n;
 			}
 			// resize function if needed
-			if (next_module_function->size < flirt_fcn_size) {
+			next_module_function_size = r_anal_fcn_size (next_module_function);
+			if (next_module_function_size < flirt_fcn_size) {
 				RListIter *iter;
 				RListIter *iter_tmp;
 				RAnalFunction *fcn;
 				r_list_foreach_safe (anal->fcns, iter, iter_tmp, fcn) {
-					if (fcn->addr >= next_module_function->addr + next_module_function->size &&
+					if (fcn->addr >= next_module_function->addr + next_module_function_size &&
 							fcn->addr < next_module_function->addr + flirt_fcn_size) {
 						r_list_join(next_module_function->refs, fcn->refs);
 						r_list_join(next_module_function->xrefs, fcn->xrefs);
@@ -569,6 +571,7 @@ static int module_match_buffer (const RAnal *anal, const RFlirtModule *module,
 					}
 				}
 				r_anal_fcn_resize(next_module_function, flirt_fcn_size);
+				next_module_function_size = r_anal_fcn_size (next_module_function);
 				r_anal_trim_jmprefs(next_module_function);
 			}
 
@@ -581,7 +584,7 @@ static int module_match_buffer (const RAnal *anal, const RFlirtModule *module,
 			free (next_module_function->name);
 			next_module_function->name = r_str_newf("flirt.%s", name);
 			anal->flb.set (anal->flb.f, next_module_function->name,
-				next_module_function->addr, next_module_function->size);
+				next_module_function->addr, next_module_function_size);
 
 			anal->cb_printf ("Found %s\n", next_module_function->name);
 			free(name);
@@ -647,15 +650,16 @@ static int node_match_functions (const RAnal *anal, const RFlirtNode *root_node)
 			continue;
 		}
 
-		func_buf = malloc (func->size);
-		size = anal->iob.read_at (anal->iob.io, func->addr, func_buf, func->size);
-		if  (size != func->size) {
+		int func_size = r_anal_fcn_size (func);
+		func_buf = malloc (func_size);
+		size = anal->iob.read_at (anal->iob.io, func->addr, func_buf, func_size);
+		if  (size != func_size) {
 			eprintf ("Couldn't read function\n");
 			ret = false;
 			goto exit;
 		}
 		r_list_foreach (root_node->child_list, node_child_it, child) {
-			if (node_match_buffer (anal, child, func_buf, func->addr, func->size, 0)) {
+			if (node_match_buffer (anal, child, func_buf, func->addr, func_size, 0)) {
 				break;
 			}
 		}

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -471,7 +471,7 @@ static int analyze_from_code_buffer ( RAnal *anal, RAnalFunction *fcn, ut64 addr
 
 	fcn->name = strdup (gen_name);
 	fcn->dsc = strdup ("unknown");
-	fcn->size = code_length;
+	r_anal_fcn_set_size (fcn, code_length);
 	fcn->type = R_ANAL_FCN_TYPE_FCN;
 	fcn->addr = addr;
 
@@ -487,7 +487,7 @@ static int analyze_from_code_buffer ( RAnal *anal, RAnalFunction *fcn, ut64 addr
 		actual_size += bb->size;
 	}
 
-	fcn->size = state->bytes_consumed;
+	r_anal_fcn_set_size (fcn, state->bytes_consumed);
 
 	result = state->anal_ret_val;
 
@@ -495,10 +495,10 @@ static int analyze_from_code_buffer ( RAnal *anal, RAnalFunction *fcn, ut64 addr
 	free (nodes);
 	r_anal_state_free (state);
 	IFDBG eprintf ("Completed analysing code from buffer, name: %s, desc: %s\n", fcn->name, fcn->dsc);
-	if (fcn->size != code_length) {
-		eprintf ("WARNING Analysis of %s Incorrect: Code Length: 0x%"PFMT64x", Function size reported 0x%x\n", fcn->name, code_length, fcn->size);
+	if (r_anal_fcn_size (fcn) != code_length) {
+		eprintf ("WARNING Analysis of %s Incorrect: Code Length: 0x%"PFMT64x", Function size reported 0x%x\n", fcn->name, code_length, r_anal_fcn_size(fcn));
 		eprintf ("Deadcode detected, setting code length to: 0x%"PFMT64x"\n", code_length);
-		fcn->size = code_length;
+		r_anal_fcn_set_size (fcn, code_length);
 	}
 	return result;
 }
@@ -513,7 +513,7 @@ static int analyze_from_code_attr (RAnal *anal, RAnalFunction *fcn, RBinJavaFiel
 	if (!code_attr) {
 		fcn->name = strdup ("sym.UNKNOWN");
 		fcn->dsc = strdup ("unknown");
-		fcn->size = code_length;
+		r_anal_fcn_set_size (fcn, code_length);
 		fcn->type = R_ANAL_FCN_TYPE_FCN;
 		fcn->addr = 0;
 		return R_ANAL_RET_ERROR;
@@ -557,7 +557,7 @@ static int analyze_method(RAnal *anal, RAnalFunction *fcn, RAnalState *state) {
 	fcn->bbs = r_anal_bb_list_new ();
 
 	IFDBG eprintf ("analyze_method: Parsing fcn %s @ 0x%08"PFMT64x", %d bytes\n",
-		fcn->name, fcn->addr, fcn->size);
+		fcn->name, fcn->addr, r_anal_fcn_size (fcn));
 	java_new_method (fcn->addr);
 	state->current_fcn = fcn;
 	// Not a resource leak.  Basic blocks should be stored in the state->fcn
@@ -607,7 +607,7 @@ static int java_analyze_fns_from_buffer( RAnal *anal, ut64 start, ut64 end, int 
 		}
 		//r_listrange_add (anal->fcnstore, fcn);
 		r_list_append (anal->fcns, fcn);
-		offset += fcn->size;
+		offset += r_anal_fcn_size (fcn);
 		if (!analyze_all) break;
 	}
 	free (buffer);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -517,7 +517,7 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int protection, const char 
 						R_ANAL_FCN_TYPE_FCN|R_ANAL_FCN_TYPE_SYM);
 			if (f) {
 				*from = f->addr;
-				*to = f->addr + f->size;
+				*to = f->addr + r_anal_fcn_size (f);
 
 				/* Search only inside the basic block */
 				if (!strcmp (mode, "anal.bb")) {

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -356,7 +356,7 @@ static int cmd_seek(void *data, const char *input) {
 			}
 			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
 			if (fcn) {
-				r_core_seek (core, fcn->addr+fcn->size, 1);
+				r_core_seek (core, fcn->addr + r_anal_fcn_size (fcn), 1);
 			}
 			break;
 		case 'o': // "so"

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -62,8 +62,8 @@ static int cmd_zign(void *data, const char *input) {
 					if (flag) {
 						name = flag->name;
 						r_cons_printf ("zb %s ", name);
-						len = (fcni->size > sizeof (buf))?
-							sizeof (buf): fcni->size;
+						len = (r_anal_fcn_size (fcni) > sizeof (buf))?
+							sizeof (buf): r_anal_fcn_size(fcni);
 						for (i=0; i<len; i++)
 							r_cons_printf ("%02x", buf[i]);
 						r_cons_newline ();

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -421,7 +421,7 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 			return fcn? fcn->ninstr: 0;
 		case 'F':
 			fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
-			return fcn? fcn->size: 0;
+			return r_anal_fcn_size (fcn);
 		}
 		break;
 	default:

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -46,7 +46,8 @@ R_API int r_core_gdiff(RCore *c, RCore *c2) {
 		}
 		/* Fingerprint fcn */
 		r_list_foreach (cores[i]->anal->fcns, iter, fcn) {
-			fcn->size = r_anal_diff_fingerprint_fcn (cores[i]->anal, fcn);
+			int newsize = r_anal_diff_fingerprint_fcn (cores[i]->anal, fcn);
+			r_anal_fcn_set_size (fcn, newsize);
 		}
 	}
 	/* Diff functions */
@@ -86,15 +87,15 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
         r_list_foreach (fcns, iter, f) {
                 if (f->name && (len = strlen(f->name)) > maxnamelen)
                         maxnamelen = len;
-                if (f->size > maxsize)
-                        maxsize = f->size;
+                if (r_anal_fcn_size (f) > maxsize)
+                        maxsize = r_anal_fcn_size (f);
         }
         fcns = r_anal_get_fcns (c2->anal);
         r_list_foreach (fcns, iter, f) {
                 if (f->name && (len = strlen(f->name)) > maxnamelen)
                         maxnamelen = len;
-                if (f->size > maxsize)
-                        maxsize = f->size;
+                if (r_anal_fcn_size (f) > maxsize)
+                        maxsize = r_anal_fcn_size (f);
         }
         while (maxsize > 9) {
                 maxsize /= 10;
@@ -115,7 +116,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
                         default:
                                 match = "NEW";
                         }
-                        diffrow (f->addr, f->name, f->size, maxnamelen,
+                        diffrow (f->addr, f->name, r_anal_fcn_size (f), maxnamelen,
 				digits, f->diff->addr, f->diff->name, f->diff->size,
 				match, f->diff->dist, bare);
                         break;
@@ -127,7 +128,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
                 case R_ANAL_FCN_TYPE_FCN:
                 case R_ANAL_FCN_TYPE_SYM:
                         if (f->diff->type == R_ANAL_DIFF_TYPE_NULL)
-                                diffrow (f->addr, f->name, f->size, maxnamelen,
+                                diffrow (f->addr, f->name, r_anal_fcn_size (f), maxnamelen,
 					digits, f->diff->addr, f->diff->name, f->diff->size,
 					"NEW", f->diff->dist, bare);
                 }

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1472,7 +1472,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 							f = r_anal_get_fcn_in (core->anal, core->offset, 0);
 						}
 						if (f && f->folded) {
-							cols = core->offset - f->addr + f->size;
+							cols = core->offset - f->addr + r_anal_fcn_size (f);
 						} else {
 							r_asm_set_pc (core->assembler, core->offset);
 							cols = r_asm_disassemble (core->assembler,

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -1594,7 +1594,7 @@ static void function_rename(RCore *core, ut64 addr, const char *name) {
 			r_flag_unset_name (core->flags, fcn->name);
 			free (fcn->name);
 			fcn->name = strdup (name);
-			r_flag_set (core->flags, name, addr, fcn->size);
+			r_flag_set (core->flags, name, addr, r_anal_fcn_size (fcn));
 			break;
 		}
 	}
@@ -1689,7 +1689,7 @@ static void r_core_visual_anal_refresh_column (RCore *core) {
 	int i;
 	int sz = 16;
 	r_cons_get_size (&h);
-	if (fcn) sz = R_MIN(fcn->size, h * 15); // max instr is 15 bytes.
+	if (fcn) sz = R_MIN(r_anal_fcn_size (fcn), h * 15); // max instr is 15 bytes.
 	char cmdf[64];
 	sprintf (cmdf, "pD %d @ 0x%"PFMT64x, sz, addr);
 	output = r_core_cmd_str (core, cmdf);
@@ -2291,7 +2291,7 @@ repeat:
 			r_cons_break_end ();
 			if (funsize) {
 				RAnalFunction *f = r_anal_get_fcn_in (core->anal, off, -1);
-				if (f) f->size = funsize;
+				r_anal_fcn_set_size (f, funsize);
 			}
 		}
 		break;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -282,7 +282,7 @@ typedef struct r_anal_fcn_store_t {
 typedef struct r_anal_type_function_t {
 	char* name;
 	char* dsc; // For producing nice listings
-	ut32 size;
+	ut32 _size;
 	int bits; // ((> bits 0) (set-bits bits))
 	short type;
 	/*item_list *rets; // Type of return value */
@@ -1294,7 +1294,9 @@ R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind);
 
 /* vars // globals. not here  */
 
-R_API int r_anal_fcn_size(RAnalFunction *fcn);
+R_API ut32 r_anal_fcn_size(const RAnalFunction *fcn);
+R_API void r_anal_fcn_set_size(RAnalFunction *fcn, ut32 size);
+R_API ut32 r_anal_fcn_realsize(const RAnalFunction *fcn);
 R_API int r_anal_fcn_cc(RAnalFunction *fcn);
 R_API int r_anal_fcn_split_bb(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bb, ut64 addr);
 R_API int r_anal_fcn_bb_overlaps(RAnalFunction *fcn, RAnalBlock *bb);


### PR DESCRIPTION
This is one of the first steps to improve analysis. This way we'll have
one single place to change if we want to change the meaning of the
"size" field. (size -> realsize)

"Fix" #4621 . In the future we would probably like to just use `r_anal_fcn_size` to get the "realsize". This is not possible at the moment because the wrong size is used in many places and we don't want to break toooo many stuff now. The `r_anal_fcn_set_size` is just a temporary api just to make easier to see where the size of a function is set; it can be probably removed sometime in the future.

Next API I'd like to add in a separate PR is `r_anal_fcn_lastaddr` that will give the first address after a given function (that is `fcn->addr + fcn->size`). This is of course wrong because it doesn't consider non-contiguous functions, but if we use an api we can then replace it with the correct implementation when we'll fix analysis.