### PR TITLE
Handle NULL strings in r_bin_demangle

### DIFF
--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -347,7 +347,7 @@ R_API int r_bin_lang_type(RBinFile *binfile, const char *def, const char *sym) {
 R_API char *r_bin_demangle(RBinFile *binfile, const char *def, const char *str) {
 	int type = -1;
 	RBin *bin;
-	if (!binfile || !*str) return NULL;
+	if (!binfile || !str || !*str) return NULL;
 
 	bin = binfile->rbin;
 	if (!strncmp (str, "sym.", 4))

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -298,7 +298,7 @@ static int step_until_flag(RCore *core, const char *instr) {
 		pc = r_debug_reg_get (core->dbg, "PC");
 		list = r_flag_get_list (core->flags, pc);
 		r_list_foreach (list, iter, f) {
-			if (!instr|| !*instr || strstr(f->realname, instr)) {
+			if (!instr|| !*instr || (f->realname && strstr(f->realname, instr))) {
 				r_cons_printf ("[ 0x%08"PFMT64x" ] %s\n",
 						f->offset, f->realname);
 				goto beach;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1254,7 +1254,7 @@ static void ds_show_flags(RDisasmState *ds) {
 		if (ds->show_color)
 			r_cons_strcat (ds->color_flag);
 		//beginch = (iter->p && printed) ? ", " : "";
-		if (ds->asm_demangle) {
+		if (ds->asm_demangle && flag->realname) {
 			const char *lang = r_config_get (core->config, "bin.lang");
 			char *name = r_bin_demangle (core->bin->cur, lang, flag->realname);
 			r_cons_printf ("%s:\n", name? name: flag->realname);


### PR DESCRIPTION
- flag->realname can be NULL (an ELF executable with null symbols). Correct two cases in `cmd_debug.c` and `disasm.c` that are assuming a non-NULL realname.
- Add a NULL check to the prelude of `r_bin_demangle`, just in case.

Avoids the following segfault during disassembly:
```
#0  0x0000197007cdc6e9 in r_bin_demangle (binfile=0x197079c5b900, def=0x19708bbe9a70 "c", str=0x0) at demangle.c:350                                   
#1  0x00001970aebff2fd in ds_show_flags (ds=0x1970965880a0) at disasm.c:1259                                                                           
#2  0x00001970aec05771 in r_core_print_disasm (p=0x197029ea2400, core=0x196db5908880, addr=134217796,                                                  
    buf=0x196ff8dce800 "...", len=410, l=41, invbreak=0, cbytes=0) at disasm.c:3056                                         
#3  0x00001970aeb92b5a in cmd_print (data=0x196db5908880, input=0x197099150ce1 "d $r") at cmd_print.c:2791                                             
#4  0x00001970aebe10a4 in r_cmd_call (cmd=0x197084cb7090, input=0x197099150ce0 "pd $r") at cmd_api.c:210                                               
...
```

(edit: one way to reproduce is to get the EQGRP free dump and do

- `radare2  Firewall/BUZZDIRECTION/BUZZ_1210/Mods/App/Buzzdirection/i386/Hash_1.2.0.3.mo`
- `pD @ 0x0x08000000`
- &lt;segfault>
)
