### PR TITLE
re construction of argument/var commands

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -281,6 +281,7 @@ void extract_arg (RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg,
 	if(!sig) return;
 	op_esil = r_strbuf_get (&op->esil);
 	if (!op_esil) {
+		free (sig);
 		return;
 	}
 	esil_buf = strdup (op_esil);
@@ -317,6 +318,8 @@ void extract_arg (RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg,
 		r_anal_var_access (anal, fcn->addr, 'v', 1, ptr, 1, op->addr);
 
 	}
+	free (varname);
+	free (sig);
 	free (esil_buf);
 }
 

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -68,7 +68,7 @@ R_API void r_anal_op_free(void *_op) {
 
 static RAnalVar *get_used_var(RAnal *anal, RAnalOp *op) {
 	char *inst_key = sdb_fmt (0, "inst.0x%"PFMT64x".vars", op->addr);
-	char *var_def = sdb_get (anal->sdb_fcns, inst_key, 0);
+	const char *var_def = sdb_const_get (anal->sdb_fcns, inst_key, 0);
 	struct VarUsedType vut;
 	RAnalVar *res;
 

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -42,11 +42,9 @@ R_API int r_anal_var_add (RAnal *a, ut64 addr, int scope, int delta, char kind, 
 	if (!type) type = "int";
 //eprintf ("VAR ADD 0x%llx  - %d\n", addr, delta);
 	switch (kind) {
-	case 'a': // stack-based argument
-	case 'r':
-	case 'v':
-	case 'A': // fastcall based argument
-	case 'e':
+	case 'a': // base pointer var/args
+	case 'v': // stack pointer var/args
+	case 'e': // registers args
 		break;
 	default:
 		eprintf ("Invalid var kind '%c'\n", kind);
@@ -54,13 +52,21 @@ R_API int r_anal_var_add (RAnal *a, ut64 addr, int scope, int delta, char kind, 
 	}
 	var_def = sdb_fmt (0,"%c,%s,%d,%s", kind, type, size, name);
 	if (scope>0) {
+		char *sign = "";
+		if (delta < 0) {
+			delta = -delta;
+			sign = "n";
+		}
 		/* local variable */
 		char *fcn_key = sdb_fmt (1, "fcn.0x%"PFMT64x".%c", addr, kind);
-		char *var_key = sdb_fmt (2, "var.0x%"PFMT64x".%c.%d.%d", addr, kind, scope, delta);
+		char *var_key = sdb_fmt (2, "var.0x%"PFMT64x".%c.%d.%s%d", addr, kind, scope, sign, delta);
 		char *name_key = sdb_fmt (3, "var.0x%"PFMT64x".%c.%d.%s", addr, kind, scope, name);
-		char *shortvar = sdb_fmt (4, "%d.%d", scope, delta);
+		char *shortvar = sdb_fmt (4, "%d.%s%d", scope, sign, delta);
 		sdb_array_add (DB, fcn_key, shortvar, 0);
 		sdb_set (DB, var_key, var_def, 0);
+		if (*sign) {
+			delta = -delta;
+		}
 		sdb_num_set (DB, name_key, delta, 0);
 	} else {
 		/* global variable */
@@ -94,9 +100,7 @@ R_API int r_anal_var_retype (RAnal *a, ut64 addr, int scope, int delta, char kin
 	}
 	switch (kind) {
 	case 'a':
-	case 'r':
 	case 'v':
-	case 'A':
 	case 'e':
 		break;
 	default:
@@ -105,13 +109,21 @@ R_API int r_anal_var_retype (RAnal *a, ut64 addr, int scope, int delta, char kin
 	}
 	var_def = sdb_fmt (0,"%c,%s,%d,%s", kind, type, size, name);
 	if (scope > 0) {
+		char *sign = "";
+		if (delta < 0) {
+			delta = -delta;
+			sign = "n";
+		}
 		/* local variable */
 		const char *fcn_key = sdb_fmt (1, "fcn.0x%"PFMT64x".%c", addr, kind);
-		const char *var_key = sdb_fmt (2, "var.0x%"PFMT64x".%c.%d.%d", addr, kind, scope, delta);
+		const char *var_key = sdb_fmt (2, "var.0x%"PFMT64x".%c.%d.%s%d", addr, kind, scope, sign, delta);
 		const char *name_key = sdb_fmt (3, "var.0x%"PFMT64x".%c.%d.%s", addr, kind, scope, name);
-		const char *shortvar = sdb_fmt (4, "%d.%d", scope, delta);
+		const char *shortvar = sdb_fmt (4, "%d.%s%d", scope, sign, delta);
 		sdb_array_add (DB, fcn_key, shortvar, 0);
 		sdb_set (DB, var_key, var_def, 0);
+		if (*sign) {
+			delta = -delta;
+		}
 		sdb_num_set (DB, name_key, delta, 0);
 	} else {
 		/* global variable */
@@ -139,19 +151,26 @@ R_API int r_anal_var_delete_all (RAnal *a, ut64 addr, const char kind) {
 
 R_API int r_anal_var_delete (RAnal *a, ut64 addr, const char kind, int scope, int delta) {
 	RAnalVar *av;
-	if (delta<0) delta = -delta;
 	av = r_anal_var_get (a, addr, kind, scope, delta);
 	if (!av) {
 		return false;
 	}
 	if (scope>0) {
+		char *sign = "";
+		if (delta < 0) {
+			delta = -delta;
+			sign = "n";
+		}
 		char *fcn_key = sdb_fmt (1, "fcn.0x%"PFMT64x".%c", addr, kind);
-		char *var_key = sdb_fmt (2, "var.0x%"PFMT64x".%c.%d.%d", addr, kind, scope, delta);
+		char *var_key = sdb_fmt (2, "var.0x%"PFMT64x".%c.%d.%s%d", addr, kind, scope, sign, delta);
 		char *name_key = sdb_fmt (3, "var.0x%"PFMT64x".%c.%d.%s", addr, kind, scope, av->name);
-		char *shortvar = sdb_fmt (4, "%d.%d", scope, delta);
+		char *shortvar = sdb_fmt (4, "%d.%s%d", scope, sign, delta);
 		sdb_array_remove (DB, fcn_key, shortvar, 0);
 		sdb_unset (DB, var_key, 0);
 		sdb_unset (DB, name_key, 0);
+		if (*sign) {
+			delta = -delta;
+		}
 	} else {
 		char *var_global = sdb_fmt (1, "var.0x%"PFMT64x, addr);
 		char *var_def = sdb_fmt (2,"%c.%s,%d,%s", kind, av->type, av->size, av->name);
@@ -173,9 +192,13 @@ R_API bool r_anal_var_delete_byname (RAnal *a, RAnalFunction *fcn, int kind, con
 		if (varlist && *varlist) {
 			do {
 				char *word = sdb_anext (ptr, &next);
+				char *sign = strstr (word, "n");
 				const char *vardef = sdb_const_get (DB, sdb_fmt (1,
 					"var.0x%"PFMT64x".%c.%s",
 					fcn->addr, kind, word), 0);
+				if (sign) {
+					*sign = '-';
+				}
 				int delta = strlen (word) < 3 ? -1 : atoi (word + 2);
 				if (vardef) {
 					const char *p = strchr (vardef, ',');
@@ -206,16 +229,20 @@ R_API bool r_anal_var_delete_byname (RAnal *a, RAnalFunction *fcn, int kind, con
 R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int delta) {
 	RAnalVar *av;
 	struct VarType vt;
+	char *sign = "";
 	RAnalFunction *fcn = r_anal_get_fcn_in (a, addr, 0);
 	if (!fcn)
 		return NULL;
-	if (delta<0) {
-		kind = 'v';
+	if (delta < 0) {
 		delta = -delta;
+		sign = "n";
 	}
 	const char *vardef = sdb_const_get (DB,
-		sdb_fmt (0, "var.0x%"PFMT64x".%c.%d.%d",
-			fcn->addr, kind, scope, delta), 0);
+		sdb_fmt (0, "var.0x%"PFMT64x".%c.%d.%s%d",
+			fcn->addr, kind, scope, sign, delta), 0);
+	if (*sign) {
+		delta = -delta;
+	}
 	if (!vardef) {
 		return NULL;
 	}
@@ -277,12 +304,17 @@ R_API int r_anal_var_rename (RAnal *a, ut64 var_addr, int scope, char kind, cons
 		return 0;
 	}
 	if (scope>0) { // local
+		char *sign = "";
 		SETKEY ("var.0x%"PFMT64x".%c.%d.%s", var_addr, kind, scope, old_name);
 		delta = sdb_num_get (DB, key, 0);
 		sdb_unset (DB, key, 0);
 		SETKEY ("var.0x%"PFMT64x".%c.%d.%s", var_addr, kind, scope, new_name);
 		sdb_num_set (DB, key, delta, 0);
-		SETKEY ("var.0x%"PFMT64x".%c.%d.%d", var_addr, kind, scope, delta);
+		if (delta < 0) {
+			delta = -delta;
+			sign = "n";
+		}
+		SETKEY ("var.0x%"PFMT64x".%c.%d.%s%d", var_addr, kind, scope, sign, delta);
 		sdb_array_set (DB, key, R_ANAL_VAR_SDB_NAME, new_name, 0);
 	} else { // global
 		SETKEY ("var.0x%"PFMT64x, var_addr);
@@ -393,6 +425,9 @@ R_API RList *r_anal_var_list(RAnal *a, RAnalFunction *fcn, int kind) {
 				const char *vardef = sdb_const_get (DB, sdb_fmt (1,
 					"var.0x%"PFMT64x".%c.%s",
 					fcn->addr, kind, word), 0);
+				if (word[2] == 'n') {
+					word[2] = '-';
+				}
 				int delta = atoi (word+2);
 				if (vardef) {
 					sdb_fmt_init (&vt, SDB_VARTYPE_FMT);
@@ -443,47 +478,60 @@ R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int m
 		switch (mode) {
 		case '*':
 			// we cant express all type info here :(
-			anal->cb_printf ("af%c %d %s %s @ 0x%"PFMT64x"\n",
-				kind, var->delta,
-				var->name, var->type, fcn->addr);
+			if (kind == 'v') { //registers
+				RRegItem *i = r_reg_index_get (anal->reg, var->delta);
+				if (!i) {
+					eprintf ("Register not found");
+					break;
+				}
+				anal->cb_printf ("af%c %s %s %s @ 0x%"PFMT64x"\n",
+					kind, i->name, var->name, var->type, fcn->addr);
+
+			} else {
+				anal->cb_printf ("af%c %d %s %s @ 0x%"PFMT64x"\n",
+					kind, var->delta, var->name, var->type,
+					fcn->addr);
+			}
 			break;
 		case 'j':
 			switch (var->kind) {
 			case 'a':
-				anal->cb_printf ("{\"name\":\"%s\","
-					"\"kind\":\"arg\",\"type\":\"%s\",\"ref\":\"%s+0x%x\"}",
-					var->name, var->type,anal->reg->name[R_REG_NAME_BP],
-					var->delta);
-				break;
-			case 'v':
-				anal->cb_printf ("{\"name\":\"%s\","
-					"\"kind\":\"var\",\"type\":\"%s\",\"ref\":\"%s-0x%x\"}",
-					var->name, var->type,anal->reg->name[R_REG_NAME_BP],
-					var->delta);
-				break;
-			case 'A':
-				if (var->delta == 0) {
-					anal->cb_printf ("{\"name\":\"%s\","
-						"\"kind\":\"arg\",\"type\":\"%s\",\"ref\":\"ecx\"}",
-						var->name, var->type);
-
-				} else if (var->delta == 1) {
-					anal->cb_printf ("{\"name\":\"%s\","
-						"\"kind\":\"arg\",\"type\":\"%s\",\"ref\":\"edx\"}",
-						var->name, var->type);
-
-				} else {
+				if (var->delta > 0) {
 					anal->cb_printf ("{\"name\":\"%s\","
 						"\"kind\":\"arg\",\"type\":\"%s\",\"ref\":\"%s+0x%x\"}",
 						var->name, var->type,anal->reg->name[R_REG_NAME_BP],
 						var->delta);
+				} else {
+					anal->cb_printf ("{\"name\":\"%s\","
+						"\"kind\":\"var\",\"type\":\"%s\",\"ref\":\"%s-0x%x\"}",
+						var->name, var->type,anal->reg->name[R_REG_NAME_BP],
+						-var->delta);
+
+				}
+				break;
+			case 'v':{
+				RRegItem *i = r_reg_index_get (anal->reg, var->delta);
+				if (!i) {
+					eprintf ("Register not found");
+					break;
+				}
+				anal->cb_printf ("{\"name\":\"%s\","
+					"\"kind\":\"reg\",\"type\":\"%s\",\"ref\":\"%s\"}",
+					var->name, var->type, i->name, anal->reg->name[var->delta]);
 				}
 				break;
 			case 'e':
-				anal->cb_printf ("{\"name\":\"%s\","
-					"\"kind\":\"var\",\"type\":\"%s\",\"ref\":\"%s+0x%x\"}",
-					var->name, var->type,anal->reg->name[R_REG_NAME_SP],
-					var->delta);
+				if (var->delta < fcn->stack) {
+					anal->cb_printf ("{\"name\":\"%s\","
+						"\"kind\":\"var\",\"type\":\"%s\",\"ref\":\"%s+0x%x\"}",
+						var->name, var->type,anal->reg->name[R_REG_NAME_SP],
+						var->delta);
+				} else {
+					anal->cb_printf ("{\"name\":\"%s\","
+						"\"kind\":\"arg\",\"type\":\"%s\",\"ref\":\"%s-0x%x\"}",
+						var->name, var->type,anal->reg->name[R_REG_NAME_SP],
+						var->delta);
+				}
 				break;
 			}
 			if (iter->n)  {
@@ -493,36 +541,42 @@ R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int m
 		default:
 			switch (kind) {
 			case 'a':
-				anal->cb_printf ("arg %s %s @ %s+0x%x\n",
-					var->type, var->name,
-					anal->reg->name[R_REG_NAME_BP],
-					var->delta);
-				break;
-			case 'v':
-				anal->cb_printf ("var %s %s @ %s-0x%x\n",
-					var->type, var->name,
-					anal->reg->name[R_REG_NAME_BP],
-					var->delta);
-				break;
-			case 'A':
-				if (var->delta==0) {
-					anal->cb_printf ("arg %s %s @ ecx\n",
-						var->type, var->name);
-				} else if (var->delta ==1) {
-					anal->cb_printf ("arg %s %s @ edx\n",
-						var->type, var->name);
-				} else {
+				if (var->delta > 0) {
 					anal->cb_printf ("arg %s %s @ %s+0x%x\n",
 						var->type, var->name,
 						anal->reg->name[R_REG_NAME_BP],
 						var->delta);
+				} else {
+					anal->cb_printf ("var %s %s @ %s-0x%x\n",
+						var->type, var->name,
+						anal->reg->name[R_REG_NAME_BP],
+						-var->delta);
+				}
+				break;
+			case 'v': {
+				RRegItem *i = r_reg_index_get (anal->reg, var->delta);
+				if (!i) {
+					eprintf("Register not found");
+					break;
+				}
+
+				anal->cb_printf ("reg %s %s @ %s\n",
+					var->type, var->name, i->name);
 				}
 				break;
 			case 'e':
-				anal->cb_printf ("var %s %s @ %s+0x%x\n",
-					var->type, var->name,
-					anal->reg->name[R_REG_NAME_SP],
-					var->delta);
+				if ( var->delta < fcn->stack) {
+					anal->cb_printf ("var %s %s @ %s+0x%x\n",
+						var->type, var->name,
+						anal->reg->name[R_REG_NAME_SP],
+						var->delta);
+				} else {
+					anal->cb_printf ("arg %s %s @ %s+0x%x\n",
+						var->type, var->name,
+						anal->reg->name[R_REG_NAME_SP],
+						var->delta);
+
+				}
 				break;
 			}
 		}

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -173,7 +173,7 @@ R_API bool r_anal_var_delete_byname (RAnal *a, RAnalFunction *fcn, int kind, con
 		if (varlist && *varlist) {
 			do {
 				char *word = sdb_anext (ptr, &next);
-				char *vardef = sdb_get (DB, sdb_fmt (1,
+				const char *vardef = sdb_const_get (DB, sdb_fmt (1,
 					"var.0x%"PFMT64x".%c.%s",
 					fcn->addr, kind, word), 0);
 				int delta = strlen (word) < 3 ? -1 : atoi (word + 2);
@@ -213,7 +213,7 @@ R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int d
 		kind = 'v';
 		delta = -delta;
 	}
-	char *vardef = sdb_get (DB,
+	const char *vardef = sdb_const_get (DB,
 		sdb_fmt (0, "var.0x%"PFMT64x".%c.%d.%d",
 			fcn->addr, kind, scope, delta), 0);
 	if (!vardef) {
@@ -222,7 +222,10 @@ R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int d
 	sdb_fmt_tobin (vardef, SDB_VARTYPE_FMT, &vt);
 
 	av = R_NEW0 (RAnalVar);
-	if (!av) return NULL;
+	if (!av) {
+		sdb_fmt_free (&vt, SDB_VARTYPE_FMT);
+		return NULL;
+	}
 	av->addr = addr;
 	av->scope = scope;
 	av->delta = delta;
@@ -355,7 +358,7 @@ R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind) {
 		if (varlist && *varlist) {
 			do {
 				char *word = sdb_anext (ptr, &next);
-				char *vardef = sdb_get (DB, sdb_fmt (1,
+				const char *vardef = sdb_const_get (DB, sdb_fmt (1,
 					"var.0x%"PFMT64x".%c.%s",
 					fcn->addr, kind, word), 0);
 				if (vardef) {
@@ -387,7 +390,7 @@ R_API RList *r_anal_var_list(RAnal *a, RAnalFunction *fcn, int kind) {
 			do {
 				struct VarType vt;
 				char *word = sdb_anext (ptr, &next);
-				char *vardef = sdb_get (DB, sdb_fmt (1,
+				const char *vardef = sdb_const_get (DB, sdb_fmt (1,
 					"var.0x%"PFMT64x".%c.%s",
 					fcn->addr, kind, word), 0);
 				int delta = atoi (word+2);
@@ -408,7 +411,6 @@ R_API RList *r_anal_var_list(RAnal *a, RAnalFunction *fcn, int kind) {
 					av->type = strdup (vt.type);
 					r_list_append (list, av);
 					sdb_fmt_free (&vt, SDB_VARTYPE_FMT);
-					free (vardef);
 				} else {
 					// eprintf ("Cannot find var definition for '%s'\n", word);
 				}

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1727,10 +1727,6 @@ R_API void fcn_callconv (RCore *core, RAnalFunction *fcn) {
 		}
 	}
 
-	if (fcn->call == R_ANAL_CC_TYPE_FASTCALL) {
-		r_anal_var_add (core->anal, fcn->addr, 1, 0,'A', "int", 4,"arg_ecx");
-		r_anal_var_add (core->anal, fcn->addr, 1, 1,'A', "int", 4,"arg_edx");
-	}
 	free (buf);
 	return;
 }

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -292,7 +292,7 @@ typedef struct r_anal_type_function_t {
 	short call; // calling convention
 	char* attr; // __attribute__(()) list
 	ut64 addr;
-	int stack;
+	int stack; //stack frame size
 	int maxstack;
 	int ninstr;
 	int nargs; // Function arguments counter

--- a/libr/parse/Makefile
+++ b/libr/parse/Makefile
@@ -1,7 +1,7 @@
 include ../config.mk
 
 NAME=r_parse
-DEPS=r_flags r_util r_anal r_syscall
+DEPS=r_flags r_util r_anal r_syscall r_reg
 
 LINK+=$(STOP)/tcc/libr_tcc.a
 CFLAGS+=-I$(STOP)/tcc/

--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -207,7 +207,7 @@ static inline int issegoff (const char *w) {
 }
 #endif
 
-static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
+static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
 #if USE_VARSUBS
 	int i;
 	char *ptr, *ptr2;
@@ -222,12 +222,12 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 		}
 	return true;
 #else
-	RAnalVar *var, *arg, *sparg;
-	RListIter *variter, *argiter, *spiter;
+	RAnalVar *reg, *bparg, *sparg;
+	RListIter *regiter, *bpargiter, *spiter;
 	char oldstr[64], newstr[64];
 	char *tstr = strdup (data);
 	if (!tstr) return false;
-	RList *vars, *args, *spargs;
+	RList *regs, *bpargs, *spargs;
 
 	if (p->relsub) {
 		char *rip = strstr (tstr, "[rip");
@@ -257,14 +257,9 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
                 free (tstr);
 		return false;
         }
-	vars = p->varlist (p->anal, f, 'v');
-	args = p->varlist (p->anal, f, 'a');
+	regs = p->varlist (p->anal, f, 'v');
+	bpargs = p->varlist (p->anal, f, 'a');
 	spargs = p->varlist (p->anal, f, 'e');
-	/* if no stack args check for fastcall ones */
-	/* XXX: this is just a hack because not all compilers store fastcall args in stack */
-	if (r_list_empty (args)) {
-		args = p->varlist (p->anal, f, 'A');
-	}
 	/*iterate over stack pointer arguments/variables*/
 	r_list_foreach (spargs, spiter,sparg) {
 		if (sparg->delta < 10) {
@@ -288,19 +283,24 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 			}
 		}
 	}
-	/* iterate over arguments */
-	r_list_foreach (args, argiter, arg) {
-		if (arg->delta < 10) snprintf (oldstr, sizeof (oldstr)-1,
-			"[%s + %d]",
+	/* iterate over base pointer args/vars */
+	r_list_foreach (bpargs, bpargiter, bparg) {
+		char sign = '+';
+		if (bparg->delta < 0) {
+			sign = '-';
+			bparg->delta = -bparg->delta;
+		}
+		if (bparg->delta < 10) snprintf (oldstr, sizeof (oldstr)-1,
+			"[%s %c %d]",
 			p->anal->reg->name[R_REG_NAME_BP],
-			arg->delta);
+			sign, bparg->delta);
 		else snprintf (oldstr, sizeof (oldstr)-1,
-			"[%s + 0x%x]",
+			"[%s %c 0x%x]",
 			p->anal->reg->name[R_REG_NAME_BP],
-			arg->delta);
-		snprintf (newstr, sizeof (newstr)-1, "[%s + %s]",
-			p->anal->reg->name[R_REG_NAME_BP],
-			arg->name);
+			sign, bparg->delta);
+		snprintf (newstr, sizeof (newstr)-1, "[%s %c %s]",
+			p->anal->reg->name[R_REG_NAME_BP], sign,
+			bparg->name);
 		if (strstr (tstr, oldstr) != NULL) {
 			tstr = r_str_replace (tstr, oldstr, newstr, 1);
 			break;
@@ -312,9 +312,9 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 			}
 		}
 		// Try with no spaces
-		snprintf (oldstr, sizeof (oldstr)-1, "[%s+0x%x]",
-			p->anal->reg->name[R_REG_NAME_BP],
-			arg->delta);
+		snprintf (oldstr, sizeof (oldstr)-1, "[%s%c0x%x]",
+			p->anal->reg->name[R_REG_NAME_BP], sign,
+			bparg->delta);
 		if (strstr (tstr, oldstr) != NULL) {
 			tstr = r_str_replace (tstr, oldstr, newstr, 1);
 			break;
@@ -332,27 +332,10 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 		bp[0] = 0;
 	}
 
-	r_list_foreach (vars, variter, var) {
-		if (var->delta < 10) snprintf (oldstr, sizeof (oldstr)-1, "[%s - %d]", bp, var->delta);
-		else snprintf (oldstr, sizeof (oldstr)-1, "[%s - 0x%x]", bp, var->delta);
-		snprintf (newstr, sizeof (newstr)-1, "[%s - %s]", bp, var->name);
-		if (strstr (tstr, oldstr) != NULL) {
-			tstr = r_str_replace (tstr, oldstr, newstr, 1);
-			break;
-		} else {
-			r_str_case (oldstr, true);
-			if (strstr (tstr, oldstr) != NULL) {
-				tstr = r_str_replace (tstr, oldstr, newstr, 1);
-				break;
-			}
-		}
-		// Try with no spaces
-		snprintf (oldstr, sizeof (oldstr)-1, "[%s - 0x%x]",
-			p->anal->reg->name[R_REG_NAME_BP],
-			var->delta);
-		if (strstr (tstr, oldstr) != NULL) {
-			tstr = r_str_replace (tstr, oldstr, newstr, 1);
-			break;
+	r_list_foreach (regs, regiter, reg) {
+		RRegItem *r = r_reg_index_get (p->anal->reg, reg->delta);
+		if (strstr (tstr, r->name)){
+			tstr = r_str_replace (tstr, r->name, reg->name, 1);
 		}
 	}
 
@@ -365,8 +348,9 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 		ret = false;
 	}
 	free (tstr);
-	r_list_free (vars);
-	r_list_free (args);
+	r_list_free (spargs);
+	r_list_free (bpargs);
+	r_list_free (regs);
 	return ret;
 #endif
 }


### PR DESCRIPTION
afa for base pointer arguments/vars
afe for stack pointet arguments/vaes
afv for registers
fixing the J and \0 suffix
using the right register indexer
fixng the negative offsets of afa
fixing the afa afe afv views of pdf
fixing errors in aa
fixing the stack bases arg/var
fixing the varsub
fixing afa*
fixing afat
making afx- space neutral
enabling register renaming at varsub
updating the built-in help
fixing merge conflicts