### PR TITLE
Have r_debug_select change IO pids too

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -347,6 +347,8 @@ R_API int r_debug_select(RDebug *dbg, int pid, int tid) {
 	if (dbg->h && dbg->h->select && !dbg->h->select (pid, tid))
 		return false;
 
+	r_io_system (dbg->iob.io, sdb_fmt (0, "pid %d", pid));
+
 	dbg->pid = pid;
 	dbg->tid = tid;
 


### PR DESCRIPTION
When changing the selected pid, we must change the IO that provides memory R/W as well.

I'm not exactly pleased with this solution but I'm sending this PR so we can start talking about it anyway.