### PR TITLE
 Coredump support for ARM and fix-ups

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1535,7 +1535,7 @@ static int r_debug_setup_ownership (int fd, RDebug *dbg) {
 static bool r_debug_gcore (RDebug *dbg, RBuffer *dest) {
 #if __APPLE__
 	return xnu_generate_corefile (dbg, dest);
-#elif __linux__ && (__x86_64__ || __i386__) && !__ANDROID__
+#elif __linux__ && (__x86_64__ || __i386__ || __arm__ || __arm64__)
 	return linux_generate_corefile (dbg, dest);
 #else
 	return false;

--- a/libr/debug/p/native/linux/linux_coredump.h
+++ b/libr/debug/p/native/linux/linux_coredump.h
@@ -3,7 +3,7 @@
 #include "elf_specs.h"
 #include <sys/procfs.h>
 
-
+#if __i386__ || __x86_64__
 /*Macros for XSAVE/XRESTORE*/
 /*
         From: http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developers-manual.pdf
@@ -50,6 +50,7 @@
 #define XSTATE_MPX_MASK         MPX_BIT
 #define XSTATE_AVX512_MASK      (XSTATE_AVX_MASK|AVX512_FULL_BIT)
 /*********************************/
+#endif
 
 #define SIZE_PR_FNAME	16
 
@@ -147,11 +148,15 @@ typedef struct auxv_buff {
 typedef struct thread_elf_note {
 	prstatus_t *prstatus;
 	elf_fpregset_t *fp_regset;
-#ifdef __i386__
+#if __i386__
 	elf_fpxregset_t	*fpx_regset;
 #endif
 	siginfo_t *siginfo;
+#if __i386__ || __x86_64__
 	void *xsave_data;
+#elif __arm__ || __arm64__
+	void *arm_vfp_data;
+#endif
 	struct thread_elf_note *n;
 } thread_elf_note_t;
 
@@ -171,10 +176,14 @@ typedef enum {
 	NT_PRSTATUS_T,
 	NT_SIGINFO_T,
 	NT_FPREGSET_T,
-#ifdef __i386__
+#if __i386__
 	NT_PRXFPREG_T,
 #endif
+#if __i386__ || __x86_64__
 	NT_X86_XSTATE_T,
+#elif __arm__ || __arm64__
+	NT_ARM_VFP_T,
+#endif
 	NT_LENGHT_T
 } note_type_t;
 


### PR DESCRIPTION
 * Fixes: 5540 (now i386 will not complain in case they're missing GETREGSET)
 * Fixup: Owner set to Linux for NT_PRXFPREG
 * Fixup: Now extra section hdr is being written with the right offset
 * Fixup: Bug with multithread cfg fixed
 * Add: Now r2 is able to generate coredumps on ARM platforms


I tested it on i386, x64_x86 and arm_32bits.
Unfortunately I don't have an arm 64bits board, so if someone could test it there, that would be great.

Besides of adding support for ARM platform, I fixed some bugs I found during my tests.

I hope it passes the tests, let's see ;)