### PR TITLE
Refactoring RBinXtr API - work in progress, draft

### DIFF
--- a/libr/bin/format/mach0/dyldcache.c
+++ b/libr/bin/format/mach0/dyldcache.c
@@ -180,6 +180,19 @@ void* r_bin_dyldcache_free(struct r_bin_dyldcache_obj_t* bin) {
 	return NULL;
 }
 
+void* r_bin_dydlcache_get_libname(struct r_bin_dyldcache_lib_t *lib, char **libname) {
+	char *cur = lib->path;
+	char *res = lib->path;
+	int path_length = strlen (lib->path);
+	while (cur < cur + path_length - 1) {
+		cur = strchr (cur, '/');
+		if (!cur) break;
+		cur++;
+		res = cur;
+	}
+	(*libname) = res;
+}
+
 struct r_bin_dyldcache_obj_t* r_bin_dyldcache_new(const char* file) {
 	struct r_bin_dyldcache_obj_t *bin;
 	ut8 *buf;

--- a/libr/bin/format/mach0/fatmach0.h
+++ b/libr/bin/format/mach0/fatmach0.h
@@ -26,5 +26,4 @@ struct r_bin_fatmach0_arch_t *r_bin_fatmach0_extract(struct r_bin_fatmach0_obj_t
 void* r_bin_fatmach0_free(struct r_bin_fatmach0_obj_t* bin);
 struct r_bin_fatmach0_obj_t* r_bin_fatmach0_new(const char* file);
 struct r_bin_fatmach0_obj_t* r_bin_fatmach0_from_bytes_new(const ut8* buf, ut64 size);
-
 #endif

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -154,5 +154,7 @@ char* MACH0_(get_cputype)(struct MACH0_(obj_t)* bin);
 char* MACH0_(get_cpusubtype)(struct MACH0_(obj_t)* bin);
 char* MACH0_(get_filetype)(struct MACH0_(obj_t)* bin);
 ut64 MACH0_(get_main)(struct MACH0_(obj_t)* bin);
-
+char* MACH0_(get_cputype_from_hdr)(struct MACH0_(mach_header) *hdr);
+int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header)* hdr);
+struct MACH0_(mach_header)* MACH0_(get_hdr_from_bytes)(RBuffer *buf);
 #endif

--- a/libr/bin/p/bin_xtr_dyldcache.c
+++ b/libr/bin/p/bin_xtr_dyldcache.c
@@ -5,6 +5,7 @@
 #include <r_lib.h>
 #include <r_bin.h>
 #include "mach0/dyldcache.h"
+#include "mach0/mach0.h"
 
 static RBinXtrData * extract(RBin *bin, int idx);
 static RList * extractall(RBin *bin);
@@ -38,7 +39,9 @@ static int free_xtr(void *xtr_obj) {
 static bool load(RBin *bin) {
 	if (!bin || !bin->cur) 
 	    	return false;
-	bin->cur->xtr_obj = r_bin_dyldcache_new (bin->cur->file);
+	if (!bin->cur->xtr_obj) {
+		bin->cur->xtr_obj = r_bin_dyldcache_new (bin->cur->file);
+	}
 	if (!bin->file)
 	    	bin->file = bin->cur->file;
 	return bin->cur->xtr_obj? true : false;
@@ -65,13 +68,34 @@ static RList * extractall(RBin *bin) {
 static RBinXtrData * extract(RBin *bin, int idx) {
 	int nlib = 0;
 	RBinXtrData *res = NULL;
+	char *libname;
+	struct MACH0_(mach_header) *hdr;
 	struct r_bin_dyldcache_lib_t *lib = r_bin_dyldcache_extract (
 		(struct r_bin_dyldcache_obj_t*)bin->cur->xtr_obj, idx, &nlib);
+
 	if (lib) {
-		res = r_bin_xtrdata_new (NULL, NULL, lib->b,
-			lib->offset, lib->size, nlib);
+		RBinXtrMetadata *metadata = R_NEW0(RBinXtrMetadata);
+		if (!metadata) {
+			return NULL;
+		}
+
+		hdr = MACH0_(get_hdr_from_bytes) (lib->b);
+		if (!hdr) {
+			free (lib);
+			free (hdr);
+			return NULL;
+		}
+
+		metadata->arch = MACH0_(get_cputype_from_hdr) (hdr);
+		metadata->bits = MACH0_(get_bits_from_hdr) (hdr);
+
+		r_bin_dydlcache_get_libname (lib, &libname);
+		metadata->libname = strdup (libname);
+
+		res = r_bin_xtrdata_new (lib->b, lib->offset, lib->size, nlib, metadata, bin->sdb);
 		r_buf_free (lib->b);
 		free (lib);
+		free (hdr);
 	}
 	return res;
 }
@@ -81,19 +105,42 @@ static RBinXtrData *oneshot(RBin *bin, const ut8* buf, ut64 size, int idx) {
 	struct r_bin_dyldcache_obj_t *xtr_obj;
 	struct r_bin_dyldcache_lib_t *lib;
 	int nlib = 0;
-	if (!bin->file) {
-		if (!load (bin))
-		    	return NULL;
-	}
-	//XXX why allocate again and again? use bin->cur->xtr_obj though is producing uaf review
-	xtr_obj = r_bin_dyldcache_from_bytes_new (buf, size);
+	char *libname;
+	struct MACH0_(mach_header) *hdr;
+
+	if (!load (bin))
+		return NULL;
+
+	xtr_obj = bin->cur->xtr_obj;
 	lib = r_bin_dyldcache_extract (xtr_obj, idx, &nlib);
 	if (!lib) {
 		free_xtr (xtr_obj);
+		bin->cur->xtr_obj = NULL;
 		return NULL;
 	}
-	res = r_bin_xtrdata_new (xtr_obj, free_xtr, lib->b, lib->offset, lib->size, nlib);
+	RBinXtrMetadata *metadata = R_NEW0 (RBinXtrMetadata);
+
+	if (!metadata) {
+		return NULL;
+	}
+
+	hdr = MACH0_(get_hdr_from_bytes) (lib->b);
+	if (!hdr) {
+		free (lib);
+		free (hdr);
+		return NULL;
+	}
+
+	metadata->arch = MACH0_(get_cputype_from_hdr) (hdr);
+	metadata->bits = MACH0_(get_bits_from_hdr) (hdr);
+
+	r_bin_dydlcache_get_libname (lib, &libname);
+
+	metadata->libname = strdup (libname);
+
+	res = r_bin_xtrdata_new (lib->b, lib->offset, lib->b->length, nlib, metadata, bin->sdb);
 	r_buf_free (lib->b);
+	free (hdr);
 	free (lib);
 	return res;
 }

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -247,6 +247,7 @@ typedef struct r_bin_xtr_extract_t {
 	ut64 size;
 	ut64 offset;
 	int file_count;
+	int loaded;
 	RBinXtrMetadata *metadata;
 } RBinXtrData;
 

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -199,6 +199,7 @@ typedef struct r_bin_file_t {
 	struct r_bin_xtr_plugin_t *curxtr;
 	struct r_bin_plugin_t *curplugin;
 	RList *objs;
+	RList *xtr_data;
 	Sdb *sdb;
 	Sdb *sdb_info;
 	Sdb *sdb_addrinfo;
@@ -233,18 +234,23 @@ typedef struct r_bin_t {
 	bool demanglercmd;
 } RBin;
 
+typedef struct r_bin_xtr_metadata_t {
+	char *arch;
+	int bits;
+	char *libname;
+} RBinXtrMetadata;
+
 typedef int (*FREE_XTR)(void *xtr_obj);
 typedef struct r_bin_xtr_extract_t {
 	char *file;
-	RBuffer *buf;
+	Sdb *sdb;
 	ut64 size;
 	ut64 offset;
 	int file_count;
-	void *xtr_obj;
-	FREE_XTR free_xtr;
+	RBinXtrMetadata *metadata;
 } RBinXtrData;
 
-R_API RBinXtrData * r_bin_xtrdata_new (void *xtr_obj, FREE_XTR free_xtr, RBuffer *buf, ut64 offset, ut64 size, ut32 file_count);
+R_API RBinXtrData * r_bin_xtrdata_new (RBuffer *buf, ut64 offset, ut64 size, ut32 file_count, RBinXtrMetadata *metadata, Sdb *sdb);
 R_API void r_bin_xtrdata_free (void /*RBinXtrData*/ *data);
 R_API void r_bin_info_free (RBinInfo *rb);
 R_API void r_bin_import_free(void *_imp);


### PR DESCRIPTION
Hey,

The current implementation of "struct RBinXtrData", has a Rbuffer* which contains the contents of the sub binary. The rest of the xtr plugin functions use this buffer for extraction and loading. As a fat binary could be huge in size and have a lot of sub-bins, the buffers could take up a lot of memory. I was thinking of nuking the buffer from RBinXtrData. And using sdb for caching the binaries instead of the heap.

I am just trying out an idea I had. This isn't supposed to be the final PR. Comments welcome.

Thanks
-Aneesh