### PR TITLE
make r_sys_truncate() obey to sandbox mode

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -102,11 +102,13 @@ R_API ut64 r_sys_now(void) {
 R_API int r_sys_truncate(const char *file, int sz) {
 #if __WINDOWS__ && !__CYGWIN__
 	int fd = r_sandbox_open (file, O_RDWR, 0644);
-	if (!fd) return false;
+	if (fd != -1) return false;
 	ftruncate (fd, sz);
 	close (fd);
 	return true;
 #else
+	if (r_sandbox_enable (0))
+		return false;
 	return truncate (file, sz)? false: true;
 #endif
 }


### PR DESCRIPTION
the diff corrects a logic error in `__WINDOWS__ && !__CYGWIN__` case, as
r_sandbox_open() will return `-1` on error.

and it makes a sandbox check before calling truncate(2) syscall.