### PR TITLE
Disable colors when stdout is not a terminal

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -892,7 +892,11 @@ int main(int argc, char **argv, char **envp) {
 		}
 		r_cons_flush ();
 	}
-
+#if __UNIX__
+	if (!r_cons_isatty ()) {
+		r_config_set_i (r.config, "scr.color", 0);
+	}
+#endif
 	ret = run_commands (cmds, files, quiet);
 	r_list_free (cmds);
 	r_list_free (files);
@@ -914,11 +918,6 @@ int main(int argc, char **argv, char **envp) {
 		r_config_set (r.config, "scr.interactive", "false");
 		r_config_set (r.config, "scr.prompt", "false");
 	}
-#if __UNIX__
-	if (!r_cons_isatty ()) {
-		r_config_set_i (r.config, "scr.color", 0);
-	}
-#endif
 	r.num->value = 0;
 	if (patchfile) {
 		char *data = r_file_slurp (patchfile, NULL);

--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -914,7 +914,11 @@ int main(int argc, char **argv, char **envp) {
 		r_config_set (r.config, "scr.interactive", "false");
 		r_config_set (r.config, "scr.prompt", "false");
 	}
-
+#if __UNIX__
+	if (!r_cons_isatty ()) {
+		r_config_set_i (r.config, "scr.color", 0);
+	}
+#endif
 	r.num->value = 0;
 	if (patchfile) {
 		char *data = r_file_slurp (patchfile, NULL);
@@ -1006,13 +1010,15 @@ int main(int argc, char **argv, char **envp) {
 		}
 	}
 #if __UNIX__
-	if (isatty (0)) {
+	if (r_cons_isatty ()) {
 #endif
 		 if (r_config_get_i (r.config, "scr.histsave") &&
 				r_config_get_i (r.config, "scr.interactive") &&
 				!r_sandbox_enable (0))
 			r_line_hist_save (R2_HOMEDIR"/history");
 #if __UNIX__
+	} else {
+		r_config_set_i (r.config, "scr.color", 0);
 	}
 #endif
 	// TODO: kill thread

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -723,6 +723,19 @@ R_API int r_cons_get_cursor(int *rows) {
 	return col;
 }
 
+R_API bool r_cons_isatty() {
+#if __UNIX__ || __CYGWIN__
+	struct winsize win = { 0 };
+        if (isatty (1) && !ioctl (0, TIOCGWINSZ, &win)) {
+                if ((win.ws_col == 0) || (win.ws_row == 0)) {
+                        const char *tty = ttyname (1);
+			return r_file_exists (tty);
+                }
+        }
+#endif
+        return false;
+}
+
 // XXX: if this function returns <0 in rows or cols expect MAYHEM
 R_API int r_cons_get_size(int *rows) {
 #if __WINDOWS__ && !__CYGWIN__
@@ -738,8 +751,8 @@ R_API int r_cons_get_size(int *rows) {
 	struct winsize win = { 0 };
 	if (isatty (0) && ioctl (0, TIOCGWINSZ, &win) == 0) {
 		if ((win.ws_col == 0) || (win.ws_row == 0)) {
-			// TODO: use ttyname() ?
-			int fd = open ("/dev/tty", O_RDONLY);
+			const char *tty = ttyname (1);
+			int fd = open (tty, O_RDONLY);
 			if (fd != -1) {
 				int ret = ioctl (fd, TIOCGWINSZ, &win);
 				if ((ret != 0) || (win.ws_col == 0) || (win.ws_row == 0)) {
@@ -775,10 +788,12 @@ R_API int r_cons_get_size(int *rows) {
 	I.rows = -1;
 	I.columns = -1;
 #endif
-	if (I.rows<0)
+	if (I.rows < 0) {
 		I.rows = 0;
-	if (I.columns<0)
+	}
+	if (I.columns < 0) {
 		I.columns = 0;
+	}
 	if (I.force_columns) I.columns = I.force_columns;
 	if (I.force_rows) I.rows = I.force_rows;
 	if (I.fix_columns) I.columns += I.fix_columns;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -438,6 +438,7 @@ R_API char *r_cons_rgb_tostring(ut8 r, ut8 g, ut8 b);
 R_API void r_cons_pal_list (int rad, const char *arg);
 R_API void r_cons_pal_show (void);
 R_API int r_cons_get_size(int *rows);
+R_API bool r_cons_isatty();
 R_API int r_cons_get_cursor(int *rows);
 R_API int r_cons_arrow_to_hjkl(int ch);
 R_API int r_cons_html_print(const char *ptr);


### PR DESCRIPTION
This fixes #5038 and is based on #5067 