### PR TITLE
Background web server does not honour port parameter

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -783,7 +783,7 @@ static int r_core_rtr_http_thread (RThread *th) {
 	HttpThread *ht = th->user;
 	if (!ht || !ht->core) return false;
 	ret = r_core_rtr_http_run (ht->core, ht->launch, ht->path);
-	free (ht->path);
+	free ((void *)ht->path);
 	return ret;
 }
 
@@ -814,7 +814,7 @@ R_API int r_core_rtr_http(RCore *core, int launch, const char *path) {
 			eprintf ("TODO: Use different eval environ for scr. for the web\n");
 			eprintf ("TODO: Visual mode should be enabled on local\n");
 		} else {
-			char *tpath = path + 1;
+			char *tpath = (char *) path + 1;
 			while (*tpath && isspace(*tpath))
 				tpath++;
 			HttpThread ht = { core, launch, strdup(tpath) };

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -777,10 +777,14 @@ the_end:
 }
 
 static int r_core_rtr_http_thread (RThread *th) {
+	int ret;
+
 	if (!th) return false;
 	HttpThread *ht = th->user;
 	if (!ht || !ht->core) return false;
-	return r_core_rtr_http_run (ht->core, ht->launch, ht->path);
+	ret = r_core_rtr_http_run (ht->core, ht->launch, ht->path);
+	free (ht->path);
+	return ret;
 }
 
 R_API int r_core_rtr_http(RCore *core, int launch, const char *path) {
@@ -810,7 +814,10 @@ R_API int r_core_rtr_http(RCore *core, int launch, const char *path) {
 			eprintf ("TODO: Use different eval environ for scr. for the web\n");
 			eprintf ("TODO: Visual mode should be enabled on local\n");
 		} else {
-			HttpThread ht = { core, launch, path };
+			char *tpath = path + 1;
+			while (*tpath && isspace(*tpath))
+				tpath++;
+			HttpThread ht = { core, launch, strdup(tpath) };
 			httpthread = r_th_new (r_core_rtr_http_thread, &ht, 0);
 			r_th_start (httpthread, 1);
 			eprintf ("Background http server started.\n");

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -31,7 +31,7 @@ typedef struct {
 typedef struct {
 	RCore *core;
 	int launch;
-	const char *path;
+	char *path;
 } HttpThread;
 
 static char *rtrcmd (TextLog T, const char *str) {
@@ -783,7 +783,7 @@ static int r_core_rtr_http_thread (RThread *th) {
 	HttpThread *ht = th->user;
 	if (!ht || !ht->core) return false;
 	ret = r_core_rtr_http_run (ht->core, ht->launch, ht->path);
-	free ((char *)ht->path);
+	free (ht->path);
 	return ret;
 }
 

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -783,7 +783,7 @@ static int r_core_rtr_http_thread (RThread *th) {
 	HttpThread *ht = th->user;
 	if (!ht || !ht->core) return false;
 	ret = r_core_rtr_http_run (ht->core, ht->launch, ht->path);
-	free ((void *)ht->path);
+	free ((char *)ht->path);
 	return ret;
 }
 
@@ -814,10 +814,8 @@ R_API int r_core_rtr_http(RCore *core, int launch, const char *path) {
 			eprintf ("TODO: Use different eval environ for scr. for the web\n");
 			eprintf ("TODO: Visual mode should be enabled on local\n");
 		} else {
-			char *tpath = (char *) path + 1;
-			while (*tpath && isspace(*tpath))
-				tpath++;
-			HttpThread ht = { core, launch, strdup(tpath) };
+			const char *tpath = r_str_trim_const (path + 1);
+			HttpThread ht = { core, launch, strdup (tpath) };
 			httpthread = r_th_new (r_core_rtr_http_thread, &ht, 0);
 			r_th_start (httpthread, 1);
 			eprintf ("Background http server started.\n");


### PR DESCRIPTION
The optional port parameter to =h& is ignored.
This is one way to fix it.

Before:

    [0x00413aa0]> =h& 8888
    Background http server started.
    [0x00413aa0]> Starting http server...
    open http://127.0.0.1:9090/
    r2 -C http://127.0.0.1:9090/cmd/

After:

    [0x004004d0]> =h& 8888
    Background http server started.
    [0x004004d0]> Starting http server...
    open http://127.0.0.1:8888/
    r2 -C http://127.0.0.1:8888/cmd/
