### PR TITLE
rahash2: Don't try to unescape inputs provided as hex strings (-x)

### DIFF
--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -544,7 +544,7 @@ int main(int argc, char **argv) {
 		hashstr = hashstr + from;
 		hashstr_len = to - from;
 		hashstr[hashstr_len] = '\0';
-		if (!bytes_read) {
+		if (!bytes_read && !hashstr_hex) {
 			hashstr_len = r_str_unescape (hashstr);
 		}
 		if (encrypt) {


### PR DESCRIPTION
Fixes #4642, which is about using '-x 5c', which is a backslash.