### PR TITLE
Check that a required argument was passed for a couple of commands.

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2983,12 +2983,12 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 		cmd_syscall_do (core, (int)r_num_get (core->num, input + 1));
 		break;
 	case 'k': // "ask"
-	    if (input[1] == ' ') {
-            out = sdb_querys (core->anal->syscall->db, NULL, 0, input + 2);
-            if (out) {
-                r_cons_printf ("%s\n", out);
-                free (out);
-            }
+		if (input[1] == ' ') {
+			out = sdb_querys (core->anal->syscall->db, NULL, 0, input + 2);
+			if (out) {
+				r_cons_printf ("%s\n", out);
+				free (out);
+			}
 		} else eprintf ("|ERROR| Usage: ask [query]\n");
 		break;
 	default:

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -980,10 +980,10 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		break;
 	case '-':
 		if (input[1] != ' ') {
-            eprintf ("|ERROR| Usage: dm- [addr]\n");
-            break;
-        }
-        addr = r_num_math (core->num, input+2);
+			eprintf ("|ERROR| Usage: dm- [addr]\n");
+			break;
+		}
+		addr = r_num_math (core->num, input+2);
 		r_list_foreach (core->dbg->maps, iter, map) {
 			if (addr >= map->addr && addr < map->addr_end) {
 				r_debug_map_dealloc(core->dbg, map);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -979,7 +979,11 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		}
 		break;
 	case '-':
-		addr = r_num_math (core->num, input+2);
+		if (input[1] != ' ') {
+            eprintf ("|ERROR| Usage: dm- [addr]\n");
+            break;
+        }
+        addr = r_num_math (core->num, input+2);
 		r_list_foreach (core->dbg->maps, iter, map) {
 			if (addr >= map->addr && addr < map->addr_end) {
 				r_debug_map_dealloc(core->dbg, map);

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -433,7 +433,7 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 			NULL
 			};
 			r_core_cmd_help (core, help_msg);
-        } else {
+		} else {
 			RFlagItem *fi;
 			const char *ret;
 			char *arg = r_str_chop (strdup (input+2));

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -425,7 +425,7 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 		r_core_cmd0 (core, "V");
 		break;
 	case 'c':
-		if (input[1]=='?') {
+		if (input[1]=='?' || input[1] != ' ') {
 			const char *help_msg[] = {
 			"Usage: fc", "<flagname> [color]", " # List colors with 'ecs'",
 			"fc", " flagname", "Get current color for given flagname",
@@ -433,7 +433,7 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 			NULL
 			};
 			r_core_cmd_help (core, help_msg);
-		} else {
+        } else {
 			RFlagItem *fi;
 			const char *ret;
 			char *arg = r_str_chop (strdup (input+2));


### PR DESCRIPTION
A couple of commands are not checking that they were called with a required parameter which results in an out-of-bounds read. As an example, here is the handling of the ask command. When typing "ask" input + 2 will point after the NULL character. This is a fairly minor issue with but trigger bugchecks when running with tools like AddressSanitizer.

This patch checks that there is a space character before passing input as a parameter. 

libr/core/cmd_anal.c
```c
	case 'k': // "ask"
		out = sdb_querys (core->anal->syscall->db, NULL, 0, input + 2);
```

Commands patched by this pull request:
```
ag
agc
ask
ahi
dm-
fc
```
