### PR TITLE
Set "options" to 0 when not waiting for threads.

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -314,7 +314,7 @@ static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 	int ret = waitpid (-1, &status, WAIT_ANY); //__WALL);
 #else
 	//eprintf ("waiting on pid %d ...\n", pid);
-	int ret = waitpid (pid, &status, WAIT_ANY); //__WALL);
+	int ret = waitpid (pid, &status, 0);
 #endif // WAIT_ON_ALL_CHILDREN
 	if (ret == -1) {
 		r_sys_perror ("waitpid");


### PR DESCRIPTION
NOTE: The Linux debugger currently doesn't work without this (since baca25dc736b1827dd77d5a8b12a7465bc7a316e).