### PR TITLE
Don't print SIGTRAP signals or stops

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -356,7 +356,9 @@ static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 			eprintf ("child received signal %d\n", WTERMSIG (status));
 			reason = R_DEBUG_REASON_SIGNAL;
 		} else if (WIFSTOPPED (status)) {
-			eprintf ("child stopped with signal %d\n", WSTOPSIG (status));
+			if (WSTOPSIG (status) != SIGTRAP) {
+				eprintf ("child stopped with signal %d\n", WSTOPSIG (status));
+			}
 
 			/* this one might be good enough... */
 			dbg->reason.signum = WSTOPSIG (status);

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -74,9 +74,12 @@ int linux_handle_signals (RDebug *dbg) {
 			default:
 				break;
 		}
-		eprintf ("[+] SIGNAL %d errno=%d addr=0x%08"PFMT64x" code=%d ret=%d\n",
-			siginfo.si_signo, siginfo.si_errno,
-			(ut64)siginfo.si_addr, siginfo.si_code, ret);
+		if (dbg->reason.signum != SIGTRAP) {
+			eprintf ("[+] SIGNAL %d errno=%d addr=0x%08"PFMT64x
+				" code=%d ret=%d\n",
+				siginfo.si_signo, siginfo.si_errno,
+				(ut64)siginfo.si_addr, siginfo.si_code, ret);
+		}
 		return true;
 	}
 	return false;


### PR DESCRIPTION
A TRAP signal signifes expected stops for breakpoints and so on. There's no
need to display these as signals or stops since they will be communicated
inside r_debug_bp_hit.