### PR TITLE
adding nonull environment variable

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1906,10 +1906,11 @@ repeat:
 		int iotrap = r_config_get_i (core->config, "esil.iotrap");
 		int exectrap = r_config_get_i (core->config, "esil.exectrap");
 		int stacksize = r_config_get_i (core->config, "esil.stacksize");
+		int nonull = r_config_get_i (core->config, "esil.nonull");
 		if (!(core->anal->esil = r_anal_esil_new (stacksize, iotrap)))
 			return 0;
 		esil = core->anal->esil;
-		r_anal_esil_setup (esil, core->anal, romem, stats); // setup io
+		r_anal_esil_setup (esil, core->anal, romem, stats, nonull); // setup io
 		esil->exectrap = exectrap;
 		RList *entries = r_bin_get_entries (core->bin);
 		RBinAddr *entry = NULL;
@@ -2185,6 +2186,7 @@ static ut8 *regstate = NULL;
 
 static void esil_init (RCore *core) {
 	const char *pc = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
+	int nonull = r_config_get_i (core->config, "esil.nonull");
 	opc = r_reg_getv (core->anal->reg, pc);
 	if (!opc || opc==UT64_MAX) opc = core->offset;
 	if (!core->anal->esil) {
@@ -2194,7 +2196,7 @@ static void esil_init (RCore *core) {
 			R_FREE (regstate);
 			return;
 		}
-		r_anal_esil_setup (core->anal->esil, core->anal, 0, 0);
+		r_anal_esil_setup (core->anal->esil, core->anal, 0, 0, nonull);
 	}
 	free (regstate);
 	regstate = r_reg_arena_peek (core->anal->reg);
@@ -2403,6 +2405,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 	int iotrap = r_config_get_i (core->config, "esil.iotrap");
 	int romem = r_config_get_i (core->config, "esil.romem");
 	int stats = r_config_get_i (core->config, "esil.stats");
+	int nonull = r_config_get_i (core->config, "esil.nonull");
 	ut64 until_addr = UT64_MAX;
 	const char *until_expr = NULL;
 	RAnalOp *op;
@@ -2456,7 +2459,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			if (!(core->anal->esil = esil = r_anal_esil_new (stacksize, iotrap)))
 				return;
 		}
-		r_anal_esil_setup (esil, core->anal, romem, stats); // setup io
+		r_anal_esil_setup (esil, core->anal, romem, stats, nonull); // setup io
 		r_anal_esil_set_pc (esil, core->offset);
 		r_anal_esil_parse (esil, input + 1);
 		r_anal_esil_dumpstack (esil);
@@ -2586,7 +2589,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			}
 			if (!(esil = core->anal->esil = r_anal_esil_new (stacksize, iotrap)))
 				return;
-			r_anal_esil_setup (esil, core->anal, romem, stats); // setup io
+			r_anal_esil_setup (esil, core->anal, romem, stats, nonull); // setup io
 			esil->debug = (int)r_config_get_i (core->config, "esil.debug");
 			/* restore user settings for interrupt handling */
 			{
@@ -3884,10 +3887,11 @@ static void cmd_anal_trace(RCore *core, const char *input) {
 			int romem = r_config_get_i (core->config, "esil.romem");
 			int stats = r_config_get_i (core->config, "esil.stats");
 			int iotrap = r_config_get_i (core->config, "esil.iotrap");
+			int nonull = r_config_get_i (core->config, "esil.nonull");
 			if (!(core->anal->esil = r_anal_esil_new (stacksize, iotrap)))
 				return;
 			r_anal_esil_setup (core->anal->esil,
-					core->anal, romem, stats);
+					core->anal, romem, stats, nonull);
 		}
 		switch (input[1]) {
 		case 0:

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1381,6 +1381,7 @@ static void do_esil_search(RCore *core, struct search_parameters *param, const c
 		const int kwidx = r_config_get_i (core->config, "search.kwidx");
 		const int iotrap = r_config_get_i (core->config, "esil.iotrap");
 		const int stacksize = r_config_get_i (core->config, "esil.stacksize");
+		int nonull = r_config_get_i (core->config, "esil.nonull");
 		int hit_happens = 0;
 		int hit_combo = 0;
 		char *res;
@@ -1394,7 +1395,7 @@ static void do_esil_search(RCore *core, struct search_parameters *param, const c
 		core->anal->esil->cb.user = core;
 		r_anal_esil_set_op (core->anal->esil, "AddrInfo", esil_addrinfo);
 		/* hook addrinfo */
-		r_anal_esil_setup (core->anal->esil, core->anal, 1, 0);
+		r_anal_esil_setup (core->anal->esil, core->anal, 1, 0, nonull);
 		r_anal_esil_stack_free (core->anal->esil);
 		core->anal->esil->debug = 0;
 		for (; addr<param->to; addr++) {

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1807,6 +1807,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB("esil.iotrap", "true", &cb_iotrap, "invalid read or writes produce a trap exception");
 	SETPREF("esil.romem", "false", "Set memory as read-only for ESIL");
 	SETPREF("esil.stats", "false", "Statistics from ESIL emulation stored in sdb");
+	SETPREF("esil.nonull", "false", "Prevent memory read, memory write at null pointer");
 
 	/* scr */
 #if __EMSCRIPTEN__

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2606,7 +2606,7 @@ static void ds_print_esil_anal_init(RDisasmState *ds) {
 			R_FREE (ds->esil_regstate);
 			return;
 		}
-		r_anal_esil_setup (core->anal->esil, core->anal, 0, 0);
+		r_anal_esil_setup (core->anal->esil, core->anal, 0, 0, 1);
 	}
 	core->anal->esil->user = ds;
 	free (ds->esil_regstate);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1171,7 +1171,7 @@ R_API void r_anal_esil_trace (RAnalEsil *esil, RAnalOp *op);
 R_API void r_anal_esil_trace_list (RAnalEsil *esil);
 R_API void r_anal_esil_trace_show (RAnalEsil *esil, int idx);
 R_API bool r_anal_esil_set_pc (RAnalEsil *esil, ut64 addr);
-R_API int r_anal_esil_setup (RAnalEsil *esil, RAnal *anal, int romem, int stats);
+R_API int r_anal_esil_setup (RAnalEsil *esil, RAnal *anal, int romem, int stats, int nonull);
 R_API void r_anal_esil_free (RAnalEsil *esil);
 R_API int r_anal_esil_parse (RAnalEsil *esil, const char *str);
 R_API int r_anal_esil_dumpstack (RAnalEsil *esil);


### PR DESCRIPTION
This is supposed to help delaying PC divergence to null by preventing all null accesses in PC and memory
I am not sure if this will be enough. 