### PR TITLE
Improve handling in the default cases

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1714,9 +1714,9 @@ void cmd_anal_reg (RCore *core, const char *str) {
 			break;
 		}
 		break;
-	case 'p': // drp
+	case 'p': // arp
 		// XXX we have to break out .h for these cmd_xxx files.
-		cmd_reg_profile (core, str);
+		cmd_reg_profile (core, 'a', str);
 		break;
 	case 't': // "drt"
 		for (i = 0; (name = r_reg_get_type (i)); i++)

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -411,6 +411,10 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		"dpt=", "<thread>", "Attach to thread",
 		NULL};
 	switch (input[1]) {
+	case 0:
+		eprintf ("Selected: %d %d\n", core->dbg->pid, core->dbg->tid);
+		r_debug_pid_list (core->dbg, core->dbg->pid, 0);
+		break;
 	case '-': // "dp-"
 		if (input[2]== ' ') {
 			r_debug_detach (core->dbg, r_num_math (core->num, input+2));
@@ -448,6 +452,9 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		break;
 	case 't': // "dpt"
 		switch (input[2]) {
+		case 0:
+			r_debug_thread_list (core->dbg, core->dbg->pid);
+			break;
 		case 'n':
 			eprintf ("TODO: debug_clone: %d\n", r_debug_child_clone (core->dbg));
 			break;
@@ -458,8 +465,9 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		case ' ':
 			r_debug_thread_list (core->dbg, atoi (input+2));
 			break;
+		case '?':
 		default:
-			r_debug_thread_list (core->dbg, core->dbg->pid);
+			r_core_cmd_help (core, help_msg);
 			break;
 		}
 		break;
@@ -507,11 +515,8 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 			(int) R_MAX (0, (int)r_num_math (core->num, input+2)), 0);
 		break;
 	case '?':
-		r_core_cmd_help (core, help_msg);
-		break;
 	default:
-		eprintf ("Selected: %d %d\n", core->dbg->pid, core->dbg->tid);
-		r_debug_pid_list (core->dbg, core->dbg->pid, 0);
+		r_core_cmd_help (core, help_msg);
 		break;
 	}
 }
@@ -744,9 +749,19 @@ static void cmd_debug_modules(RCore *core, int mode) { // "dmm"
 	RDebugMap *map;
 	RList *list;
 	RListIter *iter;
+	const char* help_msg[] = {
+		"Usage:", "dmm", " # Module memory maps commands",
+		"dmm", "", "List modules of target process",
+		"dmm.", "", "List memory map of current module",
+		"dmmj", "", "List modules of target process (JSON)",
+		"dmm*", "", "List modules of target process (r2 commands)",
+		NULL
+	};
 
+	/* avoid processing the list if the user only wants help */
 	if (mode == '?') {
-		eprintf ("Usage: dmm[j*]\n");
+show_help:
+		r_core_cmd_help (core, help_msg);
 		return;
 	}
 	if (mode == 'j') {
@@ -756,6 +771,9 @@ static void cmd_debug_modules(RCore *core, int mode) { // "dmm"
 	list = r_debug_modules_list (core->dbg);
 	r_list_foreach (list, iter, map) {
 		switch (mode) {
+		case 0:
+			r_cons_printf ("0x%08"PFMT64x" %s\n", map->addr, map->file);
+			break;
 		case ':':
 			if (addr >= map->addr && addr < map->addr_end) {
 				char *fn = strdup (map->file);
@@ -794,7 +812,9 @@ static void cmd_debug_modules(RCore *core, int mode) { // "dmm"
 			}
 			break;
 		default:
-			r_cons_printf ("0x%08"PFMT64x" %s\n", map->addr, map->file);
+			r_list_free (list);
+			goto show_help;
+			/* not reached */
 		}
 	}
 beach:
@@ -1114,7 +1134,7 @@ static void cmd_reg_profile (RCore *core, const char *str) { // "arp" and "drp"
 			  }
 			  r_cons_printf ("]}");
 		  } break;
-	default:
+	default: // TODO: show help instead and do this only on "case 0"
 		  r_reg_set_profile (core->dbg->reg, str+2);
 		  break;
 	}
@@ -1264,6 +1284,10 @@ free (rf);
 		break;
 	case 'x': // "drx"
 		switch (str[1]) {
+		case '\0':
+			r_debug_reg_sync (core->dbg, R_REG_TYPE_DRX, false);
+			r_debug_drx_list (core->dbg);
+			break;
 		case '-':
 			r_debug_reg_sync (core->dbg, R_REG_TYPE_DRX, false);
 			r_debug_drx_unset (core->dbg, atoi (str+2));
@@ -1294,25 +1318,27 @@ free (rf);
 			} else eprintf ("|Usage: drx N [address] [length] [rwx]\n");
 			free (s);
 			} break;
-		case '\0':
-			r_debug_reg_sync (core->dbg, R_REG_TYPE_DRX, false);
-			r_debug_drx_list (core->dbg);
-			break;
-		default: {
-			const char * help_message[] = {
-				"Usage: drx", "", "Hardware breakpoints commands",
-				"drx", "", "List all (x86?) hardware breakpoints",
-				"drx", " <number> <address> <length> <perms>", "Modify hardware breakpoint",
-				"drx-", "<number>", "Clear hardware breakpoint",
-				NULL
-			};
-			r_core_cmd_help (core, help_message);
+		case '?':
+		default:
+			{
+				const char * help_message[] = {
+					"Usage: drx", "", "Hardware breakpoints commands",
+					"drx", "", "List all (x86?) hardware breakpoints",
+					"drx", " <number> <address> <length> <perms>", "Modify hardware breakpoint",
+					"drx-", "<number>", "Clear hardware breakpoint",
+					NULL
+				};
+				r_core_cmd_help (core, help_message);
 			}
 			break;
 		}
 		break;
 	case 's': // "drs"
 		switch (str[1]) {
+		case 0:
+			r_cons_printf ("%d\n", r_list_length (
+				core->dbg->reg->regset[0].pool));
+			break;
 		case '-':
 			r_reg_arena_pop (core->dbg->reg);
 			// restore debug registers if in debugger mode
@@ -1321,20 +1347,18 @@ free (rf);
 		case '+':
 			r_reg_arena_push (core->dbg->reg);
 			break;
-		case '?': {
-			const char * help_message[] = {
-				"Usage: drs", "", "Register states commands",
-				"drs", "", "List register stack",
-				"drs", "+", "Push register state",
-				"drs", "-", "Pop register state",
-				NULL
-			};
-			r_core_cmd_help (core, help_message);
-			}
-			break;
+		case '?':
 		default:
-			r_cons_printf ("%d\n", r_list_length (
-				core->dbg->reg->regset[0].pool));
+			{
+				const char * help_message[] = {
+					"Usage: drs", "", "Register states commands",
+					"drs", "", "List register stack",
+					"drs", "+", "Push register state",
+					"drs", "-", "Pop register state",
+					NULL
+				};
+				r_core_cmd_help (core, help_message);
+			}
 			break;
 		}
 		break;
@@ -1430,17 +1454,9 @@ free (rf);
 		break;
 	case 't': // "drt"
 		switch (str[1]) {
-		case '?':
-			{
-			const char *help_msg[] = {
-				"Usage:", "drt", " [type] [size]    # debug register types",
-				"drt", "", "List all available register types",
-				"drt", " [size]", "Show all regs in the profile of size",
-				"drt", " [type]", "Show all regs in the profile of this type",
-				"drt", " [type] [size]", "Same as above for type and size",
-				NULL};
-			r_core_cmd_help (core, help_msg);
-			}
+		case 0:
+			for (i=0; (name = r_reg_get_type (i)); i++)
+				r_cons_printf ("%s\n", name);
 			break;
 		case ' ':
 			{
@@ -1470,9 +1486,18 @@ free (rf);
 				} else eprintf ("cmd_debug_reg: Unknown type\n");
 			}
 			} break;
+		case '?':
 		default:
-			for (i=0; (name = r_reg_get_type (i)); i++)
-				r_cons_printf ("%s\n", name);
+			{
+			const char *help_msg[] = {
+				"Usage:", "drt", " [type] [size]    # debug register types",
+				"drt", "", "List all available register types",
+				"drt", " [size]", "Show all regs in the profile of size",
+				"drt", " [type]", "Show all regs in the profile of this type",
+				"drt", " [type] [size]", "Same as above for type and size",
+				NULL};
+			r_core_cmd_help (core, help_msg);
+			}
 			break;
 		}
 		break;
@@ -1768,6 +1793,10 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			r_list_reverse (list);
 			r_list_foreach (list, iter, frame) {
 				switch (input[3]) {
+				case 0:
+					r_cons_printf ("%s0x%08"PFMT64x,
+							(i ? " " : ""), frame->addr);
+					break;
 				case 's':
 					r_cons_printf ("%s0x%08"PFMT64x,
 							(i ? " " : ""), frame->sp);
@@ -1776,9 +1805,9 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					r_cons_printf ("%s0x%08"PFMT64x,
 							(i ? " " : ""), frame->bp);
 					break;
+				case '?':
 				default:
-					r_cons_printf ("%s0x%08"PFMT64x,
-							(i ? " " : ""), frame->addr);
+					r_core_cmd0 (core, "db?~dbt");
 					break;
 				}
 				i++;
@@ -1879,6 +1908,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			}
 			r_list_free (list);
 			break;
+		case '?':
 		default:
 			r_core_cmd0 (core, "db?~dbt");
 			break;
@@ -1978,13 +2008,14 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 		break;
 	case 'h':
 		switch (input[2]) {
+		case 0:
+			r_bp_plugin_list (core->dbg->bp);
+			break;
 		case ' ':
 			if (!r_bp_use (core->dbg->bp, input + 3, core->anal->bits))
 				eprintf ("Invalid name: '%s'.\n", input+3);
 			break;
-		case 0:
-			r_bp_plugin_list (core->dbg->bp);
-			break;
+		case '?':
 		default:
 			eprintf ("Usage: dh [plugin-name]  # select a debug handler plugin\n");
 			break;
@@ -2435,7 +2466,7 @@ static void r_core_debug_kill (RCore *core, const char *input) {
 					"| c - continue into the signal handler\n"
 					"|   - no option means stop when signal is catched\n");
 				break;
-			default:
+			default: // TODO: show help instead and do this only on "case ' '"
 				if (signum<1) signum = r_debug_signal_resolve (core->dbg, name);
 				r_debug_signal_setup (core->dbg, signum, 0);
 				break;
@@ -2563,9 +2594,12 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 	};
 	// TODO: we must use this for step 'ds' too maybe...
 	switch (input[1]) {
-	case '?': // "dc?"
-		r_core_cmd_help (core, help_message);
-		return 0;
+	case 0: // "dc"
+		bypassbp (core);
+		r_reg_arena_swap (core->dbg->reg, true);
+		r_debug_continue (core->dbg);
+		checkbpcallback (core);
+		break;
 	case 'a': // "dca"
 		eprintf ("TODO: dca\n");
 		break;
@@ -2669,11 +2703,10 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 	case 't':
 		cmd_debug_backtrace (core, input+2);
 		break;
+	case '?': // "dc?"
 	default:
-		bypassbp (core);
-		r_reg_arena_swap (core->dbg->reg, true);
-		r_debug_continue (core->dbg);
-		checkbpcallback (core);
+		r_core_cmd_help (core, help_message);
+		return 0;
 	}
 	return 1;
 }
@@ -2710,9 +2743,15 @@ static int cmd_debug_step (RCore *core, const char *input) {
 		times = atoi (input+2);
 	if (times<1) times = 1;
 	switch (input[1]) {
-	case '?':
-		r_core_cmd_help (core, help_message);
-		return 0;
+	case 0:
+		r_reg_arena_swap (core->dbg->reg, true);
+		r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, false);
+		r_debug_step (core->dbg, times);
+		if (checkbpcallback (core)) {
+			eprintf ("Interrupted by a breakpoint\n");
+			break;
+		}
+		break;
 	case 'i':
 		if (input[2] == ' ') {
 			int n = 0;
@@ -2824,14 +2863,10 @@ static int cmd_debug_step (RCore *core, const char *input) {
 		r_reg_arena_swap (core->dbg->reg, true);
 		step_line (core, times);
 		break;
+	case '?':
 	default:
-		r_reg_arena_swap (core->dbg->reg, true);
-		r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, false);
-		r_debug_step (core->dbg, times);
-		if (checkbpcallback (core)) {
-			eprintf ("Interrupted by a breakpoint\n");
-			break;
-		}
+		r_core_cmd_help (core, help_message);
+		return 0;
 	}
 	return 1;
 }
@@ -2856,21 +2891,6 @@ static int cmd_debug(void *data, const char *input) {
 	case 't':
 // TODO: define ranges? to display only some traces, allow to scroll on this disasm? ~.. ?
 		switch (input[1]) {
-		case '?': {
-			const char * help_message[] = {
-				"Usage: dt", "", "Trace commands",
-				"dt", "", "List all traces ",
-				"dtd", "", "List all traced disassembled",
-				"dtc [addr]|([from] [to] [addr])", "", "Trace call/ret",
-				"dtg", "", "Graph call/ret trace",
-				"dtg*", "", "Graph in agn/age commands. use .dtg*;aggi for visual",
-				"dtgi", "", "Interactive debug trace",
-				"dt-", "", "Reset traces (instruction/calls)",
-				NULL
-			};
-			r_core_cmd_help (core, help_message);
-			}
-			break;
 		case 'c': // "dtc"
 			if (input[2] == '?') {
 				eprintf ("Usage: dtc [addr] ([from] [to] [addr]) - trace calls in debugger\n");
@@ -2894,8 +2914,22 @@ static int cmd_debug(void *data, const char *input) {
 		case '\0':
 			r_debug_trace_list (core->dbg, -1);
 			break;
+		case '?':
 		default:
-			eprintf ("Wrong arg. See dt?\n");
+			{
+				const char * help_message[] = {
+					"Usage: dt", "", "Trace commands",
+					"dt", "", "List all traces ",
+					"dtd", "", "List all traced disassembled",
+					"dtc [addr]|([from] [to] [addr])", "", "Trace call/ret",
+					"dtg", "", "Graph call/ret trace",
+					"dtg*", "", "Graph in agn/age commands. use .dtg*;aggi for visual",
+					"dtgi", "", "Interactive debug trace",
+					"dt-", "", "Reset traces (instruction/calls)",
+					NULL
+				};
+				r_core_cmd_help (core, help_message);
+			}
 			break;
 		}
 		break;
@@ -2972,21 +3006,21 @@ static int cmd_debug(void *data, const char *input) {
 			break;
 		case ' ':
 			// TODO: handle read, readwrite, append
-			r_core_syscallf (core, "open", "%s, %d, %d",
-				input+2, 2, 0644);
+			r_core_syscallf (core, "open", "%s, %d, %d", input+2, 2, 0644);
 			// open file
 			break;
 		case '?':
-		default: {
-			const char * help_message[] = {
-				"Usage: dd", "", "Descriptors commands",
-				"dd", "", "List file descriptors",
-				"dd", " <file>", "Open and map that file into the UI",
-				"dd-", "<fd>", "Close stdout fd",
-				"dd*", "", "List file descriptors (in radare commands)",
-				NULL
-			};
-			r_core_cmd_help (core, help_message);
+		default:
+			{
+				const char * help_message[] = {
+					"Usage: dd", "", "Descriptors commands",
+					"dd", "", "List file descriptors",
+					"dd", " <file>", "Open and map that file into the UI",
+					"dd-", "<fd>", "Close stdout fd",
+					"dd*", "", "List file descriptors (in radare commands)",
+					NULL
+				};
+				r_core_cmd_help (core, help_message);
 			}
 			break;
 		}
@@ -3172,19 +3206,21 @@ static int cmd_debug(void *data, const char *input) {
 			} else eprintf ("Injection opcodes so long\n");
 			}
 			break;
-		default:{
-			const char* help_msg[] = {
-			"Usage: dx", "", " # Code injection commands",
-			"dx", " <opcode>...", "Inject opcodes",
-			"dxa", " nop", "Assemble code and inject",
-			"dxe", " egg-expr", "compile egg expression and inject it",
-			"dxr", " <opcode>...", "Inject opcodes and restore state",
-			"dxs", " write 1, 0x8048, 12", "Syscall injection (see gs)",
-			"\nExamples:", "", "",
-			"dx", " 9090", "Inject two x86 nop",
-			"\"dxa mov eax,6;mov ebx,0;int 0x80\"", "", "Inject and restore state",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+		case '?':
+		default:
+			{
+				const char* help_msg[] = {
+				"Usage: dx", "", " # Code injection commands",
+				"dx", " <opcode>...", "Inject opcodes",
+				"dxa", " nop", "Assemble code and inject",
+				"dxe", " egg-expr", "compile egg expression and inject it",
+				"dxr", " <opcode>...", "Inject opcodes and restore state",
+				"dxs", " write 1, 0x8048, 12", "Syscall injection (see gs)",
+				"\nExamples:", "", "",
+				"dx", " 9090", "Inject two x86 nop",
+				"\"dxa mov eax,6;mov ebx,0;int 0x80\"", "", "Inject and restore state",
+				NULL};
+				r_core_cmd_help (core, help_msg);
 			}
 			break;
 		}
@@ -3198,7 +3234,8 @@ static int cmd_debug(void *data, const char *input) {
 			r_core_file_reopen (core, input[1] ? input + 2: NULL, 0, 1);
 			break;
 		case '?':
-		default: {
+		default:
+			{
 				const char* help_msg[] = {
 				"Usage:", "do", " # Debug commands",
 				"do", "", "Open process (reload, alias for 'oo')",
@@ -3249,7 +3286,9 @@ static int cmd_debug(void *data, const char *input) {
 			free (corefile);
 		}
 		break;
-	default: {
+	case '?':
+	default:
+		{
 			const char* help_msg[] = {
 			"Usage:", "d", " # Debug commands",
 			"db", "[?]", "Breakpoints commands",


### PR DESCRIPTION
Distinguish between "dXX" and "dXXYY" or "dXX?". Treat the latter two the same. This provides the least surprise to the user when they mistype something.

Several more improvements are included too. See the individual commit messages.