### PR TITLE
Patch 1

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -347,7 +347,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case MIPS_INS_ADDI:
 		PROTECT_ZERO () {
-			r_strbuf_appendf (&op->esil, "0,32,%s,0xffffffff,&,%s,+,>>,>,?{,1,TRAP,}{,%s,%s,+,%s,=,}",
+			r_strbuf_appendf (&op->esil, "0,32,%s,0xffffffff,&,%s,+,>>,>,?{,$$,1,TRAP,}{,%s,%s,+,%s,=,}",
 				ARG(2), ARG(1), ARG(2), ARG(1), ARG(0));
 		}
 		break;

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -347,8 +347,8 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case MIPS_INS_ADDI:
 		PROTECT_ZERO () {
-			r_strbuf_appendf (&op->esil, "0,32,%s,0xffffffff,&,%s,+,>>,>,?{,$$,1,TRAP,}{,%s,%s,+,%s,=,}",
-				ARG(2), ARG(1), ARG(2), ARG(1), ARG(0));
+			r_strbuf_appendf (&op->esil, "30,0x80000000,%s,%s,^,&,>>,31,0x80000000,%s,&,0x80000000,%s,%s,+,&,^,>>,|,1,==,?{,$$,1,TRAP,}{,%s,%s,+,%s,=,}",
+				ARG(2), ARG(1), ARG(2), ARG(2), ARG(1), ARG(2), ARG(1), ARG(0));
 		}
 		break;
 	case MIPS_INS_DADD:


### PR DESCRIPTION
Corrected ADDI logic for MIPS, based on QEMU implementation. Tested with the following code:
lui v0, 0x8000
addi v0, v0, -0xa ;TRAP
lui v0, 0x8000
addiu v0, v0, 0xa
addi v0, v0, -5 ; NO TRAP
lui v0, 0x8000
addi v0, v0, 0xa ; NO TRAP
lui v0, 0x8000
addiu v0, v0, -0xa
addi v0, v0, 0xb ;TRAP
lui v0, 0x8000
addiu v0, v0, -0xa
addi v0, v0, 5 ; NO TRAP
lui v0, 0x8000
addiu v0, v0, -0xa
addi v0, v0, -0xa ; NO TRAP
lui v0, 0
addiu v0, v0, -0xa
addi v0, v0, 0xb ; NO TRAP
lui v0, 0
addiu v0, v0, 0xa
addi v0, v0, -0xb ; NO TRAP