### PR TITLE
Add dll mfc90u to close issue 5486

### DIFF
--- a/libr/bin/d/Makefile
+++ b/libr/bin/d/Makefile
@@ -10,7 +10,7 @@ DLLS=ws2_32 oleaut32 wsock32 msi csmfpapi msvbvm60 kernel32
 DLLS+=aclui activeds atl borlndmm browseui comctl32 dsound
 DLLS+=mfc42 mfc42u mstlsapi msvbvm50 odbc32 olecli32 oledlg
 DLLS+=olepro32 olesvr32 shdocvw shell32 shlwapi uxtheme
-DLLS+=vb40032 vssapi winmm cabinet gsprop32 spr32d70
+DLLS+=vb40032 vssapi winmm cabinet gsprop32 spr32d70 mfc90u
 DLL_SDB=$(addsuffix .sdb,$(addprefix dll/,$(DLLS)))
 #-include $(OBJS:.o=.d)
 


### PR DESCRIPTION
This is an empty file because I (DanTheColoradan) was unable to
obtain any ordinal information. I tried two versions:

-  9.0.30729.1
-  9.0.30729.6161

Both were downloaded from dll-files.com. I also tried a version
from MS Windows 10, but I don't know what version it was. I'm
also on a mac and used winedump and redump. It's possible 
using dumpbin on Windows would get information, but I doubt it.

This change should close #5486.