### PR TITLE
Fix collisions in ht.c

### DIFF
--- a/libr/flags/flags.c
+++ b/libr/flags/flags.c
@@ -36,7 +36,6 @@ static void remove_offsetmap(RFlag *f, RFlagItem *item) {
 	if (fs_off) {
 		r_list_delete_data (fs_off, item);
 		if (r_list_empty (fs_off)) {
-			//here we leak memory since data is a List 
 			r_hashtable64_remove (f->ht_off, XOROFF (item->offset));
 		}
 	}


### PR DESCRIPTION
Commit 1652fcc fixed a segfault on quit, which was caused by invalid `r_list_free` call for a static variable `hash_sizes` (actually `deleted_data`, i.e., sentinel variable whose address ht.c uses to mark deleted hashtable entries).
```sh
[def@arch r2bug]% gdb --args r2 segfault.exe
Reading symbols from r2...done.
(gdb) r
Starting program: /usr/local/bin/r2 segfault.exe
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
 -- This is just an existentialist experiment.
[0x004014e0]> q

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff45fbfba in r_list_purge (list=0x7ffff46371a0 <hash_sizes>) at list.c:66
66				RListIter *next = it->n;
(gdb) p it
$1 = (RListIter *) 0x2
(gdb) bt
#0  0x00007ffff45fbfba in r_list_purge (list=0x7ffff46371a0 <hash_sizes>) at list.c:66
#1  0x00007ffff45fc021 in r_list_free (list=0x7ffff46371a0 <hash_sizes>) at list.c:77
#2  0x00007ffff4ccfcfd in r_flag_free (f=0x555555807ca0) at flags.c:108
#3  0x00007ffff7ad70ec in r_core_fini (c=0x55555575ba00 <r>) at core.c:1451
#4  0x0000555555559b7a in main (argc=2, argv=0x7fffffffe8b8, envp=0x7fffffffe8d0) at radare2.c:1000
(gdb) 
```
The bug occurs because `r_flag_free` incorrectly deallocates the hashtable entries (lists) in `core->cflags->ht_off` by calling `r_list_free` for each `entry->data` stored in the table. This works on the assumption that free entries have `entry->data == NULL` which can safely be passed to `r_list_free`. However, ht.c sets `entry->data = &deleted_data` when an entry is deleted from the hashtable, where `deleted_data` is a static variable that throws a segfault if passed to `r_list_free`.

The previous commit 1652fcc attempted to fix this by setting `entry->data = NULL` for deleted entries. Unfortunately, this breaks the hashtable lookup that must be able to distinguish unused entries from deleted entries in order to handle collisions (the search algorithm stops early if it sees a never-used entry).

My proposal is to mark deleted entries with `entry->hash = ~0, entry->data = NULL` so that `r_flag_free` no longer crashes, while ht.c can still distinguish deleted entries from non-empty entries (`entry->data || (entry->hash && entry->hash != ~0)`) and free entries (`!entry->hash && !entry->data`). Note that this approach also adds support for storing NULLs in the hashtable as long as the associated hash value is non-zero; in some peculiar cases, a data structure containing a set of hashes (_hashset_) is useful.