### PR TITLE
V810: Fix floating-point instructions

### DIFF
--- a/libr/asm/arch/v810/v810_disas.c
+++ b/libr/asm/arch/v810/v810_disas.c
@@ -271,7 +271,7 @@ static int decode_bit_op(const ut16 instr, struct v810_cmd *cmd) {
 }
 
 static int decode_extended(const ut16 word1, const ut16 word2, struct v810_cmd *cmd) {
-	ut8 subop = OPCODE(word2)>>2;
+	ut8 subop = OPCODE(word2);
 	if (subop > 0xC)
 		return -1;
 


### PR DESCRIPTION
Before:
```asm
$ rasm2 -a v810 -d edf90008eaf9001ccffb0014fe01aff9000c
cmpf.s r13, r15
invalid
mov r25, r7
ld.w 251[r28], r24
out.w r16, -20735[r20]
mov r25, r7
invalid
```

After the patch:
```asm
$ rasm2 -a v810 -d edf90008eaf9001ccffb0014fe01aff9000c
cvt.ws r13, r15
divf.s r10, r15
subf.s r15, r30
mov r30, r15
cvt.sw r15, r13
```