### PR TITLE
libr/debug: fix native debugger on Linux

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -83,6 +83,12 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 #define DEBUGGER 0
 #endif // ARCH
 
+#ifdef __WALL
+#define WAITPID_FLAGS __WALL
+#else
+#define WAITPID_FLAGS 0
+#endif
+
 #endif /* IF DEBUGGER */
 
 /* begin of debugger code */
@@ -311,10 +317,10 @@ static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 	// XXX: this is blocking, ^C will be ignored
 #ifdef WAIT_ON_ALL_CHILDREN
 	//eprintf ("waiting on all children ...\n");
-	int ret = waitpid (-1, &status, WAIT_ANY); //__WALL);
+	int ret = waitpid (-1, &status, WAITPID_FLAGS);
 #else
 	//eprintf ("waiting on pid %d ...\n", pid);
-	int ret = waitpid (pid, &status, WAIT_ANY); //__WALL);
+	int ret = waitpid (pid, &status, WAITPID_FLAGS);
 #endif // WAIT_ON_ALL_CHILDREN
 	if (ret == -1) {
 		r_sys_perror ("waitpid");


### PR DESCRIPTION
Linux kernel checks for unknown flags passed via the last argument to
waitpid() and fails waitpid() with EINVAL if it encounters one:

From kernel/exit.c:sys_wait4()

	if (options & ~(WNOHANG|WUNTRACED|WCONTINUED|
			__WNOTHREAD|__WCLONE|__WALL))
		return -EINVAL;

This makes it impossible to use debugger on Linux.

WAIT_ANY macro is actually supposed to be used as PID argument to wait
for all children without specifying particular PID.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>