### PR TITLE
Make dm work on OpenBSD by adding a native r_debug_native_map_alloc()

### DIFF
--- a/libr/debug/map.c
+++ b/libr/debug/map.c
@@ -154,9 +154,10 @@ R_API void r_debug_map_list_visual(RDebug *dbg, ut64 addr, int use_color, int co
 
 R_API RDebugMap *r_debug_map_new(char *name, ut64 addr, ut64 addr_end, int perm, int user) {
 	RDebugMap *map;
-	if (name == NULL || addr >= addr_end) {
+	/* range could be 0k on OpenBSD, it's a honeypot */
+	if (name == NULL || addr > addr_end) {
 		eprintf ("r_debug_map_new: error assert(\
-			%"PFMT64x">=%"PFMT64x")\n", addr, addr_end);
+			%"PFMT64x">%"PFMT64x")\n", addr, addr_end);
 		return NULL;
 	}
 	map = R_NEW0 (RDebugMap);


### PR DESCRIPTION
Note that OpenBSD can have mappings with zero size so relax the assert.

Also note that the protection bits are flipped. Different bit order. Will fix that later.

Before:
```
$ r2 -d /bin/ls                                                                                          $
Process with PID 61308 started...
attach 61308 61308
[p/debug_native.c:910 r_debug_native_map_get] Cannot open '/proc/61308/maps': No such file or directory
[p/debug_native.c:910 r_debug_native_map_get] Cannot open '/proc/61308/maps': No such file or directory
Assuming filepath /bin/ls
asm.bits 64
[p/debug_native.c:910 r_debug_native_map_get] Cannot open '/proc/61308/maps': No such file or directory
 -- prove you are a robot to continue ...
[0x51435c037f0]> dm
[p/debug_native.c:910 r_debug_native_map_get] Cannot open '/proc/61308/maps': No such file or directory
[0x51435c037f0]>
```
After:
```
$ r2 -d /bin/ls
Process with PID 7719 started...
attach 7719 7719
bin.baddr 0x1ea8ebc00000
Assuming filepath /bin/ls
asm.bits 64
 -- THE CAKE IS A PIE
[0x1ea8ebc037f0]> dm
sys 0000 0x0000000000001000 - 0x0000000000001000 s ---- ?
sys 224K 0x00001ea8ebc00000 * 0x00001ea8ebc38000 s -r-x ?
sys 032K 0x00001ea8ebd38000 - 0x00001ea8ebd40000 s ---x ?
sys 0000 0x00001ea8ebe00000 - 0x00001ea8ebe00000 s ---- ?
sys 004K 0x00001ea8ebe40000 - 0x00001ea8ebe41000 s --wx ?
sys 004K 0x00001ea8ebf40000 - 0x00001ea8ebf41000 s --wx ?
sys 008K 0x00001ea8ec040000 - 0x00001ea8ec042000 s --wx ?
sys 004K 0x00001ea8ec042000 - 0x00001ea8ec043000 s --wx ?
sys 040K 0x00001ea8ec043000 - 0x00001ea8ec04d000 s --wx ?
sys 0000 0x00001eaaebe00000 - 0x00001eaaebe00000 s ---- ?
sys 004K 0x00001eabbe75c000 - 0x00001eabbe75d000 s -r-x ?
sys 028M 0x00007f7ffdfea000 - 0x00007f7fffbea000 s ---- ?
sys 4.0M 0x00007f7fffbea000 - 0x00007f7ffffe0000 s --wx ?
sys 040K 0x00007f7ffffe0000 - 0x00007f7ffffea000 s --wx ?
[0x1ea8ebc037f0]>
```
