### PR TITLE
update native sandboxing method for OpenBSD

### DIFF
--- a/doc/sandbox/README.md
+++ b/doc/sandbox/README.md
@@ -19,8 +19,19 @@ the rules are described in a lispy .sb file:
 **NOTE**: r2 -S is an alias for -e cfg.sandbox=true
 
 
-OpenBSD
--------
+OpenBSD (starting to 5.9)
+-------------------------
+
+OpenBSD comes with support for sandboxing using the pledge(2) syscall.
+
+Only the following are allowed:
+
+- stdio and tty manipulation
+- filesystem reading
+- mmap(2) `PROT_EXEC` manipulation
+
+OpenBSD (until 5.9)
+-------------------
 
 OpenBSD comes with support for sandboxing using the systrace utility.
 

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -29,6 +29,17 @@
 #define LIBC_HAVE_FORK 1
 #endif
 
+#if defined(__OpenBSD__)
+#include <sys/param.h>
+#undef MAXCOMLEN	/* redefined in zipint.h */
+#endif
+
+#if (OpenBSD >= 201605) /* release >= 5.9 */
+#define LIBC_HAVE_PLEDGE 1
+#else
+#define LIBC_HAVE_PLEDGE 0
+#endif
+
 #ifdef __GNUC__
 #  define UNUSED_FUNCTION(x) __attribute__((__unused__)) UNUSED_ ## x
 #else


### PR DESCRIPTION
move from systrace(4) (removed in 6.0 release) to pledge(2) (available since 5.9).