### PR TITLE
Major rework to the native debugger (esp on Linux)

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -164,8 +164,8 @@ static RBreakpointItem *r_bp_add(RBreakpoint *bp, const ut8 *obytes, ut64 addr, 
 		/* XXX: endian .. use bp->endian */
 		// XXX for hw breakpoints there are no bytes
 		ret = r_bp_get_bytes (bp, b->bbytes, size, 0, 0);
-		if (ret == 0) {
-			eprintf ("Cannot get breakpoint bytes. No r_bp_use()?\n");
+		if (ret != size) {
+			eprintf ("Cannot get breakpoint bytes. No r_bp_use()?\n"); //XXX(jjd): what is r_bp_use ?
 			r_bp_item_free (b);
 			return NULL;
 		}

--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -153,6 +153,7 @@ static RBreakpointItem *r_bp_add(RBreakpoint *bp, const ut8 *obytes, ut64 addr, 
 	b->enabled = true;
 	b->rwx = rwx;
 	b->hw = hw;
+	// NOTE: for hw breakpoints there are no bytes to save/restore
 	if (!hw) {
 		b->bbytes = calloc (size + 16, 1);
 		if (obytes) {
@@ -162,10 +163,9 @@ static RBreakpointItem *r_bp_add(RBreakpoint *bp, const ut8 *obytes, ut64 addr, 
 			b->obytes = NULL;
 		}
 		/* XXX: endian .. use bp->endian */
-		// XXX for hw breakpoints there are no bytes
 		ret = r_bp_get_bytes (bp, b->bbytes, size, 0, 0);
 		if (ret != size) {
-			eprintf ("Cannot get breakpoint bytes. No r_bp_use()?\n"); //XXX(jjd): what is r_bp_use ?
+			eprintf ("Cannot get breakpoint bytes. No architecture selected?\n");
 			r_bp_item_free (b);
 			return NULL;
 		}

--- a/libr/bp/io.c
+++ b/libr/bp/io.c
@@ -3,6 +3,24 @@
 #include <r_bp.h>
 #include "../config.h"
 
+R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, int set) {
+	if (set) {
+		//eprintf ("Setting bp at 0x%08"PFMT64x"\n", b->addr);
+		if (b->hw || !b->bbytes) {
+			eprintf ("hw breakpoints not yet supported\n");
+		} else {
+			bp->iob.write_at (bp->iob.io, b->addr, b->bbytes, b->size);
+		}
+	} else {
+		//eprintf ("Clearing bp at 0x%08"PFMT64x"\n", b->addr);
+		if (b->hw || !b->obytes) {
+			eprintf ("hw breakpoints not yet supported\n");
+		} else {
+			bp->iob.write_at (bp->iob.io, b->addr, b->obytes, b->size);
+		}
+	}
+}
+
 /**
  * reflect all r_bp stuff in the process using dbg->bp_write or ->breakpoint
  */
@@ -16,7 +34,7 @@ R_API int r_bp_restore(RBreakpoint *bp, int set) {
  * except the specified breakpoint...
  */
 R_API bool r_bp_restore_except(RBreakpoint *bp, int set, ut64 addr) {
-	bool rc = false;
+	bool rc = true;
 	RListIter *iter;
 	RBreakpointItem *b;
 
@@ -27,37 +45,10 @@ R_API bool r_bp_restore_except(RBreakpoint *bp, int set, ut64 addr) {
 		if (bp->breakpoint && bp->breakpoint (b, set, bp->user)) {
 			continue;
 		}
-		/* write obytes from every breakpoint in r_bp if not handled by plugin */
-		if (set) {
-			//eprintf ("Setting bp at 0x%08"PFMT64x"\n", b->addr);
-			if (b->hw || !b->bbytes) {
-				eprintf ("hw breakpoints not yet supported\n");
-			} else {
-				bp->iob.write_at (bp->iob.io, b->addr, b->bbytes, b->size);
-				rc = true;
-			}
-		} else {
-			//eprintf ("Clearing bp at 0x%08"PFMT64x"\n", b->addr);
-			if (b->hw || !b->obytes) {
-				eprintf ("hw breakpoints not yet supported\n");
-			} else {
-				bp->iob.write_at (bp->iob.io, b->addr, b->obytes, b->size);
-				rc = true;
-			}
-		}
+
+		/* write (o|b)bytes from every breakpoint in r_bp if not handled by plugin */
+		r_bp_restore_one (bp, b, set);
+		rc = true;
 	}
 	return rc;
-}
-
-R_API int r_bp_recoil(RBreakpoint *bp, ut64 addr) {
-	RBreakpointItem *b = r_bp_get_in (bp, addr, 0); //XXX Don't care about rwx
-	if (b) {
-		//eprintf("HIT AT ADDR 0x%"PFMT64x"\n", addr);
-		//eprintf("  recoil = %d\n", b->recoil);
-		//eprintf("  size = %d\n", b->size);
-		if (!b->hw && b->addr == addr) {
-			return b->recoil;
-		}
-	}
-	return 0;
 }

--- a/libr/bp/io.c
+++ b/libr/bp/io.c
@@ -3,7 +3,7 @@
 #include <r_bp.h>
 #include "../config.h"
 
-R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, int set) {
+R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, bool set) {
 	if (set) {
 		//eprintf ("Setting bp at 0x%08"PFMT64x"\n", b->addr);
 		if (b->hw || !b->bbytes) {
@@ -24,7 +24,7 @@ R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, int set) {
 /**
  * reflect all r_bp stuff in the process using dbg->bp_write or ->breakpoint
  */
-R_API int r_bp_restore(RBreakpoint *bp, int set) {
+R_API int r_bp_restore(RBreakpoint *bp, bool set) {
 	return r_bp_restore_except (bp, set, 0);
 }
 
@@ -33,7 +33,7 @@ R_API int r_bp_restore(RBreakpoint *bp, int set) {
  *
  * except the specified breakpoint...
  */
-R_API bool r_bp_restore_except(RBreakpoint *bp, int set, ut64 addr) {
+R_API bool r_bp_restore_except(RBreakpoint *bp, bool set, ut64 addr) {
 	bool rc = true;
 	RListIter *iter;
 	RBreakpointItem *b;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1905,8 +1905,8 @@ repeat:
 	}
 
 	st64 follow = (st64)r_config_get_i (core->config, "dbg.follow");
+	ut64 pc = r_debug_reg_get (core->dbg, "PC");
 	if (follow > 0) {
-		ut64 pc = r_debug_reg_get (core->dbg, "PC");
 		if ((pc < core->offset) || (pc > (core->offset + follow)))
 			r_core_cmd0 (core, "sr PC");
 	}
@@ -1914,7 +1914,7 @@ repeat:
 	if (core->dbg->trace->enabled) {
 		RReg *reg = core->dbg->reg;
 		core->dbg->reg = core->anal->reg;
-		r_debug_trace_pc (core->dbg);
+		r_debug_trace_pc (core->dbg, pc);
 		core->dbg->reg = reg;
 	}
 	// check addr

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -389,7 +389,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		break;
 	case '-': // "dp-"
 		if (input[2]== ' ') {
-			r_debug_detach (core->dbg, r_num_math (core->num, input+2));
+			r_debug_detach (core->dbg, r_num_math (core->num, input + 2));
 		} else {
 			r_debug_detach (core->dbg, core->dbg->pid);
 		}
@@ -432,10 +432,10 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 			break;
 		case '=':
 			r_debug_select (core->dbg, core->dbg->pid,
-				(int) r_num_math (core->num, input+3));
+				(int) r_num_math (core->num, input + 3));
 			break;
 		case ' ':
-			r_debug_thread_list (core->dbg, atoi (input+2));
+			r_debug_thread_list (core->dbg, atoi (input + 2));
 			break;
 		case '?':
 		default:
@@ -446,7 +446,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 	case 'a': // "dpa"
 		if (input[2]) {
 			r_debug_attach (core->dbg, (int) r_num_math (
-				core->num, input+2));
+				core->num, input + 2));
 		} else {
 			if (core->file && core->file->desc) {
 				r_debug_attach (core->dbg, core->file->desc->fd);
@@ -464,7 +464,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		break;
 	case '=': // "dp="
 		r_debug_select (core->dbg,
-			(int) r_num_math (core->num, input+2), core->dbg->tid);
+			(int) r_num_math (core->num, input + 2), core->dbg->tid);
 		break;
 	case '*': // "dp*"
 		r_debug_pid_list (core->dbg, 0, 0);
@@ -474,7 +474,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		break;
 	case 'e': // "dpe"
 		{
-			int pid = (input[2] == ' ')? atoi(input+2): core->dbg->pid;
+			int pid = (input[2] == ' ')? atoi(input + 2): core->dbg->pid;
 			char *exe = r_sys_pid_to_path (pid);
 			if (exe) {
 				r_cons_printf ("%s\n", exe);
@@ -484,7 +484,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		break;
 	case ' ':
 		r_debug_pid_list (core->dbg,
-			(int) R_MAX (0, (int)r_num_math (core->num, input+2)), 0);
+			(int) R_MAX (0, (int)r_num_math (core->num, input + 2)), 0);
 		break;
 	case '?':
 	default:
@@ -579,7 +579,7 @@ static int cmd_debug_map_snapshot(RCore *core, const char *input) {
 		char *file;
 		RDebugSnap *snap;
 		if (input[1] == ' ') {
-			file = strdup (input+2);
+			file = strdup (input + 2);
 		} else {
 			file = r_str_newf ("0x%08"PFMT64x".dump", core->offset);
 		}
@@ -610,7 +610,7 @@ static int cmd_debug_map_snapshot(RCore *core, const char *input) {
 		char *file;
 		RDebugSnap *snap;
 		if (input[1] == ' ') {
-			file = strdup (input+2);
+			file = strdup (input + 2);
 		} else {
 			file = r_str_newf ("0x%08"PFMT64x".dump", core->offset);
 		}
@@ -632,17 +632,17 @@ static int cmd_debug_map_snapshot(RCore *core, const char *input) {
 		if (input[1]=='*') {
 			r_debug_snap_delete (core->dbg, -1);
 		} else {
-			r_debug_snap_delete (core->dbg, r_num_math (core->num, input+1));
+			r_debug_snap_delete (core->dbg, r_num_math (core->num, input + 1));
 		}
 		break;
 	case ' ':
-		r_debug_snap (core->dbg, r_num_math (core->num, input+1));
+		r_debug_snap (core->dbg, r_num_math (core->num, input + 1));
 		break;
 	case 'C':
-		r_debug_snap_comment (core->dbg, atoi (input+1), strchr (input, ' '));
+		r_debug_snap_comment (core->dbg, atoi (input + 1), strchr (input, ' '));
 		break;
 	case 'd':
-		__r_debug_snap_diff (core, atoi (input+1));
+		__r_debug_snap_diff (core, atoi (input + 1));
 		break;
 	case 'a':
 		r_debug_snap_all (core->dbg, 0);
@@ -819,7 +819,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 
 	switch (input[0]) {
 	case 's':
-		cmd_debug_map_snapshot (core, input+1);
+		cmd_debug_map_snapshot (core, input + 1);
 		break;
 	case '.':
 		r_list_foreach (core->dbg->maps, iter, map) {
@@ -830,7 +830,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		}
 		break;
 	case 'm': // "dmm"
-		if (!strcmp (input+1, ".*")) {
+		if (!strcmp (input + 1, ".*")) {
 			cmd_debug_modules (core, ':');
 		} else cmd_debug_modules (core, input[1]);
 		break;
@@ -842,16 +842,16 @@ static int cmd_debug_map(RCore *core, const char *input) {
 			int perms;
 			char *p, *q;
 			ut64 size, addr;
-			p = strchr (input+2, ' ');
+			p = strchr (input + 2, ' ');
 			if (p) {
 				*p++ = 0;
 				q = strchr (p, ' ');
 				if (q) {
 					*q++ = 0;
-					addr = r_num_math (core->num, input+2);
+					addr = r_num_math (core->num, input + 2);
 					size = r_num_math (core->num, p);
 					perms = r_str_rwx (q);
-					eprintf ("(%s)(%s)(%s)\n", input+2, p, q);
+					eprintf ("(%s)(%s)(%s)\n", input + 2, p, q);
 					eprintf ("0x%08"PFMT64x" %d %o\n", addr, (int) size, perms);
 					r_debug_map_protect (core->dbg, addr, size, perms);
 				} else eprintf ("See dmp?\n");
@@ -862,7 +862,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		switch (input[1]) {
 		case 'a': return dump_maps (core, 0, NULL);
 		case 'w': return dump_maps (core, R_IO_RW, NULL);
-		case ' ': return dump_maps (core, -1, input+2);
+		case ' ': return dump_maps (core, -1, input + 2);
 		case 0: return dump_maps (core, -1, NULL);
 		case '?':
 		default:
@@ -879,7 +879,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		r_list_foreach (core->dbg->maps, iter, map) {
 			if (addr >= map->addr && addr < map->addr_end) {
 				int sz;
-				char *buf = r_file_slurp (input+2, &sz);
+				char *buf = r_file_slurp (input + 2, &sz);
 				//TODO: use mmap here. we need a portable implementation
 				if (!buf) {
 					eprintf ("Cannot allocate 0x%08"PFMT64x" bytes\n", map->size);
@@ -906,10 +906,10 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		int i;
 
 		if (input[1]=='*') {
-			ptr = strdup (r_str_trim_head ((char*)input+2));
+			ptr = strdup (r_str_trim_head ((char*)input + 2));
 			mode = "-r ";
 		} else {
-			ptr= strdup (r_str_trim_head ((char*)input+1));
+			ptr= strdup (r_str_trim_head ((char*)input + 1));
 		}
 		i = r_str_word_set0 (ptr);
 		switch (i) {
@@ -954,10 +954,10 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		{
 			char *p;
 			int size;
-			p = strchr (input+2, ' ');
+			p = strchr (input + 2, ' ');
 			if (p) {
 				*p++ = 0;
-				addr = r_num_math (core->num, input+1);
+				addr = r_num_math (core->num, input + 1);
 				size = r_num_math (core->num, p);
 				r_debug_map_alloc(core->dbg, addr, size);
 			} else {
@@ -971,7 +971,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 			eprintf ("|ERROR| Usage: dm- [addr]\n");
 			break;
 		}
-		addr = r_num_math (core->num, input+2);
+		addr = r_num_math (core->num, input + 2);
 		r_list_foreach (core->dbg->maps, iter, map) {
 			if (addr >= map->addr && addr < map->addr_end) {
 				r_debug_map_dealloc(core->dbg, map);
@@ -1733,7 +1733,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 		case 'j': // "dbtj"
 			addr = UT64_MAX;
 			if (input[2] == ' ' && input[3])
-				addr = r_num_math (core->num, input+2);
+				addr = r_num_math (core->num, input + 2);
 			i = 0;
 			list = r_debug_frames (core->dbg, addr);
 			r_cons_printf ("[");
@@ -1748,7 +1748,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 		case '=': // dbt=
 			addr = UT64_MAX;
 			if (input[2] == ' ' && input[3])
-				addr = r_num_math (core->num, input+2);
+				addr = r_num_math (core->num, input + 2);
 			i = 0;
 			list = r_debug_frames (core->dbg, addr);
 			r_list_reverse (list);
@@ -1976,7 +1976,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			break;
 		case ' ':
 			if (!r_bp_use (core->dbg->bp, input + 3, core->anal->bits))
-				eprintf ("Invalid name: '%s'.\n", input+3);
+				eprintf ("Invalid name: '%s'.\n", input + 3);
 			break;
 		case '?':
 		default:
@@ -2028,7 +2028,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			}
 			break;
 		case 'c': // "dbic"
-			p = strchr (input+3, ' ');
+			p = strchr (input + 3, ' ');
 			if (p) {
 				if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
 					bpi->data = strdup (p+1);
@@ -2274,7 +2274,7 @@ static void r_core_debug_esil (RCore *core, const char *input) {
 	switch (input[0]) {
 	case ' ':
 		{
-		char *line = strdup (input+1);
+		char *line = strdup (input + 1);
 		char *p, *q;
 		int done = 0;
 		int rwx = 0, dev = 0;
@@ -2328,7 +2328,7 @@ static void r_core_debug_esil (RCore *core, const char *input) {
 			r_core_cmd0 (core, "aei");
 			r_debug_esil_prestep (core->dbg, r_config_get_i (core->config, "esil.prestep"));
 			// continue
-			r_debug_esil_step (core->dbg, r_num_math (core->num, input+1));
+			r_debug_esil_step (core->dbg, r_num_math (core->num, input + 1));
 		}
 		break;
 	case 'c':
@@ -2366,7 +2366,7 @@ static void r_core_debug_esil (RCore *core, const char *input) {
 static void r_core_debug_kill (RCore *core, const char *input) {
 	if (!input || *input=='?') {
 		if (input && input[1]) {
-			const char *signame, *arg = input+1;
+			const char *signame, *arg = input + 1;
 			int signum = atoi (arg);
 			if (signum>0) {
 				signame = r_debug_signal_resolve_i (core->dbg, signum);
@@ -2479,7 +2479,7 @@ static bool cmd_dcu (RCore *core, const char *input) {
 	}
 	from = UT64_MAX;
 	if (input[2] == '.') {
-		ptr = strchr (input+3, ' ');
+		ptr = strchr (input + 3, ' ');
 		if (ptr) { // TODO: put '\0' in *ptr to avoid
 			from = r_num_tail (core->num, core->offset, input + 2);
 			if (ptr[1]=='.') {
@@ -2492,9 +2492,9 @@ static bool cmd_dcu (RCore *core, const char *input) {
 			from = r_num_tail (core->num, core->offset, input + 2);
 		}
 	} else {
-		ptr = strchr (input+3, ' ');
+		ptr = strchr (input + 3, ' ');
 		if (ptr) { // TODO: put '\0' in *ptr to avoid
-			from = r_num_math (core->num, input+3);
+			from = r_num_math (core->num, input + 3);
 			if (ptr[1]=='.') {
 				to = r_num_tail (core->num, core->offset, ptr+2);
 			} else {
@@ -2502,7 +2502,7 @@ static bool cmd_dcu (RCore *core, const char *input) {
 			}
 			dcu_range = true;
 		} else {
-			from = r_num_math (core->num, input+3);
+			from = r_num_math (core->num, input + 3);
 		}
 	}
 	if (from == UT64_MAX) {
@@ -2588,8 +2588,8 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 	case 'k':
 		// select pid and r_debug_continue_kill (core->dbg,
 		r_reg_arena_swap (core->dbg->reg, true);
-		signum = r_num_math (core->num, input+2);
-		ptr = strchr (input+3, ' ');
+		signum = r_num_math (core->num, input + 2);
+		ptr = strchr (input + 3, ' ');
 		if (ptr) {
 			int old_pid = core->dbg->pid;
 			int old_tid = core->dbg->tid;
@@ -2609,7 +2609,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 			cmd_debug_cont_syscall (core, "-1");
 			break;
 		case ' ':
-			cmd_debug_cont_syscall (core, input+3);
+			cmd_debug_cont_syscall (core, input + 3);
 			break;
 		case '\0':
 			cmd_debug_cont_syscall (core, NULL);
@@ -2719,7 +2719,7 @@ static int cmd_debug_step (RCore *core, const char *input) {
 					break;
 				r_core_cmd0 (core, ".dr*");
 				n++;
-			} while (!r_num_conditional (core->num, input+3));
+			} while (!r_num_conditional (core->num, input + 3));
 			eprintf ("Stopped after %d instructions\n", n);
 		} else eprintf ("Missing argument\n");
 		break;
@@ -2729,17 +2729,17 @@ static int cmd_debug_step (RCore *core, const char *input) {
 	case 'u':
 		switch (input[2]) {
 		case 'f':
-			step_until_flag (core, input+3);
+			step_until_flag (core, input + 3);
 			break;
 		case 'i':
-			step_until_inst (core, input+3);
+			step_until_inst (core, input + 3);
 			break;
 		case 'e':
-			step_until_esil (core, input+3);
+			step_until_esil (core, input + 3);
 			break;
 		case ' ':
 			r_reg_arena_swap (core->dbg->reg, true);
-			step_until (core, r_num_math (core->num, input+2)); // XXX dupped by times
+			step_until (core, r_num_math (core->num, input + 2)); // XXX dupped by times
 			break;
 		default:
 			eprintf ("Usage: dsu[fei] [arg]  . step until address ' ',"
@@ -2886,8 +2886,8 @@ static int cmd_debug(void *data, const char *input) {
 		case 's':
 			{
 			ut64 off = UT64_MAX;
-			int fd = atoi (input+2);
-			char *str = strchr (input+2, ' ');
+			int fd = atoi (input + 2);
+			char *str = strchr (input + 2, ' ');
 			if (str) off = r_num_math (core->num, str+1);
 			if (off == UT64_MAX || !r_debug_desc_seek (core->dbg, fd, off))
 				if (!r_core_syscallf (core, "lseek", "%d, 0x%"PFMT64x", %d", fd, off, 0))
@@ -2897,8 +2897,8 @@ static int cmd_debug(void *data, const char *input) {
 		case 'd':
 			{
 			ut64 newfd = UT64_MAX;
-			int fd = atoi (input+2);
-			char *str = strchr (input+2, ' ');
+			int fd = atoi (input + 2);
+			char *str = strchr (input + 2, ' ');
 			if (str) newfd = r_num_math (core->num, str+1);
 			if (newfd == UT64_MAX || !r_debug_desc_dup (core->dbg, fd, newfd))
 				if (!r_core_syscallf (core, "dup2", "%d, %d", fd, (int)newfd))
@@ -2909,8 +2909,8 @@ static int cmd_debug(void *data, const char *input) {
 			{
 			ut64 off = UT64_MAX;
 			ut64 len = UT64_MAX;
-			int fd = atoi (input+2);
-			char *str = strchr (input+2, ' ');
+			int fd = atoi (input + 2);
+			char *str = strchr (input + 2, ' ');
 			if (str) off = r_num_math (core->num, str+1);
 			if (str) str = strchr (str+1, ' ');
 			if (str) len = r_num_math (core->num, str+1);
@@ -2925,8 +2925,8 @@ static int cmd_debug(void *data, const char *input) {
 			{
 			ut64 off = UT64_MAX;
 			ut64 len = UT64_MAX;
-			int fd = atoi (input+2);
-			char *str = strchr (input+2, ' ');
+			int fd = atoi (input + 2);
+			char *str = strchr (input + 2, ' ');
 			if (str) off = r_num_math (core->num, str+1);
 			if (str) str = strchr (str+1, ' ');
 			if (str) len = r_num_math (core->num, str+1);
@@ -2939,16 +2939,16 @@ static int cmd_debug(void *data, const char *input) {
 			break;
 		case '-': // "dd-"
 			// close file
-			//r_core_syscallf (core, "close", "%d", atoi (input+2));
+			//r_core_syscallf (core, "close", "%d", atoi (input + 2));
 			{
-				int fd = atoi (input+2);
-				//r_core_cmdf (core, "dxs close %d", (int)r_num_math ( core->num, input+2));
+				int fd = atoi (input + 2);
+				//r_core_cmdf (core, "dxs close %d", (int)r_num_math ( core->num, input + 2));
 				r_core_syscallf (core, "close", "%d", fd);
 			}
 			break;
 		case ' ':
 			// TODO: handle read, readwrite, append
-			r_core_syscallf (core, "open", "%s, %d, %d", input+2, 2, 0644);
+			r_core_syscallf (core, "open", "%s, %d, %d", input + 2, 2, 0644);
 			// open file
 			break;
 		case '?':
@@ -2989,10 +2989,10 @@ static int cmd_debug(void *data, const char *input) {
 		break;
 	case 'r': // "dr"
 		if (core->io->debug || input[1] == '?') {
-			cmd_debug_reg (core, input+1);
+			cmd_debug_reg (core, input + 1);
 		} else {
 			void cmd_anal_reg(RCore *core, const char *str);
-			cmd_anal_reg (core, input+1);
+			cmd_anal_reg (core, input + 1);
 		}
 		//r_core_cmd (core, "|reg", 0);
 		break;
@@ -3015,7 +3015,7 @@ static int cmd_debug(void *data, const char *input) {
 			"dij", "", "Same as above, but in JSON format",
 			NULL
 		};
-		RDebugInfo *rdi = r_debug_info (core->dbg, input+2);
+		RDebugInfo *rdi = r_debug_info (core->dbg, input + 2);
 		RDebugReasonType stop = r_debug_stop_reason(core->dbg);
 		char *escaped_str;
 		switch (input[1]) {
@@ -3079,7 +3079,7 @@ static int cmd_debug(void *data, const char *input) {
 			{
 			RAsmCode *acode;
 			r_asm_set_pc (core->assembler, core->offset);
-			acode = r_asm_massemble (core->assembler, input+2);
+			acode = r_asm_massemble (core->assembler, input + 2);
 			if (acode && *acode->buf_hex) {
 				r_reg_arena_push (core->dbg->reg);
 				r_debug_execute (core->dbg, acode->buf,
@@ -3098,7 +3098,7 @@ static int cmd_debug(void *data, const char *input) {
 			const char *asm_os = r_config_get (core->config, "asm.os");
 			r_egg_setup (egg, asm_arch, asm_bits, 0, asm_os);
 			r_egg_reset (egg);
-			r_egg_load (egg, input+1, 0);
+			r_egg_load (egg, input + 1, 0);
 			r_egg_compile (egg);
 			b = r_egg_get_bin (egg);
 			r_asm_set_pc (core->assembler, core->offset);
@@ -3113,7 +3113,7 @@ static int cmd_debug(void *data, const char *input) {
 				r_cons_push ();
 				str = r_core_cmd_str (core, sdb_fmt (0, "gs %s", input + 2));
 				r_cons_pop ();
-				r_core_cmdf (core, "dx %s", str); //`gs %s`", input+2);
+				r_core_cmdf (core, "dx %s", str); //`gs %s`", input + 2);
 				free (str);
 			} else {
 				eprintf ("Missing parameter used in gs by dxs\n");

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2705,6 +2705,9 @@ static int cmd_debug_step (RCore *core, const char *input) {
 	switch (input[1]) {
 	case 0:
 		r_reg_arena_swap (core->dbg->reg, true);
+		// sync registers for BSD PT_STEP/PT_CONT
+		// XXX(jjd): is this necessary?
+		r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, false);
 		r_debug_step (core->dbg, times);
 		break;
 	case 'i':

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -474,7 +474,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		break;
 	case 'e': // "dpe"
 		{
-			int pid = (input[2] == ' ')? atoi(input + 2): core->dbg->pid;
+			int pid = (input[2] == ' ')? atoi (input + 2): core->dbg->pid;
 			char *exe = r_sys_pid_to_path (pid);
 			if (exe) {
 				r_cons_printf ("%s\n", exe);
@@ -3016,7 +3016,7 @@ static int cmd_debug(void *data, const char *input) {
 			NULL
 		};
 		RDebugInfo *rdi = r_debug_info (core->dbg, input + 2);
-		RDebugReasonType stop = r_debug_stop_reason(core->dbg);
+		RDebugReasonType stop = r_debug_stop_reason (core->dbg);
 		char *escaped_str;
 		switch (input[1]) {
 		case '\0':
@@ -3029,7 +3029,7 @@ static int cmd_debug(void *data, const char *input) {
 				P ("signum=%d\n", core->dbg->reason.signum);
 				P ("sigpid=%d\n", core->dbg->reason.tid);
 				P ("addr=0x%"PFMT64x"\n", core->dbg->reason.addr);
-				P ("inbp=%s\n", core->dbg->reason.bp_addr? "true": "false");
+				P ("inbp=%s\n", r_str_bool (core->dbg->reason.bp_addr));
 				P ("pid=%d\n", rdi->pid);
 				P ("tid=%d\n", rdi->tid);
 				P ("uid=%d\n", rdi->uid);
@@ -3052,7 +3052,7 @@ static int cmd_debug(void *data, const char *input) {
 				P ("\"signum\":%d,", core->dbg->reason.signum);
 				P ("\"sigpid\":%d,", core->dbg->reason.tid);
 				P ("\"addr\":%"PFMT64d",", core->dbg->reason.addr);
-				P ("\"inbp\":%s,", core->dbg->reason.bp_addr? "true": "false");
+				P ("\"inbp\":%s,", r_str_bool (core->dbg->reason.bp_addr));
 				P ("\"pid\":%d,", rdi->pid);
 				P ("\"tid\":%d,", rdi->tid);
 				P ("\"uid\":%d,", rdi->uid);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -613,8 +613,9 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 		ut32 r32[2];
 	} sp_top;
 
-	if (dbg->recoil_mode == R_DBG_RECOIL_NONE)
+	if (dbg->recoil_mode == R_DBG_RECOIL_NONE) {
 		dbg->recoil_mode = R_DBG_RECOIL_STEP;
+	}
 
 	if (r_debug_is_dead (dbg)) {
 		return false;

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -26,40 +26,150 @@ R_API void r_debug_info_free (RDebugInfo *rdi) {
 	free (rdi->libname);
 }
 
-/* restore program counter after breakpoint hit */
-static int r_debug_recoil(RDebug *dbg) {
-	int recoil;
-	RRegItem *ri;
-	if (r_debug_is_dead (dbg)) {
+
+/*
+ * Recoiling after a breakpoint has two stages:
+ * 1. remove the breakpoint and fix the program counter.
+ * 2. on resume, single step once and then replace the breakpoint.
+ *
+ * Thus, we have two functions to handle these situations.
+ * r_debug_bp_hit handles stage 1.
+ * r_debug_recoil handles stage 2.
+ */
+static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc) {
+	RBreakpointItem *b;
+
+	/* if we are tracing, update the tracing data */
+	if (dbg->trace->enabled)
+		r_debug_trace_pc (dbg, pc);
+
+	/* remove all sw breakpoints for now. we'll set them back in stage 2
+	 *
+	 * this is necessary because while stopped we don't want any breakpoints in
+	 * the code messing up our analysis.
+	 */
+	if (!r_bp_restore (dbg->bp, false)) // unset sw breakpoints
+		return false;
+
+	/* if we are recoiling, tell r_debug_step that we ignored a breakpoint
+	 * event */
+	if (!dbg->swstep && dbg->recoil_mode != R_DBG_RECOIL_NONE) {
+		dbg->reason.bp_addr = 0;
+		return true;
+	}
+
+	/* see if we really have a breakpoint here... */
+	b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
+	if (!b) /* we don't. nothing left to do */
+		return true;
+
+	/* set the pc value back */
+	pc -= b->size;
+	if (!r_reg_set_value (dbg->reg, pc_ri, pc)) {
+		eprintf ("failed to set PC!\n");
 		return false;
 	}
-	r_debug_reg_sync (dbg, R_REG_TYPE_GPR, false);
-	ri = r_reg_get (dbg->reg, dbg->reg->name[R_REG_NAME_PC], -1);
-	dbg->reason.bpi = NULL;
-	if (ri) {
-		ut64 addr = r_reg_get_value (dbg->reg, ri);
-		recoil = r_bp_recoil (dbg->bp, addr - dbg->bpsize);
-		//eprintf ("[R2] Breakpoint recoil at 0x%"PFMT64x" = %d\n", addr, recoil);
-		if (recoil < 1)
-			recoil = 0; // XXX Hack :D
-		if (recoil) {
-			dbg->in_recoil = true;
-			dbg->reason.type = R_DEBUG_REASON_BREAKPOINT;
-			dbg->reason.bpi = r_bp_get_at (dbg->bp, addr-recoil);
-			dbg->reason.addr = addr - recoil;
-			r_reg_set_value (dbg->reg, ri, addr-recoil);
-			if (r_reg_get_value (dbg->reg, ri) != (addr-recoil)) {
-				eprintf ("r_debug_recoil: Cannot set program counter\n");
+	if (!r_debug_reg_sync (dbg, R_REG_TYPE_GPR, true)) {
+		eprintf ("cannot set registers!\n");
+		return false;
+	}
+
+	/* if we are on a software stepping breakpoint, we hide what is going on... */
+	if (b->swstep) {
+		dbg->reason.bp_addr = 0;
+		return true;
+	}
+
+	/* setup our stage 2 */
+	dbg->reason.bp_addr = b->addr;
+
+	/* check if cur bp demands tracing or not */
+	if (b->trace)
+		eprintf("hit tracepoint at: %" PFMT64x "\n", pc);
+	else
+		eprintf("hit breakpoint at: %" PFMT64x "\n", pc);
+
+	/* now that we've cleaned up after the breakpoint, call the other
+	 * potential breakpoint handlers
+	 */
+	if (dbg->corebind.core && dbg->corebind.bphit) {
+		dbg->corebind.bphit (dbg->corebind.core, b);
+	}
+
+	/* XXX(jjd): i don't think this goes here...
+	if (b->trace) {
+		r_debug_step (dbg, 1);
+		goto repeat;
+	}
+	 */
+	return true;
+}
+
+/*
+ * replace breakpoints before we continue execution
+ *
+ * this is called from r_debug_step_hard or r_debug_continue_kill
+ *
+ * this is a trick process because of breakpoints/tracepoints.
+ *
+ * if a breakpoint was just hit, we need step over that instruction before
+ * allowing the caller to proceed as desired.
+ *
+ * if the user wants to step, the single step here does the job.
+ */
+static int r_debug_recoil(RDebug *dbg, RDebugRecoilMode rc_mode) {
+	/* if bp_addr is not set, we must not have actually hit a breakpoint */
+	if (!dbg->reason.bp_addr) {
+		goto enable_breakpoints;
+	}
+
+	/* don't do anything if we already are recoiling */
+	if (dbg->recoil_mode != R_DBG_RECOIL_NONE) {
+		/* the first time recoil is called with swstep, we just need to
+		 * look up the bp and step past it.
+		 * the second time it's called, the new sw breakpoint should exist
+		 * so we just restore all except what we originally hit and reset.
+		 */
+		if (dbg->swstep) {
+			if (!r_bp_restore_except (dbg->bp, true, dbg->reason.bp_addr))
 				return false;
-			}
-			r_debug_reg_sync (dbg, R_REG_TYPE_GPR, true);
-			//eprintf ("[BP Hit] Setting pc to 0x%"PFMT64x"\n", (addr-recoil));
 			return true;
 		}
-	} else {
-		eprintf ("r_debug_recoil: Cannot get program counter\n");
+
+		/* otherwise, avoid recursion */
+		return true;
 	}
-	return false;
+
+	/* we have entered recoil! */
+	dbg->recoil_mode = rc_mode;
+
+	/* step over the place with the breakpoint and let the caller resume */
+	if (r_debug_step (dbg, 1) != 1)
+		return false;
+
+	/* when stepping away from a breakpoint during recoil in stepping mode,
+	 * the r_debug_bp_hit function tells us that it was called
+	 * innapropriately by setting bp_addr back to zero. however, recoil_mode
+	 * is still set. we use this condition to know not to proceed but
+	 * pretend as if we had.
+	 */
+	if (!dbg->reason.bp_addr && dbg->recoil_mode == R_DBG_RECOIL_STEP) {
+		/* restore all sw breakpoints. we are about to step/continue so these need
+		 * to be in place. */
+		if (!r_bp_restore (dbg->bp, true))
+			return false;
+		return true;
+	}
+
+enable_breakpoints:
+	/* restore all sw breakpoints. we are about to step/continue so these need
+	 * to be in place. */
+	if (!r_bp_restore (dbg->bp, true))
+		return false;
+
+	/* done recoiling... */
+	dbg->recoil_mode = R_DBG_RECOIL_NONE;
+	return true;
 }
 
 /* add a breakpoint with some typical values */
@@ -152,8 +262,6 @@ R_API RDebug *r_debug_new(int hard) {
 	dbg->tree = r_tree_new ();
 	dbg->tracenodes = sdb_new0 ();
 	dbg->swstep = 0;
-	dbg->newstate = 0;
-	dbg->in_recoil = false;
 	dbg->stop_all_threads = false;
 	dbg->trace = r_debug_trace_new ();
 	dbg->cb_printf = (void *)printf;
@@ -396,7 +504,7 @@ R_API const char *r_debug_reason_to_string(int type) {
 	return "unhandled";
 }
 
-R_API int r_debug_stop_reason(RDebug *dbg) {
+R_API RDebugReasonType r_debug_stop_reason(RDebug *dbg) {
 	// TODO: return reason to stop debugging
 	// - new process
 	// - trap instruction
@@ -406,27 +514,70 @@ R_API int r_debug_stop_reason(RDebug *dbg) {
 	return dbg->reason.type;
 }
 
-/* Returns  R_DEBUG_REASON_* */
-R_API int r_debug_wait(RDebug *dbg) {
-	int ret = 0;
-	if (!dbg)
-		return false;
+/*
+ * wait for an event to happen on the selected pid/tid
+ *
+ * Returns  R_DEBUG_REASON_*
+ */
+R_API RDebugReasonType r_debug_wait(RDebug *dbg) {
+	RDebugReasonType reason = R_DEBUG_REASON_ERROR;
+
+	if (!dbg) {
+		return reason;
+	}
+
+	/* default to unknown */
 	dbg->reason.type = R_DEBUG_REASON_UNKNOWN;
 	if (r_debug_is_dead (dbg))
-		return dbg->reason.type = R_DEBUG_REASON_DEAD;
+		return R_DEBUG_REASON_DEAD;
+
+	/* if our debugger plugin has wait */
 	if (dbg->h && dbg->h->wait) {
-		dbg->reason.type = R_DEBUG_REASON_UNKNOWN;
-		ret = dbg->h->wait (dbg, dbg->pid);
-		dbg->newstate = 1;
-		if (ret == -1) {
+		reason = dbg->h->wait (dbg, dbg->pid);
+
+		if (reason == R_DEBUG_REASON_DEAD) {
 			eprintf ("\n==> Process finished\n\n");
-			r_debug_select (dbg, -1, -1);
+			// XXX(jjd): TODO: handle fallback or something else
+			//r_debug_select (dbg, -1, -1);
+			return R_DEBUG_REASON_DEAD;
 		}
-		if (dbg->trace->enabled)
-			r_debug_trace_pc (dbg);
-		dbg->reason.type = ret;
-		if (ret == R_DEBUG_REASON_SIGNAL && dbg->reason.signum != -1) {
+
+		/* propagate errors from the plugin */
+		if (reason == R_DEBUG_REASON_ERROR)
+			return R_DEBUG_REASON_ERROR;
+
+		/* read general purpose registers */
+		if (!r_debug_reg_sync (dbg, R_REG_TYPE_GPR, false))
+			return R_DEBUG_REASON_ERROR;
+
+		/* if the underlying stop reason is a breakpoint, call the handlers */
+		if (reason == R_DEBUG_REASON_BREAKPOINT || reason == R_DEBUG_REASON_STEP) {
+			RRegItem *pc_ri;
+			ut64 pc;
+
+			/* get the program coounter */
+			pc_ri = r_reg_get (dbg->reg, dbg->reg->name[R_REG_NAME_PC], -1);
+			if (!pc_ri)  /* couldn't find PC?! */
+				return R_DEBUG_REASON_ERROR;
+
+			/* get the value */
+			pc = r_reg_get_value (dbg->reg, pc_ri);
+
+			if (!r_debug_bp_hit (dbg, pc_ri, pc))
+				return R_DEBUG_REASON_ERROR;
+
+			/* where does this really need to go?!
+				if (b->trace) {
+					r_debug_step (dbg, 1);
+					goto repeat;
+				}
+			 */
+		}
+
+		dbg->reason.type = reason;
+		if (reason == R_DEBUG_REASON_SIGNAL && dbg->reason.signum != -1) {
 			/* handle signal on continuations here */
+			eprintf ("got signal...\n");
 			int what = r_debug_signal_what (dbg, dbg->reason.signum);
 			const char *name = r_debug_signal_resolve_i (dbg, dbg->reason.signum);
 			if (name && strcmp ("SIGTRAP", name))
@@ -434,7 +585,7 @@ R_API int r_debug_wait(RDebug *dbg) {
 						dbg->reason.signum, name, what);
 		}
 	}
-	return ret;
+	return reason;
 }
 
 R_API int r_debug_step_soft(RDebug *dbg) {
@@ -447,6 +598,9 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 		ut64 r64;
 		ut32 r32[2];
 	} sp_top;
+
+	if (dbg->recoil_mode == R_DBG_RECOIL_NONE)
+		dbg->recoil_mode = R_DBG_RECOIL_STEP;
 
 	if (r_debug_is_dead (dbg)) {
 		return false;
@@ -492,7 +646,10 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 	}
 
 	for (i = 0; i < br; i++) {
-		r_bp_add_sw (dbg->bp, next[i], dbg->bpsize, R_BP_PROT_EXEC);
+		RBreakpointItem *bpi = r_bp_add_sw (dbg->bp, next[i], dbg->bpsize, R_BP_PROT_EXEC);
+		if (bpi) {
+			bpi->swstep = true;
+		}
 	}
 
 	ret = r_debug_continue (dbg);
@@ -505,43 +662,63 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 }
 
 R_API int r_debug_step_hard(RDebug *dbg) {
+	RDebugReasonType reason;
+
 	dbg->reason.type = R_DEBUG_REASON_STEP;
 	if (r_debug_is_dead (dbg)) {
 		return false;
 	}
+
+	/* only handle recoils when not already in recoil mode. */
+	if (dbg->recoil_mode == R_DBG_RECOIL_NONE) {
+		/* handle the stage-2 of breakpoints */
+		if (!r_debug_recoil (dbg, R_DBG_RECOIL_STEP))
+			return false;
+
+		/* recoil already stepped once, so we don't step again. */
+		if (dbg->recoil_mode == R_DBG_RECOIL_STEP) {
+			dbg->recoil_mode = R_DBG_RECOIL_NONE;
+			return true;
+		}
+	}
+
 	if (!dbg->h->step (dbg)) {
 		return false;
 	}
-	return r_debug_wait (dbg);
+	reason = r_debug_wait (dbg);
+	/* TODO: handle better */
+	if (reason == R_DEBUG_REASON_ERROR)
+		return false;
+	if (reason == R_DEBUG_REASON_DEAD || r_debug_is_dead (dbg))
+		return false;
+	return true;
 }
 
 R_API int r_debug_step(RDebug *dbg, int steps) {
 	int i, ret;
 
-	if (!dbg || !dbg->h) {
-		return false;
-	}
-	dbg->reason.type = R_DEBUG_REASON_STEP;
-	if (r_debug_is_dead (dbg)) {
-		return false;
-	}
-
+	/* who calls this without giving a positive number? */
 	if (steps < 1) {
 		steps = 1;
 	}
 
+	if (r_debug_is_dead (dbg))
+		return 0;
+
+	dbg->reason.type = R_DEBUG_REASON_STEP;
+
 	for (i = 0; i < steps; i++) {
-		ret = dbg->swstep
-			? r_debug_step_soft (dbg)
-			: r_debug_step_hard (dbg);
+		if (dbg->swstep)
+			ret = r_debug_step_soft (dbg);
+		else
+			ret = r_debug_step_hard (dbg);
 		if (!ret) {
 			eprintf ("Stepping failed!\n");
-			return false;
+			return i;
 		}
 		dbg->steps++;
 		dbg->reason.type = R_DEBUG_REASON_STEP;
 	}
-
 	return i;
 }
 
@@ -615,11 +792,12 @@ R_API int r_debug_step_over(RDebug *dbg, int steps) {
 }
 
 R_API int r_debug_continue_kill(RDebug *dbg, int sig) {
-	ut64 pc;
-	int retwait, ret = false;
+	RDebugReasonType reason, ret = false;
+
 	if (!dbg) {
 		return false;
 	}
+
 #if __WINDOWS__
 	r_cons_break (w32_break_process, dbg);
 #endif
@@ -628,55 +806,42 @@ repeat:
 		return false;
 	}
 	if (dbg->h && dbg->h->cont) {
-		if (dbg->in_recoil) {
-			/* if we are recoiling, we should not set the breakpoint that
-			 * caused us to stop.
-			 */
-			dbg->in_recoil = false;
-			r_bp_restore_except (dbg->bp, true, dbg->reason.addr);
-		} else {
-			r_bp_restore (dbg->bp, true); // set sw breakpoints
-		}
+		/* handle the stage-2 of breakpoints */
+		if (!r_debug_recoil (dbg, R_DBG_RECOIL_CONTINUE))
+			return false;
+
+		/* tell the inferior to go! */
 		ret = dbg->h->cont (dbg, dbg->pid, dbg->tid, sig);
-		dbg->reason.signum = 0;
-		retwait = r_debug_wait (dbg);
+
+		//XXX(jjd): why? //dbg->reason.signum = 0;
+
+		reason = r_debug_wait (dbg);
+
 #if __WINDOWS__
-		if (retwait != R_DEBUG_REASON_DEAD) {
+		if (reason != R_DEBUG_REASON_DEAD) {
+			// XXX(jjd): returning a thread id?!
 			ret = dbg->tid;
 		}
-		if (retwait == R_DEBUG_REASON_NEW_LIB ||
-				retwait == R_DEBUG_REASON_EXIT_LIB) {
+		if (reason == R_DEBUG_REASON_NEW_LIB ||
+			reason == R_DEBUG_REASON_EXIT_LIB) {
 			goto repeat;
 		}
 #endif
-		if (r_debug_is_dead (dbg))
+
+		/* if continuing killed the inferior, we won't be able to get
+		 * the registers.. */
+		if (reason == R_DEBUG_REASON_DEAD || r_debug_is_dead (dbg)) {
 			return false;
-		r_bp_restore (dbg->bp, false); // unset sw breakpoints
-		if (r_debug_recoil (dbg) || (dbg->reason.type == R_DEBUG_REASON_BREAKPOINT)) {
-			/* check if cur bp demands tracing or not */
-			pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
-			RBreakpointItem *b = r_bp_get_at (dbg->bp, pc);
-			if (b) {
-				/* check if cur bp demands tracing or not */
-				if (b->trace)
-					eprintf("hit tracepoint at: %"PFMT64x"\n",pc);
-				else
-					eprintf("hit breakpoint at: %"PFMT64x"\n",pc);
-				if (dbg->trace->enabled)
-					r_debug_trace_pc (dbg);
-				// TODO: delegate this to RCore.bphit(RCore, RBreakopintItem)
-				if (dbg->corebind.core && dbg->corebind.bphit) {
-					dbg->corebind.bphit (dbg->corebind.core, b);
-				}
-				if (b->trace) {
-					r_debug_step (dbg, 1);
-					goto repeat;
-				}
-			}
 		}
+
+		/* choose the thread that was returned from the continue function */
+		// XXX(jjd): there must be a cleaner way to do this...
 		r_debug_select (dbg, dbg->pid, ret);
 		sig = 0; // clear continuation after signal if needed
-		if (retwait == R_DEBUG_REASON_SIGNAL && dbg->reason.signum != -1) {
+
+		/* handle general signals here based on the return from the wait
+		 * function */
+		if (reason == R_DEBUG_REASON_SIGNAL && dbg->reason.signum != -1) {
 			int what = r_debug_signal_what (dbg, dbg->reason.signum);
 			if (what & R_DBG_SIGNAL_CONT) {
 				sig = dbg->reason.signum;
@@ -738,7 +903,9 @@ R_API int r_debug_continue_until_optype(RDebug *dbg, int type, int over) {
 
 	// step first, we dont want to check current optype
 	for (;;) {
-		r_debug_reg_sync (dbg, R_REG_TYPE_GPR, false);
+		if (!r_debug_reg_sync (dbg, R_REG_TYPE_GPR, false))
+			break;
+
 		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 		// Try to keep the buffer full
 		if (pc - buf_pc > sizeof (buf)) {
@@ -848,15 +1015,25 @@ R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc) {
 		return -1;
 	}
 	for (;;) {
+		RDebugReasonType reason;
+
 		if (r_cons_singleton()->breaked)
 			break;
 #if __linux__
 		// step is needed to avoid dupped contsc results
+		/* XXX(jjd): actually one stop is before the syscall, the other is
+		 * after.  this allows you to inspect the arguments before and the
+		 * return value after... */
 		r_debug_step (dbg, 1);
 #endif
 		dbg->h->contsc (dbg, dbg->pid, 0); // TODO handle return value
 		// wait until continuation
-		r_debug_wait (dbg);
+		reason = r_debug_wait (dbg);
+		if (reason == R_DEBUG_REASON_DEAD || r_debug_is_dead (dbg))
+			break;
+		if (reason != R_DEBUG_REASON_STEP)
+			break;
+
 		if (!r_debug_reg_sync (dbg, R_REG_TYPE_GPR, false)) {
 			eprintf ("--> cannot sync regs, process is probably dead\n");
 			return -1;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -225,12 +225,11 @@ static int r_debug_native_continue (RDebug *dbg, int pid, int tid, int sig) {
 	#warning "r_debug_native_continue not supported on this platform"
 	return -1;
 #else
-	int contsig;
+	int contsig = dbg->reason.signum;
 
-	if (sig != -1)
+	if (sig != -1) {
 		contsig = sig;
-	else
-		contsig = dbg->reason.signum;
+	}
 	//eprintf ("continuing with signal %d ...\n", contsig);
 	return ptrace (PTRACE_CONT, pid, NULL, contsig) == 0;
 #endif

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -329,16 +329,17 @@ static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 #endif // __linux__
 
 	/* propagate errors */
-	if (reason == R_DEBUG_REASON_ERROR)
+	if (reason == R_DEBUG_REASON_ERROR) {
 		return reason;
+	}
 
 	/* we don't know what to do yet, let's try harder to figure it out. */
 	if (reason == R_DEBUG_REASON_UNKNOWN) {
 		if (WIFEXITED (status)) {
-			eprintf ("child exited with status %d\n", WEXITSTATUS(status));
+			eprintf ("child exited with status %d\n", WEXITSTATUS (status));
 			reason = R_DEBUG_REASON_DEAD;
 		} else if (WIFSIGNALED (status)) {
-			eprintf ("child received signal %d\n", WTERMSIG(status));
+			eprintf ("child received signal %d\n", WTERMSIG (status));
 			reason = R_DEBUG_REASON_SIGNAL;
 		} else if (WIFSTOPPED (status)) {
 			eprintf ("child stopped with signal %d\n", WSTOPSIG (status));
@@ -366,11 +367,12 @@ static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 			eprintf ("STATUS=0?!?!?!?\n");
 			reason = R_DEBUG_REASON_DEAD;
 		} else {
-			if (ret != pid)
+			if (ret != pid) {
 				reason = R_DEBUG_REASON_NEW_PID;
-			else
+			} else {
 				/* ugh. still don't know :-/ */
 				eprintf ("CRAP. returning from wait without knowing why...\n");
+			}
 		}
 	}
 

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -225,9 +225,14 @@ static int r_debug_native_continue (RDebug *dbg, int pid, int tid, int sig) {
 	#warning "r_debug_native_continue not supported on this platform"
 	return -1;
 #else
-	void *data = (void*)(size_t)((sig != -1) ? sig : dbg->reason.signum);
-	//eprintf ("continuing with signal %d ...\n", dbg->reason.signum);
-	return ptrace (PTRACE_CONT, pid, NULL, data) == 0;
+	int contsig;
+
+	if (sig != -1)
+		contsig = sig;
+	else
+		contsig = dbg->reason.signum;
+	//eprintf ("continuing with signal %d ...\n", contsig);
+	return ptrace (PTRACE_CONT, pid, NULL, contsig) == 0;
 #endif
 }
 static RDebugInfo* r_debug_native_info (RDebug *dbg, const char *arg) {
@@ -257,8 +262,15 @@ static bool tracelib(RDebug *dbg, const char *mode, PLIB_ITEM item) {
 }
 #endif
 
-static int r_debug_native_wait (RDebug *dbg, int pid) {
+/*
+ * wait for an event and start trying to figure out what to do with it.
+ *
+ * Returns R_DEBUG_REASON_*
+ */
+static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 	int status = -1;
+	RDebugReasonType reason = R_DEBUG_REASON_UNKNOWN;
+
 #if __WINDOWS__ && !__CYGWIN__
 	int mode = 0;
 	status = w32_dbg_wait (dbg, pid);
@@ -273,7 +285,7 @@ static int r_debug_native_wait (RDebug *dbg, int pid) {
 		RDebugInfo *r = r_debug_native_info (dbg, "");
 		if (r && r->lib) {
 			if (tracelib (dbg, mode=='l'? "load":"unload", r->lib))
-				status=R_DEBUG_REASON_TRAP;
+				status = R_DEBUG_REASON_TRAP;
 		} else {
 			eprintf ("%soading unknown library.\n", mode?"L":"Unl");
 		}
@@ -281,76 +293,99 @@ static int r_debug_native_wait (RDebug *dbg, int pid) {
 	}
 #else
 	if (pid == -1) {
-		status = R_DEBUG_REASON_UNKNOWN;
-	} else {
-#if __APPLE__
-		// eprintf ("No waitpid here :D\n");
-		status = xnu_wait (dbg, pid);
-#else
-		// XXX: this is blocking, ^C will be ignored
-		int ret = waitpid (pid, &status, 0);
-		if (ret == -1) {
-			r_sys_perror ("waitpid");
-			status = R_DEBUG_REASON_ERROR;
-		} else {
-			//printf ("r_debug_native_wait: status=%d (return=%d)\n", status, ret);
-
-			// TODO: switch status and handle reasons here
-#if __linux__ && defined(PT_GETEVENTMSG)
-			// Handle PTRACE_EVENT_*
-			if (WIFSTOPPED (status) && WSTOPSIG (status) == SIGTRAP) {
-				ut32 pt_evt = status >> 16;
-				ut32 data;
-
-				switch (pt_evt) {
-				case 0:
-					// Normal trap?
-					break;
-
-				case PTRACE_EVENT_FORK:
-					if (dbg->trace_forks) {
-						if (ptrace (PTRACE_GETEVENTMSG, pid, 0, &data) == -1) {
-							r_sys_perror ("ptrace GETEVENTMSG");
-						} else {
-							eprintf ("PTRACE_EVENT_FORK new_pid=%d\n", data);
-							dbg->forked_pid = data;
-							// TODO: more handling here?
-						}
-					}
-					break;
-				case PTRACE_EVENT_EXIT:
-					if (ptrace (PTRACE_GETEVENTMSG, pid, 0, &data) == -1) {
-						r_sys_perror ("ptrace GETEVENTMSG");
-					} else {
-						eprintf ("PTRACE_EVENT_EXIT pid=%d, status=%d\n", pid, data);
-					}
-					break;
-				default:
-					eprintf ("Unknown PTRACE_EVENT encountered: %d\n", pt_evt);
-					break;
-				}
-			}
-#endif
-
-			r_debug_handle_signals (dbg);
-
-			if (WIFSTOPPED (status)) {
-				dbg->reason.signum = WSTOPSIG (status);
-				status = R_DEBUG_REASON_SIGNAL;
-			} else if (status == 0 || ret == -1) {
-				status = R_DEBUG_REASON_DEAD;
-			} else {
-				if (ret != pid)
-					status = R_DEBUG_REASON_NEW_PID;
-				else status = R_DEBUG_REASON_UNKNOWN;
-			}
-		}
-#endif
+		eprintf ("r_debug_native_wait called with -1 pid!\n");
+		return R_DEBUG_REASON_ERROR;
 	}
-#endif
+
+#if __APPLE__
+	// eprintf ("No waitpid here :D\n");
+	reason = xnu_wait (dbg, pid);
+#else
+	// XXX: this is blocking, ^C will be ignored
+#ifdef WAIT_ON_ALL_CHILDREN
+	//eprintf ("waiting on all children ...\n");
+	int ret = waitpid (-1, &status, __WALL);
+#else
+	//eprintf ("waiting on pid %d ...\n", pid);
+	int ret = waitpid (pid, &status, __WALL);
+#endif // WAIT_ON_ALL_CHILDREN
+	if (ret == -1) {
+		r_sys_perror ("waitpid");
+		return R_DEBUG_REASON_ERROR;
+	}
+
+	//eprintf ("r_debug_native_wait: status=%d (0x%x) (return=%d)\n", status, status, ret);
+
+#ifdef WAIT_ON_ALL_CHILDREN
+	if (ret != pid) {
+		reason = R_DEBUG_REASON_NEW_PID;
+		eprintf ("switching to pid %d\n", ret);
+		r_debug_select(dbg, ret, ret);
+	}
+#endif // WAIT_ON_ALL_CHILDREN
+
+	// TODO: switch status and handle reasons here
+#if __linux__ && defined(PT_GETEVENTMSG)
+	reason = linux_ptrace_event (dbg, pid, status);
+#endif // __linux__
+
+	/* propagate errors */
+	if (reason == R_DEBUG_REASON_ERROR)
+		return reason;
+
+	/* we don't know what to do yet, let's try harder to figure it out. */
+	if (reason == R_DEBUG_REASON_UNKNOWN) {
+		if (WIFEXITED (status)) {
+			eprintf ("child exited with status %d\n", WEXITSTATUS(status));
+			reason = R_DEBUG_REASON_DEAD;
+		} else if (WIFSIGNALED (status)) {
+			eprintf ("child received signal %d\n", WTERMSIG(status));
+			reason = R_DEBUG_REASON_SIGNAL;
+		} else if (WIFSTOPPED (status)) {
+			eprintf ("child stopped with signal %d\n", WSTOPSIG (status));
+
+			/* this one might be good enough... */
+			dbg->reason.signum = WSTOPSIG (status);
+
+			/* the ptrace documentation says GETSIGINFO is only necessary for
+			 * differentiating the various stops.
+			 *
+			 * this might modify dbg->reason.signum
+			 */
+			if (!r_debug_handle_signals (dbg))
+				return R_DEBUG_REASON_ERROR;
+			reason = dbg->reason.type;
+		} else if (WIFCONTINUED (status)) {
+			eprintf ("child continued...\n");
+			reason = R_DEBUG_REASON_NONE;
+		} else if (status == 1) {
+			/* XXX(jjd): does this actually happen? */
+			eprintf ("EEK DEAD DEBUGEE!\n");
+			reason = R_DEBUG_REASON_DEAD;
+		} else if (status == 0) {
+			/* XXX(jjd): does this actually happen? */
+			eprintf ("STATUS=0?!?!?!?\n");
+			reason = R_DEBUG_REASON_DEAD;
+		} else {
+			if (ret != pid)
+				reason = R_DEBUG_REASON_NEW_PID;
+			else
+				/* ugh. still don't know :-/ */
+				eprintf ("CRAP. returning from wait without knowing why...\n");
+		}
+	}
+
+	/* if we still don't know what to do, we have a problem... */
+	if (reason == R_DEBUG_REASON_UNKNOWN) {
+		eprintf ("%s: no idea what happened... wtf?!?!\n", __func__);
+		reason = R_DEBUG_REASON_ERROR;
+	}
+#endif // __APPLE__
+#endif // __WINDOWS__ && !__CYGWIN__
+
 	dbg->reason.tid = pid;
-	dbg->reason.type = status;
-	return status;
+	dbg->reason.type = reason;
+	return reason;
 }
 
 #undef MAXPID
@@ -1066,6 +1101,12 @@ static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, i
 	return false;
 }
 
+/*
+ * set or unset breakpoints...
+ *
+ * we only handle the case for hardware breakpoints here. otherwise,
+ * we let the caller handle the work.
+ */
 static int r_debug_native_bp (RBreakpointItem *bp, int set, void *user) {
 	if (!bp) return false;
 #if __i386__ || __x86_64__

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -97,8 +97,9 @@ RDebugReasonType linux_ptrace_event (RDebug *dbg, int pid, int status) {
 	ut32 data;
 
 	/* we only handle stops with SIGTRAP here */
-	if (!WIFSTOPPED(status) || WSTOPSIG(status) != SIGTRAP)
+	if (!WIFSTOPPED(status) || WSTOPSIG(status) != SIGTRAP) {
 		return R_DEBUG_REASON_UNKNOWN;
+	}
 
 	pt_evt = status >> 16;
 	switch (pt_evt) {

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -79,6 +79,7 @@ typedef ut64 mips64_regs_t [274];
 
 //API
 int linux_step (RDebug *dbg);
+RDebugReasonType linux_ptrace_event (RDebug *dbg, int pid, int status);
 int linux_attach (RDebug *dbg, int pid);
 RDebugInfo *linux_info (RDebug *dbg, const char *arg);
 RList *linux_thread_list (int pid, RList *list);

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -133,9 +133,9 @@ R_API int r_bp_add_fault(RBreakpoint *bp, ut64 addr, int size, int rwx);
 
 R_API RBreakpointItem *r_bp_add_sw(RBreakpoint *bp, ut64 addr, int size, int rwx);
 R_API RBreakpointItem *r_bp_add_hw(RBreakpoint *bp, ut64 addr, int size, int rwx);
-R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, int set);
-R_API int r_bp_restore(RBreakpoint *bp, int set);
-R_API bool r_bp_restore_except(RBreakpoint *bp, int set, ut64 addr);
+R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, bool set);
+R_API int r_bp_restore(RBreakpoint *bp, bool set);
+R_API bool r_bp_restore_except(RBreakpoint *bp, bool set, ut64 addr);
 
 /* traptrace */
 R_API void r_bp_traptrace_free(void *ptr);

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -46,6 +46,7 @@ typedef struct r_bp_item_t {
 	ut64 addr;
 	int size; /* size of breakpoint area */
 	int recoil; /* recoil */
+	bool swstep; 	/* is this breakpoint from a swstep? */
 	int rwx;
 	int hw;
 	int trace;
@@ -132,9 +133,9 @@ R_API int r_bp_add_fault(RBreakpoint *bp, ut64 addr, int size, int rwx);
 
 R_API RBreakpointItem *r_bp_add_sw(RBreakpoint *bp, ut64 addr, int size, int rwx);
 R_API RBreakpointItem *r_bp_add_hw(RBreakpoint *bp, ut64 addr, int size, int rwx);
+R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, int set);
 R_API int r_bp_restore(RBreakpoint *bp, int set);
 R_API bool r_bp_restore_except(RBreakpoint *bp, int set, ut64 addr);
-R_API int r_bp_recoil(RBreakpoint *bp, ut64 addr);
 
 /* traptrace */
 R_API void r_bp_traptrace_free(void *ptr);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -44,23 +44,68 @@ R_LIB_VERSION_HEADER(r_debug);
 #define PTRACE_SYSCALL PT_STEP
 #endif
 
-enum {
+
+/*
+ * states that a process can be in
+ */
+typedef enum {
 	R_DBG_PROC_STOP = 's',
 	R_DBG_PROC_RUN = 'r',
 	R_DBG_PROC_SLEEP = 'S',
 	R_DBG_PROC_ZOMBIE = 'z',
 	R_DBG_PROC_DEAD = 'd',
 	R_DBG_PROC_RAISED = 'R' // has produced a signal, breakpoint, etc..
-};
+} RDebugPidState;
 
 
 // signal handling must support application and debugger level options
-enum {
-	R_DBG_SIGNAL_IGNORE=0, // ignore signal handler
-	R_DBG_SIGNAL_CONT=1, // pass signal to chlidren and continue execution
-	R_DBG_SIGNAL_SKIP=2, //
+typedef enum {
+	R_DBG_SIGNAL_IGNORE = 0, // ignore signal handler
+	R_DBG_SIGNAL_CONT = 1, // pass signal to chlidren and continue execution
+	R_DBG_SIGNAL_SKIP = 2, //
 	//..
-};
+} RDebugSignalMode;
+
+
+/*
+ * when a user wants to resume from a breakpoint, we need to know how they want
+ * to proceed. these values indicate their intention.
+ */
+typedef enum {
+	R_DBG_RECOIL_NONE = 0,
+	R_DBG_RECOIL_STEP,
+	R_DBG_RECOIL_CONTINUE
+} RDebugRecoilMode;
+
+/*
+ * List of reasons that an inferior might have stopped
+ */
+typedef enum {
+	R_DEBUG_REASON_DEAD = -1,
+	R_DEBUG_REASON_NONE = 0,
+	R_DEBUG_REASON_SIGNAL,
+	R_DEBUG_REASON_SEGFAULT,
+	R_DEBUG_REASON_BREAKPOINT,
+	R_DEBUG_REASON_READERR,
+	R_DEBUG_REASON_STEP,
+	R_DEBUG_REASON_ABORT,
+	R_DEBUG_REASON_WRITERR,
+	R_DEBUG_REASON_DIVBYZERO,
+	R_DEBUG_REASON_ILLEGAL,
+	R_DEBUG_REASON_UNKNOWN,
+	R_DEBUG_REASON_ERROR,
+	R_DEBUG_REASON_NEW_PID,
+	R_DEBUG_REASON_NEW_TID,
+	R_DEBUG_REASON_NEW_LIB,
+	R_DEBUG_REASON_EXIT_PID,
+	R_DEBUG_REASON_EXIT_TID,
+	R_DEBUG_REASON_EXIT_LIB,
+	R_DEBUG_REASON_TRAP,
+	R_DEBUG_REASON_SWI,
+	R_DEBUG_REASON_INT,
+	R_DEBUG_REASON_FPU,
+} RDebugReasonType;
+
 
 /* TODO: move to r_anal */
 typedef struct r_debug_frame_t {
@@ -70,11 +115,12 @@ typedef struct r_debug_frame_t {
 	ut64 bp;
 } RDebugFrame;
 
+
 typedef struct r_debug_reason_t {
-	int type;
+	RDebugReasonType type;
 	int tid;
 	int signum;
-	RBreakpointItem *bpi;
+	ut64 bp_addr;
 	ut64 timestamp;
 	ut64 addr;
 	ut64 ptr;
@@ -139,47 +185,58 @@ typedef struct r_debug_tracepoint_t {
 typedef struct r_debug_t {
 	char *arch;
 	int bits; /// XXX: MUST SET ///
-	int pid;    /* selected process id */
-	int tid;    /* selected thread id */
-	int swstep; /* steps with software traps */
-	int steps;  /* counter of steps done */
-	int newstate;
-	bool in_recoil; 			/* are we stopped due to bp? */
-	RDebugReason reason; /* stop reason */
+
+	int pid;    	/* selected process id */
+	int tid;    	/* selected thread id */
+	int forked_pid;	/* last pid created by fork */
+	RList *threads; /* XXX This is platform-specific !!! */
+
+	/* dbg.* config options (see e?dbg)
+	 * NOTE: some settings are checked inline instead of tracked here.
+	 */
+	int bpsize; 			/* size of a breakpoint */
+	char *btalgo;			/* select backtrace algorithm */
+	int btdepth; 			/* backtrace depth */
+	int regcols; 			/* display columns */
+	int swstep; 			/* steps with software traps */
+	int stop_all_threads; 	/* stop all threads at any stop */
+	int trace_forks; 		/* stop on new children */
+	int trace_execs; 		/* stop on new execs */
+	int trace_clone; 		/* stop on new threads */
+	char *glob_libs; 		/* stop on lib load */
+	char *glob_unlibs; 		/* stop on lib unload */
+
+	/* tracking debugger state */
+	int steps;				/* counter of steps done */
+	RDebugReason reason; 	/* stop reason */
+	RDebugRecoilMode recoil_mode; 	/* what did the user want to do? */
+
+	/* tracing vars */
 	RDebugTrace *trace;
-	int stop_all_threads;
+	Sdb *tracenodes;
+	RTree *tree;
+
 	RReg *reg;
 	const char *creg; // current register value
 	RBreakpoint *bp;
-	int bpsize;
-	int btdepth;
-	void *user;
+	void *user; // XXX(jjd): unused?? meant for caller's use??
+
 	/* io */
 	PrintfCallback cb_printf;
+	RIOBind iob;
+
 	struct r_debug_plugin_t *h;
 	struct list_head plugins;
+
 	RAnal *anal;
-	RIOBind iob;
 	RList *maps; // <RDebugMap>
 	RList *maps_user; // <RDebugMap>
 	RList *snaps; // <RDebugSnap>
-	RTree *tree;
-	Sdb *tracenodes;
 	Sdb *sgnls;
 	RCoreBind corebind;
-	int trace_forks;
-	int forked_pid;
-	int trace_execs;
-	int trace_clone;
 	// internal use only
 	int _mode;
-	RList *threads; // XXX This is platform-specific !!!
-	/* select backtrace algorithm */
-	char *btalgo;
 	RNum *num;
-	int regcols;
-	char *glob_libs;
-	char *glob_unlibs;
 } RDebug;
 
 typedef struct r_debug_desc_plugin_t {
@@ -269,46 +326,41 @@ typedef struct r_debug_pid_t {
 	ut64 pc;
 } RDebugPid;
 
-enum RDebugReasonType {
-	R_DEBUG_REASON_DEAD = -1,
-	R_DEBUG_REASON_NONE = 0,
-	R_DEBUG_REASON_SIGNAL,
-	R_DEBUG_REASON_SEGFAULT,
-	R_DEBUG_REASON_BREAKPOINT,
-	R_DEBUG_REASON_READERR,
-	R_DEBUG_REASON_STEP,
-	R_DEBUG_REASON_ABORT,
-	R_DEBUG_REASON_WRITERR,
-	R_DEBUG_REASON_DIVBYZERO,
-	R_DEBUG_REASON_ILLEGAL,
-	R_DEBUG_REASON_UNKNOWN,
-	R_DEBUG_REASON_ERROR,
-	R_DEBUG_REASON_NEW_PID,
-	R_DEBUG_REASON_NEW_TID,
-	R_DEBUG_REASON_NEW_LIB,
-	R_DEBUG_REASON_EXIT_PID,
-	R_DEBUG_REASON_EXIT_TID,
-	R_DEBUG_REASON_EXIT_LIB,
-	R_DEBUG_REASON_TRAP,
-	R_DEBUG_REASON_SWI,
-	R_DEBUG_REASON_INT,
-	R_DEBUG_REASON_FPU,
-};
-
+/*
+ * Radare's debugger has both an external and internal API.
+ *
+ * TODO(jjd): reconcile external API and extend it for better funcitonality
+ * when using R2 as a library.
+ */
 #ifdef R_API
+R_API RDebug *r_debug_new(int hard);
+R_API RDebug *r_debug_free(RDebug *dbg);
+
 R_API int r_debug_attach(RDebug *dbg, int pid);
 R_API int r_debug_detach(RDebug *dbg, int pid);
 R_API int r_debug_startv(RDebug *dbg, int argc, char **argv);
 R_API int r_debug_start(RDebug *dbg, const char *cmd);
-R_API int r_debug_stop_reason(RDebug *dbg);
+
+/* reason we stopped */
+R_API RDebugReasonType r_debug_stop_reason(RDebug *dbg);
 R_API const char *r_debug_reason_to_string(int type);
-R_API int r_debug_wait(RDebug *dbg);
+
+/* wait for another event */
+R_API RDebugReasonType r_debug_wait(RDebug *dbg);
+
+/* continuations */
+R_API int r_debug_step(RDebug *dbg, int steps);
 R_API int r_debug_step_over(RDebug *dbg, int steps);
 R_API int r_debug_continue_until(RDebug *dbg, ut64 addr);
 R_API int r_debug_continue_until_optype(RDebug *dbg, int type, int over);
 R_API int r_debug_continue_until_nontraced(RDebug *dbg);
 R_API int r_debug_continue_syscall(RDebug *dbg, int sc);
 R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc);
+R_API int r_debug_continue(RDebug *dbg);
+R_API int r_debug_continue_kill(RDebug *dbg, int signal);
+
+/* process/thread handling */
+R_API int r_debug_select(RDebug *dbg, int pid, int tid);
 //R_API int r_debug_pid_add(RDebug *dbg);
 //R_API int r_debug_pid_add_thread(RDebug *dbg);
 //R_API int r_debug_pid_del(RDebug *dbg);
@@ -324,9 +376,6 @@ R_API bool r_debug_use(RDebug *dbg, const char *str);
 R_API RDebugInfo *r_debug_info(RDebug *dbg, const char *arg);
 R_API void r_debug_info_free (RDebugInfo *rdi);
 
-R_API RDebug *r_debug_new(int hard);
-R_API RDebug *r_debug_free(RDebug *dbg);
-
 /* send signals */
 R_API void r_debug_signal_init(RDebug *dbg);
 R_API int r_debug_signal_send(RDebug *dbg, int num);
@@ -340,10 +389,6 @@ R_API int r_debug_kill(RDebug *dbg, int pid, int tid, int sig);
 R_API RList *r_debug_kill_list(RDebug *dbg);
 // XXX: must be uint64 action
 R_API int r_debug_kill_setup(RDebug *dbg, int sig, int action);
-R_API int r_debug_step(RDebug *dbg, int steps);
-R_API int r_debug_continue(RDebug *dbg);
-R_API int r_debug_continue_kill(RDebug *dbg, int signal);
-R_API int r_debug_select(RDebug *dbg, int pid, int tid);
 
 /* handle.c */
 R_API void r_debug_plugin_init(RDebug *dbg);
@@ -395,7 +440,7 @@ R_API int r_debug_map_protect(RDebug *dbg, ut64 addr, int size, int perms);
 R_API ut64 r_debug_arg_get(RDebug *dbg, int fast, int num);
 R_API bool r_debug_arg_set(RDebug *dbg, int fast, int num, ut64 value);
 
-/*breakpoints*/
+/* breakpoints (most in r_bp, this calls those) */
 R_API RBreakpointItem *r_debug_bp_add(RDebug *dbg, ut64 addr, int hw, char *module, st64 m_delta);
 
 /* pid */
@@ -404,7 +449,7 @@ R_API int r_debug_thread_list(RDebug *dbg, int pid);
 R_API void r_debug_tracenodes_reset(RDebug *dbg);
 
 R_API void r_debug_trace_reset(RDebug *dbg);
-R_API int r_debug_trace_pc(RDebug *dbg);
+R_API int r_debug_trace_pc(RDebug *dbg, ut64 pc);
 R_API void r_debug_trace_at(RDebug *dbg, const char *str);
 R_API RDebugTracepoint *r_debug_trace_get(RDebug *dbg, ut64 addr);
 R_API void r_debug_trace_list(RDebug *dbg, int mode);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -189,7 +189,7 @@ typedef struct r_debug_t {
 	int pid; /* selected process id */
 	int tid; /* selected thread id */
 	int forked_pid; /* last pid created by fork */
-	RList *threads; /* XXX This is platform-specific !!! */
+	RList *threads; /* NOTE: list contents are platform-specific */
 
 	/* dbg.* config options (see e?dbg)
 	 * NOTE: some settings are checked inline instead of tracked here.

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -186,30 +186,30 @@ typedef struct r_debug_t {
 	char *arch;
 	int bits; /// XXX: MUST SET ///
 
-	int pid;    	/* selected process id */
-	int tid;    	/* selected thread id */
-	int forked_pid;	/* last pid created by fork */
+	int pid; /* selected process id */
+	int tid; /* selected thread id */
+	int forked_pid; /* last pid created by fork */
 	RList *threads; /* XXX This is platform-specific !!! */
 
 	/* dbg.* config options (see e?dbg)
 	 * NOTE: some settings are checked inline instead of tracked here.
 	 */
-	int bpsize; 			/* size of a breakpoint */
-	char *btalgo;			/* select backtrace algorithm */
-	int btdepth; 			/* backtrace depth */
-	int regcols; 			/* display columns */
-	int swstep; 			/* steps with software traps */
-	int stop_all_threads; 	/* stop all threads at any stop */
-	int trace_forks; 		/* stop on new children */
-	int trace_execs; 		/* stop on new execs */
-	int trace_clone; 		/* stop on new threads */
-	char *glob_libs; 		/* stop on lib load */
-	char *glob_unlibs; 		/* stop on lib unload */
+	int bpsize; /* size of a breakpoint */
+	char *btalgo; /* select backtrace algorithm */
+	int btdepth; /* backtrace depth */
+	int regcols; /* display columns */
+	int swstep; /* steps with software traps */
+	int stop_all_threads; /* stop all threads at any stop */
+	int trace_forks; /* stop on new children */
+	int trace_execs; /* stop on new execs */
+	int trace_clone; /* stop on new threads */
+	char *glob_libs; /* stop on lib load */
+	char *glob_unlibs; /* stop on lib unload */
 
 	/* tracking debugger state */
-	int steps;				/* counter of steps done */
-	RDebugReason reason; 	/* stop reason */
-	RDebugRecoilMode recoil_mode; 	/* what did the user want to do? */
+	int steps; /* counter of steps done */
+	RDebugReason reason; /* stop reason */
+	RDebugRecoilMode recoil_mode; /* what did the user want to do? */
 
 	/* tracing vars */
 	RDebugTrace *trace;

--- a/libr/include/r_reg.h
+++ b/libr/include/r_reg.h
@@ -80,9 +80,9 @@ typedef enum {
 typedef struct r_reg_item_t {
 	char *name;
 	RRegisterType type;
-	int size;			/* 8,16,32,64 ... 128/256 ??? */
-	int offset;			/* offset in data structure */
-	int packed_size;	/* 0 means no packed register, 1byte pack, 2b pack... */
+	int size; /* 8,16,32,64 ... 128/256 ??? */
+	int offset; /* offset in data structure */
+	int packed_size; /* 0 means no packed register, 1byte pack, 2b pack... */
 	bool is_float;
 	char *flags;
 	int index;

--- a/libr/include/r_reg.h
+++ b/libr/include/r_reg.h
@@ -7,7 +7,11 @@
 
 R_LIB_VERSION_HEADER (r_reg);
 
-enum {
+/*
+ * various CPUs have registers within various types/classes
+ * this enum aims to cover them all.
+ */
+typedef enum {
 	R_REG_TYPE_GPR,
 	R_REG_TYPE_DRX,
 	R_REG_TYPE_FPU,
@@ -17,9 +21,13 @@ enum {
 	R_REG_TYPE_SEG,
 	R_REG_TYPE_LAST,
 	R_REG_TYPE_ALL = -1, // TODO; rename to ANY
-};
+} RRegisterType;
 
-enum {
+/*
+ * pretty much all CPUs share some common registers
+ * this enum aims to create an abstraction to ease cross-arch handling.
+ */
+typedef enum {
 	R_REG_NAME_PC, // program counter
 	R_REG_NAME_SP, // stack pointer
 	R_REG_NAME_SR, // status register
@@ -46,7 +54,7 @@ enum {
 	/* syscall number (orig_eax,rax,r0,x0) */
 	R_REG_NAME_SN,
 	R_REG_NAME_LAST,
-};
+} RRegisterId;
 
 // TODO: use enum here?
 #define R_REG_COND_EQ 0
@@ -71,10 +79,10 @@ enum {
 
 typedef struct r_reg_item_t {
 	char *name;
-	int type;
-	int size;	/* 8,16,32,64 ... 128/256 ??? */
-	int offset;      // offset in data structure
-	int packed_size; /* 0 means no packed register, 1byte pack, 2b pack... */
+	RRegisterType type;
+	int size;			/* 8,16,32,64 ... 128/256 ??? */
+	int offset;			/* offset in data structure */
+	int packed_size;	/* 0 means no packed register, 1byte pack, 2b pack... */
 	bool is_float;
 	char *flags;
 	int index;


### PR DESCRIPTION
TODO. Test this PR on:

* [x] Linux
* [ ] FreeBSD
* [ ] NetBSD
* [x] OSX
* [ ] Windows

The major contribution here is completely re-worked breakpoint hit/recoil
handling. This work fixes #4907 and lays the ground work for future native
debugger improvements (multi-threading, etc).

NOTE: Please see comments marked with XXX as they include puzzlement and
questions.

A full list of changes includes:

* Give a human friendly type to enums
* Change many wait functions to return RDebugReasonType
* Better return checking (from r_debug_reg_sync, r_bp_restore)
* Optimized register synchronization
* Lots of comments and whitespace changes
* Improved inferior death detection

Handle EXIT_PID events differently than DEAD process events

* Move breakpoint/recoil handling to wait/cont/step

Rather than handing breakpoint related things inside cmd_debug.c, do that
inside the r_debug API functions. This seems like the most logical place for it
to live since it should apply to just about any platform/architecture.  This
also centralizes calling into "cmd.bp" handling via the CoreBind callback.

* Track how the caller wishes to continue

It turns out that handling break point recoils is very complicated. The ptrace
API on Linux returns SIGTRAP for just about every type of operation (not just
breakpoints getting hit). Add the "recoil_mode" flag to indicate whether we are
single-stepping or continuing and whether or not we are inside the recoil.

* Proper handling for swstep=true

Since r_debug_step_soft calls r_debug_continue, it's already hitting the recoil
case there. Move the recoil handling from r_debug_step to r_debug_step_hard
only.

For the swstep=true case, special handling is required inside r_debug_recoil.
By resetting all of the breakpoints except the one we just hit, we ensure we
can step the original instruction and hit the new swstep breakpoint. Add a new
bp function called r_bp_restore_except to do this.

To make matters worse, we cannot use a BreakpointItem pointer because that
leads to a use-after-free condition. Instead, we the breakpoint address
instead.

Now breakpoints should work regardless of the swtep setting.

* Always call the recoil before continuing

Some callers of r_debug_continue might not have ever inserted any breakpoints
before. If we don't restore breakpoints before each call to the underlying
continue we won't hit them.

* Hide software step breakpoint events from the user

When a breakpoint even happens due to a software-step, hide it from the user.
They aren't really breakpoints as far as they are concerned.

* Improve process exit handling on Linux

There are three types of process exiting events on Linux:

1. PTRACE_EVENT_EXIT occurs just before a process exits. It's not possible to
prevent it from exiting, but it can be used to inspect the pre-exit state.
2. The process can exit for a variety of reasons and we can notice when we call
waitpid(2).
3. The process could die randomly on us :-/

On Windows, h->wait will return R_DEBUG_REASON_EXIT_PID, but it's more likely
on Linux to find out the process is already dead.

* Check more bits within waitpid status

We can often make a decision about what happened strictly by looking at the
status returned from waitpid. In other cases, we need to call
r_debug_handle_signals.

If we reach the end of this function without knowing what happened, consider it
an error.