### PR TITLE
Implementing Function name guessing for type matching

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5,14 +5,14 @@
 static void type_cmd_help (RCore *core) {
 	const char *help_msg[] = {
 			"Usage:", "aftm", "",
-			"aftm", "", "type matching ana",
+			"aftm", "", "type matching analysis",
 			NULL
 	};
 	r_core_cmd_help (core, help_msg);
 }
 static void type_cmd(RCore *core, const char *input) {
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, -1);
-	if (!fcn) {
+	if (!fcn && *input != '?') {
 		eprintf ("cant find function here\n");
 	}
 	switch (*input) {

--- a/libr/core/tp.c
+++ b/libr/core/tp.c
@@ -15,11 +15,14 @@ static bool r_anal_emul_init (RCore *core) {
 	}
 	return true;
 }
-static void type_match (RCore *core, ut64 addr, const char *fcn_name) {
+static void type_match (RCore *core, ut64 addr, char *name) {
 	Sdb *trace = core->anal->esil->db_trace;
 	RAnal *anal = core->anal;
 	RAnalVar *v;
-	if (!r_anal_type_func_exist (anal, fcn_name)) {
+	char *fcn_name;
+	if (r_anal_type_func_exist (anal, name)) {
+		fcn_name = strdup (name);
+	} else if (!(fcn_name = r_anal_type_func_guess (anal, name))) {
 		eprintf ("can't find function prototype for %s\n",fcn_name);
 		return;
 	}
@@ -134,6 +137,7 @@ static void type_match (RCore *core, ut64 addr, const char *fcn_name) {
 		}
 		free (type);
 	}
+	free (fcn_name);
 }
 
 static int stack_clean (RCore *core, ut64 addr, RAnalFunction *fcn) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1124,7 +1124,8 @@ R_API int r_anal_type_func_exist(RAnal *anal, const char *func_name);
 R_API const char *r_anal_type_func_cc(RAnal *anal, const char *func_name);
 R_API int r_anal_type_func_args_count(RAnal *anal, const char *func_name);
 R_API char *r_anal_type_func_args_type(RAnal *anal, const char *func_name, int i);
- R_API char *r_anal_type_func_args_name(RAnal *anal, const char *func_name, int i);
+R_API char *r_anal_type_func_args_name(RAnal *anal, const char *func_name, int i);
+R_API char *r_anal_type_func_guess(RAnal *anal, char *func_name);
 /* anal.c */
 R_API RAnal *r_anal_new(void);
 R_API int r_anal_purge (RAnal *anal);


### PR DESCRIPTION
removing address from function names, the reason behind this is that type matching requires function names to be fixed (across all binaries) because functions are only identied there by their names. since adresses my change with will reuqire each binary have his own unique database of function definitions
fixing help