### PR TITLE
Allow local variable detection for mips

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -117,10 +117,10 @@ static const char *arg(csh *handle, cs_insn *insn, char *buf, int n) {
 			cs_reg_name (*handle,
 				insn->detail->mips.operands[n].mem.base));
 		} else {
-		sprintf (buf, "%s,%"PFMT64d",+",
+		sprintf (buf, "0x%"PFMT64x",%s,+",
+			(ut64)insn->detail->mips.operands[n].mem.disp,
 			cs_reg_name (*handle,
-				insn->detail->mips.operands[n].mem.base),
-			(ut64)insn->detail->mips.operands[n].mem.disp);
+				insn->detail->mips.operands[n].mem.base));
 		}
 		}
 		break;


### PR DESCRIPTION
The recently committed changes for auto-detecting arguments and variables are great and I'm looking forward to this being completed.

I wanted to try and get this working for MIPS as well as x86 and ARM so here is a small set of changes which adds support for local variables at least. I had to change the ESIL output to match what the new fill_args()/extract_arg() functions are expecting (use hex and reverse the order of the + arguments) and then add a varsub hook to the MIPS pseudo plugin.

anal/fcn.c: fill_args() is a good start but I don't think it is generic enough to support all architectures. Is it possible to add the facility for this variable/argument detection to be overridden on a per-plugin basis? Something like RAnalPlugin.findvar?

For example, on MIPS I need to do some extra work to find arguments on the stack (MIPS passes the first four arguments in registers) and watch for when the stack pointer is decremented so that I can tell if the SP offset is greater or less than the decrement. I'd also like to automatically name the pseudo-local variables that are used to hold the return address and frame pointer. This is all rather MIPS specific.

I'm happy to do the work in implementing the 'findvar' function for the MIPS parser.

Thanks for considering.
