### PR TITLE
CDIV deoptimization

### DIFF
--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1568,6 +1568,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("asm.xrefs", "true", "Show xrefs in disassembly");
 	SETPREF("asm.demangle", "true", "Show demangled symbols in disasm");
 	SETPREF("asm.describe", "false", "Show opcode description");
+	SETPREF("asm.hints", "false", "Show hints for magic numbers in disasm");
 	SETPREF("asm.marks", "true", "Show marks before the disassembly");
 	SETCB("bin.strpurge", "false", &cb_strpurge, "Try to purge false positive strings");
 	SETPREF("bin.libs", "false", "Try to load libraries after loading main binary");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -101,6 +101,7 @@ typedef struct r_disam_options_t {
 	int show_xrefs;
 	int show_functions;
 	int show_fcncalls;
+	int show_hints;
 	int show_marks;
 	int cursor;
 	int show_comment_right_default;
@@ -418,6 +419,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->show_comment_right_default = r_config_get_i (core->config, "asm.cmtright");
 	ds->show_comment_right = r_config_get_i (core->config, "asm.cmtright"); // XX conflict with show_comment_right_default
 	ds->show_flag_in_bytes = r_config_get_i (core->config, "asm.flagsinbytes");
+	ds->show_hints = r_config_get_i (core->config, "asm.hints");
 	ds->show_marks = r_config_get_i (core->config, "asm.marks");
 	ds->pre = strdup ("  ");
 	ds->ocomment = NULL;
@@ -1812,54 +1814,55 @@ static void ds_instruction_mov_lea(RDisasmState *ds, int idx) {
 }
 
 static st64 revert_cdiv_magic(st64 magic) {
-    short s;
-    st64 E;
-    const st64 N = (1L << 31) - 1; // max positive 32bit integer
-    st64 candidate;
-    if (llabs (magic) < 0xFFFFFF) {
-        return 0;
-    }
-    if (llabs (magic) > 0xFFFFFFFF) {
-        return 0;
-    }
-    if (magic < 0) {
-        magic += 1L << 32;
-    }
-    for (s = 0; s < 16; ++s) {
-        E = 1L << (32 + s);
-        candidate = (E + magic - 1) / magic;
-        if ( (N * magic) >> (32 + s) == (N / candidate) ) {
-            return candidate;
-        }
-    }
-    return 0;
+	short s;
+	st64 E;
+	const st64 N = (1L << 31) - 1; // max positive 32bit integer
+	st64 candidate;
+	if (llabs (magic) < 0xFFFFFF) {
+		return 0;
+	}
+	if (llabs (magic) > 0xFFFFFFFF) {
+		return 0;
+	}
+	if (magic < 0) {
+		magic += 1L << 32;
+	}
+	for (s = 0; s < 16; ++s) {
+		E = 1L << (32 + s);
+		candidate = (E + magic - 1) / magic;
+		if ( (N * magic) >> (32 + s) == (N / candidate) ) {
+			return candidate;
+		}
+	}
+	return 0;
 }
 
 static void ds_cdiv_optimization(RDisasmState *ds) {
-    char *esil;
-    char *end, *comma;
-    st64 imm;
-    st64 divisor;
-    // TODO: early out
-    switch (ds->analop.type) {
-    case R_ANAL_OP_TYPE_MOV:
-    case R_ANAL_OP_TYPE_MUL:
-        esil = R_STRBUF_SAFEGET (&ds->analop.esil);
-        while (esil) {
-            comma = strstr (esil, ",");
-            if (!comma) break;
-            imm = strtol (esil, &end, 10);
-            if (comma && comma == end) {
-                divisor = revert_cdiv_magic (imm);
-                if (divisor) {
-                    r_cons_printf (" ; CDIV: %lld * 2^n", divisor);
-                    break;
-                }
-            }
-            esil = comma+1;
-        }
-    }
-    // TODO: check following SHR instructions
+	char *esil;
+	char *end, *comma;
+	st64 imm;
+	st64 divisor;
+	if (!ds->show_hints)
+		return;
+	switch (ds->analop.type) {
+	case R_ANAL_OP_TYPE_MOV:
+	case R_ANAL_OP_TYPE_MUL:
+		esil = R_STRBUF_SAFEGET (&ds->analop.esil);
+		while (esil) {
+			comma = strstr (esil, ",");
+			if (!comma) break;
+			imm = strtol (esil, &end, 10);
+			if (comma && comma == end) {
+				divisor = revert_cdiv_magic (imm);
+				if (divisor) {
+					r_cons_printf (" ; CDIV: %lld * 2^n", divisor);
+					break;
+				}
+			}
+			esil = comma+1;
+		}
+	}
+	// TODO: check following SHR instructions
 }
 
 static void ds_print_show_bytes(RDisasmState *ds) {


### PR DESCRIPTION
This patch implements hints in the disassembler that
aim to assist the user in reading compiler-optimized divisions
by analysing the involved magic number.

# Background

Since integer divisions are usually very expensive on most architectures,
compilers try very hard to substitute them with cheaper operations.

One of the more advanced substitutions is described in the book __Hacker's Delight__,
chapter 10.
An actual implementation of the described algorithm in LLVM can be found in the
functions: `TargetLowering::BuildSDIV()` and `APInt::magic()`.

The optimization approximately transforms e.g.

```asm
xor edx, edx
idiv 39
```

into

```asm
mov eax, edi
mov edx, 0xd20d20d3
imul edx
lea eax, [rdx + rdi]
sar edi, 0x1f
sar eax, 5
sub eax, edi
```

Reading the optimized version and __seeing__ the constant 39 seems difficult.
Therefore I try to provide a small hint to the user.

# Limitations


* The current implementation only takes the magic number into account,
  therefore it may result in false positives.

* Due to the nature of the optimization, the given hint may be off by a power of two.
  Fixing this would require to analyse the following shift instructions.

* The hint is only shown in the line containing the magic number.
  The user still has to know which of the following instructions belong to the optimization.

# TODO


* Implement the corresponding analysis for unsigned integers

* Implement the corresponding analysis for 64-bit integers.

* Improve the heuristic by also looking at the next few instructions.
  ( I don't really know how to iterate over the instructions in the disassember
  in a non-deprecated way. Maybe someone can drop me a hint? )

* Implement an exact analysis using the actual dataflow in radeco and use it
  to revert the optimization. ( I suppose this is outside the scope of radare )