### PR TITLE
Memory efficient implemenation of Levenshtein Distance for radiff2

### DIFF
--- a/binr/radiff2/radiff2.c
+++ b/binr/radiff2/radiff2.c
@@ -29,6 +29,7 @@ static RCore *core = NULL;
 static const char *arch = NULL;
 static int bits = 0;
 static int anal_all = 0;
+static bool verbose = false;
 
 static RCore* opencore(const char *f) {
 	const ut64 baddr = UT64_MAX;
@@ -147,7 +148,7 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 }
 
 static int show_help(int v) {
-	printf ("Usage: radiff2 [-abcCdjrspOxv] [-g sym] [-t %%] [file] [file]\n");
+	printf ("Usage: radiff2 [-abcCdjrspOxvV] [-g sym] [-t %%] [file] [file]\n");
 	if (v) printf (
 		"  -a [arch]  specify architecture plugin to use (x86, arm, ..)\n"
 		"  -A [-A]    run aaa or aaaa after loading each binary (see -C)\n"
@@ -165,7 +166,8 @@ static int show_help(int v) {
 		"  -s         compute text distance\n"
 		"  -t [0-100] set threshold for code diff (default is 70%%)\n"
 		"  -x         show two column hexdump diffing\n"
-		"  -v         show version information\n");
+		"  -v         show version information\n"
+		"  -V         be verbose (current only for -s)\n");
 	return 1;
 }
 
@@ -263,7 +265,7 @@ int main(int argc, char **argv) {
 	int threshold = -1;
 	double sim;
 
-	while ((o = getopt (argc, argv, "Aa:b:CDnpg:Ojrhcdsvxt:")) != -1) {
+	while ((o = getopt (argc, argv, "Aa:b:CDnpg:OjrhcdsVvxt:")) != -1) {
 		switch (o) {
 		case 'a':
 			arch = optarg;
@@ -317,6 +319,9 @@ int main(int argc, char **argv) {
 		case 'v':
 			printf ("radiff2 v"R2_VERSION"\n");
 			return 0;
+		case 'V':
+			verbose = true;
+			break;
 		case 'j':
 			diffmode = 'j';
 			break;
@@ -432,8 +437,8 @@ int main(int argc, char **argv) {
 		r_diff_free (d);
 		break;
 	case MODE_DIST:
-		r_diff_buffers_distance (NULL, bufa, sza, bufb, szb, &count, &sim);
-		printf ("similarity: %.2f\n", sim);
+		r_diff_buffers_distance (NULL, bufa, sza, bufb, szb, &count, &sim,verbose);
+		printf ("similarity: %.3f\n", sim);
 		printf ("distance: %d\n", count);
 		break;
 	}

--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -47,7 +47,7 @@ R_API int r_diff_buffers(RDiff *d, const ut8 *a, ut32 la, const ut8 *b, ut32 lb)
 R_API int r_diff_set_callback(RDiff *d, RDiffCallback callback, void *user);
 R_API bool r_diff_buffers_distance(RDiff *d,
 	const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance,
-	double *similarity);
+	double *similarity, bool verbose);
 /* static method !??! */
 R_API int r_diff_lines(const char *file1, const char *sa, int la, const char *file2, const char *sb, int lb);
 R_API int r_diff_set_delta(RDiff *d, int delta);


### PR DESCRIPTION
Implemented the iterative two matrix row version from here: https://en.wikipedia.org/wiki/Levenshtein_distance
and here: http://www.codeproject.com/Articles/13525/Fast-memory-efficient-Levenshtein-algorithm

Memory usage was originally 200Gig for a couple of 200K files ~(sizeA*sizeB), now about 400K ~(sizeB*2). Speed seems similar.

Could use a clean-up but that's all I have time for unfortunately..