### PR TITLE
Add support for dp and dp* on OpenBSD.

### DIFF
--- a/libr/debug/Makefile
+++ b/libr/debug/Makefile
@@ -5,6 +5,10 @@ DEPS=r_reg r_anal r_bp r_io r_parse r_cons r_syscall r_hash r_flags r_util
 DEPS+=r_socket
 CFLAGS+=-DCORELIB
 
+ifeq ($(OSTYPE),bsd))
+LDFLAGS=-lkvm
+endif
+
 #SDBPATH=../../shlr/sdb/src/
 #SDBLIB=${SDBPATH}/libsdb.a
 #LINK+=${SDBLIB}

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -42,13 +42,14 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 #endif
 
 #elif __BSD__
+#include <sys/sysctl.h>
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <kvm.h>
 #define R_DEBUG_REG_T struct reg
 #include "native/procfs.h"
 #if __KFBSD__
-#include <sys/sysctl.h>
 #include <sys/user.h>
 #endif
 #include "native/procfs.h"
@@ -430,7 +431,7 @@ static RList *r_debug_native_pids (int pid) {
 			if (p) r_list_append (list, p);
 		}
 	}
-#else
+#elif __linux__
 	int i;
 	char *ptr, buf[1024];
 
@@ -505,6 +506,34 @@ static RList *r_debug_native_pids (int pid) {
 			r_list_append (list, r_debug_pid_new (buf, i, 's', 0));
 		}
 	}
+#else /* rest is BSD */
+	struct kinfo_proc* kp;
+	int cnt = 0;
+	kvm_t* kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, NULL);
+	if (kd == NULL)
+		return NULL;
+
+	if (pid) {
+		kp = kvm_getprocs(kd, KERN_PROC_PID, pid, sizeof(*kp), &cnt);
+		if (cnt == 1) {
+			RDebugPid *p = r_debug_pid_new (kp->p_comm, pid, 's', 0);
+			if (p) r_list_append (list, p);
+			/* we got our processes, now fetch the parent process */
+			kp = kvm_getprocs(kd, KERN_PROC_PID, kp->p_ppid, sizeof(*kp), &cnt);
+                        if (cnt == 1) {
+				RDebugPid *p = r_debug_pid_new (kp->p_comm, kp->p_pid, 's', 0);
+				if (p) r_list_append (list, p);
+			}
+		}
+	} else {
+		kp = kvm_getprocs(kd, KERN_PROC_UID, geteuid(), sizeof(*kp), &cnt);
+		int i;
+		for (i = 0; i < cnt; i++) {
+			RDebugPid *p = r_debug_pid_new ((kp+i)->p_comm, (kp+i)->p_pid, 's', 0);
+			if (p) r_list_append (list, p);
+		}
+	}
+	kvm_close(kd);
 #endif
 	return list;
 }

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -509,27 +509,28 @@ static RList *r_debug_native_pids (int pid) {
 #else /* rest is BSD */
 	struct kinfo_proc* kp;
 	int cnt = 0;
-	kvm_t* kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, NULL);
-	if (kd == NULL)
+	kvm_t* kd = kvm_openfiles (NULL, NULL, NULL, KVM_NO_FILES, NULL);
+	if (!kd) {
 		return NULL;
+	}
 
 	if (pid) {
-		kp = kvm_getprocs(kd, KERN_PROC_PID, pid, sizeof(*kp), &cnt);
+		kp = kvm_getprocs (kd, KERN_PROC_PID, pid, sizeof(*kp), &cnt);
 		if (cnt == 1) {
 			RDebugPid *p = r_debug_pid_new (kp->p_comm, pid, 's', 0);
 			if (p) r_list_append (list, p);
 			/* we got our processes, now fetch the parent process */
-			kp = kvm_getprocs(kd, KERN_PROC_PID, kp->p_ppid, sizeof(*kp), &cnt);
+			kp = kvm_getprocs (kd, KERN_PROC_PID, kp->p_ppid, sizeof(*kp), &cnt);
                         if (cnt == 1) {
 				RDebugPid *p = r_debug_pid_new (kp->p_comm, kp->p_pid, 's', 0);
 				if (p) r_list_append (list, p);
 			}
 		}
 	} else {
-		kp = kvm_getprocs(kd, KERN_PROC_UID, geteuid(), sizeof(*kp), &cnt);
+		kp = kvm_getprocs (kd, KERN_PROC_UID, geteuid(), sizeof(*kp), &cnt);
 		int i;
 		for (i = 0; i < cnt; i++) {
-			RDebugPid *p = r_debug_pid_new ((kp+i)->p_comm, (kp+i)->p_pid, 's', 0);
+			RDebugPid *p = r_debug_pid_new ((kp + i)->p_comm, (kp + i)->p_pid, 's', 0);
 			if (p) r_list_append (list, p);
 		}
 	}


### PR DESCRIPTION
kvm_getprocs exists on Net and Free as well so it might work there as well

With this we can do:

```
$ r2 -d /bin/ls 
[ ... ]
[0x28a410037f0]> dp
Selected: 77048 77048
 * 77048 s ls
 - 90387 s radare2
[0x28a410037f0]> 

[0x28a410037f0]> dp*
 - 97712 s ksh
 - 77350 s xterm
 * 77048 s ls
 - 90387 s radare2
 - 58861 s ssh
 - 18250 s ksh
 - 83988 s xterm
 - 31464 s ksh
 - 78940 s xterm
 - 94112 s sh
[ .. snip ... ]
[0x28a410037f0]> 
```