### PR TITLE
libr/socket/run.c: fix use of uninitialized value

### DIFF
--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -62,7 +62,7 @@ R_API void r_run_reset(RRunProfile *p) {
 
 R_API int r_run_parse(RRunProfile *pf, const char *profile) {
 	char *p, *o, *str = strdup (profile);
-	if (!p) return 0;
+	if (!str) return 0;
 	for (o = p = str; (o = strchr (p, '\n')); p = o) {
 		*o++ = 0;
 		r_run_parseline (pf, p);


### PR DESCRIPTION
Noticed by gcc:
 * QA Notice: Package triggers severe warnings which indicate that it
 *            may exhibit random runtime failures.
 * run.c:65:5: warning: ‘p’ is used uninitialized in this function [-Wuninitialized]

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>