### PR TITLE
Skiplist v2

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -323,31 +323,21 @@ R_API char *r_anal_strmask (RAnal *anal, const char *data) {
 }
 
 R_API void r_anal_trace_bb(RAnal *anal, ut64 addr) {
-	RAnalBlock *bbi;
-	RAnalFunction *fcni;
-	RSkipListNode *iter2;
-#define OLD 0
-#if OLD
-	RListIter *iter;
-	r_list_foreach (anal->fcns, iter, fcni) {
-		r_skiplist_foreach (fcni->bbs, iter2, bbi) {
-			if (addr>=bbi->addr && addr<(bbi->addr+bbi->size)) {
-				bbi->traced = true;
-				break;
-			}
-		}
-	}
-#else
-	fcni = r_anal_get_fcn_in (anal, addr, 0);
+	RAnalFunction *fcni = r_anal_get_fcn_in (anal, addr, 0);
 	if (fcni) {
-		r_skiplist_foreach (fcni->bbs, iter2, bbi) {
-			if (addr >= bbi->addr && addr < (bbi->addr + bbi->size)) {
-				bbi->traced = true;
-				break;
-			}
+		RAnalBlock search_bb;
+		RSkipListNode *res;
+
+		search_bb.addr = addr;
+		search_bb.size = 0;
+		fcni->bbs->compare = (RListComparator)r_anal_bb_compare_range;
+		res = r_skiplist_find (fcni->bbs, &search_bb);
+		fcni->bbs->compare = (RListComparator)r_anal_bb_compare;
+		if (res) {
+			RAnalBlock *b = (RAnalBlock *)res->data;
+			b->traced = true;
 		}
 	}
-#endif
 }
 
 R_API RList* r_anal_get_fcns (RAnal *anal) {

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -325,12 +325,12 @@ R_API char *r_anal_strmask (RAnal *anal, const char *data) {
 R_API void r_anal_trace_bb(RAnal *anal, ut64 addr) {
 	RAnalBlock *bbi;
 	RAnalFunction *fcni;
-	RListIter *iter2;
+	RSkipListNode *iter2;
 #define OLD 0
 #if OLD
 	RListIter *iter;
 	r_list_foreach (anal->fcns, iter, fcni) {
-		r_list_foreach (fcni->bbs, iter2, bbi) {
+		r_skiplist_foreach (fcni->bbs, iter2, bbi) {
 			if (addr>=bbi->addr && addr<(bbi->addr+bbi->size)) {
 				bbi->traced = true;
 				break;
@@ -340,7 +340,7 @@ R_API void r_anal_trace_bb(RAnal *anal, ut64 addr) {
 #else
 	fcni = r_anal_get_fcn_in (anal, addr, 0);
 	if (fcni) {
-		r_list_foreach (fcni->bbs, iter2, bbi) {
+		r_skiplist_foreach (fcni->bbs, iter2, bbi) {
 			if (addr >= bbi->addr && addr < (bbi->addr + bbi->size)) {
 				bbi->traced = true;
 				break;

--- a/libr/anal/anal_ex.c
+++ b/libr/anal/anal_ex.c
@@ -243,7 +243,9 @@ R_API RList * r_anal_ex_analysis_driver( RAnal *anal, RAnalState *state, ut64 ad
 	ut64 backup_addr = state->current_addr;
 	state->current_addr = addr;
 
-	RList *bb_list = r_anal_bb_list_new ();
+	RSkipList *bb_skiplist = r_anal_bb_list_new ();
+	RList *bb_list = r_skiplist_to_list (bb_skiplist);
+	bb_list->free = (RListFree)r_anal_bb_free;
 
 	if (state->done)
 		return bb_list;

--- a/libr/anal/anal_ex.c
+++ b/libr/anal/anal_ex.c
@@ -245,6 +245,8 @@ R_API RList * r_anal_ex_analysis_driver( RAnal *anal, RAnalState *state, ut64 ad
 
 	RSkipList *bb_skiplist = r_anal_bb_list_new ();
 	RList *bb_list = r_skiplist_to_list (bb_skiplist);
+	bb_skiplist->freefn = NULL;
+	r_skiplist_free (bb_skiplist);
 	bb_list->free = (RListFree)r_anal_bb_free;
 
 	if (state->done)

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -6,6 +6,10 @@
 
 #define DFLT_NINSTR 3
 
+R_API int r_anal_bb_compare(RAnalBlock* a, RAnalBlock* b) {
+	return a->addr - b->addr;
+}
+
 R_API RAnalBlock *r_anal_bb_new() {
 	RAnalBlock *bb = R_NEW0 (RAnalBlock);
 	if (!bb) return NULL;
@@ -42,10 +46,8 @@ R_API void r_anal_bb_free(RAnalBlock *bb) {
 	free (bb);
 }
 
-R_API RList *r_anal_bb_list_new() {
-	RList *list = r_list_new ();
-	if (!list) return NULL;
-	list->free = (void*)r_anal_bb_free;
+R_API RSkipList *r_anal_bb_list_new() {
+	RSkipList *list = r_skiplist_new ((RListFree)r_anal_bb_free, (RListComparator)r_anal_bb_compare);
 	return list;
 }
 
@@ -135,11 +137,12 @@ R_API inline int r_anal_bb_is_in_offset (RAnalBlock *bb, ut64 off) {
 }
 
 R_API RAnalBlock *r_anal_bb_from_offset(RAnal *anal, ut64 off) {
-	RListIter *iter, *iter2;
+	RListIter *iter;
+	RSkipListNode *iter2;
 	RAnalFunction *fcn;
 	RAnalBlock *bb;
 	r_list_foreach (anal->fcns, iter, fcn)
-		r_list_foreach (fcn->bbs, iter2, bb)
+		r_skiplist_foreach (fcn->bbs, iter2, bb)
 			if (r_anal_bb_is_in_offset (bb, off))
 				return bb;
 	return NULL;

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -6,6 +6,13 @@
 
 #define DFLT_NINSTR 3
 
+R_API int r_anal_bb_compare_range(RAnalBlock* a, RAnalBlock* b) {
+	if (b->addr >= a->addr && b->addr + b->size < a->addr + a->size) {
+		return 0;
+	}
+	return r_anal_bb_compare(a, b);
+}
+
 R_API int r_anal_bb_compare(RAnalBlock* a, RAnalBlock* b) {
 	return a->addr - b->addr;
 }

--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -79,14 +79,14 @@ R_API int r_anal_diff_fingerprint_bb(RAnal *anal, RAnalBlock *bb) {
 
 R_API int r_anal_diff_fingerprint_fcn(RAnal *anal, RAnalFunction *fcn) {
 	RAnalBlock *bb;
-	RListIter *iter;
+	RSkipListNode *iter;
 	int len = 0;
 
 	if (anal && anal->cur && anal->cur->fingerprint_fcn)
 		return (anal->cur->fingerprint_fcn (anal, fcn));
 
 	fcn->fingerprint = NULL;
-	r_list_foreach (fcn->bbs, iter, bb) {
+	r_skiplist_foreach (fcn->bbs, iter, bb) {
 		len += bb->size;
 		fcn->fingerprint = realloc (fcn->fingerprint, len);
 		if (!fcn->fingerprint)
@@ -98,7 +98,7 @@ R_API int r_anal_diff_fingerprint_fcn(RAnal *anal, RAnalFunction *fcn) {
 
 R_API int r_anal_diff_bb(RAnal *anal, RAnalFunction *fcn, RAnalFunction *fcn2) {
 	RAnalBlock *bb, *bb2, *mbb, *mbb2;
-	RListIter *iter, *iter2;
+	RSkipListNode *iter, *iter2;
 	double t, ot;
 
 	if (!anal) return false;
@@ -106,12 +106,12 @@ R_API int r_anal_diff_bb(RAnal *anal, RAnalFunction *fcn, RAnalFunction *fcn2) {
 		return (anal->cur->diff_bb (anal, fcn, fcn2));
 
 	fcn->diff->type = fcn2->diff->type = R_ANAL_DIFF_TYPE_MATCH;
-	r_list_foreach (fcn->bbs, iter, bb) {
+	r_skiplist_foreach (fcn->bbs, iter, bb) {
 		if (bb->diff && bb->diff->type != R_ANAL_DIFF_TYPE_NULL)
 			continue;
 		ot = 0;
 		mbb = mbb2 = NULL;
-		r_list_foreach (fcn2->bbs, iter2, bb2) {
+		r_skiplist_foreach (fcn2->bbs, iter2, bb2) {
 			if (bb2->diff && bb2->diff->type == R_ANAL_DIFF_TYPE_NULL) {
 				r_diff_buffers_distance (NULL, bb->fingerprint, bb->size,
 						bb2->fingerprint, bb2->size, NULL, &t);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -49,8 +49,8 @@ R_API int r_anal_fcn_resize (RAnalFunction *fcn, int newsize) {
 	eof = fcn->addr + r_anal_fcn_size (fcn);
 	r_skiplist_foreach_safe (fcn->bbs, iter, iter2, bb) {
 		if (bb->addr >= eof) {
-			// already called by r_list_delete r_anal_bb_free (bb);
-			r_skiplist_delete (fcn->bbs, iter);
+			// already called by r_skiplist_delete_node r_anal_bb_free (bb);
+			r_skiplist_delete_node (fcn->bbs, iter);
 			continue;
 		}
 		if (bb->addr + bb->size >= eof) {

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1427,13 +1427,13 @@ R_API int r_anal_fcn_count (RAnal *anal, ut64 from, ut64 to) {
 /* return the basic block in fcn found at the given address.
  * NULL is returned if such basic block doesn't exist. */
 R_API RAnalBlock *r_anal_fcn_bbget(RAnalFunction *fcn, ut64 addr) {
-	RSkipListNode *iter;
-	RAnalBlock *bb;
+	RSkipListNode *res;
+	RAnalBlock search_bb;
 
-	r_skiplist_foreach (fcn->bbs, iter, bb) {
-		if (bb->addr == addr) return bb;
-	}
-	return NULL;
+	search_bb.addr = addr;
+	search_bb.size = 0;
+	res = r_skiplist_find (fcn->bbs, &search_bb);
+	return res ? (RAnalBlock *)res->data : NULL;
 }
 
 /* directly set the size of the function */

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1404,12 +1404,13 @@ R_API int r_anal_fcn_is_in_offset (RAnalFunction *fcn, ut64 addr) {
 		return addr >= fcn->addr && addr < fcn->addr + r_anal_fcn_size (fcn);
 	}
 
-	r_skiplist_foreach (fcn->bbs, iter, bb) {
-		if (addr >= bb->addr && addr < bb->addr + bb->size) {
-			return true;
-		}
-	}
-	return false;
+	fcn->bbs->compare = (RListComparator)r_anal_bb_compare_range;
+	RAnalBlock search_bb;
+	search_bb.addr = addr;
+	search_bb.size = 0;
+	iter = r_skiplist_find (fcn->bbs, &search_bb);
+	fcn->bbs->compare = (RListComparator)r_anal_bb_compare;
+	return iter != NULL;
 }
 
 R_API int r_anal_fcn_count (RAnal *anal, ut64 from, ut64 to) {

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -563,7 +563,7 @@ static int module_match_buffer (const RAnal *anal, const RFlirtModule *module,
 							fcn->addr < next_module_function->addr + flirt_fcn_size) {
 						r_list_join(next_module_function->refs, fcn->refs);
 						r_list_join(next_module_function->xrefs, fcn->xrefs);
-						r_list_join(next_module_function->bbs, fcn->bbs);
+						r_skiplist_join(next_module_function->bbs, fcn->bbs);
 						r_list_join(next_module_function->locs, fcn->locs);
 						r_list_join(next_module_function->vars, fcn->vars);
 						next_module_function->ninstr += fcn->ninstr;

--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -293,7 +293,7 @@ static int avr_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 	}
 	if (((buf[1] & 0xfe) == 0x94) && ((buf[0] & 0x0e) == 0x0c)) {
 		op->addr = addr;
-		op->type = R_ANAL_OP_TYPE_CJMP; // breq, jmp (absolute)
+		op->type = R_ANAL_OP_TYPE_JMP; // jmp (absolute)
 		op->fail = op->addr + 4;
 		anal->iob.read_at (anal->iob.io, addr + 2, kbuf, 2);
 		// TODO: check return value

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -458,7 +458,7 @@ static int handle_bb_cf_linear_sweep (RAnal *anal, RAnalState *state) {
 
 static int analyze_from_code_buffer ( RAnal *anal, RAnalFunction *fcn, ut64 addr, const ut8 *code_buf, ut64 code_length  ) {
 	char gen_name[1025];
-	RListIter *bb_iter;
+	RSkipListNode *bb_iter;
 	RAnalBlock *bb;
 	ut64 actual_size = 0;
 	RAnalState *state = NULL;
@@ -483,7 +483,7 @@ static int analyze_from_code_buffer ( RAnal *anal, RAnalFunction *fcn, ut64 addr
 	state->user_state = nodes;
 
 	result = analyze_method (anal, fcn, state);
-	r_list_foreach (fcn->bbs, bb_iter, bb) {
+	r_skiplist_foreach (fcn->bbs, bb_iter, bb) {
 		actual_size += bb->size;
 	}
 
@@ -553,7 +553,7 @@ static int analyze_from_code_attr (RAnal *anal, RAnalFunction *fcn, RBinJavaFiel
 static int analyze_method(RAnal *anal, RAnalFunction *fcn, RAnalState *state) {
 	ut64 bytes_consumed = 0;
 	// deallocate niceties
-	r_list_free (fcn->bbs);
+	r_skiplist_free (fcn->bbs);
 	fcn->bbs = r_anal_bb_list_new ();
 
 	IFDBG eprintf ("analyze_method: Parsing fcn %s @ 0x%08"PFMT64x", %d bytes\n",

--- a/libr/anal/reflines.c
+++ b/libr/anal/reflines.c
@@ -210,7 +210,7 @@ R_API RList*r_anal_reflines_fcn_get(RAnal *anal, RAnalFunction *fcn, int nlines,
 	RList *list;
 	RAnalRefline *item;
 	RAnalBlock *bb;
-	RListIter *bb_iter;
+	RSkipListNode *bb_iter;
 
 	int index = 0;
 	ut32 len;
@@ -219,7 +219,7 @@ R_API RList*r_anal_reflines_fcn_get(RAnal *anal, RAnalFunction *fcn, int nlines,
 	if (!list) return NULL;
 
 	/* analyze code block */
-	r_list_foreach (fcn->bbs, bb_iter, bb) {
+	r_skiplist_foreach (fcn->bbs, bb_iter, bb) {
 		if (!bb || bb->size == 0) continue;
 		if (nlines != -1 && --nlines == 0) break;
 		len = bb->size;

--- a/libr/anal/state.c
+++ b/libr/anal/state.c
@@ -44,7 +44,7 @@ R_API void r_anal_state_insert_bb (RAnalState* state, RAnalBlock *bb) {
 		state->current_fcn) {
 		RAnalBlock *tmp_bb;
 		IFDBG eprintf ("Inserting bb 0x%04"PFMT64x" into hash table\n", bb->addr);
-		r_list_append(state->current_fcn->bbs, bb);
+		r_skiplist_insert (state->current_fcn->bbs, bb);
         state->bytes_consumed += state->current_bb->op_sz;
 		IFDBG eprintf ("[--] Consumed 0x%02x bytes, for a total of 0x%02x\n", (short )state->current_bb->op_sz, (short) state->bytes_consumed);
 		if (r_hashtable64_insert(state->ht, bb->addr, bb)) {

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -762,7 +762,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 	int is_json = opts & R_CORE_ANAL_JSON;
 	int is_keva = opts & R_CORE_ANAL_KEYVALUE;
 	struct r_anal_bb_t *bbi;
-	RListIter *iter;
+	RSkipListNode *iter_bb;
 	int left = 300;
 	int count = 0;
 	int nodes = 0;
@@ -811,7 +811,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 		if (fcn->dsc) r_cons_printf (",\"signature\":\"%s\"", fcn->dsc);
 		r_cons_printf (",\"blocks\":[");
 	}
-	r_list_foreach (fcn->bbs, iter, bbi) {
+	r_skiplist_foreach (fcn->bbs, iter_bb, bbi) {
 		count ++;
 		if (is_keva) {
 			char key[128];
@@ -987,7 +987,6 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 /* analyze a RAnalBlock at the address at and add that to the fcn function. */
 R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head) {
 	struct r_anal_bb_t *bb, *bbi;
-	RListIter *iter;
 	ut64 jump, fail;
 	int rc = true;
 	ut8 *buf = NULL;
@@ -1002,7 +1001,8 @@ R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head) {
 	if (core->anal->split) {
 		ret = r_anal_fcn_split_bb (core->anal, fcn, bb, at);
 	} else {
-		r_list_foreach (fcn->bbs, iter, bbi) {
+		RSkipListNode *iter;
+		r_skiplist_foreach (fcn->bbs, iter, bbi) {
 			if (at == bbi->addr)
 				ret = R_ANAL_RET_DUP;
 		}
@@ -1033,7 +1033,7 @@ R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head) {
 					ret = r_anal_fcn_bb_overlaps (fcn, bb);
 
 				if (ret == R_ANAL_RET_NEW) {
-					r_list_append (fcn->bbs, bb);
+					r_skiplist_insert (fcn->bbs, bb);
 					fail = bb->fail;
 					jump = bb->jump;
 					if (fail != -1)
@@ -1050,7 +1050,7 @@ R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head) {
 error:
 	rc = false;
 fin:
-	r_list_delete_data (fcn->bbs, bb);
+	r_skiplist_delete (fcn->bbs, bb);
 	r_anal_bb_free (bb);
 	free (buf);
 	return rc;
@@ -1061,9 +1061,10 @@ fin:
 R_API ut64 r_core_anal_get_bbaddr(RCore *core, ut64 addr) {
 	RAnalBlock *bbi;
 	RAnalFunction *fcni;
-	RListIter *iter, *iter2;
+	RListIter *iter;
+	RSkipListNode *iter2;
 	r_list_foreach (core->anal->fcns, iter, fcni) {
-		r_list_foreach (fcni->bbs, iter2, bbi) {
+		r_skiplist_foreach (fcni->bbs, iter2, bbi) {
 			if (addr >= bbi->addr && addr < bbi->addr+bbi->size) {
 				return bbi->addr;
 			}
@@ -1343,9 +1344,9 @@ R_API void r_core_anal_coderefs(RCore *core, ut64 addr, int fmt) {
 
 static void fcn_list_bbs(RAnalFunction *fcn) {
 	RAnalBlock *bbi;
-	RListIter *iter;
+	RSkipListNode *iter;
 
-	r_list_foreach (fcn->bbs, iter, bbi) {
+	r_skiplist_foreach (fcn->bbs, iter, bbi) {
 		r_cons_printf ("afb+ 0x%08"PFMT64x" 0x%08"PFMT64x" %d ",
 				fcn->addr, bbi->addr, bbi->size);
 		r_cons_printf ("0x%08"PFMT64x" ", bbi->jump);
@@ -1415,9 +1416,9 @@ static int fcnlist_gather_metadata(RList *fcns) {
 		ut64 min = UT64_MAX;
 		ut64 max = UT64_MIN;
 
-		RListIter *bbsiter;
+		RSkipListNode *bbsiter;
 		RAnalBlock *bbi;
-		r_list_foreach (fcn->bbs, bbsiter, bbi) {
+		r_skiplist_foreach (fcn->bbs, bbsiter, bbi) {
 			if (max < bbi->addr + bbi->size) {
 				max = bbi->addr + bbi->size;
 			}
@@ -1470,7 +1471,7 @@ static int fcn_print_verbose(RCore *core, RAnalFunction *fcn, bool use_color) {
 	r_cons_printf (FCN_LIST_VERBOSE_ENTRY, color,
 			fcn->addr,
 			r_anal_fcn_realsize (fcn),
-			r_list_length (fcn->bbs),
+			r_skiplist_length (fcn->bbs),
 			r_anal_fcn_cc (fcn),
 			fcn->meta.min,
 			r_anal_fcn_size (fcn),
@@ -1518,7 +1519,7 @@ static int fcn_print_default(RCore *core, RAnalFunction *fcn, bool quiet) {
 			msg = r_str_newf ("%-4d -> %-4d", size, realsize);
 		}
 		r_cons_printf ("0x%08"PFMT64x" %4d %4s %s\n",
-				fcn->addr, r_list_length (fcn->bbs), msg, name);
+				fcn->addr, r_skiplist_length (fcn->bbs), msg, name);
 		free (name);
 		free (msg);
 	}
@@ -1546,7 +1547,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 			fcn->addr, name, r_anal_fcn_size (fcn));
 	r_cons_printf (",\"realsz\":%d", r_anal_fcn_realsize (fcn));
 	r_cons_printf (",\"cc\":%d", r_anal_fcn_cc (fcn));
-	r_cons_printf (",\"nbbs\":%d", r_list_length (fcn->bbs));
+	r_cons_printf (",\"nbbs\":%d", r_skiplist_length (fcn->bbs));
 	r_cons_printf (",\"calltype\":\"%s\"", r_anal_cc_type2str (fcn->call));
 	r_cons_printf (",\"type\":\"%s\"",
 			fcn->type == R_ANAL_FCN_TYPE_SYM?"sym":
@@ -1669,7 +1670,7 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn) {
 				fcn->diff->type == R_ANAL_DIFF_TYPE_MATCH?"MATCH":
 				fcn->diff->type == R_ANAL_DIFF_TYPE_UNMATCH?"UNMATCH":"NEW");
 
-	r_cons_printf ("\n num-bbs: %d", r_list_length (fcn->bbs));
+	r_cons_printf ("\n num-bbs: %d", r_skiplist_length (fcn->bbs));
 	r_cons_printf ("\n call-refs: ");
 	r_list_foreach (fcn->refs, iter, refi)
 		if (refi->type == R_ANAL_REF_TYPE_CODE ||
@@ -1821,7 +1822,7 @@ static RList *recurse(RCore *core, RAnalBlock *from, RAnalBlock *dest) {
 
 R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
 	ut8 *tbuf, *buf;
-	RListIter *tmp = NULL;
+	RSkipListNode *tmp = NULL;
 	RAnalBlock *bb = NULL;
 	int i;
 
@@ -1833,7 +1834,7 @@ R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
 	if (!buf) {
 		return;
 	}
-	r_list_foreach (fcn->bbs, tmp, bb) {
+	r_skiplist_foreach (fcn->bbs, tmp, bb) {
 		if (bb->size < 1) {
 			continue;
 		}
@@ -1870,14 +1871,16 @@ R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
 
 R_API RList* r_core_anal_graph_to(RCore *core, ut64 addr, int n) {
 	RAnalBlock *bb, *root = NULL, *dest = NULL;
-	RListIter *iter, *iter2;
+	RListIter *iter;
 	RList *list2 = NULL, *list = NULL;
 	RAnalFunction *fcn;
 
 	r_list_foreach (core->anal->fcns, iter, fcn) {
+		RSkipListNode *iter2;
 		if (!r_anal_fcn_is_in_offset (fcn, core->offset))
 			continue;
-		r_list_foreach (fcn->bbs, iter2, bb) {
+
+		r_skiplist_foreach (fcn->bbs, iter2, bb) {
 			if (r_anal_bb_is_in_offset (bb, addr)) {
 				dest = bb;
 			}
@@ -2670,7 +2673,7 @@ R_API void r_core_anal_undefine (RCore *core, ut64 off) {
 /* Join function at addr2 into function at addr */
 // addr use to be core->offset
 R_API void r_core_anal_fcn_merge (RCore *core, ut64 addr, ut64 addr2) {
-	RListIter *iter;
+	RSkipListNode *iter;
 	ut64 min = 0;
 	ut64 max = 0;
 	int first = 1;
@@ -2684,7 +2687,7 @@ R_API void r_core_anal_fcn_merge (RCore *core, ut64 addr, ut64 addr2) {
 	// join all basic blocks from f1 into f2 if they are not
 	// delete f2
 	eprintf ("Merge 0x%08"PFMT64x" into 0x%08"PFMT64x"\n", addr, addr2);
-	r_list_foreach (f1->bbs, iter, bb) {
+	r_skiplist_foreach (f1->bbs, iter, bb) {
 		if (first) {
 			min = bb->addr;
 			max = bb->addr + bb->size;
@@ -2696,7 +2699,7 @@ R_API void r_core_anal_fcn_merge (RCore *core, ut64 addr, ut64 addr2) {
 				max = bb->addr + bb->size;
 		}
 	}
-	r_list_foreach (f2->bbs, iter, bb) {
+	r_skiplist_foreach (f2->bbs, iter, bb) {
 		if (first) {
 			min = bb->addr;
 			max = bb->addr + bb->size;
@@ -2707,7 +2710,7 @@ R_API void r_core_anal_fcn_merge (RCore *core, ut64 addr, ut64 addr2) {
 			if (bb->addr + bb->size > max)
 				max = bb->addr + bb->size;
 		}
-		r_list_append (f1->bbs, bb);
+		r_skiplist_insert (f1->bbs, bb);
 	}
 	// TODO: import data/code/refs
 	// update size

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -986,7 +986,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 
 /* analyze a RAnalBlock at the address at and add that to the fcn function. */
 R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head) {
-	struct r_anal_bb_t *bb, *bbi;
+	struct r_anal_bb_t *bb;
 	ut64 jump, fail;
 	int rc = true;
 	ut8 *buf = NULL;
@@ -1002,9 +1002,13 @@ R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head) {
 		ret = r_anal_fcn_split_bb (core->anal, fcn, bb, at);
 	} else {
 		RSkipListNode *iter;
-		r_skiplist_foreach (fcn->bbs, iter, bbi) {
-			if (at == bbi->addr)
-				ret = R_ANAL_RET_DUP;
+		RAnalBlock search_bb;
+
+		search_bb.addr = at;
+		search_bb.size = 0;
+		iter = r_skiplist_find (fcn->bbs, &search_bb);
+		if (iter) {
+			ret = R_ANAL_RET_DUP;
 		}
 	}
 	if (ret == R_ANAL_RET_DUP) /* Dupped bb */

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -661,14 +661,13 @@ static bool anal_fcn_del_bb(RCore *core, const char *input) {
 			r_skiplist_free (fcn->bbs);
 			fcn->bbs = NULL;
 		} else {
-			RAnalBlock *b;
-			RSkipListNode *iter;
-			r_skiplist_foreach (fcn->bbs, iter, b) {
-				if (b->addr == addr) {
-					r_skiplist_delete (fcn->bbs, b);
-					return true;
-				}
-			}
+			RAnalBlock search_bb;
+			bool res;
+
+			search_bb.addr = addr;
+			search_bb.size = 0;
+			res = r_skiplist_delete (fcn->bbs, &search_bb);
+			if (res) return true;
 
 			eprintf ("Cannot find basic block\n");
 		}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -551,16 +551,10 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 	}
 }
 
-static int bb_cmp(const void *a, const void *b) {
-	const RAnalBlock *ba = a;
-	const RAnalBlock *bb = b;
-	return ba->addr - bb->addr;
-}
-
 static int anal_fcn_list_bb(RCore *core, const char *input) {
 	RDebugTracepoint *tp = NULL;
 	RAnalFunction *fcn;
-	RListIter *iter;
+	RSkipListNode *iter;
 	RAnalBlock *b;
 	int mode = 0;
 	ut64 addr;
@@ -586,8 +580,7 @@ static int anal_fcn_list_bb(RCore *core, const char *input) {
 		r_cons_printf ("fs blocks\n");
 		break;
 	}
-	r_list_sort (fcn->bbs, bb_cmp);
-	r_list_foreach (fcn->bbs, iter, b) {
+	r_skiplist_foreach (fcn->bbs, iter, b) {
 		switch (mode) {
 		case 'r':
 			if (b->jump == UT64_MAX) {
@@ -614,11 +607,11 @@ static int anal_fcn_list_bb(RCore *core, const char *input) {
 		case 'j':
 			//r_cons_printf ("%" PFMT64d "%s", b->addr, iter->n? ",": "");
 			{
-			RListIter *iter2;
+			RSkipListNode *iter2;
 			RAnalBlock *b2;
 			int inputs = 0;
 			int outputs = 0;
-			r_list_foreach (fcn->bbs, iter2, b2) {
+			r_skiplist_foreach (fcn->bbs, iter2, b2) {
 				if (b2->jump == b->addr) {
 					inputs++;
 				}
@@ -633,7 +626,7 @@ static int anal_fcn_list_bb(RCore *core, const char *input) {
 				outputs ++;
 			}
 			r_cons_printf ("{\"addr\":%" PFMT64d ",\"size\":%d,\"inputs\":%d,\"outputs\":%d,\"ninstr\":%d,\"traced\":%s}%s",
-				b->addr, b->size, inputs, outputs, b->ninstr, r_str_bool (b->traced), iter->n? ",":"");
+				b->addr, b->size, inputs, outputs, b->ninstr, r_str_bool (b->traced), r_skiplist_islast(fcn->bbs, iter)? ",":"");
 			//%s", b->addr, iter->n? ",": "");
 			}
 			break;
@@ -665,17 +658,18 @@ static bool anal_fcn_del_bb(RCore *core, const char *input) {
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, -1);
 	if (fcn) {
 		if (!strcmp (input, "*")) {
-			r_list_free (fcn->bbs);
+			r_skiplist_free (fcn->bbs);
 			fcn->bbs = NULL;
 		} else {
 			RAnalBlock *b;
-			RListIter *iter;
-			r_list_foreach (fcn->bbs, iter, b) {
+			RSkipListNode *iter;
+			r_skiplist_foreach (fcn->bbs, iter, b) {
 				if (b->addr == addr) {
-					r_list_delete (fcn->bbs, iter);
+					r_skiplist_delete (fcn->bbs, b);
 					return true;
 				}
 			}
+
 			eprintf ("Cannot find basic block\n");
 		}
 	} else {
@@ -752,7 +746,8 @@ static void r_core_anal_nofunclist  (RCore *core, const char *input) {
 	ut64 code_size = r_num_get (core->num, "$SS");
 	ut64 base_addr = r_num_get (core->num, "$S");
 	ut64 chunk_size, chunk_offset, i;
-	RListIter *iter, *iter2;
+	RListIter *iter;
+	RSkipListNode *iter2;
 	RAnalFunction *fcn;
 	RAnalBlock *b;
 	char* bitmap;
@@ -766,7 +761,7 @@ static void r_core_anal_nofunclist  (RCore *core, const char *input) {
 	// for each function
 	r_list_foreach (core->anal->fcns, iter, fcn) {
 		// for each basic block in the function
-		r_list_foreach (fcn->bbs, iter2, b) {
+		r_skiplist_foreach (fcn->bbs, iter2, b) {
 			// if it is not withing range, continue
 			if ((fcn->addr < base_addr) || (fcn->addr >= base_addr+code_size))
 				continue;
@@ -816,7 +811,8 @@ static void r_core_anal_fmap  (RCore *core, const char *input) {
 	int cols = r_config_get_i (core->config, "hex.cols") * 4;
 	ut64 code_size = r_num_get (core->num, "$SS");
 	ut64 base_addr = r_num_get (core->num, "$S");
-	RListIter *iter, *iter2;
+	RListIter *iter;
+	RSkipListNode *iter2;
 	RAnalFunction *fcn;
 	RAnalBlock *b;
 	char* bitmap;
@@ -830,7 +826,7 @@ static void r_core_anal_fmap  (RCore *core, const char *input) {
 	// for each function
 	r_list_foreach (core->anal->fcns, iter, fcn) {
 		// for each basic block in the function
-		r_list_foreach (fcn->bbs, iter2, b) {
+		r_skiplist_foreach (fcn->bbs, iter2, b) {
 			// if it is not within range, continue
 			if ((fcn->addr < base_addr) || (fcn->addr >= base_addr+code_size))
 				continue;
@@ -2559,13 +2555,13 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		break;
 	case 'f': // "aef"
 	{
-		RListIter *iter;
+		RSkipListNode *iter;
 		RAnalBlock *bb;
 		RAnalFunction *fcn = r_anal_get_fcn_in (core->anal,
 							core->offset, R_ANAL_FCN_TYPE_FCN | R_ANAL_FCN_TYPE_SYM);
 		if (fcn) {
 			// emulate every instruction in the function recursively across all the basic blocks
-			r_list_foreach (fcn->bbs, iter, bb) {
+			r_skiplist_foreach (fcn->bbs, iter, bb) {
 				ut64 pc = bb->addr;
 				ut64 end = bb->addr + bb->size;
 				RAnalOp op;
@@ -4308,8 +4304,8 @@ static bool anal_fcn_data (RCore *core, const char *input) {
 		char *bitmap = calloc (1, fcn_size);
 		if (bitmap) {
 			RAnalBlock *b;
-			RListIter *iter;
-			r_list_foreach (fcn->bbs, iter, b) {
+			RSkipListNode *iter;
+			r_skiplist_foreach (fcn->bbs, iter, b) {
 				int f = b->addr - fcn->addr;
 				int t = R_MIN (f + b->size, fcn_size);
 				if (f>=0) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1514,8 +1514,8 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 				bool label = false;
 				/* show labels, basic blocks and (conditional) branches */
 				RAnalBlock *bb;
-				RListIter *iter;
-				r_list_foreach (fcn->bbs, iter, bb) {
+				RSkipListNode *iter;
+				r_skiplist_foreach (fcn->bbs, iter, bb) {
 					if (addr == bb->jump) {
 						r_cons_printf ("%s0x%08"PFMT64x":\n", use_color? Color_YELLOW:"", addr);
 						label = true;
@@ -1526,7 +1526,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 					r_cons_printf ("%s0x%08"PFMT64x":\n", use_color? Color_YELLOW:"", addr);
 				}
 				if (strstr (line, "=<")) {
-					r_list_foreach (fcn->bbs, iter, bb) {
+					r_skiplist_foreach (fcn->bbs, iter, bb) {
 						if (addr >= bb->addr && addr < bb->addr + bb->size) {
 							const char *op;
 							if (use_color) {
@@ -1912,10 +1912,6 @@ static void cmd_print_bars(RCore *core, const char *input) {
 	}
 beach:
 	return;
-}
-
-static int bbcmp(RAnalBlock *a, RAnalBlock *b) {
-	return a->addr - b->addr;
 }
 
 /* TODO: integrate this into r_anal */
@@ -2529,22 +2525,21 @@ static int cmd_print(void *data, const char *input) {
 				RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset,
 						R_ANAL_FCN_TYPE_FCN|R_ANAL_FCN_TYPE_SYM);
 				if (f) {
-					RListIter *iter;
+					RSkipListNode *iter;
 					RAnalBlock *b;
 					// XXX: hack must be reviewed/fixed in code analysis
-					if (r_list_length (f->bbs) == 1) {
+					if (r_skiplist_length (f->bbs) == 1) {
 						ut32 fcn_size = r_anal_fcn_size (f);
-						b = r_list_get_top (f->bbs);
+						b = r_skiplist_get_first (f->bbs);
 						if (b->size > fcn_size) {
 							b->size = fcn_size;
 						}
 					}
-					r_list_sort (f->bbs, (RListComparator)bbcmp);
 					// TODO: sort by addr
 					bool asm_lines = r_config_get_i (core->config, "asm.lines");
 					r_config_set_i (core->config, "asm.lines", 0);
 					//r_list_sort (f->bbs, &r_anal_ex_bb_address_comparator);
-					r_list_foreach (f->bbs, iter, b) {
+					r_skiplist_foreach (f->bbs, iter, b) {
 						r_core_cmdf (core, "pD %"PFMT64d" @0x%"PFMT64x, b->size, b->addr);
 #if 1
 						if (b->jump != UT64_MAX) {

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -535,10 +535,10 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int protection, const char 
 
 				/* Search only inside the basic block */
 				if (!strcmp (mode, "anal.bb")) {
-					RListIter *iter;
+					RSkipListNode *iter;
 					struct r_anal_bb_t *bb;
 
-					r_list_foreach (f->bbs, iter, bb) {
+					r_skiplist_foreach (f->bbs, iter, bb) {
 						*from = core->offset;
 						if ((*from >= bb->addr) && (*from < (bb->addr+bb->size))) {
 							*from = bb->addr;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3696,6 +3696,7 @@ R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int 
 	ut32 len = 0;
 	int ret, idx = 0, i;
 	RListIter *bb_iter;
+	RSkipListNode *bb_node;
 	RAnalBlock *bb = NULL;
 	RDisasmState *ds;
 	RList *bb_list = NULL;
@@ -3735,7 +3736,7 @@ R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int 
 	ds->addr = fcn->addr;
 	ds->fcn = fcn;
 
-	r_list_foreach (fcn->bbs, bb_iter, bb) {
+	r_skiplist_foreach (fcn->bbs, bb_node, bb) {
 		r_list_add_sorted (bb_list, bb, cmpaddr);
 	}
 	// Premptively read the bb data locs for ref lines

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -40,7 +40,8 @@ R_API int r_core_gdiff(RCore *c, RCore *c2) {
 		}
 		/* Fingerprint fcn bbs (functions basic-blocks) */
 		r_list_foreach (cores[i]->anal->fcns, iter, fcn) {
-			r_list_foreach (fcn->bbs, iter2, bb) {
+			RSkipListNode *iter_bb;
+			r_skiplist_foreach (fcn->bbs, iter_bb, bb) {
 				r_anal_diff_fingerprint_bb (cores[i]->anal, bb);
 			}
 		}

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -1584,9 +1584,9 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 
 static void get_bbupdate(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 	RAnalBlock *bb;
-	RListIter *iter;
+	RSkipListNode *iter;
 	core->keep_asmqjmps = false;
-	r_list_foreach (fcn->bbs, iter, bb) {
+	r_skiplist_foreach (fcn->bbs, iter, bb) {
 		RANode *node;
 		char *title, *body;
 
@@ -1610,12 +1610,12 @@ static void get_bbupdate(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 /* build the RGraph inside the RAGraph g, starting from the Basic Blocks */
 static int get_bbnodes(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 	RAnalBlock *bb;
-	RListIter *iter;
+	RSkipListNode *iter;
 	char *shortcut = NULL;
 	int shortcuts = 0;
 
 	core->keep_asmqjmps = false;
-	r_list_foreach (fcn->bbs, iter, bb) {
+	r_skiplist_foreach (fcn->bbs, iter, bb) {
 		RANode *node;
 		char *title, *body;
 
@@ -1640,7 +1640,7 @@ static int get_bbnodes(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 		core->keep_asmqjmps = true;
 	}
 
-	r_list_foreach (fcn->bbs, iter, bb) {
+	r_skiplist_foreach (fcn->bbs, iter, bb) {
 		RANode *u, *v;
 		char *title;
 

--- a/libr/core/p/core_java.c
+++ b/libr/core/p/core_java.c
@@ -903,7 +903,8 @@ static int r_cmd_java_handle_find_cp_const (RCore *core, const char *cmd) {
 	RBinJavaObj *obj = (RBinJavaObj *) r_cmd_java_get_bin_obj (get_anal (core));
 	RAnalFunction *fcn = NULL;
 	RAnalBlock *bb = NULL;
-	RListIter *bb_iter, *fn_iter, *iter;
+	RListIter *fn_iter, *iter;
+	RSkipListNode *bb_iter;
 	RCmdJavaCPResult *cp_res = NULL;
 	ut16 idx = -1;
 	RList *find_list;
@@ -930,7 +931,7 @@ static int r_cmd_java_handle_find_cp_const (RCore *core, const char *cmd) {
 	find_list->free = free;
 	// XXX - this will break once RAnal moves to sdb
 	r_list_foreach (core->anal->fcns, fn_iter, fcn) {
-		r_list_foreach (fcn->bbs, bb_iter, bb) {
+		r_skiplist_foreach (fcn->bbs, bb_iter, bb) {
 			char op = bb->op_bytes[0];
 			cp_res = NULL;
 			switch (op) {
@@ -1771,7 +1772,8 @@ static int r_cmd_java_handle_list_code_references (RCore *core, const char *inpu
 	RBinJavaObj *bin = anal ? (RBinJavaObj *) r_cmd_java_get_bin_obj (anal) : NULL;
 	RAnalBlock *bb = NULL;
 	RAnalFunction *fcn = NULL;
-	RListIter *bb_iter = NULL, *fcn_iter = NULL;
+	RListIter *fcn_iter = NULL;
+	RSkipListNode *bb_iter;
 	ut64 func_addr = -1;
 	const char *fmt, *p = r_cmd_java_consumetok (input, ' ', -1);
 	func_addr = p && *p && r_cmd_java_is_valid_input_num_value(core, p) ? r_cmd_java_get_input_num_value (core, p) : -1;
@@ -1791,7 +1793,7 @@ static int r_cmd_java_handle_list_code_references (RCore *core, const char *inpu
 	r_list_foreach (anal->fcns, fcn_iter, fcn) {
 		ut8 do_this_one = func_addr == -1 || r_anal_fcn_is_in_offset (fcn, func_addr);
 		if (!do_this_one) continue;
-		r_list_foreach (fcn->bbs, bb_iter, bb) {
+		r_skiplist_foreach (fcn->bbs, bb_iter, bb) {
 			char *operation = NULL, *type = NULL;
 			ut64 addr = -1;
 			ut16 cp_ref_idx = -1;

--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -809,7 +809,7 @@ repeat:
 			if (!fun) {
 				r_cons_message("Not in a function. Type 'df' to define it here");
 				break;
-			} else if (r_list_empty (fun->bbs)) {
+			} else if (r_skiplist_empty (fun->bbs)) {
 				r_cons_message("No basic blocks in this function. You may want to use 'afb+'.");
 				break;
 			}

--- a/libr/core/pseudo.c
+++ b/libr/core/pseudo.c
@@ -48,9 +48,9 @@ R_API int r_core_pseudo_code (RCore *core, const char *input) {
 	// use it for indentation
 	// asm.pseudo=true
 	// asm.decode=true
-	RAnalBlock *bb = r_list_first (fcn->bbs);
+	RAnalBlock *bb = r_skiplist_get_first (fcn->bbs);
 	char indentstr[1024];
-	int n_bb = r_list_length (fcn->bbs);
+	int n_bb = r_skiplist_length (fcn->bbs);
 	r_cons_printf ("function %s () {", fcn->name);
 	int indent = 1;
 	int nindent = 1;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1416,7 +1416,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 			if (!fun) {
 				r_cons_message ("Not in a function. Type 'df' to define it here");
 				break;
-			} else if (r_list_empty (fun->bbs)) {
+			} else if (r_skiplist_empty (fun->bbs)) {
 				r_cons_message ("No basic blocks in this function. You may want to use 'afb+'.");
 				break;
 			}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -15,6 +15,7 @@
 #include <r_io.h>
 #include <r_reg.h>
 #include <r_list.h>
+#include <r_skiplist.h>
 #include <r_util.h>
 #include <r_syscall.h>
 #include <r_flags.h>
@@ -312,7 +313,7 @@ typedef struct r_anal_type_function_t {
 	RAnalDiff *diff;
 	RList *locs; // list of local variables
 	//RList *locals; // list of local labels -> moved to anal->sdb_fcns
-	RList *bbs;
+	RSkipList *bbs;
 	RList *vars;
 #if FCN_OLD
 	RList *refs;
@@ -1191,7 +1192,7 @@ R_API const char *r_anal_get_fcnsign(RAnal *anal, const char *sym);
 
 /* bb.c */
 R_API RAnalBlock *r_anal_bb_new(void);
-R_API RList *r_anal_bb_list_new(void);
+R_API RSkipList *r_anal_bb_list_new(void);
 R_API void r_anal_bb_free(RAnalBlock *bb);
 R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb,
 		ut64 addr, ut8 *buf, ut64 len, int head);
@@ -1200,6 +1201,7 @@ R_API int r_anal_bb_is_in_offset(RAnalBlock *bb, ut64 addr);
 R_API void r_anal_bb_set_offset(RAnalBlock *bb, int i, ut16 v);
 R_API ut16 r_anal_bb_offset_inst(RAnalBlock *bb, int i);
 R_API ut64 r_anal_bb_opaddr_at(RAnalBlock *bb, ut64 addr);
+R_API int r_anal_bb_compare(RAnalBlock* a, RAnalBlock* b);
 
 /* op.c */
 R_API const char *r_anal_stackop_tostring (int s);
@@ -1333,7 +1335,7 @@ R_API int r_anal_xrefs_set (RAnal *anal, const RAnalRefType type, ut64 from, ut6
 R_API int r_anal_xrefs_deln (RAnal *anal, const RAnalRefType type, ut64 from, ut64 to);
 R_API bool r_anal_xrefs_save(RAnal *anal, const char *prjfile);
 R_API RList* r_anal_fcn_get_vars (RAnalFunction *anal);
-R_API RList* r_anal_fcn_get_bbs (RAnalFunction *anal);
+R_API RSkipList* r_anal_fcn_get_bbs(RAnalFunction *fcn);
 R_API RList* r_anal_get_fcns (RAnal *anal);
 #endif
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1202,6 +1202,7 @@ R_API void r_anal_bb_set_offset(RAnalBlock *bb, int i, ut16 v);
 R_API ut16 r_anal_bb_offset_inst(RAnalBlock *bb, int i);
 R_API ut64 r_anal_bb_opaddr_at(RAnalBlock *bb, ut64 addr);
 R_API int r_anal_bb_compare(RAnalBlock* a, RAnalBlock* b);
+R_API int r_anal_bb_compare_range(RAnalBlock* a, RAnalBlock* b);
 
 /* op.c */
 R_API const char *r_anal_stackop_tostring (int s);

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -30,6 +30,7 @@ R_API void r_skiplist_free(RSkipList *list);
 R_API void r_skiplist_purge(RSkipList *list);
 R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data);
 R_API bool r_skiplist_delete(RSkipList* list, void* data);
+R_API bool r_skiplist_delete_node(RSkipList *list, RSkipListNode *node);
 R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data);
 R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2);
 R_API void *r_skiplist_get_first(RSkipList *list);

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -1,0 +1,34 @@
+// (c) 2016 Jeffrey Crowell
+// BSD 3 Clause License
+// radare2
+
+// Skiplists are a probabilistic datastructure than can be used as a k-v store
+// with average case O(lg n) lookup time, and worst case O(n).
+
+// https://en.wikipedia.org/wiki/Skip_list
+
+#ifndef R2_SKIP_LIST_H
+#define R2_SKIP_LIST_H
+
+#include <r_list.h>
+
+typedef struct r_skiplist_node_t {
+	void *data;	// pointer to the value
+	struct r_skiplist_node_t *forward[1]; // forward pointer
+} r_skiplist_node;
+
+typedef struct r_skiplist_t {
+	r_skiplist_node *head;	// list header
+	int list_level; // current level of the list.
+	RListFree freefn;
+	RListComparator compare;
+} r_skiplist;
+
+typedef r_skiplist RSkipList;
+
+R_API r_skiplist* r_skiplist_new(RListFree freefn, RListComparator comparefn);
+R_API r_skiplist_node* r_skiplist_insert(r_skiplist* list, void* data);
+R_API void r_skiplist_delete(r_skiplist* list, void* data);
+R_API r_skiplist_node* r_skiplist_find(r_skiplist* list, void* data);
+
+#endif // R2_SKIP_LIST_H

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -15,20 +15,20 @@
 typedef struct r_skiplist_node_t {
 	void *data;	// pointer to the value
 	struct r_skiplist_node_t *forward[1]; // forward pointer
-} r_skiplist_node;
+} RSkipListNode;
 
 typedef struct r_skiplist_t {
-	r_skiplist_node *head;	// list header
+	RSkipListNode *head;	// list header
 	int list_level; // current level of the list.
 	RListFree freefn;
 	RListComparator compare;
-} r_skiplist;
+} RSkipList;
 
-typedef r_skiplist RSkipList;
-
-R_API r_skiplist* r_skiplist_new(RListFree freefn, RListComparator comparefn);
-R_API r_skiplist_node* r_skiplist_insert(r_skiplist* list, void* data);
-R_API void r_skiplist_delete(r_skiplist* list, void* data);
-R_API r_skiplist_node* r_skiplist_find(r_skiplist* list, void* data);
+R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn);
+R_API void r_skiplist_free(RSkipList *list);
+R_API void r_skiplist_purge(RSkipList *list);
+R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data);
+R_API void r_skiplist_delete(RSkipList* list, void* data);
+R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data);
 
 #endif // R2_SKIP_LIST_H

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -29,9 +29,14 @@ R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn);
 R_API void r_skiplist_free(RSkipList *list);
 R_API void r_skiplist_purge(RSkipList *list);
 R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data);
-R_API void r_skiplist_delete(RSkipList* list, void* data);
+R_API bool r_skiplist_delete(RSkipList* list, void* data);
 R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data);
 R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2);
+R_API void *r_skiplist_get_first(RSkipList *list);
+R_API bool r_skiplist_empty(RSkipList *list);
+R_API RList *r_skiplist_to_list(RSkipList *list);
+
+#define r_skiplist_islast(list, el) (el->forward[0] == list->head)
 
 #define r_skiplist_length(list) (list->size)
 

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -14,12 +14,13 @@
 
 typedef struct r_skiplist_node_t {
 	void *data;	// pointer to the value
-	struct r_skiplist_node_t *forward[1]; // forward pointer
+	struct r_skiplist_node_t **forward; // forward pointer
 } RSkipListNode;
 
 typedef struct r_skiplist_t {
 	RSkipListNode *head;	// list header
 	int list_level; // current level of the list.
+	int size;
 	RListFree freefn;
 	RListComparator compare;
 } RSkipList;
@@ -30,5 +31,11 @@ R_API void r_skiplist_purge(RSkipList *list);
 R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data);
 R_API void r_skiplist_delete(RSkipList* list, void* data);
 R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data);
+
+#define r_skiplist_length(list) (list->size)
+
+#define r_skiplist_foreach(list, it, pos)\
+	if (list)\
+		for (it = list->head->forward[0]; it != list->head && ((pos = it->data) || 1); it = it->forward[0])
 
 #endif // R2_SKIP_LIST_H

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -31,11 +31,16 @@ R_API void r_skiplist_purge(RSkipList *list);
 R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data);
 R_API void r_skiplist_delete(RSkipList* list, void* data);
 R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data);
+R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2);
 
 #define r_skiplist_length(list) (list->size)
 
 #define r_skiplist_foreach(list, it, pos)\
 	if (list)\
 		for (it = list->head->forward[0]; it != list->head && ((pos = it->data) || 1); it = it->forward[0])
+
+#define r_skiplist_foreach_safe(list, it, tmp, pos)\
+	if (list)\
+		for (it = list->head->forward[0]; it != list->head && ((pos = it->data) || 1) && ((tmp = it->forward[0]) || 1); it = tmp)
 
 #endif // R2_SKIP_LIST_H

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -10,6 +10,7 @@
 #include <r_list.h> // radare linked list
 #include <r_flist.h> // radare fixed pointer array iterators
 #include <list.h> // kernel linked list
+#include <r_skiplist.h> // skiplist
 #include <r_th.h>
 #include <dirent.h>
 #include <sys/time.h>

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -12,7 +12,7 @@ OBJS+=strpool.o bitmap.o strht.o p_date.o p_format.o print.o
 OBJS+=p_seven.o slist.o randomart.o log.o zip.o debruijn.o
 OBJS+=utf8.o strbuf.o lib.o name.o spaces.o
 OBJS+=diff.o bdiff.o stack.o queue.o tree.o des.o
-OBJS+=punycode.o r_skiplist.o
+OBJS+=punycode.o skiplist.o
 
 # DO NOT BUILD r_big api (not yet used and its buggy)
 ifeq (1,0)

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -12,7 +12,7 @@ OBJS+=strpool.o bitmap.o strht.o p_date.o p_format.o print.o
 OBJS+=p_seven.o slist.o randomart.o log.o zip.o debruijn.o
 OBJS+=utf8.o strbuf.o lib.o name.o spaces.o
 OBJS+=diff.o bdiff.o stack.o queue.o tree.o des.o
-OBJS+=punycode.o
+OBJS+=punycode.o r_skiplist.o
 
 # DO NOT BUILD r_big api (not yet used and its buggy)
 ifeq (1,0)

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -17,14 +17,12 @@ const int kSkipListDepth = 15; // max depth
 // Returns a new heap-allocated skiplist.
 R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
 	int i;
-	RSkipList* list = calloc (1, sizeof (RSkipList));
-	if ((list->head =
-				calloc (1,
-				sizeof (RSkipListNode) +
-				kSkipListDepth * sizeof (RSkipListNode*))) == NULL) {
-		eprintf ("can't init skiplist...");
-		return NULL;
-	}
+	RSkipList *list = R_NEW0 (RSkipList);
+	if (!list) return NULL;
+
+	list->head = calloc (1, sizeof (RSkipListNode) + kSkipListDepth * sizeof (RSkipListNode*));
+	if (!list->head) goto err_head;
+
 	for (i = 0; i <= kSkipListDepth; i++) {
 		list->head->forward[i] = list->head;
 	}
@@ -32,6 +30,10 @@ R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
 	list->freefn = freefn;
 	list->compare = comparefn;
 	return list;
+
+err_head:
+	free (list);
+	return NULL;
 }
 
 // Remove all elements from the list

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -139,7 +139,7 @@ R_API void r_skiplist_delete(RSkipList* list, void* data) {
 	node = list->head;
 	for (i = list->list_level; i >=0; i--) {
 		while (node->forward[i] != list->head &&
-			list->compare (node->forward[i]->data, data) < 1) {
+			list->compare (node->forward[i]->data, data) < 0) {
 			node = node->forward[i];
 		}
 		update[i] = node;

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -103,7 +103,7 @@ R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
 		update[i] = x;
 	}
 	x = x->forward[0];
-	if (x->forward[0] != list->head && list->compare(x->data, data) == 0) {
+	if (x != list->head && list->compare(x->data, data) == 0) {
 		return x;
 	}
 

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -1,0 +1,131 @@
+// (c) 2016 Jeffrey Crowell
+// BSD 3 Clause License
+// radare2
+
+// Skiplists are a probabilistic datastructure than can be used as a k-v store
+// with average case O(lg n) lookup time, and worst case O(n).
+
+// https://en.wikipedia.org/wiki/Skip_list
+
+#include <r_skiplist.h>
+
+const int kSkipListDepth = 15; // max depth
+
+// Takes in a pointer to the function to free a list element, and a pointer to
+// a function that retruns 0 on equality between two elements, and -1 or 1
+// when unequal (for sorting).
+// Returns a new heap-allocated skiplist.
+R_API r_skiplist* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
+	int i;
+	r_skiplist* list = calloc (1, sizeof (r_skiplist));
+	if ((list->head =
+				calloc (1,
+				sizeof (r_skiplist_node) +
+				kSkipListDepth * sizeof (r_skiplist_node*))) == NULL) {
+		eprintf ("can't init skiplist...");
+		return NULL;
+	}
+	for (i = 0; i <= kSkipListDepth; i++) {
+		list->head->forward[i] = list->head;
+	}
+	list->list_level = 0;
+	return list;
+}
+
+// Inserts an element to the skiplist, and returns a pointer to the element's
+// node.
+R_API r_skiplist_node* r_skiplist_insert(r_skiplist* list, void* data) {
+	int i, new_level;
+	r_skiplist_node* update [kSkipListDepth + 1];
+	r_skiplist_node* nnode;
+
+	// Find the spot for it.
+	nnode = list->head;
+	for (i = list->list_level; i >= 0; i--) {
+		while ((nnode->forward[i] != list->head) &&
+				(list->compare (nnode->forward[i]->data, data) < 1)) {
+			nnode = nnode->forward[i];
+		}
+		update[i] = nnode;
+	}
+	nnode = nnode->forward[0];
+	if (nnode != list->head && list->compare (nnode->data, data) == 0) {
+		return nnode;
+	}
+
+	// Determine the level "randomly".
+	// Skiplists are a probabilistic datastructure.
+	for (new_level = 0; rand() % 2 && new_level < kSkipListDepth; new_level++);
+
+	if (new_level < list->list_level) {
+		for (i = list->list_level + 1; i <= new_level; i++) {
+			update[i] = list->head;
+		}
+	}
+
+	// Okie, now make the node actually...
+	if ((nnode = calloc (1,
+					sizeof (r_skiplist_node) +
+					new_level * sizeof (r_skiplist_node*))) == NULL) {
+		eprintf ("can't calloc new node for skiplist");
+		return NULL;
+	}
+	nnode->data = data;
+
+	// update fwd links.
+	for (i = 0; i <= new_level; i++) {
+		nnode->forward[i] = update[i]->forward[i];
+	}
+	return nnode;
+}
+
+R_API void r_skiplist_delete(r_skiplist* list, void* data) {
+	int i;
+	r_skiplist_node *update[kSkipListDepth + 1], *node;
+
+	// Delete node with data as it's payload.
+	node = list->head;
+	for (i = list->list_level; i >=0; i--) {
+		while (node->forward[i] != list->head &&
+				list->compare (node->forward[i]->data, data) < 1) {
+			node = node->forward[i];
+		}
+		update[i] = node;
+	}
+	node = node->forward[0];
+	if (node == list->head || !list->compare(node->data, data)) {
+		return;
+	}
+
+	// Update the fwd pointers.
+	for (i = 0; i <= list->list_level; i++) {
+		if (update[i]->forward[i] != node) {
+			break;
+		} else {
+			update[i]->forward[i] = node->forward[i];
+		}
+	}
+	free (node);
+
+	// Update the level.
+	while ((list->list_level > 0) &&
+			(list->head->forward[list->list_level] == list->head)) {
+		list->list_level--;
+	}
+}
+
+R_API r_skiplist_node* r_skiplist_find(r_skiplist* list, void* data) {
+	int i;
+	r_skiplist_node* node = list->head;
+	for (i = list->list_level; i >= 0; i--) {
+		while (node->forward[i] != list->head &&
+				list->compare (node->forward[i]->data, data) < 0) {
+			node = node->forward[i];
+		}
+	}
+	node = node->forward[0];
+	if (node != list->head && list->compare (node->data, data)) {
+		return node;
+	}
+	return NULL;
+}

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -15,13 +15,13 @@ const int kSkipListDepth = 15; // max depth
 // a function that retruns 0 on equality between two elements, and -1 or 1
 // when unequal (for sorting).
 // Returns a new heap-allocated skiplist.
-R_API r_skiplist* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
+R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
 	int i;
-	r_skiplist* list = calloc (1, sizeof (r_skiplist));
+	RSkipList* list = calloc (1, sizeof (RSkipList));
 	if ((list->head =
 				calloc (1,
-				sizeof (r_skiplist_node) +
-				kSkipListDepth * sizeof (r_skiplist_node*))) == NULL) {
+				sizeof (RSkipListNode) +
+				kSkipListDepth * sizeof (RSkipListNode*))) == NULL) {
 		eprintf ("can't init skiplist...");
 		return NULL;
 	}
@@ -34,12 +34,25 @@ R_API r_skiplist* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
 	return list;
 }
 
+// Remove all elements from the list
+R_API void r_skiplist_purge(RSkipList *list) {
+	if (!list) return;
+	// TODO: implement me
+}
+
+// Free the entire list and it's element (if freefn is specified)
+R_API void r_skiplist_free(RSkipList *list) {
+	if (!list) return;
+	r_skiplist_purge (list);
+	free (list);
+}
+
 // Inserts an element to the skiplist, and returns a pointer to the element's
 // node.
-R_API r_skiplist_node* r_skiplist_insert(r_skiplist* list, void* data) {
+R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
     int i, newLevel;
-    r_skiplist_node *update[kSkipListDepth+1];
-    r_skiplist_node *x;
+    RSkipListNode *update[kSkipListDepth+1];
+    RSkipListNode *x;
 
     x = list->head;
     for (i = list->list_level; i >= 0; i--) {
@@ -62,8 +75,8 @@ R_API r_skiplist_node* r_skiplist_insert(r_skiplist* list, void* data) {
         list->list_level = newLevel;
     }
 
-    if ((x = malloc(sizeof(r_skiplist_node) +
-      newLevel*sizeof(r_skiplist_node *))) == 0) {
+    if ((x = malloc(sizeof(RSkipListNode) +
+      newLevel*sizeof(RSkipListNode *))) == 0) {
         eprintf ("can't even malloc!");
 		return NULL;
     }
@@ -77,9 +90,9 @@ R_API r_skiplist_node* r_skiplist_insert(r_skiplist* list, void* data) {
     return x;
 }
 
-R_API void r_skiplist_delete(r_skiplist* list, void* data) {
+R_API void r_skiplist_delete(RSkipList* list, void* data) {
 	int i;
-	r_skiplist_node *update[kSkipListDepth + 1], *node;
+	RSkipListNode *update[kSkipListDepth + 1], *node;
 
 	// Delete node with data as it's payload.
 	node = list->head;
@@ -112,9 +125,9 @@ R_API void r_skiplist_delete(r_skiplist* list, void* data) {
 	}
 }
 
-R_API r_skiplist_node* r_skiplist_find(r_skiplist* list, void* data) {
+R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data) {
 	int i;
-	r_skiplist_node* node = list->head;
+	RSkipListNode* node = list->head;
 	for (i = list->list_level; i >= 0; i--) {
 		while (node->forward[i] != list->head &&
 				list->compare (node->forward[i]->data, data) < 0) {

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -78,8 +78,8 @@ R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
 		list->list_level = newLevel;
 	}
 
-	if ((x = malloc(sizeof(RSkipListNode) +
-					newLevel*sizeof(RSkipListNode *))) == 0) {
+	x = malloc(sizeof(RSkipListNode) + newLevel*sizeof(RSkipListNode *));
+	if (!x) {
 		eprintf ("can't even malloc!");
 		return NULL;
 	}
@@ -101,7 +101,7 @@ R_API void r_skiplist_delete(RSkipList* list, void* data) {
 	node = list->head;
 	for (i = list->list_level; i >=0; i--) {
 		while (node->forward[i] != list->head &&
-				list->compare (node->forward[i]->data, data) < 1) {
+			list->compare (node->forward[i]->data, data) < 1) {
 			node = node->forward[i];
 		}
 		update[i] = node;
@@ -115,15 +115,14 @@ R_API void r_skiplist_delete(RSkipList* list, void* data) {
 	for (i = 0; i <= list->list_level; i++) {
 		if (update[i]->forward[i] != node) {
 			break;
-		} else {
-			update[i]->forward[i] = node->forward[i];
 		}
+		update[i]->forward[i] = node->forward[i];
 	}
 	free (node);
 
 	// Update the level.
 	while ((list->list_level > 0) &&
-			(list->head->forward[list->list_level] == list->head)) {
+		(list->head->forward[list->list_level] == list->head)) {
 		list->list_level--;
 	}
 }
@@ -133,7 +132,7 @@ R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data) {
 	RSkipListNode* node = list->head;
 	for (i = list->list_level; i >= 0; i--) {
 		while (node->forward[i] != list->head &&
-				list->compare (node->forward[i]->data, data) < 0) {
+			list->compare (node->forward[i]->data, data) < 0) {
 			node = node->forward[i];
 		}
 	}

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -145,7 +145,7 @@ R_API void r_skiplist_delete(RSkipList* list, void* data) {
 		update[i] = node;
 	}
 	node = node->forward[0];
-	if (node == list->head || !list->compare(node->data, data)) {
+	if (node == list->head || list->compare(node->data, data) != 0) {
 		return;
 	}
 

--- a/libr/util/r_skiplist.c
+++ b/libr/util/r_skiplist.c
@@ -52,44 +52,45 @@ R_API void r_skiplist_free(RSkipList *list) {
 // Inserts an element to the skiplist, and returns a pointer to the element's
 // node.
 R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
-    int i, newLevel;
-    RSkipListNode *update[kSkipListDepth+1];
-    RSkipListNode *x;
+	int i, newLevel;
+	RSkipListNode *update[kSkipListDepth+1];
+	RSkipListNode *x;
 
-    x = list->head;
-    for (i = list->list_level; i >= 0; i--) {
-        while (x->forward[i] != list->head
-          && list->compare (x->forward[i]->data, data) < 0)
-            x = x->forward[i];
-        update[i] = x;
-    }
-    x = x->forward[0];
-    if (x != list->head && list->compare(x->data, data) == 0) {
+	x = list->head;
+	for (i = list->list_level; i >= 0; i--) {
+		while (x->forward[i] != list->head
+			&& list->compare (x->forward[i]->data, data) < 0) {
+			x = x->forward[i];
+		}
+		update[i] = x;
+	}
+	x = x->forward[0];
+	if (x != list->head && list->compare(x->data, data) == 0) {
 		return x;
 	}
 
-    for (newLevel = 0; rand() < RAND_MAX/2 && newLevel < kSkipListDepth; newLevel++);
+	for (newLevel = 0; rand() < RAND_MAX/2 && newLevel < kSkipListDepth; newLevel++);
 
-    if (newLevel > list->list_level) {
-        for (i = list->list_level+ 1; i <= newLevel; i++) {
-            update[i] = list->head;
+	if (newLevel > list->list_level) {
+		for (i = list->list_level+ 1; i <= newLevel; i++) {
+			update[i] = list->head;
 		}
-        list->list_level = newLevel;
-    }
+		list->list_level = newLevel;
+	}
 
-    if ((x = malloc(sizeof(RSkipListNode) +
-      newLevel*sizeof(RSkipListNode *))) == 0) {
-        eprintf ("can't even malloc!");
+	if ((x = malloc(sizeof(RSkipListNode) +
+					newLevel*sizeof(RSkipListNode *))) == 0) {
+		eprintf ("can't even malloc!");
 		return NULL;
-    }
-    x->data = data;
+	}
+	x->data = data;
 
-    /* update forward links */
-    for (i = 0; i <= newLevel; i++) {
-        x->forward[i] = update[i]->forward[i];
-        update[i]->forward[i] = x;
-    }
-    return x;
+	/* update forward links */
+	for (i = 0; i <= newLevel; i++) {
+		x->forward[i] = update[i]->forward[i];
+		update[i]->forward[i] = x;
+	}
+	return x;
 }
 
 R_API void r_skiplist_delete(RSkipList* list, void* data) {

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -14,7 +14,7 @@ const int kSkipListDepth = 15; // max depth
 RSkipListNode *r_skiplist_node_new (void *data, int level) {
 	RSkipListNode *res = R_NEW (RSkipListNode);
 	if (!res) return NULL;
-	res->forward = R_NEWS (RSkipListNode *, level + 1);
+	res->forward = R_NEWS0 (RSkipListNode *, level + 1);
 	if (!res->forward) goto err_forward;
 	res->data = data;
 	return res;
@@ -32,10 +32,10 @@ void r_skiplist_node_free (RSkipList *list, RSkipListNode *node) {
 	free (node);
 }
 
-void init_head (RSkipList *list) {
+void init_head (RSkipListNode *head) {
 	int i;
 	for (i = 0; i <= kSkipListDepth; i++) {
-		list->head->forward[i] = list->head;
+		head->forward[i] = head;
 	}
 }
 
@@ -73,7 +73,7 @@ R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
 	list->head = r_skiplist_node_new (NULL, kSkipListDepth);
 	if (!list->head) goto err_head;
 
-	init_head (list);
+	init_head (list->head);
 	list->list_level = 0;
 	list->size = 0;
 	list->freefn = freefn;
@@ -97,7 +97,7 @@ R_API void r_skiplist_purge(RSkipList *list) {
 
 		r_skiplist_node_free (list, x);
 	}
-	init_head (list);
+	init_head (list->head);
 	list->size = 0;
 	list->list_level = 0;
 }

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -189,7 +189,7 @@ R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data) {
 	return NULL;
 }
 
-// Add all the elements of `l2` in `l1`.
+// Move all the elements of `l2` in `l1`.
 R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2) {
 	RSkipListNode *it;
 	void *data;
@@ -197,13 +197,15 @@ R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2) {
 	r_skiplist_foreach (l2, it, data) {
 		r_skiplist_insert (l1, data);
 	}
+
+	r_skiplist_purge (l2);
 }
 
 // Returns the first data element in the list, if present, NULL otherwise
 R_API void *r_skiplist_get_first(RSkipList *list) {
 	if (!list) return NULL;
 	RSkipListNode *res = list->head->forward[0];
-	return res == list->head ? NULL : res;
+	return res == list->head ? NULL : res->data;
 }
 
 // Return true if the list is empty
@@ -212,6 +214,9 @@ R_API bool r_skiplist_empty(RSkipList *list) {
 }
 
 // Return a new allocated RList representing the given `list`
+//
+// NOTE: the data will be shared between the two lists. The user of this
+//       function should choose which list will "own" the data pointers.
 R_API RList *r_skiplist_to_list(RSkipList *list) {
 	RList *res = r_list_new ();
 	RSkipListNode *n;

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -153,7 +153,7 @@ R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
 }
 
 // Delete node with data as it's payload.
-R_API void r_skiplist_delete(RSkipList* list, void* data) {
+R_API bool r_skiplist_delete(RSkipList* list, void* data) {
 	int i;
 	RSkipListNode *update[kSkipListDepth + 1], *x;
 
@@ -161,7 +161,7 @@ R_API void r_skiplist_delete(RSkipList* list, void* data) {
 	x = find_insertpoint (list, data, update);
 	// do nothing if the element is not present in the list
 	if (x == list->head || list->compare(x->data, data) != 0) {
-		return;
+		return false;
 	}
 
 	// update forward links for all `update` points,
@@ -178,6 +178,7 @@ R_API void r_skiplist_delete(RSkipList* list, void* data) {
 		list->list_level--;
 	}
 	list->size--;
+	return true;
 }
 
 R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data) {
@@ -196,4 +197,29 @@ R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2) {
 	r_skiplist_foreach (l2, it, data) {
 		r_skiplist_insert (l1, data);
 	}
+}
+
+// Returns the first data element in the list, if present, NULL otherwise
+R_API void *r_skiplist_get_first(RSkipList *list) {
+	if (!list) return NULL;
+	RSkipListNode *res = list->head->forward[0];
+	return res == list->head ? NULL : res;
+}
+
+// Return true if the list is empty
+R_API bool r_skiplist_empty(RSkipList *list) {
+	return list->size == 0;
+}
+
+// Return a new allocated RList representing the given `list`
+R_API RList *r_skiplist_to_list(RSkipList *list) {
+	RList *res = r_list_new ();
+	RSkipListNode *n;
+	void *data;
+
+	r_skiplist_foreach (list, n, data) {
+		r_list_append (res, data);
+	}
+
+	return res;
 }


### PR DESCRIPTION
Second version of the skip list implementation.
Thanks to @crowell for most of the code :) . Unit tests at https://github.com/radare/radare2-regressions/pull/475 .

This should improve the visual mode (at least on big binaries) and improves the analysis of some binaries, mainly because searching for an element doesn't require iterating over the entire list (so looking for an element and deleting an element is much faster) and the length of the skiplist is O(1). The cost to pay is that insertions will be a little bit slower. All in all, it seems this is not a problem, since for example on /bin/bash analysis takes 5 seconds less than master branch.

