### PR TITLE
fix disassembling 'backwards'

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3352,6 +3352,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 	if (nb_opcodes) { // Disassemble `nb_opcodes` opcodes.
 		if (nb_opcodes < 0) {
 			int count, nbytes = 0;
+
 			/* Backward disassembly of `nb_opcodes` opcodes:
 			 * - We compute the new starting offset
 			 * - Read at the new offset */
@@ -3361,7 +3362,10 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 				eprintf ("Too many backward instructions\n");
 				return 0;
 			}
-			if (!r_core_asm_bwdis_len (core, &nbytes, &addr, nb_opcodes)) {
+
+			if (r_core_prevop_addr (core, core->offset, nb_opcodes, &addr)) {
+				nbytes = core->offset - addr;
+			} else if (!r_core_asm_bwdis_len (core, &nbytes, &addr, nb_opcodes)) {
 				/* workaround to avoid empty arrays */
 #define BWRETRY 0
 #if BWRETRY


### PR DESCRIPTION
Bug same as #5105.
Wrong output for backwards disassembling, for example
```
[0x00000000]> wx 56687cd3400090
[0x00000000]> aaa
[0x00000000]> pd 3
╒ (fcn) fcn.00000000 513
│           0x00000000      56             push rsi
│           0x00000001      687cd34000     push 0x40d37c
│           0x00000006      90             nop
[0x00000000]> s 6
[0x00000006]> pd -1
│           0x00000006      687cd34000     push 0x40d37c
[0x00000006]> pdj -1
```

Before commit:
```
[{"offset":3,"fcn_addr":0,"fcn_last":510,"size":3,"opcode":"rol dword [rax], cl","bytes":"d34000","family":"cpu","type":"rol","type_num":36,"type2_num":0}]
```

After commit:
```
[{"offset":1,"fcn_addr":0,"fcn_last":508,"size":5,"opcode":"push 0x40d37c","bytes":"687cd34000","family":"cpu","type":"push","type_num":13,"type2_num":0}]
```