### PR TITLE
Fix a handful of boring leaks

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -897,7 +897,8 @@ int main(int argc, char **argv, char **envp) {
 	r_list_free (cmds);
 	r_list_free (files);
 	if (ret) {
-		return 0;
+		ret = 0;
+		goto beach;
 	}
 	if (r_config_get_i (r.config, "scr.prompt")) {
 		if (run_rc && r_config_get_i (r.config, "cfg.fortunes")) {
@@ -1018,6 +1019,8 @@ int main(int argc, char **argv, char **envp) {
 
 	/* capture return value */
 	ret = r.num->value;
+
+beach:
 	// not really needed, cause r_core_fini will close the file
 	// and this fh may be come stale during the command
 	// exectution.

--- a/libr/asm/arch/tms320/tms320_dasm.c
+++ b/libr/asm/arch/tms320/tms320_dasm.c
@@ -1101,6 +1101,11 @@ static insn_head_t c55x_list[] = {
 int tms320_dasm_init(tms320_dasm_t * dasm) {
 	int i = 0;
 
+	if (dasm->map) {
+		/* already initialized */
+		return 0;
+	}
+
 	dasm->map = ht_(new)();
 
 	for (i = 0; i < ARRAY_SIZE(c55x_list); i++)

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -24,7 +24,10 @@ static inline bool setimpord (ELFOBJ* eobj, ut32 ord, RBinImport *ptr) {
 	if (!eobj->imports_by_ord || ord >= eobj->imports_by_ord_size) {
 		return false;
 	}
-	free (eobj->imports_by_ord[ord]);
+	if (eobj->imports_by_ord[ord]) {
+		free (eobj->imports_by_ord[ord]->name);
+		free (eobj->imports_by_ord[ord]);
+	}
 	eobj->imports_by_ord[ord] = r_mem_dup (ptr, sizeof (RBinImport));
 	eobj->imports_by_ord[ord]->name = strdup (ptr->name);
 	return true;
@@ -40,7 +43,7 @@ static Sdb* get_sdb (RBinObject *o) {
 
 static void * load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	struct Elf_(r_bin_elf_obj_t) *res;
-	const char *elf_type;
+	char *elf_type;
 	RBuffer *tbuf;
 
 	if (!buf || sz == 0 || sz == UT64_MAX) {
@@ -64,6 +67,7 @@ static void * load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loadaddr,
 		}
 		free (regs);
 	}
+	free (elf_type);
 	r_buf_free (tbuf);
 	return res;
 }

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -154,6 +154,8 @@ R_API char *r_file_abspath(const char *file) {
 		if (abspath) {
 			free (ret);
 			ret = abspath;
+		} else {
+			free (resolved_path);
 		}
 	}
 #endif


### PR DESCRIPTION
Valgrinding to get exp. Testing with "r2 -Aqcq /bin/ls"

Before:

       definitely lost: 22,735 bytes in 250 blocks
       indirectly lost: 23,542 bytes in 605 blocks
         possibly lost: 2,464 bytes in 7 blocks
       still reachable: 3,876,216 bytes in 80,761 blocks

After:

       definitely lost: 25,216 bytes in 58 blocks
       indirectly lost: 24,830 bytes in 739 blocks
         possibly lost: 0 bytes in 0 blocks
       still reachable: 20,105 bytes in 34 blocks

The "goto beach" (named like that for consistency) change resulted in freeing most of the "still reachable" stuff on quit, which also moved stuff out of "possibly lost", so.. it looks like it's leaking more now. Yay.