### PR TITLE
Remove unused field `addr` from SymName

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1220,7 +1220,6 @@ static const char *getPrefixFor(const char *s) {
 }
 
 typedef struct {
-	ut64 addr;
 	const char *pfx; // prefix for flags
 	char *name;      // raw symbol name
 	char *nameflag;  // flag name for symbol


### PR DESCRIPTION
Not sure what the use of this was, but it confused me during debugging