### PR TITLE
Fix backward seek

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -598,7 +598,7 @@ int main(int argc, char **argv, char **envp) {
 			fh = r_core_file_open (&r, path, perms, mapaddr);
 			if (fh) {
 				r_io_write_at (r.io, 0, buf, sz);
-				r_core_block_read (&r, 0);
+				r_core_block_read (&r);
 				free (buf);
 				// TODO: load rbin thing
 			} else {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2301,7 +2301,7 @@ R_API int r_core_bin_raise(RCore *core, ut32 binfile_idx, ut32 binobj_idx) {
 	}
 	// it should be 0 to use r_io_use_fd in r_core_block_read
 	core->switch_file_view = 0;
-	return binfile && r_core_bin_set_env (core, binfile) && r_core_block_read (core, 0);
+	return binfile && r_core_bin_set_env (core, binfile) && r_core_block_read (core);
 }
 
 R_API int r_core_bin_delete(RCore *core, ut32 binfile_idx, ut32 binobj_idx) {
@@ -2316,7 +2316,7 @@ R_API int r_core_bin_delete(RCore *core, ut32 binfile_idx, ut32 binobj_idx) {
 		r_io_raise (core->io, binfile->fd);
 	}
 	core->switch_file_view = 0;
-	return binfile && r_core_bin_set_env (core, binfile) && r_core_block_read (core, 0);
+	return binfile && r_core_bin_set_env (core, binfile) && r_core_block_read (core);
 }
 
 static int r_core_bin_file_print(RCore *core, RBinFile *binfile, int mode) {

--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -322,7 +322,7 @@ R_API bool r_core_seek(RCore *core, ut64 addr, bool rb) {
 		core->offset = addr;
 	}
 	if (rb) {
-		ret = r_core_block_read (core, 0);
+		ret = r_core_block_read (core);
 		if (core->io->ff) {
 			if (ret < 1 || ret > core->blocksize)
 				memset (core->block, core->io->Oxff, core->blocksize);
@@ -358,7 +358,7 @@ R_API int r_core_seek_delta(RCore *core, st64 addr) {
 	}
 	core->offset = addr;
 	ret = r_core_seek (core, addr, 1);
-	//ret = r_core_block_read (core, 0);
+	//ret = r_core_block_read (core);
 	//if (ret == -1)
 	//	memset (core->block, 0xff, core->blocksize);
 	//	core->offset = tmp;
@@ -373,7 +373,7 @@ R_API int r_core_write_at(RCore *core, ut64 addr, const ut8 *buf, int size) {
 	if (ret != -1) {
 		ret = r_io_write_at (core->io, addr, buf, size);
 		if (addr >= core->offset && addr <= core->offset+core->blocksize)
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 	}
 	return (ret==-1)? false: true;
 }
@@ -387,7 +387,7 @@ R_API int r_core_extend_at(RCore *core, ut64 addr, int size) {
 	if (ret != -1) {
 		ret = r_io_extend_at (core->io, addr, size);
 		if (addr >= core->offset && addr <= core->offset+core->blocksize)
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 	}
 	return (ret==-1)? false: true;
 }
@@ -458,7 +458,7 @@ static RCoreFile * r_core_file_set_first_valid(RCore *core) {
 	return file;
 }
 
-R_API int r_core_block_read(RCore *core, int next) {
+R_API int r_core_block_read(RCore *core) {
 	if (core->file == NULL && r_core_file_set_first_valid(core) == NULL) {
 		memset (core->block, core->io->Oxff, core->blocksize);
 		return -1;
@@ -470,7 +470,7 @@ R_API int r_core_block_read(RCore *core, int next) {
 	} else	{
 		r_io_use_fd (core->io, core->io->raised); //possibly not needed
 	}
-	return r_io_read_at (core->io, core->offset+((next)?core->blocksize:0), core->block, core->blocksize);
+	return r_io_read_at (core->io, core->offset, core->block, core->blocksize);
 }
 
 R_API int r_core_read_at(RCore *core, ut64 addr, ut8 *buf, int size) {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -867,7 +867,7 @@ static int cmd_resize(void *data, const char *input) {
 
 	if (newsize < core->offset+core->blocksize ||
 			oldsize < core->offset+core->blocksize) {
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 	}
 	return true;
 }
@@ -1808,7 +1808,7 @@ next_arroba:
 			} else {
 				if (addr != UT64_MAX) {
 					if (!ptr[1] || r_core_seek (core, addr, 1)) {
-						r_core_block_read (core, 0);
+						r_core_block_read (core);
 						ret = r_cmd_call (core->rcmd, r_str_trim_head (cmd));
 					} else {
 						ret = 0;

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -229,7 +229,7 @@ static int cmd_info(void *data, const char *input) {
 			// plugin that will be used to load the bin (e.g. malloc://)
 			// TODO: Might be nice to reload a bin at a specified offset?
 			r_core_bin_reload (core, NULL, baddr);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 			newline = false;
 			}
 			break;

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -234,7 +234,7 @@ static void cmd_open_map (RCore *core, const char *input) {
 		r_core_cmd_help (core, help_msg);
 		break;
 	}
-	r_core_block_read (core, 0);
+	r_core_block_read (core);
 }
 
 R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
@@ -438,7 +438,7 @@ static int cmd_open(void *data, const char *input) {
 				}
 			}
 		}
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 		break;
 	case 'b':
 		cmd_open_bin (core, input);
@@ -474,7 +474,7 @@ static int cmd_open(void *data, const char *input) {
 		// hackaround to fix invalid read
 		//r_core_cmd0 (core, "oo");
 		// uninit deref
-		//r_core_block_read (core, 0);
+		//r_core_block_read (core);
 		break;
 	case 'm':
 		cmd_open_map (core, input);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1052,7 +1052,7 @@ static int pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt) {
 	} else {
 		if (len > core->blocksize) {
 			r_core_block_size (core, len);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 		}
 	}
 	r_cons_break (NULL, NULL);

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -312,9 +312,9 @@ static int cmd_seek(void *data, const char *input) {
 				RIOUndos *undo = r_io_sundo (core->io, core->offset);
 				if (undo) {
 					r_core_seek (core, undo->off, 0);
+					r_core_block_read (core, 0);
 				}
 			}
-			r_core_block_read (core, 1);
 			break;
 		case 'n':
 			r_io_sundo_push (core->io, core->offset, r_print_get_cursor (core->print));

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -226,7 +226,7 @@ static int cmd_seek(void *data, const char *input) {
 					off = cb.addr;
 					r_io_sundo_push (core->io, core->offset, r_print_get_cursor (core->print));
 					r_core_seek (core, off, 1);
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 					break;
 				default:
 					eprintf ("Too many results\n");
@@ -240,7 +240,7 @@ static int cmd_seek(void *data, const char *input) {
 		case ' ':
 			r_io_sundo_push (core->io, core->offset, r_print_get_cursor (core->print));
 			r_core_seek (core, off * sign, 1);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 			break;
 		case '/':
 			{
@@ -312,7 +312,7 @@ static int cmd_seek(void *data, const char *input) {
 				RIOUndos *undo = r_io_sundo (core->io, core->offset);
 				if (undo) {
 					r_core_seek (core, undo->off, 0);
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 				}
 			}
 			break;

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -22,7 +22,7 @@ R_API int cmd_write_hexpair(RCore* core, const char* pairs) {
 		if (r_config_get_i (core->config, "cfg.wseek")) {
 			r_core_seek_delta (core, len);
 		}
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 	} else {
 		eprintf ("Error: invalid hexpair string\n");
 	}
@@ -163,10 +163,10 @@ static void cmd_write_op (RCore *core, const char *input) {
 	case '4':
 		if (input[2]) {  // parse val from arg
 			r_core_write_op (core, input+3, input[1]);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 		} else {  // use clipboard instead of val
 			r_core_write_op (core, NULL, input[1]);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 		}
 		break;
 	case 'R':
@@ -174,7 +174,7 @@ static void cmd_write_op (RCore *core, const char *input) {
 		break;
 	case 'n':
 		r_core_write_op (core, "ff", 'x');
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 		break;
 	case 'E': // encrypt
 	case 'D': // decrypt
@@ -343,7 +343,7 @@ static void cmd_write_value (RCore *core, const char *input) {
 		WSEEK (core, 8);
 		break;
 	}
-	r_core_block_read (core, 0);
+	r_core_block_read (core);
 }
 
 static bool cmd_wf(RCore *core, const char *input) {
@@ -385,7 +385,7 @@ static bool cmd_wf(RCore *core, const char *input) {
 		r_io_write_at (core->io, core->offset, buf + u_offset, u_size);
 		WSEEK (core, size);
 		free (buf);
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 	} else {
 		eprintf ("Cannot open file '%s'\n", arg);
 	}
@@ -536,7 +536,7 @@ static int cmd_write(void *data, const char *input) {
 		if (!fail) {
 			r_core_write_at (core, core->offset, buf, len);
 			WSEEK (core, len);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 			free (buf);
 		} else {
 			eprintf ("Usage: w6[de] base64/hex\n");
@@ -572,7 +572,7 @@ static int cmd_write(void *data, const char *input) {
 					const ut64 cur_off = core->offset;
 					cmd_suc = r_core_extend_at (core, core->offset, len);
 					core->offset = cur_off;
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 				}
 			}
 			break;
@@ -589,7 +589,7 @@ static int cmd_write(void *data, const char *input) {
 					cmd_suc = r_core_extend_at (core, addr, len);
 					cmd_suc = r_core_seek (core, cur_off, 1);
 					core->offset = addr;
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 				}
 			}
 			break;
@@ -606,7 +606,7 @@ static int cmd_write(void *data, const char *input) {
 						r_core_write_at (core, cur_off, bytes, len);
 					}
 					core->offset = cur_off;
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 				}
 				free (bytes);
 			}
@@ -627,7 +627,7 @@ static int cmd_write(void *data, const char *input) {
 						r_core_write_at (core, addr, bytes, len);
 					}
 					core->offset = addr;
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 				}
 				free (bytes);
 			}
@@ -804,7 +804,7 @@ static int cmd_write(void *data, const char *input) {
 		switch (input[1]) {
 		case 'i':
 			r_io_cache_commit (core->io, 0, UT64_MAX);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 			break;
 		case 'r':
 			r_io_cache_reset (core->io, true);
@@ -812,7 +812,7 @@ static int cmd_write(void *data, const char *input) {
 			 * the cache wrote past the original EOF these changes are no
 			 * longer displayed. */
 			memset (core->block, 0xff, core->blocksize);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 			break;
 		case '+':
 			if (input[2]=='*') {
@@ -863,7 +863,7 @@ static int cmd_write(void *data, const char *input) {
 			}
 			/* See 'r' above. */
 			memset (core->block, 0xff, core->blocksize);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 			break;
 		case '?':
 			{
@@ -902,7 +902,7 @@ static int cmd_write(void *data, const char *input) {
 		r_io_write_at (core->io, core->offset, (const ut8*)str, len);
 #endif
 		WSEEK (core, len);
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 		break;
 	case 'z': // "wz"
 		/* write zero-terminated string */
@@ -917,7 +917,7 @@ static int cmd_write(void *data, const char *input) {
 		r_io_use_desc (core->io, core->file->desc);
 #endif
 		WSEEK (core, len + 1);
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 		break;
 	case 't': // "wt"
 		if (*str == '?' || *str == '\0') {
@@ -976,7 +976,7 @@ static int cmd_write(void *data, const char *input) {
 			r_io_use_desc (core->io, core->file->desc);
 			r_io_write_at (core->io, core->offset, (const ut8*)str, len);
 			WSEEK (core, len);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 			free (tmp);
 		} else {
 			eprintf ("Cannot malloc %d\n", len);
@@ -1011,7 +1011,7 @@ static int cmd_write(void *data, const char *input) {
 					WSEEK (core, size);
 				}
 				free (buf);
-				r_core_block_read (core, 0);
+				r_core_block_read (core);
 			} else eprintf ("Cannot open file '%s'\n", arg);
 			break;
 		case 's': // "wxs"
@@ -1062,7 +1062,7 @@ static int cmd_write(void *data, const char *input) {
 						eprintf ("Written %d bytes (%s) = wx %s\n", acode->len, input+2, acode->buf_hex);
 					r_core_write_at (core, core->offset, acode->buf, acode->len);
 					WSEEK (core, acode->len);
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 				}
 				r_asm_code_free (acode);
 			}
@@ -1081,7 +1081,7 @@ static int cmd_write(void *data, const char *input) {
 						eprintf ("Written %d bytes (%s)=wx %s\n", acode->len, input+1, acode->buf_hex);
 						r_core_write_at (core, core->offset, acode->buf, acode->len);
 						WSEEK (core, acode->len);
-						r_core_block_read (core, 0);
+						r_core_block_read (core);
 					}
 					r_asm_code_free (acode);
 				} else eprintf ("Cannot assemble file\n");
@@ -1112,7 +1112,7 @@ static int cmd_write(void *data, const char *input) {
 				r_mem_copyloop (core->block, buf, core->blocksize, len);
 				r_core_write_at (core, core->offset, core->block, core->blocksize);
 				WSEEK (core, core->blocksize);
-				r_core_block_read (core, 0);
+				r_core_block_read (core);
 			} else eprintf ("Wrong argument\n");
 			free (buf);
 		} else eprintf ("Cannot malloc %d\n", len+1);
@@ -1176,7 +1176,7 @@ static int cmd_write(void *data, const char *input) {
 				r_core_write_at (core, core->offset, &ulen, 1);
 				r_core_write_at (core, core->offset+1, (const ut8*)str+1, len);
 				WSEEK (core, len);
-				r_core_block_read (core, 0);
+				r_core_block_read (core);
 			}
 		} else eprintf ("Too short.\n");
 		break;
@@ -1187,7 +1187,7 @@ static int cmd_write(void *data, const char *input) {
 			r_io_use_desc (core->io, core->file->desc);
 			r_io_write (core->io, core->oobi, core->oobi_len);
 			WSEEK (core, core->oobi_len);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 		} else {
 			r_core_cmd_help (core, help_msg);
 		}

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -917,7 +917,7 @@ static int cb_iobuffer(void *user, void *data) {
 	} else {
 		r_io_buffer_close (core->io);
 	}
-	r_core_block_read (core, 0);
+	r_core_block_read (core);
 	return true;
 }
 
@@ -947,7 +947,7 @@ static int cb_iova(void *user, void *data) {
 		core->io->va = node->i_value;
 		/* ugly fix for r2 -d ... "r2 is going to die soon ..." */
 		if (r_io_desc_get (core->io, core->io->raised)) {
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 		}
 		/* reload symbol information */
 		if (r_list_length (r_bin_get_sections (core->bin)) > 0) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1570,8 +1570,6 @@ static void set_prompt (RCore *r) {
 	const char *END = "";
 	const char *remote = "";
 
-	// hacky fix fo rio
-	r_core_block_read (r, 0);
 	if (cmdprompt && *cmdprompt)
 		r_core_cmd (r, cmdprompt, 0);
 

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1684,7 +1684,7 @@ R_API int r_core_block_size(RCore *core, int bsize) {
 		core->block = bump;
 		core->blocksize = bsize;
 		memset (core->block, 0xff, core->blocksize);
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 	}
 	return ret;
 }
@@ -1904,7 +1904,7 @@ reaccept:
 					// TODO: reply error here
 					return -1;
 				} else {
-					r_core_block_read (core, 0);
+					r_core_block_read (core);
 					ptr[0] = RMT_READ | RMT_REPLY;
 					if (i>RMT_MAX)
 						i = RMT_MAX;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3224,7 +3224,7 @@ R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opc
 			nb_bytes = ds->len = core->blocksize;
 		} else {
 			r_core_block_size (core, ds->len);
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 		}
 	}
 	if (!ds->l) {

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -132,7 +132,7 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 			r_io_raise (core->io, desc->fd);
 			core->switch_file_view = 1;
 #endif
-			r_core_block_read (core, 0);
+			r_core_block_read (core);
 		} else {
 			const char *name = (cf && cf->desc) ? cf->desc->name : "ERROR";
 			eprintf ("Error: Unable to switch the view to file: %s\n", name);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1186,7 +1186,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 				r_core_visual_seek_animation (core, off);
 				core->print->cur = 0;
 			}
-			r_core_block_read (core, 1);
+			r_core_block_read (core);
 		}
 	} else
 	switch (ch) {
@@ -2009,7 +2009,7 @@ R_API int r_core_visual_cmd(RCore *core, int ch) {
 		setcursor (core, false);
 		return false;
 	}
-	r_core_block_read (core, 0);
+	r_core_block_read (core);
 	return true;
 }
 

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -117,7 +117,7 @@ static int perform_mapped_file_yank(RCore *core, ut64 offset, ut64 len, const ch
 	if (fd != -1) {
 		r_io_raise (core->io, fd);
 		core->switch_file_view = 1;
-		r_core_block_read (core, 0);
+		r_core_block_read (core);
 	}
 	return res;
 }

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -222,7 +222,7 @@ R_API void r_core_seek_previous (RCore *core, const char *type);
 R_API void r_core_seek_next (RCore *core, const char *type);
 R_API int r_core_seek_align(RCore *core, ut64 align, int count);
 R_API int r_core_seek_archbits (RCore *core, ut64 addr);
-R_API int r_core_block_read(RCore *core, int next);
+R_API int r_core_block_read(RCore *core);
 R_API int r_core_block_size(RCore *core, int bsize);
 R_API int r_core_read_at(RCore *core, ut64 addr, ut8 *buf, int size);
 R_API int r_core_is_valid_offset (RCore *core, ut64 offset);


### PR DESCRIPTION
Backward seek has a bug when used via scripts loaded with `-i <file>` on the command line.  This is accomplished with the following steps:

1. Remove the hack that hides this bug (and others) when entering commands via stdin, verses using `-i <file>` as the regression scripts do.
2. Fix the bug by reloading the current block (instead of the next block), and only for undo seeks, not backward seeks.
3. Remove the `next` parameter entirely from `r_core_block_read()`.  It's broken and confusing.