### PR TITLE
Fix #5543 - oob write in Sr command

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -373,9 +373,11 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 			r_flag_space_push (core->flags, input+2);
 			break;
 		case 'r':
-			if (input[2]==' ')
-				r_flag_space_rename (core->flags, NULL, input+2);
-			else eprintf ("Usage: fsr [newname]\n");
+			if (input[2] ==' ') {
+				r_flag_space_rename (core->flags, NULL, input + 2);
+			} else {
+				eprintf ("Usage: fsr [newname]\n");
+			}
 			break;
 		case '-':
 			switch (input[2]) {
@@ -407,20 +409,23 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 		case 'm':
 			{ RFlagItem *f;
 			ut64 off = core->offset;
-			if (input[2] == ' ')
+			if (input[2] == ' ') {
 				off = r_num_math (core->num, input+2);
+			}
 			f = r_flag_get_i (core->flags, off);
 			if (f) {
 				f->space = core->flags->space_idx;
-			} else eprintf ("Cannot find any flag at 0x%"PFMT64x".\n", off);
+			} else {
+				eprintf ("Cannot find any flag at 0x%"PFMT64x".\n", off);
+			}
 			}
 			break;
 		default: {
 			int i, j = 0;
-			for (i=0; i<R_FLAG_SPACES_MAX; i++) {
+			for (i = 0; i < R_FLAG_SPACES_MAX; i++) {
 				if (core->flags->spaces[i])
 					r_cons_printf ("%02d %c %s\n", j++,
-					(i==core->flags->space_idx)?'*':' ',
+					(i == core->flags->space_idx)?'*':' ',
 					core->flags->spaces[i]);
 			}
 			} break;

--- a/libr/core/cmd_section.c
+++ b/libr/core/cmd_section.c
@@ -65,6 +65,46 @@ static int __dump_section_to_disk(RCore *core, char *file) {
 	return false;
 }
 
+static void update_section_flag_at_with_oldname(RIOSection *s, RFlag *flags, ut64 off, char *oldname) {
+	RFlagItem *item = NULL;
+	RListIter *iter;
+	const RList *list = NULL;
+	int len = 0;
+	char *secname = NULL;
+	list = r_flag_get_list (flags, s->vaddr);
+	secname = sdb_fmt (-1, "section.%s", oldname);
+	len = strlen (secname);
+	r_list_foreach (list, iter, item) {
+		if (!item->name)  {
+			continue;
+		}
+		if (!strncmp (item->name, secname, R_MIN (strlen (item->name), len))) {
+			free (item->realname);
+			item->name = strdup (sdb_fmt (-1, "section.%s", s->name));
+			r_str_chop (item->name);
+			r_name_filter (item->name, 0);
+			item->realname = item->name;
+			break;
+		}
+	}
+	list = r_flag_get_list (flags, s->vaddr + s->size);
+	secname = sdb_fmt (-1, "section_end.%s", oldname);
+	len = strlen (secname);
+	r_list_foreach (list, iter, item) {
+		if (!item->name)  {
+			continue;
+		}
+		if (!strncmp (item->name, secname, R_MIN (strlen (item->name), len))) {
+			free (item->realname);
+			item->name = strdup (sdb_fmt (-1, "section_end.%s", s->name));
+			r_str_chop (item->name);
+			r_name_filter (item->name, 0);
+			item->realname = item->name;
+			break;
+		}
+	}
+}
+
 static int cmd_section(void *data, const char *input) {
 	RCore *core = (RCore *)data;
 	const char* help_msg[] = {
@@ -95,9 +135,10 @@ static int cmd_section(void *data, const char *input) {
 		case '\0':
 			{
 			int b = 0;
-			const char *n = r_io_section_get_archbits (core->io,
-				core->offset, &b);
-			if (n) r_cons_printf ("%s %d\n", n, b);
+			const char *n = r_io_section_get_archbits (core->io, core->offset, &b);
+			if (n) {
+				r_cons_printf ("%s %d\n", n, b);
+			}
 			}
 			break;
 		case '-':
@@ -120,19 +161,16 @@ static int cmd_section(void *data, const char *input) {
 					free (ptr);
 					break;
 				}
-				if (i == 3)
-					offset = r_num_math (core->num,
-							r_str_word_get0 (ptr, 2));
-				bits = r_num_math (core->num,
-						r_str_word_get0 (ptr, 1));
+				if (i == 3) {
+					offset = r_num_math (core->num, r_str_word_get0 (ptr, 2));
+				}
+				bits = r_num_math (core->num, r_str_word_get0 (ptr, 1));
 				arch = r_str_word_get0 (ptr, 0);
-				if (r_io_section_set_archbits (core->io,
-						offset, arch, bits)) {
+				if (r_io_section_set_archbits (core->io, offset, arch, bits)) {
 					core->section = NULL;
 					r_core_seek (core, core->offset, 0);
 				} else {
-					eprintf ("Cannot set arch/bits at "
-						" 0x%08"PFMT64x"\n",offset);
+					eprintf ("Cannot set arch/bits at 0x%08"PFMT64x"\n",offset);
 				}
 				free (ptr);
 				break;
@@ -146,6 +184,7 @@ static int cmd_section(void *data, const char *input) {
 			ut64 vaddr;
 			char *p = strchr (input + 2, ' ');
 			if (p) {
+				*p = 0;
 				vaddr = r_num_math (core->num, p + 1);
 				len = (int)(size_t)(p-input + 2);
 			} else {
@@ -153,11 +192,13 @@ static int cmd_section(void *data, const char *input) {
 			}
 			s = r_io_section_vget (core->io, vaddr);
 			if (s) {
-				if (!len) len = sizeof (s->name);
-				r_str_ncpy (s->name, input + 2, len);
+				char *oldname = s->name;
+				s->name = strdup (input + 2);
+				//update flag space for the given section
+				update_section_flag_at_with_oldname (s, core->flags, s->vaddr, oldname);
+				free (oldname);
 			} else {
-				eprintf ("No section found in "
-					" 0x%08"PFMT64x"\n", core->offset);
+				eprintf ("No section found in  0x%08"PFMT64x"\n", core->offset);
 			}
 		} else {
 			eprintf ("Usage: Sr [name] ([offset])\n");
@@ -174,8 +215,7 @@ static int cmd_section(void *data, const char *input) {
 		case ' ':
 			if (input[2]) {
 				file = (char *)malloc(len * sizeof(char));
-				snprintf (file, len,
-					"%s", input + 2);
+				snprintf (file, len, "%s", input + 2);
 			}
 			__dump_section_to_disk (core, file);
 			free (file);

--- a/libr/flags/flags.c
+++ b/libr/flags/flags.c
@@ -305,8 +305,9 @@ R_API RFlagItem *r_flag_get_at(RFlag *f, ut64 off) {
 	RListIter *iter;
 
 	r_list_foreach (f->flags, iter, item) {
-		if (f->space_strict && IS_IN_SPACE (f, item))
+		if (f->space_strict && IS_IN_SPACE (f, item)) {
 			continue;
+		}
 		if (item->offset == off) {
 			return evalFlag (f, item);
 		}
@@ -412,11 +413,17 @@ R_API int r_flag_rename(RFlag *f, RFlagItem *item, const char *name) {
 	RFlagItem *p;
 	ut64 hash;
 
-	if (!f || !item || !name || !*name) return false;
+	if (!f || !item || !name || !*name) {
+		return false;
+	}
 	hash = r_str_hash64 (name);
 	p = r_hashtable64_lookup (f->ht_name, hash);
-	if (p) return false;
-	if (!set_name (item, name)) return false;
+	if (p) {
+		return false;
+	}
+	if (!set_name (item, name)) {
+		return false;
+	}
 	r_hashtable64_remove (f->ht_name, hash);
 	r_hashtable64_insert (f->ht_name, item->namehash, item);
 	return true;

--- a/libr/flags/spaces.c
+++ b/libr/flags/spaces.c
@@ -5,17 +5,20 @@
 
 R_API int r_flag_space_get(RFlag *f, const char *name) {
 	int i;
-	for (i=0; i<R_FLAG_SPACES_MAX; i++) {
-		if (f->spaces[i] != NULL)
-			if (!strcmp (name, f->spaces[i]))
+	for (i = 0; i < R_FLAG_SPACES_MAX; i++) {
+		if (f->spaces[i] != NULL) {
+			if (!strcmp (name, f->spaces[i])) {
 				return i;
-	}
+			}
+		}
+	}	
 	return -1;
 }
 
-R_API const char *r_flag_space_get_i (RFlag *f, int idx) {
-	if (idx==-1 || idx>=R_FLAG_SPACES_MAX || !f || !f->spaces[idx] || !*f->spaces[idx])
+R_API const char *r_flag_space_get_i(RFlag *f, int idx) {
+	if (idx == -1 || idx >= R_FLAG_SPACES_MAX || !f || !f->spaces[idx] || !*f->spaces[idx]) {
 		return "";
+	}
 	return f->spaces[idx];
 }
 
@@ -50,7 +53,7 @@ R_API int r_flag_space_pop(RFlag *f) {
 
 R_API int r_flag_space_set(RFlag *f, const char *name) {
 	int i;
-	if (name == NULL || *name == '*') {
+	if (!name || *name == '*') {
 		f->space_idx = -1;
 		return f->space_idx;
 	}
@@ -76,8 +79,10 @@ R_API int r_flag_space_unset (RFlag *f, const char *fs) {
 	RListIter *iter;
 	RFlagItem *fi;
 	int i, count = 0;
-	for (i=0; i<R_FLAG_SPACES_MAX; i++) {
-		if (!f->spaces[i]) continue;
+	for (i = 0; i<R_FLAG_SPACES_MAX; i++) {
+		if (!f->spaces[i]) {
+			continue;
+		}
 		if (!fs || !strcmp (fs, f->spaces[i])) {
 			if (f->space_idx == i) {
 				f->space_idx = -1;
@@ -95,7 +100,7 @@ R_API int r_flag_space_unset (RFlag *f, const char *fs) {
 	return count;
 }
 
-static int r_flag_space_count (RFlag *f, int n) {
+static int r_flag_space_count(RFlag *f, int n) {
 	RListIter *iter;
 	int count = 0;
 	RFlagItem *fi;

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -632,8 +632,9 @@ R_API char *r_str_trim_head_tail(char *str) {
 // as '.'. 
 R_API void r_str_ncpy(char *dst, const char *src, int n) {
 	int i;
-	for (i=0; src[i] && n>0; i++, n--)
+	for (i = 0; src[i] && n > 0; i++, n--) {
 		dst[i] = IS_PRINTABLE (src[i])? src[i]: '.';
+	}
 	dst[i] = 0;
 }
 
@@ -641,20 +642,24 @@ R_API void r_str_ncpy(char *dst, const char *src, int n) {
 // Returns 1 if src and dst are equal up until the first instance of ch in src.
 R_API int r_str_ccmp(const char *dst, const char *src, int ch) {
 	int i;
-	for (i=0;src[i] && src[i] != ch; i++)
-		if (dst[i] != src[i])
+	for (i = 0; src[i] && src[i] != ch; i++) {
+		if (dst[i] != src[i]) {
 			return 1;
+		}
+	}
 	return 0;
 }
 
 // Compare two strings for the first len bytes. Returns true if they are equal.
 // NOTE: this is not useful as a comparitor, as it returns true or false.
 R_API int r_str_cmp(const char *a, const char *b, int len) {
-	if (a==b)
+	if (a == b) {
 		return true;
+	}
 	for (;len--;) {
-		if (*a=='\0'||*b=='\0'||*a!=*b)
+		if (*a == '\0' || *b == '\0' || *a != *b) {
 			return true;
+		}
 		a++; b++;
 	}
 	return false;


### PR DESCRIPTION
Beside of fixing a oob write, I added it the possibility to change the flag name associated with a section after changing the name with `Sr` command the only issue is that seeking to that new section goes to zero.

```
[0x00005c20]> S.
0x000075a0 0x00017989 .text
[0x00005c20]> f~section..text
0x00003ad0 66537 section..text
[0x00005c20]> f~section_end..text
0x00013eb9 0 section_end..text
[0x00005c20]> Sr newname
[0x00005c20]> S.
0x000075a0 0x00017989 newname
[0x00005c20]> f~section.newname
0x00003ad0 66537 section.newname
[0x00005c20]> f~section_end.newname
0x00013eb9 0 section_end.newname
[0x00005c20]> f~section_end..text
[0x00005c20]> s section.
section.                     section..interp              section..note.ABI_tag
section..note.gnu.build_id   section..gnu.hash            section..dynsym
section..dynstr              section..gnu.version         section..gnu.version_r
section..rela.dyn            section..rela.plt            section..init
section..plt                 section.newname              section..fini
section..rodata              section..eh_frame_hdr        section..eh_frame
section..init_array          section..fini_array          section..jcr
section..data.rel.ro         section..dynamic             section..got
section..data                section..bss                 section..comment
section..gnu_debuglink       section..shstrtab            section.PHDR
section.INTERP               section.LOAD0                section.LOAD1
section.DYNAMIC              section.NOTE                 section.GNU_EH_FRAME
section.GNU_STACK            section.GNU_RELRO            section.ehdr
[0x00005c20]> s section.newname
[0x00000000]>
```