### PR TITLE
make mkdir command to obey sandbox mode

### DIFF
--- a/libr/core/syscmd.c
+++ b/libr/core/syscmd.c
@@ -202,6 +202,10 @@ R_API void r_core_syscmd_mkdir(const char *dir) {
 	if (p) {
 		int ret;
 		char *dirname;
+		if (r_sandbox_enable (0)) {
+			eprintf ("sandbox: Cannot use mkdir command\n");
+			return;
+		}
 		if (!strncmp (p+1, "-p ", 3)) {
 			dirname = r_str_chop (strdup (p+3));
 			ret = r_sys_mkdirp (dirname);


### PR DESCRIPTION
the diff adds a check for sandbox mode before calling
r_sys_mkdir/r_sys_mkdirp functions.