### PR TITLE
Change inline asm constraints to "r" (#5065)

### DIFF
--- a/libr/include/sflib/linux-x86-32/sfsyscall.h
+++ b/libr/include/sflib/linux-x86-32/sfsyscall.h
@@ -72,7 +72,7 @@ __asm__ volatile ("###> " #name "(%2) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1))); \
+	: "0" (__NR_##name),"r" ((long)(arg1))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -86,7 +86,7 @@ __asm__ volatile ("###> " #name "(%2, %3) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -100,7 +100,7 @@ __asm__ volatile ("###> " #name "(%2, %3, %4) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 		  "d" ((long)(arg3)) ); \
 __sfsyscall_return(type,__res); \
 }
@@ -115,7 +115,7 @@ __asm__ volatile ("###> " #name "(%2, %3, %4, %5) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)) ); \
 __sfsyscall_return(type,__res); \
 } 
@@ -131,7 +131,7 @@ __asm__ volatile ("###> " #name "(%2, %3, %4, %5, %6) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)),"D" ((long)(arg5))); \
 __sfsyscall_return(type,__res); \
 }
@@ -150,9 +150,9 @@ __asm__ volatile ("##> " #name "(%2, %3, %4, %5, %6, %7) <###\n\t"    \
 		  "popl %%ebp\n\t"   \
                   "popl %%ebx"       \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)),"D" ((long)(arg5)), \
-	  "g" ((long)(arg6))); \
+	  "r" ((long)(arg6))); \
 __sfsyscall_return(type,__res); \
 }
 


### PR DESCRIPTION
Inline assembly constraints for linux-x86-32/sfsyscall.h are changed to "r" instead of "g". This prevents situations where the compiler may substitute the operand with a memory location that may make the inline assembly function incorrectly. See #5065 