### PR TITLE
Fix MIPS pseudo code for move op.

### DIFF
--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -51,7 +51,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ "lw",  "1 = halfword [3 + 2]", 3},
 		{ "li",   "1 = 2", 2},
 		{ "lui",  "1 = 2 << 16", 2},
-		{ "move",  "1 = 2", 1},
+		{ "move",  "1 = 2", 2},
 		{ "mult",  "1 = 2 * 3", 3},
 		{ "multu",  "1 = 2 * 3", 3},
 		{ "negu",  "1 = ~2", 2},


### PR DESCRIPTION
Trivial fix for move instruction being wrongly shown for MIPS pseudo:

Before:

    |           0x004005cc      21f0a003       sp,fp,=

    :e asm.pseudo=true
 
    |           0x004005cc      21f0a003       fp = 2

After:

    |           0x004005cc      21f0a003       fp = sp
