### PR TITLE
fixing aek-

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2639,6 +2639,9 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 				}
 			} else eprintf ("esil.stats is empty. Run 'aei'\n");
 			break;
+		case '-':
+			sdb_reset (esil->stats);
+			break;
 		}
 		break;
 	case 'f': // "aef"


### PR DESCRIPTION
according to `ae?`,  `aek-` is used to delete all esil->stats key/value pairs, but it wasn't actually implemented.
this is its implementation