### PR TITLE
fix pseudo output for MIPS sw ... (xx)

### DIFF
--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -185,6 +185,7 @@ static int parse(RParse *p, const char *data, char *str) {
 {
 	char *p = strdup (str);
 	p = r_str_replace (p, "+ -", "- ", 0);
+	p = r_str_replace(p, " + ]", " + 0]", 0);
 #if EXPERIMENTAL_ZERO
 	p = r_str_replace (p, "zero", "0", 0);
 	if (!memcmp (p, "0 = ", 4)) *p = 0; // nop


### PR DESCRIPTION
Before:

    |           0x004005ec      0000beaf       sw fp, (sp)
    e asm.pseudo=true
    |           0x004005ec      0000beaf       [sp + ] = fp

After:
  
    |           0x004005ec      0000beaf       [sp + 0] = fp

Will add a test case shortly.