### PR TITLE
Fixed order of arguments in ESIL representation of MUL.

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1187,22 +1187,18 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_MUL:
 		{
 			char *src = getarg (&gop, 0, 0, NULL);
-			char *dst;
 			switch (src[0]) {
-				case 'r':
-					dst = strdup ("rax");
-					break;
-				case 'e':
-					dst = strdup ("eax");
-					break;
-				default:
-					dst = strdup ("al");
-					break;
+			case 'r':
+				esilprintf (op, "%s,rax,*=", src);
+				break;
+			case 'e':
+				esilprintf (op, "%s,eax,*=", src);
+				break;
+			default:
+				esilprintf (op, "%s,al,*=", src);
+				break;
 			}
-
-			esilprintf (op, "%s,%s,*=", src, dst);
 			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_MULX:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1185,6 +1185,26 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		}
 		break;
 	case X86_INS_MUL:
+		{
+			char *src = getarg (&gop, 0, 0, NULL);
+			char *dst;
+			switch (src[0]) {
+				case 'r':
+					dst = strdup ("rax");
+					break;
+				case 'e':
+					dst = strdup ("eax");
+					break;
+				default:
+					dst = strdup ("al");
+					break;
+			}
+
+			esilprintf (op, "%s,%s,*=", src, dst);
+			free (src);
+			free (dst);
+		}
+		break;
 	case X86_INS_MULX:
 	case X86_INS_MULPD:
 	case X86_INS_MULPS:


### PR DESCRIPTION
The MUL instruction multiplies EAX by the argument provided, and stores the result in EAX. The way radare parsed it into ESIL was storing the result in the argument, instead.

This is fixed now. This might be relevant to some of the other types of MUL - I haven't checked.