### PR TITLE
Don't restore breakpoints on STEP recoil

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -170,11 +170,6 @@ static int r_debug_recoil(RDebug *dbg, RDebugRecoilMode rc_mode) {
 	 * pretend as if we had.
 	 */
 	if (!dbg->reason.bp_addr && dbg->recoil_mode == R_DBG_RECOIL_STEP) {
-		/* restore all sw breakpoints. we are about to step/continue so these need
-		 * to be in place. */
-		if (!r_bp_restore (dbg->bp, true)) {
-			return false;
-		}
 		return true;
 	}
 


### PR DESCRIPTION
As the comment says, we need to pretend to satisfy the caller. For some reason
I also restored the breakpoints here. I cannot for the life of me figure out
why since it should be ok with in all cases.

For swstep=false, the step will stop right away (regardless of any breakpoints)
and thus need to remove breakpoints anyway.

For swstep=true, a breakpoint is created on the next instruction and would stop
too and thus need to remove breakpoints anyway.

So yeah, don't do this. Thanks for the report skuater!