### PR TITLE
Adding R2PM_GITDIR for easy packages local testing

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -49,7 +49,9 @@ R2PM_USRDIR="${HOME}/.config/radare2/r2pm/"
 R2PM_ETCD="${R2HOMEDIR}/radare2/radare2rc.d"
 
 # TODO. support system plugin installs R2PM_PLUGDIR="${R2PM_PREFIX}/lib/radare2/last"
-
+if [ -z "${R2PM_GITDIR}" ]; then
+	R2PM_GITDIR="${R2PM_USRDIR}/git/"
+fi
 if [ -z "${R2PM_DBDIR}" ]; then
 	if [ -d "${HOME}/.config/radare2/r2pm/db" ]; then
 		R2PM_DBDIR="${HOME}/.config/radare2/r2pm/db"
@@ -100,7 +102,7 @@ if [ ! -d "${R2PM_DBDIR}" ]; then
 fi
 
 mkdir -p "${R2PM_USRDIR}/pkg/"
-mkdir -p "${R2PM_USRDIR}/git/"
+mkdir -p "${R2PM_GITDIR}"
 mkdir -p "${R2PM_PLUGDIR}"
 
 R2PM_SYSPKG() {
@@ -143,8 +145,8 @@ R2PM_ListUninstalled() {
 R2PM_GIT() {
 	URL="$1"
 	DIR="`basename $1`"
-	cd "${R2PM_USRDIR}/git/"
-	if [ -d "${R2PM_USRDIR}/git/${DIR}" ]; then
+	cd "${R2PM_GITDIR}"
+	if [ -d "${R2PM_GITDIR}/${DIR}" ]; then
 		cd "${DIR}"
 		git pull
 	else
@@ -294,8 +296,8 @@ case "$1" in
 -c|clean)
 	R2PM_List radare2 | grep radare2
 	if [ $? != 0 ]; then
-		rm -rf "${R2PM_USRDIR}/git/"
-		mkdir -p "${R2PM_USRDIR}/git/"
+		rm -rf "${R2PM_GITDIR}"
+		mkdir -p "${R2PM_GITDIR}"
 	else
 		echo "r2 is installed with r2pm, do not clean the cache to avoid autodestruction"
 		echo "do not disassemble do not disassemble do not disassemble do not disassemble"

--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -47,10 +47,13 @@ TRAVIS_JOB=86948888
 IS_SYSPKG=0
 R2PM_USRDIR="${HOME}/.config/radare2/r2pm/"
 R2PM_ETCD="${R2HOMEDIR}/radare2/radare2rc.d"
+IS_LOCAL=0
 
 # TODO. support system plugin installs R2PM_PLUGDIR="${R2PM_PREFIX}/lib/radare2/last"
 if [ -z "${R2PM_GITDIR}" ]; then
 	R2PM_GITDIR="${R2PM_USRDIR}/git/"
+else
+	IS_LOCAL=1
 fi
 if [ -z "${R2PM_DBDIR}" ]; then
 	if [ -d "${HOME}/.config/radare2/r2pm/db" ]; then
@@ -146,13 +149,15 @@ R2PM_GIT() {
 	URL="$1"
 	DIR="`basename $1`"
 	cd "${R2PM_GITDIR}"
-	if [ -d "${R2PM_GITDIR}/${DIR}" ]; then
-		cd "${DIR}"
-		git pull
-	else
-		git clone "${URL}" || R2PM_FAIL "Oops"
-		cd "${DIR}" || R2PM_FAIL "Oops"
-	fi
+	if [ ${IS_LOCAL} = 0 ]; then
+	        if [ -d "${R2PM_GITDIR}/${DIR}" ]; then
+		        cd "${DIR}"
+		        git pull
+	        else
+		        git clone "${URL}" || R2PM_FAIL "Oops"
+		        cd "${DIR}" || R2PM_FAIL "Oops"
+	        fi
+    	fi
 }
 
 R2PM_FAIL() {


### PR DESCRIPTION
Usage:

export R2PM_DBDIR="/path/to/the/folder/with/package/description"
export R2PM_GITDIR="/path/to/the/root/folder/of/the/local/repository"
r2pm -i package