### PR TITLE
Refactor nz assembler 

### DIFF
--- a/libr/asm/p/Makefile
+++ b/libr/asm/p/Makefile
@@ -3,8 +3,8 @@ include ../../../mk/platform.mk
 
 CFLAGS+=-I$(TOP)/shlr -I../../include -I../arch/ -I../arch/include
 CFLAGS+=-Wall -shared ${PIC_CFLAGS} ${LDFLAGS_LIB} ${LDFLAGS_LINKPATH}..
-LDFLAGS+=-L../../util -L../../lib
-LDFLAGS+=${LINK} -lr_util
+LDFLAGS+=-L../../util -L../../lib -L../../flags
+LDFLAGS+=${LINK} -lr_flags -lr_util
 
 CURDIR=
 

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1,209 +1,1952 @@
 /* Copyright (C) 2008-2016 - pancake */
 
+#include <r_flags.h>
+#include <r_core.h>
 #include <r_asm.h>
 #include <r_lib.h>
 #include <r_types.h>
 #include <stdio.h>
 #include <string.h>
 
-static int getnum(RAsm *a, const char *s);
-static int isnum(RAsm *a, const char *str);
-static ut8 getreg(const char *s);
-#if 0
-TODO
-	mov [esp+4], N
-	mov [esp+4], reg
-BLA:
-	Add support for AND, OR, ..
-        0x100000ec5    1    4883e4f0         and rsp, 0xfffffffffffffff0
-#endif
+static ut64 getnum(RAsm *a, const char *s);
 
-static int getnum(RAsm *a, const char *s) {
+#define ENCODING_SHIFT 0
+#define OPTYPE_SHIFT   6
+#define REGMASK_SHIFT  16
+#define OPSIZE_SHIFT   24
+
+// How to encode the operand?
+#define OT_REGMEM      (1 << (ENCODING_SHIFT + 0))
+#define OT_SPECIAL     (1 << (ENCODING_SHIFT + 1))
+#define OT_IMMEDIATE   (1 << (ENCODING_SHIFT + 2))
+#define OT_JMPADDRESS  (1 << (ENCODING_SHIFT + 3))
+
+// Register indices - by default, we allow all registers
+#define OT_REGALL   (0xff << REGMASK_SHIFT)
+
+// Memory or register operands: how is the operand written in assembly code?
+#define OT_MEMORY      (1 << (OPTYPE_SHIFT + 0))
+#define OT_CONSTANT    (1 << (OPTYPE_SHIFT + 1))
+#define OT_GPREG      ((1 << (OPTYPE_SHIFT + 2)) | OT_REGALL)
+#define OT_SEGMENTREG ((1 << (OPTYPE_SHIFT + 3)) | OT_REGALL)
+#define OT_FPUREG     ((1 << (OPTYPE_SHIFT + 4)) | OT_REGALL)
+#define OT_MMXREG     ((1 << (OPTYPE_SHIFT + 5)) | OT_REGALL)
+#define OT_XMMREG     ((1 << (OPTYPE_SHIFT + 6)) | OT_REGALL)
+#define OT_CONTROLREG ((1 << (OPTYPE_SHIFT + 7)) | OT_REGALL)
+#define OT_DEBUGREG   ((1 << (OPTYPE_SHIFT + 8)) | OT_REGALL)
+#define OT_SREG       ((1 << (OPTYPE_SHIFT + 9)) | OT_REGALL)
+// more?
+
+#define OT_REGTYPE    ((OT_GPREG | OT_SEGMENTREG | OT_FPUREG | OT_MMXREG | OT_XMMREG | OT_CONTROLREG | OT_DEBUGREG) & ~OT_REGALL)
+
+// Register mask
+#define OT_REG(num)  ((1 << (REGMASK_SHIFT + (num))) | OT_REGTYPE)
+
+#define OT_UNKNOWN    (0 << OPSIZE_SHIFT)
+#define OT_BYTE       (1 << OPSIZE_SHIFT)
+#define OT_WORD       (2 << OPSIZE_SHIFT)
+#define OT_DWORD      (4 << OPSIZE_SHIFT)
+#define OT_QWORD      (8 << OPSIZE_SHIFT)
+#define OT_OWORD     (16 << OPSIZE_SHIFT)
+#define OT_TBYTE     (32 << OPSIZE_SHIFT)
+
+// For register operands, we mostl don't care about the size.
+// So let's just set all relevant flags.
+#define OT_FPUSIZE  (OT_DWORD | OT_QWORD | OT_TBYTE)
+#define OT_XMMSIZE  (OT_DWORD | OT_QWORD | OT_OWORD)
+
+// Macros for encoding
+#define OT_REGMEMOP(type)  (OT_##type##REG | OT_MEMORY | OT_REGMEM)
+#define OT_REGONLYOP(type) (OT_##type##REG | OT_REGMEM)
+#define OT_MEMONLYOP       (OT_MEMORY | OT_REGMEM)
+#define OT_MEMIMMOP        (OT_MEMORY | OT_IMMEDIATE)
+#define OT_REGSPECOP(type) (OT_##type##REG | OT_SPECIAL)
+#define OT_IMMOP           (OT_CONSTANT | OT_IMMEDIATE)
+#define OT_MEMADDROP       (OT_MEMORY | OT_IMMEDIATE)
+
+// Some operations are encoded via opcode + spec field
+#define SPECIAL_SPEC 0x00010000
+#define SPECIAL_MASK 0x00000007
+
+typedef enum tokentype_t {
+	TT_EOF,
+	TT_WORD,
+	TT_NUMBER,
+	TT_SPECIAL
+} x86newTokenType;
+
+typedef enum register_t {
+	X86R_UNDEFINED = -1,
+	X86R_EAX = 0, X86R_ECX, X86R_EDX, X86R_EBX, X86R_ESP, X86R_EBP, X86R_ESI, X86R_EDI,
+	X86R_AX = 0, X86R_CX, X86R_DX, X86R_BX, X86R_SP, X86R_BP, X86R_SI, X86R_DI,
+	X86R_AL = 0, X86R_CL, X86R_DL, X86R_BL, X86R_AH, X86R_CH, X86R_DH, X86R_BH,
+	X86R_RAX = 0, X86R_RCX, X86R_RDX, X86R_RBX, X86R_RSP, X86R_RBP, X86R_RSI, X86R_RDI,
+	X86R_CS = 0, X86R_SS, X86R_DS, X86R_ES, X86R_FS, X86R_GS	// Is this the right order?
+} Register;
+
+typedef struct operand_t {
+	ut32 type;
+	st8 sign;
+	union {
+		Register reg;
+		struct {
+			long offset;
+			st8 offset_sign;
+			Register regs[2];
+			int scale[2];
+		};
+		struct {
+			ut64 immediate;
+			bool is_good_flag;
+		};
+	};
+} Operand;
+
+typedef struct Opcode_t {
+	char *mnemonic;
+	ut32 op[3];
+	size_t op_len;
+	ut8 opcode[3];
+	Operand operands[2];
+} Opcode;
+
+static ut8 getsib(const ut8 sib) {
+	if (!sib) {
+		return 0;
+	}
+	return (sib & 0x8) ? 3 : getsib ((sib << 1) | 1) - 1;
+}
+
+static int process_group_1(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int modrm = 0;
+	int mod_byte = 0;
+	int offset = 0;
+	st32 immediate = 0;
+
+	if (a->bits == 64) data[l++] = 0x48;
+
+	if (!strcmp (op.mnemonic, "adc")) {
+		modrm = 2;
+	} else if (!strcmp (op.mnemonic, "add")) {
+		modrm = 0;
+	} else if (!strcmp (op.mnemonic, "or")) {
+		modrm = 1;
+	} else if (!strcmp (op.mnemonic, "and")) {
+		modrm = 4;
+	} else if (!strcmp (op.mnemonic, "xor")) {
+		modrm = 6;
+	} else if (!strcmp (op.mnemonic, "sbb")) {
+		modrm = 3;
+	} else if (!strcmp (op.mnemonic, "sub")) {
+		modrm = 5;
+	} else if (!strcmp (op.mnemonic, "cmp")) {
+		modrm = 7;
+	}
+	immediate = op.operands[1].immediate * op.operands[1].sign;
+
+	if (op.operands[0].type & OT_DWORD ||
+		op.operands[0].type & OT_QWORD) {
+		data[l++] = (op.operands[1].immediate > 127) ? 0x81 : 0x83;
+	} else if (op.operands[0].type & OT_BYTE) {
+		if (immediate > 255 || immediate < -256) {
+			eprintf ("Error: Immediate exceeds bounds\n");
+			return -1;
+		}
+		data[l++] = 0x80;
+	}
+	if (op.operands[0].type & OT_MEMORY) {
+		offset = op.operands[0].offset * op.operands[0].offset_sign;
+		if (op.operands[0].offset || op.operands[0].regs[0] == X86R_EBP) {
+			mod_byte = 1;
+		}
+		if (offset < ST8_MIN || offset > ST8_MAX) {
+			mod_byte = 2;
+		}
+		data[l++] = mod_byte << 6 | modrm << 3 | op.operands[0].regs[0];
+
+		if (op.operands[0].regs[0] == X86R_ESP) {
+			data[l++] = 0x24;
+		}
+		if (mod_byte) {
+			data[l++] = offset;
+			if (mod_byte == 2) {
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			}
+		}
+	} else {
+		mod_byte = 3;
+		data[l++] = mod_byte << 6 | modrm << 3 | op.operands[0].reg;
+	}
+
+	data[l++] = immediate;
+	if ((immediate > 127 || immediate < -128) && op.operands[0].type & OT_DWORD) {
+		data[l++] = immediate >> 8;
+		data[l++] = immediate >> 16;
+		data[l++] = immediate >> 24;
+	}
+	return l;
+}
+
+static int process_group_2(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int modrm = 0;
+	int mod_byte = 0;
+	int reg0 = 0;
+
+	if (a->bits == 64) {
+		data[l++] = 0x48;
+	}
+
+	if (!strcmp (op.mnemonic, "rol")) {
+		modrm = 0;
+	} else if (!strcmp (op.mnemonic, "ror")) {
+		modrm = 1;
+	} else if (!strcmp (op.mnemonic, "rcl")) {
+		modrm = 2;
+	} else if (!strcmp (op.mnemonic, "rcr")) {
+		modrm = 3;
+	} else if (!strcmp (op.mnemonic, "shl")) {
+		modrm = 4;
+	} else if (!strcmp (op.mnemonic, "shr")) {
+		modrm = 5;
+	} else if (!strcmp (op.mnemonic, "sal")) {
+		modrm = 6;
+	} else if (!strcmp (op.mnemonic, "sar")) {
+		modrm = 7;
+	}
+
+	st32 immediate = op.operands[1].immediate * op.operands[1].sign;
+	if (immediate > 255 || immediate < -128) {
+		eprintf ("Error: Immediate exceeds bounds\n");
+		return -1;
+	}
+
+	if (op.operands[0].type & (OT_DWORD | OT_QWORD)) {
+		if (op.operands[1].type & (OT_GPREG | OT_BYTE)) {
+			data[l++] = 0xd3;
+		} else if (immediate == 1) {
+			data[l++] = 0xd1;
+		} else {
+			data[l++] = 0xc1;
+		}
+	} else if (op.operands[0].type & OT_BYTE) {
+		if (op.operands[1].type & (OT_GPREG | OT_WORD)) {
+			data[l++] = 0xd2;
+		} else if (immediate == 1) {
+			data[l++] = 0xd0;
+		} else {
+			data[l++] = 0xc0;
+		}
+	}
+	if (op.operands[0].type & OT_MEMORY) {
+		reg0 = op.operands[0].regs[0];
+		mod_byte = 0;
+	} else {
+		reg0 = op.operands[0].reg;
+		mod_byte = 3;
+	}
+	data[l++] = mod_byte << 6 | modrm << 3 | reg0;
+	if (immediate != 1 && !(op.operands[1].type & OT_GPREG)) {
+		data[l++] = immediate;
+	}
+	return l;
+}
+
+static int process_1byte_op(RAsm *a, ut8 *data, const Opcode op, int op1) {
+	int l = 0;
+	int mod_byte = 0;
+	int reg = 0;
+	int rm = 0;
+	st32 offset = 0;
+
+	if (a->bits == 64 &&
+		((op.operands[0].type & OT_QWORD) |
+		 (op.operands[1].type & OT_QWORD))) {
+		data[l++] = 0x48;
+	}
+
+	if (op.operands[0].type & OT_MEMORY && op.operands[1].type & OT_REGALL) {
+		if (op.operands[0].type & OT_BYTE && op.operands[1].type & OT_BYTE) {
+			data[l++] = op1;
+		} else if (op.operands[0].type & (OT_DWORD | OT_QWORD) &&
+				   op.operands[1].type & (OT_DWORD | OT_QWORD)) {
+			data[l++] = op1 + 0x1;
+		} else {
+			eprintf ("Error: mismatched operand sizes\n");
+			return -1;
+		}
+		reg = op.operands[1].reg;
+		rm = op.operands[0].regs[0];
+
+		offset = op.operands[0].offset * op.operands[0].offset_sign;
+		if (offset) {
+			mod_byte = 1;
+			if (offset < ST8_MIN || offset > ST8_MAX) {
+				mod_byte = 2;
+			}
+		}
+	} else if (op.operands[0].type & OT_REGALL) {
+		if (op.operands[1].type & OT_MEMORY) {
+			if (op.operands[0].type & OT_BYTE && op.operands[1].type & OT_BYTE) {
+				data[l++] = op1 + 0x2;
+			} else if (op.operands[0].type & (OT_DWORD | OT_QWORD) &&
+					   op.operands[1].type & (OT_DWORD | OT_QWORD)) {
+				data[l++] = op1 + 0x3;
+			} else {
+				eprintf ("Error: mismatched operand sizes\n");
+				return -1;
+			}
+			reg = op.operands[0].reg;
+			rm = op.operands[1].regs[0];
+
+			if (op.operands[1].scale[0] > 1) {
+				if (op.operands[1].regs[1] != X86R_UNDEFINED) {
+					data[l++] = op.operands[0].reg << 3 | 4;
+					data[l++] = getsib (op.operands[1].scale[0]) << 6 |
+										op.operands[1].regs[0] << 3 |
+										op.operands[1].regs[1];
+					return l;
+				}
+				data[l++] = op.operands[0].reg << 3 | 4; // 4 = SIB
+				data[l++] = getsib (op.operands[1].scale[0]) << 6 | op.operands[1].regs[0] << 3 | 5;
+				data[l++] = op.operands[1].offset * op.operands[1].offset_sign;
+				data[l++] = 0;
+				data[l++] = 0;
+				data[l++] = 0;
+				return l;
+			}
+			offset = op.operands[1].offset * op.operands[1].offset_sign;
+			if (offset) {
+				mod_byte = 1;
+				if (offset < ST8_MIN || offset > ST8_MAX) {
+					mod_byte = 2;
+				}
+			}
+
+		} else if (op.operands[1].type & OT_REGALL) {
+			if (op.operands[0].type & OT_BYTE && op.operands[1].type & OT_BYTE) {
+				data[l++] = op1;
+			} else if (op.operands[0].type & OT_DWORD && op.operands[1].type & OT_DWORD) {
+				data[l++] = op1 + 0x1;
+			}
+			if (a->bits == 64) {data[l++] = op1 + 0x1;}
+			mod_byte = 3;
+			reg = op.operands[1].reg;
+			rm = op.operands[0].reg;
+		}
+	}
+	data[l++] = mod_byte << 6 | reg << 3 | rm;
+	if (mod_byte > 0 && mod_byte < 3) {
+		data[l++] = offset;
+		if (mod_byte == 2) {
+			data[l++] = offset >> 8;
+			data[l++] = offset >> 16;
+			data[l++] = offset >> 24;
+		}
+	}
+	return l;
+}
+
+static int opadc(RAsm *a, ut8 *data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x10);
+}
+
+static int opadd(RAsm *a, ut8 *data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x00);
+}
+
+static int opand(RAsm *a, ut8 *data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x20);
+}
+
+static int opcmp(RAsm *a, ut8 *data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x38);
+}
+
+static int opsub(RAsm *a, ut8 *data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x28);
+}
+
+static int opor(RAsm *a, ut8 * data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x08);
+}
+
+static int opxor(RAsm *a, ut8 * data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x30);
+}
+
+static int opsbb(RAsm *a, ut8 *data, const Opcode op) {
+	if (op.operands[1].type & OT_CONSTANT) {
+		return process_group_1 (a, data, op);
+	}
+	return process_1byte_op (a, data, op, 0x18);
+}
+
+static int opbswap(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	if (op.operands[0].type & OT_REGALL) {
+		if (op.operands[0].reg == X86R_UNDEFINED) {
+			return -1;
+		}
+		data[l++] = 0x0f;
+		data[l++] = 0xc8 + op.operands[0].reg;
+	}
+	return l;
+}
+
+static int opcall(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int immediate = 0;
+	int offset = 0;
+	int mod = 0;
+
+	if (op.operands[0].type & OT_GPREG) {
+		if (op.operands[0].reg == X86R_UNDEFINED) {
+			return -1;
+		}
+		data[l++] = 0xff;
+		mod = 3;
+		data[l++] = mod << 6 | 2 << 3 | op.operands[0].reg;
+	} else if (op.operands[0].type & OT_MEMORY) {
+		if (op.operands[0].regs[0] == X86R_UNDEFINED) {
+			return -1;
+		}
+		data[l++] = 0xff;
+		offset = op.operands[0].offset * op.operands[0].offset_sign;
+		if (offset) {
+			mod = 1;
+			if (offset > 127 || offset < -128) {
+				mod = 2;
+			}
+		}
+		data[l++] = mod << 6 | 2 << 3 | op.operands[0].regs[0];
+		if (mod) {
+			data[l++] = offset;
+			if (mod == 2) {
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			}
+		}
+	} else {
+		ut64 instr_offset = a->pc;
+		data[l++] = 0xe8;
+		immediate = op.operands[0].immediate * op.operands[0].sign;
+		immediate -= instr_offset + 5;
+		data[l++] = immediate;
+		data[l++] = immediate >> 8;
+		data[l++] = immediate >> 16;
+		data[l++] = immediate >> 24;
+	}
+	return l;
+}
+
+static int opaam(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int immediate = op.operands[0].immediate * op.operands[0].sign;
+	data[l++] = 0xd4;
+	if (immediate == 0) {
+		data[l++] = 0x0a;
+	} else if (immediate < 256 && immediate > -129) {
+		data[l++] = immediate;
+	}
+	return l;
+}
+
+static int opdec(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	if (op.operands[1].type) {
+		eprintf ("Error: Invalid operands\n");
+		return -1;
+	}
+	if (op.operands[0].type & OT_BYTE) {
+		data[l++] = 0xfe;
+		if (op.operands[0].type & OT_MEMORY) {
+			data[l++] = 0x1 << 3 | op.operands[0].regs[0];
+		} else {
+			data[l++] = 0x19 << 3 | op.operands[0].reg;
+		}
+	} else {
+		if (op.operands[0].type & OT_MEMORY) {
+			data[l++] = 0xff;
+			data[l++] = 0x1 << 3 | op.operands[0].regs[0];
+		} else {
+			if (a->bits == 32) {
+				data[l++] = 0x48 | op.operands[0].reg;
+			} else if (a->bits == 64) {
+				data[l++] = 0x48;
+				data[l++] = 0xff;
+				data[l++] = 0xc8 | op.operands[0].reg;
+			}
+		}
+	}
+	return l;
+}
+
+static int opimul(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int offset = 0;
+	int mod = 0;
+	int base = 0;
+	ut64 immediate = 0;
+
+	if (op.operands[1].type & OT_CONSTANT) {
+		if (op.operands[1].immediate == -1) {
+			eprintf ("Error: Immediate exceeds max\n");
+			return -1;
+		}
+		immediate = op.operands[1].immediate * op.operands[1].sign;
+		if (a->bits == 64 && immediate > UT32_MAX) {
+			data[l++] = 0x48;
+		}
+		if (op.operands[0].type & OT_GPREG) {
+			data[l++] = 0xb8 | op.operands[0].reg;
+			data[l++] = immediate;
+			data[l++] = immediate >> 8;
+			data[l++] = immediate >> 16;
+			data[l++] = immediate >> 24;
+			if (a->bits == 64 && immediate > UT32_MAX) {
+				data[l++] = immediate >> 32;
+				data[l++] = immediate >> 40;
+				data[l++] = immediate >> 48;
+				data[l++] = immediate >> 56;
+			}
+		} else if (op.operands[0].type & OT_MEMORY) {
+			if (op.operands[0].type & OT_DWORD) {
+				data[l++] = 0xc7;
+			} else if (op.operands[0].type & OT_BYTE) {
+				data[l++] = 0xc6;
+			}
+			offset = op.operands[0].offset * op.operands[0].offset_sign;
+			if (offset) {
+				mod = (offset > 128 || offset < 129) ? 0x2 : 0x1;
+			}
+
+			if (op.operands[0].regs[0] == X86R_EBP) {
+				mod = 0x2;
+			}
+			if (op.operands[0].regs[0] == X86R_UNDEFINED) {
+				data[l++] = 0x5;
+				mod = 0x02;
+			} else {
+				data[l++] = mod << 6 | op.operands[0].regs[0];
+			}
+			if (op.operands[0].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+			if (op.operands[0].regs[0] == X86R_EBP && !offset) {
+				data[l++] = 0x00;
+			}
+			if (offset) {data[l++] = offset;}
+			if (mod == 2) {
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			}
+			data[l++] = immediate;
+			if (op.operands[0].type & OT_DWORD) {
+				data[l++] = immediate >> 8;
+				data[l++] = immediate >> 16;
+				data[l++] = immediate >> 24;
+			}
+		}
+	} else if (op.operands[1].type & OT_GPREG &&
+			 !(op.operands[1].type & OT_MEMORY)) {
+		if (a->bits == 64) {
+			data[l++] = 0x48;
+		}
+		offset = op.operands[0].offset * op.operands[0].offset_sign;
+		data[l++] = (op.operands[0].type & OT_BYTE) ? 0x88 : 0x89;
+
+		if (!(op.operands[0].type & OT_MEMORY)) {
+			mod = 0x3;
+			data[l++] = mod << 6 | op.operands[1].reg << 3 | op.operands[0].reg;
+		} else if (op.operands[0].regs[0] == X86R_UNDEFINED) {
+			data[l++] = op.operands[1].reg << 3 | 0x5;
+			data[l++] = offset;
+			data[l++] = offset >> 8;
+			data[l++] = offset >> 16;
+			data[l++] = offset >> 24;
+		} else {
+			if (op.operands[0].type & OT_MEMORY) {
+				if (op.operands[0].regs[1] != X86R_UNDEFINED) {
+					data[l++] = op.operands[1].reg << 3 | 0x4;
+					data[l++] = op.operands[0].regs[1] << 3 | op.operands[0].regs[0];
+					return l;
+				}
+				if (offset) {
+					mod = (offset > 128 || offset < 129) ? 0x2 : 0x1;
+				}
+				if (op.operands[0].regs[0] == X86R_EBP) {
+					mod = 0x2;
+				}
+				data[l++] = mod << 6 | op.operands[1].reg << 3 | op.operands[0].regs[0];
+				if (op.operands[0].regs[0] == X86R_ESP) {
+					data[l++] = 0x24;
+				}
+				if (offset) {
+					data[l++] = offset;
+					}
+				if (mod == 2) {
+					data[l++] = offset >> 8;
+					data[l++] = offset >> 16;
+					data[l++] = offset >> 24;
+				}
+			}
+		}
+	} else if (op.operands[1].type & OT_MEMORY) {
+		if (a->bits == 64 && !(op.operands[1].regs[0] == X86R_RBP)) {
+			data[l++] = 0x48;
+		}
+		offset = op.operands[1].offset * op.operands[1].offset_sign;
+		data[l++] = (op.operands[1].type & OT_BYTE ||
+					 op.operands[0].type & OT_BYTE) ? 0x8a : 0x8b;
+		if (op.operands[1].regs[0] == X86R_UNDEFINED) {
+			data[l++] = op.operands[0].reg << 3 | 0x5;
+			data[l++] = offset;
+			data[l++] = offset >> 8;
+			data[l++] = offset >> 16;
+			data[l++] = offset >> 24;
+		} else {
+			if (op.operands[1].scale[0] > 1) {
+				data[l++] = op.operands[0].reg << 3 | 4;
+
+				if (op.operands[1].scale[0] > 2) {
+					base = 5;
+				}
+				if (base) {
+					data[l++] = getsib (op.operands[1].scale[0]) << 6 |
+										op.operands[1].regs[0] << 3 | base;
+				} else {
+					data[l++] = getsib (op.operands[1].scale[0]) << 3 |
+										op.operands[1].regs[0];
+				}
+				if (offset || base) {
+					data[l++] = offset;
+					data[l++] = offset >> 8;
+					data[l++] = offset >> 16;
+					data[l++] = offset >> 24;
+				}
+				return l;
+			}
+			if (op.operands[1].regs[1] != X86R_UNDEFINED) {
+				data[l++] = op.operands[0].reg << 3 | 0x3;
+				data[l++] = op.operands[1].regs[0] << 3 | op.operands[1].regs[1];
+				return l;
+			}
+
+			if (offset || op.operands[1].regs[0] == X86R_EBP) {
+				mod = 0x2;
+			}
+			if (a->bits == 64 && offset) {
+				if (offset < 128) {
+					mod = 0x1;
+				}
+			}
+			data[l++] = mod << 6 | op.operands[0].reg << 3 | op.operands[1].regs[0];
+			if (op.operands[1].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+			if (mod == 0x2) {
+				data[l++] = offset;
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			} else if (a->bits == 64 && offset) {
+				data[l++] = offset;
+			}
+		}
+	}
+	return l;
+}
+
+static int opin(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	st32 immediate = 0;
+	if (op.operands[1].reg == X86R_DX) {
+		if (op.operands[0].reg == X86R_AL &&
+			op.operands[0].type & OT_BYTE) {
+			data[l++] = 0xec;
+			return l;
+		}
+		if (op.operands[0].reg == X86R_AX &&
+			op.operands[0].type & OT_WORD) {
+			data[l++] = 0x66;
+			data[l++] = 0xed;
+			return l;
+		}
+		if (op.operands[0].reg == X86R_EAX &&
+			op.operands[0].type & OT_DWORD) {
+			data[l++] = 0xed;
+			return l;
+		}
+	} else if (op.operands[1].type & OT_CONSTANT) {
+		immediate = op.operands[1].immediate * op.operands[1].sign;
+		if (immediate > 255 || immediate < -128) {
+			return -1;
+		}
+		if (op.operands[0].reg == X86R_AL &&
+			op.operands[0].type & OT_BYTE) {
+			data[l++] = 0xe4;
+		} else if (op.operands[0].reg == X86R_AX &&
+				   op.operands[0].type & OT_BYTE) {
+			data[l++] = 0x66;
+			data[l++] = 0xe5;
+		} else if (op.operands[0].reg == X86R_EAX &&
+				   op.operands[0].type & OT_DWORD) {
+			data[l++] = 0xe5;
+		}
+		data[l++] = immediate;
+	}
+	return l;
+}
+
+static int opinc(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	if (a->bits == 64) {
+		if (op.operands[0].type & OT_GPREG) {
+			data[l++] = 0x48;
+			data[l++] = 0xff;
+			data[l++] = 0xc0 | op.operands[0].reg;
+		}
+		return l;
+	}
+	if (op.operands[0].type & OT_REGALL) {
+		if (op.operands[0].type & OT_BYTE) {
+			data[l++] = 0xfe;
+			data[l++] = 0xc0 | op.operands[0].reg;
+		} else {
+			data[l++] = 0x40 | op.operands[0].reg;
+		}
+	} else {
+		if (op.operands[0].type & OT_BYTE) {
+			data[l++] = 0xfe;
+		} else {
+			data[l++] = 0xff;
+		}
+		data[l++] = op.operands[0].regs[0];
+	}
+	return l;
+}
+
+static int opint(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	if (op.operands[0].type & OT_CONSTANT) {
+		st32 immediate = op.operands[0].immediate * op.operands[0].sign;
+		if (immediate <= 255 && immediate >= -128) {
+			data[l++] = 0xcd;
+			data[l++] = immediate;
+		}
+	}
+	return l;
+}
+
+static int opjc(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	ut64 instr_offset = a->pc;
+	int immediate = op.operands[0].immediate * op.operands[0].sign;
+	if (!strcmp (op.mnemonic, "jmp")) {
+		if (op.operands[0].type & OT_GPREG) {
+			data[l++] = 0xff;
+			data[l++] = 0xe0 | op.operands[0].reg;
+		} else {
+			immediate -= instr_offset;
+			if (-0x80 <= (immediate - 2) && (immediate - 2) <= 0x7f) {
+					/* relative byte address */
+					data[l++] = 0xeb;
+					data[l++] = immediate - 2;
+				} else {
+					/* relative address */
+					immediate -= 5;
+					data[l++] = 0xe9;
+					data[l++] = immediate;
+					data[l++] = immediate >> 8;
+					data[l++] = immediate >> 16;
+					data[l++] = immediate >> 24;
+				}
+		}
+		return l;
+	}
+	immediate -= 6;
+	data[l++] = 0x0f;
+	if (!strcmp (op.mnemonic, "ja") ||
+		!strcmp (op.mnemonic, "jnbe")) {
+		data[l++] = 0x87;
+	} else if (!strcmp (op.mnemonic, "jae") ||
+			   !strcmp (op.mnemonic, "jnb") ||
+			   !strcmp (op.mnemonic, "jnc")) {
+		data[l++] = 0x83;
+	} else if (!strcmp (op.mnemonic, "jz") ||
+			   !strcmp (op.mnemonic, "je")) {
+		data[l++] = 0x84;
+	} else if (!strcmp (op.mnemonic, "jb") ||
+			   !strcmp (op.mnemonic, "jnae") ||
+			   !strcmp (op.mnemonic, "jc")) {
+		data[l++] = 0x82;
+	} else if (!strcmp (op.mnemonic, "jbe") ||
+			   !strcmp (op.mnemonic, "jna")) {
+		data[l++] = 0x86;
+	} else if (!strcmp (op.mnemonic, "jg")) {
+		data[l++] = 0x8f;
+	} else if (!strcmp (op.mnemonic, "jge") ||
+			   !strcmp (op.mnemonic, "jnl")) {
+		data[l++] = 0x8d;
+	} else if (!strcmp (op.mnemonic, "jl") ||
+			   !strcmp (op.mnemonic, "jnge")) {
+		data[l++] = 0x8c;
+	} else if (!strcmp (op.mnemonic, "jle") ||
+			   !strcmp (op.mnemonic, "jng")) {
+		data[l++] = 0x8e;
+	} else if (!strcmp (op.mnemonic, "jne") ||
+			   !strcmp (op.mnemonic, "jnz")) {
+		data[l++] = 0x85;
+	} else if (!strcmp (op.mnemonic, "jno")) {
+		data[l++] = 0x81;
+	} else if (!strcmp (op.mnemonic, "jnp")) {
+		data[l++] = 0x8b;
+	} else if (!strcmp (op.mnemonic, "jns")) {
+		data[l++] = 0x89;
+	} else if (!strcmp (op.mnemonic, "jo")) {
+		data[l++] = 0x80;
+	} else if (!strcmp (op.mnemonic, "jp") ||
+			!strcmp(op.mnemonic, "jpe")) {
+		data[l++] = 0x8a;
+	} else if (!strcmp (op.mnemonic, "js") ||
+			   !strcmp (op.mnemonic, "jz") ||
+			   !strcmp (op.mnemonic, "jpo")) {
+		data[l++] = 0x88;
+	}
+	data[l++] = immediate;
+	data[l++] = immediate >> 8;
+	data[l++] = immediate >> 16;
+	data[l++] = immediate >> 24;
+	return l;
+}
+
+static int oplea(RAsm *a, ut8 *data, const Opcode op){
+	int l =0;
+	int mod = 0;
+	st32 offset = 0;
+	int reg = 0;
+	int rm = 0;
+	if (op.operands[0].type & OT_REGALL &&
+	    op.operands[1].type & OT_MEMORY) {
+		data[l++] = 0x8d;
+		if (op.operands[1].regs[0] == X86R_UNDEFINED) {
+			data[l++] = op.operands[0].reg << 3 | 5;
+			data[l++] = op.operands[1].offset;
+			data[l++] = op.operands[1].offset >> 6;
+			data[l++] = op.operands[1].offset >> 16;
+			data[l++] = op.operands[1].offset >> 24;
+			return l;
+		} else {
+			reg = op.operands[0].reg;
+			rm = op.operands[1].regs[0];
+
+			offset = op.operands[1].offset * op.operands[1].offset_sign;
+			if (offset != 0 || op.operands[1].regs[0] == X86R_EBP) {
+				mod = 1;
+				if (offset >= 128 || offset < -128) {
+					mod = 2;
+				}
+				data[l++] = mod << 6 | reg << 3 | rm;
+				if (op.operands[1].regs[0] == X86R_ESP) {
+					data[l++] = 0x24;
+				}
+				data[l++] = offset;
+				if (mod == 2) {
+					data[l++] = offset >> 8;
+					data[l++] = offset >> 16;
+					data[l++] = offset >> 24;
+				}
+			} else {
+				data[l++] = op.operands[0].reg << 3 | op.operands[1].regs[0];
+				if (op.operands[1].regs[0] == X86R_ESP) {
+					data[l++] = 0x24;
+				}
+			}
+
+		}
+	}
+	return l;
+}
+
+static int oples(RAsm *a, ut8* data, const Opcode op) {
+	int l = 0;
+	int offset = 0;
+	int mod = 0;
+
+	if (op.operands[1].type & OT_MEMORY) {
+		data[l++] = 0xc4;
+		if (op.operands[1].type & OT_GPREG) {
+			offset = op.operands[1].offset * op.operands[1].offset_sign;
+			if (offset) {
+				mod = 1;
+				if (offset > 128 || offset < -128) {
+					mod = 2;
+				}
+			}
+			data[l++] = mod << 6 | op.operands[0].reg << 3 | op.operands[1].regs[0];
+			if (mod) {
+				data[l++] = offset;
+				if (mod > 1) {
+					data[l++] = offset >> 8;
+					data[l++] = offset >> 16;
+					data[l++] = offset >> 24;
+				}
+			}
+		} else {
+			offset = op.operands[1].offset * op.operands[1].offset_sign;
+			data[l++] = 0x05;
+			data[l++] = offset;
+			data[l++] = offset >> 8;
+			data[l++] = offset >> 16;
+			data[l++] = offset >> 24;
+		}
+	}
+	return l;
+}
+
+static int opmov(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int offset = 0;
+	int mod = 0;
+	int base = 0;
+	ut64 immediate = 0;
+	if (op.operands[1].type & OT_CONSTANT) {
+		if (!op.operands[1].is_good_flag) {
+			return -1;
+		}
+		if (op.operands[1].immediate == -1) {
+			eprintf ("Error: Immediate exceeds max\n");
+			return -1;
+		}
+		immediate = op.operands[1].immediate * op.operands[1].sign;
+
+		if (op.operands[0].type & OT_GPREG && !(op.operands[0].type & OT_MEMORY)) {
+			if (a->bits == 64 && ((op.operands[0].type & OT_QWORD) | (op.operands[1].type & OT_QWORD))) {
+				data[l++] = 0x48;
+			}
+			if (op.operands[0].type & OT_BYTE) {
+				data[l++] = 0xb0 | op.operands[0].reg;
+				data[l++] = immediate;
+			} else {
+				if (a->bits == 64 &&
+					((op.operands[0].type & OT_QWORD) |
+					(op.operands[1].type & OT_QWORD)) &&
+					immediate < UT32_MAX) {
+						data[l++] = 0xc7;
+				 		data[l++] = 0xc0 | op.operands[0].reg;
+				} else {
+					data[l++] = 0xb8 | op.operands[0].reg;
+				}
+				data[l++] = immediate;
+				data[l++] = immediate >> 8;
+				data[l++] = immediate >> 16;
+				data[l++] = immediate >> 24;
+				if (a->bits == 64 && immediate > UT32_MAX) {
+					data[l++] = immediate >> 32;
+					data[l++] = immediate >> 40;
+					data[l++] = immediate >> 48;
+					data[l++] = immediate >> 56;
+				}
+			}
+		} else if (op.operands[0].type & OT_MEMORY) {
+			if (a->bits == 64 && !(op.operands[0].type & OT_QWORD)) {
+				data[l++] = 0x67;
+			}
+			if (op.operands[0].type & (OT_DWORD | OT_QWORD)) {
+				data[l++] = 0xc7;
+			} else if (op.operands[0].type & OT_BYTE) {
+				data[l++] = 0xc6;
+			}
+
+			offset = op.operands[0].offset * op.operands[0].offset_sign;
+			if (offset) {
+				mod = (offset > 128 || offset < -129) ? 0x2 : 0x1;
+			}
+
+			//if (op.operands[0].regs[0] == X86R_EBP) mod = 0x2;
+			if (op.operands[0].regs[0] == X86R_UNDEFINED) {
+				data[l++] = 0x5;
+				mod = 0x02;
+			} else {
+				data[l++] = mod << 6 | op.operands[0].regs[0];
+			}
+			if (op.operands[0].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+			if (op.operands[0].regs[0] == X86R_EBP && !offset) {
+				data[l++] = 0x00;
+			}
+			if (offset) {
+				data[l++] = offset;
+			}
+			if (mod == 2) {
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			}
+			data[l++] = immediate;
+			if (op.operands[0].type & (OT_DWORD | OT_QWORD)) {
+				data[l++] = immediate >> 8;
+				data[l++] = immediate >> 16;
+				data[l++] = immediate >> 24;
+			}
+		}
+	} else if (op.operands[1].type & OT_GPREG &&
+			 !(op.operands[1].type & OT_MEMORY)) {
+		if (op.operands[0].type & OT_CONSTANT) {
+			return -1;
+		}
+		if (a->bits == 64) {
+			data[l++] = 0x48;
+		}
+		offset = op.operands[0].offset * op.operands[0].offset_sign;
+		data[l++] = (op.operands[0].type & OT_BYTE) ? 0x88 : 0x89;
+
+		if (!(op.operands[0].type & OT_MEMORY)) {
+			if (op.operands[0].reg == X86R_UNDEFINED ||
+				op.operands[1].reg == X86R_UNDEFINED) {
+				return -1;
+			}
+			mod = 0x3;
+			data[l++] = mod << 6 | op.operands[1].reg << 3 | op.operands[0].reg;
+		} else if (op.operands[0].regs[0] == X86R_UNDEFINED) {
+			data[l++] = op.operands[1].reg << 3 | 0x5;
+			data[l++] = offset;
+			data[l++] = offset >> 8;
+			data[l++] = offset >> 16;
+			data[l++] = offset >> 24;
+		} else {
+			if (op.operands[0].type & OT_MEMORY) {
+				if (op.operands[0].regs[1] != X86R_UNDEFINED) {
+					data[l++] = op.operands[1].reg << 3 | 0x4;
+					data[l++] = op.operands[0].regs[1] << 3 | op.operands[0].regs[0];
+					return l;
+				}
+				if (offset) {
+					mod = (offset > 128 || offset < 129) ? 0x2 : 0x1;
+				}
+				if (op.operands[0].regs[0] == X86R_EBP) {
+					mod = 0x2;
+				}
+				data[l++] = mod << 6 | op.operands[1].reg << 3 | op.operands[0].regs[0];
+				if (op.operands[0].regs[0] == X86R_ESP) {
+					data[l++] = 0x24;
+				}
+				if (offset) {
+					data[l++] = offset;
+				}
+				if (mod == 2) {
+					data[l++] = offset >> 8;
+					data[l++] = offset >> 16;
+					data[l++] = offset >> 24;
+				}
+			}
+		}
+	} else if (op.operands[1].type & OT_MEMORY) {
+		if (a->bits == 64 && !(op.operands[1].regs[0] == X86R_RBP)) {
+			data[l++] = 0x48;
+		}
+		offset = op.operands[1].offset * op.operands[1].offset_sign;
+		data[l++] = (op.operands[1].type & OT_BYTE ||
+					op.operands[0].type & OT_BYTE) ?
+					0x8a : 0x8b;
+		if (op.operands[1].regs[0] == X86R_UNDEFINED) {
+			data[l++] = op.operands[0].reg << 3 | 0x5;
+			data[l++] = offset;
+			data[l++] = offset >> 8;
+			data[l++] = offset >> 16;
+			data[l++] = offset >> 24;
+		} else {
+			if (op.operands[1].scale[0] > 1) {
+				data[l++] = op.operands[0].reg << 3 | 4;
+
+				if (op.operands[1].scale[0] > 2) {
+					base = 5;
+				}
+				if (base) {
+					data[l++] = getsib (op.operands[1].scale[0]) << 6 | op.operands[1].regs[0] << 3 | base;
+				} else {
+					data[l++] = getsib (op.operands[1].scale[0]) << 3 | op.operands[1].regs[0];
+				}
+				if (offset || base) {
+					data[l++] = offset;
+					data[l++] = offset >> 8;
+					data[l++] = offset >> 16;
+					data[l++] = offset >> 24;
+				}
+				return l;
+			}
+			if (op.operands[1].regs[1] != X86R_UNDEFINED) {
+				data[l++] = op.operands[0].reg << 3 | 0x3;
+				data[l++] = op.operands[1].regs[0] << 3 | op.operands[1].regs[1];
+				return l;
+			}
+
+			if (offset || op.operands[1].regs[0] == X86R_EBP) {
+				mod = 0x2;
+			}
+			if (a->bits == 64 && offset) {
+				if (offset < 128) {
+					mod = 0x1;
+				}
+			}
+			data[l++] = mod << 6 | op.operands[0].reg << 3 | op.operands[1].regs[0];
+			if (op.operands[1].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+			if (mod == 0x2) {
+				data[l++] = offset;
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			} else if (a->bits == 64 && offset) {
+				data[l++] = offset;
+			}
+		}
+	}
+	return l;
+}
+
+static int oppop(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int offset = 0;
+	int mod = 0;
+	if (op.operands[0].type & OT_GPREG) {
+		ut8 base = 0x58;
+		data[l++] = base + op.operands[0].reg;
+	} else if (op.operands[0].type & OT_MEMORY) {
+		data[l++] = 0x8f;
+		offset = op.operands[0].offset * op.operands[0].offset_sign;
+		if (offset != 0 || op.operands[0].regs[0] == X86R_EBP) {
+			mod = 1;
+			if (offset >= 128 || offset < -128) {
+				mod = 2;
+			}
+			data[l++] = mod << 6 | op.operands[0].regs[0];
+			if (op.operands[0].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+			data[l++] = offset;
+			if (mod == 2) {
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			}
+		} else {
+			data[l++] = op.operands[0].regs[0];
+			if (op.operands[0].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+		}
+
+	}
+	return l;
+}
+
+static int oppush(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int mod = 0;
+	st32 immediate = 0;;
+	st32 offset = 0;
+	if (op.operands[0].type & OT_GPREG) {
+		ut8 base = 0x50;
+		data[l++] = base + op.operands[0].reg;
+	} else if (op.operands[0].type & OT_MEMORY) {
+		data[l++] = 0xff;
+		offset = op.operands[0].offset * op.operands[0].offset_sign;
+		mod = 0;
+		if (offset != 0 || op.operands[0].regs[0] == X86R_EBP) {
+			mod = 1;
+			if (offset >= 128 || offset < -128) {
+				mod = 2;
+			}
+			data[l++] = mod << 6 | 6 << 3 | op.operands[0].regs[0];
+			if (op.operands[0].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+			data[l++] = offset;
+			if (mod == 2) {
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+			}
+		} else {
+			mod = 3;
+			data[l++] = mod << 4 | op.operands[0].regs[0];
+			if (op.operands[0].regs[0] == X86R_ESP) {
+				data[l++] = 0x24;
+			}
+		}
+	} else {
+		immediate = op.operands[0].immediate * op.operands[0].sign;
+		if (immediate >= 128 || immediate < -128) {
+			data[l++] = 0x68;
+			data[l++] = immediate;
+			data[l++] = immediate >> 8;
+			data[l++] = immediate >> 16;
+			data[l++] = immediate >> 24;
+		} else {
+			data[l++] = 0x6a;
+			data[l++] = immediate;
+		}
+	}
+	return l;
+}
+
+static int opout(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	st32 immediate = 0;
+	if (op.operands[0].reg == X86R_DX) {
+		if (op.operands[1].reg == X86R_AL && op.operands[1].type & OT_BYTE) {
+			data[l++] = 0xec;
+			return l;
+		}
+		if (op.operands[1].reg == X86R_AX && op.operands[1].type & OT_WORD) {
+			data[l++] = 0x66;
+			data[l++] = 0xed;
+			return l;
+		}
+		if (op.operands[1].reg == X86R_EAX && op.operands[1].type & OT_DWORD) {
+			data[l++] = 0xed;
+			return l;
+		}
+	} else if (op.operands[0].type & OT_CONSTANT) {
+		immediate = op.operands[0].immediate * op.operands[0].sign;
+		if (immediate > 255 || immediate < -128) {
+			return -1;
+		}
+		if (op.operands[0].reg == X86R_AL && op.operands[1].type & OT_BYTE) {
+			data[l++] = 0xe6;
+		} else if (op.operands[0].reg == X86R_AX && op.operands[0].type & OT_BYTE) {
+			data[l++] = 0x66;
+			data[l++] = 0xe7;
+		} else if (op.operands[1].reg == X86R_EAX && op.operands[1].type & OT_DWORD) {
+			data[l++] = 0xe7;
+		}
+		data[l++] = immediate;
+	}
+	return l;
+}
+
+static int opret(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int immediate = 0;
+	 if (op.operands[0].type == OT_UNKNOWN) {
+		data[l++] = 0xc3;
+	} else if (op.operands[0].type & (OT_CONSTANT | OT_WORD)) {
+		data[l++] = 0xc2;
+		immediate = op.operands[0].immediate * op.operands[0].sign;
+		data[l++] = immediate;
+		data[l++] = immediate << 8;
+	}
+	return l;
+}
+
+static int opretf(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	st32 immediate = 0;
+	if (op.operands[0].type & OT_CONSTANT) {
+		immediate = op.operands[0].immediate * op.operands[0].sign;
+		data[l++] = 0xca;
+		data[l++] = immediate;
+		data[l++] = immediate >> 8;
+	} else if (op.operands[0].type == OT_UNKNOWN) {
+		data[l++] = 0xcb;
+	}
+	return l;
+}
+
+static int opset(RAsm *a, ut8 *data, const Opcode op) {
+	if (!(op.operands[0].type & (OT_GPREG | OT_BYTE))) {return -1;}
+	int l = 0;
+	int mod = 0;
+	int reg = op.operands[0].regs[0];
+
+	data[l++] = 0x0f;
+	if (!strcmp (op.mnemonic, "seto")) {
+		data[l++] = 0x90;
+	} else if (!strcmp (op.mnemonic, "setno")) {
+		data[l++] = 0x91;
+	} else if (!strcmp (op.mnemonic, "setb") ||
+			  !strcmp (op.mnemonic, "setnae") ||
+			  !strcmp (op.mnemonic, "setc")) {
+		data[l++] = 0x92;
+	} else if (!strcmp (op.mnemonic, "setnb") ||
+			   !strcmp (op.mnemonic, "setae") ||
+			   !strcmp (op.mnemonic, "setnc")) {
+		data[l++] = 0x93;
+	} else if (!strcmp (op.mnemonic, "setz") ||
+			   !strcmp (op.mnemonic, "sete")) {
+		data[l++] = 0x94;
+	} else if (!strcmp (op.mnemonic, "setnz") ||
+			   !strcmp (op.mnemonic, "setne")) {
+		data[l++] = 0x95;
+	} else if (!strcmp (op.mnemonic, "setbe") ||
+			   !strcmp (op.mnemonic, "setna")) {
+		data[l++] = 0x96;
+	} else if (!strcmp (op.mnemonic, "setnbe") ||
+			   !strcmp (op.mnemonic, "seta")) {
+		data[l++] = 0x97;
+	} else if (!strcmp (op.mnemonic, "sets")) {
+		data[l++] = 0x98;
+	} else if (!strcmp (op.mnemonic, "setns")) {
+		data[l++] = 0x99;
+	} else if (!strcmp (op.mnemonic, "setp") ||
+			   !strcmp (op.mnemonic, "setpe")) {
+		data[l++] = 0x9a;
+	} else if (!strcmp (op.mnemonic, "setnp") ||
+			   !strcmp (op.mnemonic, "setpo")) {
+		data[l++] = 0x9b;
+	} else if (!strcmp (op.mnemonic, "setl") ||
+			   !strcmp (op.mnemonic, "setnge")) {
+		data[l++] = 0x9c;
+	} else if (!strcmp (op.mnemonic, "setnl") ||
+			   !strcmp (op.mnemonic, "setge")) {
+		data[l++] = 0x9d;
+	} else if (!strcmp (op.mnemonic, "setle") ||
+			   !strcmp (op.mnemonic, "setng")) {
+		data[l++] = 0x9e;
+	} else if (!strcmp (op.mnemonic, "setnle") ||
+			   !strcmp (op.mnemonic, "setg")) {
+		data[l++] = 0x9f;
+	} else {
+		return -1;
+	}
+	if (!(op.operands[0].type & OT_MEMORY)) {
+		mod = 3;
+		reg = op.operands[0].reg;
+	}
+	data[l++] = mod << 6 | reg;
+	return l;
+}
+
+static int optest(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	if (!op.operands[0].type || !op.operands[1].type) {
+		eprintf ("Error: Invalid operands\n");
+		return -1;
+	}
+	if (a->bits == 64) {
+		data[l++] = 0x48;
+	}
+
+	if (op.operands[1].type & OT_CONSTANT) {
+		if (op.operands[0].type & OT_BYTE) {
+			data[l++] = 0xf6;
+			data[l++] = op.operands[0].regs[0];
+			data[l++] = op.operands[1].reg;
+			return l;
+		}
+		data[l++] = 0xf7;
+		if (op.operands[0].type & OT_MEMORY) {
+			data[l++] = 0x01 | op.operands[0].reg;
+		} else {
+			data[l++] = 0xc0 | op.operands[0].reg;
+		}
+		data[l++] = op.operands[1].reg >> 0;
+		data[l++] = op.operands[1].reg >> 8;
+		data[l++] = op.operands[1].reg >> 16;
+		data[l++] = op.operands[1].reg >> 24;
+		return l;
+	}
+	data[l++] = 0x85;
+	if (op.operands[0].type & OT_MEMORY) {
+		data[l++] = 0x01 | op.operands[1].reg << 3 | op.operands[0].reg;
+	} else {
+		data[l++] = 0xc0 | op.operands[1].reg << 3 | op.operands[0].reg;
+	}
+	return l;
+}
+
+static int opxchg(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int mod_byte = 0;
+	int reg = 0;
+	int rm = 0;
+	st32 offset = 0;
+
+	if (op.operands[0].type & OT_MEMORY || op.operands[1].type & OT_MEMORY) {
+		data[l++] = 0x87;
+		if (op.operands[0].type & OT_MEMORY) {
+			rm = op.operands[0].regs[0];
+			offset = op.operands[0].offset * op.operands[0].offset_sign;
+			reg = op.operands[1].reg;
+		} else if (op.operands[1].type & OT_MEMORY) {
+			rm = op.operands[1].regs[0];
+			offset = op.operands[1].offset * op.operands[1].offset_sign;
+			reg = op.operands[0].reg;
+		}
+		if (offset) {
+			mod_byte = 1;
+			if (offset < ST8_MIN || offset > ST8_MAX) {
+				mod_byte = 2;
+			}
+		}
+	} else {
+		if (op.operands[0].reg == X86R_EAX &&
+			op.operands[1].type & OT_GPREG) {
+			data[l++] = 0x90 + op.operands[1].reg;
+			return l;
+		} else if (op.operands[1].reg == X86R_EAX &&
+				   op.operands[0].type & OT_GPREG) {
+			data[l++] = 0x90 + op.operands[0].reg;
+			return l;
+		} else if (op.operands[0].type & OT_GPREG &&
+				   op.operands[1].type & OT_GPREG) {
+			mod_byte = 3;
+			data[l++] = 0x87;
+			reg = op.operands[1].reg;
+			rm = op.operands[0].reg;
+		}
+	}
+	data[l++] = mod_byte << 6 | reg << 3 | rm;
+	if (mod_byte > 0 && mod_byte < 3) {
+		data[l++] = offset;
+		if (mod_byte == 2) {
+			data[l++] = offset >> 8;
+			data[l++] = offset >> 16;
+			data[l++] = offset >> 24;
+		}
+	}
+	return l;
+}
+
+typedef struct lookup_t {
+	char mnemonic[12];
+	int (*opdo)(RAsm*, ut8*, const Opcode);
+	ut64 opcode;
+	int size;
+} LookupTable;
+
+LookupTable oplookup[] = {
+	{"aaa", NULL, 0x37, 1},
+	{"aad", NULL, 0xd50a, 2},
+	{"aam", opaam, 0},
+	{"aas", NULL, 0x3f, 1},
+	{"adc", &opadc, 0},
+	{"add", &opadd, 0},
+	{"adx", NULL, 0xd4, 1},
+	{"amx", NULL, 0xd5, 1},
+	{"and", &opand, 0},
+	{"bswap", &opbswap, 0},
+	{"call", &opcall, 0},
+	{"cbw", NULL, 0x6698, 2},
+	{"cdq", NULL, 0x99, 1},
+	{"cdqe", NULL, 0x98, 1},
+	{"clc", NULL, 0xf8, 1},
+	{"cld", NULL, 0xfc, 1},
+	{"clgi", NULL, 0x0f01dd, 3},
+	{"cli", NULL, 0xfa, 1},
+	{"clts", NULL, 0x0f06, 2},
+	{"cmc", NULL, 0xf5, 1},
+	{"cmp", &opcmp, 0},
+	{"cmpsb", NULL, 0xa6, 1},
+	{"cmpsd", NULL, 0xa7, 1},
+	{"cmpsw", NULL, 0x66a7, 2},
+	{"cpuid", NULL, 0x0fa2, 2},
+	{"cwd", NULL, 0x6699, 2},
+	{"cwde", NULL, 0x98, 1},
+	{"daa", NULL, 0x27, 1},
+	{"das", NULL, 0x2f, 1},
+	{"dec", &opdec, 0},
+	{"emms", NULL, 0x0f77, 2},
+	{"femms", NULL, 0x0f0e, 2},
+	{"fsin", NULL, 0xd9fe, 2},
+	{"fsincos", NULL, 0xd9fb, 2},
+	{"fwait", NULL, 0x9b, 1},
+	{"getsec", NULL, 0x0f37, 2},
+	{"hlt", NULL, 0xf4, 1},
+	{"imul", &opimul, 0},
+	{"in", &opin, 0},
+	{"inc", &opinc, 0},
+	{"ins", NULL, 0x6d, 1},
+	{"insb", NULL, 0x6c, 1},
+	{"insd", NULL, 0x6d, 1},
+	{"insw", NULL, 0x666d, 2},
+	{"int", &opint, 0},
+	{"int1", NULL, 0xf1, 1},
+	{"int3", NULL, 0xcc, 1},
+	{"into", NULL, 0xce, 1},
+	{"invd", NULL, 0x0f08, 2},
+	{"iret", NULL, 0x66cf, 2},
+	{"iretd", NULL, 0xcf, 1},
+	{"ja", &opjc, 0},
+	{"jae", &opjc, 0},
+	{"jb", &opjc, 0},
+	{"jbe", &opjc, 0},
+	{"je", &opjc, 0},
+	{"jg", &opjc, 0},
+	{"jge", &opjc, 0},
+	{"jl", &opjc, 0},
+	{"jle", &opjc, 0},
+	{"jmp", &opjc, 0},
+	{"jna", &opjc, 0},
+	{"jnae", &opjc, 0},
+	{"jnbe", &opjc, 0},
+	{"jne", &opjc, 0},
+	{"jng", &opjc, 0},
+	{"jnge", &opjc, 0},
+	{"jnl", &opjc, 0},
+	{"jno", &opjc, 0},
+	{"jnp", &opjc, 0},
+	{"jns", &opjc, 0},
+	{"jnz", &opjc, 0},
+	{"jo", &opjc, 0},
+	{"jp", &opjc, 0},
+	{"jpe", &opjc, 0},
+	{"jpo", &opjc, 0},
+	{"js", &opjc, 0},
+	{"jz", &opjc, 0},
+	{"lahf", NULL, 0x9f},
+	{"lea", &oplea, 0},
+	{"leave", NULL, 0xc9, 1},
+	{"les", &oples, 0},
+	{"lfence", NULL, 0x0faee8, 3},
+	{"lodsb", NULL, 0xac, 1},
+	{"lodsd", NULL, 0xad, 1},
+	{"lodsw", NULL, 0x66ad, 2},
+	{"mfence", NULL, 0x0faef0, 3},
+	{"monitor", NULL, 0x0f01c8, 3},
+	{"mov", &opmov, 0},
+	{"movsb", NULL, 0xa4, 1},
+	{"movsd", NULL, 0xa5, 1},
+	{"movsw", NULL, 0x66a5, 2},
+	{"mwait", NULL, 0x0f01c9, 3},
+	{"nop", NULL, 0x90, 1},
+	{"or", &opor, 0},
+	{"out", &opout, 0},
+	{"outsb", NULL, 0x6e, 1},
+	{"outs", NULL, 0x6f, 1},
+	{"outsd", NULL, 0x6f, 1},
+	{"outsw", NULL, 0x666f, 2},
+	{"pop", &oppop, 0},
+	{"popa", NULL, 0x61, 1},
+	{"popad", NULL, 0x61, 1},
+	{"popal", NULL, 0x61, 1},
+	{"popaw", NULL, 0x6661, 2},
+	{"popfd", NULL, 0x9d, 1},
+	{"prefetch", NULL, 0x0f0d, 2},
+	{"push", &oppush, 0},
+	{"pusha", NULL, 0x60, 1},
+	{"pushad", NULL, 0x60, 1},
+	{"pushal", NULL, 0x60, 1},
+	{"pushfd", NULL, 0x9c, 1},
+	{"rcl", &process_group_2, 0},
+	{"rcr", &process_group_2, 0},
+	{"rdmsr", NULL, 0x0f32, 2},
+	{"rdpmc", NULL, 0x0f33, 2},
+	{"rdtsc", NULL, 0x0f31, 2},
+	{"rdtscp", NULL, 0x0f01f9, 3},
+	{"ret", &opret, 0},
+	{"retf", &opretf, 0},
+	{"retw", NULL, 0x66c3, 2},
+	{"rol", &process_group_2, 0},
+	{"ror", &process_group_2, 0},
+	{"rsm", NULL, 0x0faa, 2},
+	{"sahf", NULL, 0x9e, 1},
+	{"sal", &process_group_2, 0},
+	{"salc", NULL, 0xd6, 1},
+	{"sar", &process_group_2, 0},
+	{"sbb", &opsbb, 0},
+	{"scasb", NULL, 0xae, 1},
+	{"scasd", NULL, 0xaf, 1},
+	{"scasw", NULL, 0x66af, 2},
+	{"seto", &opset, 0},
+	{"setno",&opset, 0},
+	{"setb", &opset, 0},
+	{"setnae", &opset, 0},
+	{"setc", &opset, 0},
+	{"setnb", &opset, 0},
+	{"setae", &opset, 0},
+	{"setnc", &opset, 0},
+	{"setz", &opset, 0},
+	{"sete", &opset, 0},
+	{"setnz", &opset, 0},
+	{"setne", &opset, 0},
+	{"setbe", &opset, 0},
+	{"setna", &opset, 0},
+	{"setnbe", &opset, 0},
+	{"seta", &opset, 0},
+	{"sets", &opset, 0},
+	{"setns", &opset, 0},
+	{"setp", &opset, 0},
+	{"setpe", &opset, 0},
+	{"setnp", &opset, 0},
+	{"setpo", &opset, 0},
+	{"setl", &opset, 0},
+	{"setnge", &opset, 0},
+	{"setnl", &opset, 0},
+	{"setge", &opset, 0},
+	{"setle", &opset, 0},
+	{"setng", &opset, 0},
+	{"setnle", &opset, 0},
+	{"setg", &opset, 0},
+	{"sfence", NULL, 0x0faef8, 3},
+	{"shl", &process_group_2, 0},
+	{"shr", &process_group_2, 0},
+	{"stc", NULL, 0xf9, 1},
+	{"std", NULL, 0xfd, 1},
+	{"stgi", NULL, 0x0f01dc, 3},
+	{"sti", NULL, 0xfb, 1},
+	{"stosb", NULL, 0xaa, 1},
+	{"stosd", NULL, 0xab, 1},
+	{"stosw", NULL, 0x66ab, 2},
+	{"sub", &opsub, 0},
+	{"swapgs", NULL, 0x0f1ff8, 3},
+	{"syscall", NULL, 0x0f05, 2},
+	{"sysenter", NULL, 0x0f34, 2},
+	{"sysexit", NULL, 0x0f35, 2},
+	{"sysret", NULL, 0x0f07, 2},
+	{"ud2", NULL, 0x0f0b, 2},
+	{"vmcall", NULL, 0x0f01c1, 3},
+	{"vmlaunch", NULL, 0x0f01c2, 3},
+	{"vmload", NULL, 0x0f01da, 3},
+	{"vmmcall", NULL, 0x0f01d9, 3},
+	{"vmresume", NULL, 0x0f01c3, 3},
+	{"vmrun", NULL, 0x0f01d8, 3},
+	{"vmsave", NULL, 0x0f01db, 3},
+	{"vmxoff", NULL, 0x0f01c4, 3},
+	{"vzeroall", NULL, 0xc5fc77, 3},
+	{"vzeroupper", NULL, 0xc5f877, 3},
+	{"wait", NULL, 0x9b, 1},
+	{"wbinvd", NULL, 0x0f09, 2},
+	{"wrmsr", NULL, 0x0f30, 2},
+	{"xchg", &opxchg, 0},
+	{"xgetbv", NULL, 0x0f01d0, 3},
+	{"xlatb", NULL, 0xd7, 1},
+	{"xor", &opxor, 0},
+	{"xsetbv", NULL, 0x0f01d1, 3},
+	{"test", &optest, 0},
+};
+
+static x86newTokenType getToken(const char *str, size_t *begin, size_t *end) {
+	// Skip whitespace
+	while (isspace ((int)str[*begin]))
+		++(*begin);
+
+	if (!str[*begin]) {                // null byte
+		*end = *begin;
+		return TT_EOF;
+	} else if (isalpha ((int)str[*begin])) {   // word token
+		*end = *begin;
+		while (isalnum ((int)str[*end]))
+			++(*end);
+		return TT_WORD;
+	} else if (isdigit ((int)str[*begin])) {   // number token
+		*end = *begin;
+		while (isalnum ((int)str[*end]))     // accept alphanumeric characters, because hex.
+			++(*end);
+		return TT_NUMBER;
+	} else {                             // special character: [, ], +, *, ...
+		*end = *begin + 1;
+		return TT_SPECIAL;
+	}
+}
+
+/**
+ * Get the register at position pos in str. Increase pos afterwards.
+ */
+static Register parseReg(RAsm *a, const char *str, size_t *pos, ut32 *type) {
+	int i;
+	// Must be the same order as in enum register_t
+	const char *regs[] = { "eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi", NULL };
+	const char *regs8[] = { "al", "cl", "dl", "bl", "ah", "ch", "dh", "bh", NULL };
+	const char *regs16[] = { "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", NULL };
+	const char *regs64[] = { "rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi", NULL };
+	const char *sregs[] = { "es", "cs", "ss", "ds", "fs", "gs", NULL};
+
+	// Get token (especially the length)
+	size_t nextpos, length;
+	const char *token;
+	getToken (str, pos, &nextpos);
+	token = str + *pos;
+	length = nextpos - *pos;
+	*pos = nextpos;
+
+	// General purpose registers
+	if (length == 3 && token[0] == 'e')
+		for (i = 0; regs[i]; i++)
+			if (!strncasecmp (regs[i], token, length)) {
+				*type = (OT_GPREG & OT_REG(i)) | OT_DWORD;
+				return i;
+			}
+	if (length == 2 && (token[1] == 'l' || token[1] == 'h'))
+		for (i = 0; regs8[i]; i++)
+			if (!strncasecmp (regs8[i], token, length)) {
+				*type = (OT_GPREG & OT_REG(i)) | OT_BYTE;
+				return i;
+			}
+	if (length == 2) {
+		for (i = 0; regs16[i]; i++) {
+			if (!strncasecmp (regs16[i], token, length)) {
+				*type = (OT_GPREG & OT_REG(i)) | OT_WORD;
+				return i;
+			}
+		}
+		// This isn't working properly yet
+		for (i = 0; sregs[i]; i++) {
+			if (!strncasecmp (sregs[i], token, length)) {
+				*type = (OT_GPREG & OT_REG(i)) | OT_BYTE;
+				return i;
+			}
+		}
+	}
+	if (token[0] == 'r') {
+		for (i = 0; regs64[i]; i++) {
+			if (!strncasecmp (regs64[i], token, length)) {
+				*type = (OT_GPREG & OT_REG(i)) | OT_QWORD;
+				return i;
+			}
+		}
+	}
+
+	// Numbered registers
+	if (!strncasecmp ("st", token, length)) {
+		*type = (OT_FPUREG & ~OT_REGALL);
+	}
+	if (!strncasecmp ("mm", token, length)) {
+		*type = (OT_MMXREG & ~OT_REGALL);
+	}
+	if (!strncasecmp ("xmm", token, length)) {
+		*type = (OT_XMMREG & ~OT_REGALL);
+	}
+
+	// Now read number, possibly with parantheses
+	if (*type & (OT_FPUREG | OT_MMXREG | OT_XMMREG) & ~OT_REGALL) {
+		Register reg = X86R_UNDEFINED;
+
+		// pass by '(',if there is one
+		if (getToken (str, pos, &nextpos) == TT_SPECIAL && str[*pos] == '(')
+			*pos = nextpos;
+
+		// read number
+		if (getToken (str, pos, &nextpos) != TT_NUMBER ||
+				(reg = getnum (a, str + *pos)) > 7)
+			eprintf ("Too large register index!");
+		*pos = nextpos;
+
+		// pass by ')'
+		if (getToken (str, pos, &nextpos) == TT_SPECIAL && str[*pos] == ')')
+			*pos = nextpos;
+
+		*type |= (OT_REG(reg) & ~OT_REGTYPE);
+		return reg;
+	}
+
+	return X86R_UNDEFINED;
+}
+
+// Parse operand
+static int parseOperand(RAsm *a, const char *str, Operand *op) {
+	size_t pos, nextpos = 0;
+	x86newTokenType last_type;
+	int size_token = 1;
+	bool explicit_size = false;
+	int reg_index = 0;
+	// Reset type
+	op->type = 0;
+
+	// Consume tokens denoting the operand size
+	while (size_token) {
+		pos = nextpos;
+		last_type = getToken (str, &pos, &nextpos);
+
+		// Token may indicate size: then skip
+		if (!strncasecmp (str + pos, "ptr", 3))
+			continue;
+		else if (!strncasecmp (str + pos, "byte", 4)) {
+			op->type |= OT_MEMORY | OT_BYTE;
+			explicit_size = true;
+		} else if (!strncasecmp (str + pos, "word", 4)) {
+			op->type |= OT_MEMORY | OT_WORD;
+			explicit_size = true;
+		} else if (!strncasecmp (str + pos, "dword", 5)) {
+			op->type |= OT_MEMORY | OT_DWORD;
+			explicit_size = true;
+		} else if (!strncasecmp (str + pos, "qword", 5)) {
+			op->type |= OT_MEMORY | OT_QWORD;
+			explicit_size = true;
+		} else if (!strncasecmp (str + pos, "oword", 5)) {
+			op->type |= OT_MEMORY | OT_OWORD;
+			explicit_size = true;
+		} else if (!strncasecmp (str + pos, "tbyte", 5)) {
+			op->type |= OT_MEMORY | OT_TBYTE;
+			explicit_size = true;
+		} else	// the current token doesn't denote a size
+			size_token = 0;
+	}
+
+	// Next token: register, immediate, or '['
+	if (str[pos] == '[') {
+		// Don't care about size, if none is given.
+		if (!op->type) op->type = OT_MEMORY;
+
+		// At the moment, we only accept plain linear combinations:
+		// part := address | [factor *] register
+		// address := part {+ part}*
+		op->offset = op->scale[0] = op->scale[1] = 0;
+
+		ut64 temp = 1;
+		Register reg = X86R_UNDEFINED;
+		while (str[pos] != ']') {
+			pos = nextpos;
+			last_type = getToken (str, &pos, &nextpos);
+
+			if (last_type == TT_SPECIAL) {
+				if (str[pos] == '+' || str[pos] == '-' || str[pos] == ']') {
+					if (reg != X86R_UNDEFINED) {
+						op->regs[reg_index] = reg;
+						op->scale[reg_index] = temp;
+						++reg_index;
+					}
+					else {
+						op->offset += temp;
+						op->regs[reg_index] = X86R_UNDEFINED;
+					}
+
+					temp = 1;
+					reg = X86R_UNDEFINED;
+				}
+				else if (str[pos] == '*') {
+					// go to ], + or - to get scale
+
+					// Something to do here?
+					// Seems we are just ignoring '*' or assuming it implicitly.
+				}
+			}
+			else if (last_type == TT_WORD) {
+				ut32 reg_type = 0;
+
+				// We can't multiply registers
+				if (reg != X86R_UNDEFINED) {
+					op->type = 0;	// Make the result invalid
+				}
+
+				// Reset nextpos: parseReg wants to parse from the beginning
+				nextpos = pos;
+				reg = parseReg (a, str, &nextpos, &reg_type);
+				// Still going to need to know the size if not specified
+				if (!explicit_size) {
+					op->type |= reg_type;
+				}
+				// Addressing only via general purpose registers
+				if (!(reg_type & OT_GPREG)) {
+					op->type = 0;	// Make the result invalid
+				}
+			}
+			else {
+				char *p = strchr (str, '+');
+				op->offset_sign = 1;
+				if (!p) {
+					p = strchr (str, '-');
+					if (p) {
+						op->offset_sign = -1;
+					}
+				}
+				// If there's a scale, we don't want to parse out the
+				// scale with the offset (scale + offset) otherwise the scale
+				// will be the sum of the two. This splits the numbers
+				char *tmp;
+				tmp = malloc (strlen (str + pos) + 1);
+				strcpy (tmp, str + pos);
+				strtok (tmp, "+-");
+				st64 read = getnum (a, tmp);
+				free (tmp);
+				temp *= read;
+			}
+		}
+	} else if (last_type == TT_WORD) {   // register
+		nextpos = pos;
+		RFlagItem *flag;
+		op->reg = parseReg (a, str, &nextpos, &op->type);
+
+		if (op->reg == X86R_UNDEFINED && a->num) {
+			RCore *core = (RCore *)(a->num->userptr);
+			op->is_good_flag = true;
+			if (!(flag = r_flag_get (core->flags, str))) {
+				op->is_good_flag = false;
+				return nextpos;
+			}
+			op->type = OT_CONSTANT;
+			char *p = strchr (str, '-');
+			if (p) {
+				op->sign = -1;
+				str = ++p;
+			}
+			op->immediate = getnum (a, str);
+
+			//if (op->immediate == -1) {op->immediate = 0;}
+		}
+	} else {                             // immediate
+		// We don't know the size, so let's just set no size flag.
+		op->type = OT_CONSTANT;
+		op->sign = 1;
+		char *p = strchr (str, '-');
+		if (p) {
+			op->sign = -1;
+			str = ++p;
+		}
+		op->immediate = getnum (a, str);
+	}
+
+	return nextpos;
+}
+
+static int parseOpcode(RAsm *a, const char *op, Opcode *out) {
+	char *args = strchr (op, ' ');
+	out->mnemonic = args ? r_str_ndup (op, args - op) : strdup (op);
+	out->operands[0].type = out->operands[1].type = 0;
+	out->operands[0].reg = out->operands[0].regs[0] = out->operands[0].regs[1] = X86R_UNDEFINED;
+	out->operands[1].reg = out->operands[1].regs[0] = out->operands[1].regs[1] = X86R_UNDEFINED;
+	out->operands[0].immediate = out->operands[1].immediate = 0;
+	out->operands[0].sign = out->operands[1].sign = 1;
+	out->operands[0].is_good_flag = out->operands[1].is_good_flag = true;
+
+	if (args) {
+		args++;
+	} else {
+		return 1;
+	}
+	parseOperand (a, args, &(out->operands[0]));
+	args = strchr (args, ',');
+	if (args) {
+		args++;
+		parseOperand (a, args, &(out->operands[1]));
+	}
+	return 0;
+}
+
+static ut64 getnum(RAsm *a, const char *s) {
 	if (!s) return 0;
 	if (*s == '$') s++;
 	return r_num_math (a->num, s);
-}
-
-static ut8 getshop(const char *s) {
-	int i;
-	const char *ops =
-		"sar\xf8"
-		"shl\xf0"
-		"shr\xe8"
-		"shl\xe0"
-		"rcr\xd8"
-		"rcl\xd0"
-		"ror\xc8"
-		"rol\xc0";
-	if (strlen (s) < 3)
-		return 0;
-	for (i = 0; i < strlen (ops); i += 4)
-		if (!memcmp (s, ops + i, 3))
-			return (ut8)ops[i + 3];
-	return 0;
-}
-
-static int jop(RAsm *a, ut8 *data, ut8 x, ut8 b, const char *arg) {
-	ut32 dst32;
-	int l = 0;
-	ut64 addr = a->pc;
-	int num = getnum (a, arg);
-	if (!isnum (a, arg))
-		return 0;
-	dst32 = num - addr;
-#if 0
-	d = num - addr; // obey sign
-	if (d>-127 && d<127) {
-		d-=2;
-		data[l++] = a;
-		data[l++] = (char)d;
-		return 2;
-	}
-#endif
-	data[l++] = 0x0f;
-	data[l++] = b;
-	dst32 -= 6;
-	memcpy (data + l, &dst32, 4);
-	return 6;
-}
-
-static int bits8(const char *p) {
-	const char *b8r[] = {"al", "cl", "dl", "bl", NULL};
-	int i;
-	if (strlen (p) == 2)
-		for (i = 0; b8r[i]; i++)
-			if (!strcmp (b8r[i], p))
-				return i;
-	return -1;
-}
-
-static bool is64reg(const char *str) {
-	int i;
-	const char *regs[] = {"r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15", NULL};
-	for (i = 0; regs[i]; i++)
-		if (!strcmp (regs[i], str))
-			return true;
-	return false;
-}
-
-static bool is8bitrex(const char *str) {
-	int i;
-	const char *regs[] = {"spl", "bpl", "sil", "dil", NULL};
-	for (i = 0; regs[i]; i++) {
-		if (!strcmp (regs[i], str))
-			return true;
-	}
-	return false;
-}
-
-static ut8 getreg(const char *str) {
-	int i;
-	const char *regs[] = {"eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi", NULL};
-	const char *regs16[] = {"al", "cl", "dl", "bl", "ah", "ch", "dh", "bh", NULL};
-	const char *regs16_rex[] = {"al", "cl", "dl", "bl", "spl", "bpl", "sil", "dil", NULL};
-	const char *regs64[] = {"rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi", NULL};
-	const char *regs64_2[] = {"r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15", NULL};
-	if (!str)
-		return 0xff;
-	for (i = 0; regs[i]; i++)
-		if (!strncmp (regs[i], str, strlen (regs[i])))
-			return i;
-	for (i = 0; regs64[i]; i++)
-		if (!strncmp (regs64[i], str, strlen (regs64[i])))
-			return i;
-	for (i = 0; regs64_2[i]; i++)
-		if (!strcmp (regs64_2[i], str))
-			return i;
-	for (i = 0; regs16[i]; i++)
-		if (!strncmp (regs16[i], str, strlen (regs16[i])))
-			return i;
-	for (i = 0; regs16_rex[i]; i++)
-		if (!strncmp (regs16_rex[i], str, strlen (regs16_rex[i])))
-			return i;
-	return 0xff;
-}
-
-static ut8 getsib(const ut8 sib) {
-	switch (sib) {
-	case 0:
-	case 1:
-		return 0;
-		break;
-	case 2:
-		return 1;
-		break;
-	case 4:
-		return 2;
-		break;
-	case 8:
-		return 3;
-		break;
-	default:
-		return 0;
-		break;
-	}
-}
-
-// Returns the size of the register in bits.
-static ut8 regsize(const char *str) {
-	int i;
-	const char *regs[] = {"eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi", NULL};
-	const char *regs16[] = {"al", "cl", "dl", "bl", "ah", "ch", "dh", "bh", NULL};
-	const char *regs64[] = {"rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi", NULL};
-	const char *regs64_2[] = {"r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15", NULL};
-	if (!str)
-		return 0xff;
-	for (i = 0; regs[i]; i++)
-		if (!strncmp (regs[i], str, strlen (regs[i])))
-			return 32;
-	for (i = 0; regs64[i]; i++)
-		if (!strncmp (regs64[i], str, strlen (regs64[i])))
-			return 64;
-	for (i = 0; regs64_2[i]; i++)
-		if (!strcmp (regs64_2[i], str))
-			return 64;
-	for (i = 0; regs16[i]; i++)
-		if (!strncmp (regs16[i], str, strlen (regs16[i])))
-			return 16;
-	return 0xff;
-}
-
-static int isnum(RAsm *a, const char *str) {
-	if (r_num_get (a->num, str) != 0)
-		return 1;
-	return str && (*str == '-' || (*str >= '0' && *str <= '9'));
-}
-
-static int hasDword(char *op) {
-	char *arg = strstr (op, "dword ptr");
-	if (arg) {
-		const int dword_len = strlen ("dword ptr");
-		memmove (arg, arg + dword_len, strlen (arg + dword_len) + 1);
-		return 1;
-	}
-	arg = strstr (op, "dword ");
-	if (arg) {
-		const int dword_len = strlen ("dword ");
-		memmove (arg, arg + dword_len, strlen (arg + dword_len) + 1);
-		return 1;
-	}
-	return 0;
-}
-
-static int hasByte(char *op) {
-	char *arg = strstr (op, "byte ptr");
-	if (arg) {
-		const int dword_len = strlen ("byte ptr");
-		memmove (arg, arg + dword_len, strlen (arg + dword_len) + 1);
-		return 1;
-	}
-	arg = strstr (op, "byte ");
-	if (arg) {
-		const int dword_len = strlen ("byte ");
-		memmove (arg, arg + dword_len, strlen (arg + dword_len) + 1);
-		return 1;
-	}
-	return 0;
 }
 
 static int assemble16(RAsm *a, RAsmOp *ao, const char *str) {
@@ -228,1421 +1971,35 @@ static int assemble16(RAsm *a, RAsmOp *ao, const char *str) {
 }
 
 static int assemble(RAsm *a, RAsmOp *ao, const char *str) {
-	int wordsize = 0;
-	ut64 offset = a->pc;
-	ut8 t, *data = ao->buf;
-	char *arg, op[128];
-	int l = 0;
+	ut8 *data = ao->buf;
+	char op[128];
+	LookupTable *lt_ptr;
 
 	if (a->bits == 16) {
 		return assemble16 (a, ao, str);
 	}
-
 	strncpy (op, str, sizeof (op) - 1);
 	op[sizeof (op) - 1] = '\0';
 
-	if (hasDword (op)) wordsize = 4;
-	if (hasByte (op)) wordsize = 1;
+	Opcode instr;
+	parseOpcode (a, op, &instr);
 
-	if (!memcmp (op, "ret ", 4) || !memcmp (op, "retn ", 5)) {
-		int n = getnum (a, op + 4);
-		data[l++] = 0xc2;
-		data[l++] = n & 0xff;
-		data[l++] = (n >> 8) & 0xff;
-		return l;
-	}
-	if (!memcmp (op, "retf ", 5)) {
-		int n = getnum (a, op + 4);
-		data[l++] = 0xca;
-		data[l++] = n & 0xff;
-		data[l++] = (n >> 8) & 0xff;
-		return l;
-	}
-
-	if (!memcmp (op, "rep ", 4)) {
-		data[l++] = 0xf3;
-		memmove (op, op + 4, strlen (op + 4) + 1);
-	}
-
-	if (!strcmp (op, "scasb")) {
-		data[l++] = 0xae;
-		return l;
-	}
-	if (!strcmp (op, "scasw")) {
-		data[l++] = 0x66;
-		return l;
-	}
-	if (!strcmp (op, "scasd")) {
-		data[l++] = 0xaf;
-		return l;
-	}
-
-	if (!strcmp (op, "movsb")) {
-		data[l++] = 0xa4;
-		return l;
-	}
-	if (!strcmp (op, "movsw")) {
-		data[0] = 0x66;
-		data[1] = 0xa5;
-		return 2;
-	}
-	if (!strcmp (op, "movsd")) {
-		data[0] = 0xa5;
-		return 1;
-	}
-	if (!strcmp (op, "outsd")) {
-		data[0] = 0x6f;
-		return 1;
-	}
-	if (!strcmp (op, "outsb")) {
-		data[0] = 0x6e;
-		return 1;
-	}
-	if (!strcmp (op, "insb")) {
-		data[0] = 0x6c;
-		return 1;
-	}
-	if (!strcmp (op, "hlt")) {
-		data[0] = 0xf4;
-		return 1;
-	}
-	if (!strcmp (op, "cpuid")) {
-		data[0] = 0xf;
-		data[1] = 0xa2;
-		return 2;
-	}
-	if (!strcmp (op, "fsincos")) {
-		data[0] = 0xd9;
-		data[1] = 0xfb;
-		return 2;
- 	}
-
-	if (!strcmp (str, "call $$")) {
-		memcpy (data, "\xE8\xFF\xFF\xFF\xFF\xC1", 6);
-		return 6;
-	}
-	if (!strcmp (op, "hang") || !strcmp (str, "jmp $$")) {
-		data[l++] = 0xeb;
-		data[l++] = 0xfe;
-		return l;
-	}
-	if (!strcmp (op, "ud2")) {
-		data[l++] = 0x0f;
-		data[l++] = 0x0b;
-		return l;
-	}
-	if (!strncmp (op, "neg ", 4)) {
-		const char *arg = op + 4;
-		int arg0 = getreg (arg);
-		if (a->bits == 64 && *arg == 'r')
-			data[l++] = 0x48;
-		data[l++] = 0xf7;
-		data[l++] = 0xd8 | arg0;
-		return l;
-	}
-	if (!strcmp (op, "rdtsc")) {
-		data[l++] = 0x0f;
-		data[l++] = 0x31;
-		return l;
-	}
-    if (!strcmp (op, "lfence")) {
-		data[l++] = 0x0f;
-		data[l++] = 0xae;
-        data[l++] = 0xe8;
-		return l;
-	}
-    if (!strcmp (op, "mfence")) {
-		data[l++] = 0x0f;
-		data[l++] = 0xae;
-        data[l++] = 0xf0;
-		return l;
-	}
-    if (!strcmp (op, "sfence")) {
-		data[l++] = 0x0f;
-		data[l++] = 0xae;
-        data[l++] = 0xf8;
-		return l;
-	}
-	if (!strncmp (op, "set", 3)) {
-#if 0
-SETAE/SETNB - Set if Above or Equal / Set if Not Below (386+)
-SETB/SETNAE - Set if Below / Set if Not Above or Equal (386+)
-SETBE/SETNA - Set if Below or Equal / Set if Not Above (386+)
-SETE/SETZ - Set if Equal / Set if Zero (386+)
-SETNE/SETNZ - Set if Not Equal / Set if Not Zero (386+)
-SETL/SETNGE - Set if Less / Set if Not Greater or Equal (386+)
-SETGE/SETNL - Set if Greater or Equal / Set if Not Less (386+)
-SETLE/SETNG - Set if Less or Equal / Set if Not greater or Equal (386+)
-SETG/SETNLE - Set if Greater / Set if Not Less or Equal (386+)
-SETS - Set if Signed (386+)
-SETNS - Set if Not Signed (386+)
-SETC - Set if Carry (386+)
-SETNC - Set if Not Carry (386+)
-SETO - Set if Overflow (386+)
-SETNO - Set if Not Overflow (386+)
-SETP/SETPE - Set if Parity / Set if Parity Even (386+)
-SETNP/SETPO - Set if No Parity / Set if Parity Odd (386+)
-#endif
-		const char *keys[] = {"o ", "no ", "b ", "ae ", "e ", "ne ", "be ", "a ",
-				"s ", "ns ", "p ", "np ", "l ", "ge ", "le ", "g ", NULL};
-		char *tmp;
-		int i, arg0;
-		arg = strchr (op, ' ');
-		if (!arg) {
-			eprintf ("Missing parameter for '%s'\n", op);
-			return -1;
-		} else arg++;
-		tmp = strchr (arg, ' ');
-		if (!tmp) tmp = strchr (arg, '[');
-		if (tmp) {
-			if (*tmp != '[')
-				arg = tmp + 1;
-			else arg = tmp;
-		}
-
-		data[l++] = 0x0f;
-		for (i = 0; keys[i]; i++) {
-			if (!strncmp (op + 3, keys[i], strlen (keys[i]))) {
-				data[l++] = 0x90 | i;
-				break;
+	for (lt_ptr = oplookup; lt_ptr - oplookup < sizeof (oplookup); ++lt_ptr) {
+		if (!strcasecmp (instr.mnemonic, lt_ptr->mnemonic)) {
+			if (lt_ptr->opcode > 0) {
+				ut8 *ptr = (ut8 *)&lt_ptr->opcode;
+				int i = 0;
+				for (; i < lt_ptr->size; i++) {
+					data[i] = ptr[lt_ptr->size - (i + 1)];
+				}
+				return lt_ptr->size;
+			} else {
+				return lt_ptr->opdo (a, data, instr);
 			}
 		}
-		if (l == 1) {
-			eprintf ("Invalid instruction\n");
-			return -1;
-		}
-		if (*arg == '[') {
-			// skip/implicit byte [...]
-			arg0 = getreg (arg + 1);
-			if (arg0 == 4 || arg0 == 5) {
-				eprintf ("Invalid arg for '%s'\n", op);
-				return -1;
-			}
-			data[l++] = arg0;
-		} else {
-			arg0 = getreg (arg);
-			data[l++] = 0xc0 | arg0;
-		}
-		//TODO: verify if (l!=3)
-		return 3;
 	}
-	arg = strchr (op, ' ');
-	if (arg) {
-		*arg = '\0';
-		for (arg++; *arg == ' '; arg++)
-			;
-	}
-	if (arg) {
-		char *arg2 = strchr (arg, ',');
-		if (arg2) {
-			*arg2 = 0;
-			//arg2 = skipspaces (arg2+1);
-			for (arg2++; *arg2 == ' '; arg2++)
-				;
-		}
-		if (!strcmp (op, "xchg")) {
-			if (arg2) {
-				if (*arg == '[' || *arg2 == '[') {
-					eprintf ("xchg with memory access not yet implemented\n");
-				} else {
-					int reg1 = getreg (arg);
-					int reg2 = getreg (arg2);
-					if (reg1 == reg2) {
-						data[l++] = 0x90;
-					} else if (regsize(arg) == 64){
-						// 64 bit reg has a different encoding.
-						data[l++] = 0x48;
-						data[l++] = 0x90 | reg2 | reg1 << 3;
-					} else {
-						data[l++] = 0x87;
-						data[l++] = 0xc0 | reg1 | reg2 << 3;
-					}
-					return l;
-				}
-			} else {
-				eprintf ("xchg expects 2 arguments\n");
-				return 0;
-			}
-		} else if (!strcmp (op, "add")) {
-			int pfx;
-			int N = 1;
-			char *delta;
-			if (*arg == '[') {
-				delta = strchr (++arg, '+');
-				pfx = 0;
-				if (delta) {
-					int n = getnum (a, arg2);
-					int d = getnum (a, delta + 1);
-					int r = getreg (arg);
-					if (d < ST8_MAX && d > ST8_MIN) {
-						data[l++] = 0x83;
-						if (r != 4)
-							data[l++] = 0x40 | r; // XXX: hardcoded
-						else {
-							data[l++] = 0x44;
-							data[l++] = 0x20 | r;
-						}
-						data[l++] = getnum (a, delta + 1);
-						data[l++] = getnum (a, arg2);
-					} else {
-						ut8 *ptr = (ut8 *)&d;
-						data[l++] = 0x83;
-						if (r != 4)
-							data[l++] = 0x80 | r;
-						else {
-							data[l++] = 0x84;
-							data[l++] = 0x20 | r;
-						}
-
-						data[l++] = ptr[0];
-						data[l++] = ptr[1];
-						data[l++] = ptr[2];
-						data[l++] = ptr[3];
-						// XXX: for big numbere here
-						data[l++] = n;
-					}
-					return l;
-				}
-			} else pfx = 0xc0;
-			if (arg2 == NULL) {
-				eprintf ("Invalid syntax\n");
-				return 0;
-			}
-			if (*arg == 'r') {
-				if (a->bits == 64) {
-					data[l++] = 0x48;
-				} else {
-					eprintf ("Error: instruction not supported in 32 bit mode\n");
-					return 0;
-				}
-			}
-			if (*arg2 == 'r' && a->bits != 64) {
-				eprintf ("Error: instruction not supported in 32 bit mode\n");
-				return 0;
-			}
-
-			if (isnum (a, arg2)) {
-				int num = getnum (a, arg2);
-				if (num > 127 || num < -127) {
-					ut8 *ptr = (ut8 *)&num;
-					data[l++] = 0x81;
-					data[l++] = pfx | getreg (arg);
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-				} else {
-					data[l++] = 0x83;
-					data[l++] = pfx | getreg (arg);
-					data[l++] = num;
-				}
-			} else {
-				if (*arg2 == '[') {
-					data[l++] = 0x03;
-					arg2++;
-					delta = strchr (arg2, '+');
-					if (delta) {
-						N = 1;
-						*delta++ = 0;
-					} else {
-						delta = strchr (arg2, '-');
-						if (delta) {
-							N = -1;
-							*delta++ = 0;
-						}
-					}
-					if (delta) {
-						st32 d = r_num_math (NULL, delta) * N;
-						st16 mod_byte = 1;
-						if ((ST8_MIN > d) || (d > ST8_MAX)) {
-							mod_byte = 2;
-						}
-						data[l++] = mod_byte << 6 | getreg (arg) << 3 | getreg (arg2);
-						data[l++] = d;
-						if (mod_byte == 2) {
-							data[l++] = d >> 8;
-							data[l++] = d >> 16;
-							data[l++] = d >> 24;
-						}
-						return l;
-					}
-					data[l++] = getreg (arg2);
-					return l;
-				} else {
-					data[l++] = 0x01;
-				}
-				data[l++] = pfx | getreg (arg2) << 3 | getreg (arg);
-			}
-			return l;
-		} else if (!strcmp (op, "bt")) {
-			data[l++] = 0x0f;
-			if (isnum (a, arg)) {
-				eprintf ("Error: bad operand\n");
-				return -1;
-			}
-			if (isnum (a, arg2)) {
-				int n = getnum (a, arg2);
-				if (n < ST8_MIN || (n > 0 && n > UT8_MAX)) {
-					eprintf ("Error: Immediate exceeds bounds\n");
-					return -1;
-				}
-				data[l++] = 0xba;
-				if (*arg == '[') {
-					arg++;
-					data[l++] = 0x20 | getreg (arg);
-				} else {
-					data[l++] = 0xe0 | getreg (arg);
-				}
-				data[l++] = getnum (a, arg2);
-			} else {
-				data[l++] = 0xa3;
-				if (*arg == '[') {
-					arg++;
-					data[l++] = getreg (arg2) << 3 | getreg (arg);
-				} else {
-					data[l++] = 0x3 << 6 | getreg (arg2) << 3 | getreg (arg);
-				}
-			}
-			return l;
-		} else if (!strcmp (op, "sub")) {
-			int parg0 = 0;
-			int pfx;
-			int N = 1;
-			if (*arg == '[') {
-				char *delta = strchr (arg + 1, '+');
-				if (!delta){
-					delta = strchr (arg + 1, '-');
-					N = -1;
-				}
-				arg++;
-				parg0 = 1;
-				pfx = 0;
-				if (delta) {
-					int n = getnum (a, arg2);
-					int d = getnum (a, delta + 1) * N;
-					int r = getreg (arg);
-					if ((ST8_MIN > n) || (n > ST8_MAX)) {
-						data[l++] = 0x81;
-					} else {
-						data[l++] = 0x83;
-					}
-					if (d < ST8_MAX && d > ST8_MIN) {
-						if (r != 4)
-							data[l++] = 0x68 | r; // XXX: hardcoded
-						else {
-							data[l++] = 0x6C;
-							data[l++] = 0x20 | r;
-						}
-						data[l++] = d;
-					} else {
-						ut8 *ptr = (ut8 *)&d;
-						if (r != 4)
-							data[l++] = 0xA8 | r;
-						else {
-							data[l++] = 0xAC;
-							data[l++] = 0x20 | r;
-						}
-
-						data[l++] = ptr[0];
-						data[l++] = ptr[1];
-						data[l++] = ptr[2];
-						data[l++] = ptr[3];
-					}
-					data[l++] = n;
-					if ((ST8_MIN > n) || (n > ST8_MAX)) {
-						data[l++] = n >> 8;
-						data[l++] = n >> 16;
-						data[l++] = n >> 24;
-					}
-					return l;
-				}
-			} else pfx = 0xc0;
-			if (arg2 == NULL) {
-				eprintf ("Invalid syntax\n");
-				return 0;
-			}
-			if (a->bits == 64)
-				if (*arg == 'r')
-					data[l++] = 0x48;
-			if (isnum (a, arg2)) {
-				int num = getnum (a, arg2);
-				if (num > 127 || num < -127) {
-					ut8 *ptr = (ut8 *)&num;
-					if (parg0) {
-						data[l++] = 0x81;
-						//data[l++] = 0xe8 | getreg (arg);
-						data[l++] = 0x28 | getreg (arg);
-						data[l++] = ptr[0];
-						data[l++] = ptr[1];
-						data[l++] = ptr[2];
-						data[l++] = ptr[3];
-					} else {
-						int r = getreg (arg);
-						if (r == 0) { // eax
-							data[l++] = 0x2d;
-							data[l++] = ptr[0];
-							data[l++] = ptr[1];
-							data[l++] = ptr[2];
-							data[l++] = ptr[3];
-						} else {
-							data[l++] = 0x81;
-							data[l++] = 0xe8 | getreg (arg);
-							data[l++] = ptr[0];
-							data[l++] = ptr[1];
-							data[l++] = ptr[2];
-							data[l++] = ptr[3];
-						}
-					}
-				} else {
-					data[l++] = 0x83;
-					if (parg0) {
-						data[l++] = 0x28 | getreg (arg);
-					} else {
-						data[l++] = 0xe8 | getreg (arg);
-					}
-					data[l++] = getnum (a, arg2);
-				}
-			} else {
-				data[l++] = 0x29;
-				data[l++] = pfx | getreg (arg2) << 3 | getreg (arg);
-			}
-			return l;
-		} else if (!strcmp (op, "cmp")) {
-			int arg0 = getreg (arg);
-			int arg1 = getreg (arg2);
-			if (arg2 == NULL) {
-				eprintf ("Invalid syntax\n");
-				return 0;
-			}
-			if (a->bits == 64)
-				if (*arg == 'r')
-					data[l++] = 0x48;
-			if (*arg2 == '[') {
-				char *p = strchr (arg2 + 1, '+');
-				if (!p) {
-					p = strchr (arg2 + 1, '-');
-				}
-				if (p) {
-					*p = 0;
-					ut32 n = getnum (a, p + 1);
-					ut8 *ptr = (ut8 *)&n;
-					arg1 = getreg (arg2 + 1);
-					data[l++] = 0x3b;
-					if (arg1 == 4) { // esp
-						data[l++] = 0x80 | arg1 | (arg0 << 3);
-						data[l++] = 0x24;
-					} else {
-						data[l++] = 0xb8 | arg1;
-					}
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-
-					return l;
-				} else {
-					eprintf ("unknown cmp\n");
-					return 0;
-				}
-
-				return 0;
-			}
-			if (isnum (a, arg2)) { // reg, num
-				int n = getnum (a, arg2);
-				if (n > 127 || n < -127) {
-					ut8 *ptr = (ut8 *)&n;
-					data[l++] = 0x81;
-					data[l++] = 0xf8 | arg0;
-					//data[l++] = 0x50 | arg0;
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-				} else {
-					data[l++] = 0x83;
-					data[l++] = 0xc0 | arg0 | (arg1 << 3);
-					data[l++] = getnum (a, arg2);
-				}
-				return l;
-			} else // reg, reg
-				if (arg0 != 0xff && arg1 != 0xff) {
-				data[l++] = 0x39;
-				data[l++] = 0xc0 | arg0 | (arg1 << 3);
-				return l;
-			}
-		} else if (!strcmp (op, "test")) {
-			int arg0 = getreg (arg);
-			if (a->bits == 64)
-				if (*arg == 'r')
-					data[l++] = 0x48;
-			data[l++] = 0x85;
-			//data[l++] = 0xc0 | arg0<<3 | getreg (arg2);
-			data[l++] = 0xc0 | getreg (arg2) << 3 | arg0; //getreg (arg2);
-			return l;
-		} else if (!strcmp (op, "int")) {
-			int b = (int)getnum (a, arg);
-			data[l++] = 0xcd;
-			data[l++] = (ut8)b;
-			return l;
-		} else if (!strcmp (op, "call")) {
-			if (arg[0] == '[' && arg[strlen (arg) - 1] == ']') {
-				if (getreg (arg + 4) != 0xff) {
-					eprintf ("Cannot use reg here\n");
-					return -1;
-				}
-				if (!memcmp (arg + 1, "rip", 3)) {
-					ut64 dst = getnum (a, arg + 4);
-					ut32 addr = dst;
-					ut8 *ptr = (ut8 *)&addr;
-					data[l++] = 0xff;
-					data[l++] = 0x1d;
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-					return l;
-				} else {
-					ut64 dst = r_num_math (a->num, arg + 1);
-					ut32 addr = dst;
-					ut8 *ptr = (ut8 *)&addr;
-					if (dst != 0) {
-						data[l++] = 0xff;
-						data[l++] = 0x15;
-						data[l++] = ptr[0];
-						data[l++] = ptr[1];
-						data[l++] = ptr[2];
-						data[l++] = ptr[3];
-						return l;
-					}
-					return -1;
-				}
-			} else {
-				int reg = getreg (arg);
-				if (reg != 0xff) {
-					data[l++] = '\xff';
-					data[l] = getreg (arg) | 0xd0;
-					if (data[l] == 0xff)
-						return 0;
-					l++;
-					return l;
-				} else {
-					ut64 dst = r_num_math (a->num, arg);
-					ut32 addr = dst;
-					ut8 *ptr = (ut8 *)&addr;
-
-					if (dst == 0 && *arg != '0') {
-					}
-					addr = addr - offset - 5;
-
-					data[l++] = 0xe8;
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-					return l;
-				}
-			}
-		} else if (!strcmp (op, "inc")) {
-			if (a->bits == 64) {
-				if (arg[0] == 'r') {
-					data[l++] = 0x48;
-				}
-				data[l++] = 0xff;
-				data[l++] = 0xc0 | getreg (arg);
-			} else {
-				data[l++] = 0x40 | getreg (arg);
-				if (data[l - 1] == 0xff) {
-					data[l++] = 0x00;
-				}
-			}
-			return l;
-		} else if (!strcmp (op, "dec")) {
-			if (a->bits == 64) {
-				if (arg[0] == 'r') {
-					data[l++] = 0x48;
-				}
-				data[l++] = 0xff;
-				data[l++] = 0xc8 | getreg (arg);
-			} else {
-				data[l++] = 0x48 | getreg (arg);
-			}
-			return l;
-		} else if (!strcmp (op, "push")) {
-			char *delta;
-			ut64 dst;
-			ut32 addr;
-			ut8 *ptr;
-
-			if (*arg == '[') {
-				while (*arg == '[') arg++;
-				delta = strchr (arg, '+');
-				if (!delta) delta = strchr (arg, '-');
-				if (delta) {
-					int r = getreg (arg);
-					int d = getnum (a, delta + 1);
-					if (*delta == '-') d = -d;
-					*delta++ = 0;
-					data[l++] = 0xff;
-					if (d < ST8_MAX && d > ST8_MIN) {
-						data[l++] = 0x70 | r;
-						if (r == 4)
-							data[l++] = 0x24; // wtf
-						data[l++] = d;
-					} else {
-						data[l++] = 0xb0 | r;
-						addr = d;
-						ptr = (ut8 *)&addr;
-						data[l++] = ptr[0];
-						data[l++] = ptr[1];
-						data[l++] = ptr[2];
-						data[l++] = ptr[3];
-					}
-				} else {
-					int r = getreg (arg);
-					data[l++] = 0xff;
-					if (r == 4) { //ESP
-						data[l++] = 0x34;
-						data[l++] = 0x24;
-					} else if (r == 5) { // EBP
-						data[l++] = 0x75;
-						data[l++] = 0;
-					} else data[l++] = 0x30 | r;
-				}
-				return l;
-			}
-			if (!arg) {
-				eprintf ("Missing argument for push\n");
-				return 0;
-			}
-			dst = r_num_math (NULL, arg);
-			addr = dst;
-			ptr = (ut8 *)&addr;
-			if (arg[0] && arg[1] == 's' && !arg[2]) {
-				data[l++] = 0x0f;
-				switch (arg[0]) {
-				case 'c': data[0] = 0x0e; return 1;
-				case 'd': data[0] = 0x1e; return 1;
-				case 's': data[0] = 0x16; return 1;
-				case 'f': data[l++] = 0xa0; break;
-				case 'g': data[l++] = 0xa8; break;
-				}
-				return l;
-			}
-			if (!isnum (a, arg)) {
-				ut8 ch = getreg (arg) | 0x50;
-				if (ch == 0xff) {
-					eprintf ("Invalid register name (%s)\n", arg);
-					return 0;
-				}
-				if (is64reg (arg)) {
-					data[l++] = 0x41;
-				}
-				data[l++] = ch;
-				return l;
-			}
-			{
-				int n = addr;
-				if (n > -127 && n <= 127) {
-					data[l++] = 0x6a;
-					data[l++] = addr;
-					return 2;
-				}
-			}
-			data[l++] = 0x68;
-			data[l++] = ptr[0];
-			data[l++] = ptr[1];
-			data[l++] = ptr[2];
-			data[l++] = ptr[3];
-			return 5;
-		} else if (!strcmp (op, "div")) {
-			int pfx = 0xf0;
-			int arg0 = getreg (arg);
-			if (arg0 == 0xff)
-				return -1;
-			if (*arg == 'r')
-				data[l++] = 0x48;
-			data[l++] = 0xf7;
-			data[l++] = arg0 | pfx;
-			return l;
-		} else if (!strcmp (op, "mul")) {
-			int pfx = 0xe0;
-			int arg0 = getreg (arg);
-			if (arg0 == 0xff)
-				return -1;
-			if (*arg == 'r')
-				data[l++] = 0x48;
-			data[l++] = 0xf7;
-			data[l++] = arg0 | pfx;
-			return l;
-		} else if (!strcmp (op, "pop")) {
-			char *delta;
-			ut64 dst;
-			if (*arg == '[') {
-				arg++;
-				delta = strchr (arg, '+');
-				if (delta) {
-					*delta++ = 0;
-					data[l++] = 0x8f;
-					data[l++] = 0x40 | getreg (arg);
-					data[l++] = getnum (a, delta);
-				} else {
-					int r = getreg (arg);
-					data[l++] = 0x8f;
-					if (r == 4) { //ESP
-						data[l++] = 0x04;
-						data[l++] = 0x24;
-					} else if (r == 5) { // EBP
-						data[l++] = 0x45;
-						data[l++] = 0;
-					} else data[l++] = r;
-				}
-				return l;
-			}
-			if (arg[0] && arg[1] == 's' && !arg[2]) {
-				data[l++] = 0x0f;
-				switch (arg[0]) {
-				case 's': data[0] = 0x17; return 1;
-				case 'f': data[l++] = 0xa1; break;
-				case 'g': data[l++] = 0xa9; break;
-				case 'd': data[0] = 0x1f; return 1;
-				}
-				return l;
-			}
-			dst = r_num_math (NULL, arg);
-			if (dst == 0) {
-				ut8 r = getreg (arg);
-				if (r == (ut8)-1) return 0;
-				if (is64reg (arg)) {
-					data[l++] = 0x41;
-				}
-				data[l++] = r | 0x58;
-				return l;
-			}
-			eprintf ("Invalid pop syntax\n");
-			return 0;
-		} else if (!strcmp (op, "or")) {
-			int pfx, arg0;
-			if (*arg == '[') {
-				arg++;
-				pfx = 0;
-			} else pfx = 0xc0;
-			arg0 = getreg (arg);
-			if (a->bits == 64) {
-				if (*arg == 'r')
-					data[l++] = 0x48;
-				data[l++] = 0x09;
-				data[l++] = arg0 | (getreg (arg2) << 3) | pfx;
-			} else {
-				if (strchr (arg, ']')) {
-					data[l++] = 0x09;
-					data[l++] = arg0; // | 0xf0;
-				} else {
-					if (isnum (a, arg2)) {
-						int n = getnum (a, arg2);
-						if (n > -256 && n < 256) {
-							data[l++] = 0x83;
-							data[l++] = 0xc0 | (arg0);
-							data[l++] = (char)n;
-						} else {
-							data[l++] = 0x81;
-							data[l++] = 0xc9 | (arg0);
-							data[l++] = n >> 0;
-							data[l++] = n >> 8;
-							data[l++] = n >> 16;
-							data[l++] = n >> 24;
-						}
-					} else {
-						data[l++] = arg0 | (getreg (arg2) << 3) | pfx;
-					}
-				}
-			}
-			return l;
-		} else if (!strcmp (op, "and")) {
-			int pfx, arg0;
-			if (*arg == '[') {
-				arg++;
-				pfx = 0;
-			} else pfx = 0xc0;
-			arg0 = getreg (arg);
-			if (a->bits == 64) {
-				if (*arg == 'r')
-					data[l++] = 0x48;
-				data[l++] = 0x21;
-				data[l++] = arg0 | (getreg (arg2) << 3) | pfx;
-			} else {
-				data[l++] = 0x21;
-				if (isnum (a, arg2)) {
-					data[l++] = arg0 | 0xf0;
-					data[l++] = getnum (a, arg2);
-				} else {
-					data[l++] = arg0 | (getreg (arg2) << 3) | pfx;
-				}
-			}
-			return l;
-		} else if (!strcmp (op, "xor")) {
-			int pfx, arg0;
-			if (*arg == '[') {
-				arg++;
-				pfx = 0;
-			} else pfx = 0xc0;
-			arg0 = getreg (arg);
-			if (!arg2) {
-				return -1;
-			}
-			if (a->bits == 64) {
-				if (*arg == 'r' || *arg2 == 'r') {
-					bool a = is64reg (arg);
-					bool b = is64reg (arg2);
-					if (a) {
-						data[l++] = b? 0x4d: 0x49;
-					} else {
-						data[l++] = b? 0x4c: 0x48;
-					}
-				}
-				if (*arg == 'r') {
-				}
-				data[l++] = 0x31; // NOTE: 0x33 is also a valid encoding for xor.. polimorfi?
-				data[l++] = arg0 | (getreg (arg2) << 3) | pfx;
-			} else {
-				data[l++] = 0x31;
-				if (isnum (a, arg2)) {
-					data[l++] = arg0 | 0xf0;
-					data[l++] = getnum (a, arg2);
-				} else {
-					data[l++] = arg0 | (getreg (arg2) << 3) | pfx;
-				}
-			}
-			return l;
-		} else if (!strcmp (op, "lea")) {
-			if (!arg || !arg2) {
-				eprintf ("No args for lea?\n");
-				return 0;
-			}
-			if (a->bits == 64)
-				if (*arg == 'r')
-					data[l++] = 0x48;
-			data[l++] = 0x8d;
-			if (*arg2 == '[') {
-				int r = getreg (arg);
-				int r2 = getreg (arg2 + 1);
-				arg2++;
-				if (isnum (a, arg2)) {
-					ut64 n = getnum (a, arg2);
-					ut32 n32 = (ut32)n;
-					ut8 *ptr;
-					data[l++] = 0x05 | getreg (arg) << 3;
-					ptr = (ut8 *)&n32;
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-				} else {
-					char *p = strchr (arg2, '+');
-					if (!p) p = strchr (arg2, '-');
-					if (p) {
-						if (isnum (a, p + 1)) {
-							int n = getnum (a, p + 1);
-							*p++ = 0;
-							ut8 *ptr = (ut8 *)&n;
-							if (n > 127 || n < -127 || r2 == 4) {
-								if (!strcmp (arg2, "rip")) {
-									// the rip exception
-									data[l++] = 0x5 + (getreg (arg) << 3);
-								} else {
-									data[l++] = 0x80 | getreg (arg) << 3 | getreg (arg2);
-								}
-								if (r2 == 4)
-									data[l++] = 0x24; // THE ESP EXCEPTION
-								data[l++] = ptr[0];
-								data[l++] = ptr[1];
-								data[l++] = ptr[2];
-								data[l++] = ptr[3];
-								// TODO
-							} else {
-								data[l++] = 0x40 | getreg (arg) << 3 | getreg (arg2);
-								data[l++] = n;
-							}
-						} else {
-							int r3 = getreg (p + 1);
-							// lea reg, [reg+reg]
-							data[l++] = (r << 3) | 4;
-							if (r2 > r3) {
-								data[l++] = (r3) | (r2 << 3);
-							} else {
-								data[l++] = (r3 << 3) | (r2);
-							}
-						}
-					} else {
-						if (r2 == 4) { //ESP
-							data[l++] = r << 3 | r2;
-							data[l++] = 0x24;
-						} else if (r2 == 5) { // EBP
-							data[l++] = 0x5d;
-							data[l++] = 0;
-						} else data[l++] = r << 3 | r2;
-					}
-				}
-			} else eprintf ("Invalid args for lea?\n");
-			return l;
-		} else if ((t = getshop (op))) { // sar, shl, shr, rcr, rcl, ror, rol
-			if (arg[1] == 'l') {     // 8bits
-				data[l++] = 0xc0;
-				data[l++] = t | getreg (arg);
-				data[l++] = getnum (a, arg2);
-			} else if (*arg == 'r') { // 64bits
-				data[l++] = 0x48;
-				data[l++] = 0xc1;
-				data[l++] = t | getreg (arg);
-				data[l++] = getnum (a, arg2);
-			} else { // 32bits
-				data[l++] = 0xc1;
-				data[l++] = t | getreg (arg);
-				data[l++] = getnum (a, arg2);
-			}
-			return l;
-		} else if (!strcmp (op, "cmovz")) {
-			ut8 a, b;
-			if ((a = getreg (arg)) == 0xff) return 0;
-			if ((b = getreg (arg2)) == 0xff) return 0;
-			data[l++] = 0x0f;
-			data[l++] = 0x44;
-			data[l++] = 0xc0 + (b | (a << 3));
-			return 3;
-		} else if (!strcmp (op, "mov")) {
-			st64 dst;
-			st8 *ptr;
-			int pfx;
-			int N = 1;
-			char *delta = NULL;
-			char *sib = NULL;
-			ut8 rm_byte = 0x40;
-			int argk = (*arg == '[');
-			ut64 t;
-			if (arg2 && *arg2 == '-') {
-				N = -1;
-				// Don't modify arg2 here as sign is needed further down
-				t = r_num_math (NULL, arg2 + 1);
-			} else {
-				t = r_num_math (NULL, arg2);
-			}
-			if (t >> 63 != 0) {
-				eprintf ("Error: source value too big for register\n");
-				return 1;
-			}
-			dst = t * N;
-			ptr = (st8 *)&dst;
-			if (dst > ST32_MAX || dst < ST32_MIN) {
-				if (a->bits == 64) {
-					if (*arg == 'r') {
-						data[l++] = 0x48;
-					} else {
-						eprintf ("Error: destination register is not 64 bit\n");
-						return -1;
-					}
-					data[1] = 0xb8 | getreg (arg);
-					data[2] = ptr[0];
-					data[3] = ptr[1];
-					data[4] = ptr[2];
-					data[5] = ptr[3];
-					data[6] = ptr[4];
-					data[7] = ptr[5];
-					data[8] = ptr[6];
-					data[9] = ptr[7];
-					return 10;
-				} else {
-					eprintf ("Error: cannot encode 64bit value in 32bit mode\n");
-					return -1;
-				}
-			}
-
-			if (!arg || !arg2) {
-				eprintf ("No args for mov?\n");
-				return 0;
-			}
-			{
-				int b0 = bits8 (arg);
-				int b1 = bits8 (arg2);
-				if (b0 != -1 && b1 != -1) {
-					data[0] = 0x8a;
-					data[1] = 0xc0 | (b0 << 3) | b1;
-					return 2;
-				}
-			}
-
-			if (argk) {
-				arg++;
-				delta = strchr (arg, '+');
-				if (delta) {
-					N = 1;
-					*delta++ = 0;
-				} else {
-					delta = strchr (arg, '-');
-					if (delta) {
-						N = -1;
-						*delta++ = 0;
-					}
-				}
-				pfx = 0;
-			} else pfx = 0xc0;
-
-			if (*arg2 == '[') {
-				if (argk) {
-					eprintf ("Error: Both operands cannot be memory\n");
-					return -1;
-				}
-				arg2++;
-				if (a->bits == 64)
-					if (*arg == 'r')
-						data[l++] = 0x48;
-
-				sib = strchr (arg2, '*');
-
-				delta = strchr (arg2, '+');
-				if (delta) {
-					N = 1;
-					*delta++ = 0;
-				} else {
-					delta = strchr (arg2, '-');
-					if (delta) {
-						N = -1;
-						*delta++ = 0;
-					}
-				}
-				int r0 = getreg (arg);
-				int r1 = getreg (arg2);
-				data[l++] = 0x8b;
-				if (sib) {
-					*sib++ = 0;
-					ut32 s = r_num_math (NULL, sib);
-					ut32 d = r_num_math (NULL, delta) * N;
-
-					data[l++] = 0 << 6 | r0 << 3 | 4;
-					data[l++] = getsib (s) << 6 | r1 << 3 | 5;
-
-					data[l++] = d;
-					data[l++] = d >> 8;
-					data[l++] = d >> 16;
-					data[l++] = d >> 14;
-				} else if (delta) {
-					ut32 d = r_num_math (NULL, delta) * N;
-					// Check if delta is short or dword
-					if ((ST8_MIN > d) && (d > ST8_MAX)) rm_byte = 0x80;
-					data[l++] = r0 << 3 | r1 | rm_byte;
-					if (r1 == 4) data[l++] = 0x24; // ESP
-					data[l++] = d;
-					if ((ST8_MIN > d) && (d > ST8_MAX)) {
-						data[l++] = d >> 8;
-						data[l++] = d >> 16;
-						data[l++] = d >> 24;
-					}
-				} else {
-					if (r1 == 4) { //ESP
-						data[l++] = r0 << 3 | r1;
-						data[l++] = 0x24;
-					} else if (r1 == 5) { // EBP
-						data[l++] = r0 << 3 | r1 | 0x40;
-						data[l++] = 0;
-					} else {
-						if (r1 == 0xff) {
-							ut32 d = getnum (a , arg2);
-							data[l++] = r0 << 3 | 5;
-							data[l++] = d;
-							data[l++] = d >> 8;
-							data[l++] = d >> 16;
-							data[l++] = d >> 24;
-						} else data[l++] = r0 << 3 | r1;
-					}
-				}
-				return l;
-			}
-
-			int r0 = getreg (arg);
-			int r1 = getreg (arg2);
-
-			if (isnum (a, arg) && argk) {
-				int num = getnum (a, arg);
-				if (r1 == 0xff) {
-					return 0;
-				} else {
-					// mov [num], reg
-					data[l++] = 0x89;
-					data[l++] = (r1 << 3) | 5;
-					data[l++] = num;
-					data[l++] = num >> 8;
-					data[l++] = num >> 16;
-					data[l++] = num >> 24;
-					return l;
-				}
-			}
-			// mov rax, 33
-			if (a->bits == 64 && *arg == 'r' && !argk) {
-				data[l++] = 0x48;
-				if (isnum (a, arg2)) {
-					data[l++] = 0xc7;
-					data[l++] = r0 | pfx;
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-					return l;
-				}
-				data[l++] = 0x89;
-				data[l++] = r0 | (r1 << 3) | pfx;
-				return l;
-			}
-
-			if (isnum (a, arg2)) {
-				r1 = getnum (a, arg2);
-				if (delta) {
-					int d = getnum (a, delta) * N;
-					if (*arg != 'r' && a->bits == 64)
-						data[l++] = 0x67;
-					data[l++] = 0xc7;
-					if ((ST8_MIN > d) || (d > ST8_MAX)) rm_byte = 0x80;
-					data[l++] = rm_byte | r0;
-					if (r0 == 4) data[l++] = 0x24; //ESP
-					data[l++] = d;
-					if (rm_byte == 0x80) {
-						data[l++] = d >> 8;
-						data[l++] = d >> 16;
-						data[l++] = d >> 24;
-					}
-				} else {
-					if (argk) {
-						if (wordsize == 1) {
-							// byte ptr
-							data[l++] = 0xc6;
-							data[l++] = r0;
-							data[l++] = r1;
-							return l;
-						} else {
-							data[l++] = 0xc7;
-							if (r0 == 4) { //ESP
-								data[l++] = 0x04;
-								data[l++] = 0x24;
-							} else if (r0 == 5) { // EBP
-								data[l++] = 0x75;
-								data[l++] = 0;
-							} else data[l++] = r0;
-						}
-#define is16reg(x) (x[1] == 'l' || x[1] == 'h')
-					} else {
-						if (is16reg (arg)) {
-							int op = 0xc0;
-							if (arg[1] == 'h') op |= 4;
-							data[l++] = 0xc6;
-							data[l++] = op | r0;
-							data[l++] = r1;
-							return l;
-						} else {
-							if (is8bitrex (arg)) {
-								if (a->bits != 64) {
-									eprintf ("Error: Unable to assemble instruction in 32bit\n");
-									return -1;
-								}
-								data[l++] = 0x40;
-								data[l++] = 0x16 << 3 | r0;
-								data[l++] = r1;
-								return l;
-							} else {
-								data[l++] = 0xb8 | r0;
-							}
-						}
-					}
-				}
-				data[l++] = r1;
-				data[l++] = r1 >> 8;
-				data[l++] = r1 >> 16;
-				data[l++] = r1 >> 24;
-				return l;
-			} else {
-				if (r0 == 0xff) {
-					return 0;
-				}
-				if (r1 == 0xff) {
-					return 0;
-				}
-				if (a->bits == 64) {
-					if (*arg == 'r')
-						data[l++] = 0x48;
-					if (is8bitrex (arg)) {
-						if (a->bits != 64) {
-							eprintf ("Error: Unable to assemble instruction in 32bit\n");
-							return -1;
-						}
-						data[l++] = 0x40;
-						data[l++] = 0x88;
-						data[l++] = 0x3 << 6 | r1 << 3 | r0;
-						return l;
-					}
-				}
-
-				data[l++] = 0x89;
-				if (delta) {
-					if (isnum (a, delta)) {
-						int n = getnum (a, delta) * N;
-						if ((ST8_MIN > n) || (n > ST8_MAX)) rm_byte = 0x80;
-						data[l++] = rm_byte | r0 | r1 << 3;
-						if (r0 == 4) data[l++] = 0x24; //ESP
-						data[l++] = n;
-						if (rm_byte == 0x80) {
-							data[l++] = n >> 8;
-							data[l++] = n >> 16;
-							data[l++] = n >> 24;
-						}
-					} else {
-						data[l++] = r1 << 3 | 0x4;
-						data[l++] = (getreg (delta) << 3) | r0;
-					}
-				} else {
-					data[l++] = r1 << 3 | r0 | pfx;
-				}
-			}
-			return l;
-		} else if (!strcmp (op, "jmp")) {
-			if (arg[0] == '[' && arg[strlen (arg) - 1] == ']') {
-				ut8 reg = getreg (arg + 1);
-				if (reg != 0xff) {
-					char *plus = strchr (arg + 1, '+');
-					if (!plus) plus = strchr (arg + 1, '-');
-					if (plus) { // "jmp [reg+off]"
-						int d = getnum (a, plus + 1);
-						data[l++] = 0xff;
-						data[l++] = 0xa0 | reg;
-						data[l++] = d;
-						data[l++] = d >> 8;
-						data[l++] = d >> 16;
-						data[l++] = d >> 24;
-					} else { // "jmp [reg]"
-						data[l++] = 0xff;
-						data[l++] = 0x20 | reg;
-					}
-					return l;
-				} else if (!memcmp (arg + 1, "rip", 3)) {
-					ut64 dst = getnum (a, arg + 4);
-					ut32 addr = dst;
-					ut8 *ptr = (ut8 *)&addr;
-					data[l++] = 0xff;
-					data[l++] = 0x25;
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-					return l;
-				} else {
-					ut64 dst = getnum (a, arg + 1);
-					ut32 addr = dst;
-					ut8 *ptr = (ut8 *)&addr;
-					if (dst != 0) {
-						data[l++] = 0xff;
-						data[l++] = 0x25;
-						data[l++] = ptr[0];
-						data[l++] = ptr[1];
-						data[l++] = ptr[2];
-						data[l++] = ptr[3];
-						return l;
-					}
-					return -1;
-				}
-			} else {
-				st64 dst = getnum (a, arg); // - offset;
-				ut32 addr = dst;
-				ut8 *ptr = (ut8 *)&addr;
-
-				if (dst == 0 && *arg != '0') {
-					data[l++] = '\xff';
-					data[l] = getreg (arg) | 0xe0;
-					if (data[l] != 0xff)
-						return 2;
-					if (arg[0] == '[' && arg[strlen (arg) - 1] == ']') {
-						data[l] = getreg (arg + 1) | 0x20;
-						if (data[l] != 0xff)
-							return l + 1;
-						l++;
-					}
-					return -1;
-				}
-
-				dst -= offset;
-				if (-0x80 <= (dst - 2) && (dst - 2) <= 0x7f) {
-					/* relative byte address */
-					data[l++] = 0xeb;
-					data[l++] = (char)(dst - 2);
-					return l;
-				} else {
-					/* relative address */
-					addr -= offset;
-					addr -= 5;
-					data[l++] = 0xe9;
-					data[l++] = ptr[0];
-					data[l++] = ptr[1];
-					data[l++] = ptr[2];
-					data[l++] = ptr[3];
-					return l;
-				}
-			}
-		} else // SPAGUETTI
-			if (!strcmp (op, "jle")) {
-			return jop (a, data, 0x7e, 0x8e, arg);
-		} else if (!strcmp (op, "jl")) {
-			return jop (a, data, 0x7c, 0x8c, arg);
-		} else if (!strcmp (op, "jg")) {
-			return jop (a, data, 0x7f, 0x8f, arg);
-		} else if (!strcmp (op, "jge")) {
-			return jop (a, data, 0x7d, 0x8d, arg);
-		} else if (!strcmp (op, "ja")) {
-			return jop (a, data, 0x77, 0x87, arg);
-		} else if (!strcmp (op, "jb")) {
-			return jop (a, data, 0x72, 0x82, arg);
-		} else if (!strcmp (op, "jnz") || !strcmp (op, "jne")) {
-			return jop (a, data, 0x75, 0x85, arg);
-		} else if (!strcmp (op, "jz") || !strcmp (op, "je")) {
-			return jop (a, data, 0x74, 0x84, arg);
-		}
-	} else {
-		if (!strcmp (op, "leave")) {
-			data[l++] = 0xc9;
-		} else if (!strcmp (op, "syscall")) {
-			data[l++] = 0x0f;
-			data[l++] = 0x05;
-		} else if (!strcmp (op, "retf")) {
-			data[l++] = 0xcb;
-		} else if (!strcmp (op, "ret")) {
-			data[l++] = 0xc3;
-		} else if (!strcmp (op, "ret0")) {
-			memcpy (data + l, "\x31\xc0\xc3", 3);
-			l += 3;
-		} else if (!strcmp (op, "int3")) {
-			data[l++] = 0xcc;
-		} else if (!strcmp (op, "iret") || !strcmp (op, "iretd")) {
-			data[l++] = 0xcf;
-		} else if (!strcmp (op, "pusha") || !strcmp (op, "pushad")) {
-			data[l++] = 0x60;
-		} else if (!strcmp (op, "popa") || !strcmp (op, "popad")) {
-			data[l++] = 0x61;
-		} else if (!strcmp (op, "cli")) {
-			data[l++] = 0xfa;
-		} else if (!strcmp (op, "sti")) {
-			data[l++] = 0xfb;
-		} else if (!strcmp (op, "sysret")) {
-			data[l++] = 0x0f;
-			data[l++] = 0x07;
-		} else if (!strcmp (op, "sysexit")) {
-			data[l++] = 0x0f;
-			data[l++] = 0x35;
-		} else if (!strcmp (op, "nop")) {
-			data[l++] = 0x90;
-		} else if (!strcmp (op, "clac")) {
-			memcpy (data + l, "\x0f\x01\xca", 3);
-			l += 3;
-		} else if (!strcmp (op, "stac")) {
-			memcpy (data + l, "\x0f\x01\xcb", 3);
-			l += 3;
-		}
-		return l;
-	}
-	eprintf ("Unknown opcode (%s)\n", op);
-	return 0;
+	eprintf ("Error: Unknown instruction (%s)\n", instr.mnemonic);
+	return -1;
 }
 
 RAsmPlugin r_asm_plugin_x86_nz = {

--- a/libr/asm/p/asm_x86_tab.c
+++ b/libr/asm/p/asm_x86_tab.c
@@ -390,273 +390,273 @@ Opcode opcodes[] = {
 	//////////////////////
 
 	/////// 0x0_ ///////
-	{"add", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x00}},
-	{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x01}},
-	{"add", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x02}},
-	{"add", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x03}},
-	{"add", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x04}},
-	{"add", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x05}},
+	//{"add", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x00}},
+	//{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x01}},
+	//{"add", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x02}},
+	//{"add", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x03}},
+	//{"add", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x04}},
+	//{"add", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x05}},
+//
+	//{"push", {(OT_SEGMENTREG & OT_REG(X86R_ES))}, 1, {0x06}},
+	//{"pop", {(OT_SEGMENTREG & OT_REG(X86R_ES))}, 1, {0x07}},
+//
+	//{"or", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x08}},
+	//{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x09}},
+	//{"or", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0A}},
+	//{"or", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x0B}},
+	//{"or", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x0C}},
+	//{"or", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x0D}},
+//
+	//{"push", {(OT_SEGMENTREG & OT_REG(X86R_CS))}, 1, {0x0E}},
+	//// Two byte opcodes start with 0x0F
+//
+	///////// 0x1_ ///////
+	//{"adc", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x10}},
+	//{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x11}},
+	//{"adc", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x12}},
+	//{"adc", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x13}},
+	//{"adc", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x14}},
+	//{"adc", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x15}},
+//
+	//{"push", {(OT_SEGMENTREG & OT_REG(X86R_SS))}, 1, {0x16}},
+	//{"pop", {(OT_SEGMENTREG & OT_REG(X86R_SS))}, 1, {0x17}},
+//
+	//{"sbb", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x18}},
+	//{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x19}},
+	//{"sbb", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x1A}},
+	//{"sbb", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x1B}},
+	//{"sbb", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x1C}},
+	//{"sbb", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x1D}},
+//
+	//{"push", {(OT_SEGMENTREG & OT_REG(X86R_DS))}, 1, {0x1E}},
+	//{"pop", {(OT_SEGMENTREG & OT_REG(X86R_DS))}, 1, {0x1F}},
+//
+	///////// 0x2_ ///////
+	//{"and", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x20}},
+	//{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x21}},
+	//{"and", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x22}},
+	//{"and", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x23}},
+	//{"and", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x24}},
+	//{"and", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x25}},
+//
+	//// 0x26: ES segment prefix
+	//{"daa", {}, 1, {0x27}},
+//
+	//{"sub", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x28}},
+	//{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x29}},
+	//{"sub", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x2A}},
+	//{"sub", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x2B}},
+	//{"sub", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x2C}},
+	//{"sub", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x2D}},
+//
+	//// 0x2E: CS segment prefix
+	//{"das", {}, 1, {0x2F}},
+//
+	///////// 0x3_ ///////
+	//{"xor", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x30}},
+	//{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x31}},
+	//{"xor", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x32}},
+	//{"xor", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x33}},
+	//{"xor", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x34}},
+	//{"xor", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x35}},
+//
+	//// 0x36: SS segment prefix
+	//{"aaa", {}, 1, {0x37}},
+//
+	//{"cmp", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x38}},
+	//{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x39}},
+	//{"cmp", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x3A}},
+	//{"cmp", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x3B}},
+	//{"cmp", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x3C}},
+	//{"cmp", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x3D}},
+//
+	//// 0x3E: DS segment prefix
+	//{"aas", {}, 1, {0x3F}},
+//
+	///////// 0x4_ ///////
+	//{"inc", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x40}},
+	//{"inc", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x41}},
+	//{"inc", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x42}},
+	//{"inc", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x43}},
+	//{"inc", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x44}},
+	//{"inc", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x45}},
+	//{"inc", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x46}},
+	//{"inc", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x47}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x48}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x49}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x4A}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x4B}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x4C}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x4D}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x4E}},
+	//{"dec", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x4F}},
 
-	{"push", {(OT_SEGMENTREG & OT_REG(X86R_ES))}, 1, {0x06}},
-	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_ES))}, 1, {0x07}},
-
-	{"or", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x08}},
-	{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x09}},
-	{"or", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0A}},
-	{"or", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x0B}},
-	{"or", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x0C}},
-	{"or", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x0D}},
-
-	{"push", {(OT_SEGMENTREG & OT_REG(X86R_CS))}, 1, {0x0E}},
-	// Two byte opcodes start with 0x0F
-
-	/////// 0x1_ ///////
-	{"adc", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x10}},
-	{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x11}},
-	{"adc", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x12}},
-	{"adc", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x13}},
-	{"adc", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x14}},
-	{"adc", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x15}},
-
-	{"push", {(OT_SEGMENTREG & OT_REG(X86R_SS))}, 1, {0x16}},
-	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_SS))}, 1, {0x17}},
-
-	{"sbb", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x18}},
-	{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x19}},
-	{"sbb", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x1A}},
-	{"sbb", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x1B}},
-	{"sbb", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x1C}},
-	{"sbb", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x1D}},
-
-	{"push", {(OT_SEGMENTREG & OT_REG(X86R_DS))}, 1, {0x1E}},
-	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_DS))}, 1, {0x1F}},
-
-	/////// 0x2_ ///////
-	{"and", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x20}},
-	{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x21}},
-	{"and", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x22}},
-	{"and", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x23}},
-	{"and", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x24}},
-	{"and", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x25}},
-
-	// 0x26: ES segment prefix
-	{"daa", {}, 1, {0x27}},
-
-	{"sub", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x28}},
-	{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x29}},
-	{"sub", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x2A}},
-	{"sub", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x2B}},
-	{"sub", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x2C}},
-	{"sub", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x2D}},
-
-	// 0x2E: CS segment prefix
-	{"das", {}, 1, {0x2F}},
-
-	/////// 0x3_ ///////
-	{"xor", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x30}},
-	{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x31}},
-	{"xor", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x32}},
-	{"xor", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x33}},
-	{"xor", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x34}},
-	{"xor", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x35}},
-
-	// 0x36: SS segment prefix
-	{"aaa", {}, 1, {0x37}},
-
-	{"cmp", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x38}},
-	{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x39}},
-	{"cmp", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x3A}},
-	{"cmp", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x3B}},
-	{"cmp", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x3C}},
-	{"cmp", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x3D}},
-
-	// 0x3E: DS segment prefix
-	{"aas", {}, 1, {0x3F}},
-
-	/////// 0x4_ ///////
-	{"inc", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x40}},
-	{"inc", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x41}},
-	{"inc", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x42}},
-	{"inc", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x43}},
-	{"inc", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x44}},
-	{"inc", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x45}},
-	{"inc", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x46}},
-	{"inc", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x47}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x48}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x49}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x4A}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x4B}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x4C}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x4D}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x4E}},
-	{"dec", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x4F}},
-
-	/////// 0x5_ ///////
-	{"push", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x50}},
-	{"push", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x51}},
-	{"push", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x52}},
-	{"push", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x53}},
-	{"push", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x54}},
-	{"push", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x55}},
-	{"push", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x56}},
-	{"push", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x57}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x58}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x59}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x5A}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x5B}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x5C}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x5D}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x5E}},
-	{"pop", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x5F}},
-
-	/////// 0x6_ ///////
-	{"pusha", {}, 1, {0x60}},	{"pushad", {}, 1, {0x60}},
-	{"popa", {}, 1, {0x61}},	{"popad", {}, 1, {0x61}},
+	///////// 0x5_ ///////
+	//{"push", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x50}},
+	//{"push", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x51}},
+	//{"push", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x52}},
+	//{"push", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x53}},
+	//{"push", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x54}},
+	//{"push", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x55}},
+	//{"push", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x56}},
+	//{"push", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x57}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x58}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x59}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x5A}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x5B}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x5C}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x5D}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x5E}},
+	//{"pop", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x5F}},
+//
+	///////// 0x6_ ///////
+	//{"pusha", {}, 1, {0x60}},	{"pushad", {}, 1, {0x60}},
+	//{"popa", {}, 1, {0x61}},	{"popad", {}, 1, {0x61}},
 	{"bound", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_QWORD}, 1, {0x62}},
 	{"arpl", {OT_REGMEMOP(GP) | OT_WORD, OT_REGSPECOP(GP) | OT_WORD}, 1, {0x63}},
 	// 0x64: FS segment prefix
 	// 0x65: GS segment prefix
 	// 0x66: operand size prefix
 	// 0x67: address size prefix
-	{"push", {OT_IMMOP | OT_DWORD}, 1, {0x68}},
+	//{"push", {OT_IMMOP | OT_DWORD}, 1, {0x68}},
 	{"imul", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x69}},
-	{"push", {OT_IMMOP | OT_BYTE}, 1, {0x6A}},
+	//{"push", {OT_IMMOP | OT_BYTE}, 1, {0x6A}},
 	{"imul", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x6B}},
-	{"insb", {}, 1, {0x6C}},
-	{"ins", {}, 1, {0x6D}}, {"insd", {}, 1, {0x6D}},
-	{"insw", {}, 2, {0x66, 0x6D}},
-	{"outsb", {}, 1, {0x6E}},
-	{"outs", {}, 1, {0x6F}}, {"outsd", {}, 1, {0x6F}},
-	{"outsw", {}, 2, {0x66, 0x6F}},
+	//{"insb", {}, 1, {0x6C}},
+	//{"ins", {}, 1, {0x6D}}, {"insd", {}, 1, {0x6D}},
+	//{"insw", {}, 2, {0x66, 0x6D}},
+	//{"outsb", {}, 1, {0x6E}},
+	//{"outs", {}, 1, {0x6F}}, {"outsd", {}, 1, {0x6F}},
+	//{"outsw", {}, 2, {0x66, 0x6F}},
 
 	/////// 0x7_ ///////
-	{"jo", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x70}},
-	{"jno", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x71}},
-	{"jb", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
-	{"jnae", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
-	{"jc", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
-	{"jnb", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
-	{"jae", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
-	{"jnc", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
-	{"jz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
-	{"je", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
-	{"jnz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
-	{"jne", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
-	{"jbe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
-	{"jna", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
-	{"jnbe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
-	{"ja", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
-	{"js", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x78}},
-	{"jns", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x79}},
-	{"jp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
-	{"jpe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
-	{"jnp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
-	{"jpo", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
-	{"jl", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
-	{"jnge", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
-	{"jnl", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
-	{"jge", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
-	{"jle", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
-	{"jng", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
-	{"jnle", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
-	{"jg", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
+	//{"jo", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x70}},
+	//{"jno", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x71}},
+	//{"jb", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
+	//{"jnae", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
+	//{"jc", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x72}},
+	//{"jnb", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
+	//{"jae", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
+	//{"jnc", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x73}},
+	//{"jz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
+	//{"je", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x74}},
+	//{"jnz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
+	//{"jne", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x75}},
+	//{"jbe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
+	//{"jna", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x76}},
+	//{"jnbe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
+	//{"ja", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x77}},
+	//{"js", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x78}},
+	//{"jns", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x79}},
+	//{"jp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
+	//{"jpe", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7A}},
+	//{"jnp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
+	//{"jpo", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7B}},
+	//{"jl", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
+	//{"jnge", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7C}},
+	//{"jnl", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
+	//{"jge", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7D}},
+	//{"jle", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
+	//{"jng", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7E}},
+	//{"jnle", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
+	//{"jg", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0x7F}},
 
 	/////// 0x8_ ///////
 	// 0x80 -- 0x83: immediate group 1
 	// 0x84, 0x85: TODO: test
 	// 0x86, 0x87: TODO: xchg
-	{"mov", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x88}},
-	{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x89}},
-	{"mov", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x8A}},
-	{"mov", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x8B}},
-	{"mov", {OT_MEMONLYOP | OT_WORD, OT_REGSPECOP(SEGMENT) | OT_WORD}, 1, {0x8C}}, // ?
-	{"lea", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_DWORD}, 1, {0x8D}},	// allow all sizes?
-	{"mov", {OT_REGSPECOP(SEGMENT) | OT_WORD, OT_MEMONLYOP | OT_WORD}, 1, {0x8E}}, // ?
-	{"pop", {}, 1, {0x8F}},  // ?
+	//{"mov", {OT_REGMEMOP(GP) | OT_BYTE, OT_REGSPECOP(GP) | OT_BYTE}, 1, {0x88}},
+	////{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 1, {0x89}},
+	//{"mov", {OT_REGSPECOP(GP) | OT_BYTE, OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x8A}},
+	//{"mov", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 1, {0x8B}},
+	//{"mov", {OT_MEMONLYOP | OT_WORD, OT_REGSPECOP(SEGMENT) | OT_WORD}, 1, {0x8C}}, // ?
+	//{"lea", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_DWORD}, 1, {0x8D}},	// allow all sizes?
+	//{"mov", {OT_REGSPECOP(SEGMENT) | OT_WORD, OT_MEMONLYOP | OT_WORD}, 1, {0x8E}}, // ?
+	//{"pop", {}, 1, {0x8F}},  // ?
 
 	/////// 0x9_ ///////
-	{"nop", {}, 1, {0x90}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x90}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x91}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x92}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x93}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x94}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x95}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x96}},
-	{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x97}},
-	{"cbw", {}, 1, {0x98}},
-	{"cwde", {}, 2, {0x66, 0x98}},  // ?
-	{"cwd", {}, 1, {0x99}},
-	{"cdq", {}, 2, {0x66, 0x99}},  // ?
+	//{"nop", {}, 1, {0x90}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0x90}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 1, {0x91}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 1, {0x92}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 1, {0x93}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 1, {0x94}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 1, {0x95}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 1, {0x96}},
+	//{"xchg", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 1, {0x97}},
+	//{"cbw", {}, 1, {0x98}},
+	//{"cwde", {}, 2, {0x66, 0x98}},  // ?
+	//{"cwd", {}, 1, {0x99}},
+	//{"cdq", {}, 2, {0x66, 0x99}},  // ?
 	// 0x9A: TODO far call
-	{"wait", {}, 1, {0x9B}},
-	{"fwait", {}, 1, {0x9B}},
-	{"pushfd", {}, 1, {0x9C}},
-	{"popfd", {}, 1, {0x9D}},
-	{"sahf", {}, 1, {0x9E}},
-	{"lahf", {}, 1, {0x9F}},
+	//{"wait", {}, 1, {0x9B}},
+	//{"fwait", {}, 1, {0x9B}},
+	//{"pushfd", {}, 1, {0x9C}},
+	//{"popfd", {}, 1, {0x9D}},
+	//{"sahf", {}, 1, {0x9E}},
+	//{"lahf", {}, 1, {0x9F}},
 
 	/////// 0xA_ ///////
-	{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_MEMIMMOP | OT_BYTE}, 1, {0xA0}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_MEMIMMOP | OT_DWORD}, 1, {0xA1}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_MEMIMMOP | OT_BYTE}, 1, {0xA0}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_MEMIMMOP | OT_DWORD}, 1, {0xA1}},
 	// 0xA2 -- 0xA3
-	{"movsb", {}, 1, {0xA4}},
-	{"movsd", {}, 1, {0xA5}},
-	{"movsw", {}, 2, {0x66, 0xA5}},
-	{"cmpsb", {}, 1, {0xA6}},
-	{"cmpsd", {}, 1, {0xA7}},
-	{"cmpsw", {}, 2, {0x66, 0xA7}},
+	//{"movsb", {}, 1, {0xA4}},
+	//{"movsd", {}, 1, {0xA5}},
+	//{"movsw", {}, 2, {0x66, 0xA5}},
+	//{"cmpsb", {}, 1, {0xA6}},
+	//{"cmpsd", {}, 1, {0xA7}},
+	//{"cmpsw", {}, 2, {0x66, 0xA7}},
 	// 0xA8 -- 0xA9: as above
-	{"stosb", {}, 1, {0xAA}},
-	{"stosd", {}, 1, {0xAB}},
-	{"stosw", {}, 2, {0x66, 0xAB}},
-	{"lodsb", {}, 1, {0xAC}},
-	{"lodsd", {}, 1, {0xAD}},
-	{"lodsw", {}, 2, {0x66, 0xAD}},
-	{"scasb", {}, 1, {0xAE}},
-	{"scasd", {}, 1, {0xAF}},
-	{"scasw", {}, 2, {0x66, 0xAF}},
+	//{"stosb", {}, 1, {0xAA}},
+	//{"stosd", {}, 1, {0xAB}},
+	//{"stosw", {}, 2, {0x66, 0xAB}},
+	//{"lodsb", {}, 1, {0xAC}},
+	//{"lodsd", {}, 1, {0xAD}},
+	//{"lodsw", {}, 2, {0x66, 0xAD}},
+	//{"scasb", {}, 1, {0xAE}},
+	//{"scasd", {}, 1, {0xAF}},
+	//{"scasw", {}, 2, {0x66, 0xAF}},
 
 	/////// 0xB_ ///////
-	{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB0}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB1}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_DL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB2}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_BL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB3}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_AH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB4}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_CH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB5}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_DH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB6}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_BH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB7}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xB8}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xB9}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBA}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBB}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBC}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBD}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBE}},
-	{"mov", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBF}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB0}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB1}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_DL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB2}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_BL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB3}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_AH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB4}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_CH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB5}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_DH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB6}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_BH)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xB7}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xB8}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xB9}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBA}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBB}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBC}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBD}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBE}},
+	//{"mov", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0xBF}},
 
 	/////// 0xC_ ///////
 	// 0xC0 -- 0xC1: shift group 2
-	{"ret", {OT_IMMOP | OT_WORD}, 1, {0xC2}},
-	{"ret", {}, 1, {0xC3}},
+	//{"ret", {OT_IMMOP | OT_WORD}, 1, {0xC2}},
+	//{"ret", {}, 1, {0xC3}},
 	{"les", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_BYTE}, 1, {0xC4}},
 	{"lds", {OT_REGSPECOP(GP) | OT_DWORD, OT_MEMONLYOP | OT_BYTE}, 1, {0xC5}},
 	// 0xC6 -- 0xC7 mov group
 	{"enter", {OT_IMMOP | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0xC8}},
-	{"leave", {}, 1, {0xC9}},
-	{"retf", {OT_IMMOP | OT_WORD}, 1, {0xCA}},
-	{"retf", {}, 1, {0xCB}},
-	{"int3", {}, 1, {0xCC}},
-	{"int", {OT_IMMOP | OT_BYTE}, 1, {0xCD}},
-	{"into", {}, 1, {0xCE}},
-	{"iretd", {OT_IMMOP | OT_BYTE}, 1, {0xCF}},
+	//{"leave", {}, 1, {0xC9}},
+	//{"retf", {OT_IMMOP | OT_WORD}, 1, {0xCA}},
+	//{"retf", {}, 1, {0xCB}},
+	//{"int3", {}, 1, {0xCC}},
+	//{"int", {OT_IMMOP | OT_BYTE}, 1, {0xCD}},
+	//{"into", {}, 1, {0xCE}},
+	//{"iretd", {OT_IMMOP | OT_BYTE}, 1, {0xCF}},
 
 	/////// 0xD_ ///////
 	// 0xD0 -- 0xD3: shift group 2
 	{"aam", {OT_IMMOP | OT_BYTE}, 1, {0xD4}},  // ?
 	{"aad", {OT_IMMOP | OT_BYTE}, 1, {0xD5}},  // ?
 	// 0xD6: reserved
-	{"xlatb", {}, 1, {0xD7}},
+	//{"xlatb", {}, 1, {0xD7}},
 	// 0xD8 -- 0xDF: FPU
 
 	/////// 0xE_ ///////
@@ -665,33 +665,33 @@ Opcode opcodes[] = {
 	{"loop", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE2}},
 	{"jcxz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE3}},
 	{"jecxz", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xE3}},
-	{"in", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xE4}},
-	{"in", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0xE5}},
-	{"out", {OT_IMMOP | OT_BYTE, (OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE}, 1, {0xE6}},
-	{"out", {OT_IMMOP | OT_BYTE, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0xE7}},
-	{"call", {OT_IMMOP | OT_DWORD}, 1, {0xE8}},
-	{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0xE9}},
-	{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0xEA}},  // ?
-	{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xEB}},
-	{"in", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, (OT_GPREG & OT_REG(X86R_DX)) | OT_WORD}, 1, {0xEC}},
-	{"in", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_DX)) | OT_WORD}, 1, {0xED}},
-	{"out", {(OT_GPREG & OT_REG(X86R_DX)) | OT_WORD, (OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE}, 1, {0xEE}},
-	{"out", {(OT_GPREG & OT_REG(X86R_DX)) | OT_WORD, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0xEF}},
+	//{"in", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0xE4}},
+	//{"in", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0xE5}},
+	//{"out", {OT_IMMOP | OT_BYTE, (OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE}, 1, {0xE6}},
+	//{"out", {OT_IMMOP | OT_BYTE, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0xE7}},
+	//{"call", {OT_IMMOP | OT_DWORD}, 1, {0xE8}},
+	//{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0xE9}},
+	//{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0xEA}},  // ?
+	//{"jmp", {OT_IMMOP | OT_JMPADDRESS | OT_BYTE}, 1, {0xEB}},
+	//{"in", {(OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE, (OT_GPREG & OT_REG(X86R_DX)) | OT_WORD}, 1, {0xEC}},
+	//{"in", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD, (OT_GPREG & OT_REG(X86R_DX)) | OT_WORD}, 1, {0xED}},
+	//{"out", {(OT_GPREG & OT_REG(X86R_DX)) | OT_WORD, (OT_GPREG & OT_REG(X86R_AL)) | OT_BYTE}, 1, {0xEE}},
+	//{"out", {(OT_GPREG & OT_REG(X86R_DX)) | OT_WORD, (OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 1, {0xEF}},
 
 	/////// 0xF_ ///////
 	// 0xF0: lock prefix
 	// 0xF1: reserved
 	// 0xF2: repne prefix
 	// 0xF3: rep(e) prefix
-	{"hlt", {}, 1, {0xF4}},
-	{"cmc", {}, 1, {0xF5}},
+	//{"hlt", {}, 1, {0xF4}},
+	//{"cmc", {}, 1, {0xF5}},
 	// 0xF6 -- 0xF7: unary group 3
-	{"clc", {}, 1, {0xF8}},
-	{"stc", {}, 1, {0xF9}},
-	{"cli", {}, 1, {0xFA}},
-	{"sti", {}, 1, {0xFB}},
-	{"cld", {}, 1, {0xFC}},
-	{"std", {}, 1, {0xFD}},
+	//{"clc", {}, 1, {0xF8}},
+	//{"stc", {}, 1, {0xF9}},
+	//{"cli", {}, 1, {0xFA}},
+	//{"sti", {}, 1, {0xFB}},
+	//{"cld", {}, 1, {0xFC}},
+	//{"std", {}, 1, {0xFD}},
 	// 0xFE: group 4
 	// 0xFF: group 5
 
@@ -705,15 +705,15 @@ Opcode opcodes[] = {
 	{"lar", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x02}},
 	{"lsl", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x03}},
 	// 0x0F 0x04-0x05: reserved
-	{"clts", {}, 2, {0x0F, 0x06}},
+	//{"clts", {}, 2, {0x0F, 0x06}},
 	// 0x0F 0x07: reserved
-	{"invd", {}, 2, {0x0F, 0x08}},
-	{"wbinvd", {}, 2, {0x0F, 0x09}},
+	//{"invd", {}, 2, {0x0F, 0x08}},
+	//{"wbinvd", {}, 2, {0x0F, 0x09}},
 	// 0x0F 0x0A: reserved
-	{"ud2", {}, 2, {0x0F, 0x0B}},
+	//{"ud2", {}, 2, {0x0F, 0x0B}},
 	// 0x0F 0x0C: reserved
-	{"prefetch", {}, 2, {0x0F, 0x0D}},
-	{"femms", {}, 2, {0x0F, 0x0E}},
+	//{"prefetch", {}, 2, {0x0F, 0x0D}},
+	//{"femms", {}, 2, {0x0F, 0x0E}},
 	// 0x0F 0x0F: 3DNow! prefix
 
 	/////// 0x0F 0x1_ ///////
@@ -729,10 +729,10 @@ Opcode opcodes[] = {
 	// 0x0F 0x19-0x1F: reserved
 
 	/////// 0x0F 0x2_ ///////
-	{"mov", {OT_CONTROLREG, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x20}},
-	{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_DEBUGREG}, 2, {0x0F, 0x21}},
-	{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_CONTROLREG}, 2, {0x0F, 0x22}},
-	{"mov", {OT_DEBUGREG, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x23}},
+	//{"mov", {OT_CONTROLREG, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x20}},
+	//{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_DEBUGREG}, 2, {0x0F, 0x21}},
+	//{"mov", {OT_REGMEMOP(GP) | OT_DWORD, OT_CONTROLREG}, 2, {0x0F, 0x22}},
+	//{"mov", {OT_DEBUGREG, OT_REGMEMOP(GP) | OT_DWORD}, 2, {0x0F, 0x23}},
 	// 0x0F 0x24-0x27: reserved
 	{"movaps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x28}},
 	{"movaps", {OT_REGMEMOP(XMM) | OT_OWORD, OT_REGSPECOP(XMM) | OT_OWORD}, 2, {0x0F, 0x29}},
@@ -744,12 +744,12 @@ Opcode opcodes[] = {
 	{"comiss", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD}, 2, {0x0F, 0x2F}},
 
 	/////// 0x0F 0x3_ ///////
-	{"wrmsr", {}, 2, {0x0F, 0x30}},
-	{"rdtsc", {}, 2, {0x0F, 0x31}},
-	{"rdmsr", {}, 2, {0x0F, 0x32}},
-	{"rdpmc", {}, 2, {0x0F, 0x33}},
-	{"sysenter", {}, 2, {0x0F, 0x34}},
-	{"sysexit", {}, 2, {0x0F, 0x35}},
+	//{"wrmsr", {}, 2, {0x0F, 0x30}},
+	//{"rdtsc", {}, 2, {0x0F, 0x31}},
+	//{"rdmsr", {}, 2, {0x0F, 0x32}},
+	//{"rdpmc", {}, 2, {0x0F, 0x33}},
+	//{"sysenter", {}, 2, {0x0F, 0x34}},
+	//{"sysexit", {}, 2, {0x0F, 0x35}},
 	// 0x0F 0x36-0x3F: reserved
 
 	/////// 0x0F 0x4_ ///////
@@ -833,36 +833,36 @@ Opcode opcodes[] = {
 	{"movq", {OT_REGMEMOP(MMX) | OT_QWORD, OT_REGSPECOP(MMX) | OT_QWORD}, 2, {0x0F, 0x7F}},
 
 	/////// 0x0F 0x8_ ///////
-	{"jo", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x80}},
-	{"jno", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x81}},
-	{"jb", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
-	{"jnae", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
-	{"jc", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
-	{"jnb", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
-	{"jae", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
-	{"jnc", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
-	{"jz", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
-	{"je", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
-	{"jnz", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
-	{"jne", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
-	{"jbe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
-	{"jna", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
-	{"jnbe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
-	{"ja", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
-	{"js", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x88}},
-	{"jns", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x89}},
-	{"jp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
-	{"jpe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
-	{"jnp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
-	{"jpo", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
-	{"jl", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
-	{"jnge", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
-	{"jnl", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
-	{"jge", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
-	{"jle", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
-	{"jng", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
-	{"jnle", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
-	{"jg", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
+	//{"jo", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x80}},
+	//{"jno", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x81}},
+	//{"jb", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	//{"jnae", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	//{"jc", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x82}},
+	//{"jnb", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	//{"jae", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	//{"jnc", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x83}},
+	//{"jz", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
+	//{"je", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x84}},
+	//{"jnz", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
+	//{"jne", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x85}},
+	//{"jbe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
+	//{"jna", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x86}},
+	//{"jnbe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
+	//{"ja", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x87}},
+	//{"js", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x88}},
+	//{"jns", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x89}},
+	//{"jp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
+	//{"jpe", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8A}},
+	//{"jnp", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
+	//{"jpo", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8B}},
+	//{"jl", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
+	//{"jnge", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8C}},
+	//{"jnl", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
+	//{"jge", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8D}},
+	//{"jle", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
+	//{"jng", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8E}},
+	//{"jnle", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
+	//{"jg", {OT_IMMOP | OT_JMPADDRESS | OT_DWORD}, 1, {0x0F, 0x8F}},
 
 	/////// 0x0F 0x9_ ///////
 	// TODO: what is the value of spec for these instructions?
@@ -898,16 +898,16 @@ Opcode opcodes[] = {
 	{"setg", {OT_REGMEMOP(GP) | OT_BYTE}, 1, {0x0F, 0x9F}},
 
 	/////// 0x0F 0xA_ ///////
-	{"push", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA0}},
-	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA1}},
-	{"cpuid", {}, 2, {0x0F, 0xA2}},
-	{"bt", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xA3}},
+	//{"push", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA0}},
+	//{"pop", {(OT_SEGMENTREG & OT_REG(X86R_FS))}, 2, {0x0F, 0xA1}},
+	//{"cpuid", {}, 2, {0x0F, 0xA2}},
+	//{"bt", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xA3}},
 	{"shld", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xA4}},
 	{"shld", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xA5}},
 	// 0x0F 0xA6-0xA7: reserved
-	{"push", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA8}},
-	{"pop", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA9}},
-	{"rsm", {}, 2, {0x0F, 0xAA}},
+	//{"push", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA8}},
+	//{"pop", {(OT_SEGMENTREG & OT_REG(X86R_GS))}, 2, {0x0F, 0xA9}},
+	//{"rsm", {}, 2, {0x0F, 0xAA}},
 	{"bts", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD}, 2, {0x0F, 0xAB}},
 	{"shrd", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xAC}},
 	{"shrd", {OT_REGMEMOP(GP) | OT_DWORD, OT_REGSPECOP(GP) | OT_DWORD, (OT_GPREG & OT_REG(X86R_CL)) | OT_BYTE}, 2, {0x0F, 0xAD}},
@@ -941,14 +941,14 @@ Opcode opcodes[] = {
 	{"pextrw", {OT_REGSPECOP(GP) | OT_DWORD, OT_REGONLYOP(MMX) | OT_QWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xC5}},
 	{"shufps", {OT_REGSPECOP(XMM) | OT_OWORD, OT_REGMEMOP(XMM) | OT_OWORD, OT_IMMOP | OT_BYTE}, 2, {0x0F, 0xC6}},
 	// 0x0F 0xB7: group 9
-	{"bswap", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 2, {0x0F, 0xC8}},
-	{"bswap", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 2, {0x0F, 0xC9}},
-	{"bswap", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 2, {0x0F, 0xCA}},
-	{"bswap", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 2, {0x0F, 0xCB}},
-	{"bswap", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 2, {0x0F, 0xCC}},
-	{"bswap", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 2, {0x0F, 0xCD}},
-	{"bswap", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 2, {0x0F, 0xCE}},
-	{"bswap", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 2, {0x0F, 0xCF}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_EAX)) | OT_DWORD}, 2, {0x0F, 0xC8}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_ECX)) | OT_DWORD}, 2, {0x0F, 0xC9}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_EDX)) | OT_DWORD}, 2, {0x0F, 0xCA}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_EBX)) | OT_DWORD}, 2, {0x0F, 0xCB}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_ESP)) | OT_DWORD}, 2, {0x0F, 0xCC}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_EBP)) | OT_DWORD}, 2, {0x0F, 0xCD}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_ESI)) | OT_DWORD}, 2, {0x0F, 0xCE}},
+	//{"bswap", {(OT_GPREG & OT_REG(X86R_EDI)) | OT_DWORD}, 2, {0x0F, 0xCF}},
 
 	/////// 0x0F 0xD_ ///////
 	// 0x0F 0xD0: reserved
@@ -1015,34 +1015,34 @@ Opcode opcodes[] = {
 	///////////////////////////////////////////
 
 	// IMMEDIATE GROUP 1
-	{"add", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 0},
-	{"or", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 1},
-	{"adc", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 2},
-	{"sbb", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 3},
-	{"and", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 4},
-	{"sub", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 5},
-	{"xor", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 6},
-	{"cmp", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 7},
-
-	{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 0},
-	{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 1},
-	{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 2},
-	{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 3},
-	{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 4},
-	{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 5},
-	{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 6},
-	{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 7},
+	//{"add", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 0},
+	//{"or", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 1},
+	//{"adc", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 2},
+	//{"sbb", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 3},
+	//{"and", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 4},
+	//{"sub", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 5},
+	//{"xor", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 6},
+	//{"cmp", {OT_REGMEMOP(GP) | OT_BYTE, OT_IMMOP | OT_BYTE}, 1, {0x80}, SPECIAL_SPEC + 7},
+//
+	//{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 0},
+	//{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 1},
+	//{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 2},
+	//{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 3},
+	//{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 4},
+	//{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 5},
+	//{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 6},
+	//{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_DWORD}, 1, {0x81}, SPECIAL_SPEC + 7},
 
 	// Are there opcodes starting with 0x82?
 
-	{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 0},
-	{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 1},
-	{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 2},
-	{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 3},
-	{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 4},
-	{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 5},
-	{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 6},
-	{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 7},
+	//{"add", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 0},
+	//{"or", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 1},
+	//{"adc", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 2},
+	//{"sbb", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 3},
+	//{"and", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 4},
+	//{"sub", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 5},
+	//{"xor", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 6},
+	//{"cmp", {OT_REGMEMOP(GP) | OT_DWORD, OT_IMMOP | OT_BYTE}, 1, {0x83}, SPECIAL_SPEC + 7},
 
 	// SHIFT GROUP 2
 	// TODO
@@ -1057,7 +1057,7 @@ Opcode opcodes[] = {
 	{"fadd", {OT_REGONLYOP(FPU), (OT_FPUREG & OT_REG(0)) | OT_FPUSIZE}, 1, {0xDC}, SPECIAL_SPEC + 0},
 	// ...
 
-	{"fsin", {}, 2, {0xD9, 0xFE}}
+	//{"fsin", {}, 2, {0xD9, 0xFE}}
 };
 
 


### PR DESCRIPTION
Beginning to refactor the handmade assembler to incorporate some concepts of the tab assembler with the hackability of the nz assembler.
The idea is that each instruction that takes arguments is handled by its own function. Instructions without arguments just resolve to hardcoded instructions for the lookup table. Special cases are also group 1 and group 2 instructions

http://www.sandpile.org/x86/opc_grp.htm

A further aim is to remove the tab assetmbler in order to reduce the number of assemblers that ship with r2.

Second PR