### PR TITLE
Fix #5322: Consistent documentation and added r_help

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -96,15 +96,9 @@ R_API RAsmOp *r_core_disassemble (RCore *core, ut64 addr) {
 #endif
 
 static int cmd_uname(void *data, const char *input) {
-	const char* help_msg[] = {
-		"Usage:", "u", "uname or undo write/seek",
-		"u", "", "show system uname",
-		"uw", "", "alias for wc (requires: e io.cache=true)",
-		"us", "", "alias for s- (seek history)",
-		NULL};
 	switch (input[0]) {
 	case '?':
-		r_core_cmd_help (data, help_msg);
+		r_core_cmd_help (data, help_msg_u);
 		return 1;
 	case 's':
 		r_core_cmdf (data, "s-%s", input+1);
@@ -131,17 +125,7 @@ static int cmd_alias(void *data, const char *input) {
 	char *def, *q, *desc, *buf;
 	RCore *core = (RCore *)data;
 	if (*input=='?') {
-		const char* help_msg[] = {
-			"Usage:", "$alias[=cmd] [args...]", "Alias commands",
-			"$", "", "list all defined aliases",
-			"$*", "", "same as above, but using r2 commands",
-			"$", "dis='af;pdf'", "create command - analyze to show function",
-			"$", "test=#!pipe node /tmp/test.js", "create command - rlangpipe script",
-			"$", "dis=", "undefine alias",
-			"$", "dis", "execute the previously defined alias",
-			"$", "dis?", "show commands aliased by 'analyze'",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_alias);
 		return 0;
 	}
 	i = strlen (input);
@@ -243,9 +227,7 @@ static void aliascmd(RCore *core, const char *str) {
 		}
 		break;
 	case '?':
-		eprintf ("Usage: =$[-][remotecmd]  # remote command alias\n");
-		eprintf (" =$dr   # makes 'dr' alias for =!dr\n");
-		eprintf (" =$-dr  # unset 'dr' alias\n");
+		r_core_cmd_help(core, help_msg_remotecmd_alias);
 		break;
 	case 0:
 		r_core_cmd0 (core, "$");
@@ -342,25 +324,7 @@ static int cmd_yank(void *data, const char *input) {
 		r_core_yank_dump (core, r_num_math (core->num, ""));
 		break;
 	default:{
-		const char* help_msg[] = {
-		"Usage:", "y[ptxy] [len] [[@]addr]", " # See wd? for memcpy, same as 'yf'.",
-		"y", "", "show yank buffer information (srcoff len bytes)",
-		"y", " 16", "copy 16 bytes into clipboard",
-		"y", " 16 0x200", "copy 16 bytes into clipboard from 0x200",
-		"y", " 16 @ 0x200", "copy 16 bytes into clipboard from 0x200",
-		"yz", "", "copy up to blocksize zero terminated string bytes into clipboard",
-		"yz", " 16", "copy up to 16 zero terminated string bytes into clipboard",
-		"yz", " @ 0x200", "copy up to blocksize zero terminated string bytes into clipboard from 0x200",
-		"yz", " 16 @ 0x200", "copy up to 16 zero terminated string bytes into clipboard from 0x200",
-		"yp", "", "print contents of clipboard",
-		"yx", "", "print contents of clipboard in hexadecimal",
-		"ys", "", "print contents of clipboard as string",
-		"yt", " 64 0x200", "copy 64 bytes from current seek to 0x200",
-		"yf", " 64 0x200", "file copy 64 bytes from 0x200 from file (opens w/ io), use -1 for all bytes",
-		"yfa", " file copy", "copy all bytes from file (opens w/ io)",
-		"yy", " 0x3344", "paste clipboard",
-		NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_yank);
 		}
 		break;
 	}
@@ -548,19 +512,7 @@ static int cmd_interpret(void *data, const char *input) {
 		r_cmd_macro_call (&core->rcmd->macro, input + 1);
 		break;
 	case '?':{
-		const char* help_msg[] = {
-		"Usage:", ".[r2cmd] | [file] | [!command] | [(macro)]", " # define macro or load r2, cparse or rlang file",
-		".", "", "repeat last command backward",
-		".", "r2cmd", "interpret the output of the command as r2 commands",
-		"..", "", "repeat last command forward (same as \\n)",
-		".:", "8080", "listen for commands on given tcp port",
-		".", " foo.r2", "interpret r2 script",
-		".-", "", "open cfg.editor and interpret tmp file",
-		".!", "rabin -ri $FILE", "interpret output of command",
-		".", "(foo 1 2 3)", "run macro 'foo' with args 1, 2, 3",
-		"./", " ELF", "interpret output of command /m ELF as r. commands",
-		NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_dot);
 		}
 		break;
 #if 1
@@ -703,22 +655,7 @@ static int cmd_kuery(void *data, const char *input) {
 		}
 		break;
 	case '?': {
-			const char* help_msg[] = {
-			"Usage:", "k[s] [key[=value]]", "Sdb Query",
-			"k", " foo=bar", "set value",
-			"k", " foo", "show value",
-			"k", "", "list keys",
-			"ko", " [file.sdb] [ns]", "open file into namespace",
-			"kd", " [file.sdb] [ns]", "dump namespace to disk",
-			"ks", " [ns]", "enter the sdb query shell",
-			"k", " anal/meta/*", "ist kv from anal > meta namespaces",
-			"k", " anal/**", "list namespaces under anal",
-			"k", " anal/meta/meta.0x80404", "get value for meta.0x80404 key",
-			//"kl", " ha.sdb", "load keyvalue from ha.sdb",
-			//"ks", " ha.sdb", "save keyvalue to ha.sdb",
-			NULL,
-			};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_k);
 		}
 		break;
 	}
@@ -773,17 +710,7 @@ static int cmd_bsize(void *data, const char *input) {
 		r_cons_printf ("0x%x\n", core->blocksize);
 		break;
 	case '?':{
-		const char* help_msg[] = {
-			"Usage:",  "b[f] [arg]\n", "Get/Set block size",
-			"b", "", "display current block size",
-			"b", " 33", "set block size to 33",
-			"b", "+3", "increase blocksize by 3",
-			"b", "-16", "decrease blocksize by 16",
-			"b", " eip+4", "numeric argument can be an expression",
-			"bf", " foo", "set block size to flag size",
-			"bm", " 1M", "set max block size",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_b);
 		}
 		break;
 	default:
@@ -835,16 +762,7 @@ static int cmd_resize(void *data, const char *input) {
 		break;
 	default:
 	case '?':{
-		const char* help_msg[] = {
-			"Usage:", "r[+-][ size]", "Resize file",
-			"r", "", "display file size",
-			"r", " size", "expand or truncate file to given size",
-			"r-", "num", "remove num bytes, move following data down",
-			"r+", "num", "insert num bytes, move following data up",
-			"rm" ," [file]", "remove file",
-			"r2" ," [file]", "launch r2",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_r);
 		}
 		return true;
 	}
@@ -951,25 +869,8 @@ static int cmd_thread(void *data, const char *input) {
 		break;
 	case '?':
 		{
-		const char* help_msg[] = {
-			"Usage:", "&[-|<cmd>]", "Manage tasks",
-			"&", "", "list all running threads",
-			"&=", "", "show output of all tasks",
-			"&=", " 3", "show output of task 3",
-			"&j", "", "list all running threads (in JSON)",
-			"&?", "", "show this help",
-			"&+", " aa", "push to the task list",
-			"&-", " 1", "delete task #1",
-			"&", "-*", "delete all threads",
-			"&", " aa", "run analysis in background",
-			"&", " &&", "run all tasks in background",
-			"&&", "", "run all pendings tasks (and join threads)",
-			"&&&", "", "run all pendings tasks until ^C",
-			"","","TODO: last command should honor asm.bits",
-			"","","WARN: this feature is very experimental. Use it with caution",
-			NULL};
 		// TODO: integrate with =h& and bg anal/string/searchs/..
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_ampersand);
 		}
 		break;
 	case ' ':
@@ -1003,14 +904,7 @@ static int cmd_pointer(void *data, const char *input) {
 	char *str, *eq;
 	while (*input==' ') input++;
 	if (!*input || *input=='?') {
-		const char* help_msg[] = {
-			"Usage:", "*<addr>[=[0x]value]", "Pointer read/write data/values",
-			"*", "entry0=cc", "write trap in entrypoint",
-			"*", "entry0+10=0x804800", "write value in delta address",
-			"*", "entry0", "read byte at given address",
-			"TODO: last command should honor asm.bits", "", "",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_star);
 		return ret;
 	}
 	str = strdup (input);
@@ -1878,14 +1772,7 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) {
 
 	switch (each[0]) {
 	case '?':
-		r_cons_printf ("Usage: @@@ [type]     # types:\n");
-		r_cons_printf (" symbols\n");
-		r_cons_printf (" imports\n");
-		r_cons_printf (" regs\n");
-		r_cons_printf (" threads\n");
-		r_cons_printf (" comments\n");
-		r_cons_printf (" functions\n");
-		r_cons_printf (" flags\n");
+		r_core_cmd_help (core, help_msg_3at);
 		break;
 	case 'c':
 		switch (each[1]) {
@@ -2004,19 +1891,7 @@ R_API int r_core_cmd_foreach(RCore *core, const char *cmd, char *each) {
 
 	switch (each[0]) {
 	case '?':{
-		const char* help_msg[] = {
-		"@@", "", " # foreach iterator command:",
-		"Repeat a command over a list of offsets", "", "",
-		"x", " @@ sym.*", "run 'x' over all flags matching 'sym.' in current flagspace",
-		"x", " @@dbt[abs]", "run a command on every backtrace address, bp or sp",
-		"x", " @@.file", "\"\" over the offsets specified in the file (one offset per line)",
-		"x", " @@=off1 off2 ..", "manual list of offsets",
-		"x", " @@k sdbquery", "\"\" on all offsets returned by that sdbquery",
-		"x", " @@t", "\"\" on all threads (see dp)",
-		"x", " @@=`pdf~call[0]`", "run 'x' at every call offset of the current function",
-		// TODO: Add @@k sdb-query-expression-here
-		NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_2at);
 		}
 		break;
 	case 't':

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -10,7 +10,7 @@ static void find_refs(RCore *core, const char *glob) {
 	if (!*glob)
 		glob = "str.";
 	if (*glob == '?') {
-		eprintf ("Usage: arf [flag-str-filter]\n");
+		r_core_cmd_help (core, help_msg_arf);
 		return;
 	}
 	eprintf ("Finding references of flags matching '%s'...\n", glob);
@@ -34,65 +34,18 @@ static void flag_every_function(RCore *core) {
 }
 
 static void var_help(RCore *core, char ch) {
-	const char *help_sp[] = {
-		"Usage:", "afvs", " [idx] [type] [name]",
-		"afvs", "", "list stack based arguments and variables",
-		"afvs*", "", "same as afvs but in r2 commands",
-		"afvs", " [idx] [name] [type]", "define stack based arguments,variables",
-		"afvsn", " [old_name] [new_name]", "rename stack based argument or variable",
-		"afvst", " [name] [new_type]", "change type for given argument or variable",
-		"afvsj", "", "return list of stack based arguments and variables in JSON format",
-		"afvs-", " [name]", "delete stack based argument or variables with the given name",
-		"afvsg", " [idx] [addr]", "define var get reference",
-		"afvss", " [idx] [addr]", "define var set reference",
-		NULL
-	};
-	const char *help_bp[] = {
-		"Usage:", "afvb", " [idx] [type] [name]",
-		"afvb", "", "list base pointer based arguments, variables",
-		"afvb*", "", "same as afvb but in r2 commands",
-		"afvb", " [idx] [name] ([type])", "define base pointer based argument, variable",
-		"afvbn", " [old_name] [new_name]", "rename base pointer based argument or variable",
-		"afvbt", " [name] [new_type]", "change type for given base pointer based argument or variable",
-		"afvbj", "", "return list of base pointer based arguments, variables in JSON format",
-		"afvb-", " [name]", "delete argument/ variables at the given name",
-		"afvbg", " [idx] [addr]", "define var get reference",
-		"afvbs", " [idx] [addr]", "define var set reference",
-		NULL
-	};
-	const char *help_reg[] = {
-		"Usage:", "afvr", " [reg] [type] [name]",
-		"afvr", "", "list register based arguments",
-		"afvr*", "", "same as afvr but in r2 commands",
-		"afvr", " [reg] [name] ([type])", "define register arguments",
-		"afvrn", " [old_name] [new_name]", "rename argument",
-		"afvrt", " [name] [new_type]", "change type for given argument",
-		"afvrj", "", "return list of register arguments in JSON format",
-		"afvr-", " [name]", "delete register arguments at the given index",
-		"afvrg", " [reg] [addr]", "define var get reference",
-		"afvrs", " [reg] [addr]", "define var set reference",
-		NULL
-	};
-	const char *help_general[] = {
-		"Usage:", "afv","[rbsa]",
-		"afvr", "?", "manipulate register based arguments",
-		"afvb", "?", "manipulate bp based arguments/ vars",
-		"afvs", "?", "manipulate sp based arguments/ vars",
-		"afva", "", "analyze function arguments/vars",
-		NULL
-	};
 	switch (ch) {
 	case 'b':
-		r_core_cmd_help (core, help_bp);
+		r_core_cmd_help (core, help_msg_afvb);
 		break;
 	case 's':
-		r_core_cmd_help (core, help_sp);
+		r_core_cmd_help (core, help_msg_afvs);
 		break;
 	case 'r':
-		r_core_cmd_help (core, help_reg);
+		r_core_cmd_help (core, help_msg_afvr);
 		break;
 	case '?':
-		r_core_cmd_help (core, help_general);
+		r_core_cmd_help (core, help_msg_afv);
 		break;
 	default:
 		eprintf ("See afv?, afvb?, afvr? and afvs?\n");
@@ -1011,10 +964,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 	case 'i': // "afi"
 		switch (input[2]) {
 		case '?':
-			eprintf ("Usage: afi[jl*] <addr>\n"); break;
-			eprintf ("afij - function info in json format\n");
-			eprintf ("afil - verbose function info\n");
-			eprintf ("afi* - function, variables and arguments\n");
+			r_core_cmd_help (core, help_msg_afi);
 			break;
 		case 'j':   // "afij"
 		case 'l':   // "afil"
@@ -1029,13 +979,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 	case 'l': // "afl"
 		switch (input[2]) {
 		case '?':
-			eprintf ("Usage: afl[jlqs*]\n");
-			eprintf ("List all functions in quiet, commands or json format\n");
-			eprintf ("afl  - list functions\n");
-			eprintf ("aflj - list functions in json format\n");
-			eprintf ("afll - list functions in verbose mode\n");
-			eprintf ("aflq - list functions in 'quiet' mode\n");
-			eprintf ("afls - print sum of sizes of all functions\n");
+			r_core_cmd_help (core, help_msg_afl);
 			break;
 		case 'j':
 		case 'l':
@@ -1096,13 +1040,6 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			eprintf ("Cant find function here\n");
 			break;
 		}
-		const char *help_afC[] = {
-			"Usage:", "afC[agl?]", "",
-			"afC", " convention", "Manually set calling convention for current function",
-			"afC", "", "Show Calling convention for the Current function",
-			"afCa", "", "Analyse function for finding the current calling convention",
-			"afCl", "", "List all available calling conventions",
-			NULL };
 		switch (input[2]) {
 		case'?': {
 			r_core_cmd_help (core, help_afC);
@@ -1115,7 +1052,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			//should I test for null ... no ;)
 			} break;
 		case 'a':
-			eprintf ("Todo\n");
+			eprintf ("TODO\n");
 			break;
 		case ' ': {
 			int type = r_anal_cc_str2type (input + 3);
@@ -1163,26 +1100,14 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			break;
 		default:
 		case '?':
-			/* TODO: use r_core_help */
-			eprintf ("Usage: afb+ or afbb or afb\n"
-				/* TODO: move afbr into afr? */
-				" afbr        - show addresses of instructions which leave the function\n"
-				" .afbr*      - set breakpoint on every return address of the fcn\n"
-				" .afbr-*     - undo the above operation\n"
-				" afbj        - show basic blocks information in JSON\n"
-				" afB [bits]  - define asm.bits for given function\n"
-				" afb [addr]  - list basic blocks of function (see afbq, afbj, afb*)\n"
-				" afb+ fcn_at bbat bbsz [jump] [fail] ([type] ([diff]))  add bb to function @ fcnaddr\n");
+			r_core_cmd_help (core, help_msg_afb);
 			break;
 		}
 		break;
 	case 'n': // "afn"
 		switch (input[2]) {
 		case '?':
-			eprintf ("Usage: afn[sa] - analyze function names\n");
-			eprintf (" afna       - construct a function name for the current offset\n");
-			eprintf (" afns       - list all strings associated with the current function\n");
-			eprintf (" afn [name] - rename function\n");
+			r_core_cmd_help (core, help_msg_afn);
 			break;
 		case 's':
 			free (r_core_anal_fcn_autoname (core, core->offset, 1));
@@ -1319,14 +1244,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		default:
 		case '?':
 			{
-			const char *help_msg[] = {
-				"Usage:", "afx[-cCd?] [src] [dst]", "# manage function references (see also ar?)",
-				"afxc", " sym.main+0x38 sym.printf", "add code ref",
-				"afxC", " sym.main sym.puts", "add call ref",
-				"afxd", " sym.main str.helloworld", "add data ref",
-				"afx-", " sym.main str.helloworld", "remove reference",
-				NULL };
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_afx);
 			}
 			break;
 		}
@@ -1346,30 +1264,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		break;
 	case '?':
 		{ // "af?"
-		const char *help_msg[] = {
-			"Usage:", "af", "",
-			"af", " ([name]) ([addr])", "analyze functions (start at addr or $$)",
-			"afr", " ([name]) ([addr])", "analyze functions recursively",
-			"af+", " addr size name [type] [diff]", "hand craft a function (requires afb+)",
-			"af-", " [addr]", "clean all function analysis data (or function at addr)",
-			"afv[bsra]", "?", "manipulate args, registers and variables in function",
-			"afb+", " fa a sz [j] [f] ([t]( [d]))", "add bb to function @ fcnaddr",
-			"afb", " [addr]", "List basic blocks of given function",
-			"afB", " 16", "set current function as thumb (change asm.bits)",
-			"afc", "@[addr]", "calculate the Cyclomatic Complexity (starting at addr)",
-			"afC[?]", " type @[addr]", "set calling convention for function",
-			"aff", "", "re-adjust function boundaries to fit",
-			"afF", "[1|0|]", "fold/unfold/toggle",
-			"afg", "", "non-interactive ascii-art basic-block graph (See VV)",
-			"afi", " [addr|fcn.name]", "show function(s) information (verbose afl)",
-			"afl", "[l*] [fcn name]", "list functions (addr, size, bbs, name) (see afll)",
-			"afo", " [fcn.name]", "show address for the function named like this",
-			"afn", " name [addr]", "rename name for function at address (change flag too)",
-			"afna", "", "suggest automatic name for current offset",
-			"afs", " [addr] [fcnsign]", "get/set function signature at current address",
-			"afx", "[cCd-] src dst", "add/remove code/Call/data/string reference",
-			NULL };
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_af);
 		}
 		break;
 	case 'r': // "afr" // analyze function recursively
@@ -1509,54 +1404,6 @@ static void __anal_reg_list(RCore *core, int type, int size, char mode) {
 	core->dbg->reg = hack;
 }
 
-static void ar_show_help(RCore *core) {
-	const char *help_message[] = {
-		"Usage: ar", "", "# Analysis Registers",
-		"ar", "", "Show 'gpr' registers",
-		"ar0", "", "Reset register arenas to 0",
-		"ara", "", "Manage register arenas",
-		"ar", " 16", "Show 16 bit registers",
-		"ar", " 32", "Show 32 bit registers",
-		"ar", " all", "Show all bit registers",
-		"ar", " <type>", "Show all registers of given type",
-		"arC", "", "Display register profile comments",
-		"arr", "", "Show register references (telescoping)",
-		"ar=", "", "Show register values in columns",
-		"ar?", " <reg>", "Show register value",
-		"arb", " <type>", "Display hexdump of the given arena",
-		"arc", " <name>", "Conditional flag registers",
-		"ard", " <name>", "Show only different registers",
-		"arn", " <regalias>", "Get regname for pc,sp,bp,a0-3,zf,cf,of,sg",
-		"aro", "", "Show old (previous) register values",
-		"arp", " <file>", "Load register profile from file",
-		"ars", "", "Stack register state",
-		"art", "", "List all register types",
-		"arw", " <hexnum>", "Set contents of the register arena",
-		".ar*", "", "Import register values as flags",
-		".ar-", "", "Unflag all registers",
-		NULL };
-	r_core_cmd_help (core, help_message);
-}
-
-static void cmd_ara_help(RCore *core) {
-	const char *help_msg[] = {
-		"Usage:", "ara[+-s]", "Register Arena Push/Pop/Swap",
-		"ara", "", "show all register arenas allocated",
-		"ara", "+", "push a new register arena for each type",
-		"ara", "-", "pop last register arena",
-		"aras", "", "swap last two register arenas",
-		NULL };
-	r_core_cmd_help (core, help_msg);
-}
-
-static void cmd_arw_help (RCore *core) {
-	const char *help_msg[] = {
-		"Usage:", " arw ", "# Set contents of the register arena",
-		"arw", " <hexnum>", "Set contents of the register arena",
-		NULL };
-	r_core_cmd_help (core, help_msg);
-}
-
 // XXX dup from drp :OOO
 void cmd_anal_reg (RCore *core, const char *str) {
 	int size = 0, i, type = R_REG_TYPE_GPR;
@@ -1597,21 +1444,21 @@ void cmd_anal_reg (RCore *core, const char *str) {
 	case 'w':
 		switch (str[1]) {
 		case '?': {
-			cmd_arw_help (core);
+			r_core_cmd_help (core, help_msg_arw);
 			break;
 		}
 		case ' ':
 			r_reg_arena_set_bytes (core->anal->reg, str + 1);
 			break;
 		default:
-			cmd_arw_help (core);
+			r_core_cmd_help (core, help_msg_arw);
 			break;
 		}
                 break;
 	case 'a': // "ara"
 		switch (str[1]) {
 		case '?':
-			cmd_ara_help (core);
+			r_core_cmd_help (core, help_msg_ara);
 			break;
 		case 's':
 			r_reg_arena_swap (core->anal->reg, false);
@@ -1643,7 +1490,9 @@ void cmd_anal_reg (RCore *core, const char *str) {
 		if (str[1]) {
 			ut64 off = r_reg_getv (core->anal->reg, str + 1);
 			r_cons_printf ("0x%08" PFMT64x "\n", off);
-		} else ar_show_help (core);
+		} else { 
+			r_core_cmd_help (core, help_msg_ar);
+		}
 		break;
 	case 'r':
 		r_core_debug_rr (core, core->anal->reg);
@@ -1718,13 +1567,7 @@ void cmd_anal_reg (RCore *core, const char *str) {
 			r_reg_arena_push (core->dbg->reg);
 			break;
 		case '?': {
-			const char *help_msg[] = {
-				"Usage:", "drs", " # Register states commands",
-				"drs", "", "List register stack",
-				"drs+", "", "Push register state",
-				"drs-", "", "Pop register state",
-				NULL };
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_drs);
 		} break;
 		default:
 			r_cons_printf ("%d\n", r_list_length (
@@ -2308,27 +2151,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	return true;
 }
 
-static void aea_help(RCore *core) {
-	const char *help_msg[] = {
-		"Examples:", "aea", " show regs used in a range",
-		"aea", " [ops]", "Show regs used in N instructions",
-		"aeaf", "", "Show regs used in current function",
-		"aear", " [ops]", "Show regs read in N instructions",
-		"aeaw", " [ops]", "Show regs written in N instructions",
-		"aean", " [ops]", "Show regs not written in N instructions",
-		"aeA", " [len]", "Show regs used in N bytes (subcommands are the same)",
-		NULL };
-	r_core_cmd_help (core, help_msg);
-}
-
 static void cmd_anal_esil(RCore *core, const char *input) {
-	const char *help_msg[] = {
-		"Usage:", "aep[-c] ", " [...]",
-		"aepc", " [addr]", "change program counter for esil",
-		"aep", "-[addr]", "remove pin",
-		"aep", " [name] @ [addr]", "set pin",
-		"aep", "", "list pins",
-		NULL };
 	RAnalEsil *esil = core->anal->esil;
 	ut64 addr = core->offset;
 	int stacksize = r_config_get_i (core->config, "esil.stacksize");
@@ -2365,7 +2188,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			r_anal_pin (core->anal, addr, input + 2);
 			break;
 		default:
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_aep);
 			break;
 		}
 		break;
@@ -2441,10 +2264,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		break;
 	case 'c':
 		if (input[1] == '?') { // "aec?"
-			eprintf ("aecs         - continue until syscall\n");
-			eprintf ("aec          - continue until exception\n");
-			eprintf ("aecu [addr]  - continue until address\n");
-			eprintf ("aecue [expr] - continue until esil expression\n");
+			r_core_cmd_help (core, help_msg_aec);
 		} else if (input[1] == 's') { // "aecs"
 			const char *pc = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 			ut64 newaddr;
@@ -2609,7 +2429,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		break;
 	case 'A': // "aeA"
 		if (input[1] == '?') {
-			aea_help (core);
+			r_core_cmd_help (core, help_msg_aea);
 		} else if (input[1] == 'r') {
 			cmd_aea (core, 1 + (1<<1), core->offset, r_num_math (core->num, input+2));
 		} else if (input[1] == 'w') {
@@ -2625,7 +2445,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		break;
 	case 'a': // "aea"
 		if (input[1] == '?') {
-			aea_help (core);
+			r_core_cmd_help (core, help_msg_aea);
 		} else if (input[1] == 'r') {
 			cmd_aea (core, 1<<1, core->offset, r_num_math (core->num, input+2));
 		} else if (input[1] == 'w') {
@@ -2680,79 +2500,17 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		break;
 	case '?':
 		if (input[1] == '?') {
-			const char *help_msg[] = {
-				"Examples:", "ESIL", " examples and documentation",
-				"+", "=", "A+=B => B,A,+=",
-				"+", "", "A=A+B => B,A,+,A,=",
-				"*", "=", "A*=B => B,A,*=",
-				"/", "=", "A/=B => B,A,/=",
-				"&", "=", "and ax, bx => bx,ax,&=",
-				"|", "", "or r0, r1, r2 => r2,r1,|,r0,=",
-				"^", "=", "xor ax, bx => bx,ax,^=",
-				">>", "=", "shr ax, bx => bx,ax,>>=  # shift right",
-				"<<", "=", "shr ax, bx => bx,ax,<<=  # shift left",
-				"", "[]", "mov eax,[eax] => eax,[],eax,=",
-				"=", "[]", "mov [eax+3], 1 => 1,3,eax,+,=[]",
-				"=", "[1]", "mov byte[eax],1 => 1,eax,=[1]",
-				"=", "[8]", "mov [rax],1 => 1,rax,=[8]",
-				"$", "", "int 0x80 => 0x80,$",
-				"$$", "", "simulate a hardware trap",
-				"==", "", "pops twice, compare and update esil flags",
-				"<", "", "compare for smaller",
-				"<", "=", "compare for smaller or equal",
-				">", "", "compare for bigger",
-				">", "=", "compare bigger for or equal",
-				"?{", "", "if popped value != 0 run the block until }",
-				"POP", "", "drops last element in the esil stack",
-				"TODO", "", "the instruction is not yet esilized",
-				"STACK", "", "show contents of stack",
-				"CLEAR", "", "clears the esil stack",
-				"BREAK", "", "terminates the string parsing",
-				"GOTO", "", "jump to the Nth word popped from the stack",
-				NULL };
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_esil);
 			break;
 		}
 	/* fall through */
 	default: {
-		const char *help_msg[] = {
-			"Usage:", "ae[idesr?] [arg]", "ESIL code emulation",
-			"ae?", "", "show this help",
-			"ae??", "", "show ESIL help",
-			"aei", "", "initialize ESIL VM state (aei- to deinitialize)",
-			"aeim", "", "initialize ESIL VM stack (aeim- remove)",
-			"aeip", "", "initialize ESIL program counter to curseek",
-			"ae", " [expr]", "evaluate ESIL expression",
-			"aex", " [hex]", "evaluate opcode expression",
-			"ae[aA]", "[f] [count]", "analyse esil accesses (regs, mem..)",
-			"aep", " [addr]", "change esil PC to this address",
-			"aef", " [addr]", "emulate function",
-			"aek", " [query]", "perform sdb query on ESIL.info",
-			"aek-", "", "resets the ESIL.info sdb instance",
-			"aec", "", "continue until ^C",
-			"aecs", " [sn]", "continue until syscall number",
-			"aecu", " [addr]", "continue until address",
-			"aecue", " [esil]", "continue until esil expression match",
-			"aetr", "[esil]", "Convert an ESIL Expression to REIL",
-			"aes", "", "perform emulated debugger step",
-			"aeso", " ", "step over",
-			"aesu", " [addr]", "step until given address",
-			"aesue", " [esil]", "step until esil expression match",
-			"aer", " [..]", "handle ESIL registers like 'ar' or 'dr' does",
-			NULL };
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_ae);
 	} break;
 	}
 }
 
 static void cmd_anal_noreturn(RCore *core, const char *input) {
-	const char *help_msg[] = {
-		"Usage:", "an [-][0xaddr|symname]", " manage no-return marks",
-		"an[a]", " 0x3000", "stop function analysis if call/jmp to this address",
-		"an[n]", " sym.imp.exit", "same as above but for flag/fcn names",
-		"an", "-*", "remove all no-return references",
-		"an", "", "list them all",
-		NULL };
 	switch (input[0]) {
 	case '-':
 		r_anal_noreturn_drop (core->anal, input + 1);
@@ -2770,11 +2528,11 @@ static void cmd_anal_noreturn(RCore *core, const char *input) {
 		if (input[1] == ' ') {
 			r_anal_noreturn_add (core->anal, NULL,
 					r_num_math (core->num, input + 1));
-		} else r_core_cmd_help (core, help_msg);
+		} else r_core_cmd_help (core, help_msg_an);
 		break;
 	case 'n':
 		if (input[1] == ' ') {
-		} else r_core_cmd_help (core, help_msg);
+		} else r_core_cmd_help (core, help_msg_an);
 		break;
 	case '*':
 	case 'r':
@@ -2785,7 +2543,7 @@ static void cmd_anal_noreturn(RCore *core, const char *input) {
 		break;
 	default:
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_an);
 		break;
 	}
 }
@@ -2796,16 +2554,7 @@ static void cmd_anal_opcode(RCore *core, const char *input) {
 
 	switch (input[0]) {
 	case '?': {
-		const char *help_msg[] = {
-			"Usage:", "ao[e?] [len]", "Analyze Opcodes",
-			"aoj", " N", "display opcode analysis information in JSON for N opcodes",
-			"aoe", " N", "display esil form for N opcodes",
-			"aor", " N", "display reil form for N opcodes",
-			"aos", " [esil]", "show sdb representation of esil expression (TODO)",
-			"ao", " 5", "display opcode analysis of 5 opcodes",
-			"ao*", "", "display opcode in r commands",
-			NULL };
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_ao);
 	} break;
 	case 'j':
 	case 'e':
@@ -2951,17 +2700,6 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 	RList *list;
 	char *out;
 	int n;
-	const char *help_msg[] = {
-		"Usage: as[ljk?]", "", "syscall name <-> number utility",
-		"as", "", "show current syscall and arguments",
-		"as", " 4", "show syscall 4 based on asm.os and current regs/mem",
-		"asf", " [k[=[v]]]", "list/set/unset pf function signatures (see fcnsign)",
-		"asj", "", "list of syscalls in JSON",
-		"asl", "", "list of syscalls by asm.os and asm.arch",
-		"asl", " close", "returns the syscall number for close",
-		"asl", " 4", "returns the name of the syscall number 4",
-		"ask", " [query]", "perform syscall/ queries",
-		NULL };
 
 	switch (input[0]) {
 	case 'f': // "asf"
@@ -3019,7 +2757,7 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 		break;
 	default:
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_as);
 		break;
 	}
 }
@@ -3076,22 +2814,6 @@ static void anal_axg (RCore *core, const char *input, int level, Sdb *db) {
 
 static bool cmd_anal_refs(RCore *core, const char *input) {
 	ut64 addr = core->offset;
-	const char *help_msg[] = {
-		"Usage:", "ax[?d-l*]", " # see also 'afx?'",
-		"ax", " addr [at]", "add code ref pointing to addr (from curseek)",
-		"axc", " addr [at]", "add code jmp ref // unused?",
-		"axC", " addr [at]", "add code call ref",
-		"axg", " addr", "show xrefs graph to reach current function",
-		"axd", " addr [at]", "add data ref",
-		"axj", "", "list refs in json format",
-		"axF", " [flg-glob]", "find data/code references of flags",
-		"axt", " [addr]", "find data/code references to this address",
-		"axf", " [addr]", "find data/code references from this address",
-		"ax-", " [at]", "clean all refs (or refs from addr)",
-		"ax", "", "list refs",
-		"axk", " [query]", "perform sdb query",
-		"ax*", "", "output radare commands",
-		NULL };
 	switch (input[0]) {
 	case '-': { // "ax-"
 		const char *inp;
@@ -3287,7 +3009,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	} break;
 	default:
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_ax);
 		break;
 	}
 
@@ -3315,31 +3037,12 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	*/
 
 static void cmd_anal_hint(RCore *core, const char *input) {
-	const char *help_msg[] = {
-		"Usage:", "ah[lba-]", "Analysis Hints",
-		"ah?", "", "show this help",
-		"ah?", " offset", "show hint of given offset",
-		"ah", "", "list hints in human-readable format",
-		"ah.", "", "list hints in human-readable format from current offset",
-		"ah-", "", "remove all hints",
-		"ah-", " offset [size]", "remove hints at given offset",
-		"ah*", " offset", "list hints in radare commands format",
-		"aha", " ppc 51", "set arch for a range of N bytes",
-		"ahb", " 16 @ $$", "force 16bit for current instruction",
-		"ahc", " 0x804804", "override call/jump address",
-		"ahf", " 0x804840", "override fallback address for call",
-		"ahi", " 10", "define numeric base for immediates (1, 8, 10, 16, s)",
-		"ahs", " 4", "set opcode size=4",
-		"ahS", " jz", "set asm.syntax=jz for this opcode",
-		"aho", " foo a0,33", "replace opcode string",
-		"ahe", " eax+=3", "set vm analysis string",
-		NULL };
 	switch (input[0]) {
 	case '?':
 		if (input[1]) {
 			ut64 addr = r_num_math (core->num, input+1);
 			r_core_anal_hint_print (core->anal, addr);
-		} else r_core_cmd_help (core, help_msg);
+		} else r_core_cmd_help (core, help_msg_ah);
 		break;
 	case '.': // ah.
 		r_core_anal_hint_print(core->anal, core->offset);
@@ -3370,18 +3073,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 		break;
 	case 'i': // "ahi"
 		if (input[1] == '?') {
-			const char* help_msg[] = {
-				"Usage", "ahi [sbodh] [@ offset]", " Define numeric base",
-				"ahi", " [base]", "set numeric base (1, 2, 8, 10, 16)",
-				"ahi", " b", "set base to binary (1)",
-				"ahi", " d", "set base to decimal (10)",
-				"ahi", " h", "set base to hexadecimal (16)",
-				"ahi", " o", "set base to octal (8)",
-				"ahi", " i", "set base to IP address (32)",
-				"ahi", " S", "set base to syscall (80)",
-				"ahi", " s", "set base to string (2)",
-				NULL };
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_ahi);
 		} else if (input[1] == ' ') {
 		// You can either specify immbase with letters, or numbers
 			const int base =
@@ -3498,16 +3190,6 @@ static void agraph_print_edge(RANode *from, RANode *to, void *user) {
 }
 
 static void cmd_agraph_node(RCore *core, const char *input) {
-	const char *help_msg[] = {
-		"Usage:", "agn [title] [body]", "",
-		"Examples:", "", "",
-		"agn", " title1 body1", "Add a node with title \"title1\" and body \"body1\"",
-		"agn", " \"title with space\" \"body with space\"", "Add a node with spaces in the title and in the body",
-		"agn", " title1 base64:Ym9keTE=", "Add a node with the body specified as base64",
-		"agn-", " title1", "Remove a node with title \"title1\"",
-		"agn?", "", "Show this help",
-		NULL };
-
 	switch (*input) {
 	case ' ': {
 		char *newbody = NULL;
@@ -3562,21 +3244,12 @@ static void cmd_agraph_node(RCore *core, const char *input) {
 	}
 	case '?':
 	default:
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_agn);
 		break;
 	}
 }
 
 static void cmd_agraph_edge(RCore *core, const char *input) {
-	const char *help_msg[] = {
-		"Usage:", "age [title1] [title2]", "",
-		"Examples:", "", "",
-		"age", " title1 title2", "Add an edge from the node with \"title1\" as title to the one with title \"title2\"",
-		"age", " \"title1 with spaces\" title2", "Add an edge from node \"title1 with spaces\" to node \"title2\"",
-		"age-", " title1 title2", "Remove an edge from the node with \"title1\" as title to the one with title \"title2\"",
-		"age?", "", "Show this help",
-		NULL };
-
 	switch (*input) {
 	case ' ':
 	case '-': {
@@ -3608,21 +3281,12 @@ static void cmd_agraph_edge(RCore *core, const char *input) {
 	}
 	case '?':
 	default:
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_age);
 		break;
 	}
 }
 
 static void cmd_agraph_print(RCore *core, const char *input) {
-	const char *help_msg[] = {
-		"Usage:", "agg[kid?*]", "print graph",
-		"agg", "", "show current graph in ascii art",
-		"aggk", "", "show graph in key=value form",
-		"aggd", "", "print the current graph in GRAPHVIZ dot format",
-		"aggi", "", "enter interactive mode for the current graph",
-		"aggd", "", "print the current graph in GRAPHVIZ dot format",
-		"agg*", "", "in r2 commands, to save in projects, etc",
-		NULL };
 	switch (*input) {
 	case 'k': // "aggk"
 	{
@@ -3659,7 +3323,7 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		r_agraph_foreach_edge (core->graph, agraph_print_edge, NULL);
 		break;
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_agg);
 		break;
 	default:
 		core->graph->can->linemode = 1;
@@ -3674,25 +3338,6 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 static void cmd_anal_graph(RCore *core, const char *input) {
 	RList *list;
 	const char *arg;
-	const char *help_msg[] = {
-		"Usage:", "ag[?f]", "Graphviz/graph code",
-		"ag", " [addr]", "output graphviz code (bb at addr and children)",
-		"ag-", "", "Reset the current ASCII art graph (see agn, age, agg?)",
-		"aga", " [addr]", "idem, but only addresses",
-		"agc", "[j] [addr]", "output graphviz call graph of function",
-		"agC", "[j]", "Same as agc -1. full program callgraph",
-		"agd", " [fcn name]", "output graphviz code of diffed function",
-		"age", "[?] title1 title2", "Add an edge to the current graph",
-		"agf", " [addr]", "Show ASCII art graph of given function",
-		"agg", "[kdi*]", "Print graph in ASCII-Art, graphviz, k=v, r2 or visual",
-		"agj", " [addr]", "idem, but in JSON format",
-		"agk", " [addr]", "idem, but in SDB key-value format",
-		"agl", " [fcn name]", "output graphviz code using meta-data",
-		"agn", "[?] title body", "Add a node to the current graph",
-		"ags", " [addr]", "output simple graphviz call graph of function (only bb offset)",
-		"agt", " [addr]", "find paths from current offset to given address",
-		"agv", "[acdltfl] [a]", "view function using graphviz",
-		NULL };
 
 	switch (input[0]) {
 	case 'f':			// "agf"
@@ -3762,7 +3407,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 		r_core_cmd0 (core, "=H /graph/");
 		break;
 	case '?': // "ag?"
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_ag);
 		break;
 	case ' ': // "ag"
 		arg = strchr (input, ' ');
@@ -3783,24 +3428,6 @@ static void cmd_anal_trace(RCore *core, const char *input) {
 	RDebugTracepoint *t;
 	const char *ptr;
 	ut64 addr = core->offset;
-	const char *help_msg[] = {
-		"Usage:", "at", "[*] [addr]",
-		"at", "", "list all traced opcode ranges",
-		"at-", "", "reset the tracing information",
-		"at*", "", "list all traced opcode offsets",
-		"at+", " [addr] [times]", "add trace for address N times",
-		"at", " [addr]", "show trace info at address",
-		"ate", "", "show esil trace logs (anal.trace)",
-		"ate", " [idx]", "show commands to restore to this trace index",
-		"ate", "-", "clear esil trace logs",
-		"att", " [tag]", "select trace tag (no arg unsets)",
-		"at%", "", "TODO",
-		"ata", " 0x804020 ...", "only trace given addresses",
-		"atr", "", "show traces as range commands (ar+)",
-		"atd", "", "show disassembly trace (use .atd)",
-		"atl", "", "list all traced addresses (useful for @@= `atl`)",
-		"atD", "", "show dwarf trace (at*|rsc dwarf-traces $FILE)",
-		NULL };
 
 	switch (input[0]) {
 	case 'r':
@@ -3858,16 +3485,11 @@ static void cmd_anal_trace(RCore *core, const char *input) {
 			}
 			break;
 		default:
-			eprintf ("|Usage: ate[ilk] [-arg]\n"
-				"| ate           esil trace log single instruction\n"
-				"| ate idx       show commands for that index log\n"
-				"| ate-*         delete all esil traces\n"
-				"| atei          esil trace log single instruction\n"
-				"| atek  [sdbq]  esil trace log single instruction\n");
+			r_core_cmd_help (core, help_msg_ate);
 		}
 		break;
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_at);
 		eprintf ("Current Tag: %d\n", core->dbg->trace->tag);
 		break;
 	case 'a':
@@ -3929,12 +3551,7 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 	ut64 from, to;
 	char *ptr;
 	int rad, n;
-	const char *help_msg_aar[] = {
-		"Usage:", "aar", "[j*] [sz] # search and analyze xrefs",
-		"aar", " [sz]", "analyze xrefs in current section or sz bytes of code",
-		"aarj", " [sz]", "list found xrefs in JSON format",
-		"aar*", " [sz]", "list found xrefs in radare commands format",
-		NULL };
+
 	if (*input == '?') {
 		r_core_cmd_help (core, help_msg_aar);
 		return 0;
@@ -4136,23 +3753,6 @@ static void cmd_anal_aav(RCore *core, const char *input) {
 }
 
 static int cmd_anal_all(RCore *core, const char *input) {
-	const char *help_msg_aa[] = {
-		"Usage:", "aa[0*?]", " # see also 'af' and 'afna'",
-		"aa", " ", "alias for 'af@@ sym.*;af@entry0;afva'", //;.afna @@ fcn.*'",
-		"aa*", "", "analyze all flags starting with sym. (af @@ sym.*)",
-		"aaa", "", "autoname functions after aa (see afna)",
-		"aac", " [len]", "analyze function calls (af @@ `pi len~call[1]`)",
-		"aae", " [len] ([addr])", "analyze references with ESIL (optionally to address)",
-		"aai", "[j]", "show info of all analysis parameters",
-		"aar", " [len]", "analyze len bytes of instructions for references",
-		"aan", "", "autoname functions that either start with fcn.* or sym.func.*",
-		"aas", " [len]", "analyze symbols (af @@= `isq~[0]`)",
-		"aat", " [len]", "analyze all consecutive functions in section",
-		"aap", "", "find and analyze function preludes",
-		"aav", " [sat]", "find values referencing a specific section or map",
-		"aau", " [len]", "list mem areas (larger than len bytes) not covered by functions",
-		NULL };
-
 	switch (*input) {
 	case '?': r_core_cmd_help (core, help_msg_aa); break;
 	case 'c': cmd_anal_calls (core, input + 1); break; // "aac"
@@ -4373,36 +3973,6 @@ static int cmd_anal(void *data, const char *input) {
 	const char *r;
 	RCore *core = (RCore *)data;
 	ut32 tbs = core->blocksize;
-	const char *help_msg_ad[] = {
-		"Usage:", "ad", "[kt] [...]",
-		"ad", " [N] [D]", "analyze N data words at D depth",
-		"adf", "", "analyze data in function (use like .adf @@=`afl~[0]`",
-		"adfg", "", "analyze data in function gaps",
-		"adt", "", "analyze data trampolines (wip)",
-		"adk", "", "analyze data kind (code, text, data, invalid, ...)",
-		NULL };
-	const char *help_msg[] = {
-		"Usage:", "a", "[abdefFghoprxstc] [...]",
-		"ab", " [hexpairs]", "analyze bytes",
-		"aa", "", "analyze all (fcns + bbs) (aa0 to avoid sub renaming)",
-		"ac", " [cycles]", "analyze which op could be executed in [cycles]",
-		"ad", "", "analyze data trampoline (wip)",
-		"ad", " [from] [to]", "analyze data pointers to (from-to)",
-		"ae", " [expr]", "analyze opcode eval expression (see ao)",
-		"af", "[rnbcsl?+-*]", "analyze Functions",
-		"aF", "", "same as above, but using anal.depth=1",
-		"ag", "[?acgdlf]", "output Graphviz code",
-		"ah", "[?lba-]", "analysis hints (force opcode size, ...)",
-		"ai", " [addr]", "address information (show perms, stack, heap, ...)",
-		"ao", "[e?] [len]", "analyze Opcodes (or emulate it)",
-		"an", "[an-] [...]", "manage no-return addresses/symbols/functions",
-		"ar", "", "like 'dr' but for the esil vm. (registers)",
-		"ap", "", "find prelude for current offset",
-		"ax", "[?ld-*]", "manage refs/xrefs (see also afx?)",
-		"as", " [num]", "analyze syscall using dbg.reg",
-		"at", "[trd+-%*?] [.]", "analyze execution traces",
-		//"ax", " [-cCd] [f] [t]", "manage code/call/data xrefs",
-		NULL };
 
 	r_cons_break (NULL, NULL);
 
@@ -4559,7 +4129,8 @@ static int cmd_anal(void *data, const char *input) {
 		else r_cons_printf ("No plugins for this analysis plugin\n");
 		break;
 	default:
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_a);
+		// TODO move in separate help_msg or the same as above?
 		r_cons_printf ("Examples:\n"
 			" f ts @ `S*~text:0[3]`; f t @ section..text\n"
 			" f ds @ `S*~data:0[3]`; f d @ section..data\n"

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -2,33 +2,6 @@
 
 #include "r_core.h"
 
-static void showhelp(RCore *core) {
-	const char* help_msg[] = {
-		"Usage:", "c[?dfx] [argument]", " # Compare",
-		"c", " [string]", "Compare a plain with escaped chars string",
-		"c*", " [string]", "Compare a plain with escaped chars string (output r2 commands)",
-		"c4", " [value]", "Compare a doubleword from a math expression",
-		"c8", " [value]", "Compare a quadword from a math expression",
-		"cat", " [file]", "Show contents of file (see pwd, ls)",
-		"cc", " [at] [(at)]", "Compares in two hexdump columns of block size",
-		"ccc", " [at] [(at)]", "Same as above, but only showing different lines",
-		"ccd", " [at] [(at)]", "Compares in two disasm columns of block size",
-		//"cc", " [offset]", "code bindiff current block against offset"
-		//"cD", " [file]", "like above, but using radiff -b",
-		"cf", " [file]", "Compare contents of file at current seek",
-		"cg", "[o] [file]","Graphdiff current file and [file]",
-		"cl|cls|clear", "", "Clear screen, (clear0 to goto 0, 0 only)",
-		"cu", " [addr] @at", "Compare memory hexdumps of $$ and dst in unified diff",
-		"cud", " [addr] @at", "Unified diff disasm from $$ and given address",
-		"cv", "[1248] [addr] @at", "Compare 1,2,4,8-byte value",
-		"cw", "[us?] [...]", "Compare memory watchers",
-		"cx", " [hexpair]", "Compare hexpair string (use '.' as nibble wildcard)",
-		"cx*", " [hexpair]", "Compare hexpair string (output r2 commands)",
-		"cX", " [addr]", "Like 'cc' but using hexdiff output",
-		NULL
-	};
-	r_core_cmd_help (core, help_msg);
-}
 R_API void r_core_cmpwatch_free (RCoreCmpWatcher *w) {
 	free (w->ndata);
 	free (w->odata);
@@ -240,18 +213,7 @@ static void cmd_cmp_watcher (RCore *core, const char *input) {
 		r_core_cmpwatch_show (core, UT64_MAX, 0);
 		break;
 	case '?': {
-			const char * help_message[] = {
-				"Usage: cw", "", "Watcher commands",
-				"cw", "", "List all compare watchers",
-				"cw", " addr", "List all compare watchers",
-				"cw", " addr sz cmd", "Add a memory watcher",
-				//"cws", " [addr]", "Show watchers",
-				"cw", "*", "List compare watchers in r2 cmds",
-				"cwr", " [addr]", "Reset/revert watchers",
-				"cwu", " [addr]", "Update watchers",
-				NULL
-			};
-			r_core_cmd_help(core, help_message);
+			r_core_cmd_help(core, help_msg_cw);
 		}
 		break;
 	}
@@ -566,14 +528,7 @@ static int cmd_cmp(void *data, const char *input) {
 				r_anal_diff_setup (core->anal, false, -1, -1);
 				break;
 			default: {
-				const char * help_message[] = {
-				"Usage: cg", "", "Graph code commands",
-				"cg",  "", "diff ratio among functions (columns: off-A, match-ratio, off-B)",
-				"cgf", "[fcn]", "Compare functions (curseek vs fcn)",
-				"cgo", "", "Opcode-bytes code graph diff",
-				NULL
-				};
-				r_core_cmd_help(core, help_message);
+				r_core_cmd_help(core, help_msg_cg);
 				return false;
 				}
 			}
@@ -621,17 +576,11 @@ static int cmd_cmp(void *data, const char *input) {
 			cmd_cmp_disasm (core, input+2, 'u');
 			break;
 		default: {
-			const char* help_msg[] = {
-			"Usage: cu",  " [offset]", "# Creates a unified hex patch",
-			"cu", " $$+1 > p", "Compare current seek and +1",
-			"cud", " $$+1 > p", "Compare disasm current seek and +1",
-			"wu", " p", "Apply unified hex patch",
-			NULL};
-			r_core_cmd_help (core, help_msg); }
+			r_core_cmd_help (core, help_msg_cu); }
 		}
 		break;
 	case '?':
-		showhelp (core);
+		r_core_cmd_help (core, help_msg_c);
 		break;
 	case 'v': // "cv"
 		{
@@ -665,12 +614,7 @@ static int cmd_cmp(void *data, const char *input) {
 			break;
 		default:
 		case '?':
-			eprintf ("Usage: cv[1248] [num]\n"
-			"Show offset if current value equals to the one specified\n"
-			" /v 18312   # serch for a known value\n"
-			" dc\n"
-			" cv4 18312 @@ hit*\n"
-			" dc\n");
+			r_core_cmd_help (core, help_msg_cv);
 			break;
 		}
 		}
@@ -691,7 +635,7 @@ static int cmd_cmp(void *data, const char *input) {
 		//		r_cons_flush ();
 		break;
 	default:
-		showhelp (core);
+		r_core_cmd_help (core, help_msg_c);
 	}
 	if (val != UT64_MAX)
 		core->num->value = val;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -368,25 +368,8 @@ static int step_line(RCore *core, int times) {
 
 static void cmd_debug_pid(RCore *core, const char *input) {
 	int pid, sig;
-	const char *ptr, *help_msg[] = {
-		"Usage:", "dp", " # Process commands",
-		"dp", "", "List current pid and childrens",
-		"dp", " <pid>", "List children of pid",
-		"dp*", "", "List all attachable pids",
-		"dp=", "<pid>", "Select pid",
-		"dp-", " <pid>", "Dettach select pid",
-		"dpa", " <pid>", "Attach and select pid",
-		"dpc", "", "Select forked pid (see dbg.forks)",
-		"dpc*", "", "Display forked pid (see dbg.forks)",
-		"dpe", "", "Show path to executable",
-		"dpf", "", "Attach to pid like file fd // HACK",
-		"dpk", " <pid> [<signal>]", "Send signal to process (default 0)",
-		"dpn", "", "Create new process (fork)",
-		"dptn", "", "Create new thread (clone)",
-		"dpt", "", "List threads of current pid",
-		"dpt", " <pid>", "List threads of process",
-		"dpt=", "<thread>", "Attach to thread",
-		NULL};
+	const char *ptr;
+
 	switch (input[1]) {
 		case 0:
 			eprintf ("Selected: %d %d\n", core->dbg->pid, core->dbg->tid);
@@ -444,7 +427,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 					break;
 				case '?':
 				default:
-					r_core_cmd_help (core, help_msg);
+					r_core_cmd_help (core, help_msg_dp);
 					break;
 			}
 			break;
@@ -493,7 +476,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 			break;
 		case '?':
 		default:
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_dp);
 			break;
 	}
 }
@@ -562,22 +545,6 @@ static int __r_debug_snap_diff(RCore *core, int idx) {
 }
 
 static int cmd_debug_map_snapshot(RCore *core, const char *input) {
-	const char* help_msg[] = {
-		"Usage:", "dms", " # Memory map snapshots",
-		"dms", "", "List memory snapshots",
-		"dmsj", "", "list snapshots in JSON",
-		"dms*", "", "list snapshots in r2 commands",
-		"dms", " addr", "take snapshot with given id of map at address",
-		"dms", "-id", "delete memory snapshot",
-		"dmsC", " id comment", "add comment for given snapshot",
-		"dmsd", " id", "hexdiff given snapshot. See `ccc`.",
-		"dmsw", "", "snapshot of the writable maps",
-		"dmsa", "", "full snapshot of all `dm` maps",
-		"dmsf", " [file] @ addr", "read snapshot from disk",
-		"dmst", " [file] @ addr", "dump snapshot to disk",
-		// TODO: dmsj - for json
-		NULL
-	};
 	switch (*input) {
 		case 'f':
 			{
@@ -631,7 +598,7 @@ static int cmd_debug_map_snapshot(RCore *core, const char *input) {
 			}
 			break;
 		case '?':
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_dms);
 			break;
 		case '-':
 			if (input[1]=='*') {
@@ -722,19 +689,11 @@ static void cmd_debug_modules(RCore *core, int mode) { // "dmm"
 	RDebugMap *map;
 	RList *list;
 	RListIter *iter;
-	const char* help_msg[] = {
-		"Usage:", "dmm", " # Module memory maps commands",
-		"dmm", "", "List modules of target process",
-		"dmm.", "", "List memory map of current module",
-		"dmmj", "", "List modules of target process (JSON)",
-		"dmm*", "", "List modules of target process (r2 commands)",
-		NULL
-	};
 
 	/* avoid processing the list if the user only wants help */
 	if (mode == '?') {
 show_help:
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_dmm);
 		return;
 	}
 	if (mode == 'j') {
@@ -1379,17 +1338,6 @@ static int cmd_dbg_map_heap_glibc(RCore *core, const char *input) {
 		return false;
 	}
 	static ut64 m_arena = UT64_MAX;
-	const char* help_msg[] = {
-		"Usage:", "dmh", " # Memory map heap info glibc",
-		"dmha", "", "Struct Malloc State (main_arena)",
-		"dmhb", "", "Show bins information",
-		"dmhb", " [bin_num]", "Print double linked list of the number of bin",
-		"dmhc", " @[malloc_addr]", "Print malloc_chunk struct for a given malloc chunk",
-		"dmhf", "", "Show fastbins information",
-		"dmhf", " [fastbin_num]", "Print single linked list of the number of fastbin",
-		"dmh?", "", "Show map heap help",
-		NULL
-	};
 
 	switch (input[0]) {
 		case '\0': //"dmh"
@@ -1422,7 +1370,7 @@ static int cmd_dbg_map_heap_glibc(RCore *core, const char *input) {
 			eprintf ("TODO: JSON output for dmh is not yet implemented\n");
 			break;
 		case '?':
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_dmh);
 			break;
 	}
 
@@ -1432,27 +1380,6 @@ static int cmd_dbg_map_heap_glibc(RCore *core, const char *input) {
 #endif // __linux__ && __GNU_LIBRARY__ && __GLIBC__ && __GLIBC_MINOR__
 
 static int cmd_debug_map(RCore *core, const char *input) {
-	const char* help_msg[] = {
-		"Usage:", "dm", " # Memory maps commands",
-		"dm", "", "List memory maps of target process",
-		"dm=", "", "List memory maps of target process (ascii-art bars)",
-		"dm", " <address> <size>", "Allocate <size> bytes at <address> (anywhere if address is -1) in child process",
-		"dm.", "", "Show map name of current address",
-		"dm*", "", "List memmaps in radare commands",
-		"dm-", "<address>", "Deallocate memory map of <address>",
-		"dmd", "[a] [file]", "Dump current (all) debug map region to a file (from-to.dmp) (see Sd)",
-		"dmi", " [addr|libname] [symname]", "List symbols of target lib",
-		"dmi*", " [addr|libname] [symname]", "List symbols of target lib in radare commands",
-		"dmj", "", "List memmaps in JSON format",
-		"dml", " <file>", "Load contents of file into the current map region (see Sl)",
-		"dmm", "[j*]", "List modules (libraries, binaries loaded in memory)",
-		"dmp", " <address> <size> <perms>", "Change page at <address> with <size>, protection <perms> (rwx)",
-		"dms", " <id> <mapaddr>", "take memory snapshot",
-		"dms-", " <id> <mapaddr>", "restore memory snapshot",
-		"dmh", "", "Show map of heap",
-		//"dm, " rw- esp 9K", "set 9KB of the stack as read+write (no exec)",
-		"TODO:", "", "map files in process memory. (dmf file @ [addr])",
-		NULL};
 	RListIter *iter;
 	RDebugMap *map;
 	ut64 addr = core->offset;
@@ -1475,7 +1402,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 			} else cmd_debug_modules (core, input[1]);
 			break;
 		case '?':
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_dm);
 			break;
 		case 'p': // "dmp"
 			if (input[1] == ' ') {
@@ -1757,22 +1684,13 @@ static void cmd_reg_profile (RCore *core, int from, const char *str) { // "arp" 
 		default:
 			{
 				const char *from_a[] = { "arp", "arp.", "arpj", "arps" };
-				const char *help_msg[] = {
-					"Usage:", "drp", " # Register profile commands",
-					"drp", "", "Show the current register profile",
-					"drp", " [regprofile-file]", "Set the current register profile",
-					"drp.", "", "Show the current fake size",
-					"drpj", "", "Show the current register profile (JSON)",
-					"drps", " [new fake size]", "Set the fake size",
-					NULL
-				};
 				if (from == 'a') {
-					help_msg[1] = help_msg[3] = help_msg[6] = from_a[0];
-					help_msg[9] = from_a[1];
-					help_msg[12] = from_a[2];
-					help_msg[15] = from_a[3];
+					help_msg_drp[1] = help_msg_drp[3] = help_msg_drp[6] = from_a[0];
+					help_msg_drp[9] = from_a[1];
+					help_msg_drp[12] = from_a[2];
+					help_msg_drp[15] = from_a[3];
 				}
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_drp);
 				break;
 			}
 	}
@@ -1814,43 +1732,8 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				core->num->value = off;
 				//r_reg_get_value (core->dbg->reg, r));
 			} else {
-				const char * help_message[] = {
-					"Usage: dr", "", "Registers commands",
-					"dr", "", "Show 'gpr' registers",
-					"dr", " <register>=<val>", "Set register value",
-					"dr=", "", "Show registers in columns",
-					"dr?", "<register>", "Show value of given register",
-					"drb", " [type]", "Display hexdump of gpr arena (WIP)",
-					"drC", "", "Show register profile comments",
-					"drc", " [name]", "Related to conditional flag registers",
-					"drd", "", "Show only different registers",
-					"drl", "", "List all register names",
-					"drn", " <pc>", "Get regname for pc,sp,bp,a0-3,zf,cf,of,sg",
-					"dro", "", "Show previous (old) values of registers",
-					"drp", " <file>", "Load register metadata file",
-					"drp", "", "Display current register profile",
-					"drps", "", "Fake register profile size",
-					"drr", "", "Show registers references (telescoping)",
-					"drs", " [?]", "Stack register states",
-					"drt", "", "Show all register types",
-					"drt", " flg", "Show flag registers",
-					"drt", " all", "Show all registers",
-					"drt", " 16", "Show 16 bit registers",
-					"drt", " 32", "Show 32 bit registers",
-					"drt", " 80", "Show 80 bit registers (long double)",
-					"drx", "", "Show all debug registers",
-					"drx", " idx addr len rwx", "Modify hardware breakpoint",
-					"drx-", "number", "Clear hardware breakpoint",
-					"drf","","show fpu registers (80 bit long double)",
-					"drm","","show multimedia packed registers",
-					"drm"," mmx0 0 32 = 12","set the first 32 bit word of the mmx reg to 12",
-					"drw"," <hexnum>", "Set contents of the register arena",
-					".dr", "*", "Include common register values in flags",
-					".dr", "-", "Unflag all registers",
-					NULL
-				};
 				// TODO: 'drs' to swap register arenas and display old register valuez
-				r_core_cmd_help (core, help_message);
+				r_core_cmd_help (core, help_msg_dr);
 			}
 			break;
 		case 'l': // "drl"
@@ -1959,14 +1842,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				case '?':
 				default:
 						  {
-							  const char * help_message[] = {
-								  "Usage: drx", "", "Hardware breakpoints commands",
-								  "drx", "", "List all (x86?) hardware breakpoints",
-								  "drx", " <number> <address> <length> <perms>", "Modify hardware breakpoint",
-								  "drx-", "<number>", "Clear hardware breakpoint",
-								  NULL
-							  };
-							  r_core_cmd_help (core, help_message);
+							  r_core_cmd_help (core, help_msg_drx);
 						  }
 						  break;
 			}
@@ -1988,21 +1864,14 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				case '?':
 				default:
 					{
-						const char * help_message[] = {
-							"Usage: drs", "", "Register states commands",
-							"drs", "", "List register stack",
-							"drs", "+", "Push register state",
-							"drs", "-", "Pop register state",
-							NULL
-						};
-						r_core_cmd_help (core, help_message);
+						r_core_cmd_help (core, help_msg_drs);
 					}
 					break;
 			}
 			break;
 		case 'm': // "drm"
 			if (str[1]=='?') {
-				eprintf ("Usage: drm [reg] [idx] [wordsize] [= value]\n");
+				r_core_cmd_help (core, help_msg_drm);
 			} else if (str[1]==' ') {
 				int word = 0;
 				int size = 0; // auto
@@ -2048,7 +1917,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 			r_debug_reg_sync (core->dbg, -R_REG_TYPE_FPU, false);
 			//r_debug_drx_list (core->dbg);
 			if (str[1]=='?') {
-				eprintf ("Usage: drf [fpureg] [= value]\n");
+				r_core_cmd_help (core, help_msg_drf);
 			} else if (str[1]==' ') {
 				char *p, *name = strdup (str+2);
 				char *eq = strchr (name, '=');
@@ -2128,14 +1997,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				case '?':
 				default:
 					{
-						const char *help_msg[] = {
-							"Usage:", "drt", " [type] [size]    # debug register types",
-							"drt", "", "List all available register types",
-							"drt", " [size]", "Show all regs in the profile of size",
-							"drt", " [type]", "Show all regs in the profile of this type",
-							"drt", " [type] [size]", "Same as above for type and size",
-							NULL};
-						r_core_cmd_help (core, help_msg);
+						r_core_cmd_help (core, help_msg_drt);
 					}
 					break;
 			}
@@ -2288,43 +2150,6 @@ static void static_debug_stop(void *u) {
 
 static void r_core_cmd_bp(RCore *core, const char *input) {
 	RBreakpointItem *bpi;
-	const char* help_msg[] = {
-		"Usage: db", "", " # Breakpoints commands",
-		"db", "", "List breakpoints",
-		"db", " sym.main", "Add breakpoint into sym.main",
-		"db", " <addr>", "Add breakpoint",
-		"db", " -<addr>", "Remove breakpoint",
-		"db.", "", "Show breakpoint info in current offset",
-		"dbj", "", "List breakpoints in JSON format",
-		// "dbi", " 0x848 ecx=3", "stop execution when condition matches",
-		"dbc", " <addr> <cmd>", "Run command when breakpoint is hit",
-		"dbd", " <addr>", "Disable breakpoint",
-		"dbe", " <addr>", "Enable breakpoint",
-		"dbs", " <addr>", "Toggle breakpoint",
-
-		"dbt", "", "Display backtrace based on dbg.btdepth and dbg.btalgo",
-		"dbt*", "", "Display backtrace in flags",
-		"dbt=", "", "Display backtrace in one line (see dbt=s and dbt=b for sp or bp)",
-		"dbtj", "", "Display backtrace in JSON",
-		"dbte", " <addr>", "Enable Breakpoint Trace",
-		"dbtd", " <addr>", "Disable Breakpoint Trace",
-		"dbts", " <addr>", "Swap Breakpoint Trace",
-		"dbm", " <module> <offset>", "Add a breakpoint at an offset from a module's base",
-		"dbn", " [<name>]", "Show or set name for current breakpoint",
-		//
-		"dbi", "", "List breakpoint indexes",
-		"dbic", " <index> <cmd>", "Run command at breakpoint index",
-		"dbie", " <index>", "Enable breakpoint by index",
-		"dbid", " <index>", "Disable breakpoint by index",
-		"dbis", " <index>", "Swap Nth breakpoint",
-		"dbite", " <index>", "Enable breakpoint Trace by index",
-		"dbitd", " <index>", "Disable breakpoint Trace by index",
-		"dbits", " <index>", "Swap Nth breakpoint trace",
-		//
-		"dbh", " x86", "Set/list breakpoint plugin handlers",
-		"drx", " number addr len rwx", "Modify hardware breakpoint",
-		"drx-", "number", "Clear hardware breakpoint",
-		NULL};
 	int i, hwbp = r_config_get_i (core->config, "dbg.hwbp");
 	RDebugFrame *frame;
 	RListIter *iter;
@@ -2723,7 +2548,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 				   break;
 		case '?':
 		default:
-				   r_core_cmd_help (core, help_msg);
+				   r_core_cmd_help (core, help_msg_db);
 				   break;
 	}
 }
@@ -2943,11 +2768,7 @@ static void r_core_debug_esil (RCore *core, const char *input) {
 					}
 				}
 				if (!done) {
-					const char *help_de_msg[] = {
-						"Usage:", "de", " [rwx] [reg|mem] [expr]",
-						NULL
-					};
-					r_core_cmd_help (core, help_de_msg);
+					r_core_cmd_help (core, help_msg_de);
 				}
 				free (line);
 			}
@@ -2972,13 +2793,7 @@ static void r_core_debug_esil (RCore *core, const char *input) {
 					addr = naddr;
 				}
 			} else if (input[1] == '?' || !input[1]) {
-				const char *help_des_msg[] = {
-					"Usage:", "des", "[u] [arg]",
-					"des", " [N]", "step-in N instructions with esildebug",
-					"desu", " [addr]", "esildebug until specific address",
-					NULL
-				};
-				r_core_cmd_help (core, help_des_msg);
+				r_core_cmd_help (core, help_msg_des);
 			} else {
 				r_core_cmd0 (core, "aei");
 				r_debug_esil_prestep (core->dbg, r_config_get_i (core->config, "esil.prestep"));
@@ -3002,22 +2817,7 @@ static void r_core_debug_esil (RCore *core, const char *input) {
 		case '?':
 		default:
 			{
-				const char *help_msg[] = {
-					"Usage:", "de", "[-sc] [rwx] [rm] [expr]",
-					"de", "", "list esil watchpoints",
-					"de-*", "", "delete all esil watchpoints",
-					"de", " [rwx] [rm] [addr|reg|from..to]", "stop on condition",
-					"dec", "", "continue execution until matching expression",
-					"des", " [N]", "step-in N instructions with esildebug",
-					"desu", " [addr]", "esildebug until specific address",
-					NULL
-				};
-				r_core_cmd_help (core, help_msg);
-				r_cons_printf ("Examples:\n"
-						" de r r rip       # stop when reads rip\n"
-						" de rw m ADDR     # stop when read or write in ADDR\n"
-						" de w r rdx       # stop when rdx register is modified\n"
-						" de x m FROM..TO  # stop when rip in range\n");
+				r_core_cmd_help (core, help_msg_de);
 			}
 			break;
 	}
@@ -3039,18 +2839,7 @@ static void r_core_debug_kill (RCore *core, const char *input) {
 				}
 			}
 		} else {
-			const char * help_message[] = {
-				"Usage: dk", "", "Signal commands",
-				"dk", "", "List all signal handlers of child process",
-				"dk", " <signal>", "Send KILL signal to child",
-				"dk", " <signal>=1", "Set signal handler for <signal> in child",
-				"dk?", "<signal>", "Name/signum resolver",
-				"dko", " <signal>", "Reset skip or cont options for given signal",
-				"dko", " <signal> [|skip|cont]", "On signal SKIP handler or CONT into",
-				"dkj", "", "List all signal handlers in JSON",
-				NULL
-			};
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_dk);
 		}
 	} else if (*input=='o') {
 		switch (input[1]) {
@@ -3088,17 +2877,7 @@ static void r_core_debug_kill (RCore *core, const char *input) {
 			case '?':
 			default:
 				{
-					const char* help_msg[] = {
-						"Usage:", "dko", " # Signal handling commands",
-						"dko", "", "List existing signal handling",
-						"dko", " [signal]", "Clear handling for a signal",
-						"dko", " [signal] [skip|cont]", "Set handling for a signal",
-						NULL
-					};
-					r_core_cmd_help (core, help_msg);
-					eprintf ("NOTE: [signal] can be a number or a string that resolves with dk?\n"
-							"  skip means do not enter into the signal handler\n"
-							"  continue means enter into the signal handler\n");
+					r_core_cmd_help (core, help_msg_dko);
 				}
 		}
 	} else if (*input == 'j') {
@@ -3197,27 +2976,9 @@ static bool cmd_dcu (RCore *core, const char *input) {
 static int cmd_debug_continue (RCore *core, const char *input) {
 	int pid, old_pid, signum;
 	char *ptr;
-	const char * help_message[] = {
-		"Usage: dc", "", "Execution continuation commands",
-		"dc", "", "Continue execution of all children",
-		"dc", " <pid>", "Continue execution of pid",
-		"dc", "[-pid]", "Stop execution of pid",
-		"dca", " [sym] [sym].", "Continue at every hit on any given symbol",
-		"dcc", "", "Continue until call (use step into)",
-		"dccu", "", "Continue until unknown call (call reg)",
-		"dcf", "", "Continue until fork (TODO)",
-		"dck", " <signal> <pid>", "Continue sending signal to process",
-		"dco", " <num>", "Step over <num> instructions",
-		"dcp", "", "Continue until program code (mapped io section)",
-		"dcr", "", "Continue until ret (uses step over)",
-		"dcs", " <num>", "Continue until syscall",
-		"dct", " <len>", "Traptrace from curseek to len, no argument to list",
-		"dcu", "[..end|addr] ([end])", "Continue until address (or range)",
-		/*"TODO: dcu/dcr needs dbg.untilover=true??",*/
-		/*"TODO: same for only user/libs side, to avoid steping into libs",*/
-		/*"TODO: support for threads?",*/
-		NULL
-	};
+	/*"TODO: dcu/dcr needs dbg.untilover=true??",*/
+	/*"TODO: same for only user/libs side, to avoid steping into libs",*/
+	/*"TODO: support for threads?",*/
 	// TODO: we must use this for step 'ds' too maybe...
 	switch (input[1]) {
 		case 0: // "dc"
@@ -3277,11 +3038,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 					break;
 				default:
 				case '?':
-					eprintf ("|Usage: dcs [syscall-name-or-number]\n");
-					eprintf ("|dcs         : continue until next syscall\n");
-					eprintf ("|dcs mmap    : continue until next call to mmap\n");
-					eprintf ("|dcs*        : trace all syscalls (strace)\n");
-					eprintf ("|dcs?        : show this help\n");
+					r_core_cmd_help (core, help_msg_dcs);
 					break;
 			}
 			break;
@@ -3323,7 +3080,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 			break;
 		case '?': // "dc?"
 		default:
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_dc);
 			return 0;
 	}
 	return 1;
@@ -3340,23 +3097,6 @@ static int cmd_debug_step (RCore *core, const char *input) {
 	ut8 buf[64];
 	RAnalOp aop;
 	int i, times = 1;
-	const char * help_message[] = {
-		"Usage: ds", "", "Step commands",
-		"ds", "", "Step one instruction",
-		"ds", " <num>", "Step <num> instructions",
-		"dsf", "", "Step until end of frame",
-		"dsi", " <cond>", "Continue until condition matches",
-		"dsl", "", "Step one source line",
-		"dsl", " <num>", "Step <num> source lines",
-		"dso", " <num>", "Step over <num> instructions",
-		"dsp", "", "Step into program (skip libs)",
-		"dss", " <num>", "Skip <num> step instructions",
-		"dsu", " <address>", "Step until address",
-		"dsui", " <instr>", "Step until an instruction that matches `instr`",
-		"dsue", " <esil>", "Step until esil expression matches",
-		"dsuf", " <flag>", "Step until pc == flag matching name",
-		NULL
-	};
 	if (strlen (input) > 2) {
 		times = atoi (input + 2);
 	}
@@ -3471,7 +3211,7 @@ static int cmd_debug_step (RCore *core, const char *input) {
 			break;
 		case '?':
 		default:
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_ds);
 			return 0;
 	}
 	return 1;
@@ -3499,7 +3239,7 @@ static int cmd_debug(void *data, const char *input) {
 			switch (input[1]) {
 				case 'c': // "dtc"
 					if (input[2] == '?') {
-						eprintf ("Usage: dtc [addr] ([from] [to] [addr]) - trace calls in debugger\n");
+						r_core_cmd_help (core, help_msg_dtc);
 					} else {
 						debug_trace_calls (core, input + 2);
 					}
@@ -3523,18 +3263,7 @@ static int cmd_debug(void *data, const char *input) {
 				case '?':
 				default:
 					{
-						const char * help_message[] = {
-							"Usage: dt", "", "Trace commands",
-							"dt", "", "List all traces ",
-							"dtd", "", "List all traced disassembled",
-							"dtc [addr]|([from] [to] [addr])", "", "Trace call/ret",
-							"dtg", "", "Graph call/ret trace",
-							"dtg*", "", "Graph in agn/age commands. use .dtg*;aggi for visual",
-							"dtgi", "", "Interactive debug trace",
-							"dt-", "", "Reset traces (instruction/calls)",
-							NULL
-						};
-						r_core_cmd_help (core, help_message);
+						r_core_cmd_help (core, help_msg_dt);
 					}
 					break;
 			}
@@ -3618,15 +3347,7 @@ static int cmd_debug(void *data, const char *input) {
 				case '?':
 				default:
 					{
-						const char * help_message[] = {
-							"Usage: dd", "", "Descriptors commands",
-							"dd", "", "List file descriptors",
-							"dd", " <file>", "Open and map that file into the UI",
-							"dd-", "<fd>", "Close stdout fd",
-							"dd*", "", "List file descriptors (in radare commands)",
-							NULL
-						};
-						r_core_cmd_help (core, help_message);
+						r_core_cmd_help (core, help_msg_dd);
 					}
 					break;
 			}
@@ -3673,12 +3394,6 @@ static int cmd_debug(void *data, const char *input) {
 			break;
 		case 'i':
 			{
-				const char * help_message[] = {
-					"Usage: di", "", "Debugger target information",
-					"di", "", "Show debugger target information",
-					"dij", "", "Same as above, but in JSON format",
-					NULL
-				};
 				RDebugInfo *rdi = r_debug_info (core->dbg, input + 2);
 				RDebugReasonType stop = r_debug_stop_reason (core->dbg);
 				char *escaped_str;
@@ -3731,7 +3446,7 @@ static int cmd_debug(void *data, const char *input) {
 #undef PS
 					case '?':
 					default:
-						r_core_cmd_help (core, help_message);
+						r_core_cmd_help (core, help_msg_di);
 				}
 				if (rdi)
 					r_debug_info_free (rdi);
@@ -3815,18 +3530,7 @@ static int cmd_debug(void *data, const char *input) {
 				case '?':
 				default:
 					{
-						const char* help_msg[] = {
-							"Usage: dx", "", " # Code injection commands",
-							"dx", " <opcode>...", "Inject opcodes",
-							"dxa", " nop", "Assemble code and inject",
-							"dxe", " egg-expr", "compile egg expression and inject it",
-							"dxr", " <opcode>...", "Inject opcodes and restore state",
-							"dxs", " write 1, 0x8048, 12", "Syscall injection (see gs)",
-							"\nExamples:", "", "",
-							"dx", " 9090", "Inject two x86 nop",
-							"\"dxa mov eax,6;mov ebx,0;int 0x80\"", "", "Inject and restore state",
-							NULL};
-						r_core_cmd_help (core, help_msg);
+						r_core_cmd_help (core, help_msg_dx);
 					}
 					break;
 			}
@@ -3842,12 +3546,7 @@ static int cmd_debug(void *data, const char *input) {
 				case '?':
 				default:
 					{
-						const char* help_msg[] = {
-							"Usage:", "do", " # Debug commands",
-							"do", "", "Open process (reload, alias for 'oo')",
-							"doo", "[args]", "Reopen in debugger mode with args (alias for 'ood')",
-							NULL};
-						r_core_cmd_help (core, help_msg);
+						r_core_cmd_help (core, help_msg_do);
 					}
 					break;
 			}
@@ -3895,29 +3594,7 @@ static int cmd_debug(void *data, const char *input) {
 		case '?':
 		default:
 			{
-				const char* help_msg[] = {
-					"Usage:", "d", " # Debug commands",
-					"db", "[?]", "Breakpoints commands",
-					"dbt", "", "Display backtrace based on dbg.btdepth and dbg.btalgo",
-					"dc", "[?]", "Continue execution",
-					"dd", "[?]", "File descriptors (!fd in r1)",
-					"de", "[-sc] [rwx] [rm] [e]", "Debug with ESIL (see de?)",
-					"dg", " <file>", "Generate a core-file (WIP)",
-					"dh", " [handler]", "List or set debugger handler",
-					"dH", " [handler]", "Transplant process to a new handler",
-					"di", "", "Show debugger backend information (See dh)",
-					"dk", "[?]", "List, send, get, set, signal handlers of child",
-					"dm", "[?]", "Show memory maps",
-					"do", "", "Open process (reload, alias for 'oo')",
-					"doo", "[args]", "Reopen in debugger mode with args (alias for 'ood')",
-					"dp", "[?]", "List, attach to process or thread id",
-					"dr", "[?]", "Cpu registers",
-					"ds", "[?]", "Step, over, source line",
-					"dt", "[?]", "Display instruction traces (dtr=reset)",
-					"dw", " <pid>", "Block prompt until pid dies",
-					"dx", "[?]", "Inject and run code on target process (See gs)",
-					NULL};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_d);
 			}
 			break;
 	}

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -150,21 +150,7 @@ eprintf ("TODO: list options\n");
 		}
 		break;
 	case '?': {
-		const char* help_msg[] = {
-			"Usage:", "g[wcilper] [arg]", "Go compile shellcodes",
-			"g", " foo.r", "Compile r_egg source file",
-			"gw", "", "Compile and write",
-			"gc", " cmd=/bin/ls", "Set config option for shellcodes and encoders",
-			"gc", "", "List all config options",
-			"gl", "", "List plugins (shellcodes, encoders)",
-			"gs", " name args", "Compile syscall name(args)",
-			"gi", " exec", "Compile shellcode. like ragg2 -i",
-			"gp", " padding", "Define padding for command",
-			"ge", " xor", "Specify an encoder",
-			"gr", "", "Reset r_egg",
-			"EVAL VARS:", "", "asm.arch, asm.bits, asm.os",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_g);
 		}
 		break;
 	}

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -139,7 +139,7 @@ static int cmd_eval(void *data, const char *input) {
 				}
 			}
 		} else {
-			eprintf ("Usage: et [varname]  ; show type of eval var\n");
+			r_core_cmd_help (core, help_msg_et);
 		}
 		break;
 	case 'n': // env
@@ -184,27 +184,7 @@ static int cmd_eval(void *data, const char *input) {
 			r_cons_pal_init (NULL);
 			break;
 		case '?': {
-			const char *helpmsg[] = {
-			"Usage ec[s?] [key][[=| ]fg] [bg]","","",
-			"ec","","list all color keys",
-			"ec*","","same as above, but using r2 commands",
-			"ecd","","set default palette",
-			"ecr","","set random palette",
-			"ecs","","show a colorful palette",
-			"ecj","","show palette in JSON",
-			"ecc"," [prefix]","show palette in CSS",
-			"eco"," dark|white","load white color scheme template",
-			"ecp","","load previous color theme",
-			"ecn","","load next color theme",
-			"ec"," prompt red","change color of prompt",
-			"ec"," prompt red blue","change color and background of prompt",
-			""," ","",
-			"colors:","","rgb:000, red, green, blue, ...",
-			"e scr.rgbcolor","=1|0","for 256 color cube (boolean)",
-			"e scr.truecolor","=1|0","for 256*256*256 colors (boolean)",
-			"$DATADIR/radare2/cons","","~/.config/radare2/cons ./",
-			NULL};
-			r_core_cmd_help (core, helpmsg);
+			r_core_cmd_help (core, help_msg_ec);
 			}
 			break;
 		case 'o': // "eco"
@@ -316,23 +296,7 @@ static int cmd_eval(void *data, const char *input) {
 		case '?': r_config_list (core->config, input+2, 2); break;
 		default: r_config_list (core->config, input+1, 2); break;
 		case 0:{
-			const char* help_msg[] = {
-			"Usage:", "e[?] [var[=value]]", "Evaluable vars",
-			"e","?asm.bytes", "show description",
-			"e", "??", "list config vars with description",
-			"e", "", "list config vars",
-			"e-", "", "reset config vars",
-			"e*", "", "dump config vars in r commands",
-			"e!", "a", "invert the boolean value of 'a' var",
-			"ee", "var", "open editor to change the value of var",
-			"er", " [key]", "set config key as readonly. no way back",
-			"ec", " [k] [color]", "set color for given key (prompt, offset, ...)",
-			"et", " [key]", "show type of given config variable",
-			"e", " a", "get value of var 'a'",
-			"e", " a=b", "set var 'a' the 'b' value",
-			"env", " [k[=v]]", "get/set environment variable",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_e);
 			}
 		}
 		break;

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -74,7 +74,7 @@ rep:
 			flagenum = 0;
 			break;
 		default:
-			eprintf ("|Usage: fe[-| name] @@= 1 2 3 4\n");
+			r_core_cmd_help (core, help_msg_fe);
 			break;
 		}
 		break;
@@ -84,7 +84,7 @@ rep:
 			flagbars_dos (core);
 			break;
 		case '?':
-			eprintf ("Usage: f= or f== to display flag bars\n");
+			r_core_cmd_help (core, help_msg_fequals);
 			break;
 		default:
 			flagbars (core);
@@ -128,8 +128,7 @@ rep:
 			}
 			break;
 		case '?':
-			eprintf ("Usage: fV[*-] [nkey] [offset]\n");
-			eprintf ("Dump/Restore visual marks (mK/'K)\n");
+			r_core_cmd_help (core, help_msg_fV);
 			break;
 		default:
 			r_core_visual_mark_dump (core);
@@ -165,9 +164,7 @@ rep:
 			ret = r_flag_relocate (core->flags, from, mask, to);
 			eprintf ("Relocated %d flags\n", ret);
 		} else {
-			eprintf ("Usage: fR [from] [to] ([mask])\n");
-			eprintf ("Example to relocate PIE flags on debugger:\n"
-				" > fR entry0 `dm~:1[1]`\n");
+			r_core_cmd_help (core, help_msg_fR);
 		}
 		}
 		break;
@@ -199,7 +196,7 @@ rep:
 				core->flags->base);
 			break;
 		default:
-			eprintf ("Usage: fb [addr] [[flags*]]\n");
+			r_core_cmd_help (core, help_msg_fb);
 			break;
 		}
 		break;
@@ -353,20 +350,7 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 		switch (input[1]) {
 		case '?':
 			{
-			const char *help_msg[] = {
-			"Usage: fs","[*] [+-][flagspace|addr]", " # Manage flagspaces",
-			"fs","","display flagspaces",
-			"fs"," *","select all flagspaces",
-			"fs"," flagspace","select flagspace or create if it doesn't exist",
-			"fs","-flagspace","remove flagspace",
-			"fs","-*","remove all flagspaces",
-			"fs","+foo","push previous flagspace and set",
-			"fs","-","pop to the previous flagspace",
-			"fs","-.","remove the current flagspace",
-			"fsm"," [addr]","move flags at given address to the current flagspace",
-			"fsr"," newname","rename selected flagspace",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_fs);
 			}
 			break;
 		case '+':
@@ -431,13 +415,7 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 		break;
 	case 'c':
 		if (input[1]=='?' || input[1] != ' ') {
-			const char *help_msg[] = {
-			"Usage: fc", "<flagname> [color]", " # List colors with 'ecs'",
-			"fc", " flagname", "Get current color for given flagname",
-			"fc", " flagname color", "Set color to a flag",
-			NULL
-			};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_fc);
 		} else {
 			RFlagItem *fi;
 			const char *ret;
@@ -478,7 +456,9 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 				}
 			}
 			free (p);
-		} else eprintf ("Usage: fC [name] [comment]\n");
+		} else {
+			r_core_cmd_help (core, help_msg_fC);
+		}
 		break;
 	case 'o':
 		{ // TODO: use file.fortunes // can be dangerous in sandbox mode
@@ -581,7 +561,7 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 			RFlagItem *f = NULL;
 			switch (input[1]) {
 			case '?':
-				eprintf ("Usage: fd [offset|flag|expression]\n");
+				r_core_cmd_help (core, help_msg_fd);
 				if (str) {
 					free (str);
 				}
@@ -608,44 +588,7 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 		break;
 	case '?':
 	{
-		const char *help_msg[] = {
-		"Usage: f","[?] [flagname]", " # Manage offset-name flags",
-		"f","","list flags (will only list flags from selected flagspaces)",
-		"f."," [*[*]]","list local per-function flags (*) as r2 commands",
-		"f.","blah=$$+12","set local function label named 'blah'",
-		"f*","","list flags in r commands",
-		"f"," name 12 @ 33","set flag 'name' with length 12 at offset 33",
-		"f"," name = 33","alias for 'f name @ 33' or 'f name 1 33'",
-		"f"," name 12 33 [cmt]","same as above + optional comment",
-		"f-",".blah@fcn.foo","delete local label from function at current seek (also f.-)",
-		"f--","","delete all flags and flagspaces (deinit)",
-		"f+","name 12 @ 33","like above but creates new one if doesnt exist",
-		"f-","name","remove flag 'name'",
-		"f-","@addr","remove flag at address expression",
-		"f."," fname","list all local labels for the given function",
-		"fa"," [name] [alias]","alias a flag to evaluate an expression",
-		"fb"," [addr]","set base address for new flags",
-		"fb"," [addr] [flag*]","move flags matching 'flag' to relative addr",
-		"fc"," [name] [color]","set color for given flag",
-		"fC"," [name] [cmt]","set comment for given flag",
-		"fd"," addr","return flag+delta",
-		"fe-","","resets the enumerator counter",
-		"fe"," [name]","create flag name.#num# enumerated flag. See fe?",
-		"fi"," [size] | [from] [to]","show flags in current block or range",
-		"fg","","bring visual mode to foreground",
-		"fj","","list flags in JSON format",
-		"fl"," [flag] [size]","show or set flag length (size)",
-		"fm"," addr","move flag at current offset to new address",
-		"fn","","list flags displaying the real name (demangled)",
-		"fo","","show fortunes",
-		//" fc [name] [cmt]  ; set execution command for a specific flag"
-		"fr"," [old] [[new]]","rename flag (if no new flag current seek one is used)",
-		"fR"," [f] [t] [m]","relocate all flags matching f&~m 'f'rom, 't'o, 'm'ask",
-		"fs"," ?+-*","manage flagspaces",
-		"fS","[on]","sort flags by offset or name",
-		"fx","[d]","show hexdump (or disasm) of flag:flagsize",
-		NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_f);
 		break;
 	}
 	}

--- a/libr/core/cmd_hash.c
+++ b/libr/core/cmd_hash.c
@@ -174,16 +174,7 @@ static int cmd_hash(void *data, const char *input) {
 		return cmd_hash_bang (core, input);
 	}
 	if (*input == '?') {
-		const char *helpmsg3[] = {
-		"Usage #!interpreter [<args>] [<file] [<<eof]","","",
-		" #", "", "comment - do nothing",
-		" #!","","list all available interpreters",
-		" #!python","","run python commandline",
-		" #!python"," foo.py","run foo.py python script (same as '. foo.py')",
-		//" #!python <<EOF        get python code until 'EOF' mark\n"
-		" #!python"," arg0 a1 <<q","set arg0 and arg1 and read until 'q'",
-		NULL};
-		r_core_cmd_help (core, helpmsg3);
+		r_core_cmd_help (core, help_msg_hash);
 		return false;
 	}
 	/* this is a comment - captain obvious */

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -91,12 +91,7 @@ static int cmd_help(void *data, const char *input) {
 		RListIter *iter;
 		RCorePlugin *cp;
 		if (input[1]=='?') {
-			const char* help_msg[] = {
-				"Usage:", ":[plugin] [args]", "",
-				":", "", "list RCore plugins",
-				":java", "", "run java plugin",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_colon);
 			return 0;
 		}
 		if (input[1])
@@ -261,13 +256,7 @@ static int cmd_help(void *data, const char *input) {
 		}
 		switch (input[1]) {
 		case '?':
-			r_cons_printf ("|Usage: ?v[id][ num]  # Show value\n"
-				"|?vi1 200    -> 1 byte size value (char)\n"
-				"|?vi2 0xffff -> 2 byte size value (short)\n"
-				"|?vi4 0xffff -> 4 byte size value (int)\n"
-				"|?vi8 0xffff -> 8 byte size value (st64)\n"
-				"| No argument shows $? value\n"
-				"|?vi will show in decimal instead of hex\n");
+			r_core_cmd_help (core, help_msg_quev);
 			break;
 		case '\0':
 		        r_cons_printf ("%d\n", (st32)n);
@@ -324,101 +313,18 @@ static int cmd_help(void *data, const char *input) {
 		break;
 	case '@':
 		{
-		const char* help_msg[] = {
-			"Usage: [.][#]<cmd>[*] [`cmd`] [@ addr] [~grep] [|syscmd] [>[>]file]", "", "",
-			"0", "", "alias for 's 0'",
-			"0x", "addr", "alias for 's 0x..'",
-			"#", "cmd", "if # is a number repeat the command # times",
-			"/*", "", "start multiline comment",
-			"*/", "", "end multiline comment",
-			".", "cmd", "execute output of command as r2 script",
-			".:", "8080", "wait for commands on port 8080",
-			".!", "rabin2 -re $FILE", "run command output as r2 script",
-			"*", "", "output of command in r2 script format (CC*)",
-			"j", "", "output of command in JSON format (pdj)",
-			"~", "?", "count number of lines (like wc -l)",
-			"~", "??", "show internal grep help",
-			"~", "..", "internal less",
-			"~", "{}", "json indent",
-			"~", "{}..", "json indent and less",
-			"~", "word", "grep for lines matching word",
-			"~", "!word", "grep for lines NOT matching word",
-			"~", "word[2]", "grep 3rd column of lines matching word",
-			"~", "word:3[0]", "grep 1st column from the 4th line matching mov",
-			"@", " 0x1024", "temporary seek to this address (sym.main+3",
-			"@", " addr[!blocksize]", "temporary set a new blocksize",
-			"@a:", "arch[:bits]", "temporary set arch and bits",
-			"@b:", "bits", "temporary set asm.bits",
-			"@e:", "k=v,k=v", "temporary change eval vars",
-			"@r:", "reg", "tmp seek to reg value (f.ex pd@r:PC)",
-			"@f:", "file", "temporary replace block with file contents",
-			"@o:", "fd", "temporary switch to another fd",
-			"@s:", "string", "same as above but from a string",
-			"@x:", "909192", "from hex pairs string",
-			"@..", "from to", "temporary set from and to for commands supporting ranges",
-			"@@=", "1 2 3", "run the previous command at offsets 1, 2 and 3",
-			"@@", " hit*", "run the command on every flag matching 'hit*'",
-			"@@@", " [type]", "run a command on every [type] (see @@@? for help)",
-			">", "file", "pipe output of command to file",
-			">>", "file", "append to file",
-			"`", "pdi~push:0[0]`",  "replace output of command inside the line",
-			"|", "cmd", "pipe output to command (pd|less) (.dr*)",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_at_general);
 		return 0;
 		}
 	case '$':{
-		const char* help_msg[] = {
-			"Usage: ?v [$.]","","",
-			"$$", "", "here (current virtual seek)",
-			"$?", "", "last comparison value",
-			"$alias", "=value", "Alias commands (simple macros)",
-			"$b", "", "block size",
-			"$B", "", "base address (aligned lowest map address)",
-			"$F", "", "current function size",
-			"$FB", "", "begin of function",
-			"$FE", "", "end of function",
-			"$FS", "", "function size",
-			"$FI", "", "function instructions",
-			"$c,$r", "", "get width and height of terminal",
-			"$Cn", "", "get nth call of function",
-			"$Dn", "", "get nth data reference in function",
-			"$D", "", "current debug map base address ?v $D @ rsp",
-			"$DD", "", "current debug map size",
-			"$e", "", "1 if end of block, else 0",
-			"$f", "", "jump fail address (e.g. jz 0x10 => next instruction)",
-			"$j", "", "jump address (e.g. jmp 0x10, jz 0x10 => 0x10)",
-			"$Ja", "", "get nth jump of function",
-			"$Xn", "", "get nth xref of function",
-			"$l", "", "opcode length",
-			"$m", "", "opcode memory reference (e.g. mov eax,[0x10] => 0x10)",
-			"$M", "", "map address (lowest map address)",
-			"$o", "", "here (current disk io offset)",
-			"$p", "", "getpid()",
-			"$P", "", "pid of children (only in debug)",
-			"$s", "", "file size",
-			"$S", "", "section offset",
-			"$SS", "", "section size",
-			"$v", "", "opcode immediate value (e.g. lui a0,0x8010 => 0x8010)",
-			"$w", "", "get word size, 4 if asm.bits=32, 8 if 64, ...",
-			"${ev}", "", "get value of eval config variable",
-			"$k{kv}", "", "get value of an sdb query value",
-			"RNum", "", "$variables usable in math expressions",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_dollar_sign);
 		}
 		return true;
 	case 'V':
 		switch (input[1]) {
 		case '?':
 			{
-				const char* help_msg[] = {
-					"Usage: ?V[jq]","","",
-					"?V", "", "show version information",
-					"?Vj", "", "same as above but in JSON",
-					"?Vq", "", "quiet mode, just show the version number",
-					NULL};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_queV);
 			}
 			break;
 		case 0:
@@ -597,47 +503,7 @@ static int cmd_help(void *data, const char *input) {
 					r_core_cmd (core, input+1, 0);
 				break;
 			}
-			const char* help_msg[] = {
-			"Usage: ?[?[?]] expression", "", "",
-			"?", " eip-0x804800", "show hex and dec result for this math expr",
-			"?:", "", "list core cmd plugins",
-			"?!", " [cmd]", "? != 0",
-			"?+", " [cmd]", "? > 0",
-			"?-", " [cmd]", "? < 0",
-			"?=", " eip-0x804800", "hex and dec result for this math expr",
-			"??", "", "show value of operation",
-			"??", " [cmd]", "? == 0 run command when math matches",
-			"?B", " [elem]", "show range boundaries like 'e?search.in",
-			"?P", " paddr", "get virtual address for given physical one",
-			"?S", " addr", "return section name of given address",
-			"?T", "", "show loading times",
-			"?V", "", "show library version of r_core",
-			"?X", " num|expr", "returns the hexadecimal value numeric expr",
-			"?_", " hudfile", "load hud menu with given file",
-			"?b", " [num]", "show binary value of number",
-			"?b64[-]", " [str]", "encode/decode in base64",
-			"?d[.]", " opcode", "describe opcode for asm.arch",
-			"?e", " string", "echo string",
-			"?f", " [num] [str]", "map each bit of the number as flag string index",
-			"?h", " [str]", "calculate hash for given string",
-			"?i", "[ynmkp] arg", "prompt for number or Yes,No,Msg,Key,Path and store in $$?",
-			"?ik", "", "press any key input dialog",
-			"?im", " message", "show message centered in screen",
-			"?in", " prompt", "noyes input prompt",
-			"?iy", " prompt", "yesno input prompt",
-			"?l", " str", "returns the length of string",
-			"?o", " num", "get octal value",
-			"?p", " vaddr", "get physical address for given virtual address",
-			"?r", " [from] [to]", "generate random number between from-to",
-			"?s", " from to step", "sequence of numbers from to by steps",
-			"?t", " cmd", "returns the time to run a command",
-			"?u", " num", "get value in human units (KB, MB, GB, TB)",
-			"?v", " eip-0x804800", "show hex value of math expr",
-			"?vi", " rsp-rbp", "show decimal value of math expr",
-			"?x", " num|str|-hexst", "returns the hexpair of number or string",
-			"?y", " [str]", "show contents of yank buffer, or set with string",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_queque);
 			return 0;
 		} else if (input[1]) {
 			if (core->num->value) {
@@ -652,52 +518,7 @@ static int cmd_help(void *data, const char *input) {
 		break;
 	case '\0':
 	default:{
-		const char* help_message[] = {
-		"%var", "=value", "Alias for 'env' command",
-		"*", "off[=[0x]value]", "Pointer read/write data/values (see ?v, wx, wv)",
-		"(macro arg0 arg1)",  "", "Manage scripting macros",
-		".", "[-|(m)|f|!sh|cmd]", "Define macro or load r2, cparse or rlang file",
-		"="," [cmd]", "Run this command via rap://",
-		"/","", "Search for bytes, regexps, patterns, ..",
-		"!"," [cmd]", "Run given command as in system(3)",
-		"#"," [algo] [len]", "Calculate hash checksum of current block",
-		"#","!lang [..]", "Hashbang to run an rlang script",
-		"a","", "Perform analysis of code",
-		"b","", "Get or change block size",
-		"c"," [arg]", "Compare block with given data",
-		"C","", "Code metadata management",
-		"d","", "Debugger commands",
-		"e"," [a[=b]]", "List/get/set config evaluable vars",
-		"f"," [name][sz][at]", "Set flag at current address",
-		"g"," [arg]", "Go compile shellcodes with r_egg",
-		"i"," [file]", "Get info about opened file",
-		"k"," [sdb-query]", "Run sdb-query. see k? for help, 'k *', 'k **' ...",
-		"m","", "Mountpoints commands",
-		"o"," [file] ([offset])", "Open file at optional address",
-		"p"," [len]", "Print current block with format and length",
-		"P","", "Project management utilities",
-		"q"," [ret]", "Quit program with a return value",
-		"r"," [len]", "Resize file",
-		"s"," [addr]", "Seek to address (also for '0x', '0x1' == 's 0x1')",
-		"S","", "Io section manipulation information",
-		"t","", "Cparse types management",
-		"T"," [-] [num|msg]", "Text log utility",
-		"u","", "uname/undo seek/write",
-		"V","", "Enter visual mode (vcmds=visualvisual  keystrokes)",
-		"w"," [str]", "Multiple write operations",
-		"x"," [len]", "Alias for 'px' (print hexadecimal)",
-		"y"," [len] [[[@]addr", "Yank/paste bytes from/to memory",
-		"z", "", "Zignatures management",
-		"?[??]","[expr]", "Help or evaluate math expression",
-		"?$?", "", "Show available '$' variables and aliases",
-		"?@?", "", "Misc help for '@' (seek), '~' (grep) (see ~?""?)",
-		"?:?", "", "List and manage core plugins",
-		NULL
-		};
-		r_cons_printf("Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...\n"
-			"Append '?' to any char command to get detailed help\n"
-			"Prefix with number to repeat command N times (f.ex: 3x)\n");
-		r_core_cmd_help (core, help_message);
+		r_core_cmd_help (core, help_msg_que);
 		}
 		break;
 	}

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -454,42 +454,7 @@ static int cmd_info(void *data, const char *input) {
 			}
 			break;
 		case '?': {
-			const char * help_message[] = {
-				"Usage: i", "", "Get info from opened file",
-				"Output mode:", "", "",
-				"'*'", "", "Output in radare commands",
-				"'j'", "", "Output in json",
-				"'q'", "", "Simple quiet output",
-				"Actions:", "", "",
-				"i|ij", "", "Show info of current file (in JSON)",
-				"iA", "", "List archs",
-				"ia", "", "Show all info (imports, exports, sections..)",
-				"ib", "", "Reload the current buffer for setting of the bin (use once only)",
-				"ic", "", "List classes, methods and fields",
-				"iC", "", "Show signature info (entitlements, ...)",
-				"id", "", "Debug information (source lines)",
-				"iD", " lang sym", "demangle symbolname for given language",
-				"ie", "", "Entrypoint",
-				"iE", "", "Exports (global symbols)",
-				"ih", "", "Headers",
-				"ii", "", "Imports",
-				"iI", "", "Binary info",
-				"ik", " [query]", "Key-value database from RBinObject",
-				"il", "", "Libraries",
-				"iL", "", "List all RBin plugins loaded",
-				"im", "", "Show info about predefined memory allocation",
-				"iM", "", "Show main address",
-				"io", " [file]", "Load info from file (or last opened) use bin.baddr",
-				"ir|iR", "", "Relocs",
-				"is", "", "Symbols",
-				"iS ", "[entropy,sha1]", "Sections (choose which hash algorithm to use)",
-				"iV", "", "Display file version info",
-				"iz", "", "Strings in data sections",
-				"izz", "", "Search for Strings in the whole binary",
-				"iZ", "", "Guess size of binary program",
-				NULL
-				};
-				r_core_cmd_help (core, help_message);
+				r_core_cmd_help (core, help_msg_i);
 			}
 			goto done;
 		case '*':

--- a/libr/core/cmd_log.c
+++ b/libr/core/cmd_log.c
@@ -86,23 +86,7 @@ static int cmd_log(void *data, const char *input) {
 		r_core_log_del (core, n);
 		break;
 	case '?':{
-			const char* help_msg[] = {
-			"Usage:", "T","[-][ num|msg]",
-			"T", "", "List all Text log messages",
-			"T", " message", "Add new log message",
-			"T", " 123", "List log from 123",
-			"T", " 10 3", "List 3 log messages starting from 10",
-			"T*", "", "List in radare commands",
-			"T-", "", "Delete all logs",
-			"T-", " 123", "Delete logs before 123",
-			"Tl", "", "Get last log message id",
-			"Tj", "", "List in json format",
-			"Tm", " [idx]", "Display log messages without index",
-			"Ts", "", "List files in current directory (see pwd, cd)",
-			"Tp", "[-plug]", "Tist, load, unload plugins",
-			"TT", "", "Enter into the text log chat console",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_T);
 		}
 		break;
 	case 'T':
@@ -122,13 +106,7 @@ static int cmd_log(void *data, const char *input) {
 			r_lib_open (core->lib, input+2);
 			break;
 		case '?': {
-			const char* help_msg[] = {
-			"Usage:", "Tp", "[-name][ file]",
-			"Tp", "", "List all plugins loaded by RCore.lib",
-			"Tp-", "duk", "Unload plugin matching in filename",
-			"Tp", " blah."R_LIB_EXT, "Load plugin file",
-			NULL};
-			r_core_cmd_help(core, help_msg);
+			r_core_cmd_help(core, help_msg_Tp);
 			}
 			break;
 		}

--- a/libr/core/cmd_macro.c
+++ b/libr/core/cmd_macro.c
@@ -13,22 +13,7 @@ static int cmd_macro(void *data, const char *input) {
 	case '\0': r_cmd_macro_list (&core->rcmd->macro); break;
 	case '(':
 	case '?': {
-		const char* help_msg[] = {
-			"Usage:", "(foo args,cmd1,cmd2,..)", "Aliases",
-			"(foo args,..,..)", "", "define a macro",
-			"(foo args,..,..)()", "", "define and call a macro",
-			"(-foo)", "", "remove a macro",
-			".(foo)", "", "to call it",
-			"()", "", "break inside macro",
-			"(*", "", "list all defined macros",
-			"", "Argument support:", "",
-			"(foo x y\\n$0 @ $1)", "", "define fun with args",
-			".(foo 128 0x804800)", "", "call it with args",
-			"", "Iterations:", "",
-			".(foo\\n() $@)", "", "define iterator returning iter index",
-			"x @@ .(foo)", "", "iterate over them",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_paren);
 		}
 		break;
 	default: {

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -210,20 +210,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 	ut64 addr = core->offset;
 	switch (input[1]) {
 	case '?': {
-		const char* help_msg[] = {
-			"Usage:", "CC[-+!*au] [base64:..|str] @ addr", "",
-			"CC", "", "list all comments in human friendly form",
-			"CC*", "", "list all comments in r2 commands",
-			"CC.", "", "show comment at current offset",
-			"CC,", " [file]", "show or set comment file",
-			"CC", " or maybe not", "append comment at current address",
-			"CC+", " same as above", "append comment at current address",
-			"CC!", "", "edit comment using cfg.editor (vim, ..)",
-			"CC-", " @ cmt_addr", "remove comment at given address",
-			"CCu", " good boy @ addr", "add good boy comment at given address",
-			"CCu", " base64:AA== @ addr", "add comment in base64",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_CC);
 		} break;
 	case ',': // "CC,"
 		if (input[2]=='?') {
@@ -524,49 +511,16 @@ static int cmd_meta_hsdmf (RCore *core, const char *input) {
 	return true;
 }
 void r_comment_var_help (RCore *core, char type) {
-	const char *help_bp[] = {
-		"Usage:", "Cvb", "[name] [comment]",
-		"Cvb?", "", "show this help",
-		"Cvb", "", "list all base pointer args/vars comments in human friendly format",
-		"Cvb*", "", "list all base pointer args/vars comments in r2 format",
-		"Cvb-", "[name]", "delete comments for var/arg at current offset for base pointer",
-		"Cvb", "[name]", "Show comments for var/arg at current offset for base pointer",
-		"Cvb", "[name] [comment]", "add/append comment for the variable with the current name",
-		"Cvb!", "[name]", "edit comment using cfg editor",
-		NULL
-	};
-	const char *help_sp[] = {
-		"Usage:", "Cvs", "[name] [comment]",
-		"Cvs?", "", "show this help",
-		"Cvs", "", "list all stack based args/vars comments in human friendly format",
-		"Cvs*", "", "list all stack based args/vars comments in r2 format",
-		"Cvs-", "[name]", "delete comments for stack pointer var/arg with that name",
-		"Cvs", "[name]", "Show comments for stack pointer var/arg with that name",
-		"Cvs", "[name] [comment]", "add/append comment for the variable",
-		"Cvs!", "[name]", "edit comment using cfg editor",
-		NULL
-	};
-	const char *help_reg[] = {
-		"Usage:", "Cvr", "[name] [comment]",
-		"Cvr?", "", "show this help",
-		"Cvr", "", "list all register based args comments in human friendly format",
-		"Cvr*", "", "list all register based args comments in r2 format",
-		"Cvr-", "[name]", "delete comments for register based arg for that name",
-		"Cvr", "[name]", "Show comments for register based arg for that name",
-		"Cvr", "[name] [comment]", "add/append comment for the variable",
-		"Cvr!", "[name]", "edit comment using cfg editor",
-		NULL
-	};
 
 	switch (type) {
 	case 'b':
-		r_core_cmd_help (core, help_bp);
+		r_core_cmd_help (core, help_msg_Cvb);
 		break;
 	case 's':
-		r_core_cmd_help (core, help_sp);
+		r_core_cmd_help (core, help_msg_Cvs);
 		break;
 	case 'r':
-		r_core_cmd_help (core, help_reg);
+		r_core_cmd_help (core, help_msg_Cvr);
 		break;
 	default:
 		r_cons_printf("See Cvb, Cvs and Cvr\n");
@@ -732,27 +686,7 @@ static int cmd_meta(void *data, const char *input) {
 		break;
 	case '\0':
 	case '?':{
-			const char* help_msg[] = {
-				"Usage:", "C[-LCvsdfm*?][*?] [...]", " # Metadata management",
-				"C*", "", "list meta info in r2 commands",
-				"C-", " [len] [[@]addr]", "delete metadata at given address range",
-				"CL", "[-][*] [file:line] [addr]", "show or add 'code line' information (bininfo)",
-				"CS", "[-][space]", "manage meta-spaces to filter comments, etc..",
-				"CC", "[-] [comment-text] [@addr]", "add/remove comment",
-				"CC!", " [@addr]", "edit comment with $EDITOR",
-				"CCa", "[-at]|[at] [text] [@addr]", "add/remove comment at given address",
-				"CCu", " [comment-text] [@addr]", "add unique comment",
-				"Ca", "[?]", "add comments to base pointer bases args/vars",
-				"Ce", "[?]", "add comments to stack pointer based args/vars",
-				"Cv", "[?]", "add comments to register based args",
-				"Cs", "[-] [size] [@addr]", "add string",
-				"Cz", "[@addr]", "add zero-terminated string",
-				"Ch", "[-] [size] [@addr]", "hide data",
-				"Cd", "[-] [size] [repeat] [@addr]", "hexdump data array (Cd 4 10 == dword [10])",
-				"Cf", "[-] [sz] [fmt..] [@addr]", "format memory (see pf?)",
-				"Cm", "[-] [sz] [fmt..] [@addr]", "magic parse (see pm?)",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_C);
 			}
 		break;
 	case 'F':
@@ -767,19 +701,7 @@ static int cmd_meta(void *data, const char *input) {
 		switch (input[1]) {
 		case '?':
 			{
-				const char *help_msg[] = {
-					"Usage: CS","[*] [+-][metaspace|addr]", " # Manage metaspaces",
-					"CS","","display metaspaces",
-					"CS"," *","select all metaspaces",
-					"CS"," metaspace","select metaspace or create if it doesn't exist",
-					"CS","-metaspace","remove metaspace",
-					"CS","-*","remove all metaspaces",
-					"CS","+foo","push previous metaspace and set",
-					"CS","-","pop to the previous metaspace",
-					//	"CSm"," [addr]","move metas at given address to the current metaspace",
-					"CSr"," newname","rename selected metaspace",
-					NULL};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_CS);
 			}
 			break;
 		case '+':

--- a/libr/core/cmd_mount.c
+++ b/libr/core/cmd_mount.c
@@ -150,11 +150,7 @@ static int cmd_mount(void *data, const char *_input) {
 		input++;
 		switch (*input) {
 		case '?':
-			r_cons_printf (
-			"Usage: mf[no] [...]\n"
-			" mfn /foo *.c       ; search files by name in /foo path\n"
-			" mfo /foo 0x5e91    ; search files by offset in /foo path\n"
-			);
+			r_core_cmd_help (core, help_msg_mf);
 			break;
 		case 'n':
 			input++;
@@ -203,25 +199,8 @@ static int cmd_mount(void *data, const char *_input) {
 		eprintf ("TODO\n");
 		break;
 	case '?': {
-		const char* help_msg[] = {
-			"Usage:", "m[-?*dgy] [...] ", "Mountpoints management",
-			"m", "", "List all mountpoints in human readable format",
-			"m*", "", "Same as above, but in r2 commands",
-			"ml", "", "List filesystem plugins",
-			"m", " /mnt", "Mount fs at /mnt with autodetect fs and current offset",
-			"m", " /mnt ext2 0", "Mount ext2 fs at /mnt with delta 0 on IO",
-			"m-/", "", "Umount given path (/)",
-			"my", "", "Yank contents of file into clipboard",
-			"mo", " /foo", "Get offset and size of given file",
-			"mg", " /foo", "Get contents of file/dir dumped to disk (XXX?)",
-			"mf", "[o|n]", "Search files for given filename or for offset",
-			"md", " /", "List directory contents for path",
-			"mp", "", "List all supported partition types",
-			"mp", " msdos 0", "Show partitions in msdos format at offset 0",
-			"ms", " /mnt", "Open filesystem prompt at /mnt",
-			//"TODO: support multiple mountpoints and RFile IO's (need io+core refactorn",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		//"TODO: support multiple mountpoints and RFile IO's (need io+core refactorn",
+		r_core_cmd_help (core, help_msg_m);
 		}
 		break;
 	}

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -17,15 +17,6 @@ static inline ut32 find_binfile_id_by_fd (RBin *bin, ut32 fd) {
 }
 
 static void cmd_open_bin(RCore *core, const char *input) {
-	const char* help_msg[] = {
-		"Usage:", "ob", " # List open binary files backed by fd",
-		"ob", "", "List opened binfiles and bin objects",
-		"ob", " [fd # bobj #]", "Prioritize by fd number and object number",
-		"obb", " [fd #]", "Prioritize by fd number with current selected object",
-		"ob-", " [fd #]", "Delete binfile by fd",
-		"obd", " [binobject #]", "Delete binfile object numbers, if more than 1 object is loaded",
-		"obo", " [binobject #]", "Prioritize by bin object number",
-		NULL};
 	const char *value = NULL;
 	ut32 binfile_num = -1, binobj_num = -1;
 
@@ -142,20 +133,12 @@ static void cmd_open_bin(RCore *core, const char *input) {
 		r_core_bin_delete (core, -1, binobj_num);
 		break;
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_ob);
 		break;
 	}
 }
 
 static void cmd_open_map (RCore *core, const char *input) {
-	const char* help_msg[] = {
-		"Usage:", "om[-] [arg]", " # map opened files",
-		"om", "", "list all defined IO maps",
-		"om", "-0x10000", "remove the map at given address",
-		"om", " fd addr [size]", "create new io map",
-		"omr", " fd|0xADDR ADDR", "relocate current map",
-		"om*", "", "show r2 commands to restore mapaddr",
-		NULL };
 	ut64 fd = 0LL;
 	ut64 addr = 0LL;
 	ut64 size = 0LL;
@@ -231,7 +214,7 @@ static void cmd_open_map (RCore *core, const char *input) {
 		break;
 	default:
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_om);
 		break;
 	}
 	r_core_block_read (core, 0);
@@ -281,42 +264,6 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 }
 
 static int cmd_open(void *data, const char *input) {
-	const char *help_msg[] = {
-		"Usage: o","[com- ] [file] ([offset])","",
-		"o","","list opened files",
-		"o*","","list opened files in r2 commands",
-		"oa"," [addr]","Open bin info from the given address",
-		"ob","[lbdos] [...]","list open binary files backed by fd",
-		"ob"," 4","priorize io and fd on 4 (bring to binfile to front)",
-		"oc"," [file]","open core file, like relaunching r2",
-		"oj","","list opened files in JSON format",
-		"oL","","list all IO plugins registered",
-		"om","[?]","create, list, remove IO maps",
-		"on"," [file] 0x4000","map raw file at 0x4000 (no r_bin involved)",
-		"oo","","reopen current file (kill+fork in debugger)",
-		"oo","+","reopen current file in read-write",
-		"ood"," [args]","reopen in debugger mode (with args)",
-		"op"," ["R_LIB_EXT"]","open r2 native plugin (asm, bin, core, ..)",
-		"o"," 4","priorize io on fd 4 (bring to front)",
-		"o","-1","close file descriptor 1",
-		"o-","*","close all opened files",
-		"o--","","close all files, analysis, binfiles, flags, same as !r2 --",
-		"o"," [file]","open [file] file in read-only",
-		"o","+[file]","open file in read-write mode",
-		"o"," [file] 0x4000","map file at 0x4000",
-		NULL
-	};
-	const char* help_msg_oo[] = {
-		"Usage:", "oo[-] [arg]", " # map opened files",
-		"oo", "", "reopen current file",
-		"oo+", "", "reopen in read-write",
-		"oob", "", "reopen loading rbin info",
-		"ood", "", "reopen in debug mode",
-		"oon", "", "reopen without loading rbin info",
-		"oon+", "", "reopen in read-write mode without loading rbin info",
-		"oonn", "", "reopen without loading rbin info, but with header flags",
-		"oonn+", "", "reopen in read-write mode without loading rbin info, but with",
-		NULL};
 	RCore *core = (RCore*)data;
 	int perms = R_IO_READ;
 	ut64 addr, baddr = r_config_get_i (core->config, "bin.baddr");
@@ -337,20 +284,12 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case '*':
 		if ('?' == input[1]) {
-			const char *help_msg[] = {
-				"Usage:", "o* [> files.r2]", "",
-				"o*", "", "list opened files in r2 commands", NULL
-			};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_ostar);
 			break;
 		}
 	case 'j':
 		if ('?' == input[1]) {
-			const char *help_msg[] = {
-				"Usage:", "oj [~{}]", " # Use ~{} to indent the JSON",
-				"oj", "", "list opened files in JSON format", NULL
-			};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_oj);
 			break;
 		}
 		r_core_file_list (core, (int)(*input));
@@ -360,11 +299,7 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case 'a':
 		if ('?' == input[1]) {
-			const char *help_msg[] = {
-				"Usage:", "oa [addr]", " #",
-				"oa", " [addr]", "Open bin info from the given address",NULL
-			};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_oa);
 			break;
 		}
 		addr = core->offset;
@@ -483,20 +418,14 @@ static int cmd_open(void *data, const char *input) {
 		switch (input[1]) {
 		case 'd': // "ood" : reopen in debugger
 			if ('?' == input[2]) {
-				const char *help_msg[] = {
-					"ood"," [args]","reopen in debugger mode (with args)",NULL
-				};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_ood);
 			} else {
 				r_core_file_reopen_debug (core, input + 2);
 			}
 			break;
 		case 'b': // "oob" : reopen with bin info
 			if ('?' == input[2]) {
-				const char *help_msg[] = {
-					"oob", "", "reopen loading rbin info",NULL
-				};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_oob);
 			} else {
 				r_core_file_reopen (core, input + 2, 0, 2);
 			}
@@ -504,10 +433,7 @@ static int cmd_open(void *data, const char *input) {
 		case 'n':
 			if ('n' == input[2]) {
 				if ('?' == input[3]) {
-					const char *help_msg[] = {
-						"oonn", "", "reopen without loading rbin info, but with header flags",NULL
-					};
-					r_core_cmd_help (core, help_msg);
+					r_core_cmd_help (core, help_msg_oonn);
 					break;
 				}
 				perms = (input[3] == '+')? R_IO_READ|R_IO_WRITE: 0;
@@ -515,10 +441,7 @@ static int cmd_open(void *data, const char *input) {
 				// TODO: Use API instead of !rabin2 -rk
 				r_core_cmdf (core, ".!rabin2 -rk '' '%s'", core->file->desc->name);
 			} else if ('?' == input[2]) {
-				const char *help_msg[] = {
-					"oon", "", "reopen without loading rbin info",NULL
-				};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_oon);
 				break;
 			}
 
@@ -527,10 +450,7 @@ static int cmd_open(void *data, const char *input) {
 			break;
 		case '+':
 			if ('?' == input[2]) {
-				const char *help_msg[] = {
-					"oo+", "", "reopen in read-write",NULL
-				};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_ooplus);
 			} else {
 				r_core_file_reopen (core, input + 2, R_IO_READ | R_IO_WRITE, 1);
 			}
@@ -546,10 +466,7 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case 'c':
 		if ('?' == input[1]) {
-			const char *help_msg[] = {
-				"oc"," [file]","open core file, like relaunching r2",NULL
-			};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_oc);
 			break;
 		}
 		if (r_sandbox_enable (0)) {
@@ -571,7 +488,7 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case '?':
 	default:
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_o);
 		break;
 	}
 	return 0;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -286,91 +286,6 @@ R_API int r_core_process_input_pade(RCore *core, const char *input, char** hex, 
 	return result;
 }
 
-static void print_format_help(RCore *core) {
-	const char* help_msg[] = {
-	"pf:", "pf[.k[.f[=v]]|[ v]]|[n]|[0][ [sz] fmt] [a0 a1 ...]", "",
-	"Commands:","","",
-	"pf", "?", "Show this help",
-	"pf", "??", "Format characters",
-	"pf", "???", "pf usage examples",
-	"pf", " xsi foo bar cow", "format named hex str and int (see `pf??`)",
-	"pf.", "", "List all formats",
-	"pf?", "fmt_name", "Show format of that stored one",
-	"pfs", " fmt_name", "Print the size of the format in bytes",
-	"pfo", "", "List all format files",
-	"pfo", " elf32", "Load the elf32 format definition file",
-	"pf.", "fmt_name", "Run stored format",
-	"pf.", "fmt_name.field_name", "Show specific field inside format",
-	"pf.", "fmt_name.size=33", "Set new value for the size field in obj",
-	"pfj.", "fmt_name", "Print format in JSON",
-	"pfv.", "fmt_name", "Print the value(s) only. Useful for one-liners",
-	"pf*.", "fmt_name", "Display flag commands",
-	"pfd.", "fmt_name", "Display graphviz commands",
-	NULL};
-	r_core_cmd_help (core, help_msg);
-}
-
-static void print_format_help_help(RCore *core) {
-	const char* help_msg[] = {
-	"pf:", "pf[.k[.f[=v]]|[ v]]|[n]|[0][ [sz] fmt] [a0 a1 ...]", "",
-	"Format:", "", "",
-	" ", "b", "byte (unsigned)",
-	" ", "B", "resolve enum bitfield (see t?)",
-	" ", "c", "char (signed byte)",
-	" ", "d", "0x%%08x hexadecimal value (4 bytes)",
-	" ", "D", "disassemble one opcode",
-	" ", "e", "temporally swap endian",
-	" ", "E", "resolve enum name (see t?)",
-	" ", "f", "float value (4 bytes)",
-	" ", "i", "%%i integer value (4 bytes)",
-	" ", "o", "0x%%08o octal value (4 byte)",
-	" ", "p", "pointer reference (2, 4 or 8 bytes)",
-	" ", "q", "quadword (8 bytes)",
-	" ", "r", "CPU register `pf r (eax)plop`",
-	" ", "s", "32bit pointer to string (4 bytes)",
-	" ", "S", "64bit pointer to string (8 bytes)",
-	" ", "t", "UNIX timestamp (4 bytes)",
-	" ", "T", "show Ten first bytes of buffer",
-	" ", "u", "uleb128 (variable length)",
-	" ", "w", "word (2 bytes unsigned short in hex)",
-	" ", "x", "0x%%08x hex value and flag (fd @ addr)",
-	" ", "X", "show formatted hexpairs",
-	" ", "z", "\\0 terminated string",
-	" ", "Z", "\\0 terminated wide string",
-	" ", "?", "data structure `pf ? (struct_name)example_name`",
-	" ", "*", "next char is pointer (honors asm.bits)",
-	" ", "+", "toggle show flags for each offset",
-	" ", ":", "skip 4 bytes",
-	" ", ".", "skip 1 byte",
-	NULL};
-	r_core_cmd_help (core, help_msg);
-}
-
-static void print_format_help_help_help(RCore *core) {
-	const char* help_msg[] = {
-	"pf:", "pf[.k[.f[=v]]|[ v]]|[n]|[0][ [sz] fmt] [a0 a1 ...]", "",
-	"Examples:","","",
-	"pf", " B (BitFldType)arg_name`", "bitfield type",
-	"pf", " E (EnumType)arg_name`", "enum type",
-	"pf.", "obj xxdz prev next size name", "Define the obj format as xxdz",
-	"pf",  " obj=xxdz prev next size name", "Same as above",
-	"pf", " iwq foo bar troll", "Print the iwq format with foo, bar, troll as the respective names for the fields",
-	"pf", " 0iwq foo bar troll", "Same as above, but considered as a union (all fields at offset 0)",
-	"pf.", "plop ? (troll)mystruct", "Use structure troll previously defined",
-	"pf", " 10xiz pointer length string", "Print a size 10 array of the xiz struct with its field names",
-	"pf", " {integer}bifc", "Print integer times the following format (bifc)",
-	"pf", " [4]w[7]i", "Print an array of 4 words and then an array of 7 integers",
-	NULL};
-	r_core_cmd_help (core, help_msg);
-}
-
-static void print_format_help_help_help_help(RCore *core) {
-	const char* help_msg[] = {
-	"    STAHP IT!!!", "", "",
-	NULL};
-	r_core_cmd_help (core, help_msg);
-}
-
 static void cmd_print_format(RCore *core, const char *_input, int len) {
 	char *input;
 	int mode = R_PRINT_MUSTSEE;
@@ -423,12 +338,12 @@ static void cmd_print_format(RCore *core, const char *_input, int len) {
 				if (_input && *_input == '?') {
 					_input++;
 					if (_input && *_input == '?') {
-						print_format_help_help_help_help (core);
+						r_core_cmd_help (core, help_msg_pfquequeque);
 					} else {
-						print_format_help_help_help (core);
+						r_core_cmd_help (core, help_msg_pfqueque);
 					}
 				} else {
-					print_format_help_help (core);
+					r_core_cmd_help (core, help_msg_pfque);
 				}
 			} else {
 				RListIter *iter;
@@ -444,7 +359,7 @@ static void cmd_print_format(RCore *core, const char *_input, int len) {
 				}
 			}
 		} else {
-			print_format_help (core);
+			r_core_cmd_help (core, help_msg_pf);
 		}
 		return;
 	}
@@ -1646,15 +1561,6 @@ static void cmd_print_pv(RCore *core, const char *input) {
 	int i, n = core->assembler->bits / 8;
 	int type = 'v';
 	bool fixed_size = true;
-	const char* help_msg[] = {
-		 "Usage: pv[j][1,2,4,8,z]", "", "",
-		 "pv", "",  "print bytes based on asm.bits",
-		 "pv1", "", "print 1 byte in memory",
-		 "pv2", "", "print 2 bytes in memory",
-		 "pv4", "", "print 4 bytes in memory",
-		 "pv8", "", "print 8 bytes in memory",
-		 "pvz", "", "print value as string (alias for ps)",
-		 NULL};
 	switch (input[0]) {
 	case '1':
 		n = 1;
@@ -1717,7 +1623,7 @@ static void cmd_print_pv(RCore *core, const char *input) {
 		}
 		break;
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_pv);
 		break;
 	default:
 		{
@@ -1819,15 +1725,7 @@ static void cmd_print_bars(RCore *core, const char *input) {
 
 	switch (mode) {
 	case '?': { // bars
-			 const char* help_msg[] = {
-				 "Usage:", "p=[bep?][qj] [num-of-blocks] ([len]) ([block-offset]) ", "show entropy/printable chars/chars bars",
-				 "p=", "", "print bytes of current block in bars",
-				 "p=", "b", "same as above",
-				 "p=", "d", "print different bytes from block",
-				 "p=", "e", "print entropy for each filesize/blocksize",
-				 "p=", "p", "print number of printable bytes for each filesize/blocksize",
-				 NULL};
-			 r_core_cmd_help (core, help_msg);
+			 r_core_cmd_help (core, help_msg_pequals);
 		 }
 		 break;
 	case 'd':
@@ -2099,13 +1997,7 @@ static int cmd_print(void *data, const char *input) {
 		//eprintf ("RANGE = %llx %llx\n", from, to);
 		switch (mode) {
 		case '?':{
-			const char* help_msg[] = {
-				"Usage:", "p%%[jh] [pieces]", "bar|json|histogram blocks",
-				"p-", "", "show ascii-art bar of metadata in file boundaries",
-				"p-j", "", "show json format",
-				"p-h", "", "show histogram analysis of metadata per block",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_pminus);
 			}
 			return 0;
 		case 'j': //p-j
@@ -2260,7 +2152,7 @@ static int cmd_print(void *data, const char *input) {
 		}
 		if (input[1]=='e') { // "pae"
 			if (input[2]=='?') {
-				r_cons_printf ("|Usage: pae [hex]       assemble esil from hexpairs\n");
+				r_core_cmd_help (core, help_msg_pae);
 			} else {
 				int ret, bufsz;
 				RAnalOp aop = {0};
@@ -2277,13 +2169,13 @@ static int cmd_print(void *data, const char *input) {
 			}
 		} else if (input[1] == 'D') {
 			if (input[2]=='?') {
-				r_cons_printf ("|Usage: paD [asm]       disasm like in pdi\n");
+				r_core_cmd_help (core, help_msg_paD);
 			} else {
 				r_core_cmdf (core, "pdi@x:%s", input+2);
 			}
 		} else if (input[1]=='d') { // "pad"
 			if (input[2]=='?') {
-				r_cons_printf ("|Usage: pad [asm]       disasm\n");
+				r_core_cmd_help (core, help_msg_pad);
 			} else {
 				RAsmCode *c;
 				r_asm_set_pc (core->assembler, core->offset);
@@ -2294,8 +2186,7 @@ static int cmd_print(void *data, const char *input) {
 				} else eprintf ("Invalid hexstr\n");
 			}
 		} else if (input[1]=='?') {
-			r_cons_printf("|Usage: pa[ed] [hex|asm]  assemble (pa) disasm (pad)"
-				" esil (pae) from hexpairs\n");
+			r_core_cmd_help (core, help_msg_paed);
 		} else {
 			RAsmCode *acode;
 			int i;
@@ -2320,7 +2211,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'b': { // "pb"
 		if (input[1]=='?') {
-			r_cons_printf("|Usage: p[bB] [len] ([skip])  ; see also pB and pxb\n");
+			r_core_cmd_help (core, help_msg_pb);
 		} else if (l != 0) {
 			int from, to;
 			const int size = len*8;
@@ -2359,7 +2250,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'B': { // "pB"
 		if (input[1]=='?') {
-			r_cons_printf ("|Usage: p[bB] [len]       bitstream of N bytes\n");
+			r_core_cmd_help (core, help_msg_pB);
 		} else if (l != 0) {
 			const int size = len*8;
 			char *buf = malloc (size+1);
@@ -2396,9 +2287,8 @@ static int cmd_print(void *data, const char *input) {
 				pdi (core, 0, l, 0);
 			}
 			break;
-		case '?': // "pi?"
-			r_cons_printf ("|Usage: p[iI][df] [len]   print N instructions/bytes"
-					"(f=func) (see pi? and pdi)\n");
+		case '?': // "pI?"
+			r_core_cmd_help (core, help_msg_pI);
 			break;
 		default:
 			if (l) {
@@ -2409,7 +2299,7 @@ static int cmd_print(void *data, const char *input) {
 	case 'i': // "pi"
 		switch (input[1]) {
 		case '?':
-			r_cons_printf ("|Usage: pi[defj] [num]\n");
+			r_core_cmd_help (core, help_msg_pi);
 			break;
 		case 'a': // "pia" is like "pda", but with "pi" output
 			if (l != 0) {
@@ -2598,7 +2488,7 @@ static int cmd_print(void *data, const char *input) {
 		case 's': // "pds" and "pdsf"
 			processed_cmd = true;
 			if (input[2] == '?') {
-				r_cons_printf ("Usage: pds[f]  - sumarize N bytes or function (pdfs)\n");
+				r_core_cmd_help (core, help_msg_pds);
 			} else {
 				disasm_strings (core, input, NULL);
 			}
@@ -2606,7 +2496,7 @@ static int cmd_print(void *data, const char *input) {
 		case 'f': // "pdf"
 			processed_cmd = true;
 			if (input[2] == '?') {
-				r_cons_printf ("Usage: pdf[sj]  - disassemble function (summary+cjmp), json)\n");
+				r_core_cmd_help (core, help_msg_pdfs);
 			} else if (input[2] == 's') { // "pdfs"
 				ut64 oseek = core->offset;
 				int oblock = core->blocksize;
@@ -2690,26 +2580,7 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case '?': // "pd?"
 			processed_cmd = true;
-			const char* help_msg[] = {
-				"Usage:", "p[dD][ajbrfils] [sz] [arch] [bits]", " # Print Disassembly",
-				"NOTE: ", "len", "parameter can be negative",
-				"NOTE: ", "", "Pressing ENTER on empty command will repeat last pd command and also seek to end of disassembled range.",
-				"pd", " N", "disassemble N instructions",
-				"pd", " -N", "disassemble N instructions backward",
-				"pD", " N", "disassemble N bytes",
-				"pda", "", "disassemble all possible opcodes (byte per byte)",
-				"pdb", "", "disassemble basic block",
-				"pdc", "", "pseudo disassembler output in C-like syntax",
-				"pdj", "", "disassemble to json",
-				"pdr", "", "recursive disassemble across the function graph",
-				"pdf", "", "disassemble function",
-				"pdi", "", "like 'pi', with offset and bytes",
-				"pdl", "", "show instruction sizes",
-				//"pds", "", "disassemble with back sweep (greedy disassembly backwards)",
-				"pds", "", "disassemble summary (strings, calls, jumps, refs) (see pdsf and pdfs)",
-				"pdt", "", "disassemble the debugger traces (see atd)",
-				NULL};
-				r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_pd);
 			pd_result = 0;
 		}
 		if (!processed_cmd) {
@@ -2798,19 +2669,7 @@ static int cmd_print(void *data, const char *input) {
 	case 's': // "ps"
 		switch (input[1]) {
 		case '?':{
-			const char* help_msg[] = {
-				"Usage:", "ps[zpw] [N]", "Print String",
-				"ps", "", "print string",
-				"psi", "", "print string inside curseek",
-				"psb", "", "print strings in current block",
-				"psx", "", "show string with scaped chars",
-				"psz", "", "print zero terminated string",
-				"psp", "", "print pascal string",
-				"psu", "", "print utf16 unicode (json)",
-				"psw", "", "print wide string",
-				"psj", "", "print string in JSON format",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_ps);
 			}
 			break;
 		case 'j':
@@ -2975,15 +2834,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'm': // "pm"
 		if (input[1]=='?') {
-			r_cons_printf ("|Usage: pm [file|directory]\n"
-				"| r_magic will use given file/dir as reference\n"
-				"| output of those magic can contain expressions like:\n"
-				"|   foo@0x40   # use 'foo' magic file on address 0x40\n"
-				"|   @0x40      # use current magic file on address 0x40\n"
-				"|   \\n         # append newline\n"
-				"| e dir.magic  # defaults to "R_MAGIC_PATH"\n"
-				"| /m           # search for magic signatures\n"
-				);
+			r_core_cmd_help (core, help_msg_pm);
 		} else {
 			// XXX: need cmd_magic header for r_core_magic
 			if (l > 0) {
@@ -2993,8 +2844,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'u': // "pu"
 		if (input[1]=='?') {
-			r_cons_printf ("|Usage: pu[w] [len]       print N url"
-					"encoded bytes (w=wide)\n");
+			r_core_cmd_help (core, help_msg_pu);
 		} else {
 			if (l > 0) {
 				r_print_string (core->print, core->offset, core->block, len,
@@ -3011,19 +2861,12 @@ static int cmd_print(void *data, const char *input) {
 	case 'r': // "pr"
 		switch (input[1]) {
 		case '?':
-			r_cons_printf ("|Usage: pr[glx] [size]\n"
-			"| prl: print raw with lines offsets\n"
-			"| prx: printable chars with real offset (hyew)\n"
-			"| prg: print raw GUNZIPped block\n"
-			"| prz: print raw zero terminated string\n");
+			r_core_cmd_help (core, help_msg_pr);
 			break;
 		case 'g': // "prg" // gunzip
 			switch (input[2]) {
 			case '?':
-				r_cons_printf ("|Usage: prg[io]\n"
-				"| prg: print gunzipped data of current block\n"
-				"| prgi: show consumed bytes when inflating\n"
-				"| prgo: show output bytes after inflating\n");
+				r_core_cmd_help (core, help_msg_prg);
 				break;
 			case 'i':
 				 {
@@ -3087,7 +2930,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case '3': // "p3" [file]
 		if (input[1]=='?') {
-			eprintf ("Usage: p3 [file] - print 3D stereogram image of current block\n");
+			r_core_cmd_help (core, help_msg_p3);
 		} else
 		if (input[1]==' ') {
 			char *data = r_file_slurp (input+2, NULL);
@@ -3118,30 +2961,7 @@ static int cmd_print(void *data, const char *input) {
 			r_core_print_examine (core, input+2);
 			break;
 		case '?':{
-			const char* help_msg[] = {
-				"Usage:", "px[afoswqWqQ][f]", " # Print heXadecimal",
-				"px",  "", "show hexdump",
-				"px/", "", "same as x/ in gdb (help x)",
-				"pxa", "", "show annotated hexdump",
-				"pxA", "", "show op analysis color map",
-				"pxb", "", "dump bits in hexdump form",
-				"pxd", "[124]", "signed integer dump (1 byte, 2 and 4)",
-				"pxe", "", "emoji hexdump! :)",
-				"pxi", "", "HexII compact binary representation",
-				"pxf", "", "show hexdump of current function",
-				"pxh", "", "show hexadecimal half-words dump (16bit)",
-				"pxH", "", "same as above, but one per line",
-				"pxl", "", "display N lines (rows) of hexdump",
-				"pxo", "", "show octal dump",
-				"pxq", "", "show hexadecimal quad-words dump (64bit)",
-				"pxQ", "", "same as above, but one per line",
-				"pxr", "[j]", "show words with references to flags and code",
-				"pxs", "", "show hexadecimal in sparse mode",
-				"pxt", "[*.] [origin]", "show delta pointer table in r2 commands",
-				"pxw", "", "show hexadecimal words dump (32bit)",
-				"pxW", "", "same as above, but one per line",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_px);
 			}
 			break;
 		case 'a': // "pxa"
@@ -3153,22 +2973,7 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'A': // "pxA"
 			if (input[2]=='?') {
-				eprintf ("Usage: pxA [len]   # f.ex: pxA 4K\n"
-				" mv    move,lea,li\n"
-				" ->    push\n"
-				" <-    pop\n"
-				" io    in/out ops\n"
-				" $$    int/swi/trap/new\n"
-				" ..    nop\n"
-				" +-*/  math ops\n"
-				" |&^   bin ops\n"
-				" <<>>  shift ops\n"
-				" _J    jump\n"
-				" cJ    conditional jump\n"
-				" _C    call\n"
-				" _R    ret\n"
-				" ==    cmp/test\n"
-				" XX    invalid\n");
+				r_core_cmd_help (core, help_msg_pxA);
 			} else if (l != 0) {
 				cmd_print_pxA (core, len, input+1);
 			}
@@ -3214,7 +3019,7 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 't': // "pxt"
 			if (input[2] == '?') {
-				r_cons_printf ("Usage: pxt[.*] - print delta pointer table\n");
+				r_core_cmd_help (core, help_msg_pxt);
 			} else {
 				ut64 origin = core->offset;
 				const char *arg = strchr (input, ' ');
@@ -3533,8 +3338,7 @@ static int cmd_print(void *data, const char *input) {
 	case '2': // "p2"
 		if (l != 0) {
 			if (input[1] == '?')
-				r_cons_printf ("|Usage: p2 [number of bytes representing tiles]\n"
-						"NOTE: Only full tiles will be printed\n");
+				r_core_cmd_help (core, help_msg_p2);
 			else r_print_2bpp_tiles (core->print, core->block, len/16);
 		}
 		break;
@@ -3547,14 +3351,14 @@ static int cmd_print(void *data, const char *input) {
 		switch (input[1]) {
 		case 'd':
 			if (input[2] == '?')
-				r_cons_printf ("|Usage: p6d [len]    base 64 decode\n");
+				r_core_cmd_help (core, help_msg_p6d);
 			else if (r_base64_decode (buf, (const char *)core->block, len))
 				r_cons_println ((const char*)buf);
 			else eprintf ("r_base64_decode: invalid stream\n");
 			break;
 		case 'e':
 			if (input[2] == '?') {
-				r_cons_printf ("|Usage: p6e [len]    base 64 encode\n");
+				r_core_cmd_help (core, help_msg_p6e);
 				break;
 			} else {
 				len = len > core->blocksize ? core->blocksize : len;
@@ -3564,7 +3368,7 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case '?':
 		default:
-			r_cons_printf ("|Usage: p6[ed] [len]    base 64 encode/decode\n");
+			r_core_cmd_help (core, help_msg_p6ed);
 			break;
 		}
 		free (buf);
@@ -3572,7 +3376,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case '8': // "p8"
 		if (input[1] == '?') {
-			r_cons_printf("|Usage: p8[fj] [len]     8bit hexpair list of bytes (see pcj)\n");
+			r_core_cmd_help (core, help_msg_p8);
 		} else if (l !=0) {
 			if (input[1] == 'j') {
 			r_core_cmdf (core, "pcj %s", input+2);
@@ -3586,7 +3390,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'k': // "pk"
 		if (input[1] == '?') {
-			r_cons_printf ("|Usage: pk [len]       print key in randomart\n");
+			r_core_cmd_help (core, help_msg_pk);
 		} else if (l > 0) {
 			len = len > core->blocksize ? core->blocksize : len;
 			char *s = r_print_randomart (core->block, len, core->offset);
@@ -3596,7 +3400,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'K': // "pK"
 		if (input[1] == '?') {
-			r_cons_printf ("|Usage: pK [len]       print key in randomart mosaic\n");
+			r_core_cmd_help (core, help_msg_pK);
 		} else if (l > 0) {
 			len = len > core->blocksize ? core->blocksize : len;
 			int w, h;
@@ -3654,35 +3458,14 @@ static int cmd_print(void *data, const char *input) {
 				r_print_date_w32 (core->print, core->block+l, sizeof (ut64));
 			break;
 		case '?':{
-			const char* help_msg[] = {
-			"Usage: pt", "[dn]", "print timestamps",
-			"pt", "", "print unix time (32 bit `cfg.bigendian`)",
-			"ptd","", "print dos time (32 bit `cfg.bigendian`)",
-			"ptn","", "print ntfs time (64 bit `cfg.bigendian`)",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_pt);
 			}
 			break;
 		}
 		break;
 	case 'z': // "pz"
 		if (input[1]=='?') {
-			const char *help_msg[] = {
-			"Usage: pz [len]", "", "print zoomed blocks (filesize/N)",
-			"e ","zoom.maxsz","max size of block",
-			"e ","zoom.from","start address",
-			"e ","zoom.to","end address",
-			"e ","zoom.byte","specify how to calculate each byte",
-			"pzp","","number of printable chars",
-			"pzf","","count of flags in block",
-			"pzs","","strings in range",
-			"pz0","","number of bytes with value '0'",
-			"pzF","","number of bytes with value 0xFF",
-			"pze","","calculate entropy and expand to 0-255 range",
-			"pzh","","head (first byte value); This is the default mode",
-			//"WARNING: On big files, use 'zoom.byte=h' or restrict ranges\n");
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_pz);
 		} else {
 			char *oldzoom = NULL;
 			ut64 maxsize = r_config_get_i (core->config, "zoom.maxsz");
@@ -3717,36 +3500,7 @@ static int cmd_print(void *data, const char *input) {
 		}
 		break;
 	default: {
-		 const char* help_msg[] = {
-			 "Usage:", "p[=68abcdDfiImrstuxz] [arg|len] [@addr]", "",
-			 "p=","[bep?] [blks] [len] [blk]","show entropy/printable chars/chars bars",
-			 "p2"," [len]","8x8 2bpp-tiles",
-			 "p3"," [file]","print stereogram (3D)",
-			 "p6","[de] [len]", "base64 decode/encode",
-			 "p8","[j] [len]","8bit hexpair list of bytes",
-			 "pa","[edD] [arg]", "pa:assemble  pa[dD]:disasm or pae: esil from hexpairs",
-			 "pA","[n_ops]", "show n_ops address and type",
-			 "p","[b|B|xb] [len] ([skip])", "bindump N bits skipping M",
-			 "p","[bB] [len]","bitstream of N bytes",
-			 "pc","[p] [len]","output C (or python) format",
-			 "p","[dD][?] [sz] [a] [b]","disassemble N opcodes/bytes for Arch/Bits (see pd?)",
-			 "pf","[?|.nam] [fmt]","print formatted data (pf.name, pf.name $<expr>)",
-			 "ph","[?=|hash] ([len])","calculate hash for a block",
-			 "p","[iI][df] [len]", "print N ops/bytes (f=func) (see pi? and pdi)",
-			 "pm"," [magic]","print libmagic data (see pm? and /m?)",
-			 "pr","[glx] [len]","print N raw bytes (in lines or hexblocks, 'g'unzip)",
-			 "p","[kK] [len]","print key in randomart (K is for mosaic)",
-			 "ps","[pwz] [len]","print pascal/wide/zero-terminated strings",
-			 "pt","[dn?] [len]","print different timestamps",
-			 "pu","[w] [len]","print N url encoded bytes (w=wide)",
-			 "pv","[jh] [mode]","show variable/pointer/value in memory",
-			 "p-","[jh] [mode]","bar|json|histogram blocks (mode: e?search.in)",
-			 "px","[owq] [len]","hexdump of N bytes (o=octal, w=32bit, q=64bit)",
-			 "pz"," [len]","print zoom view (see pz? for help)",
-			 "pwd","","display current working directory",
-			 NULL
-		};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_p);
 		}
 		break;
 	}

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -19,7 +19,9 @@ static int cmd_project(void *data, const char *input) {
 	case 'c':
 		if (input[1]==' ') {
 			r_core_project_cat (core, input+2);
-		} else eprintf ("Usage: Pc [prjname]\n");
+		} else {
+			r_core_cmd_help (core, help_msg_Pc);
+		}
 		break;
 	case 'o':
 	//	if (r_file_is_regular (file))
@@ -45,7 +47,9 @@ static int cmd_project(void *data, const char *input) {
 	case 'S':
 		if (input[1] == ' ') {
 			r_core_project_save_rdb (core, input+2, R_CORE_PRJ_ALL);
-		} else eprintf ("Usage: PS [file]\n");
+		} else {
+			r_core_cmd_help (core, help_msg_PS);
+		}
 		break;
 	case 'n':
 		if (!fileproject || !*fileproject) {
@@ -134,7 +138,7 @@ static int cmd_project(void *data, const char *input) {
 					free (data);
 				}
 			} else {
-				eprintf ("Usage: `Pnj` or `Pnj ...`\n");
+				r_core_cmd_help (core, help_msg_Pnj);
 			}
 			break;
 		case 0:
@@ -150,16 +154,7 @@ static int cmd_project(void *data, const char *input) {
 			break;
 		case '?':
 			{
-				const char* help_msg[] = {
-					"Usage:", "Pn[j-?] [...]", "Project Notes",
-					"Pn", "", "show project notes",
-					"Pn", " -", "edit notes with cfg.editor",
-					"Pn-", "", "delete notes",
-					"Pn-", "str", "delete lines matching /str/ in notes",
-					"Pnj", "", "show notes in base64",
-					"Pnj", " [base64]", "set notes in base64",
-					NULL};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_Pn);
 			}
 			break;
 		}
@@ -169,22 +164,7 @@ static int cmd_project(void *data, const char *input) {
 		free (r_core_project_info (core, file));
 		break;
 	default: {
-		const char* help_msg[] = {
-		"Usage:", "P[?osi] [file]", "Project management",
-		"Pc", " [file]", "show project script to console",
-		"Pd", " [file]", "delete project",
-		"Pi", " [file]", "show project information",
-		"Pl", "", "list all projects",
-		"Pn", "[j]", "show project notes (Pnj for json)",
-		"Pn", " [base64]", "set notes text",
-		"Pn", " -", "edit notes with cfg.editor",
-		"Po", " [file]", "open project",
-		"Ps", " [file]", "save project",
-		"PS", " [file]", "save script file",
-		"NOTE:", "", "See 'e file.project'",
-		"NOTE:", "", "project files are stored in ~/.config/radare2/projects",
-		NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_P);
 		}
 		break;
 	}

--- a/libr/core/cmd_quit.c
+++ b/libr/core/cmd_quit.c
@@ -3,19 +3,10 @@
 
 static int cmd_quit(void *data, const char *input) {
 	RCore *core = (RCore *)data;
-	const char* help_msg[] = {
-		"Usage:",  "q[!][!] [retval]", "",
-		"q","","quit program",
-		"q!","","force quit (no questions)",
-		"q!!","","force quit without saving history",
-		"q"," 1","quit with return value 1",
-		"q"," a-b","quit with return value a-b",
-		"q[y/n][y/n]","","quit, chose to kill process, chose to save project ",
-		NULL};
 	if (input)
 	switch (*input) {
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_q);
 		break;
 	case '!':
 		if (input[1] == '!') {

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1933,7 +1933,7 @@ reread:
 		break;
 	case 'b':
 		if (*(++input) == '?'){
-			eprintf ("Usage: /b<command> [value] backward search, see '/?'\n");
+			r_core_cmd_help (core, help_msg_slashb);
 			goto beach;
 		}
 		core->search->bckwrds = param.bckwrds = param.do_bckwrd_srch = true;
@@ -1957,16 +1957,7 @@ reread:
 		break;
 	case 'R':
 		if (input[1]=='?') {
-			const char* help_msg[] = {
-				"Usage: /R", "", "Search for ROP gadgets",
-				"/R", " [filter-by-string]" , "Show gadgets",
-				"/R/", " [filter-by-regexp]" , "Show gadgets [regular expression]",
-				"/Rl", " [filter-by-string]" , "Show gadgets in a linear manner",
-				"/R/l", " [filter-by-regexp]" , "Show gadgets in a linear manner [regular expression]",
-				"/Rj", " [filter-by-string]", "JSON output",
-				"/R/j", " [filter-by-regexp]", "JSON output [regular expression]",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_slashR);
 		} else if (input[1] == '/') {
 			r_core_search_rop (core, param.from, param.to, 0, input+1, 1);
 		} else r_core_search_rop (core, param.from, param.to, 0, input+1, 0);
@@ -2023,12 +2014,7 @@ reread:
 			default:{
 				dosearch = false;
 				param.crypto_search = false;
-				const char* help_msg[] = {
-					"Usage: /C", "", "Search for crypto materials",
-					"/Ca", "" , "Search for AES keys",
-					"/Cr", "", "Search for private RSA keys",
-					NULL};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_slashC);
 				}
 			}
 		} break;
@@ -2288,12 +2274,7 @@ reread:
 		break;
 	case 'x': /* search hex */
 		if (input[1]=='?') {
-			const char* help_msg[] = {
-				"Usage:", "/x [hexpairs]:[binmask]", "Search in memory",
-				"/x ", "9090cd80", "search for those bytes",
-				"/x ", "9090cd80:ffff7ff0", "search with binary mask",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_slashx);
 		} else {
 			RSearchKeyword *kw;
 			char *s, *p = strdup (input+json+2);
@@ -2320,17 +2301,7 @@ reread:
 		break;
 	case 'c': /* search asm */
 		if (input[1] == '?') {
-			const char* help_msg[] = {
-				"Usage:", "/c [inst]", " Search for asm",
-				"/c ", "instr", "search for instruction 'instr'",
-				"/c/ ", "instr", "search for instruction that matches regexp 'instr'",
-				"/c ", "instr1;instr2", "search for instruction 'instr1' followed by 'instr2'",
-				"/c/ ", "instr1;instr2", "search for regex instruction 'instr1' followed by regex 'instr2'",
-				"/cj ", "instr", "json output",
-				"/c/j ", "instr", "regex search with json output",
-				"/c* ", "instr", "r2 command output",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_slashc);
 		}
 		do_asm_search (core, &param, input);
 		dosearch = 0;
@@ -2403,49 +2374,7 @@ reread:
 		}
 		break;
 	case '?':{
-		const char* help_msg[] = {
-			"Usage:", "/[amx/] [arg]", "Search stuff (see 'e??search' for options)",
-			"/"," foo\\x00", "search for string 'foo\\0'",
-			"/j"," foo\\x00", "search for string 'foo\\0' (json output)",
-			"/!", " ff", "search for first occurrence not matching",
-			"/+", " /bin/sh", "construct the string with chunks",
-			"/!x", " 00", "inverse hexa search (find first byte != 0x00)",
-			"//", "", "repeat last search",
-			"/h", "[t] [hash] [len]", "find block matching this hash. See /#?",
-			"/a", " jmp eax", "assemble opcode and search its bytes",
-			"/A", " jmp", "find analyzed instructions of this type (/A? for help)",
-			"/b", "", "search backwards",
-			"/B", "", "search recognized RBin headers",
-			"/c", " jmp [esp]", "search for asm code",
-			"/C", "[ar]", "search for crypto materials",
-			"/d", " 101112", "search for a deltified sequence of bytes",
-			"/e", " /E.F/i", "match regular expression",
-			"/E", " esil-expr", "offset matching given esil expressions %%= here ",
-			"/i", " foo", "search for string 'foo' ignoring case",
-			"/m", " magicfile", "search for matching magic file (use blocksize)",
-			"/p", " patternsize", "search for pattern of given size",
-			"/P", "", "show offset of previous instruction",
-			"/r", " sym.printf", "analyze opcode reference an offset",
-			"/R", " [grepopcode]", "search for matching ROP gadgets, semicolon-separated",
-			"/v", "[1248] value", "look for an `asm.bigendian` 32bit value",
-			"/V", "[1248] min max", "look for an `asm.bigendian` 32bit value in range",
-			"/w", " foo", "search for wide string 'f\\0o\\0o\\0'",
-			"/wi", " foo", "search for wide string ignoring case 'f\\0o\\0o\\0'",
-			"/x"," ff..33", "search for hex string ignoring some nibbles",
-			"/x"," ff0033", "search for hex string",
-			"/x"," ff43 ffd0", "search for hexpair with mask",
-			"/z"," min max", "search for strings of given size",
-#if 0
-			"\nConfiguration:", "", " (type `e??search.` for a complete list)",
-			"e", " cmd.hit = x", "command to execute on every search hit",
-			"e", " search.in = ?", "specify where to search stuff (depends on .from/.to)",
-			"e", " search.align = 4", "only catch aligned search hits",
-			"e", " search.from = 0", "start address",
-			"e", " search.to = 0", "end address",
-			"e", " search.flags = true", "if enabled store flags on keyword hits",
-#endif
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_slash);
 		}
 		break;
 	default:

--- a/libr/core/cmd_section.c
+++ b/libr/core/cmd_section.c
@@ -67,24 +67,9 @@ static int __dump_section_to_disk(RCore *core, char *file) {
 
 static int cmd_section(void *data, const char *input) {
 	RCore *core = (RCore *)data;
-	const char* help_msg[] = {
-		"Usage:","S[?-.*=adlr] [...]","",
-		"S","","list sections",
-		"S.","","show current section name",
-		"S*","","list sections (in radare commands)",
-		"S=","","list sections (ascii-art bars) (io.va to display paddr or vaddr)",
-		"Sa","[-] [A] [B] [[off]]","Specify arch and bits for given section",
-		"Sd[a]"," [file]","dump current (all) section to a file (see dmd)",
-		"Sl"," [file]","load contents of file into current section (see dml)",
-		"Sj","","list sections in JSON (alias for iSj)",
-		"Sr"," [name]","rename section on current seek",
-		"S"," off va sz vsz name mrwx","add new section (if(!vsz)vsz=sz)",
-		"S-","[id|0xoff|*]","remove this section definition",
-		NULL
-	};
 	switch (*input) {
 	case '?':
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_S);
 // TODO: add command to resize current section
 		break;
 	case 'j':

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -233,9 +233,9 @@ static int cmd_seek(void *data, const char *input) {
 					break;
 				}
 				free (cb.str);
-			} else eprintf ("Usage: sC[?*] comment-grep\n"
-				"sC*        list all comments\n"
-				"sC const   seek to comment matching 'const'\n");
+			} else {
+				r_core_cmd_help (core, help_msg_sC);
+			}
 			break;
 		case ' ':
 			r_io_sundo_push (core->io, core->offset, r_print_get_cursor (core->print));
@@ -404,13 +404,6 @@ static int cmd_seek(void *data, const char *input) {
 		case 'l': // "sl"
 			{
 			int sl_arg = r_num_math (core->num, input+1);
-			const char *help_msg[] = {
-				"Usage:", "sl+ or sl- or slc", "",
-				"sl", " [line]", "Seek to absolute line",
-				"sl", "[+-][line]", "Seek to relative line",
-				"slc", "", "Clear line cache",
-				"sll", "", "Show total number of lines",
-				NULL };
 			switch (input[1]) {
 			case 0:
 				if (!core->print->lines_cache) {
@@ -441,40 +434,13 @@ static int cmd_seek(void *data, const char *input) {
 				eprintf ("%d lines\n", core->print->lines_cache_sz-1);
 				break;
 			case '?':
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_sl);
 				break;
 			}
 			}
 			break;
 		case '?': {
-			const char * help_message[] = {
-			"Usage: s", "", " # Seek commands",
-			"s", "", "Print current address",
-			"s", " addr", "Seek to address",
-			"s-", "", "Undo seek",
-			"s-", " n", "Seek n bytes backward",
-			"s--", "", "Seek blocksize bytes backward",
-			"s+", "", "Redo seek",
-			"s+", " n", "Seek n bytes forward",
-			"s++", "", "Seek blocksize bytes forward",
-			"s[j*=]", "", "List undo seek history (JSON, =list, *r2)",
-			"s/", " DATA", "Search for next occurrence of 'DATA'",
-			"s/x", " 9091", "Search for next occurrence of \\x90\\x91",
-			"s.", "hexoff", "Seek honoring a base from core->offset",
-			"sa", " [[+-]a] [asz]", "Seek asz (or bsize) aligned to addr",
-			"sb", "", "Seek aligned to bb start",
-			"sC", " string", "Seek to comment matching given string",
-			"sf", "", "Seek to next function (f->addr+f->size)",
-			"sf", " function", "Seek to address of specified function",
-			"sg/sG", "", "Seek begin (sg) or end (sG) of section or file",
-			"sl", "[+-]line", "Seek to line",
-			"sn/sp", "", "Seek next/prev scr.nkey",
-			"so", " [N]", "Seek to N next opcode(s)",
-			"sr", " pc", "Seek to register",
-			//"sp [page]  seek page N (page = block)",
-			NULL
-			};
-			r_core_cmd_help(core, help_message);
+			r_core_cmd_help(core, help_msg_s);
 		}
 			break;
 		}

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -6,33 +6,6 @@
 #include "r_core.h"
 #include "sdb/sdb.h"
 
-static void show_help(RCore *core) {
-	const char *help_message[] = {
-		"Usage: t", "", "# cparse types commands",
-		"t", "", "List all loaded types",
-		"t", " <type>", "Show type in 'pf' syntax",
-		"t*", "", "List types info in r2 commands",
-		"t-", " <name>", "Delete types by its name",
-		"t-*", "", "Remove all types",
-		//"t-!", "",          "Use to open $EDITOR",
-		"tb", " <enum> <value>", "Show matching enum bitfield for given number",
-		"te", "", "List all loaded enums",
-		"te", " <enum> <value>", "Show name for given enum number",
-		"td", " <string>", "Load types from string",
-		"tf", "", "List all loaded functions signatures",
-		"tk", " <sdb-query>", "Perform sdb query",
-		"tl", "[?]", "Show/Link type to an address",
-		//"to",  "",         "List opened files",
-		"to", " -", "Open cfg.editor to load types",
-		"to", " <path>", "Load types from C header file",
-		"tp", " <type>  = <address>", "cast data at <adress> to <type> and print it",
-		"ts", "", "print loaded struct types",
-		"tu", "", "print loaded union types",
-		//"| ts k=v k=v @ link.addr set fields at given linked type\n"
-		NULL };
-	r_core_cmd_help (core, help_message);
-}
-
 static void save_parsed_type(RCore *core, const char *parsed) {
 	if (!core || !core->anal || !parsed) {
 		return;
@@ -160,12 +133,7 @@ static int cmd_type(void *data, const char *input) {
 	case 'u': // "tu"
 		switch (input[1]) {
 		case '?': {
-			const char *help_message[] = {
-				"USAGE tu[...]", "", "",
-				"tu", "", "List all loaded unions",
-				"tu?", "", "show this help",
-				NULL };
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_tu);
 		} break;
 		case 0:
 			sdb_foreach (core->anal->sdb_types, stdprintifunion, core);
@@ -181,12 +149,7 @@ static int cmd_type(void *data, const char *input) {
 	case 's': // "ts"
 		switch (input[1]) {
 		case '?': {
-			const char *help_message[] = {
-				"USAGE ts[...]", "", "",
-				"ts", "", "List all loaded structs",
-				"ts?", "", "show this help",
-				NULL };
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_ts);
 		} break;
 		case 0:
 			sdb_foreach (core->anal->sdb_types, stdprintifstruct, core);
@@ -235,13 +198,7 @@ static int cmd_type(void *data, const char *input) {
 			break;
 		}
 		if (input[1] == '?') {
-			const char *help_message[] = {
-				"USAGE te[...]", "", "",
-				"te", "", "List all loaded enums",
-				"te", " <enum> <value>", "Show name for given enum number",
-				"te?", "", "show this help",
-				NULL };
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_te);
 			break;
 		}
 		char *p, *s = strdup (input + 2);
@@ -325,14 +282,7 @@ static int cmd_type(void *data, const char *input) {
 	// td - parse string with cparse engine and load types from it
 	case 'd':
 		if (input[1] == '?') {
-			const char *help_message[] = {
-				"Usage:", "\"td [...]\"", "",
-				"td", "[string]", "Load types from string",
-				NULL };
-			r_core_cmd_help (core, help_message);
-			r_cons_printf ("Note: The td command should be put between double quotes\n"
-				"Example: \" td struct foo {int bar;int cow};\""
-				"\nt");
+			r_core_cmd_help (core, help_msg_td);
 
 		} else if (input[1] == ' ') {
 			char tmp[8192];
@@ -353,18 +303,7 @@ static int cmd_type(void *data, const char *input) {
 	case 'l':
 		switch (input[1]) {
 		case '?': {
-			const char *help_message[] = {
-				"Usage:", "", "",
-				"tl", "", "list all links in readable format",
-				"tl", "[typename]", "link a type to current adress.",
-				"tl", "[typename] = [address]", "link type to given address.",
-				"tls", "[address]", "show link at given address",
-				"tl-*", "", "delete all links.",
-				"tl-", "[address]", "delete link at given address.",
-				"tl*", "", "list all links in radare2 command format",
-				"tl?", "", "print this help.",
-				NULL };
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_tl);
 			} break;
 		case ' ': {
 			char *type = strdup (input + 2);
@@ -463,10 +402,7 @@ static int cmd_type(void *data, const char *input) {
 		break;
 	case '-':
 		if (input[1] == '?') {
-			const char *help_message[] = {
-				"Usage: t-", " <type>", "Delete type by its name",
-				NULL };
-			r_core_cmd_help (core, help_message);
+			r_core_cmd_help (core, help_msg_tminus);
 		} else if (input[1] == '*') {
 			sdb_foreach (core->anal->sdb_types, sdbdelete, core);
 		} else {
@@ -499,7 +435,7 @@ static int cmd_type(void *data, const char *input) {
 		break;
 
 	case '?':
-		show_help (core);
+		r_core_cmd_help (core, help_msg_t);
 		break;
 	}
 	return true;

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -118,28 +118,6 @@ static void cmd_write_inc(RCore *core, int size, st64 num) {
 static void cmd_write_op (RCore *core, const char *input) {
 	ut8 *buf;
 	int len;
-	const char* help_msg[] = {
-		"Usage:","wo[asmdxoArl24]"," [hexpairs] @ addr[!bsize]",
-		"wo[aAdlmorwx24]","", "without hexpair values, clipboard is used",
-		"woa"," [val]", "+=  addition (f.ex: woa 0102)",
-		"woA"," [val]","&=  and",
-		"wod"," [val]", "/=  divide",
-		"woD","[algo] [key] [IV]","decrypt current block with given algo and key",
-		"woe"," [from to] [step] [wsz=1]","..  create sequence",
-		"woE"," [algo] [key] [IV]", "encrypt current block with given algo and key",
-		"wol"," [val]","<<= shift left",
-		"wom"," [val]", "*=  multiply",
-		"woo"," [val]","|=  or",
-		"wop[DO]"," [arg]","De Bruijn Patterns",
-		"wor"," [val]", ">>= shift right",
-		"woR","","random bytes (alias for 'wr $b')",
-		"wos"," [val]", "-=  substraction",
-		"wow"," [val]", "==  write looped value (alias for 'wb')",
-		"wox"," [val]","^=  xor  (f.ex: wox 0x90)",
-		"wo2"," [val]","2=  2 byte endian swap",
-		"wo4"," [val]", "4=  4 byte endian swap",
-		NULL
-	};
 	if (!input[0])
 		return;
 	switch (input[1]) {
@@ -244,13 +222,7 @@ static void cmd_write_op (RCore *core, const char *input) {
 		case '?':
 		default:
 			{
-				const char* wop_help_msg[] = {
-					"Usage:","wop[DO]"," len @ addr | value",
-					"wopD"," len [@ addr]","Write a De Bruijn Pattern of length 'len' at address 'addr'",
-					"wopO"," value", "Finds the given value into a De Bruijn Pattern at current offset",
-					NULL
-				};
-				r_core_cmd_help (core, wop_help_msg);
+				r_core_cmd_help (core, help_msg_wop);
 				break;
 			}
 		}
@@ -258,7 +230,7 @@ static void cmd_write_op (RCore *core, const char *input) {
 	case '\0':
 	case '?':
 	default:
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_wo);
 		break;
 	}
 }
@@ -277,13 +249,7 @@ static void cmd_write_value (RCore *core, const char *input) {
 	switch (input[1]) {
 	case '?':
 	{
-		const char* help_msg[] = {
-			"Usage:", "wv[size] [value]", "write value of given size",
-			"wv1", " 234", "write one byte with this value",
-			"wv", " 0x834002", "write dword with this value",
-			"Supported sizes are:", "1, 2, 4, 8", "",
-			NULL};
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_wv);
 		return;
 	}
 	case '1': type = 1; break;
@@ -382,36 +348,6 @@ static int cmd_write(void *data, const char *input) {
 	ut64 off;
 	ut8 *buf;
 	st64 num = 0;
-	const char* help_msg[] = {
-		"Usage:","w[x] [str] [<file] [<<EOF] [@addr]","",
-		"w","[1248][+-][n]","increment/decrement byte,word..",
-		"w"," foobar","write string 'foobar'",
-		"w0"," [len]","write 'len' bytes with value 0x00",
-		"w6","[de] base64/hex","write base64 [d]ecoded or [e]ncoded string",
-		"wa"," push ebp","write opcode, separated by ';' (use '\"' around the command)",
-		"waf"," file","assemble file and write bytes",
-		"wao"," op","modify opcode (change conditional of jump. nop, etc)",
-		"wA"," r 0","alter/modify opcode at current seek (see wA?)",
-		"wb"," 010203","fill current block with cyclic hexpairs",
-		"wB","[-]0xVALUE","set or unset bits with given value",
-		"wc","","list all write changes",
-		"wc","[ir*?]","write cache undo/commit/reset/list (io.cache)",
-		"wd"," [off] [n]","duplicate N bytes from offset at current seek (memcpy) (see y?)",
-		"we","[nNsxX] [arg]","extend write operations (insert instead of replace)",
-		"wf"," -|file","write contents of file at current offset",
-		"wh"," r2","whereis/which shell command",
-		"wm"," f0ff","set binary mask hexpair to be used as cyclic write mask",
-		"wo?"," hex","write in block with operation. 'wo?' fmi",
-		"wp"," -|file","apply radare patch file. See wp? fmi",
-		"wr"," 10","write 10 random bytes",
-		"ws"," pstring","write 1 byte for length and then the string",
-		"wt"," file [sz]","write to file (from current seek, blocksize or sz bytes)",
-		"ww"," foobar","write wide string 'f\\x00o\\x00o\\x00b\\x00a\\x00r\\x00'",
-		"wx[fs]"," 9090","write two intel nops (from wxfile or wxseek)",
-		"wv"," eip+34","write 32-64 bit value",
-		"wz"," string","write zero terminated string (like w + \\x00)",
-		NULL
-	};
 
 	if (!input)
 		return 0;
@@ -646,15 +582,7 @@ static int cmd_write(void *data, const char *input) {
 
 
 		if (cmd_suc == false) {
-			const char* help_msg[] = {
-			"Usage", "", "write extend",
-			"wen", " <num>", "insert num null bytes at current offset",
-			"wex", " <hex_bytes>", "insert bytes at current offset",
-			"weN", " <addr> <len>", "insert bytes at address",
-			"weX", " <addr> <hex_bytes>", "insert bytes at address",
-			"wes", " <addr>  <dist> <block_size>", "shift a blocksize left or write in the editor",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_we);
 		}
 		}
 		break;
@@ -673,8 +601,7 @@ static int cmd_write(void *data, const char *input) {
 					free (data);
 				}
 			} else {
-				eprintf ("Usage: wp [-|r2patch-file]\n"
-			         "TODO: rapatch format documentation here\n");
+				r_core_cmd_help (core, help_msg_wp);
 			}
 		}
 		break;
@@ -765,17 +692,7 @@ static int cmd_write(void *data, const char *input) {
 		case '?':
 		default:
 			{
-			const char* help_msg[] = {
-				"Usage:", " wA", "[type] [value]",
-				"Types", "", "",
-				"r", "", "raw write value",
-				"v", "", "set value (taking care of current address)",
-				"d", "", "destination register",
-				"0", "", "1st src register",
-				"1", "", "2nd src register",
-				"Example:",  "wA r 0", "# e800000000",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_wA);
 			break;
 			}
 		}
@@ -847,17 +764,7 @@ static int cmd_write(void *data, const char *input) {
 			break;
 		case '?':
 			{
-				const char* help_msg[] = {
-					"Usage:", "wc[ir+-*?]","  # NOTE: Uses io.cache=true",
-					"wc","","list all write changes",
-					"wc-"," [from] [to]","remove write op at curseek or given addr",
-					"wc+"," [addr]","commit change from cache to io",
-					"wc*","","\"\" in radare commands",
-					"wcr","","reset all write changes in cache",
-					"wci","","commit write cache",
-					NULL
-				};
-				r_core_cmd_help (core, help_msg);
+				r_core_cmd_help (core, help_msg_wc);
 			}
 			break;
 		case '*':
@@ -901,7 +808,7 @@ static int cmd_write(void *data, const char *input) {
 		break;
 	case 't': // "wt"
 		if (*str == '?' || *str == '\0') {
-			eprintf ("Usage: wt[a] file [size]   write 'size' bytes in current block to file\n");
+			r_core_cmd_help (core, help_msg_wt);
 			free (ostr);
 			return 0;
 		} else {
@@ -1010,13 +917,7 @@ static int cmd_write(void *data, const char *input) {
 			break;
 		default:
 			{
-			const char* help_msg[] = {
-				"Usage:", "wx[f] [arg]", "",
-				"wx", " 9090", "write two intel nops",
-				"wxf", " -|file", "write contents of hexpairs file here",
-				"wxs", " 9090", "write hexpairs and seek at the end",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_wx);
 			break;
 			}
 		}
@@ -1069,15 +970,7 @@ static int cmd_write(void *data, const char *input) {
 			break;
 		default:
 			{
-			const char* help_msg[] = {
-				"Usage:", "wa[of*] [arg]", "",
-				"wa", " nop", "write nopcode using asm.arch and asm.bits",
-				"wa*", " mov eax, 33", "show 'wx' op with hexpair bytes of assembled opcode",
-				"\"wa nop;nop\"", "" , "assemble more than one instruction (note the quotes)",
-				"waf", "foo.asm" , "assemble file and write bytes",
-				"wao?", "", "show help for assembler operation on current opcode (hack)",
-				NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_wa);
 			break;
 			}
 		}
@@ -1144,7 +1037,9 @@ static int cmd_write(void *data, const char *input) {
 				free (data);
 			} else eprintf ("See wd?\n");
 			free (inp);
-		} else eprintf ("Usage: wd [source-offset] [length] @ [dest-offset]\n");
+		} else {
+			r_core_cmd_help (core, help_msg_wd);
+		}
 		break;
 	case 's':
 		if (str && *str && str[1]) {
@@ -1169,7 +1064,7 @@ static int cmd_write(void *data, const char *input) {
 			WSEEK (core, core->oobi_len);
 			r_core_block_read (core, 0);
 		} else {
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_w);
 		}
 		break;
 	}

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -209,29 +209,7 @@ static int cmd_zign(void *data, const char *input) {
 		break;
 	default:
 	case '?':{
-		const char* help_msg[] = {
-			"Usage:", "z[abcp/*-] [arg]", "Zignatures",
-			"z", "", "show status of zignatures",
-			"z*", "", "display all zignatures",
-			"z-", " namespace", "Unload zignatures in namespace",
-			"z-*", "", "unload all zignatures",
-			"z/", " [ini] [end]", "search zignatures between these regions",
-			"za", " ...", "define new zignature for analysis",
-			"zb", " name bytes", "define zignature for bytes",
-			"zB", " size", "Generate zignatures for current offset/flag",
-			"zc", " @ fcn.foo", "flag signature if matching (.zc@@fcn)",
-			"zf", " name fmt", "define function zignature (fast/slow, args, types)",
-			"zF", " file", "Open a FLIRT signature file and scan opened file",
-			"zFd", " file", "Dump a FLIRT signature",
-			"zg", " namespace [file]", "Generate zignatures for current file",
-			"zh", " name bytes", "define function header zignature",
-			"zn", " namespace", "Define namespace for following zignatures (until zn-)",
-			"zn", "", "Display current namespace",
-			"zn-", "", "Unset namespace",
-			"zp", " name bytes", "define new zignature for function body",
-			"NOTE:", "", "bytes can contain '.' (dots) to specify a binary mask",
-			NULL};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_z);
 			 }
 		break;
 	}

--- a/libr/core/help.c
+++ b/libr/core/help.c
@@ -3,6 +3,2585 @@
 
 #include <r_core.h>
 
+// CMD_ANAL
+const char* help_msg_u[] = {
+	"Usage: u", "", "uname or undo write/seek",
+	"u", "", "Show system uname",
+	"us", "", "Alias for s- (seek history)",
+	"uw", "", "Alias for wc (requires: e io.cache=true)",
+	NULL
+};
+
+const char *help_msg_ad[] = {
+	"Usage: ad[fkt]", "[...]", "Analyze data",
+	"ad", " [N] [D]", "Analyze N data words at D depth",
+	"adf", "", "Analyze data in function (use like .adf @@=`afl~[0]`",
+	"adfg", "", "Analyze data in function gaps",
+	"adk", "", "Analyze data kind (code, text, data, invalid, ...)",
+	"adt", "", "Analyze data trampolines (wip)",
+	NULL
+};
+
+const char *help_msg_a[] = {
+	"Usage: a[abcdefFghoprstx]", "[...]", "Analysis commands",
+	"ab", " [hexpairs]", "Analyze bytes",
+	"aa", "", "Analyze all (fcns + bbs) (aa0 to avoid sub renaming)",
+	"ac", " [cycles]", "Analyze which op could be executed in [cycles]",
+	"ad", "", "Analyze data trampoline (wip)",
+	"ad", " [from] [to]", "Analyze data pointers to (from-to)",
+	"ae", " [expr]", "Analyze opcode eval expression (see ao)",
+	"af", "[rnbcsl?+-*]", "Analyze functions",
+	"aF", "", "Same as above, but using anal.depth=1",
+	"ag", "[?acgdlf]", "Output Graphviz code",
+	"ah", "[?lba-]", "Analysis hints (force opcode size, ...)",
+	"ai", " [addr]", "Address information (show perms, stack, heap, ...)",
+	"an", "[an-] [...]", "Manage no-return addresses/symbols/functions",
+	"ao", "[e?] [len]", "Analyze opcode (or emulate it)",
+	"ap", "", "Find prelude for current offset",
+	"ar", "", "Like 'dr' but for the ESIL VM (registers)",
+	"as", " [num]", "Analyze syscall using dbg.reg",
+	"at", "[trd+-%*?] [.]", "Analyze execution traces",
+	"ax", "[?ld-*]", "Manage refs/xrefs (see also afx?)",
+	//"ax", " [-cCd] [f] [t]", "manage code/call/data xrefs",
+	NULL
+};
+
+const char *help_msg_aa[] = {
+	"Usage: aa[0*?]", "", "See also 'af' and 'afna'",
+	"aa", "", "Alias for 'af@@ sym.*;af@entry0;afva'", //;.afna @@ fcn.*'",
+	"aa*", "", "Analyze all flags starting with sym. (af @@ sym.*)",
+	"aaa", "", "Autoname functions after aa (see afna)",
+	"aac", " [len]", "Analyze function calls (af @@ `pi len~call[1]`)",
+	"aae", " [len] ([addr])", "Analyze references with ESIL (optionally to address)",
+	"aai", "[j]", "Show info of all analysis parameters",
+	"aan", "", "Autoname functions that either start with fcn.* or sym.func.*",
+	"aap", "", "Find and analyze function preludes",
+	"aar", " [len]", "Analyze len bytes of instructions for references",
+	"aas", " [len]", "Analyze symbols (af @@= `isq~[0]`)",
+	"aat", " [len]", "Analyze all consecutive functions in section",
+	"aau", " [len]", "List mem areas (larger than len bytes) not covered by functions",
+	"aav", " [sat]", "Find values referencing a specific section or map",
+	NULL
+};
+
+const char *help_msg_aar[] = {
+	"Usage: aar[j*]", "[N]", "Search and analyze xrefs",
+	"aar", " [N]", "Analyze xrefs in current section or N bytes of code",
+	"aarj", " [N]", "List found xrefs in JSON format",
+	"aar*", " [N]", "List found xrefs in radare commands format",
+	NULL
+};
+
+const char *help_msg_at[] = {
+	"Usage: at[*]", "[addr]", "Analyze tracing information",
+	"at", "", "List all traced opcode ranges",
+	"at", " [addr]", "Show trace info at address",
+	"at-", "", "Reset the tracing information",
+	"at*", "", "List all traced opcode offsets",
+	"at+", " [addr] [N]", "Add trace for address N times",
+	"ata", " 0x804020 ...", "Only trace given addresses",
+	"atd", "", "Show disassembly trace (use .atd)",
+	"ate", "", "Show esil trace logs (anal.trace)",
+	"ate", " [N]", "Show commands to restore to this trace index N",
+	"ate", "-", "Clear esil trace logs",
+	"atl", "", "List all traced addresses (useful for @@= `atl`)",
+	"atr", "", "Show traces as range commands (ar+)",
+	"att", " [tag]", "Select trace tag (no arg unsets)",
+	//"at%", "", "TODO",
+	"atD", "", "Show dwarf trace (at*|rsc dwarf-traces $FILE)",
+	NULL
+};
+
+const char *help_msg_ate[] = {
+	"Usage: ate[ilk-]", "[arg]", "Analyze ESIL traces",
+	"ate", "", "ESIL trace log single instruction",
+	"ate", " [idx]", "Show commands for that index log",
+	"ate-*", "", "Delete all ESIL traces",
+	"atei", "", "ESIL trace log single instruction",
+	"atek", " [sdbq]", "ESIL trace log single instruction",
+	NULL
+};
+
+const char *help_msg_ae[] = {
+	"Usage: ae[idesr?]", "[arg]", "ESIL code emulation",
+	"ae?", "", "Show this help",
+	"ae??", "", "Show ESIL help",
+	"ae", " [expr]", "Evaluate ESIL expression",
+	"ae[aA]", "[f] [count]", "Analyse ESIL accesses (regs, mem..)",
+	"aec", "", "Continue until ^C",
+	"aecs", " [N]", "Continue until syscall number",
+	"aecu", " [addr]", "Continue until address",
+	"aecue", " [esil]", "Continue until ESIL expression match",
+	"aef", " [addr]", "Emulate function",
+	"aei", "", "Initialize ESIL VM state (aei- to deinitialize)",
+	"aeim", "", "Initialize ESIL VM stack (aeim- remove)",
+	"aeip", "", "Initialize ESIL program counter to curseek",
+	"aek", " [query]", "Perform sdb query on ESIL.info",
+	"aek-", "", "Resets the ESIL.info sdb instance",
+	"aep", " [addr]", "Change ESIL PC to this address",
+	"aer", " [..]", "Handle ESIL registers like 'ar' or 'dr' does",
+	"aes", "", "Perform emulated debugger step",
+	"aeso", " ", "Step over",
+	"aesu", " [addr]", "Step until given address",
+	"aesue", " [esil]", "Step until ESIL expression match",
+	"aetr", "[esil]", "Convert an ESIL Expression to REIL",
+	"aex", " [hex]", "Evaluate opcode expression",
+	NULL
+};
+
+const char* help_msg_alias[] = {
+	"Usage: $alias[=cmd]", "[args...]", "Alias commands",
+	"$", "", "List all defined aliases",
+	"$*", "", "Same as above, but using r2 commands",
+	"$", "dis='af;pdf'", "Create command - analyze to show function",
+	"$", "test=#!pipe node /tmp/test.js", "Create command - rlangpipe script",
+	"$", "dis=", "Undefine alias",
+	"$", "dis", "Execute the previously defined alias",
+	"$", "dis?", "Show commands aliased by 'analyze'",
+	NULL
+};
+
+const char* help_msg_remotecmd_alias[] = {
+	"Usage: =$[-]","[remotecmd]", "Remote command alias",
+	"=$dr", "", "Makes 'dr' alias for =!dr",
+	"=$-dr", "", "Unset 'dr' alias",
+	NULL
+};
+
+const char* help_msg_yank[] = {
+	"Usage: y[ptxy]", "[len] [[@]addr]", "See wd? for memcpy, same as 'yf'",
+	"y", "", "Show yank buffer information (srcoff len bytes)",
+	"y", " 16", "Copy 16 bytes into clipboard",
+	"y", " 16 0x200", "Copy 16 bytes into clipboard from 0x200",
+	"y", " 16 @ 0x200", "Copy 16 bytes into clipboard from 0x200",
+	"yf", " 64 0x200", "File copy 64 bytes from 0x200 from file (opens w/ io), use -1 for all bytes",
+	"yfa", " file copy", "Copy all bytes from file (opens w/ io)",
+	"yp", "", "Print contents of clipboard",
+	"ys", "", "Print contents of clipboard as string",
+	"yt", " 64 0x200", "Copy 64 bytes from current seek to 0x200",
+	"yx", "", "Print contents of clipboard in hexadecimal",
+	"yy", " 0x3344", "Paste clipboard",
+	"yz", "", "Copy up to blocksize zero terminated string bytes into clipboard",
+	"yz", " 16", "Copy up to 16 zero terminated string bytes into clipboard",
+	"yz", " @ 0x200", "Copy up to blocksize zero terminated string bytes into clipboard from 0x200",
+	"yz", " 16 @ 0x200", "Copy up to 16 zero terminated string bytes into clipboard from 0x200",
+	NULL
+};
+
+const char* help_msg_dot[] = {
+	"Usage: .[r2cmd]", "| [file] | [!command] | [(macro)]", "Define macro or load r2, cparse or rlang file",
+	".", "", "Repeat last command backward",
+	".", "r2cmd", "Interpret the output of the command as r2 commands",
+	"..", "", "Repeat last command forward (same as \\n)",
+	".:", "8080", "Listen for commands on given tcp port",
+	".", " foo.r2", "Interpret r2 script",
+	".-", "", "Open cfg.editor and interpret tmp file",
+	".!", "rabin -ri $FILE", "Interpret output of command",
+	".", "(foo 1 2 3)", "Run macro 'foo' with args 1, 2, 3",
+	"./", " ELF", "Interpret output of command /m ELF as r. commands",
+	NULL
+};
+
+const char* help_msg_k[] = {
+	"Usage: k[s]", "[key[=value]]", "Sdb query",
+	"k", " foo=bar", "Set value",
+	"k", " foo", "Show value",
+	"k", "", "List keys",
+	"k", " anal/meta/*", "List kv from anal > meta namespaces",
+	"k", " anal/**", "List namespaces under anal",
+	"k", " anal/meta/meta.0x80404", "Get value for meta.0x80404 key",
+	"kd", " [file.sdb] [ns]", "Dump namespace to disk",
+	"ko", " [file.sdb] [ns]", "Open file into namespace",
+	"ks", " [ns]", "Enter the Sdb query shell",
+	//"kl", " ha.sdb", "load keyvalue from ha.sdb",
+	//"ks", " ha.sdb", "save keyvalue to ha.sdb",
+	NULL
+};
+
+const char* help_msg_b[] = {
+	"Usage: b[f]", "[arg]", "Get/Set block size",
+	"b", "", "Display current block size",
+	"b", " 33", "Set block size to 33",
+	"b", "+3", "Increase blocksize by 3",
+	"b", "-16", "Decrease blocksize by 16",
+	"b", " eip+4", "Numeric argument can be an expression",
+	"bf", " foo", "Set block size to flag size",
+	"bm", " 1M", "Set max block size",
+	NULL
+};
+
+const char* help_msg_r[] = {
+	"Usage: r[+-]", "[size]", "Resize file",
+	"r", "", "Display file size",
+	"r", " [size]", "Expand or truncate file to given size",
+	"r-", "[N]", "Remove N bytes, move following data down",
+	"r+", "[N]", "Insert N bytes, move following data up",
+	"rm" ," [file]", "Remove file",
+	"r2" ," [file]", "Launch r2",
+	NULL
+};
+
+const char* help_msg_ampersand[] = {
+	"Usage: &[-|[cmd]]", "", "Manage tasks",
+	"&", "", "List all running threads",
+	"&=", "", "Show output of all tasks",
+	"&=", " 3", "Show output of task 3",
+	"&j", "", "List all running threads (in JSON)",
+	"&?", "", "Show this help",
+	"&+", " aa", "Push to the task list",
+	"&-", " 1", "Delete task #1",
+	"&", "-*", "Delete all threads",
+	"&", " aa", "Run analysis in background",
+	"&", " &&", "Run all tasks in background",
+	"&&", "", "Run all pendings tasks (and join threads)",
+	"&&&", "", "Run all pendings tasks until ^C",
+	"","","TODO: last command should honor asm.bits",
+	"","","WARN: this feature is very experimental. Use it with caution",
+	NULL
+};
+
+const char* help_msg_star[] = {
+	"Usage: *[addr][=[0x]value]", "", "Pointer read/write data/values",
+	"*", "entry0=cc", "Write trap in entrypoint",
+	"*", "entry0+10=0x804800", "Write value in delta address",
+	"*", "entry0", "Read byte at given address",
+	"TODO: last command should honor asm.bits", "", "",
+	NULL
+};
+
+const char* help_msg_3at[] = {
+	"Usage: @@@", "[type]", "Run command on every [type]",
+	"Types:", "", "",
+	" symbols", "", "",
+	" imports", "" , "",
+	" regs", "", "",
+	" threads", "", "",
+	" comments", "", "",
+	" functions", "", "",
+	" flags", "", "",
+	NULL
+};
+
+const char* help_msg_2at[] = {
+	"Usage: command @@", "[iterable]", "'Foreach' iterator command",
+	"Repeat a command over a list of offsets", "", "",
+	"Examples:", "", "",
+	"x", " @@ sym.*", "Run 'x' over all flags matching 'sym.' in current flagspace",
+	"x", " @@dbt[abs]", "Run a command on every backtrace address, bp or sp",
+	"x", " @@.file", "\"\" over the offsets specified in the file (one offset per line)",
+	"x", " @@=off1 off2 ..", "Manual list of offsets",
+	"x", " @@k sdbquery", "\"\" on all offsets returned by that sdbquery",
+	"x", " @@t", "\"\" on all threads (see dp)",
+	"x", " @@=`pdf~call[0]`", "Run 'x' at every call offset of the current function",
+	// TODO: Add @@k sdb-query-expression-here
+	NULL
+};
+
+const char* help_msg_arf[] = {
+	"Usage: arf", "[flag-str-filter]", "",
+	NULL
+};
+
+const char *help_msg_af[] = {
+	"Usage: af", "", "Function analysis",
+	"af", " ([name]) ([addr])", "Analyze functions (start at addr or $$)",
+	"af+", " addr size name [type] [diff]", "Hand craft a function (requires afb+)",
+	"af-", " [addr]", "Clean all function analysis data (or function at addr)",
+	"afb", " [addr]", "List basic blocks of given function",
+	"afb+", " fa a sz [j] [f] ([t] ([d]))", "Add bb to function @ fcnaddr",
+	"afc", "@[addr]", "Calculate the Cyclomatic Complexity (starting at addr)",
+	"aff", "", "Re-adjust function boundaries to fit",
+	"afg", "", "Non-interactive ascii-art basic-block graph (See VV)",
+	"afi", " [addr|fcn.name]", "Show function(s) information (verbose afl)",
+	"afl", "[l*] [fcn name]", "List functions (addr, size, bbs, name) (see afll)",
+	"afn", " name [addr]", "Rename name for function at address (change flag too)",
+	"afna", "", "Suggest automatic name for current offset",
+	"afo", " [fcn.name]", "Show address for the function named like this",
+	"afr", " ([name]) ([addr])", "Analyze functions recursively",
+	"afs", " [addr] [fcnsign]", "Get/set function signature at current address",
+	"afv[bsra]", "?", "Manipulate args, registers and variables in function",
+	"afx", "[cCd-] src dst", "Add/remove code/Call/data/string reference",
+	"afB", " 16", "Set current function as thumb (change asm.bits)",
+	"afC[?]", " type @[addr]", "Set calling convention for function",
+	"afF", "[1|0|]", "Fold/unfold/toggle",
+	NULL
+};
+
+const char *help_msg_ar[] = {
+	"Usage: ar", "", "Analysis Registers",
+	"ar", "", "Show 'gpr' registers",
+	"ar", " 16", "Show 16 bit registers",
+	"ar", " 32", "Show 32 bit registers",
+	"ar", " all", "Show all bit registers",
+	"ar", " [type]", "Show all registers of given type",
+	"ar?", " [reg]", "Show register value",
+	"ar=", "", "Show register values in columns",
+	"ar0", "", "Reset register arenas to 0",
+	"ara", "", "Manage register arenas",
+	"arb", " [type]", "Display hexdump of the given arena",
+	"arc", " [name]", "Conditional flag registers",
+	"ard", " [name]", "Show only different registers",
+	"arn", " [regalias]", "Get regname for pc,sp,bp,a0-3,zf,cf,of,sg",
+	"aro", "", "Show old (previous) register values",
+	"arp", " [file]", "Load register profile from file",
+	"arr", "", "Show register references (telescoping)",
+	"ars", "", "Stack register state",
+	"art", "", "List all register types",
+	"arw", " [val]", "Set contents of the register arena (val is hex)",
+	"arC", "", "Display register profile comments",
+	".ar*", "", "Import register values as flags",
+	".ar-", "", "Unflag all registers",
+	NULL
+};
+
+const char *help_msg_ara[] = {
+	"Usage: ara[+-s]", "", "Register Arena Push/Pop/Swap",
+	"ara", "", "Show all register arenas allocated",
+	"ara", "+", "Push a new register arena for each type",
+	"ara", "-", "Pop last register arena",
+	"aras", "", "Swap last two register arenas",
+	NULL
+};
+
+const char *help_msg_arw[] = {
+	"Usage: arw", "[val]", "Set contents of the register arena",
+	"arw", " [val]", "Set contents of the register arena (val in hex)",
+	NULL
+};
+
+const char *help_msg_aea[] = {
+	"Usage: aea", "", " Show regs used in a range",
+	"aea", " [N]", "Show regs used in N instructions",
+	"aeaf", "", "Show regs used in current function",
+	"aear", " [N]", "Show regs read in N instructions",
+	"aeaw", " [N]", "Show regs written in N instructions",
+	"aean", " [N]", "Show regs not written in N instructions",
+	"aeA", " [N]", "Show regs used in N bytes (subcommands are the same)",
+	NULL
+};
+
+const char *help_msg_aec[] = {
+	"Usage: aec[sue]", "", "Continue emulation until condition",
+	"aec", "", "Continue until exception",
+	"aecs", "", "Continue until syscall",
+	"aecu", " [addr]", "Continue untill address",
+	"aecue", " [expr]", "Continue until ESIL expression",
+	NULL
+};
+
+const char *help_msg_aep[] = {
+	"Usage: aep[-c]", "[...]", "ESIL VM pin management",
+	"aep", "-[addr]", "Remove pin",
+	"aep", " [name] @ [addr]", "Set pin",
+	"aep", "", "List pins",
+	"aepc", " [addr]", "Change program counter for ESIL VM",
+	NULL
+};
+
+const char* help_msg_afvs[] = {
+	"Usage: afvs", "[idx] [type] [name]", "",
+	"afvs", "", "List stack based arguments and variables",
+	"afvs*", "", "Same as afvs but in r2 commands",
+	"afvs", " [idx] [name] [type]", "Define stack based arguments,variables",
+	"afvs-", " [name]", "Delete stack based argument or variables with the given name",
+	"afvsj", "", "Return list of stack based arguments and variables in JSON format",
+	"afvsn", " [old_name] [new_name]", "Rename stack based argument or variable",
+	"afvst", " [name] [new_type]", "Change type for given argument or variable",
+	"afvsg", " [idx] [addr]", "Define var get reference",
+	"afvss", " [idx] [addr]", "Define var set reference",
+	NULL
+};
+
+const char* help_msg_afvb[] = {
+	"Usage: afvb", "[idx] [type] [name]", "",
+	"afvb", "", "List base pointer based arguments, variables",
+	"afvb*", "", "Same as afvb but in r2 commands",
+	"afvb", " [idx] [name] ([type])", "Define base pointer based argument, variable",
+	"afvb-", " [name]", "Delete argument/ variables at the given name",
+	"afvbj", "", "Return list of base pointer based arguments, variables in JSON format",
+	"afvbn", " [old_name] [new_name]", "Rename base pointer based argument or variable",
+	"afvbt", " [name] [new_type]", "Change type for given base pointer based argument or variable",
+	"afvbg", " [idx] [addr]", "Define var get reference",
+	"afvbs", " [idx] [addr]", "Define var set reference",
+	NULL
+};
+
+const char* help_msg_afvr[] = {
+	"Usage: afvr", "[reg] [type] [name]", "",
+	"afvr", "", "List register based arguments",
+	"afvr*", "", "Same as afvr but in r2 commands",
+	"afvr", " [reg] [name] ([type])", "Define register arguments",
+	"afvr-", " [name]", "Delete register arguments at the given index",
+	"afvrj", "", "Return list of register arguments in JSON format",
+	"afvrn", " [old_name] [new_name]", "Rename argument",
+	"afvrt", " [name] [new_type]", "Change type for given argument",
+	"afvrg", " [reg] [addr]", "Define var get reference",
+	"afvrs", " [reg] [addr]", "Define var set reference",
+	NULL
+};
+
+const char* help_msg_afv[] = {
+	"Usage: afv[rbsa]", "", "",
+	"afva", "", "Analyze function arguments/vars",
+	"afvb", "?", "Manipulate bp based arguments/vars",
+	"afvr", "?", "Manipulate register based arguments",
+	"afvs", "?", "Manipulate sp based arguments/vars",
+	NULL
+};
+
+const char* help_msg_afi[] = {
+	"Usage: afi[jl*]", "[addr|fcn.name]", "Show function information (verbose afl)",
+	"afij", "", "Function info in JSON format",
+	"afil", "", "Verbose function info",
+	"afi*", "", "Function, variables and arguments",
+	NULL
+};
+
+const char* help_msg_afl[] = {
+	"Usage: afl[jlqs*]", "", "List all functions in quiet, commands or JSON format",
+	"afl", "", "List functions",
+	"aflj", "", "List functions in JSON format",
+	"afll", "", "List functions in verbose mode",
+	"aflq", "", "List functions in 'quiet' mode",
+	"afls", "", "print sum of sizes of all functions",
+	NULL
+};
+
+const char *help_afC[] = {
+	"Usage: afC[agl?]", "", "Analyze calling convention",
+	"afC", " [convention]", "Manually set calling convention for current function",
+	"afC", "", "Show calling convention for the current function",
+	"afCa", "", "Analyse function for finding the current calling convention",
+	"afCl", "", "List all available calling conventions",
+	NULL
+};
+
+const char *help_msg_afb[] = {
+	"Usage: afb[+b][-*j]", "", "",
+	"afb", " [addr]", "List basic blocks of function (see afbq, afbj, afb*)",
+	"afb+", " fcn_at bbat bbsz [jump] [fail] ([type] ([diff]))", "Add bb to function @ fcnaddr",
+	"afbj", "", "Show basic blocks information in JSON",
+	"afbr", "", "Show addresses of instructions which leave the function",
+	".afbr*", "", "Set breakpoint on every return address of the fcn",
+	".afbr-*", "", "Undo the above operation",
+	"afB", " [bits]", "Define asm.bits for given function",
+	NULL
+};
+
+const char *help_msg_afn[] = {
+	"Usage: afn[sa]", "", "Analyze function names",
+	"afn", " [name]", "Rename function",
+	"afna", "", "Construct a function name for the current offset",
+	"afns", "", "List all strings associated with the current function",
+	NULL
+};
+
+const char *help_msg_afx[] = {
+	"Usage: afx[-cCd?]", "[src] [dst]", "Manage function references (see also ar?)",
+	"afxc", " sym.main+0x38 sym.printf", "Add code ref",
+	"afxC", " sym.main sym.puts", "Add call ref",
+	"afxd", " sym.main str.helloworld", "Add data ref",
+	"afx-", " sym.main str.helloworld", "Remove reference",
+	NULL
+};
+
+const char *help_msg_esil[] = {
+	"Examples:", "ESIL", "instructions, examples and documentation",
+	"+", "=", "A+=B => B,A,+=",
+	"+", "", "A=A+B => B,A,+,A,=",
+	"*", "=", "A*=B => B,A,*=",
+	"/", "=", "A/=B => B,A,/=",
+	"&", "=", "and ax, bx => bx,ax,&=",
+	"|", "", "or r0, r1, r2 => r2,r1,|,r0,=",
+	"^", "=", "xor ax, bx => bx,ax,^=",
+	">>", "=", "shr ax, bx => bx,ax,>>=  # shift right",
+	"<<", "=", "shr ax, bx => bx,ax,<<=  # shift left",
+	"", "[]", "mov eax,[eax] => eax,[],eax,=",
+	"=", "[]", "mov [eax+3], 1 => 1,3,eax,+,=[]",
+	"=", "[1]", "mov byte[eax],1 => 1,eax,=[1]",
+	"=", "[8]", "mov [rax],1 => 1,rax,=[8]",
+	"$", "", "int 0x80 => 0x80,$",
+	"$$", "", "Simulate a hardware trap",
+	"==", "", "Pops twice, compare and update esil flags",
+	"<", "", "Compare for smaller",
+	"<", "=", "Compare for smaller or equal",
+	">", "", "Compare for bigger",
+	">", "=", "Compare bigger for or equal",
+	"?{", "", "If popped value != 0 run the block until }",
+	"POP", "", "Drops last element in the esil stack",
+	"TODO", "", "The instruction is not yet esilized",
+	"STACK", "", "Show contents of stack",
+	"CLEAR", "", "Clears the esil stack",
+	"BREAK", "", "Terminates the string parsing",
+	"GOTO", "", "Jump to the Nth word popped from the stack",
+	NULL
+};
+
+const char *help_msg_an[] = {
+	"Usage: an[an]", "[-][0xaddr|symname]", "Manage no-return marks",
+	"an", "", "List all no-return references",
+	"an", "-*", "Remove all no-return references",
+	"an[a]", " 0x3000", "Stop function analysis if call/jmp to this address",
+	"an[n]", " sym.imp.exit", "Same as above but for flag/fcn names",
+	NULL
+};
+
+const char *help_msg_ao[] = {
+	"Usage: ao[e?]", "[len]", "Analyze opcodes",
+	"ao", " 5", "Display opcode analysis of 5 opcodes",
+	"ao*", "", "Display opcode in r commands",
+	"aoe", " [N]", "Display esil form for N opcodes",
+	"aoj", " [N]", "Display opcode analysis information in JSON for N opcodes",
+	"aor", " [N]", "Display reil form for N opcodes",
+	"aos", " [esil]", "Show Sdb representation of ESIL expression (TODO)",
+	NULL
+};
+
+const char *help_msg_as[] = {
+	"Usage: as[ljk?]", "", "System call analysis, listing and translation",
+	"as", "", "Show current syscall and arguments",
+	"as", " 4", "Show syscall 4 based on asm.os and current regs/mem",
+	"asf", " [k[=[v]]]", "List/set/unset pf function signatures (see fcnsign)",
+	"asj", "", "List of syscalls in JSON",
+	"ask", " [query]", "Perform syscall/queries",
+	"asl", "", "List of syscalls by asm.os and asm.arch",
+	"asl", " close", "Returns the syscall number for close",
+	"asl", " 4", "Returns the name of the syscall number 4",
+	NULL
+};
+
+const char *help_msg_ah[] = {
+	"Usage: ah[lba-]", "", "Analysis hints",
+	"ah?", "", "Show this help",
+	"ah?", " offset", "Show hint of given offset",
+	"ah", "", "List hints in human-readable format",
+	"ah.", "", "List hints in human-readable format from current offset",
+	"ah-", "", "Remove all hints",
+	"ah-", " offset [size]", "Remove hints at given offset",
+	"ah*", " offset", "List hints in radare commands format",
+	"aha", " ppc 51", "Set arch for a range of N bytes",
+	"ahb", " 16 @ $$", "Force 16bit for current instruction",
+	"ahc", " 0x804804", "Override call/jump address",
+	"ahe", " eax+=3", "Set VM analysis string",
+	"ahf", " 0x804840", "Override fallback address for call",
+	"ahi", " 10", "Define numeric base for immediates (1, 8, 10, 16, s)",
+	"ahs", " 4", "Set opcode size=4",
+	"ahS", " jz", "Set asm.syntax=jz for this opcode",
+	"aho", " foo a0,33", "Replace opcode string",
+	NULL
+};
+
+const char* help_msg_ahi[] = {
+	"Usage: ahi", "[sbodh] [@ offset]", "Define numeric base",
+	"ahi", " [base]", "Set numeric base (1, 2, 8, 10, 16)",
+	"ahi", " b", "Set base to binary (1)",
+	"ahi", " d", "Set base to decimal (10)",
+	"ahi", " h", "Set base to hexadecimal (16)",
+	"ahi", " o", "Set base to octal (8)",
+	"ahi", " i", "Set base to IP address (32)",
+	"ahi", " S", "Set base to syscall (80)",
+	"ahi", " s", "Set base to string (2)",
+	NULL
+};
+
+const char *help_msg_ax[] = {
+	"Usage: ax[?d-l*]", "", "See also 'afx?'",
+	"ax", " addr [at]", "Add code ref pointing to addr (from curseek)",
+	"axc", " addr [at]", "Add code jmp ref // unused?",
+	"axC", " addr [at]", "Add code call ref",
+	"axg", " addr", "Show xrefs graph to reach current function",
+	"axd", " addr [at]", "Add data ref",
+	"axj", "", "List refs in json format",
+	"axF", " [flg-glob]", "Find data/code references of flags",
+	"axt", " [addr]", "Find data/code references to this address",
+	"axf", " [addr]", "Find data/code references from this address",
+	"ax-", " [at]", "Clean all refs (or refs from addr)",
+	"ax", "", "List refs",
+	"axk", " [query]", "Perform Sdb query",
+	"ax*", "", "Output radare commands",
+	NULL
+};
+
+const char *help_msg_ag[] = {
+	"Usage: ag[?f]", "", "Graphviz/graph code",
+	"ag", " [addr]", "Output graphviz code (bb at addr and children)",
+	"ag-", "", "Reset the current ASCII art graph (see agn, age, agg?)",
+	"aga", " [addr]", "Idem, but only addresses",
+	"agc", "[j] [addr]", "Output graphviz call graph of function",
+	"agC", "[j]", "Same as agc -1. full program callgraph",
+	"agd", " [fcn name]", "Output graphviz code of diffed function",
+	"age", "[?] title1 title2", "Add an edge to the current graph",
+	"agf", " [addr]", "Show ASCII art graph of given function",
+	"agg", "[kdi*]", "Print graph in ASCII-Art, graphviz, k=v, r2 or visual",
+	"agj", " [addr]", "Idem, but in JSON format",
+	"agk", " [addr]", "Idem, but in SDB key-value format",
+	"agl", " [fcn name]", "Output graphviz code using meta-data",
+	"agn", "[?] title body", "Add a node to the current graph",
+	"ags", " [addr]", "Output simple graphviz call graph of function (only bb offset)",
+	"agt", " [addr]", "Find paths from current offset to given address",
+	"agv", "[acdltfl] [a]", "View function using graphviz",
+	NULL};
+
+const char *help_msg_agn[] = {
+	"Usage: agn", "[title] [body]", "",
+	"Examples:", "", "",
+	"agn", " title1 body1", "Add a node with title \"title1\" and body \"body1\"",
+	"agn", " \"title with space\" \"body with space\"", "Add a node with spaces in the title and in the body",
+	"agn", " title1 base64:Ym9keTE=", "Add a node with the body specified as base64",
+	"agn-", " title1", "Remove a node with title \"title1\"",
+	"agn?", "", "Show this help",
+	NULL
+};
+
+const char *help_msg_age[] = {
+	"Usage: age", "[title1] [title2]", "",
+	"Examples:", "", "",
+	"age", " title1 title2", "Add an edge from the node with \"title1\" as title to the one with title \"title2\"",
+	"age", " \"title1 with spaces\" title2", "Add an edge from node \"title1 with spaces\" to node \"title2\"",
+	"age-", " title1 title2", "Remove an edge from the node with \"title1\" as title to the one with title \"title2\"",
+	"age?", "", "Show this help",
+	NULL
+};
+
+const char *help_msg_agg[] = {
+	"Usage: agg[kid?*]", "", "Print graph",
+	"agg", "", "Show current graph in ascii art",
+	"aggk", "", "Show graph in key=value form",
+	"aggd", "", "Print the current graph in GRAPHVIZ dot format",
+	"aggi", "", "Enter interactive mode for the current graph",
+	"aggd", "", "Print the current graph in GRAPHVIZ dot format",
+	"agg*", "", "In r2 commands, to save in projects, etc",
+	NULL
+};
+
+// CMD_CMP
+const char* help_msg_c[] = {
+	"Usage: c[?dfx]", "[arg]", "Comparison operations",
+	"c", " [string]", "Compare a plain with escaped chars string",
+	"c*", " [string]", "Compare a plain with escaped chars string (output r2 commands)",
+	"c4", " [value]", "Compare a doubleword from a math expression",
+	"c8", " [value]", "Compare a quadword from a math expression",
+	"cat", " [file]", "Show contents of file (see pwd, ls)",
+	"cc", " [at] [(at)]", "Compares in two hexdump columns of block size",
+	"ccc", " [at] [(at)]", "Same as above, but only showing different lines",
+	"ccd", " [at] [(at)]", "Compares in two disasm columns of block size",
+	//"cc", " [offset]", "code bindiff current block against offset"
+	//"cD", " [file]", "like above, but using radiff -b",
+	"cf", " [file]", "Compare contents of file at current seek",
+	"cg", "[o] [file]","Graphdiff current file and [file]",
+	"cl|cls|clear", "", "Clear screen, (clear0 to goto 0, 0 only)",
+	"cu", " [addr] @at", "Compare memory hexdumps of $$ and dst in unified diff",
+	"cud", " [addr] @at", "Unified diff disasm from $$ and given address",
+	"cv", "[1248] [addr] @at", "Compare 1,2,4,8-byte value",
+	"cw", "[us?] [...]", "Compare memory watchers",
+	"cx", " [hexpair]", "Compare hexpair string (use '.' as nibble wildcard)",
+	"cx*", " [hexpair]", "Compare hexpair string (output r2 commands)",
+	"cX", " [addr]", "Like 'cc' but using hexdiff output",
+	NULL
+};
+const char *help_msg_cw[] = {
+	"Usage: cw", "", "Watcher commands",
+	"cw", "", "List all compare watchers",
+	"cw", " addr", "List all compare watchers",
+	"cw", " addr sz cmd", "Add a memory watcher",
+	//"cws", " [addr]", "Show watchers",
+	"cw", "*", "List compare watchers in r2 cmds",
+	"cwr", " [addr]", "Reset/revert watchers",
+	"cwu", " [addr]", "Update watchers",
+	NULL
+};
+
+const char *help_msg_cg[] = {
+	"Usage: cg", "", "Graph code commands",
+	"cg",  "", "Diff ratio among functions (columns: off-A, match-ratio, off-B)",
+	"cgf", "[fcn]", "Compare functions (curseek vs fcn)",
+	"cgo", "", "Opcode-bytes code graph diff",
+	NULL
+};
+const char* help_msg_cu[] = {
+	"Usage: cu",  "[offset]", "Creates a unified hex patch",
+	"cu", " $$+1 > p", "Compare current seek and +1",
+	"cud", " $$+1 > p", "Compare disasm current seek and +1",
+	"wu", " p", "Apply unified hex patch",
+	NULL
+};
+
+const char* help_msg_cv[] = {
+	"Usage: cv[1248]", "[num]", "Show offset if current value equals to the one specified",
+	"Example:", "", "",
+	"/v", " [val]", "Search for a known value",
+	"dc", "", "Continue execution",
+	"cv4", " [val] @@ hit*", "Show offset",
+	"dc", "", "Continue execution",
+	NULL
+};
+
+// CMD_DBG
+const char* help_msg_d[] = {
+	"Usage: d", "", "Debug commands",
+	"db", "[?]", "Breakpoints commands",
+	"dbt", "", "Display backtrace based on dbg.btdepth and dbg.btalgo",
+	"dc", "[?]", "Continue execution",
+	"dd", "[?]", "File descriptors (!fd in r1)",
+	"de", "[-sc] [rwx] [rm] [e]", "Debug with ESIL (see de?)",
+	"dg", " <file>", "Generate a core-file (WIP)",
+	"dh", " [handler]", "List or set debugger handler",
+	"dH", " [handler]", "Transplant process to a new handler",
+	"di", "", "Show debugger backend information (See dh)",
+	"dk", "[?]", "List, send, get, set, signal handlers of child",
+	"dm", "[?]", "Show memory maps",
+	"do", "", "Open process (reload, alias for 'oo')",
+	"doo", "[args]", "Reopen in debugger mode with args (alias for 'ood')",
+	"dp", "[?]", "List, attach to process or thread id",
+	"dr", "[?]", "Cpu registers",
+	"ds", "[?]", "Step, over, source line",
+	"dt", "[?]", "Display instruction traces (dtr=reset)",
+	"dw", " <pid>", "Block prompt until pid dies",
+	"dx", "[?]", "Inject and run code on target process (See gs)",
+	NULL
+};
+
+const char* help_msg_db[] = {
+	"Usage: db", "", "Breakpoints commands",
+	"db", "", "List breakpoints",
+	"db", " sym.main", "Add breakpoint into sym.main",
+	"db", " [addr]", "Add breakpoint",
+	"db", " -[addr]", "Remove breakpoint",
+	"db.", "", "Show breakpoint info in current offset",
+	// "dbi", " 0x848 ecx=3", "stop execution when condition matches",
+	"dbc", " [addr] [cmd]", "Run command when breakpoint is hit",
+	"dbd", " [addr]", "Disable breakpoint",
+	"dbe", " [addr]", "Enable breakpoint",
+	"dbh", " x86", "Set/list breakpoint plugin handlers",
+	"dbi", "", "List breakpoint indexes",
+	"dbic", " [index] [cmd]", "Run command at breakpoint index",
+	"dbie", " [index]", "Enable breakpoint by index",
+	"dbid", " [index]", "Disable breakpoint by index",
+	"dbis", " [index]", "Swap Nth breakpoint",
+	"dbite", " [index]", "Enable breakpoint Trace by index",
+	"dbitd", " [index]", "Disable breakpoint Trace by index",
+	"dbits", " [index]", "Swap Nth breakpoint trace",
+	"dbj", "", "List breakpoints in JSON format",
+	"dbm", " [module] [offset]", "Add a breakpoint at an offset from a module's base",
+	"dbn", " [name]", "Show or set name for current breakpoint",
+	"dbs", " [addr]", "Toggle breakpoint",
+	"dbt", "", "Display backtrace based on dbg.btdepth and dbg.btalgo",
+	"dbt*", "", "Display backtrace in flags",
+	"dbt=", "", "Display backtrace in one line (see dbt=s and dbt=b for sp or bp)",
+	"dbtj", "", "Display backtrace in JSON",
+	"dbte", " [addr]", "Enable Breakpoint Trace",
+	"dbtd", " [addr]", "Disable Breakpoint Trace",
+	"dbts", " [addr]", "Swap Breakpoint Trace",
+	"drx", " number addr len rwx", "Modify hardware breakpoint",
+	"drx-", "number", "Clear hardware breakpoint",
+	NULL
+};
+
+const char * help_msg_dc[] = {
+	"Usage: dc", "", "Execution continuation commands",
+	"dc", "", "Continue execution of all children",
+	"dc", " [pid]", "Continue execution of pid",
+	"dc", "-[pid]", "Stop execution of pid",
+	"dca", " [sym] [sym].", "Continue at every hit on any given symbol",
+	"dcc", "", "Continue until call (use step into)",
+	"dccu", "", "Continue until unknown call (call reg)",
+	"dcf", "", "Continue until fork (TODO)",
+	"dck", " [signal] [pid]", "Continue sending signal to process",
+	"dco", " [N]", "Step over N instructions",
+	"dcp", "", "Continue until program code (mapped io section)",
+	"dcr", "", "Continue until ret (uses step over)",
+	"dcs", " [N|syscall]", "Continue until syscall number/name",
+	"dct", " [len]", "Traptrace from curseek to len, no argument to list",
+	"dcu", "[..end|addr] ([end])", "Continue until address (or range)",
+	NULL
+};
+
+const char *help_msg_dcs[] = {
+	"Usage: dcs", "[syscall-name-or-number]", "",
+	"dcs", "", "Continue until next syscall",
+	"dcs mmap", "", "Continue until next call to mmap",
+	"dcs*", "", "Trace all syscalls (strace)",
+	"dcs?", "", "Show this help",
+	NULL
+};
+
+const char *help_msg_dd[] = {
+	"Usage: dd", "", "Descriptors commands",
+	"dd", "", "List file descriptors",
+	"dd", " [file]", "Open and map that file into the UI",
+	"dd-", "[fd]", "Close stdout fd",
+	"dd*", "", "List file descriptors (in radare commands)",
+	NULL
+};
+
+const char *help_msg_de[] = {
+	"Usage: de[-sc]", "[rwx] [rm] [expr]", "",
+	"de", "", "List ESIL watchpoints",
+	"de-*", "", "Delete all ESIL watchpoints",
+	"de", " [rwx] [rm] [addr|reg|from..to]", "Stop on condition",
+	"dec", "", "Continue execution until matching expression",
+	"des", " [N]", "Step-in N instructions with ESIL debug",
+	"desu", " [addr]", "ESIL debug until specific address",
+	"", "", "",
+	"Examples:", "", "",
+	" de", " r r rip", "Stop when rip is read",
+	" de", " rw m [addr]", "Stop when read or write in [addr]",
+	" de", " w r rdx", "Stop when rdx register is modified",
+	" de", " x m FROM..TO", "Stop when rip is in specified range",
+	NULL
+};
+
+const char *help_msg_des[] = {
+	"Usage: des[u]", "[arg]", "ESIL debug stepping",
+	"des", " [N]", "Step-in N instructions with ESIL debug",
+	"desu", " [addr]", "ESIL debug until specific address",
+	NULL
+};
+
+const char *help_msg_di[] = {
+	"Usage: di", "", "Debugger target information",
+	"di", "", "Show debugger target information",
+	"dij", "", "Same as above, but in JSON format",
+	NULL
+};
+
+const char *help_msg_dk[] = {
+	"Usage: dk", "", "Signal commands",
+	"dk", "", "List all signal handlers of child process",
+	"dk", " [signal]", "Send KILL signal to child",
+	"dk", " [signal]=1", "Set signal handler for <signal> in child",
+	"dk?", "[signal]", "Name/signum resolver",
+	"dkj", "", "List all signal handlers in JSON",
+	"dko", " [signal]", "Reset skip or cont options for given signal",
+	"dko", " [signal] [skip|cont]", "On signal SKIP handler or CONT into",
+	NULL
+};
+
+const char *help_msg_dko[] = {
+	"Usage: dko", "", "Signal handling commands",
+	"dko", "", "List existing signal handling",
+	"dko", " [signal]", "Clear handling for a signal",
+	"dko", " [signal] [skip|cont]", "Set handling for a signal",
+	"NOTE: [signal] can be a number or a string that resolves with dk?", "", "",
+	" skip means do not enter into the signal handler", "", "",
+	" continue means enter into the signal handler", "", "",
+	NULL
+};
+
+const char* help_msg_dm[] = {
+	"Usage: dm", "", "Memory maps commands",
+	"dm", "", "List memory maps of target process",
+	"dm=", "", "List memory maps of target process (ascii-art bars)",
+	"dm", " [address] [size]", "Allocate [size] bytes at [address] (anywhere if address is -1) in child process",
+	"dm.", "", "Show map name of current address",
+	"dm*", "", "List memmaps in radare commands",
+	"dm-", "[address]", "Deallocate memory map of [address]",
+	"dmd", "[a] [file]", "Dump current (all) debug map region to a file (from-to.dmp) (see Sd)",
+	"dmh", "", "Show map of heap",
+	"dmi", " [addr|libname] [symname]", "List symbols of target lib",
+	"dmi*", " [addr|libname] [symname]", "List symbols of target lib in radare commands",
+	"dmj", "", "List memmaps in JSON format",
+	"dml", " [file]", "Load contents of file into the current map region (see Sl)",
+	"dmm", "[j*]", "List modules (libraries, binaries loaded in memory)",
+	"dmp", " [address] [size] [perms]", "Change page at [address] with [size], protection [perms] (rwx)",
+	"dms", " [id] [mapaddr]", "Take memory snapshot",
+	"dms-", " [id] [mapaddr]", "Restore memory snapshot",
+	//"dm, " rw- esp 9K", "set 9KB of the stack as read+write (no exec)",
+	//"TODO:", "", "map files in process memory. (dmf file @ [addr])",
+	NULL
+};
+
+const char* help_msg_dmh[] = {
+	"Usage: dmh", "", "Memory map heap info glibc",
+	"dmha", "", "Struct Malloc State (main_arena)",
+	"dmhb", "", "Show bins information",
+	"dmhb", " [bin_num]", "Print double linked list of the number of bin",
+	"dmhc", " @[malloc_addr]", "Print malloc_chunk struct for a given malloc chunk",
+	"dmhf", "", "Show fastbins information",
+	"dmhf", " [fastbin_num]", "Print single linked list of the number of fastbin",
+	"dmh?", "", "Show map heap help",
+	NULL
+};
+const char* help_msg_dmm[] = {
+	"Usage: dmm", "", "Module memory maps commands",
+	"dmm", "", "List modules of target process",
+	"dmm.", "", "List memory map of current module",
+	"dmmj", "", "List modules of target process (JSON)",
+	"dmm*", "", "List modules of target process (r2 commands)",
+	NULL
+};
+
+const char* help_msg_dms[] = {
+	"Usage: dms", "", "Memory map snapshots manangement",
+	"dms", "", "List memory snapshots",
+	"dmsj", "", "List snapshots in JSON",
+	"dms*", "", "List snapshots in r2 commands",
+	"dms", " [addr]", "Take snapshot with given id of map at address",
+	"dms", "- [id]", "Delete memory snapshot",
+	"dmsC", " [id] comment", "Add comment for given snapshot",
+	"dmsd", " [id]", "Hexdiff given snapshot. See `ccc`.",
+	"dmsw", "", "Snapshot of the writable maps",
+	"dmsa", "", "Full snapshot of all `dm` maps",
+	"dmsf", " [file] @ addr", "Read snapshot from disk",
+	"dmst", " [file] @ addr", "Dump snapshot to disk",
+	// TODO: dmsj - for json
+	NULL
+};
+
+const char* help_msg_do[] = {
+	"Usage: do", "", "Debug open commands",
+	"do", "", "Open process (reload, alias for 'oo')",
+	"doo", "[args]", "Reopen in debugger mode with args (alias for 'ood')",
+	NULL
+};
+
+const char *help_msg_dp[] = {
+	"Usage: dp", "", "Process commands",
+	"dp", "", "List current pid and children",
+	"dp", " [pid]", "List children of pid",
+	"dp*", "", "List all attachable pids",
+	"dp=", "[pid]", "Select pid",
+	"dp-", " [pid]", "Dettach select pid",
+	"dpa", " [pid]", "Attach and select pid",
+	"dpc", "", "Select forked pid (see dbg.forks)",
+	"dpc*", "", "Display forked pid (see dbg.forks)",
+	"dpe", "", "Show path to executable",
+	"dpf", "", "Attach to pid like file fd // HACK",
+	"dpk", " [pid] [signal]", "Send signal to process (default 0)",
+	"dpn", "", "Create new process (fork)",
+	"dptn", "", "Create new thread (clone)",
+	"dpt", "", "List threads of current pid",
+	"dpt", " [pid]", "List threads of process",
+	"dpt=", "[thread]", "Attach to thread",
+	NULL
+};
+
+const char *help_msg_dr[] = {
+	"Usage: dr", "", "Registers commands",
+	"dr", "", "Show 'gpr' registers",
+	"dr", " [register]=[val]", "Set register value",
+	"dr=", "", "Show registers in columns",
+	"dr?", "[register]", "Show value of given register",
+	"drb", " [type]", "Display hexdump of gpr arena (WIP)",
+	"drC", "", "Show register profile comments",
+	"drc", " [name]", "Related to conditional flag registers",
+	"drd", "", "Show only different registers",
+	"drl", "", "List all register names",
+	"drn", " [pc]", "Get regname for pc,sp,bp,a0-3,zf,cf,of,sg",
+	"dro", "", "Show previous (old) values of registers",
+	"drp", " [file]", "Load register metadata file",
+	"drp", "", "Display current register profile",
+	"drps", "", "Fake register profile size",
+	"drr", "", "Show registers references (telescoping)",
+	"drs", " [?]", "Stack register states",
+	"drt", "", "Show all register types",
+	"drt", " flg", "Show flag registers",
+	"drt", " all", "Show all registers",
+	"drt", " 16", "Show 16 bit registers",
+	"drt", " 32", "Show 32 bit registers",
+	"drt", " 80", "Show 80 bit registers (long double)",
+	"drx", "", "Show all debug registers",
+	"drx", " [idx] [addr] [len] [rwx]", "Modify hardware breakpoint",
+	"drx-", "[idx]", "Clear hardware breakpoint",
+	"drf","","show fpu registers (80 bit long double)",
+	"drm","","show multimedia packed registers",
+	"drm"," mmx0 0 32 = 12","set the first 32 bit word of the mmx reg to 12",
+	"drw"," [val]", "Set contents of the register arena (val in hex)",
+	".dr", "*", "Include common register values in flags",
+	".dr", "-", "Unflag all registers",
+	NULL
+};
+
+const char *help_msg_drf[] = {
+	"Usage: drf", "[fpureg] [= value]", "",
+	NULL
+};
+const char *help_msg_drm[] = {
+	"Usage: drm", "[reg] [idx] [wordsize] [= value]", "",
+	NULL
+};
+const char *help_msg_drp[] = {
+	"Usage: drp", "", "Register profile commands",
+	"drp", "", "Show the current register profile",
+	"drp", " [regprofile-file]", "Set the current register profile",
+	"drp.", "", "Show the current fake size",
+	"drpj", "", "Show the current register profile (JSON)",
+	"drps", " [new fake size]", "Set the fake size",
+	NULL
+};
+
+const char *help_msg_drs[] = {
+	"Usage: drs", "", "Register states commands",
+	"drs", "", "List register stack",
+	"drs", "+", "Push register state",
+	"drs", "-", "Pop register state",
+	NULL
+};
+
+const char *help_msg_drt[] = {
+	"Usage: drt", "[type] [size]", "Debug register types",
+	"drt", "", "List all available register types",
+	"drt", " [size]", "Show all regs in the profile of size",
+	"drt", " [type]", "Show all regs in the profile of this type",
+	"drt", " [type] [size]", "Same as above for type and size",
+	NULL
+};
+
+const char *help_msg_drx[] = {
+  "Usage: drx", "", "Hardware breakpoints commands",
+  "drx", "", "List all (x86?) hardware breakpoints",
+  "drx", " [idx] [address] [len] [perms]", "Modify hardware breakpoint",
+  "drx-", "[idx]", "Clear hardware breakpoint",
+  NULL
+};
+
+const char *help_msg_ds[] = {
+	"Usage: ds", "", "Step commands",
+	"ds", "", "Step one instruction",
+	"ds", " [N]", "Step N instructions",
+	"dsf", "", "Step until end of frame",
+	"dsi", " [cond]", "Continue until condition matches",
+	"dsl", "", "Step one source line",
+	"dsl", " [N]", "Step N source lines",
+	"dso", " [N]", "Step over N instructions",
+	"dsp", "", "Step into program (skip libs)",
+	"dss", " [N]", "Skip N step instructions",
+	"dsu", " [address]", "Step until address",
+	"dsui", " [instr]", "Step until an instruction that matches `instr`",
+	"dsue", " [esil]", "Step until ESIL expression matches",
+	"dsuf", " [flag]", "Step until pc == flag matching name",
+	NULL
+};
+
+const char *help_msg_dt[] = {
+	"Usage: dt", "", "Trace commands",
+	"dt", "", "List all traces ",
+	"dtd", "", "List all traced disassembled",
+	"dtc [addr]|([from] [to] [addr])", "", "Trace call/ret",
+	"dtg", "", "Graph call/ret trace",
+	"dtg*", "", "Graph in agn/age commands. use .dtg*;aggi for visual",
+	"dtgi", "", "Interactive debug trace",
+	"dt-", "", "Reset traces (instruction/calls)",
+	NULL
+};
+
+const char *help_msg_dtc[] = {
+	"Usage: dtc", "[addr] ([from] [to] [addr])", "Trace calls in debugger",
+	NULL
+};
+
+const char *help_msg_dx[] = {
+	"Usage: dx", "", " # Code injection commands",
+	"dx", " [opcode]...", "Inject opcodes",
+	"dxa", " nop", "Assemble code and inject",
+	"dxe", " egg-expr", "Compile egg expression and inject it",
+	"dxr", " [opcode]...", "Inject opcodes and restore state",
+	"dxs", " write 1, 0x8048, 12", "Syscall injection (see gs)",
+	"\nExamples:", "", "",
+	"dx", " 9090", "Inject two x86 nop",
+	"\"dxa mov eax,6;mov ebx,0;int 0x80\"", "", "Inject and restore state",
+	NULL
+};
+
+// CMD_EGG
+const char *help_msg_g[] = {
+	"Usage: g[wcilper]", "[arg]", "Go compile shellcodes",
+	"g", " foo.r", "Compile r_egg source file",
+	"gw", "", "Compile and write",
+	"gc", " cmd=/bin/ls", "Set config option for shellcodes and encoders",
+	"gc", "", "List all config options",
+	"gl", "", "List plugins (shellcodes, encoders)",
+	"gs", " name args", "Compile syscall name(args)",
+	"gi", " exec", "Compile shellcode. like ragg2 -i",
+	"gp", " padding", "Define padding for command",
+	"ge", " xor", "Specify an encoder",
+	"gr", "", "Reset r_egg",
+	"EVAL VARS:", "", "asm.arch, asm.bits, asm.os",
+	NULL
+};
+
+// CMD_EVAL
+
+const char* help_msg_e[] = {
+	"Usage: e[?]", "[var[=value]]", "Evaluable variables",
+	"e","?asm.bytes", "Show description",
+	"e", "??", "List config vars with description",
+	"e", "", "List config vars",
+	"e-", "", "Reset config vars",
+	"e*", "", "Dump config vars in r commands",
+	"e!", "a", "Invert the boolean value of 'a' var",
+	"ee", "var", "Open editor to change the value of var",
+	"er", " [key]", "Set config key as readonly. no way back",
+	"ec", " [k] [color]", "Set color for given key (prompt, offset, ...)",
+	"et", " [key]", "Show type of given config variable",
+	"e", " a", "Get value of var 'a'",
+	"e", " a=b", "Set var 'a' the 'b' value",
+	"env", " [k[=v]]", "Get/set environment variable",
+	NULL
+};
+
+const char *help_msg_ec[] = {
+	"Usage: ec[s?]", "[key][[=| ]fg] [bg]", "Color configuration",
+	"ec", "", "List all color keys",
+	"ec*", "", "Same as above, but using r2 commands",
+	"ecd", "", "Set default palette",
+	"ecr", "", "Set random palette",
+	"ecs", "", "Show a colorful palette",
+	"ecj", "", "Show palette in JSON",
+	"ecc", " [prefix]", "Show palette in CSS",
+	"eco", " dark|white", "Load white color scheme template",
+	"ecp", "", "Load previous color theme",
+	"ecn", "", "Load next color theme",
+	"ec", " prompt red", "Change color of prompt",
+	"ec", " prompt red blue", "Change color and background of prompt",
+	"", "", "",
+	"colors:", "", "rgb:000, red, green, blue, ...",
+	"e scr.rgbcolor", "=1|0", "for 256 color cube (boolean)",
+	"e scr.truecolor", "=1|0", "for 256*256*256 colors (boolean)",
+	"$DATADIR/radare2/cons","","~/.config/radare2/cons ./",
+	NULL
+};
+
+const char *help_msg_et[] = {
+	"Usage: et", "[varname]", "Show type of eval var",
+	NULL
+};
+
+// CMD_FLAG
+
+const char *help_msg_f[] = {
+	"Usage: f[?]","[flagname]", "Manage offset-name flags",
+	"f","","List flags (will only list flags from selected flagspaces)",
+	"f."," [*[*]]","List local per-function flags (*) as r2 commands",
+	"f.","blah=$$+12","Set local function label named 'blah'",
+	"f*","","List flags in r commands",
+	"f"," name 12 @ 33","Set flag 'name' with length 12 at offset 33",
+	"f"," name = 33","Alias for 'f name @ 33' or 'f name 1 33'",
+	"f"," name 12 33 [cmt]","Same as above + optional comment",
+	"f-",".blah@fcn.foo","Delete local label from function at current seek (also f.-)",
+	"f--","","Delete all flags and flagspaces (deinit)",
+	"f+","name 12 @ 33","Like above but creates new one if doesnt exist",
+	"f-","name","Remove flag 'name'",
+	"f-","@addr","Remove flag at address expression",
+	"f."," fname","List all local labels for the given function",
+	"fa"," [name] [alias]","Alias a flag to evaluate an expression",
+	"fb"," [addr]","Set base address for new flags",
+	"fb"," [addr] [flag*]","Move flags matching 'flag' to relative addr",
+	"fc"," [name] [color]","Set color for given flag",
+	"fC"," [name] [cmt]","Set comment for given flag",
+	"fd"," addr","Return flag+delta",
+	"fe-","","Resets the enumerator counter",
+	"fe"," [name]","Create flag name.#num# enumerated flag. See fe?",
+	"fi"," [size] | [from] [to]","Show flags in current block or range",
+	"fg","","Bring visual mode to foreground",
+	"fj","","List flags in JSON format",
+	"fl"," [flag] [size]","Show or set flag length (size)",
+	"fm"," addr","Move flag at current offset to new address",
+	"fn","","List flags displaying the real name (demangled)",
+	"fo","","Show fortunes",
+	//" fc [name] [cmt]  ; set execution command for a specific flag"
+	"fr"," [old] [[new]]","Rename flag (if no new flag current seek one is used)",
+	"fR"," [f] [t] [m]","Relocate all flags matching f&~m 'f'rom, 't'o, 'm'ask",
+	"fs"," ?+-*","Manage flagspaces",
+	"fS","[on]","Sort flags by offset or name",
+	"fx","[d]","Show hexdump (or disasm) of flag:flagsize",
+	NULL
+};
+
+const char *help_msg_fb[] = {
+	"Usage: fb", "[addr] [[flags*]]", "",
+	NULL
+};
+
+const char *help_msg_fc[] = {
+	"Usage: fc", "[flagname] [color]", "List colors with 'ecs'",
+	"fc", " flagname", "Get current color for given flagname",
+	"fc", " flagname color", "Set color to a flag",
+	NULL
+};
+
+const char *help_msg_fC[] = {
+	"Usage: fC", " [name] [comment]", "Set comment for given flag",
+	NULL
+};
+
+const char *help_msg_fd[] = {
+	"Usage: fd", " [offset|flag|expression]", "Return flag+delta",
+	NULL
+};
+
+const char *help_msg_fe[] = {
+	"Usage: fe", "[-| name] @@= 1 2 3 4", "",
+	NULL
+};
+
+const char *help_msg_fequals[] = {
+	"Usage: f= or f== to display flag bars", "", "",
+	NULL
+};
+
+const char *help_msg_fR[] = {
+	"Usage: fR", "[from] [to] ([mask])", "",
+	"\nExample: Relocate PIE flags on debugger", "", "",
+	" fR entyr0 `dm~:1[1]`", "", "",
+	NULL
+};
+
+const char *help_msg_fs[] = {
+	"Usage: fs[mr*+-]","[flagspace|addr]", "Manage flagspaces",
+	"fs","","Display flagspaces",
+	"fs"," *","Select all flagspaces",
+	"fs"," flagspace","Select flagspace or create if it doesn't exist",
+	"fs","-flagspace","Remove flagspace",
+	"fs","-*","Remove all flagspaces",
+	"fs","+foo","Push previous flagspace and set",
+	"fs","-","Pop to the previous flagspace",
+	"fs","-.","Remove the current flagspace",
+	"fsm"," [addr]","Move flags at given address to the current flagspace",
+	"fsr"," newname","Rename selected flagspace",
+	NULL
+};
+
+const char *help_msg_fV[] = {
+	"Usage: fV[+-]", "[nkey] [offset]", "Dump/Restore visual marks (mK/'K)",
+	NULL
+};
+
+// CMD_HASH
+
+const char *help_msg_hash[] = {
+	"Usage: #!interpreter", "[args] [<file] [<<eof]","",
+	" #", "", "Comment - do nothing",
+	" #!","","List all available interpreters",
+	" #!python","","Run python commandline",
+	" #!python"," foo.py","Run foo.py python script (same as '. foo.py')",
+	//" #!python <<EOF        get python code until 'EOF' mark\n"
+	" #!python"," arg0 a1 <<q","Set arg0 and arg1 and read until 'q'",
+	NULL
+};
+
+// CMD_HELP
+const char *help_msg_colon[] = {
+	"Usage: :[plugin]", "[args]", "",
+	":", "", "List RCore plugins",
+	":java", "", "Run Java plugin",
+	NULL
+};
+
+const char *help_msg_quev[] = {
+	"Usage: ?v[id]", "[val]", "Show value",
+	"?vi1 200", "", "1 byte suze value (char)",
+	"?vi2 0xffff", "", "2 byte size value (short)",
+	"?vi4 0xffff", "", "4 byte size value (int)",
+	"?vi8 0xffff", "", "8 byte size value (st64)",
+	"No argument shows $? value", "", "",
+	"?vi will show in decimal instead of hex", "", "",
+	NULL
+};
+
+const char *help_msg_at_general[] = {
+	"Usage: [.][#][cmd][*]", "[`cmd`] [@ addr] [~grep] [|syscmd] [>[>]file]", "",
+	"0", "", "Alias for 's 0'",
+	"0x", "addr", "Alias for 's 0x..'",
+	"#", "cmd", "If # is a number repeat the command # times",
+	"/*", "", "Start multiline comment",
+	"*/", "", "End multiline comment",
+	".", "cmd", "Execute output of command as r2 script",
+	".:", "8080", "Wait for commands on port 8080",
+	".!", "rabin2 -re $FILE", "Run command output as r2 script",
+	"*", "", "Output of command in r2 script format (CC*)",
+	"j", "", "Output of command in JSON format (pdj)",
+	"~", "?", "Count number of lines (like wc -l)",
+	"~", "??", "Show internal grep help",
+	"~", "..", "Internal less",
+	"~", "{}", "JSON indent",
+	"~", "{}..", "JSON indent and less",
+	"~", "word", "Grep for lines matching word",
+	"~", "!word", "Grep for lines NOT matching word",
+	"~", "word[2]", "Grep 3rd column of lines matching word",
+	"~", "word:3[0]", "Grep 1st column from the 4th line matching mov",
+	"@", " 0x1024", "Temporary seek to this address (sym.main+3",
+	"@", " addr[!blocksize]", "Temporary set a new blocksize",
+	"@a:", "arch[:bits]", "Temporary set arch and bits",
+	"@b:", "bits", "Temporary set asm.bits",
+	"@e:", "k=v,k=v", "Temporary change eval vars",
+	"@r:", "reg", "Tmp seek to reg value (f.ex pd@r:PC)",
+	"@f:", "file", "Temporary replace block with file contents",
+	"@o:", "fd", "Temporary switch to another fd",
+	"@s:", "string", "Same as above but from a string",
+	"@x:", "909192", "From hex pairs string",
+	"@..", "from to", "Temporary set from and to for commands supporting ranges",
+	"@@=", "1 2 3", "Run the previous command at offsets 1, 2 and 3",
+	"@@", " hit*", "Run the command on every flag matching 'hit*'",
+	"@@@", " [type]", "Run a command on every [type] (see @@@? for help)",
+	">", "file", "Pipe output of command to file",
+	">>", "file", "Append to file",
+	"`", "pdi~push:0[0]`", "Replace output of command inside the line",
+	"|", "cmd", "Pipe output to command (pd|less) (.dr*)",
+	NULL
+};
+
+const char *help_msg_dollar_sign[] = {
+	"Usage: ?v [$.]","","",
+	"$$", "", "Here (current virtual seek)",
+	"$?", "", "Last comparison value",
+	"$alias", "=value", "Alias commands (simple macros)",
+	"$b", "", "Block size",
+	"$B", "", "Base address (aligned lowest map address)",
+	"$F", "", "Current function size",
+	"$FB", "", "Begin of function",
+	"$FE", "", "End of function",
+	"$FS", "", "Function size",
+	"$FI", "", "Function instructions",
+	"$c,$r", "", "Get width and height of terminal",
+	"$Cn", "", "Get nth call of function",
+	"$Dn", "", "Get nth data reference in function",
+	"$D", "", "Current debug map base address ?v $D @ rsp",
+	"$DD", "", "Current debug map size",
+	"$e", "", "1 if end of block, else 0",
+	"$f", "", "Jump fail address (e.g. jz 0x10 => next instruction)",
+	"$j", "", "Jump address (e.g. jmp 0x10, jz 0x10 => 0x10)",
+	"$Ja", "", "Get nth jump of function",
+	"$Xn", "", "Get nth xref of function",
+	"$l", "", "Opcode length",
+	"$m", "", "Opcode memory reference (e.g. mov eax,[0x10] => 0x10)",
+	"$M", "", "Map address (lowest map address)",
+	"$o", "", "Here (current disk io offset)",
+	"$p", "", "Getpid()",
+	"$P", "", "PID of children (only in debug)",
+	"$s", "", "File size",
+	"$S", "", "Section offset",
+	"$SS", "", "Section size",
+	"$v", "", "Opcode immediate value (e.g. lui a0,0x8010 => 0x8010)",
+	"$w", "", "Get word size, 4 if asm.bits=32, 8 if 64, ...",
+	"${ev}", "", "Get value of eval config variable",
+	"$k{kv}", "", "Get value of an sdb query value",
+	"RNum", "", "$variables usable in math expressions",
+	NULL
+};
+
+const char *help_msg_queV[] = {
+	"Usage: ?V[jq]","","",
+	"?V", "", "Show version information",
+	"?Vj", "", "Same as above but in JSON",
+	"?Vq", "", "Quiet mode, just show the version number",
+	NULL
+};
+
+const char *help_msg_queque[] = {
+	"Usage: ?[?[?]] expression", "", "",
+	"?", " eip-0x804800", "Show hex and dec result for this math expr",
+	"?:", "", "List core cmd plugins",
+	"?!", " [cmd]", "? != 0",
+	"?+", " [cmd]", "? > 0",
+	"?-", " [cmd]", "? < 0",
+	"?=", " eip-0x804800", "Hex and dec result for this math expr",
+	"??", "", "Show value of operation",
+	"??", " [cmd]", "? == 0 run command when math matches",
+	"?B", " [elem]", "Show range boundaries like 'e?search.in",
+	"?P", " paddr", "Get virtual address for given physical one",
+	"?S", " addr", "Return section name of given address",
+	"?T", "", "Show loading times",
+	"?V", "", "Show library version of r_core",
+	"?X", " num|expr", "Returns the hexadecimal value numeric expr",
+	"?_", " hudfile", "Load hud menu with given file",
+	"?b", " [num]", "Show binary value of number",
+	"?b64[-]", " [str]", "Encode/decode in base64",
+	"?d[.]", " opcode", "Describe opcode for asm.arch",
+	"?e", " string", "Echo string",
+	"?f", " [num] [str]", "Map each bit of the number as flag string index",
+	"?h", " [str]", "Calculate hash for given string",
+	"?i", "[ynmkp] arg", "Prompt for number or Yes,No,Msg,Key,Path and store in $$?",
+	"?ik", "", "Press any key input dialog",
+	"?im", " message", "Show message centered in screen",
+	"?in", " prompt", "No/yes input prompt",
+	"?iy", " prompt", "Yes/no input prompt",
+	"?l", " str", "Returns the length of string",
+	"?o", " num", "Get octal value",
+	"?p", " vaddr", "Get physical address for given virtual address",
+	"?r", " [from] [to]", "Generate random number between from-to",
+	"?s", " from to step", "Sequence of numbers from to by steps",
+	"?t", " cmd", "Returns the time to run a command",
+	"?u", " num", "Get value in human units (KB, MB, GB, TB)",
+	"?v", " eip-0x804800", "Show hex value of math expr",
+	"?vi", " rsp-rbp", "Show decimal value of math expr",
+	"?x", " num|str|-hexst", "Returns the hexpair of number or string",
+	"?y", " [str]", "Show contents of yank buffer, or set with string",
+	NULL
+};
+
+const char* help_msg_que[] = {
+	"Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...", "", "",
+	"Append '?' to any char command to get detailed help", "", "",
+	"Prefix with number to repeat command N times (f.ex: 3x)", "", "",
+	"%var", "=value", "Alias for 'env' command",
+	"*", "off[=[0x]value]", "Pointer read/write data/values (see ?v, wx, wv)",
+	"(macro arg0 arg1)",  "", "Manage scripting macros",
+	".", "[-|(m)|f|!sh|cmd]", "Define macro or load r2, cparse or rlang file",
+	"="," [cmd]", "Run this command via rap://",
+	"/","", "Search for bytes, regexps, patterns, ..",
+	"!"," [cmd]", "Run given command as in system(3)",
+	"#"," [algo] [len]", "Calculate hash checksum of current block",
+	"#","!lang [..]", "Hashbang to run an rlang script",
+	"a","", "Perform analysis of code",
+	"b","", "Get or change block size",
+	"c"," [arg]", "Compare block with given data",
+	"C","", "Code metadata management",
+	"d","", "Debugger commands",
+	"e"," [a[=b]]", "List/get/set config evaluable vars",
+	"f"," [name][sz][at]", "Set flag at current address",
+	"g"," [arg]", "Go compile shellcodes with r_egg",
+	"i"," [file]", "Get info about opened file",
+	"k"," [sdb-query]", "Run sdb-query. see k? for help, 'k *', 'k **' ...",
+	"m","", "Mountpoints commands",
+	"o"," [file] ([offset])", "Open file at optional address",
+	"p"," [len]", "Print current block with format and length",
+	"P","", "Project management utilities",
+	"q"," [ret]", "Quit program with a return value",
+	"r"," [len]", "Resize file",
+	"s"," [addr]", "Seek to address (also for '0x', '0x1' == 's 0x1')",
+	"S","", "Io section manipulation information",
+	"t","", "Cparse types management",
+	"T"," [-] [num|msg]", "Text log utility",
+	"u","", "uname/undo seek/write",
+	"V","", "Enter visual mode (vcmds=visualvisual  keystrokes)",
+	"w"," [str]", "Multiple write operations",
+	"x"," [len]", "Alias for 'px' (print hexadecimal)",
+	"y"," [len] [[[@]addr", "Yank/paste bytes from/to memory",
+	"z", "", "Zignatures management",
+	"?[??]","[expr]", "Help or evaluate math expression",
+	"?$?", "", "Show available '$' variables and aliases",
+	"?@?", "", "Misc help for '@' (seek), '~' (grep) (see ~?""?)",
+	"?:?", "", "List and manage core plugins",
+	NULL
+};
+
+// CMD INFO
+const char *help_msg_i[] = {
+	"Usage: i", "", "Get info from opened file",
+	"Output mode:", "", "",
+	"'*'", "", "Output in radare commands",
+	"'j'", "", "Output in json",
+	"'q'", "", "Simple quiet output",
+	"Actions:", "", "",
+	"i|ij", "", "Show info of current file (in JSON)",
+	"iA", "", "List archs",
+	"ia", "", "Show all info (imports, exports, sections..)",
+	"ib", "", "Reload the current buffer for setting of the bin (use once only)",
+	"ic", "", "List classes, methods and fields",
+	"iC", "", "Show signature info (entitlements, ...)",
+	"id", "", "Debug information (source lines)",
+	"iD", " lang sym", "demangle symbolname for given language",
+	"ie", "", "Entrypoint",
+	"iE", "", "Exports (global symbols)",
+	"ih", "", "Headers",
+	"ii", "", "Imports",
+	"iI", "", "Binary info",
+	"ik", " [query]", "Key-value database from RBinObject",
+	"il", "", "Libraries",
+	"iL", "", "List all RBin plugins loaded",
+	"im", "", "Show info about predefined memory allocation",
+	"iM", "", "Show main address",
+	"io", " [file]", "Load info from file (or last opened) use bin.baddr",
+	"ir|iR", "", "Relocs",
+	"is", "", "Symbols",
+	"iS ", "[entropy,sha1]", "Sections (choose which hash algorithm to use)",
+	"iV", "", "Display file version info",
+	"iz", "", "Strings in data sections",
+	"izz", "", "Search for strings in the whole binary",
+	"iZ", "", "Guess size of binary program",
+	NULL
+};
+
+// CMD_LOG
+const char *help_msg_T[] = {
+	"Usage:", "T","[-][ num|msg]",
+	"T", "", "List all Text log messages",
+	"T", " message", "Add new log message",
+	"T", " 123", "List log from 123",
+	"T", " 10 3", "List 3 log messages starting from 10",
+	"T*", "", "List in radare commands",
+	"T-", "", "Delete all logs",
+	"T-", " 123", "Delete logs before 123",
+	"Tl", "", "Get last log message id",
+	"Tj", "", "List in json format",
+	"Tm", " [idx]", "Display log messages without index",
+	"Ts", "", "List files in current directory (see pwd, cd)",
+	"Tp", "[-plug]", "Tist, load, unload plugins",
+	"TT", "", "Enter into the text log chat console",
+	NULL
+};
+
+const char *help_msg_Tp[] = {
+	"Usage:", "Tp", "[-name][ file]",
+	"Tp", "", "List all plugins loaded by RCore.lib",
+	"Tp-", "duk", "Unload plugin matching in filename",
+	"Tp", " blah."R_LIB_EXT, "Load plugin file",
+	NULL
+};
+
+// CMD_MACRO
+const char *help_msg_paren[] = {
+	"Usage:", "(foo args,cmd1,cmd2,..)", "Macro management",
+	"(foo args,..,..)", "", "Define a macro named 'foo'",
+	"(foo args,..,..)()", "", "Define and call a macro",
+	"(-foo)", "", "Remove a macro",
+	".(foo)", "", "Call macro named 'foo'",
+	"()", "", "Break inside macro",
+	"(*", "", "List all defined macros",
+	"", "Argument support:", "",
+	"(foo x y\\n$0 @ $1)", "", "Define fun with args",
+	".(foo 128 0x804800)", "", "Call it with args",
+	"", "Iterations:", "",
+	".(foo\\n() $@)", "", "Define iterator returning iter index",
+	"x @@ .(foo)", "", "Iterate over macros",
+	NULL
+};
+
+// CMD_META
+const char* help_msg_C[] = {
+	"Usage: C[-LCvsdfm*?][*?]", "[...]", "Metadata management",
+	"C*", "", "List meta info in r2 commands",
+	"C-", " [len] [[@]addr]", "Delete metadata at given address range",
+	"CL", "[-][*] [file:line] [addr]", "Show or add 'code line' information (bininfo)",
+	"CS", "[-][space]", "Manage meta-spaces to filter comments, etc..",
+	"CC", "[-] [comment-text] [@addr]", "Add/remove comment",
+	"CC!", " [@addr]", "Edit comment with $EDITOR",
+	"CCa", "[-at]|[at] [text] [@addr]", "Add/remove comment at given address",
+	"CCu", " [comment-text] [@addr]", "Add unique comment",
+	"Ca", "[?]", "Add comments to base pointer bases args/vars",
+	"Ce", "[?]", "Add comments to stack pointer based args/vars",
+	"Cv", "[?]", "Add comments to register based args",
+	"Cs", "[-] [size] [@addr]", "Add string",
+	"Cz", "[@addr]", "Add zero-terminated string",
+	"Ch", "[-] [size] [@addr]", "Hide data",
+	"Cd", "[-] [size] [repeat] [@addr]", "Hexdump data array (Cd 4 10 == dword [10])",
+	"Cf", "[-] [sz] [fmt..] [@addr]", "Format memory (see pf?)",
+	"Cm", "[-] [sz] [fmt..] [@addr]", "Magic parse (see pm?)",
+	NULL
+};
+
+const char *help_msg_CC[] = {
+	"Usage: CC[-+!*au]", "[base64:..|str] @ addr", "",
+	"CC", "", "List all comments in human friendly form",
+	"CC*", "", "List all comments in r2 commands",
+	"CC.", "", "Show comment at current offset",
+	"CC,", " [file]", "Show or set comment file",
+	"CC", " [comment]", "Append comment at current address",
+	"CC+", " [comment]", "Append comment at current address",
+	"CC!", "", "Edit comment using cfg.editor (vim, ..)",
+	"CC-", " @ cmt_addr", "Remove comment at given address",
+	"CCu", " good boy @ addr", "Add 'good boy' comment at given address",
+	"CCu", " base64:AA== @ addr", "Add comment in base64",
+	NULL
+};
+
+const char *help_msg_CS[] = {
+	"Usage: CS[*]", "[+-][metaspace|addr]", "Manage metaspaces",
+	"CS","","Display metaspaces",
+	"CS","*","Select all metaspaces",
+	"CS"," metaspace","Select metaspace or create if it doesn't exist",
+	"CS","-metaspace","Remove metaspace",
+	"CS","-*","Remove all metaspaces",
+	"CS","+foo","Push previous metaspace and set",
+	"CS","-","Pop to the previous metaspace",
+	//	"CSm"," [addr]","move metas at given address to the current metaspace",
+	"CSr"," newname","Rename selected metaspace",
+	NULL
+};
+
+const char *help_msg_Cvb[] = {
+	"Usage: Cvb", "[name] [comment]", "",
+	"Cvb?", "", "show this help",
+	"Cvb", "", "List all base pointer args/vars comments in human friendly format",
+	"Cvb*", "", "List all base pointer args/vars comments in r2 format",
+	"Cvb-", "[name]", "Delete comments for var/arg at current offset for base pointer",
+	"Cvb", "[name]", "Show comments for var/arg at current offset for base pointer",
+	"Cvb", "[name] [comment]", "Add/append comment for the variable with the current name",
+	"Cvb!", "[name]", "Edit comment using cfg editor",
+	NULL
+};
+
+const char *help_msg_Cvs[] = {
+	"Usage: Cvs", "[name] [comment]", "",
+	"Cvs?", "", "Show this help",
+	"Cvs", "", "List all stack based args/vars comments in human friendly format",
+	"Cvs*", "", "List all stack based args/vars comments in r2 format",
+	"Cvs-", "[name]", "Delete comments for stack pointer var/arg with that name",
+	"Cvs", "[name]", "Show comments for stack pointer var/arg with that name",
+	"Cvs", "[name] [comment]", "Add/append comment for the variable",
+	"Cvs!", "[name]", "Edit comment using cfg editor",
+	NULL
+};
+
+const char *help_msg_Cvr[] = {
+	"Usage: Cvr", "[name] [comment]", "",
+	"Cvr?", "", "Show this help",
+	"Cvr", "", "List all register based args comments in human friendly format",
+	"Cvr*", "", "List all register based args comments in r2 format",
+	"Cvr-", "[name]", "Delete comments for register based arg for that name",
+	"Cvr", "[name]", "Show comments for register based arg for that name",
+	"Cvr", "[name] [comment]", "Add/append comment for the variable",
+	"Cvr!", "[name]", "Edit comment using cfg editor",
+	NULL
+};
+
+// CMD_MOUNT
+
+const char* help_msg_m[] = {
+	"Usage: m[-?*dgy]", "[...]", "Mountpoints management",
+	"m", "", "List all mountpoints in human readable format",
+	"m*", "", "Same as above, but in r2 commands",
+	"ml", "", "List filesystem plugins",
+	"m", " /mnt", "Mount fs at /mnt with autodetect fs and current offset",
+	"m", " /mnt ext2 0", "Mount ext2 fs at /mnt with delta 0 on IO",
+	"m-/", "", "Umount given path (/)",
+	"my", "", "Yank contents of file into clipboard",
+	"mo", " /foo", "Get offset and size of given file",
+	"mg", " /foo", "Get contents of file/dir dumped to disk (XXX?)",
+	"mf", "[o|n]", "Search files for given filename or for offset",
+	"md", " /", "List directory contents for path",
+	"mp", "", "List all supported partition types",
+	"mp", " msdos 0", "Show partitions in msdos format at offset 0",
+	"ms", " /mnt", "Open filesystem prompt at /mnt",
+	NULL
+};
+
+const char *help_msg_mf[] = {
+	"Usage: mf", "[no] [...]", "",
+	"mfn /foo *.c", "", "Search files by name in /foo path",
+	"mfn /foo 0x5e91", "", "Search files by offset in /foo path",
+	NULL
+};
+
+// CMD_OPEN
+
+const char *help_msg_o[] = {
+	"Usage: o[com-]","[file] ([offset])","File management commands",
+	"o","","List opened files",
+	"o*","","List opened files in r2 commands",
+	"oa"," [addr]","Open bin info from the given address",
+	"ob","[lbdos] [...]","List open binary files backed by fd",
+	"ob"," 4","Prioritize io and fd on 4 (bring to binfile to front)",
+	"oc"," [file]","Open core file, like relaunching r2",
+	"oj","","List opened files in JSON format",
+	"oL","","List all IO plugins registered",
+	"om","[?]","Create, list, remove IO maps",
+	"on"," [file] 0x4000","Map raw file at 0x4000 (no r_bin involved)",
+	"oo","","Reopen current file (kill+fork in debugger)",
+	"oo","+","Reopen current file in read-write",
+	"ood"," [args]","Reopen in debugger mode (with args)",
+	"op"," ["R_LIB_EXT"]","Open r2 native plugin (asm, bin, core, ..)",
+	"o"," 4","Priorize io on fd 4 (bring to front)",
+	"o","-1","Close file descriptor 1",
+	"o-","*","Close all opened files",
+	"o--","","Close all files, analysis, binfiles, flags, same as !r2 --",
+	"o"," [file]","Open [file] file in read-only",
+	"o","+[file]","Open file in read-write mode",
+	"o"," [file] 0x4000","Map file at 0x4000",
+	NULL
+};
+
+const char *help_msg_oa[] = {
+	"Usage:", "oa [addr]", "",
+	"oa", " [addr]", "Open bin info from the given address",
+	NULL
+};
+
+const char* help_msg_ob[] = {
+	"Usage:", "ob", " # List open binary files backed by fd",
+	"ob", "", "List opened binfiles and bin objects",
+	"ob", " [fd # bobj #]", "Prioritize by fd number and object number",
+	"obb", " [fd #]", "Prioritize by fd number with current selected object",
+	"ob-", " [fd #]", "Delete binfile by fd",
+	"obd", " [binobject #]", "Delete binfile object numbers, if more than 1 object is loaded",
+	"obo", " [binobject #]", "Prioritize by bin object number",
+	NULL
+};
+
+const char *help_msg_oc[] = {
+	"Usage: oc","[file]","Open core file, like relaunching r2",
+	NULL
+};
+
+const char *help_msg_oj[] = {
+	"Usage: oj", "[~{}]", "Use ~{} to indent the JSON",
+	"oj", "", "List opened files in JSON format",
+	NULL
+};
+
+const char* help_msg_om[] = {
+	"Usage: om[-]", "[arg]", "Map opened files",
+	"om", "", "List all defined IO maps",
+	"om", "-0x10000", "Remove the map at given address",
+	"om", " fd addr [size]", "Create new io map",
+	"omr", " fd|0xADDR ADDR", "Relocate current map",
+	"om*", "", "Show r2 commands to restore mapaddr",
+	NULL
+};
+
+const char* help_msg_oo[] = {
+	"Usage: oo[-]", "[arg]", "Map opened files",
+	"oo", "", "Reopen current file",
+	"oo+", "", "Reopen in read-write",
+	"oob", "", "Reopen loading rbin info",
+	"ood", "", "Reopen in debug mode",
+	"oon", "", "Reopen without loading rbin info",
+	"oon+", "", "Reopen in read-write mode without loading rbin info",
+	"oonn", "", "Reopen without loading rbin info, but with header flags",
+	"oonn+", "", "Reopen in read-write mode without loading rbin info, but with",
+	NULL
+};
+
+const char *help_msg_oob[] = {
+	"Usage: oob", "", "Reopen loading rbin info",
+	NULL
+};
+
+const char *help_msg_ood[] = {
+	"Usage: ood"," [args]","Reopen in debugger mode (with args)",
+	NULL
+};
+
+const char *help_msg_oon[] = {
+	"Usage: oon", "", "Reopen without loading rbin info",
+	NULL
+};
+
+const char *help_msg_oonn[] = {
+	"Usage: oonn", "", "Reopen without loading rbin info, but with header flags",
+	NULL
+};
+
+const char *help_msg_ostar[] = {
+	"Usage: o*", "[> files.r2]", "",
+	"o*", "", "List opened files in r2 commands",
+	NULL
+};
+
+const char *help_msg_ooplus[] = {
+	"Usage: oo+", "", "Reopen in read-write",
+	NULL
+};
+
+// CMD_PRINT
+
+const char *help_msg_p[] = {
+	"Usage:", "p[=68abcdDfiImrstuxz] [arg|len] [@addr]", "",
+	"p=","[bep?] [blks] [len] [blk]","Show entropy/printable chars/chars bars",
+	"p2"," [N]","8x8 2bpp-tiles",
+	"p3"," [file]","Print stereogram (3D)",
+	"p6","[de] [N]", "base64 decode/encode",
+	"p8","[j] [N]","8bit hexpair list of bytes",
+	"pa","[edD] [arg]", "pa:assemble  pa[dD]:disasm or pae: ESIL from hexpairs",
+	"pA","[n_ops]", "Show n_ops address and type",
+	"p","[b|B|xb] [N] ([skip])", "Bindump N bits skipping M",
+	"p","[bB] [N]","Bitstream of N bytes",
+	"pc","[p] [N]","Output C (or python) format",
+	"p","[dD][?] [N] [a] [b]","Disassemble N opcodes/bytes for arch/bits (see pd?)",
+	"pf","[?|.nam] [fmt]","Print formatted data (pf.name, pf.name $<expr>)",
+	"ph","[?=|hash] ([len])","Calculate hash for a block",
+	"p","[iI][df] [N]", "Print N ops/bytes (f=func) (see pi? and pdi)",
+	"pm"," [magic]","Print libmagic data (see pm? and /m?)",
+	"pr","[glx] [N]","Print N raw bytes (in lines or hexblocks, 'g'unzip)",
+	"p","[kK] [N]","Print key in randomart (K is for mosaic)",
+	"ps","[pwz] [N]","Print pascal/wide/zero-terminated strings",
+	"pt","[dn?] [N]","Print different timestamps",
+	"pu","[w] [N]","Print N url encoded bytes (w=wide)",
+	"pv","[jh] [mode]","Show variable/pointer/value in memory",
+	"p-","[jh] [mode]","Bar|JSON|histogram blocks (mode: e?search.in)",
+	"px","[owq] [N]","Hexdump of N bytes (o=octal, w=32bit, q=64bit)",
+	"pz"," [N]","Print zoom view (see pz? for help)",
+	"pwd","","Display current working directory",
+	NULL
+};
+
+const char *help_msg_p2[] = {
+	"Usage: p2", "[N]", "N is the number of bytes represeting tiles",
+	"NOTE: Only full tiles will be printed", "", "",
+	NULL
+};
+
+const char *help_msg_p3[] = {
+	"Usage: p3", "[file]", "Print 3D stereogram image of current block",
+	NULL
+};
+
+const char *help_msg_p6d[] = {
+	"Usage: p6d", "[N]", "base64 decode",
+	NULL
+};
+
+const char *help_msg_p6e[] = {
+	"Usage: p6e", "[N]", "base64 encode",
+	NULL
+};
+
+const char *help_msg_p6ed[] = {
+	"Usage: p6[ed]", "[N]", "base64 encode/decode",
+	NULL
+};
+
+const char *help_msg_p8[] = {
+	"Usage: p8[fj]", "[N]", "8bit hexpair list of bytes (see pcj)",
+	NULL
+};
+
+const char *help_msg_pad[] = {
+	"Usage: pad", "[hex]", "Diassemble",
+	NULL
+};
+
+const char *help_msg_pae[] = {
+	"Usage: pae", "[hex]", "Assemble from hexpairs",
+	NULL
+};
+
+const char *help_msg_paed[] = {
+	"Usage: pa[ed]", "[hex|asm]", "Assemble/Disassemble (ESIL - pae) from hexpairs",
+	NULL
+};
+
+const char *help_msg_paD[] = {
+	"Usage: paD", "[hex]", "Disasm like in pdi",
+	NULL
+};
+
+const char *help_msg_pb[] = {
+	"Usage: p[bB]", "[N] ([skip])", "See also pB and pxb",
+	NULL
+};
+
+const char *help_msg_pB[] = {
+	"Usage: p[bB]", "[N]", "Bitstream of N bytes",
+	NULL
+};
+
+const char* help_msg_pd[] = {
+	"Usage: p[dD][ajbrfils]", "[N] [arch] [bits]", "Print disassembly",
+	"NOTE: ", "N", "Parameter can be negative",
+	"NOTE: ", "", "Pressing ENTER on empty command will repeat last pd command and also seek to end of disassembled range.",
+	"pd", " N", "Disassemble N instructions",
+	"pd", " -N", "Disassemble N instructions backward",
+	"pD", " N", "Disassemble N bytes",
+	"pda", "", "Disassemble all possible opcodes (byte per byte)",
+	"pdb", "", "Disassemble basic block",
+	"pdc", "", "Pseudo disassembler output in C-like syntax",
+	"pdj", "", "Disassemble to json",
+	"pdr", "", "Recursive disassemble across the function graph",
+	"pdf", "", "Disassemble function",
+	"pdi", "", "Like 'pi', with offset and bytes",
+	"pdl", "", "Show instruction sizes",
+	//"pds", "", "disassemble with back sweep (greedy disassembly backwards)",
+	"pds", "", "Disassemble summary (strings, calls, jumps, refs) (see pdsf and pdfs)",
+	"pdt", "", "Disassemble the debugger traces (see atd)",
+	NULL
+};
+
+const char *help_msg_pdfs[] = {
+	"Usage: pdf[sj]", "", "Disassemble function (summary + cjmp), JSON",
+	NULL
+};
+
+const char *help_msg_pds[] = {
+	"Usage: pds[f]", "[N]", "Summarize N bytes of function (pdfs)",
+	NULL
+};
+
+const char *help_msg_pf[] = {
+	"Usage: pf[.k[.f[=v]]|[v]]|[n]|[0]", "[[size] fmt] [a0 a1 ...]", "Print formatted data",
+	"Commands:","","",
+	"pf", "?", "Show this help",
+	"pf", "??", "Format characters",
+	"pf", "???", "pf usage examples",
+	"pf", " xsi foo bar cow", "Format named hex str and int (see `pf??`)",
+	"pf.", "", "List all formats",
+	"pf?", "fmt_name", "Show format of that stored one",
+	"pfs", " fmt_name", "Print the size of the format in bytes",
+	"pfo", "", "List all format files",
+	"pfo", " elf32", "Load the elf32 format definition file",
+	"pf.", "fmt_name", "Run stored format",
+	"pf.", "fmt_name.field_name", "Show specific field inside format",
+	"pf.", "fmt_name.size=33", "Set new value for the size field in obj",
+	"pfj.", "fmt_name", "Print format in JSON",
+	"pfv.", "fmt_name", "Print the value(s) only. Useful for one-liners",
+	"pf*.", "fmt_name", "Display flag commands",
+	"pfd.", "fmt_name", "Display graphviz commands",
+	NULL
+};
+
+const char *help_msg_pfque[] = {
+	"Usage: pf[.k[.f[=v]]|[v]]|[n]|[0]", "[[size] fmt] [a0 a1 ...]", "",
+	"Format:", "", "",
+	" ", "b", "byte (unsigned)",
+	" ", "B", "Resolve enum bitfield (see t?)",
+	" ", "c", "char (signed byte)",
+	" ", "d", "0x%%08x hexadecimal value (4 bytes)",
+	" ", "D", "Disassemble one opcode",
+	" ", "e", "Temporally swap endian",
+	" ", "E", "Resolve enum name (see t?)",
+	" ", "f", "float value (4 bytes)",
+	" ", "i", "%%i integer value (4 bytes)",
+	" ", "o", "0x%%08o octal value (4 byte)",
+	" ", "p", "Pointer reference (2, 4 or 8 bytes)",
+	" ", "q", "quadword (8 bytes)",
+	" ", "r", "CPU register `pf r (eax)plop`",
+	" ", "s", "32bit pointer to string (4 bytes)",
+	" ", "S", "64bit pointer to string (8 bytes)",
+	" ", "t", "UNIX timestamp (4 bytes)",
+	" ", "T", "Show ten first bytes of buffer",
+	" ", "u", "uleb128 (variable length)",
+	" ", "w", "word (2 bytes unsigned short in hex)",
+	" ", "x", "0x%%08x hex value and flag (fd @ addr)",
+	" ", "X", "Show formatted hexpairs",
+	" ", "z", "\\0 terminated string",
+	" ", "Z", "\\0 terminated wide string",
+	" ", "?", "Data structure `pf ? (struct_name)example_name`",
+	" ", "*", "Next char is pointer (honors asm.bits)",
+	" ", "+", "Toggle show flags for each offset",
+	" ", ":", "Skip 4 bytes",
+	" ", ".", "Skip 1 byte",
+	NULL
+};
+
+const char *help_msg_pfqueque[] = {
+	"Usage: pf[.k[.f[=v]]|[v]]|[n]|[0]", "[[size] fmt] [a0 a1 ...]", "",
+	"Examples:","","",
+	"pf", " B (BitFldType)arg_name`", "bitfield type",
+	"pf", " E (EnumType)arg_name`", "enum type",
+	"pf.", "obj xxdz prev next size name", "Define the obj format as xxdz",
+	"pf",  " obj=xxdz prev next size name", "Same as above",
+	"pf", " iwq foo bar troll", "Print the iwq format with foo, bar, troll as the respective names for the fields",
+	"pf", " 0iwq foo bar troll", "Same as above, but considered as a union (all fields at offset 0)",
+	"pf.", "plop ? (troll)mystruct", "Use structure troll previously defined",
+	"pf", " 10xiz pointer length string", "Print a size 10 array of the xiz struct with its field names",
+	"pf", " {integer}bifc", "Print integer times the following format (bifc)",
+	"pf", " [4]w[7]i", "Print an array of 4 words and then an array of 7 integers",
+	NULL
+};
+
+const char *help_msg_pfquequeque[] = {
+	"    STAHP IT!!!", "", "",
+	NULL
+};
+
+const char *help_msg_pi[] = {
+	"Usage: pi[defj]", "[num]", "",
+	NULL
+};
+
+const char *help_msg_pI[] = {
+	"Usage: p[iI][df]", "[N]", "Print N instructions/bytes (f=func) see pi and pdi",
+	NULL
+};
+
+const char *help_msg_pk[] = {
+	"Usage: pk", "[N]", "Print key in randomart",
+	NULL
+};
+
+const char *help_msg_pK[] = {
+	"Usage: pK", "[N]", "Print key in randomart mosaic",
+	NULL
+};
+
+const char *help_msg_pm[] = {
+	"Usage: pm", "[file|directory]", "",
+	" r_magic will use given file/dir as reference", "", "",
+	" output of those magic can contain expressions like:", "", "",
+	"   foo@0x40", "", "Use 'foo' magic file on address 0x40",
+	"   @0x40", "", "Use current magic file on address 0x40",
+	"   \\n", "", "Append newline",
+	" e dir.magic", "", "defaults to "R_MAGIC_PATH"",
+	" /m", "", "Search for magic signatures",
+	NULL
+};
+
+const char* help_msg_pr[] = {
+	"Usage: pr[glx]", " [size]", "",
+	"prl", "", "Print raw with lines offsets",
+	"prx", "", "Printable chars with real offset (hyew)",
+	"prg", "", "Print raw GUNZIPped block",
+	"prz", "", "Print raw zero-terminated string",
+	NULL
+};
+
+const char* help_msg_prg[] = {
+	"Usage: prg[io]", "", "",
+	"prg", "", "Print gunzipped data of current block",
+	"prgi", "", "Show consumed bytes when inflating",
+	"prgo", "", "Show output bytes after inflating",
+	NULL
+};
+
+const char* help_msg_ps[] = {
+	"Usage: ps[zpw]", " [N]", "Print string",
+	"ps", "", "Print string",
+	"psi", "", "Print string inside curseek",
+	"psb", "", "Print strings in current block",
+	"psx", "", "Show string with scaped chars",
+	"psz", "", "Print zero terminated string",
+	"psp", "", "Print pascal string",
+	"psu", "", "Print utf16 unicode (json)",
+	"psw", "", "Print wide string",
+	"psj", "", "Print string in JSON format",
+	NULL
+};
+
+const char* help_msg_pt[] = {
+	"Usage: pt[dn]", "", "Print timestamps",
+	"pt", "", "Print unix time (32 bit `cfg.bigendian`)",
+	"ptd","", "Print dos time (32 bit `cfg.bigendian`)",
+	"ptn","", "Print ntfs time (64 bit `cfg.bigendian`)",
+	NULL
+};
+
+const char *help_msg_pu[] = {
+	"Usage: pu[w]", "[N]", "Print N url encoded bytes (w=wide)",
+	NULL
+};
+
+const char *help_msg_pv[] = {
+	 "Usage: pv[j][1,2,4,8,z]", "", "",
+	 "pv", "",  "Print bytes based on asm.bits",
+	 "pv1", "", "Print 1 byte in memory",
+	 "pv2", "", "Print 2 bytes in memory",
+	 "pv4", "", "Print 4 bytes in memory",
+	 "pv8", "", "Print 8 bytes in memory",
+	 "pvz", "", "Print value as string (alias for ps)",
+	 NULL
+};
+
+const char* help_msg_px[] = {
+	"Usage: px[afoswqWqQ][f]", "", "Print hexadecimal",
+	"px",  "", "Show hexdump",
+	"px/", "", "Same as x/ in gdb (help x)",
+	"pxa", "", "Show annotated hexdump",
+	"pxA", "", "Show op analysis color map",
+	"pxb", "", "Dump bits in hexdump form",
+	"pxd", "[124]", "Signed integer dump (1 byte, 2 and 4)",
+	"pxe", "", "Emoji hexdump! :)",
+	"pxi", "", "HexII compact binary representation",
+	"pxf", "", "Show hexdump of current function",
+	"pxh", "", "Show hexadecimal half-words dump (16bit)",
+	"pxH", "", "Same as above, but one per line",
+	"pxl", "", "Display N lines (rows) of hexdump",
+	"pxo", "", "Show octal dump",
+	"pxq", "", "Show hexadecimal quad-words dump (64bit)",
+	"pxQ", "", "Same as above, but one per line",
+	"pxr", "[j]", "Show words with references to flags and code",
+	"pxs", "", "Show hexadecimal in sparse mode",
+	"pxt", "[*.] [origin]", "Show delta pointer table in r2 commands",
+	"pxw", "", "Show hexadecimal words dump (32bit)",
+	"pxW", "", "Same as above, but one per line",
+	NULL
+};
+
+const char *help_msg_pxA[] = {
+	"Usage: pxA", "[N]", "Print op analysis colormap",
+	"Legend:", "", "",
+	" mv", "", "move,lea,li",
+	" ->", "", "push",
+	" <-", "", "pop",
+	" io", "", "in/out ops",
+	" $$", "", "int/swi/trap/new",
+	" ..", "", "nop",
+	" +-*/", "", "math ops",
+	" |&^", "", "bin ops",
+	" <<>>", "", "shift ops",
+	" _J", "", "jump",
+	" cJ", "", "conditional jump",
+	" _C", "", "call",
+	" _R", "", "ret",
+	" ==", "", "cmp/test",
+	" XX", "", "invalid",
+    NULL
+};
+
+const char *help_msg_pxt[] = {
+	"Usage: pxt[.*]", "", "Print delta pointer table",
+	NULL
+};
+
+const char *help_msg_pz[] = {
+	"Usage: pz", "[N]", "Print zoomed blocks (filesize/N)",
+	"e ","zoom.maxsz","Max size of block",
+	"e ","zoom.from","Start address",
+	"e ","zoom.to","End address",
+	"e ","zoom.byte","Specify how to calculate each byte",
+	"pzp","","Number of printable chars",
+	"pzf","","Count of flags in block",
+	"pzs","","Strings in range",
+	"pz0","","Number of bytes with value '0'",
+	"pzF","","Number of bytes with value 0xFF",
+	"pze","","Calculate entropy and expand to 0-255 range",
+	"pzh","","Head (first byte value); This is the default mode",
+	//"WARNING: On big files, use 'zoom.byte=h' or restrict ranges\n");
+	NULL
+};
+
+const char *help_msg_pequals[] = {
+	"Usage: p=[bep?][qj]", "[num-of-blocks] ([len]) ([block-offset]) ", "Show entropy/printable chars/chars bars",
+	"p=", "", "Print bytes of current block in bars",
+	"p=", "b", "Same as above",
+	"p=", "d", "Print different bytes from block",
+	"p=", "e", "Print entropy for each filesize/blocksize",
+	"p=", "p", "Print number of printable bytes for each filesize/blocksize",
+	NULL
+};
+
+const char *help_msg_pminus[] = {
+	"Usage: p-[jh]", "[pieces]", "Bar|JSON|histogram blocks",
+	"p-", "", "Show ascii-art bar of metadata in file boundaries",
+	"p-j", "", "Show JSON format",
+	"p-h", "", "Show histogram analysis of metadata per block",
+	NULL
+};
+
+// CMD_PROJECT
+const char* help_msg_P[] = {
+	"Usage: P[?osi]", "[file]", "Project management",
+	"Pc", " [file]", "Show project script to console",
+	"Pd", " [file]", "Delete project",
+	"Pi", " [file]", "Show project information",
+	"Pl", "", "List all projects",
+	"Pn", "[j]", "Show project notes (Pnj for json)",
+	"Pn", " [base64]", "Set notes text",
+	"Pn", " -", "Edit notes with cfg.editor",
+	"Po", " [file]", "Open project",
+	"Ps", " [file]", "Save project",
+	"PS", " [file]", "Save script file",
+	"NOTE:", "", "See 'e file.project'",
+	"NOTE:", "", "Project files are stored in ~/.config/radare2/projects",
+	NULL
+};
+
+const char *help_msg_Pc[] = {
+	"Usage: Pc", "[prjname]", "",
+	NULL
+};
+
+const char *help_msg_PS[] = {
+	"Usage: PS", "[file]", "",
+	NULL
+};
+
+const char* help_msg_Pn[] = {
+	"Usage: Pn[j-?]", "[...]", "Project notes",
+	"Pn", "", "Show project notes",
+	"Pn", " -", "Edit notes with cfg.editor",
+	"Pn-", "", "Delete notes",
+	"Pn-", "str", "Delete lines matching /str/ in notes",
+	"Pnj", "", "Show notes in base64",
+	"Pnj", " [base64]", "Set notes in base64",
+	NULL
+};
+
+const char *help_msg_Pnj[] = {
+	"Usage: Pnj", "[base64]", "Show or save notes in base64",
+	NULL
+};
+
+// CMD_QUIT
+
+const char *help_msg_q[] = {
+	"Usage: q[!][!]",  "[retval]", "Quit commands",
+	"q","","Quit program",
+	"q!","","Force quit (no questions)",
+	"q!!","","Force quit without saving history",
+	"q"," 1","Quit with return value 1",
+	"q"," a-b","Quit with return value a-b",
+	"q[y/n][y/n]","","Quit, auto-yes to kill process, auto-yes to save project ",
+	NULL
+};
+
+// CMD_SEARCH
+const char* help_msg_slash[] = {
+	"Usage: /[amx/]", "[arg]", "Search commands (see 'e??search' for options)",
+	"/"," foo\\x00", "Search for string 'foo\\0'",
+	"/j"," foo\\x00", "Search for string 'foo\\0' (json output)",
+	"/!", " ff", "Search for first occurrence not matching",
+	"/+", " /bin/sh", "Construct the string with chunks",
+	"/!x", " 00", "Inverse hexa search (find first byte != 0x00)",
+	"//", "", "Repeat last search",
+	"/h", "[t] [hash] [len]", "Find block matching this hash. See /#?",
+	"/a", " jmp eax", "Assemble opcode and search its bytes",
+	"/A", " jmp", "Find analyzed instructions of this type (/A? for help)",
+	"/b", "", "Search backwards",
+	"/B", "", "Search recognized RBin headers",
+	"/c", " jmp [esp]", "Search for asm code",
+	"/C", "[ar]", "Search for crypto materials",
+	"/d", " 101112", "Search for a deltified sequence of bytes",
+	"/e", " /E.F/i", "Match regular expression",
+	"/E", " esil-expr", "Offset matching given esil expressions %%= here ",
+	"/i", " foo", "Search for string 'foo' ignoring case",
+	"/m", " magicfile", "Search for matching magic file (use blocksize)",
+	"/p", " patternsize", "Search for pattern of given size",
+	"/P", "", "Show offset of previous instruction",
+	"/r", " sym.printf", "Analyze opcode reference an offset",
+	"/R", " [grepopcode]", "Search for matching ROP gadgets, semicolon-separated",
+	"/v", "[1248] value", "Look for an `asm.bigendian` 32bit value",
+	"/V", "[1248] min max", "Look for an `asm.bigendian` 32bit value in range",
+	"/w", " foo", "Search for wide string 'f\\0o\\0o\\0'",
+	"/wi", " foo", "Search for wide string ignoring case 'f\\0o\\0o\\0'",
+	"/x"," ff..33", "Search for hex string ignoring some nibbles",
+	"/x"," ff0033", "Search for hex string",
+	"/x"," ff43 ffd0", "Search for hexpair with mask",
+	"/z"," min max", "Search for strings of given size",
+#if 0
+	"\nConfiguration:", "", " (type `e??search.` for a complete list)",
+	"e", " cmd.hit = x", "command to execute on every search hit",
+	"e", " search.in = ?", "specify where to search stuff (depends on .from/.to)",
+	"e", " search.align = 4", "only catch aligned search hits",
+	"e", " search.from = 0", "start address",
+	"e", " search.to = 0", "end address",
+	"e", " search.flags = true", "if enabled store flags on keyword hits",
+#endif
+	NULL
+};
+
+const char *help_msg_slashb[] = {
+	"Usage: /b[command]", "[value]", "Backward search, see '/?'",
+	NULL
+};
+
+const char* help_msg_slashc[] = {
+	"Usage: /c", "[instr]", "Search for asm",
+	"/c ", "instr", "Search for instruction 'instr'",
+	"/c/ ", "instr", "Search for instruction that matches regexp 'instr'",
+	"/c ", "instr1;instr2", "Search for instruction 'instr1' followed by 'instr2'",
+	"/c/ ", "instr1;instr2", "Search for regex instruction 'instr1' followed by regex 'instr2'",
+	"/cj ", "instr", "JSON output",
+	"/c/j ", "instr", "Regex search with JSON output",
+	"/c* ", "instr", "r2 command output",
+	NULL
+};
+
+const char *help_msg_slashC[] = {
+	"Usage: /C", "", "Search for crypto materials",
+	"/Ca", "" , "Search for AES keys",
+	"/Cr", "", "Search for private RSA keys",
+	NULL
+};
+
+const char *help_msg_slashR[] = {
+	"Usage: /R", "", "Search for ROP gadgets",
+	"/R", " [filter-by-string]" , "Show gadgets",
+	"/R/", " [filter-by-regexp]" , "Show gadgets [regular expression]",
+	"/Rl", " [filter-by-string]" , "Show gadgets in a linear manner",
+	"/R/l", " [filter-by-regexp]" , "Show gadgets in a linear manner [regular expression]",
+	"/Rj", " [filter-by-string]", "JSON output",
+	"/R/j", " [filter-by-regexp]", "JSON output [regular expression]",
+	NULL
+};
+
+const char* help_msg_slashx[] = {
+	"Usage: /x", "[hexpairs]:[binmask]", "Search in memory",
+	"/x ", "9090cd80", "search for those bytes",
+	"/x ", "9090cd80:ffff7ff0", "search with binary mask",
+	NULL
+};
+
+// CMD_SECTION
+
+const char* help_msg_S[] = {
+	"Usage: S[?-.*=adlr]","[...]","Section-related commands",
+	"S","","List sections",
+	"S.","","Show current section name",
+	"S*","","List sections (in radare commands)",
+	"S=","","List sections (ascii-art bars) (io.va to display paddr or vaddr)",
+	"Sa","[-] [A] [B] [[off]]","Specify arch and bits for given section",
+	"Sd[a]"," [file]","Dump current (all) section to a file (see dmd)",
+	"Sl"," [file]","Load contents of file into current section (see dml)",
+	"Sj","","List sections in JSON (alias for iSj)",
+	"Sr"," [name]","Rename section on current seek",
+	"S"," off va sz vsz name mrwx","Add new section (if(!vsz)vsz=sz)",
+	"S-","[id|0xoff|*]","Remove this section definition",
+	NULL
+};
+
+// CMD_SEEK
+
+const char *help_msg_s[] = {
+	"Usage: s", "", "Seek commands",
+	"s", "", "Print current address",
+	"s", " addr", "Seek to address",
+	"s-", "", "Undo seek",
+	"s-", " n", "Seek n bytes backward",
+	"s--", "", "Seek blocksize bytes backward",
+	"s+", "", "Redo seek",
+	"s+", " n", "Seek n bytes forward",
+	"s++", "", "Seek blocksize bytes forward",
+	"s[j*=]", "", "List undo seek history (JSON, =list, *r2)",
+	"s/", " DATA", "Search for next occurrence of 'DATA'",
+	"s/x", " 9091", "Search for next occurrence of \\x90\\x91",
+	"s.", "hexoff", "Seek honoring a base from core->offset",
+	"sa", " [[+-]a] [asz]", "Seek asz (or bsize) aligned to addr",
+	"sb", "", "Seek aligned to bb start",
+	"sC", " string", "Seek to comment matching given string",
+	"sf", "", "Seek to next function (f->addr+f->size)",
+	"sf", " function", "Seek to address of specified function",
+	"sg/sG", "", "Seek begin (sg) or end (sG) of section or file",
+	"sl", "[+-]line", "Seek to line",
+	"sn/sp", "", "Seek next/prev scr.nkey",
+	"so", " [N]", "Seek to N next opcode(s)",
+	"sr", " pc", "Seek to register",
+	//"sp [page]  seek page N (page = block)",
+	NULL
+};
+
+const char *help_msg_sC[] = {
+	"Usage: sC[?*]", "", "Comment grep",
+	"sC*", "", "List all comments",
+	"sC", " [const]", "Seek to comment matching [const]",
+	NULL
+};
+const char *help_msg_sl[] = {
+	"Usage: sl[c+-]", "", "",
+	"sl", " [line]", "Seek to absolute line",
+	"sl", "[+-][line]", "Seek to relative line",
+	"slc", "", "Clear line cache",
+	"sll", "", "Show total number of lines",
+	NULL
+};
+
+// CMD_TYPE
+
+const char *help_msg_t[] = {
+	"Usage: t", "", "cparse types commands",
+	"t", "", "List all loaded types",
+	"t", " [type]", "Show type in 'pf' syntax",
+	"t*", "", "List types info in r2 commands",
+	"t-", " [name]", "Delete types by its name",
+	"t-*", "", "Remove all types",
+	//"t-!", "",          "Use to open $EDITOR",
+	"tb", " [enum] [val]", "Show matching enum bitfield for given number",
+	"te", "", "List all loaded enums",
+	"te", " [enum] [val]", "Show name for given enum number",
+	"td", " [string]", "Load types from string",
+	"tf", "", "List all loaded functions signatures",
+	"tk", " [sdb-query]", "Perform sdb query",
+	"tl", "[?]", "Show/Link type to an address",
+	//"to",  "",         "List opened files",
+	"to", " -", "Open cfg.editor to load types",
+	"to", " [path]", "Load types from C header file",
+	"tp", " [type]  = [address]", "cast data at [adress] to [type] and print it",
+	"ts", "", "print loaded struct types",
+	"tu", "", "print loaded union types",
+	//"| ts k=v k=v @ link.addr set fields at given linked type\n"
+	NULL
+};
+
+const char *help_msg_td[] = {
+	"Usage: \"td", "[...]\"", "",
+	"td", "[string]", "Load types from string",
+	"NOTE: The td command should be put between double quotes", "", "",
+	"Example: \" td struct foo {int bar; int cow};\"", "", "",
+	NULL
+};
+
+const char *help_msg_te[] = {
+	"USAGE te[...]", "", "",
+	"te", "", "List all loaded enums",
+	"te", " [enum] [val]", "Show name for given enum number",
+	"te?", "", "Show this help",
+	NULL
+};
+
+const char *help_msg_tl[] = {
+	"Usage: tl[s-*?]", "", "",
+	"tl", "", "List all links in readable format",
+	"tl", "[typename]", "Link a type to current adress.",
+	"tl", "[typename] = [address]", "Link type to given address.",
+	"tls", "[address]", "Show link at given address",
+	"tl-*", "", "Delete all links.",
+	"tl-", "[address]", "Delete link at given address.",
+	"tl*", "", "List all links in radare2 command format",
+	"tl?", "", "Print this help.",
+	NULL
+};
+
+const char *help_msg_ts[] = {
+	"Usage: ts[?]", "", "",
+	"ts", "", "List all loaded structs",
+	"ts?", "", "Show this help",
+	NULL
+};
+
+const char *help_msg_tu[] = {
+	"Usage: tu[?]", "", "",
+	"tu", "", "List all loaded unions",
+	"tu?", "", "Show this help",
+	NULL
+};
+
+const char *help_msg_tminus[] = {
+	"Usage: t-", "[type]", "Delete type by its name",
+	NULL
+};
+// CMD_WRITE
+
+const char* help_msg_w[] = {
+	"Usage: w[x]", "[str] [<file] [<<EOF] [@addr]","",
+	"w","[1248][+-][n]","Increment/decrement byte,word..",
+	"w"," foobar","Write string 'foobar'",
+	"w0"," [len]","Write 'len' bytes with value 0x00",
+	"w6","[de] base64/hex","Write base64 [d]ecoded or [e]ncoded string",
+	"wa"," push ebp","Write opcode, separated by ';' (use '\"' around the command)",
+	"waf"," file","Assemble file and write bytes",
+	"wao"," op","Modify opcode (change conditional of jump. nop, etc)",
+	"wA"," r 0","Alter/modify opcode at current seek (see wA?)",
+	"wb"," 010203","Fill current block with cyclic hexpairs",
+	"wB","[-]0xVALUE","Set or unset bits with given value",
+	"wc","","List all write changes",
+	"wc","[ir*?]","Write cache undo/commit/reset/list (io.cache)",
+	"wd"," [off] [n]","Duplicate N bytes from offset at current seek (memcpy) (see y?)",
+	"we","[nNsxX] [arg]","Extend write operations (insert instead of replace)",
+	"wf"," -|file","Write contents of file at current offset",
+	"wh"," r2","Whereis/which shell command",
+	"wm"," f0ff","Set binary mask hexpair to be used as cyclic write mask",
+	"wo?"," hex","Write in block with operation. 'wo?' fmi",
+	"wp"," -|file","Apply radare patch file. See wp? fmi",
+	"wr"," 10","Write 10 random bytes",
+	"ws"," pstring","Write 1 byte for length and then the string",
+	"wt"," file [sz]","Write to file (from current seek, blocksize or sz bytes)",
+	"ww"," foobar","Write wide string 'f\\x00o\\x00o\\x00b\\x00a\\x00r\\x00'",
+	"wx[fs]"," 9090","Write two intel nops (from wxfile or wxseek)",
+	"wv"," eip+34","Write 32-64 bit value",
+	"wz"," string","Write zero terminated string (like w + \\x00)",
+	NULL
+};
+
+const char* help_msg_wa[] = {
+	"Usage: Wa[of*]", "[arg]", "",
+	"wa", " nop", "Write nopcode using asm.arch and asm.bits",
+	"wa*", " mov eax, 33", "Show 'wx' op with hexpair bytes of assembled opcode",
+	"\"wa nop;nop\"", "" , "Assemble more than one instruction (note the quotes)",
+	"waf", "foo.asm" , "Assemble file and write bytes",
+	"wao?", "", "Show help for assembler operation on current opcode (hack)",
+	NULL
+};
+
+const char* help_msg_wA[] = {
+	"Usage: wA", "[type] [value]", "",
+	"Types:", "", "",
+	"r", "", "Raw write value",
+	"v", "", "Set value (taking care of current address)",
+	"d", "", "Destination register",
+	"0", "", "1st src register",
+	"1", "", "2nd src register",
+	"Example:",  "wA r 0", "# e800000000",
+	NULL
+};
+
+const char* help_msg_wc[] = {
+	"Usage: wc[ir+-*?]", "", "Write cache; NOTE: Uses io.cache=true",
+	"wc","","List all write changes",
+	"wc-"," [from] [to]","Remove write op at curseek or given addr",
+	"wc+"," [addr]","Commit change from cache to io",
+	"wc*","","\"\" in radare commands",
+	"wcr","","Reset all write changes in cache",
+	"wci","","Commit write cache",
+	NULL
+};
+
+const char *help_msg_wd[] = {
+	"Usage: wd", "[src-offset] [length] @ [dest-offset]", "",
+	NULL
+};
+
+const char* help_msg_we[] = {
+	"Usage: we", "", "Write extend",
+	"wen", " [num]", "Insert num null bytes at current offset",
+	"wex", " [hex_bytes]", "Insert bytes at current offset",
+	"weN", " [addr] [len]", "Insert bytes at address",
+	"weX", " [addr] [hex]", "Insert bytes at address",
+	"wes", " [addr] [dist] [block_size]", "Shift a blocksize left or write in the editor",
+	NULL
+};
+
+const char* help_msg_wo[] = {
+	"Usage: wo[asmdxoArl24]","[hexpairs] @ addr[!bsize]","",
+	"wo[aAdlmorwx24]","", "Without hexpair values, clipboard is used",
+	"woa"," [val]", "+=  addition (f.ex: woa 0102)",
+	"woA"," [val]","&=  and",
+	"wod"," [val]", "/=  divide",
+	"woD","[algo] [key] [IV]","Decrypt current block with given algo and key",
+	"woe"," [from to] [step] [wsz=1]","Create increasing/decreasing sequence",
+	"woE"," [algo] [key] [IV]", "Encrypt current block with given algo and key",
+	"wol"," [val]", "<<= shift left",
+	"wom"," [val]", "*= multiply",
+	"woo"," [val]", "|= or",
+	"wop[DO]"," [arg]","De Bruijn Patterns",
+	"wor"," [val]", ">>= shift right",
+	"woR","","Random bytes (alias for 'wr $b')",
+	"wos"," [val]", "-= substraction",
+	"wow"," [val]", "== write looped value (alias for 'wb')",
+	"wox"," [val]", "^= xor  (f.ex: wox 0x90)",
+	"wo2"," [val]", "2= 2 byte endian swap",
+	"wo4"," [val]", "4= 4 byte endian swap",
+	NULL
+};
+
+const char* help_msg_wop[] = {
+	"Usage: wop[DO]", "[len] [@ addr | value]", "De Bruijin Pattern generation and offset",
+	"wopD"," [len] [@ addr]", "Write a De Bruijn Pattern of length 'len' at address 'addr'",
+	"wopO"," [value]", "Finds the given value into a De Bruijn Pattern at current offset",
+	NULL
+};
+
+// TODO rapatch format documentation
+const char* help_msg_wp[] = {
+	"Usage: wp", "[-|rapatch-file]", "",
+	NULL
+};
+
+const char* help_msg_wt[] = {
+	"Usage: wt[a]", "file [size]", "Write 'size' bytes in current block to file",
+	NULL
+};
+
+const char* help_msg_wv[] = {
+	"Usage: wv[size]", "[val]", "Write value of given size",
+	"wv1", " 234", "Write one byte with this value",
+	"wv", " 0x834002", "Write dword with this value",
+	"Supported sizes are:", "1, 2, 4, 8", "",
+	NULL
+};
+
+const char* help_msg_wx[] = {
+	"Usage: wx[f]", "[hex]", "",
+	"wx", " 9090", "Write two intel nops",
+	"wxf", " -|file", "Write contents of hexpairs file here",
+	"wxs", " 9090", "Write hexpairs and seek at the end",
+	NULL
+};
+
+// CMD_ZIGN
+const char* help_msg_z[] = {
+	"Usage: z[abcp/*-]", "[arg]", "Zignatures commands",
+	"z", "", "Show status of zignatures",
+	"z*", "", "Display all zignatures",
+	"z-", " namespace", "Unload zignatures in namespace",
+	"z-*", "", "Unload all zignatures",
+	"z/", " [ini] [end]", "Search zignatures between these regions",
+	"za", " ...", "Define new zignature for analysis",
+	"zb", " name bytes", "Define zignature for bytes",
+	"zB", " size", "Generate zignatures for current offset/flag",
+	"zc", " @ fcn.foo", "Flag signature if matching (.zc@@fcn)",
+	"zf", " name fmt", "Define function zignature (fast/slow, args, types)",
+	"zF", " file", "Open a FLIRT signature file and scan opened file",
+	"zFd", " file", "Dump a FLIRT signature",
+	"zg", " namespace [file]", "Generate zignatures for current file",
+	"zh", " name bytes", "Define function header zignature",
+	"zn", " namespace", "Define namespace for following zignatures (until zn-)",
+	"zn", "", "Display current namespace",
+	"zn-", "", "Unset namespace",
+	"zp", " name bytes", "Define new zignature for function body",
+	"NOTE:", "", "bytes can contain '.' (dots) to specify a binary mask",
+	NULL
+};
+
 /* Prints a coloured help message.
  * help should be an array of the following form:
  * {"command", "args", "description",

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -28,6 +28,7 @@
 #include "r_util.h"
 #include "r_crypto.h"
 #include "r_bind.h"
+#include "r_help.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/libr/include/r_help.h
+++ b/libr/include/r_help.h
@@ -1,0 +1,250 @@
+#ifndef R2_HELP_H
+#define R2_HELP_H
+
+// CMD_ANAL
+extern const char *help_msg_u[];
+extern const char *help_msg_ad[];
+extern const char *help_msg_a[];
+extern const char *help_msg_aa[];
+extern const char *help_msg_aar[];
+extern const char *help_msg_at[];
+extern const char *help_msg_ate[];
+extern const char *help_msg_ae[];
+extern const char *help_msg_alias[];
+extern const char *help_msg_remotecmd_alias[];
+extern const char *help_msg_yank[];
+extern const char *help_msg_dot[];
+extern const char *help_msg_k[];
+extern const char *help_msg_b[];
+extern const char *help_msg_r[];
+extern const char *help_msg_ampersand[];
+extern const char *help_msg_star[];
+extern const char *help_msg_3at[];
+extern const char *help_msg_2at[];
+extern const char *help_msg_arf[];
+extern const char *help_msg_af[];
+extern const char *help_msg_ar[];
+extern const char *help_msg_ara[];
+extern const char *help_msg_arw[];
+extern const char *help_msg_aea[];
+extern const char *help_msg_aec[];
+extern const char *help_msg_aep[];
+extern const char *help_msg_afvs[];
+extern const char *help_msg_afvb[];
+extern const char *help_msg_afvr[];
+extern const char *help_msg_afv[];
+extern const char *help_msg_afi[];
+extern const char *help_msg_afl[];
+extern const char *help_afC[];
+extern const char *help_msg_afb[];
+extern const char *help_msg_afn[];
+extern const char *help_msg_afx[];
+extern const char *help_msg_esil[];
+extern const char *help_msg_an[];
+extern const char *help_msg_ao[];
+extern const char *help_msg_as[];
+extern const char *help_msg_ah[];
+extern const char *help_msg_ahi[];
+extern const char *help_msg_ax[];
+extern const char *help_msg_ag[];
+extern const char *help_msg_agn[];
+extern const char *help_msg_age[];
+extern const char *help_msg_agg[];
+
+// CMD_CMP
+extern const char *help_msg_c[];
+extern const char *help_msg_cw[];
+extern const char *help_msg_cg[];
+extern const char *help_msg_cu[];
+extern const char *help_msg_cv[];
+
+// CMD_DBG
+extern const char *help_msg_d[];
+extern const char *help_msg_db[];
+extern const char *help_msg_dc[];
+extern const char *help_msg_dcs[];
+extern const char *help_msg_dd[];
+extern const char *help_msg_de[];
+extern const char *help_msg_des[];
+extern const char *help_msg_di[];
+extern const char *help_msg_dk[];
+extern const char *help_msg_dko[];
+extern const char *help_msg_dm[];
+extern const char *help_msg_dmh[];
+extern const char *help_msg_dmm[];
+extern const char *help_msg_dms[];
+extern const char *help_msg_do[];
+extern const char *help_msg_dp[];
+extern const char *help_msg_dr[];
+extern const char *help_msg_drf[];
+extern const char *help_msg_drm[];
+extern const char *help_msg_drp[];
+extern const char *help_msg_drs[];
+extern const char *help_msg_drt[];
+extern const char *help_msg_drx[];
+extern const char *help_msg_ds[];
+extern const char *help_msg_dt[];
+extern const char *help_msg_dtc[];
+extern const char *help_msg_dx[];
+
+// CMD_EGG
+extern const char *help_msg_g[];
+
+// CMD_EVAL
+extern const char *help_msg_e[];
+extern const char *help_msg_ec[];
+extern const char *help_msg_et[];
+
+// CMD_FLAG
+extern const char *help_msg_f[];
+extern const char *help_msg_fb[];
+extern const char *help_msg_fc[];
+extern const char *help_msg_fC[];
+extern const char *help_msg_fd[];
+extern const char *help_msg_fe[];
+extern const char *help_msg_fequals[];
+extern const char *help_msg_fR[];
+extern const char *help_msg_fs[];
+extern const char *help_msg_fV[];
+
+// CMD_HASH
+extern const char *help_msg_hash[];
+
+// CMD_HELP
+extern const char *help_msg_colon[];
+extern const char *help_msg_quev[];
+extern const char *help_msg_at_general[];
+extern const char *help_msg_dollar_sign[];
+extern const char *help_msg_queV[];
+extern const char *help_msg_queque[];
+extern const char *help_msg_que[];
+
+// CMD INFO
+extern const char *help_msg_i[];
+
+// CMD_LOG
+extern const char *help_msg_T[];
+extern const char *help_msg_Tp[];
+
+// CMD_MACRO
+extern const char *help_msg_paren[];
+
+// CMD_META
+extern const char *help_msg_C[];
+extern const char *help_msg_CC[];
+extern const char *help_msg_CS[];
+extern const char *help_msg_Cvb[];
+extern const char *help_msg_Cvs[];
+extern const char *help_msg_Cvr[];
+
+// CMD_MOUNT
+extern const char *help_msg_m[];
+extern const char *help_msg_mf[];
+
+// CMD_OPEN
+extern const char *help_msg_o[];
+extern const char *help_msg_oa[];
+extern const char *help_msg_ob[];
+extern const char *help_msg_oc[];
+extern const char *help_msg_oj[];
+extern const char *help_msg_om[];
+extern const char *help_msg_oo[];
+extern const char *help_msg_oob[];
+extern const char *help_msg_ood[];
+extern const char *help_msg_oon[];
+extern const char *help_msg_oonn[];
+extern const char *help_msg_ostar[];
+extern const char *help_msg_ooplus[];
+
+// CMD_PRINT
+extern const char *help_msg_p[];
+extern const char *help_msg_p2[];
+extern const char *help_msg_p3[];
+extern const char *help_msg_p6d[];
+extern const char *help_msg_p6e[];
+extern const char *help_msg_p6ed[];
+extern const char *help_msg_p8[];
+extern const char *help_msg_pad[];
+extern const char *help_msg_pae[];
+extern const char *help_msg_paed[];
+extern const char *help_msg_paD[];
+extern const char *help_msg_pb[];
+extern const char *help_msg_pB[];
+extern const char *help_msg_pd[];
+extern const char *help_msg_pdfs[];
+extern const char *help_msg_pds[];
+extern const char *help_msg_pf[];
+extern const char *help_msg_pfque[];
+extern const char *help_msg_pfqueque[];
+extern const char *help_msg_pfquequeque[];
+extern const char *help_msg_pi[];
+extern const char *help_msg_pI[];
+extern const char *help_msg_pk[];
+extern const char *help_msg_pK[];
+extern const char *help_msg_pm[];
+extern const char *help_msg_pr[];
+extern const char *help_msg_prg[];
+extern const char *help_msg_ps[];
+extern const char *help_msg_pt[];
+extern const char *help_msg_pu[];
+extern const char *help_msg_pv[];
+extern const char *help_msg_px[];
+extern const char *help_msg_pxA[];
+extern const char *help_msg_pxt[];
+extern const char *help_msg_pz[];
+extern const char *help_msg_pequals[];
+extern const char *help_msg_pminus[];
+
+// CMD_PROJECT
+extern const char *help_msg_P[];
+extern const char *help_msg_Pc[];
+extern const char *help_msg_PS[];
+extern const char *help_msg_Pn[];
+extern const char *help_msg_Pnj[];
+
+// CMD_QUIT
+extern const char *help_msg_q[];
+
+// CMD_SEARCH
+extern const char *help_msg_slash[];
+extern const char *help_msg_slashb[];
+extern const char *help_msg_slashc[];
+extern const char *help_msg_slashC[];
+extern const char *help_msg_slashR[];
+extern const char *help_msg_slashx[];
+
+// CMD_SECTION
+extern const char *help_msg_S[];
+
+// CMD_SEEK
+extern const char *help_msg_s[];
+extern const char *help_msg_sC[];
+extern const char *help_msg_sl[];
+
+// CMD_TYPE
+extern const char *help_msg_t[];
+extern const char *help_msg_td[];
+extern const char *help_msg_te[];
+extern const char *help_msg_tl[];
+extern const char *help_msg_ts[];
+extern const char *help_msg_tu[];
+extern const char *help_msg_tminus[];
+
+// CMD_WRITE
+extern const char *help_msg_w[];
+extern const char *help_msg_wa[];
+extern const char *help_msg_wA[];
+extern const char *help_msg_wc[];
+extern const char *help_msg_wd[];
+extern const char *help_msg_we[];
+extern const char *help_msg_wo[];
+extern const char *help_msg_wop[];
+extern const char *help_msg_wp[];
+extern const char *help_msg_wt[];
+extern const char *help_msg_wv[];
+extern const char *help_msg_wx[];
+
+// CMD_ZIGN
+extern const char *help_msg_z[];
+
+#endif


### PR DESCRIPTION
This PR changes two things about r2's self-documentation:
- Move everything out of cmd_*.c into help.c and r_help.h. Now the code should be cleaner and unobstructed by random blocks of string everywhere.
- Make the documentation consistent: use r_core_cmd_help everywhere (instead of eprintf and r_cons_printf), Capitalize descriptions, sort commands, use [N] instead of [sz], [size], [len], use square brackets everywhere etc.

Now that (almost) all docs are in one place, this is a good starting point towards Sdb-ization and/or using a Trie struct to handle the tree-like documentation (see https://github.com/radare/radare2/issues/4459).