### PR TITLE
Get rid of the error when 'mkdir' wanted to remove unexisting directory

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -75,10 +75,16 @@ init|update)
 		git clone https://github.com/radare/radare2-pm || exit 1
 		cd radare2-pm
 	fi
-	rm -f "${R2PM_DBDIR}"
-	rm -f "${R2PM_DBDIR}/*"
-	rmdir "${R2PM_DBDIR}"
-	rm -f "${R2PM_DBDIR}"
+
+	if [ -d "${R2PM_DBDIR}" ] && [ ! -L "${R2PM_DBDIR}" ]; then
+	    # that's weird, it should be a symlink
+	    rm -f "${R2PM_DBDIR}/"*
+	    rmdir "${R2PM_DBDIR}"
+	else
+	    # doesn't exist, is a file or symlink
+	    rm -f "${R2PM_DBDIR}"
+	fi
+
 	ln -fs "${R2PM_USRDIR}"/git/radare2-pm/db "${R2PM_DBDIR}" || exit 1
 	echo "r2pm database initialized. Use 'r2pm update' to update"
 	exit 0


### PR DESCRIPTION
Following error is thrown when running 'r2pm update':
```bash
$ r2pm update
Already up-to-date.
rmdir: failed to remove ‘/home/jaroslav/.config/radare2/r2pm/db’: No such file or directory
```
I've fixed this by actually running different rm/rmdir commands when $R2PM_DBDIR is actual directory, or a symlink (which is standard scenario). It will also handle broken cases, where the $R2PM_DBDIR doesn't exist at all or is a plain file.

Actually, I'm not sure why we can't run "rm -rf ${R2PM_DBDIR}". I assumed there's some rationale here, and just tried to make this code more clear.

Previous code had another bug, the line:
```bash
rm -f "${R2PM_DBDIR}/*"
```
is wrong. The star in quotes is not expanded by shell, and files are not removed:
```bash
✔ 14:12 /tmp $ mkdir test && touch test/a_file
✔ 14:12 /tmp $ rm -f "test/*"
✔ 14:12 /tmp $ ls test
a_file
✔ 14:12 /tmp $ rm -f "test"/*
✔ 14:13 /tmp $ ls test
✔ 14:13 /tmp $ 
```