### PR TITLE
kvm_openfiles can fail so make sure we print the error message.

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -528,7 +528,7 @@ static RList *r_debug_native_pids (int pid) {
 	int cnt = 0;
 	kvm_t* kd = kvm_openfiles (NULL, NULL, NULL, KVM_OPEN_FLAG, &errbuf);
 	if (!kd) {
-		r_sys_perror("kvm_openfiles says %s\n", errbuf);
+		eprintf ("kvm_openfiles says %s\n", errbuf);
 		return NULL;
 	}
 


### PR DESCRIPTION
On OpenBSD you can use the kvm interface without /dev/kmem access but on FreeBSD
you need root or kmem access which one do not want to give a user.

Look at ps(1) on FreeBSD and see how they do it.