### PR TITLE
Properly handle forks on Linux 2.5.46+

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -399,6 +399,8 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		"dp=", "<pid>", "Select pid",
 		"dp-", " <pid>", "Dettach select pid",
 		"dpa", " <pid>", "Attach and select pid",
+		"dpc", "", "Select forked pid (see dbg.forks)",
+		"dpc*", "", "Display forked pid (see dbg.forks)",
 		"dpe", "", "Show path to executable",
 		"dpf", "", "Attach to pid like file fd // HACK",
 		"dpk", " <pid> <signal>", "Send signal to process",
@@ -416,7 +418,19 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 			r_debug_detach (core->dbg, core->dbg->pid);
 		}
 		break;
-	case 'k':
+	case 'c': // "dpc"
+		if (core->dbg->forked_pid != -1) {
+			if (input[2] == '*') {
+				eprintf ("dp %d\n", core->dbg->forked_pid);
+			} else {
+				r_debug_select (core->dbg, core->dbg->forked_pid, core->dbg->tid);
+				core->dbg->forked_pid = -1;
+			}
+		} else {
+			eprintf ("No recently forked children\n");
+		}
+		break;
+	case 'k': // "dpk"
 		/* stop, print, pass -- just use flags*/
 		/* XXX: not for threads? signal is for a whole process!! */
 		/* XXX: but we want fine-grained access to process resources */

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -129,6 +129,7 @@ R_API RDebug *r_debug_new(int hard) {
 	dbg->arch = strdup (R_SYS_ARCH);
 	dbg->bits = R_SYS_BITS;
 	dbg->trace_forks = 1;
+	dbg->forked_pid = -1;
 	dbg->trace_clone = 0;
 	R_FREE (dbg->btalgo);
 	dbg->trace_execs = 0;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -294,6 +294,42 @@ static int r_debug_native_wait (RDebug *dbg, int pid) {
 		} else {
 			//printf ("status=%d (return=%d)\n", status, ret);
 			// TODO: switch status and handle reasons here
+#if __linux__ && defined(PT_GETEVENTMSG)
+			// Handle PTRACE_EVENT_*
+			if (WIFSTOPPED (status) && WSTOPSIG (status) == SIGTRAP) {
+				ut32 pt_evt = status >> 16;
+				ut32 data;
+
+				switch (pt_evt) {
+				case 0:
+					// Normal trap?
+					break;
+
+				case PTRACE_EVENT_FORK:
+					if (dbg->trace_forks) {
+						if (ptrace (PTRACE_GETEVENTMSG, pid, 0, &data) == -1) {
+							r_sys_perror ("ptrace GETEVENTMSG");
+						} else {
+							eprintf ("PTRACE_EVENT_FORK new_pid=%d\n", data);
+							dbg->forked_pid = data;
+							// TODO: more handling here?
+						}
+					}
+					break;
+				case PTRACE_EVENT_EXIT:
+					if (ptrace (PTRACE_GETEVENTMSG, pid, 0, &data) == -1) {
+						r_sys_perror ("ptrace GETEVENTMSG");
+					} else {
+						eprintf ("PTRACE_EVENT_EXIT pid=%d, status=%d\n", pid, data);
+					}
+					break;
+				default:
+					eprintf ("Unknown PTRACE_EVENT encountered: %d\n", pt_evt);
+					break;
+				}
+			}
+#endif
+
 			r_debug_handle_signals (dbg);
 
 			if (WIFSTOPPED (status)) {

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -71,7 +71,7 @@ typedef struct r_debug_frame_t {
 } RDebugFrame;
 
 typedef struct r_debug_reason_t {
-        int type;
+	int type;
 	int tid;
 	int signum;
 	RBreakpointItem *bpi;
@@ -168,6 +168,7 @@ typedef struct r_debug_t {
 	Sdb *sgnls;
 	RCoreBind corebind;
 	int trace_forks;
+	int forked_pid;
 	int trace_execs;
 	int trace_clone;
 	// internal use only


### PR DESCRIPTION
Linux 2.5.46 made changes to the ptrace(2) API to inform a tracer when various
events occur. These are known as PTRACE_EVENTs. Start handling PTRACE_EVENTs
by:

 * Handling PTRACE_EVENT_FORK and PTRACE_EVENT_EXIT
 * For _FORK, stores the newly created pid in dbg->forked_pid
 * Add the "dpc" command to select the most recently forked child process.

Additional minor changes to white space are included.

NOTE: This partially addresses #3549