### PR TITLE
Esil internal set

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -367,11 +367,11 @@ static int esil_internal_read(RAnalEsil *esil, const char *str, ut64 *num) {
 		}
 		break;
 	case 'b': //borrow
-		bit = (ut8)r_num_get (NULL, &str[2]);
+		bit = (ut8) r_num_get (NULL, &str[2]);
 		*num = esil_internal_borrow_check (esil, bit);
 		break;
 	case 'c': //carry
-		bit = (ut8)r_num_get (NULL, &str[2]);
+		bit = (ut8) r_num_get (NULL, &str[2]);
 		*num = esil_internal_carry_check (esil, bit);
 		break;
 	case 'o': //overflow
@@ -406,6 +406,12 @@ static int esil_internal_read(RAnalEsil *esil, const char *str, ut64 *num) {
 		default:
 			return false;
 		}
+		break;
+	case '0': // unset flag without affecting esil vars cur, old and lastsz
+		*num = 0;
+		break;
+	case '1': // set flag without affecting esil vars cur, old and lastsz
+		*num = 1;
 		break;
 	default:
 		return false;

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -366,16 +366,16 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_FMULP:
 		break;
 	case X86_INS_CLI:
-		esilprintf (op, "0,if,=");
+		esilprintf (op, "$0,if,=");
 		break;
 	case X86_INS_STI:
-		esilprintf (op, "1,if,=");
+		esilprintf (op, "$1,if,=");
 		break;
 	case X86_INS_CLC:
-		esilprintf (op, "0,cf,=");
+		esilprintf (op, "$0,cf,=");
 		break;
 	case X86_INS_STC:
-		esilprintf (op, "1,cf,=");
+		esilprintf (op, "$1,cf,=");
 		break;
 	case X86_INS_CLAC:
 	case X86_INS_CLGI:
@@ -740,7 +740,7 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		if (insn->id == X86_INS_TEST) {
 			char *src = getarg (&gop, 1, 0, NULL);
 			char *dst = getarg (&gop, 0, 0, NULL);
-			esilprintf (op, "0,%s,%s,&,==,$z,zf,=,$p,pf,=,$s,sf,=,0,cf,=,0,of,=",
+			esilprintf (op, "0,%s,%s,&,==,$z,zf,=,$p,pf,=,$s,sf,=,$0,cf,=,$0,of,=",
 				src, dst);
 			free (src);
 			free (dst);
@@ -1045,7 +1045,7 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		{
 			char *src = getarg (&gop, 1, 0, NULL);
 			char *dst = getarg (&gop, 0, 1, "^");
-			esilprintf (op, "%s,%s,$z,zf,=,$p,pf,=,$s,sf,=,0,cf,=,0,of,=",
+			esilprintf (op, "%s,%s,$z,zf,=,$p,pf,=,$s,sf,=,$0,cf,=,$0,of,=",
 				src, dst);
 			free (src);
 			free (dst);
@@ -1063,7 +1063,7 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		{
 			char *src = getarg (&gop, 1, 0, NULL);
 			char *dst = getarg (&gop, 0, 0, NULL);
-			esilprintf (op, "%s,%s,|=,$s,sf,=,$z,zf,=,$p,pf,=,0,of,=,0,cf,=", src, dst);
+			esilprintf (op, "%s,%s,|=,$s,sf,=,$z,zf,=,$p,pf,=,$0,of,=,$0,cf,=", src, dst);
 			free (src);
 			free (dst);
 		}
@@ -1106,11 +1106,12 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		{
 			char *src = getarg (&gop, 1, 0, NULL);
 			char *dst = getarg (&gop, 0, 1, "-");
+			ut64 size = INSOP(0).size;
 			// Set OF, SF, ZF, AF, PF, and CF flags.
 			// We use $b rather than $c here as the carry flag really
 			// represents a "borrow"
-			esilprintf (op, "%s,%s,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b,cf,=",
-				src, dst);
+			esilprintf (op, "%s,%s,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b%d,cf,=",
+				src, dst, size);
 			free (src);
 			free (dst);
 		}
@@ -1120,7 +1121,8 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		{
 			char *src = getarg (&gop, 1, 0, NULL);
 			char *dst = getarg (&gop, 0, 0, NULL);
-			esilprintf (op, "cf,%s,+,%s,-=,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b,cf,=", src, dst);
+			ut64 size = INSOP(0).size;
+			esilprintf (op, "cf,%s,+,%s,-=,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b%d,cf,=", src, dst, size);
 			free (src);
 			free (dst);
 		}
@@ -1160,7 +1162,7 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		{
 			char *src = getarg (&gop, 1, 0, NULL);
 			char *dst = getarg (&gop, 0, 1, "&");
-			esilprintf (op, "%s,%s,0,of,=,0,cf,=,$z,zf,=,$s,sf,=,$o,pf,=", src, dst);
+			esilprintf (op, "%s,%s,$0,of,=,$0,cf,=,$z,zf,=,$s,sf,=,$o,pf,=", src, dst);
 			free (src);
 			free (dst);
 		}


### PR DESCRIPTION
**Introduces esil internal set and unset**
- $0 and $1 can be used to set and unset registers without affecting esil
  variables cur, old and lastsz and thereby not affecting any flag
  computations.
- Minor bug and style fixes in anal_x86_cs.c	

**Generalizes set/unset**
- This commit makes set/unset more generic by allowing any value to be assigned
to a register (as opposed to just 0/1 before) without any side effects.
- $[0-9]* represents a value to be set, in decimal representation, without
having any side effects of changing esil vars old, cur and lastsz and hence
not affecting the flag computations. Example: Set rax to 100. ("$100,rax,=").

If the second one is taking it too far, I'll drop that commit and we can have just $0 and $1 to set/unset. If this is acceptable by everyone, I'll squash the commits. Let me know what you think.