### PR TITLE
Correct macro name for the i386 platform

### DIFF
--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -902,7 +902,7 @@ static elf_fpxregset_t *linux_get_fpx_regset (int tid) {
 	if (!fpxregset) return NULL;
 	transfer.iov_base = fpxregset;
 	transfer.iov_len = sizeof (elf_fpxregset_t);
-	if (ptrace (PTRACE_GETREGSET, tid, (unsigned int)NT_PRXFPREG, &transfer) < 0) {
+	if (ptrace (PTRACE_GETREGS, tid, (unsigned int)NT_PRXFPREG, &transfer) < 0) {
 		perror ("linux_get_fpx_regset");
 		return NULL;
 	}


### PR DESCRIPTION
Some more info in this issue:
https://github.com/radare/radare2/issues/5131