### PR TITLE
Add support for 'pf [size]D'

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2770,7 +2770,7 @@ static int cmd_print(void *data, const char *input) {
 						const int bs = core->blocksize;
 						int instr_len;
 						r_core_asm_bwdis_len (core, &instr_len, &addr, l);
-						ut32 prevaddr = core->offset;
+						ut64 prevaddr = core->offset;
 						r_core_seek(core, prevaddr - instr_len, true);
 						block = realloc (block, R_MAX(instr_len, bs));
 						memcpy (block, core->block, bs);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -941,14 +941,18 @@ static const char *r_core_print_offname(void *p, ut64 addr) {
 	return NULL;
 }
 
+/**
+ * Disassemble one instruction at specified address.
+ */
 static int __disasm(void *_core, ut64 addr) {
 	RCore *core = _core;
-	ut8 buf[32], *oblock;
+	ut64 prevaddr = core->offset;
 	int len;
-	oblock = core->block;
-	r_io_read_at (core->io, addr, (ut8*)buf, sizeof (buf));
-	len = r_core_print_disasm_instructions (core, sizeof (buf), 1);
-	core->block = oblock;
+
+	r_core_seek (core, addr, true);
+	len = r_core_print_disasm_instructions (core, 0, 1);
+	r_core_seek (core, prevaddr, true);
+
 	return len;
 }
 

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3035,7 +3035,7 @@ toro:
  * Set to 0 the parameter you don't use */
 R_API int r_core_print_disasm_instructions (RCore *core, int nb_bytes, int nb_opcodes) {
 	RDisasmState *ds = NULL;
-	int i, j, ret, err = 0;
+	int i, j, ret, len = 0;
 	RAnalFunction *f;
 	char *tmpopstr;
 	const ut64 old_offset = core->offset;
@@ -3066,7 +3066,6 @@ R_API int r_core_print_disasm_instructions (RCore *core, int nb_bytes, int nb_op
 		core->anal->cur->reset_counter (core->anal, core->offset);
 
 	ds = ds_init (core);
-	ds->len = nb_bytes;
 	ds->l = nb_opcodes;
 	ds->len = nb_opcodes * 8;
 
@@ -3134,6 +3133,7 @@ R_API int r_core_print_disasm_instructions (RCore *core, int nb_bytes, int nb_op
 			ds->analop.size = ret;
 			ds->asmop.size = ret;
 		}
+		len += R_MAX (0, ret);
 		if (ds->hint && ds->hint->opcode) {
 			free (ds->opstr);
 			ds->opstr = strdup (ds->hint->opcode);
@@ -3187,10 +3187,6 @@ R_API int r_core_print_disasm_instructions (RCore *core, int nb_bytes, int nb_op
 				ds->opstr = (tmpopstr)? tmpopstr: strdup (ds->asmop.buf_asm);
 			}
 		}
-		if (ret < 1) {
-			err = 1;
-			ret = 1;
-		}
 		{
 			const char *opcolor = NULL;
 			if (ds->show_color) {
@@ -3213,8 +3209,9 @@ R_API int r_core_print_disasm_instructions (RCore *core, int nb_bytes, int nb_op
 	}
 	ds_free (ds);
 	core->offset = old_offset;
-r_reg_arena_pop (core->anal->reg);
-	return err;
+	r_reg_arena_pop (core->anal->reg);
+
+	return len;
 }
 
 R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_bytes, int nb_opcodes) {

--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -486,6 +486,20 @@ static void r_print_format_hex(const RPrint* p, int endian, int mode,
 	}
 }
 
+static int r_print_format_disasm(const RPrint* p, ut64 seeki, int size) {
+	ut64 prevseeki = seeki;
+
+	if (!p->disasm || !p->user) return 0;
+
+	size = R_MAX (1, size);
+
+	while (size-- > 0) {
+		seeki += p->disasm (p->user, seeki);
+	}
+
+	return seeki - prevseeki;
+}
+
 static void r_print_format_octal (const RPrint* p, int endian, int mode,
 		const char* setval, ut64 seeki, ut8* buf, int i, int size) {
 	ut64 addr;
@@ -1499,9 +1513,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 					i+= (size==-1) ? 4 : 4*size;
 					break;
 				case 'D':
-					if (size>0) p->cb_printf ("Size not yet implemented\n");
-					if (p->disasm && p->user)
-						i += p->disasm (p->user, seeki);
+					i += r_print_format_disasm (p, seeki, size);
 					break;
 				case 'o':
 					r_print_format_octal (p, endian, mode, setval, seeki, buf, i, size);


### PR DESCRIPTION
Proposal fix for #4494

__disasm was changed to disassemble at specified address, otherwise it always disassemble at current offset (or i am missing smth)
r_core_print_disasm_instructions was changed to return number of bytes processed

Is there any good reason why RPrint->disasm() exist? Probably should be removed and this code rewritten to use "R" disasm api directly.