### PR TITLE
change bin file size to ut64 to support binaries larger than 2G

### DIFF
--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -157,7 +157,7 @@ typedef struct r_bin_object_t {
 	ut64 baddr_shift;
 	ut64 loadaddr;
 	ut64 boffset;
-	int size;
+	ut64 size;
 	ut64 obj_size;
 	RList/*<RBinSection>*/ *sections;
 	RList/*<RBinImport>*/ *imports;
@@ -183,7 +183,7 @@ typedef struct r_bin_object_t {
 typedef struct r_bin_file_t {
 	char *file;
 	int fd;
-	int size;
+	ut64 size;
 	int rawstr;
 	ut32 id;
 	RBuffer *buf;


### PR DESCRIPTION
for binaries larger than 2G, rabin2 reports an incorrect `binsz` due to wraparound: 

    $ rabin2 -I libchrome_public.so 
    havecode false
    pic      false
    canary   false
    nx       false
    crypto   false
    va       false
    bits     64
    minopsz  1
    maxopsz  16
    pcalign  0
    endian   little
    stripped false
    static   true
    linenum  false
    lsyms    false
    relocs   false
    binsz    -671209680

changing the bin file size to ut64 fixes this issue:

    $ rabin2 -I libchrome_public.so
    havecode false
    pic      false
    canary   false
    nx       false
    crypto   false
    va       false
    bits     64
    minopsz  1
    maxopsz  16
    pcalign  0
    endian   little
    stripped false
    static   true
    linenum  false
    lsyms    false
    relocs   false
    binsz    3623757616