### PR TITLE
Fix crash due to ht.c implementation

### DIFF
--- a/libr/flags/flags.c
+++ b/libr/flags/flags.c
@@ -36,6 +36,7 @@ static void remove_offsetmap(RFlag *f, RFlagItem *item) {
 	if (fs_off) {
 		r_list_delete_data (fs_off, item);
 		if (r_list_empty (fs_off)) {
+			//here we leak memory since data is a List 
 			r_hashtable64_remove (f->ht_off, XOROFF (item->offset));
 		}
 	}

--- a/libr/util/ht.c
+++ b/libr/util/ht.c
@@ -228,7 +228,7 @@ R_API bool ht_(insert) (RHT *ht, utH hash, void *data) {
 R_API void ht_(remove) (RHT *ht, utH hash) {
 	RHTE *entry = ht_(search) (ht, hash);
 	if (entry) {
-		entry->data = (void *) &deleted_data;
+		entry->data = NULL;
 		ht->entries--;
 		ht->deleted_entries++;
 	}

--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -75,7 +75,7 @@ R_API void r_list_purge (RList *list) {
 R_API void r_list_free (RList *list) {
 	if (list) {
 		r_list_purge (list);
-		free (list);
+		R_FREE (list);
 	}
 }
 

--- a/shlr/capstone-patches/oobfix-X86_insn_reg_intel.patch
+++ b/shlr/capstone-patches/oobfix-X86_insn_reg_intel.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/X86/X86Mapping.c b/arch/X86/X86Mapping.c
+index f7d35d2..16450d1 100644
+--- a/arch/X86/X86Mapping.c
++++ b/arch/X86/X86Mapping.c
+@@ -2780,7 +2780,7 @@ x86_reg X86_insn_reg_intel(unsigned int id, enum cs_ac_type *access)
+ 		intel_regs_sorted = true;
+ 	}
+ 
+-	while (first <= last) {
++	while (first <= last && mid < ARR_SIZE(insn_regs_intel)) {
+ 		if (insn_regs_intel_sorted[mid].insn < id) {
+ 			first = mid + 1;
+ 		} else if (insn_regs_intel_sorted[mid].insn == id) {


### PR DESCRIPTION
Let see if it does not broke something.

Hashtable must be rewritten to support a free function as RList does