### PR TITLE
Fixes #4875: Refactor process listing

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -45,10 +45,12 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 #include <sys/types.h>
 #include <sys/wait.h>
 #define R_DEBUG_REG_T struct reg
+#include "native/procfs.h"
 #if __KFBSD__
 #include <sys/sysctl.h>
 #include <sys/user.h>
 #endif
+#include "native/procfs.h"
 
 #elif __APPLE__
 #include <sys/resource.h>
@@ -63,6 +65,7 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 
 #elif __linux__
 #include "native/linux/linux_debug.h"
+#include "native/procfs.h"
 #if __x86_64__
 #include "native/linux/linux_coredump.h"
 #endif
@@ -337,14 +340,81 @@ static RList *r_debug_native_pids (int pid) {
 			if (p) r_list_append (list, p);
 		}
 	}
-#elif __linux__
-	return linux_pid_list (pid, list);
 #else
-#warning No r_debug_native_pids implementation provided
-	eprintf ("TODO: list processes\n");
-	r_list_free(list);
-	return NULL;
+	int i;
+	char *ptr, buf[1024];
+
+	list->free = (RListFree)&r_debug_pid_free;
+	if (pid) {
+		DIR *dh;
+		struct dirent *de;
+
+		/* add the requested pid. should we do this? we don't even know if it's valid still.. */
+		r_list_append (list, r_debug_pid_new ("(current)", pid, 's', 0));
+
+		/* list parents */
+		dh = opendir ("/proc");
+		if (dh == NULL) {
+			r_sys_perror ("opendir /proc");
+			r_list_free (list);
+			return NULL;
+		}
+		while ((de = readdir (dh))) {
+			/* for each existing pid file... */
+			i = atoi (de->d_name);
+			if (i <= 0) {
+				continue;
+			}
+
+			/* try to read the status */
+			if (procfs_pid_slurp (i, "status", buf, sizeof(buf)) == -1) {
+				continue;
+			}
+
+			/* look for the parent process id */
+			ptr = strstr (buf, "PPid:");
+			if (ptr) {
+				int ppid = atoi (ptr + 6);
+
+				/* if this is the requested process... */
+				if (i == pid) {
+					//eprintf ("PPid: %d\n", ppid);
+					/* append it to the list with parent */
+					r_list_append (list, r_debug_pid_new (
+						"(ppid)", ppid, 's', 0));
+				}
+
+				/* ignore it if it is not one of our children */
+				if (ppid != pid) {
+					continue;
+				}
+
+				/* it's a child of the requested pid, read it's command line and add it */
+				if (procfs_pid_slurp (ppid, "cmdline", buf, sizeof(buf)) == -1) {
+					continue;
+				}
+
+				r_list_append (list, r_debug_pid_new (buf, i, 's', 0));
+			}
+		}
+		closedir (dh);
+	} else {
+		/* try to bruteforce the processes
+		 * XXX(jjd): wouldn't listing the processes like before work better?
+		 */
+		for (i = 2; i < MAXPID; i++) {
+			/* try to send signal 0, if it fails it must not be valid */
+			if (r_sandbox_kill (i, 0) == -1)
+				continue;
+
+			if (procfs_pid_slurp (i, "cmdline", buf, sizeof(buf)) == -1)
+				continue;
+
+			r_list_append (list, r_debug_pid_new (buf, i, 's', 0));
+		}
+	}
 #endif
+	return list;
 }
 
 

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -81,7 +81,6 @@ typedef ut64 mips64_regs_t [274];
 int linux_step (RDebug *dbg);
 int linux_attach (RDebug *dbg, int pid);
 RDebugInfo *linux_info (RDebug *dbg, const char *arg);
-RList *linux_pid_list (int pid, RList *list);
 RList *linux_thread_list (int pid, RList *list);
 int linux_reg_read (RDebug *dbg, int type, ut8 *buf, int size);
 int linux_reg_write (RDebug *dbg, int type, const ut8 *buf, int size);

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -81,6 +81,7 @@ typedef ut64 mips64_regs_t [274];
 int linux_step (RDebug *dbg);
 int linux_attach (RDebug *dbg, int pid);
 RDebugInfo *linux_info (RDebug *dbg, const char *arg);
+RList *linux_pid_list (int pid, RList *list);
 RList *linux_thread_list (int pid, RList *list);
 int linux_reg_read (RDebug *dbg, int type, ut8 *buf, int size);
 int linux_reg_write (RDebug *dbg, int type, const ut8 *buf, int size);

--- a/libr/debug/p/native/procfs.c
+++ b/libr/debug/p/native/procfs.c
@@ -1,0 +1,31 @@
+/* radare - LGPL - Copyright 2009-2016 - pancake */
+
+#include <r_userconf.h>
+#include <r_debug.h>
+
+int procfs_pid_slurp(int pid, char *prop, char *out, size_t len) {
+	char *filename;
+	int fd, ret = -1;
+	ssize_t nr;
+
+	filename = r_str_newf ("/proc/%d/%s", pid, prop);
+	if (!filename)
+		return -1;
+	fd = r_sandbox_open (filename, O_RDONLY, 0);
+	if (fd == -1) {
+		free (filename);
+		return -1;
+	}
+	nr = read (fd, out, len);
+	if (nr > 0) {
+		out[nr - 1] = '\0';  /* terminate at newline */
+		ret = 0;
+	} else if (nr < 0) {
+		r_sys_perror ("read");
+	} else {
+		eprintf ("proc_pid_slurp: got EOF reading from \"%s\"\n", filename);
+	}
+	close (fd);
+	free (filename);
+	return ret;
+}

--- a/libr/debug/p/native/procfs.h
+++ b/libr/debug/p/native/procfs.h
@@ -1,0 +1,3 @@
+/* radare - LGPL - Copyright 2009-2016 - pancake */
+
+int procfs_pid_slurp (int pid, char *prop, char *out, size_t len);


### PR DESCRIPTION
 * Move procfs-based process listing into linux_debug.c, guarded by __linux__
 * Provide a warning and eprintf a TODO on the remaining platforms.
 * Break reusable parts into linux_get_proc_pid and call it as needed.
 * Add/remove comments for clarity