### PR TITLE
Make "dbt" output aligned to columns based on dbg->bits

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1789,9 +1789,11 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			i = 0;
 			list = r_debug_frames (core->dbg, addr);
 			r_list_foreach (list, iter, frame) {
-				char flagdesc[1024], flagdesc2[1024];
+				char flagdesc[1024], flagdesc2[1024], pcstr[32], spstr[32];
 				RFlagItem *f = r_flag_get_at (core->flags, frame->addr);
+
 				flagdesc[0] = flagdesc2[0] = 0;
+
 				if (f) {
 					if (f->offset != addr) {
 						int delta = (int)(frame->addr - f->offset);
@@ -1809,8 +1811,6 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 						snprintf (flagdesc, sizeof(flagdesc),
 							"%s", f->name);
 					}
-				} else {
-					flagdesc[0] = 0;
 				}
 				f = r_flag_get_at (core->flags, frame->addr);
 				if (f && !strchr (f->name, '.')) {
@@ -1833,24 +1833,30 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 						snprintf (flagdesc2, sizeof (flagdesc2),
 							"%s", f->name);
 					}
-				} else {
-					flagdesc2[0] = 0;
 				}
 				if (!strcmp (flagdesc, flagdesc2)) {
 					flagdesc2[0] = 0;
 				}
-				RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, frame->addr, 0);
-				if (fcn) {
-					r_cons_printf ("%d  0x%08"PFMT64x" sp: 0x%"PFMT64x"  %d"
-							"[%s]  %s %s\n", i++,
-							frame->addr, frame->sp,
-							(int)frame->size, fcn->name, flagdesc,
-							flagdesc2);
+
+				if (core->dbg->bits & R_SYS_BITS_64) {
+					snprintf (pcstr, sizeof(pcstr), "0x%-16" PFMT64x, frame->addr);
+					snprintf (spstr, sizeof(spstr), "0x%-16" PFMT64x, frame->sp);
+				} else if (core->dbg->bits & R_SYS_BITS_32) {
+					snprintf (pcstr, sizeof(pcstr), "0x%-8" PFMT64x, frame->addr);
+					snprintf (spstr, sizeof(spstr), "0x%-8" PFMT64x, frame->sp);
 				} else {
-					r_cons_printf ("%d  0x%08"PFMT64x"  sp: 0x%"PFMT64x"  %d"
-							"   %s %s\n", (int)i++, (ut64)frame->addr,
-							frame->sp, (int)frame->size, flagdesc, flagdesc2);
+					snprintf (pcstr, sizeof(pcstr), "0x%" PFMT64x, frame->addr);
+					snprintf (spstr, sizeof(spstr), "0x%" PFMT64x, frame->sp);
 				}
+
+				RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, frame->addr, 0);
+				r_cons_printf ("%d  %s sp: %s  %-5d"
+						"[%s]  %s %s\n", i++,
+						pcstr, spstr,
+						(int)frame->size,
+						fcn ? fcn->name : "??",
+						flagdesc,
+						flagdesc2);
 			}
 			r_list_free (list);
 			break;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1798,17 +1798,17 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					if (f->offset != addr) {
 						int delta = (int)(frame->addr - f->offset);
 						if (delta > 0) {
-							snprintf (flagdesc, sizeof(flagdesc),
+							snprintf (flagdesc, sizeof (flagdesc),
 								"%s+%d", f->name, delta);
 						} else if (delta < 0) {
-							snprintf (flagdesc, sizeof(flagdesc),
+							snprintf (flagdesc, sizeof (flagdesc),
 								"%s%d", f->name, delta);
 						} else {
-							snprintf (flagdesc, sizeof(flagdesc),
+							snprintf (flagdesc, sizeof (flagdesc),
 								"%s", f->name);
 						}
 					} else {
-						snprintf (flagdesc, sizeof(flagdesc),
+						snprintf (flagdesc, sizeof (flagdesc),
 							"%s", f->name);
 					}
 				}
@@ -1820,13 +1820,13 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					if (f->offset != addr) {
 						int delta = (int)(frame->addr - 1 - f->offset);
 						if (delta > 0) {
-							snprintf (flagdesc2, sizeof(flagdesc2),
+							snprintf (flagdesc2, sizeof (flagdesc2),
 								"%s+%d", f->name, delta + 1);
 						} else if (delta<0) {
-							snprintf (flagdesc2, sizeof(flagdesc2),
+							snprintf (flagdesc2, sizeof (flagdesc2),
 								"%s%d", f->name, delta + 1);
 						} else {
-							snprintf (flagdesc2, sizeof(flagdesc2),
+							snprintf (flagdesc2, sizeof (flagdesc2),
 								"%s+1", f->name);
 						}
 					} else {
@@ -1839,14 +1839,14 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 				}
 
 				if (core->dbg->bits & R_SYS_BITS_64) {
-					snprintf (pcstr, sizeof(pcstr), "0x%-16" PFMT64x, frame->addr);
-					snprintf (spstr, sizeof(spstr), "0x%-16" PFMT64x, frame->sp);
+					snprintf (pcstr, sizeof (pcstr), "0x%-16" PFMT64x, frame->addr);
+					snprintf (spstr, sizeof (spstr), "0x%-16" PFMT64x, frame->sp);
 				} else if (core->dbg->bits & R_SYS_BITS_32) {
-					snprintf (pcstr, sizeof(pcstr), "0x%-8" PFMT64x, frame->addr);
-					snprintf (spstr, sizeof(spstr), "0x%-8" PFMT64x, frame->sp);
+					snprintf (pcstr, sizeof (pcstr), "0x%-8" PFMT64x, frame->addr);
+					snprintf (spstr, sizeof (spstr), "0x%-8" PFMT64x, frame->sp);
 				} else {
-					snprintf (pcstr, sizeof(pcstr), "0x%" PFMT64x, frame->addr);
-					snprintf (spstr, sizeof(spstr), "0x%" PFMT64x, frame->sp);
+					snprintf (pcstr, sizeof (pcstr), "0x%" PFMT64x, frame->addr);
+					snprintf (spstr, sizeof (spstr), "0x%" PFMT64x, frame->sp);
 				}
 
 				RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, frame->addr, 0);
@@ -2075,7 +2075,7 @@ static RTreeNode *add_trace_tree_child (Sdb *db, RTree *t, RTreeNode *cur, ut64 
 	snprintf (dbkey, TN_KEY_LEN, TN_KEY_FMT, addr);
 	t_node = (struct trace_node *)(size_t)sdb_num_get (db, dbkey, NULL);
 	if (!t_node) {
-		t_node = (struct trace_node *)malloc (sizeof(*t_node));
+		t_node = (struct trace_node *)malloc (sizeof (*t_node));
 		t_node->addr = addr;
 		t_node->refs = 1;
 		sdb_num_set (db, dbkey, (ut64)(size_t)t_node, 0);


### PR DESCRIPTION
When outputting a backtrace, line things up depending on the number of bits in the target CPU.