### PR TITLE
Fix #4927 - Add rabin2 -qqz to list only strings (no offsets or sizes)

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -60,6 +60,7 @@ static int rabin_show_help(int v) {
 		" -P              show debug/pdb information\n"
 		" -PP             download pdb file for binary\n"
 		" -q              be quiet, just show fewer data\n"
+		" -qq             show less info (no offset/size for -z for ex.)\n"
 		" -Q              show load address used by dlopen (non-aslr libs)\n"
 		" -r              radare output\n"
 		" -R              relocations\n"
@@ -532,7 +533,12 @@ int main(int argc, char **argv) {
 			set_action (R_BIN_REQ_VERSIONINFO);
 			break;
 		case 'V': set_action (R_BIN_REQ_VERSIONINFO); break;
-		case 'q': rad = R_CORE_BIN_SIMPLE; break;
+		case 'q':
+			if (rad & R_CORE_BIN_SIMPLE)
+				rad = R_CORE_BIN_SIMPLEST;
+			else
+				rad = R_CORE_BIN_SIMPLE;
+			break;
 		case 'j': rad = R_CORE_BIN_JSON; break;
 		case 'A': set_action (R_BIN_REQ_LISTARCHS); break;
 		case 'a': arch = optarg; break;

--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -534,10 +534,8 @@ int main(int argc, char **argv) {
 			break;
 		case 'V': set_action (R_BIN_REQ_VERSIONINFO); break;
 		case 'q':
-			if (rad & R_CORE_BIN_SIMPLE)
-				rad = R_CORE_BIN_SIMPLEST;
-			else
-				rad = R_CORE_BIN_SIMPLE;
+			rad = (rad & R_CORE_BIN_SIMPLE ?
+				R_CORE_BIN_SIMPLEST : R_CORE_BIN_SIMPLE);
 			break;
 		case 'j': rad = R_CORE_BIN_JSON; break;
 		case 'A': set_action (R_BIN_REQ_LISTARCHS); break;

--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -10,6 +10,7 @@
 
 #define IS_MODE_SET(mode) (mode & R_CORE_BIN_SET)
 #define IS_MODE_SIMPLE(mode) (mode & R_CORE_BIN_SIMPLE)
+#define IS_MODE_SIMPLEST(mode) (mode & R_CORE_BIN_SIMPLEST)
 #define IS_MODE_JSON(mode) (mode & R_CORE_BIN_JSON)
 #define IS_MODE_RAD(mode) (mode & R_CORE_BIN_RADARE)
 #define IS_MODE_NORMAL(mode) (!mode)
@@ -343,6 +344,8 @@ static int bin_strings(RCore *r, int mode, int va) {
 		} else if (IS_MODE_SIMPLE (mode)) {
 			r_cons_printf ("0x%"PFMT64x" %d %d %s\n", addr,
 				string->size, string->length, string->string);
+		} else if (IS_MODE_SIMPLEST (mode)) {
+			r_cons_printf ("%s\n", string->string);
 		} else if (IS_MODE_JSON (mode)) {
 			q = r_base64_encode_dyn (string->string, -1);
 			r_cons_printf ("%s{\"vaddr\":%"PFMT64d

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -418,6 +418,7 @@ R_API void fcn_callconv (RCore *core, RAnalFunction *fcn);
 #define R_CORE_BIN_SIMPLE	0x004
 #define R_CORE_BIN_JSON         0x008
 #define R_CORE_BIN_ARRAY 	0x010
+#define R_CORE_BIN_SIMPLEST 	0x020
 
 #define R_CORE_BIN_ACC_STRINGS	0x001
 #define R_CORE_BIN_ACC_INFO	0x002


### PR DESCRIPTION
$ rabin2 -qqz /bin/dd |head -3 
out of memory
unknown operand %s
no value specified for %s

$ rabin2 -qz /bin/dd |head -3  
0x1163e0 14 13 out of memory
0x1163ee 19 18 unknown operand %s
0x116401 26 25 no value specified for %s

$ rabin2 -z /bin/dd |head -3  
vaddr=0x001163e0 paddr=0x000163e0 ordinal=000 sz=14 len=13 section=.rodata type=ascii string=out of memory
vaddr=0x001163ee paddr=0x000163ee ordinal=001 sz=19 len=18 section=.rodata type=ascii string=unknown operand %s
vaddr=0x00116401 paddr=0x00016401 ordinal=002 sz=26 len=25 section=.rodata type=ascii string=no value specified for %s
