### PR TITLE
fixed breakpoint size based on arch

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -183,7 +183,20 @@ static int r_debug_recoil(RDebug *dbg, RDebugRecoilMode rc_mode) {
 
 /* add a breakpoint with some typical values */
 R_API RBreakpointItem *r_debug_bp_add(RDebug *dbg, ut64 addr, int hw, char *module, st64 m_delta) {
-	int bpsz = strcmp (dbg->arch, "arm") ? 1 : 4;
+	int bpsz;
+	if (!strcmp (arch,"arm")) {
+		bpsz = 4;
+	} else if (!strcmp (arch,"mips")) {
+		bpsz = 4;
+	} else if (!strcmp (arch,"ppc")) {
+		bpsz = 4;
+	} else if (!strcmp (arch,"sparc")) {
+		bpsz = 4;
+	} else if (!strcmp (arch,"sh")) {
+		bpsz = 2;
+	} else {
+		bpsz = 1;
+	}
 	RBreakpointItem *bpi;
 	const char *module_name = module;
 	RListIter *iter;


### PR DESCRIPTION
I was debugging a MIPS binary and received the following error:
> Cannot get breakpoint bytes. No architecture selected?

The issue is the same that was mentioned here #2464. The code used to assume that all breakpoint sizes were 1 byte. The issue was fixed for ARM but not any of the other architectures mentioned.

https://github.com/radare/radare2/blob/master/libr/debug/debug.c#L186
`int bpsz = strcmp (dbg->arch, "arm") ? 1 : 4;`

My change fixed this for MIPS, PPC, SPARC, and SH.