### PR TITLE
Fix of memory leak in 'r_anal_var_get_byname'

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -228,7 +228,7 @@ static char *get_varname (RAnal *a, RAnalFunction *fcn, char type, const char *p
 			break;
 		}
 		free (varname);
-		free (v);
+		r_anal_var_free (v);
 		varname = r_str_newf ("%s_%xh_%d", pfx, idx, i);
 		i++;
 	}

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -230,6 +230,7 @@ R_API RAnalVar *r_anal_var_get_byname (RAnal *anal, RAnalFunction *fcn, char kin
 	RList *var_list;
 	RListIter *iter;
 	RAnalVar *var = NULL;
+	RAnalVar *av;
 	if (!fcn || !anal || !name) {
 		return 0;
 	}
@@ -239,10 +240,23 @@ R_API RAnalVar *r_anal_var_get_byname (RAnal *anal, RAnalFunction *fcn, char kin
 			break;
 		}
 	}
+	
 	if (!var || strcmp (name, var->name)) {
+		r_list_free (var_list);
 		return 0;
 	}
-	return  var;
+
+	av = R_NEW0 (RAnalVar);
+	if (av) {
+		av->addr = var->addr;
+		av->scope = var->scope;
+		av->delta = var->delta;
+		av->name = strdup (var->name);
+		av->size = var->size;
+		av->type = strdup (var->type);
+	}
+	r_list_free (var_list);
+	return  av;
 }
 R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int delta) {
 	RAnalVar *av;


### PR DESCRIPTION
This pull-request is trying to address #5165 

Please note, that i'm not too familiar with the the codebase and the coding style of the project, so please validate the changes here, or feel free to reject this, and reimplement in your way. 

In `r_anal_var_get_byname` (`anal/var.c`):
```c
 	var_list = r_anal_var_list (anal, fcn, kind);
 	r_list_foreach (var_list, iter, var) {
 		if (!strcmp (name, var->name)) {
 			break;
 		}
 	}
 	if (!var || strcmp (name, var->name)) {
 		return 0;
 	}
	return  var;
```
the `var_list` variable is not `free`-d. This is responsible for most of the memleak. But we can't just simply `free` it, because it returns a pointer to one element of the list, which would be destroyed by free, so it needs to be copied.

There is also a minor leak (a missing `free`) in `get_varname` (`anal/fcn.c`).

It seems for me that the `r_anal_var_free` function should be used, for freeing `RAnalVar` objects, since calling simply `free` on them will not release the memory allocated by the `name` and `type` fields of the structure.  I've fixed those also in the `ąnal` "module". (The same errors exists in the `core` module, but I couldn't fix those, because `r_anal_var_free` is not visible there by the linker. )