### PR TITLE
fix pf

### DIFF
--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -1291,6 +1291,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 			}
 		}
 		arg = orig;
+		int flag = 0;
 		for (idx = 0; i < len && arg < argend && *arg; arg++) {
 			int size = 0, elem = 0; /* size of the array, element of the array */
 			char *fieldname = NULL, *fmtname = NULL;
@@ -1377,8 +1378,9 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 					elem = -1;
 				}
 				idx++;
-				if (MUSTSEE && !SEEVALUE) {
+				if (MUSTSEE && !SEEVALUE && !flag) {
 					p->cb_printf (namefmt, fieldname);
+					flag = 1;
 				}
 			}
 
@@ -1439,9 +1441,11 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 			case ':': // skip 4 bytes
 				if (size == -1) i+=4;
 				else while (size--) i+=4;
+				idx--;
 				continue;
 			case '.': // skip 1 byte
 				i += (size == -1)? 1: size;
+				idx--;
 				continue;
 			case 'p': // pointer reference
 				if (*(arg+1) == '2') {
@@ -1461,6 +1465,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 				}
 				break;
 			}
+			flag = 0;
 
 			/* flags */
 			if (mode & R_PRINT_SEEFLAGS && isptr != NULLPTR) {


### PR DESCRIPTION
fix pf.name output when `.` or `:` are used in the format

Before patch:
```
[0x00404890]> pf.abc ic...i:pii a b c d e f
[0x00404890]> pf.abc
a : 0x00404890 = 2303323441
b : 0x00404894 = '.'
c : d : e : f : 0x00404898 = 3833809122
0x004048a0 = (qword)0xc74800411ed0c0c7
0x004048a8 = 1092509889
0x004048ac = 3351726080
```

After patch:
```
[0x00404890]> pf.abc ic...i:pii a b c d e f
[0x00404890]> pf.abc
a : 0x00404890 = 2303323441
b : 0x00404894 = '.'
c : 0x00404898 = 3833809122
d : 0x004048a0 = (qword)0xc74800411ed0c0c7
e : 0x004048a8 = 1092509889
f : 0x004048ac = 3351726080
```

This also corrects the json output