### PR TITLE
Fixes to ESIL

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -14,11 +14,6 @@
 		R_BIT_UNSET (&esil->flags, FLG (x));\
 	}
 
-typedef union {
-	ut64 n;
-	double d;
-} dualtype;
-
 /* internal helper functions */
 static void err(RAnalEsil *esil, const char *msg) {
 	eprintf ("0x%08" PFMT64x " %s\n", esil->address, msg);
@@ -284,8 +279,7 @@ static int esil_internal_borrow_check(RAnalEsil *esil, ut8 bit) {
 }
 
 static int esil_internal_carry_check(RAnalEsil *esil, ut8 bit) {
-	bit &= 0x3f;
-	return ((esil->cur & genmask (bit)) < (esil->old & genmask (bit)));
+	return esil->cur > (((ut64) 1 << ((ut64) bit + 1)) - 1);
 }
 
 static int esil_internal_parity_check(RAnalEsil *esil) {
@@ -342,8 +336,6 @@ R_API int r_anal_esil_get_parm_type(RAnalEsil *esil, const char *str) {
 	}
 	if (!strncmp (str, "0x", 2))
 		return R_ANAL_ESIL_PARM_NUM;
-	if (!strncmp (str, "Fx", 2))
-		return R_ANAL_ESIL_PARM_FLOAT;
 	if (!((str[0] >= '0' && str[0] <= '9') || str[0] == '-'))
 		goto not_a_number;
 	for (i = 1; i < len; i++)
@@ -369,7 +361,10 @@ static int esil_internal_read(RAnalEsil *esil, const char *str, ut64 *num) {
 		*num = esil->address;
 		break;
 	case 'z': //zero-flag
-		*num = (esil->cur == 0);
+		{
+			ut64 m = genmask(esil->lastsz - 1);
+			*num = (((ut64) esil->cur & m) == 0);
+		}
 		break;
 	case 'b': //borrow
 		bit = (ut8)r_num_get (NULL, &str[2]);
@@ -451,8 +446,6 @@ static int esil_internal_write(RAnalEsil *esil, const char *str, ut64 num) {
 }
 
 R_API int r_anal_esil_get_parm_size(RAnalEsil *esil, const char *str, ut64 *num, int *size) {
-	dualtype dual;
-	char buf[64] = {0};
 	int parm_type = r_anal_esil_get_parm_type (esil, str);
 	if (!num || !esil) return false;
 	switch (parm_type) {
@@ -462,13 +455,6 @@ R_API int r_anal_esil_get_parm_size(RAnalEsil *esil, const char *str, ut64 *num,
 		return esil_internal_read (esil, str, num);
 	case R_ANAL_ESIL_PARM_NUM:
 		*num = r_num_get (NULL, str);
-		if (size) *size = esil->anal->bits;
-		return true;
-	case R_ANAL_ESIL_PARM_FLOAT:
-		memcpy (buf, str, strlen (str));
-		buf[0] = '0';
-		dual.d = r_num_get_float (NULL, buf);
-		*num = dual.n;
 		if (size) *size = esil->anal->bits;
 		return true;
 	case R_ANAL_ESIL_PARM_REG:
@@ -762,6 +748,9 @@ static int esil_cmp(RAnalEsil *esil) {
 				esil->lastsz = esil_internal_sizeof_reg (esil, dst);
 			} else if (r_reg_get (esil->anal->reg, src, -1)) {
 				esil->lastsz = esil_internal_sizeof_reg (esil, src);
+			} else {
+				// default size is set to 64 as internally operands are ut64
+				esil->lastsz = 64;
 			}
 		}
 	}
@@ -1150,45 +1139,22 @@ static int esil_modeq(RAnalEsil *esil) {
 
 static int esil_div(RAnalEsil *esil) {
 	int ret = 0;
-	dualtype s, d, result;
+	ut64 s, d;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
-	int type = r_anal_esil_get_parm_type (esil, src);
-	if (type == R_ANAL_ESIL_PARM_NUM) {
-		if (src && dst && r_anal_esil_get_parm (esil, src, &s.n)
-				&& r_anal_esil_get_parm (esil, dst, &d.n)) {
-			if (s.n == 0) {
+	if (src && r_anal_esil_get_parm (esil, src, &s)) {
+		if (dst && r_anal_esil_get_parm (esil, dst, &d)) {
+			if (s == 0) {
 				ERR ("esil_div: Division by zero!");
 				esil->trap = R_ANAL_TRAP_DIVBYZERO;
 				esil->trap_code = 0;
 			} else {
-				r_anal_esil_pushnum (esil, d.n / s.n);
-				ret = 1;
+				r_anal_esil_pushnum (esil, d / s);
 			}
-		} else {
-			ERR ("esil_div: invalid (ut64) parameters");
-		}
-	} else if (type == R_ANAL_ESIL_PARM_FLOAT) {
-		if (src && dst && r_anal_esil_get_parm (esil, src, &s.n)
-				&& r_anal_esil_get_parm (esil, dst, &d.n)) {
-			if (s.d == (double)0.0) {
-				ERR ("esil_div: Division by zero!");
-				esil->trap = R_ANAL_TRAP_DIVBYZERO;
-				esil->trap_code = 0;
-			} else {
-				result.d = (double)d.d / (double)s.d;
-				esil->old = d.n;
-				esil->cur = result.n;
-				r_anal_esil_pushnum (esil, esil->cur);
-				ret = 1;
-			}
-		} else {
-			ERR ("esil_div: invalid (double) parameters");
+			ret = 1;
 		}
 	} else {
-		ERR ("esil_div: default case");
-		r_anal_esil_pushnum (esil, d.n / s.n);
-		ret = 1;
+		ERR ("esil_div: invalid parameters");
 	}
 	free (src);
 	free (dst);
@@ -1198,28 +1164,17 @@ static int esil_div(RAnalEsil *esil) {
 static int esil_diveq(RAnalEsil *esil) {
 	int ret = 0;
 	ut64 s, d;
-	dualtype dual1, dual2, result;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, &s)) {
 		if (dst && r_anal_esil_reg_read (esil, dst, &d, NULL)) {
 			if (s) {
-				if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_NUM) {
+				if (r_anal_esil_get_parm_type (esil, src) != R_ANAL_ESIL_PARM_INTERNAL) {
 					esil->old = d;
 					esil->cur = d / s;
 					esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-					r_anal_esil_reg_write (esil, dst, esil->cur);
-				} else if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_FLOAT) {
-					dual1.n = d;
-					dual2.n = s;
-					result.d = (double)dual1.d / (double)dual2.d;
-					esil->old = d;
-					esil->cur = result.n;
-					esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-					r_anal_esil_reg_write (esil, dst, esil->cur);
-				} else {
-					r_anal_esil_reg_write (esil, dst, d / s);
 				}
+				r_anal_esil_reg_write (esil, dst, d / s);
 			} else {
 				// eprintf ("0x%08"PFMT64x" esil_diveq: Division by zero!\n", esil->address);
 				esil->trap = R_ANAL_TRAP_DIVBYZERO;
@@ -1240,21 +1195,11 @@ static int esil_diveq(RAnalEsil *esil) {
 static int esil_mul(RAnalEsil *esil) {
 	int ret = 0;
 	ut64 s, d;
-	dualtype dual1, dual2, result;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, &s)) {
 		if (dst && r_anal_esil_get_parm (esil, dst, &d)) {
-			if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_NUM) {
-				r_anal_esil_pushnum (esil, d * s);
-			} else if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_FLOAT) {
-				dual1.n = d;
-				dual2.n = s;
-				result.d = (double)dual1.d * (double)dual2.d;
-				r_anal_esil_pushnum (esil, result.n);
-			} else {
-				r_anal_esil_pushnum (esil, d * s);
-			}
+			r_anal_esil_pushnum (esil, d * s);
 			ret = 1;
 		} else {
 			ERR ("esil_mul: empty stack");
@@ -1270,27 +1215,16 @@ static int esil_mul(RAnalEsil *esil) {
 static int esil_muleq(RAnalEsil *esil) {
 	int ret = 0;
 	ut64 s, d;
-	dualtype dual1, dual2, result;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, &s)) {
 		if (dst && r_anal_esil_reg_read (esil, dst, &d, NULL)) {
-			if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_NUM) {
+			if (r_anal_esil_get_parm_type (esil, src) != R_ANAL_ESIL_PARM_INTERNAL) {
 				esil->old = d;
 				esil->cur = d * s;
 				esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-				r_anal_esil_reg_write (esil, dst, esil->cur);
-			} else if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_FLOAT) {
-				dual1.n = d;
-				dual2.n = s;
-				result.d = (double)dual1.d * (double)dual2.d;
-				esil->old = d;
-				esil->cur = result.n;
-				esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-				r_anal_esil_reg_write (esil, dst, esil->cur);
-			} else {
-				r_anal_esil_reg_write (esil, dst, d * s);
 			}
+			r_anal_esil_reg_write (esil, dst, s * d);
 			ret = true;
 		} else {
 			ERR ("esil_muleq: empty stack");
@@ -1306,21 +1240,11 @@ static int esil_muleq(RAnalEsil *esil) {
 static int esil_add(RAnalEsil *esil) {
 	int ret = 0;
 	ut64 s, d;
-	dualtype dual1, dual2, result;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, &s)) {
 		if (dst && r_anal_esil_get_parm (esil, dst, &d)) {
-			if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_NUM) {
-				r_anal_esil_pushnum (esil, s + d);
-			} else if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_FLOAT) {
-				dual1.n = s;
-				dual2.n = d;
-				result.d = (double)dual1.d + (double)dual2.d;
-				r_anal_esil_pushnum (esil, result.n);
-			} else {
-				r_anal_esil_pushnum (esil, s + d);
-			}
+			r_anal_esil_pushnum (esil, s + d);
 			ret = true;
 		}
 	} else {
@@ -1334,27 +1258,16 @@ static int esil_add(RAnalEsil *esil) {
 static int esil_addeq(RAnalEsil *esil) {
 	int ret = 0;
 	ut64 s, d;
-	dualtype dual1, dual2, result;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, &s)) {
 		if (dst && r_anal_esil_reg_read (esil, dst, &d, NULL)) {
-			if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_NUM) {
+			if (r_anal_esil_get_parm_type (esil, src) != R_ANAL_ESIL_PARM_INTERNAL) {
 				esil->old = d;
 				esil->cur = d + s;
 				esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-				r_anal_esil_reg_write (esil, dst, esil->cur);
-			} else if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_FLOAT) {
-				dual1.n = d;
-				dual2.n = s;
-				result.d = (double)dual1.d + (double)dual2.d;
-				esil->old = d;
-				esil->cur = result.n;
-				esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-				r_anal_esil_reg_write (esil, dst, esil->cur);
-			} else {
-				r_anal_esil_reg_write (esil, dst, d + s);
 			}
+			r_anal_esil_reg_write (esil, dst, s + d);
 			ret = true;
 		}
 	} else {
@@ -1400,56 +1313,31 @@ static int esil_inceq(RAnalEsil *esil) {
 
 static int esil_sub(RAnalEsil *esil) {
 	ut64 s = 0, d = 0;
-	dualtype dual1, dual2, result;
-	int ret = 0;
-	char *dst = r_anal_esil_pop (esil);
-	char *src = r_anal_esil_pop (esil);
-	if (src && r_anal_esil_get_parm (esil, src, &s)) {
-		if (dst && r_anal_esil_get_parm (esil, dst, &d)) {
-			if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_NUM) {
-				r_anal_esil_pushnum (esil, d - s);
-			} else if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_FLOAT) {
-				dual1.n = d;
-				dual2.n = s;
-				result.d = (double)dual1.d - (double)dual2.d;
-				r_anal_esil_pushnum (esil, result.n);
-			} else {
-				r_anal_esil_pushnum (esil, d - s);
-			}
-			ret = 1;
-		}
-	} else {
-		ERR ("esil_sub: invalid parameters");
+	if (!popRN (esil, &d)) {
+		ERR ("esil_sub: dst is broken");
+		return false;
 	}
-	free (src);
-	free (dst);
-	return ret;
+	if (!popRN (esil, &s)) {
+		ERR ("esil_sub: src is broken");
+		return false;
+	}
+	r_anal_esil_pushnum (esil, d - s);
+	return true;
 }
 
 static int esil_subeq(RAnalEsil *esil) {
 	int ret = 0;
 	ut64 s, d;
-	dualtype dual1, dual2, result;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, &s)) {
 		if (dst && r_anal_esil_reg_read (esil, dst, &d, NULL)) {
-			if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_NUM) {
+			if (r_anal_esil_get_parm_type (esil, src) != R_ANAL_ESIL_PARM_INTERNAL) {
 				esil->old = d;
 				esil->cur = d - s;
 				esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-				r_anal_esil_reg_write (esil, dst, esil->cur);
-			} else if (r_anal_esil_get_parm_type (esil, src) == R_ANAL_ESIL_PARM_FLOAT) {
-				dual1.n = d;
-				dual2.n = s;
-				result.d = (double)dual1.d - (double)dual2.d;
-				esil->old = d;
-				esil->cur = result.n;
-				esil->lastsz = esil_internal_sizeof_reg (esil, dst);
-				r_anal_esil_reg_write (esil, dst, esil->cur);
-			} else {
-				r_anal_esil_reg_write (esil, dst, d - s);
 			}
+			r_anal_esil_reg_write (esil, dst, d - s);
 			ret = true;
 		}
 	} else {
@@ -1515,7 +1403,7 @@ static int esil_poke_n(RAnalEsil *esil, int bits) {
 				r_anal_esil_mem_read (esil, addr, b, bytes);
 				n = r_read_ble64 (b, esil->anal->big_endian);
 				esil->old = n;
-				esil->cur = (num & bitmask);
+				esil->cur = num;
 				esil->lastsz = bits;
 				num = num & bitmask;
 			}
@@ -1902,11 +1790,15 @@ static int esil_mem_modeq_n(RAnalEsil *esil, int bits) {
 			r_anal_esil_push (esil, dst);
 			ret = (!!esil_peek_n (esil, bits));
 			src1 = r_anal_esil_pop (esil);
-			if (src1 && r_anal_esil_get_parm (esil, src1, &d)) {
+			if (src1 && r_anal_esil_get_parm (esil, src1, &d) && s >= 1) {
 				r_anal_esil_pushnum (esil, d % s);
+				d = d % s;
+				r_anal_esil_pushnum (esil, d);
 				r_anal_esil_push (esil, dst);
 				ret &= (!!esil_poke_n (esil, bits));
-			} else ret = 0;
+			} else {
+				ret = 0;
+			}
 		}
 	}
 	if (!ret) {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -81,12 +81,12 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop) {
 	csh handle = gop->handle;
 	cs_insn *insn = gop->insn;
 	char buf[64];
-	char *setarg = setop? setop : "";
+	char *setarg = setop ? setop : "";
 	cs_x86_op op;
 	if (!insn->detail)
 		return NULL;
 	buf[0] = 0;
-	if (n<0 || n>=INSOPS)
+	if (n < 0 || n >= INSOPS)
 		return NULL;
 	op = INSOP (n);
 	switch (op.type) {
@@ -1055,10 +1055,15 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		// The OF and CF flags are cleared; the SF, ZF, and PF flags are
 		// set according to the result. The state of the AF flag is
 		// undefined.
+		// NOTE: Flag clearing should always be the last operation to be done
+		// as this resets esil->cur and esil->old and resulting in the wrong
+		// computation of the rest of the flags.
+		// XXX: Fix the above issue in esil.c to ensure we never make this
+		// mistake.
 		{
 			char *src = getarg (&gop, 1, 0, NULL);
 			char *dst = getarg (&gop, 0, 0, NULL);
-			esilprintf (op, "%s,%s,|=,0,of,=,0,cf,=,$s,sf,=,$z,zf,=,$p,pf,=", src, dst);
+			esilprintf (op, "%s,%s,|=,$s,sf,=,$z,zf,=,$p,pf,=,0,of,=,0,cf,=", src, dst);
 			free (src);
 			free (dst);
 		}
@@ -1342,55 +1347,27 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		// result.
 		{
 		char *src = getarg (&gop, 1, 0, NULL);
-		char *dst_r = getarg (&gop, 0, 0, NULL);
-		char *dst_w = getarg (&gop, 0,1, "+");
-		switch(INSOP(0).size) {
-			case 1:
-				esilprintf (op, "0,zf,=,0,cf,=,0xff,%s,%s,+,>,?{,1,cf,=,},%s,%s,$o,of,=,$s,sf,=,0xff,%s,&,!,?{,1,zf,=,},$p,pf,=", src, dst_r, src, dst_w, dst_r);
-				break;
-			case 2:
-				esilprintf (op, "0,zf,=,0,cf,=,0xffff,%s,%s,+,>,?{,1,cf,=,},%s,%s,$o,of,=,$s,sf,=,0xffff,%s,&,!,?{,1,zf,=,},p,pf,=", src, dst_r, src, dst_w, dst_r);
-				break;
-			case 4:
-				esilprintf (op, "0,zf,=,0,cf,=,0xffffffff,%s,%s,+,>,?{,1,cf,=,},%s,%s,$o,of,=,$s,sf,=,0xffffffff,%s,&,!,?{,1,zf,=,},$p,pf,=", src, dst_r, src, dst_w, dst_r);
-				break;
-			case 8:
-				esilprintf (op, "0,zf,=,0,cf,=,0xffffffffffffffff,%s,%s,+,>,?{,1,cf,=,},%s,%s,$o,of,=,$s,sf,=,0xffffffffffffffff,%s,&,!,?{,1,zf,=,},$p,pf,=", src, dst_r, src, dst_w, dst_r);
-				break;
-		}
-		free(src);
-		free(dst_r);
-		free(dst_w);
+		char *dst = getarg (&gop, 0, 1, "+");
+		int carry_out_bit = (INSOP(0).size * 8) - 1;
+		esilprintf (op, "%s,%s,$o,of,=,$s,sf,=,$z,zf,=,$c%d,cf,=,$p,pf,=", src, dst, carry_out_bit);
+		free (src);
+		free (dst);
 		}
 		break;
 	case X86_INS_ADC:
 		{
 			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst_r = getarg (&gop, 0, 0, NULL);
-			char *dst_w = getarg (&gop, 0, 1, NULL);
+			char *dst = getarg (&gop, 0, 1, "+");
+			int carry_out_bit = (INSOP(0).size * 8) - 1;
 			// dst = dst + src + cf
 			// NOTE: We would like to add the carry first before adding the
 			// source to ensure that the flag computation from $c belongs
 			// to the operation of adding dst += src rather than the one
 			// that adds carry (as esil only keeps track of the last
 			// addition to set the flags).
-			switch(INSOP(0).size) {
-				case 1:
-					esilprintf (op, "0,zf,=,cf,%s,+,%s,+,0,cf,=,DUP,0xff,<,?{,1,cf,=,},%s,=,0xff,%s,&,!,?{,1,zf,=,}", src, dst_r, dst_w, dst_r);
-					break;
-				case 2:
-			    esilprintf (op, "0,zf,=,cf,%s,+,%s,+,0,cf,=,DUP,0xffff,<,?{,1,cf,=,},%s,=,0xffff,%s,&,!,?{,1,zf,=,}", src, dst_r, dst_w, dst_r);
-					break;
-				case 4:
-					esilprintf (op, "0,zf,=,cf,%s,+,%s,+,0,cf,=,DUP,0xffffffff,<,?{,1,cf,=,},%s,=,0xffffffff,%s,&,!,?{,1,zf,=,}", src, dst_r, dst_w, dst_r);
-					break;
-				case 8:
-					esilprintf (op, "0,zf,=,cf,%s,+,%s,+,0,cf,=,DUP,0xffffffffffffffff,<,?{,1,cf,=,},%s,=,0xffffffffffffffff,%s,&,!,?{,1,zf,=,}", src, dst_r, dst_w, dst_r);
-					break;
-			}
-			free(src);
-			free(dst_r);
-			free(dst_w);
+			esilprintf (op, "cf,%s,+,%s,$o,of,=,$s,sf,=,$z,zf,=,$c%d,cf,=,$p,pf,=", src, dst, carry_out_bit);
+			free (src);
+			free (dst);
 		}
 		break;
 		/* Direction flag */
@@ -1406,11 +1383,11 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	}
 
 	if (op->prefix & R_ANAL_OP_PREFIX_REP) {
-		r_strbuf_appendf(&op->esil, ",%s,--=,%s,?{,5,GOTO,}", counter, counter);
+		r_strbuf_appendf (&op->esil, ",%s,--=,%s,?{,5,GOTO,}", counter, counter);
 	}
 }
 
-static void anop (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn) {
+static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn) {
 	struct Getarg gop = {
 		.handle = *handle,
 		.insn = insn,

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -882,7 +882,6 @@ enum {
 	R_ANAL_ESIL_PARM_INTERNAL,
 	R_ANAL_ESIL_PARM_REG,
 	R_ANAL_ESIL_PARM_NUM,
-	R_ANAL_ESIL_PARM_FLOAT,
 };
 
 /* Constructs to convert from ESIL to REIL */
@@ -1001,7 +1000,6 @@ typedef struct r_anal_esil_t {
 	ut64 old;	//used for carry-flagging and borrow-flagging
 	ut64 cur;	//used for carry-flagging and borrow-flagging
 	ut8 lastsz;	//in bits //used for signature-flag
-	int curtype;	//used for detecting type of flags (double / ut64)
 	/* native ops and custom ops */
 	Sdb *ops;
 	Sdb *interrupts;

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -372,7 +372,6 @@ R_API const char *r_num_calc_index (RNum *num, const char *p);
 R_API ut64 r_num_chs (int cylinder, int head, int sector, int sectorsize);
 R_API int r_num_is_valid_input(RNum *num, const char *input_value);
 R_API ut64 r_num_get_input_value(RNum *num, const char *input_value);
-R_API double r_num_get_float (RNum *num, const char *str);
 R_API char* r_num_as_string(RNum *___, ut64 n);
 R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex);
 

--- a/libr/reg/value.c
+++ b/libr/reg/value.c
@@ -81,15 +81,15 @@ R_API bool r_reg_set_value(RReg *reg, RRegItem *item, ut64 value) {
 		break;
 	case 32:
 		if (reg->big_endian)
-			r_write_be32(src, (ut32)(value & UT32_MAX));
+			r_write_be32(src, value);
 		else
-			r_write_le32(src, (ut32)(value & UT32_MAX));
+			r_write_le32(src, value);
 		break;
 	case 16:
 		if (reg->big_endian)
-			r_write_be16(src, (ut16)(value & UT16_MAX));
+			r_write_be16(src, value);
 		else
-			r_write_le16(src, (ut16)(value & UT16_MAX));
+			r_write_le16(src, value);
 		break;
 	case 8:
 		r_write_ble8(src, (ut8)(value & UT8_MAX));

--- a/libr/util/num.c
+++ b/libr/util/num.c
@@ -1,7 +1,9 @@
 /* radare - LGPL - Copyright 2007-2015 - pancake */
 
+#if __WINDOWS__ && MINGW32 && !__CYGWIN__
 #include <stdlib.h>
-#include <r_types.h>
+#endif
+
 #include <r_util.h>
 #define R_NUM_USE_CALC 1
 
@@ -277,19 +279,15 @@ R_API ut64 r_num_math(RNum *num, const char *str) {
 #endif
 }
 
-R_API int r_num_is_float (struct r_num_t *num, const char *str) {
+R_API int r_num_is_float(RNum *num, const char *str) {
 	// TODO: also support 'f' terminated strings
 	return (strchr (str, '.') != NULL)? R_TRUE:R_FALSE;
 }
 
-R_API double r_num_get_float (RNum *num, const char *str) {
-	typedef union {
-		ut64 n;
-		double d;
-	} dualtype;
-	dualtype dual;
-	dual.n = (ut64)r_num_get (NULL, str);
-	return (double)dual.d;
+R_API double r_num_get_float(RNum *num, const char *str) {
+	double d = 0.0f;
+	(void) sscanf (str, "%lf", &d);
+	return d;
 }
 
 R_API int r_num_to_bits (char *out, ut64 num) {


### PR DESCRIPTION
- Reverted ADD and ADC to set flags based on internal variables
- Fixed calculation of carry and zero flags from internal vars
- Revert "ESIL: add floating point instructions (#4794)"
  This reverts commit 964d12b392afedb87d7ba29db62f51aa8e51af2c. Since we
  decided that floating point operations will be implemented using separate
  ops, these unions are no longer needed. This commit introduced a regression
  in setting esil->old and esil->cur