### PR TITLE
Fixing coverity CIDs

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -76,7 +76,9 @@ R_API int r_anal_var_retype(RAnal *a, ut64 addr, int scope, int delta, char kind
 	if (!type) {
 		type = "int";
 	}
-
+	if (!a || !fcn) {
+		return false;
+	}
 	if (size == -1) {
 		RList *list = r_anal_var_list (a, fcn, kind);
 		RListIter *iter;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1614,11 +1614,7 @@ static void __anal_reg_list(RCore *core, int type, int size, char mode) {
 		}
 	}
 	r_debug_reg_list (core->dbg, type, bits, mode, use_color);
-	if (type != R_REG_TYPE_FLG && size == 1) {
-		r_debug_reg_list (core->dbg, R_REG_TYPE_FLG, bits, mode, use_color);
-	} else {
-		r_debug_reg_list (core->dbg, R_REG_TYPE_FLG, bits, mode, use_color);
-	}
+	r_debug_reg_list (core->dbg, R_REG_TYPE_FLG, bits, mode, use_color);
 	core->dbg->reg = hack;
 }
 

--- a/libr/core/tp.c
+++ b/libr/core/tp.c
@@ -145,6 +145,7 @@ static int stack_clean (RCore *core, ut64 addr, RAnalFunction *fcn) {
 	char *str = strdup (r_strbuf_get (&op->esil));
 	char *tmp = strchr (str, ',');
 	if (!tmp) {
+		free (str);
 		return 0;
 	}
 	*tmp++ = 0;
@@ -167,7 +168,7 @@ static int stack_clean (RCore *core, ut64 addr, RAnalFunction *fcn) {
 R_API void r_anal_type_match(RCore *core, RAnalFunction *fcn) {
 	const char *pc = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 	ut64 addr = fcn->addr;
-	if (!r_anal_emul_init (core)) {
+	if (!core || !r_anal_emul_init (core) || !fcn ) {
 		return;
 	}
 	RRegItem *pc_reg = r_reg_get (core->anal->reg, pc, -1);


### PR DESCRIPTION
fix CID 1361617
Resource leaks (RESOURCE_LEAK)
/libr/core/tp.c: 148 in stack_clean()
 Var iable "str" going out of scope leaks the storage it points to.

fix CID 1361612
Null pointer dereferences (NULL_RETURNS)
/libr/core/tp.c: 178 in r_anal_type_match()
Dereferencing a null pointer "op".

fix CID 1361611
/libr/anal/var.c: 112 in r_anal_var_retype()
/libr/anal/var.c: 125 in r_anal_var_retype()
Dereferencing a null pointer "fcn".

fix CID 1361610
Incorrect expression (IDENTICAL_BRANCHES)
/libr/core/cmd_anal.c: 1616 in __anal_reg_list()
Dereferencing null pointer "fcn".