### PR TITLE
separate debruijn to it's own header file

### DIFF
--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -13,6 +13,7 @@
 #include <r_th.h>
 #include <dirent.h>
 #include <sys/time.h>
+#include <r_util/r_debruijn.h>
 #if __UNIX__
 #include <signal.h>
 #endif
@@ -834,10 +835,6 @@ R_API FILE *r_sandbox_fopen(const char *path, const char *mode);
 R_API int r_sandbox_chdir(const char *path);
 R_API int r_sandbox_check_path(const char *path);
 R_API int r_sandbox_kill(int pid, int sig);
-
-/* derbuijn.c */
-R_API char* r_debruijn_pattern(int size, int start, const char* charset);
-R_API int r_debruijn_offset(ut64 value, int guest_endian);
 
 /* strpool */
 #define R_STRPOOL_INC 1024

--- a/libr/include/r_util/r_debruijn.h
+++ b/libr/include/r_util/r_debruijn.h
@@ -1,0 +1,23 @@
+/* radare - LGPL - Copyright 2014 - crowell */
+
+#ifndef R_DEBRUIJN_H
+#define R_DEBRUIJN_H
+
+#include <r_types.h>
+
+// For information about the algorithm, see Joe Sawada and Frank Ruskey, "An
+// Efficient Algorithm for Generating Necklaces with Fixed Density"
+
+// Generate a cyclic pattern of desired size, and charset, return with starting
+// offset of start.
+// The returned string is malloced, and it is the responsibility of the caller
+// to free the memory.
+R_API char* r_debruijn_pattern(int size, int start, const char* charset);
+
+
+// Finds the offset of a given value in a cyclic pattern of an integer.
+// Guest endian = 1 if little, 0 if big.
+// Host endian = 1 if little, 0 if big.
+R_API int r_debruijn_offset(ut64 value, int guest_endian);
+
+#endif // R_DEBRUIJN_H

--- a/libr/util/debruijn.c
+++ b/libr/util/debruijn.c
@@ -2,9 +2,6 @@
 
 #include <r_util.h>
 
-// For information about the algorithm, see Joe Sawada and Frank Ruskey, "An
-// Efficient Algorithm for Generating Necklaces with Fixed Density"
-
 // The following two (commented out) lines are the character set used in peda.
 // You may use this charset instead of the A-Za-z0-9 charset normally used.
 // char* peda_charset =


### PR DESCRIPTION
example for #5314

perhaps the includes for the utils should be in `#include <util/r_xxx.h>` instead?