### PR TITLE
MIPS esil small fixes, this will unbreak esil/mips regressions

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -288,7 +288,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case MIPS_INS_BGTZC:
 		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,%s,==,$z,?{,BREAK,},", ARG (0));
 		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,"ES_IS_NEGATIVE ("%s")",==,$z,?{,"ES_J("%s")",}",
-			ARG (0), ARG (1));		
+			ARG (0), ARG (1));
 		break;
 	case MIPS_INS_BTEQZ:
 		r_strbuf_appendf (&op->esil, ES_TRAP_DS () ",0,t,==,$z,?{,"ES_J ("%s")",}", ARG (0));
@@ -317,22 +317,12 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case MIPS_INS_FSUB:
 	case MIPS_INS_SUB:
-		PROTECT_ZERO () {
-			r_strbuf_appendf(&op->esil, "%s,%s,-,%s,=",
-				ARG (1), ARG (2), ARG (0));
-			//r_strbuf_appendf(&op->esil, "%s,%s,>,?{,1,TRAP,}{,%s,%s,-,%s,=",
-			//	ARG (1), ARG (2), ARG (1), ARG (2), ARG (0));
-		}
-		break;
 	case MIPS_INS_SUBU:
 	case MIPS_INS_DSUB:
 	case MIPS_INS_DSUBU:
-		{
-		const char *arg0 = ARG(0);
-		const char *arg1 = ARG(1);
-		const char *arg2 = ARG(2);
-		r_strbuf_appendf (&op->esil, "%s,%s,-,%s,=",
-			arg2, arg1, arg0);
+		PROTECT_ZERO () {
+			r_strbuf_appendf(&op->esil, "%s,%s,-,%s,=",
+				ARG (2), ARG (1), ARG (0));
 		}
 		break;
 	case MIPS_INS_NEG:
@@ -345,7 +335,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case MIPS_INS_ADD:
 		{
 		PROTECT_ZERO () {
-			r_strbuf_appendf(&op->esil, "%s,%s,-,%s,=",
+			r_strbuf_appendf(&op->esil, "%s,%s,+,%s,=",
 				ARG (1), ARG (2), ARG (0));
 #if 0
 			r_strbuf_appendf (&op->esil,
@@ -795,7 +785,7 @@ static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 		} else {
 			op->type = R_ANAL_OP_TYPE_CJMP;
 		}
-		
+
 		if (OPERAND(0).type == MIPS_OP_IMM) {
 			op->jump = IMM(0);
 		} else if (OPERAND(1).type == MIPS_OP_IMM) {
@@ -818,7 +808,7 @@ static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 			op->fail = addr+8;
 			break;
 		}
-		
+
 		break;
 	case MIPS_INS_JR:
 	case MIPS_INS_JRC:


### PR DESCRIPTION
+ fixed "sub" operands order
+ fixed "add" typo (was implemented using "-" instead of "+")