### PR TITLE
 fix do command, temp fix for reg arena

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1938,12 +1938,12 @@ void cmd_anal_reg (RCore *core, const char *str) {
 			*arg = 0;
 			ostr = r_str_chop (strdup (str + 1));
 			regname = r_str_clean (ostr);
-			r = r_reg_get (core->dbg->reg, regname, -1);
+			r = r_reg_get (core->dbg->reg, regname, R_REG_TYPE_GPR); //-1);
 			if (!r) {
 				int type = r_reg_get_name_idx (regname);
 				if (type != -1) {
 					const char *alias = r_reg_get_name (core->dbg->reg, type);
-					r = r_reg_get (core->dbg->reg, alias, -1);
+					r = r_reg_get (core->dbg->reg, alias, R_REG_TYPE_GPR);
 				}
 			}
 			if (r) {
@@ -1951,7 +1951,7 @@ void cmd_anal_reg (RCore *core, const char *str) {
 				//	r_reg_get_value (core->dbg->reg, r));
 				r_reg_set_value (core->dbg->reg, r,
 						r_num_math (core->num, arg + 1));
-				r_debug_reg_sync (core->dbg, -1, true);
+				r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, true);
 				//eprintf ("0x%08"PFMT64x"\n",
 				//	r_reg_get_value (core->dbg->reg, r));
 			} else {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1676,13 +1676,13 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 						r_reg_get_name_idx (string));
 				if (!regname)
 					regname = string;
-				r = r_reg_get (core->dbg->reg, regname, -1); //R_REG_TYPE_GPR);
+				r = r_reg_get (core->dbg->reg, regname, R_REG_TYPE_GPR);
 				if (r) {
 					if (r->flags) {
 						r_cons_printf ("0x%08"PFMT64x" ->",
 								r_reg_get_value (core->dbg->reg, r));
 						r_reg_set_bvalue (core->dbg->reg, r, arg+1);
-						r_debug_reg_sync (core->dbg, -1, true);
+						r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, true);
 						r_cons_printf ("0x%08"PFMT64x"\n",
 								r_reg_get_value (core->dbg->reg, r));
 					} else {
@@ -1690,7 +1690,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 								r_reg_get_value (core->dbg->reg, r));
 						r_reg_set_value (core->dbg->reg, r,
 								r_num_math (core->num, arg+1));
-						r_debug_reg_sync (core->dbg, -1, true);
+						r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, true);
 						r_cons_printf ("0x%08"PFMT64x"\n",
 								r_reg_get_value (core->dbg->reg, r));
 					}

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -114,13 +114,19 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 		eprintf ("Cannot reopen\n");
 	}
 	if (isdebug) {
+		int newtid = newpid;
 		// XXX - select the right backend
 		if (core->file && core->file->desc) {
 			newpid = core->file->desc->fd;
+#if __WINDOWS__
+			newpid = core->io->winpid;
+			newtid = core->io->wintid;
+			r_debug_select(core->dbg, newpid, newtid);
+#endif
 		}
 		//reopen and attach
 		r_core_setup_debugger (core, "native", true);
-		r_debug_select (core->dbg, newpid, newpid);
+		r_debug_select (core->dbg, newpid, newtid);
 		//
 	}
 

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -535,7 +535,7 @@ static int w32_dbg_wait(RDebug *dbg, int pid) {
 	/* handle debug events */
 	do {
 		/* do not continue when already exited but still open for examination */
-		if (exited_already) {
+		if (exited_already == pid) {
 			return -1;
 		}
 		if (WaitForDebugEvent (&de, INFINITE) == 0) {
@@ -563,7 +563,7 @@ static int w32_dbg_wait(RDebug *dbg, int pid) {
 				(int)de.u.ExitProcess.dwExitCode);
 			//debug_load();
 			next_event = 0;
-			exited_already = 1;
+			exited_already = pid;
 			ret = R_DEBUG_REASON_EXIT_PID;
 			break;
 		case CREATE_THREAD_DEBUG_EVENT:

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -151,6 +151,8 @@ typedef struct r_io_t {
 	int autofd;
 	int aslr;
 	ut64 winbase;
+	int wintid;
+	int winpid;
 	ut64 maxalloc;
 	char *runprofile;
 	char *args;

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -168,6 +168,8 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 
 	eprintf ("Spawned new process with pid %d, tid = %d\n", pid, tid);
 	io->winbase = de.u.CreateProcessInfo.lpBaseOfImage;
+	io->wintid = tid;
+	io->winpid = pid;
         return pid;
 
 err_fork:


### PR DESCRIPTION
"do" command fixed, now is possible reopen a windows debug process.
"dr" / "ar" command fixed:

r_reg_get dont manage correctly the arena size for registers out of gpr type, in windows for example exist 6 DRX registers and the profile have it. The main problem become when r_geg_get try to get arena for drx regs, the size returned is a full arena size and this corrupt the arena with random values.
To do a quick fix only GPR registers are retrieved.

Note: "ar" command is for ESIL; in visual mode the command "." have a "ar `arn PC`=value" i think is used to correctly set the cursor under ESIL emulation, but x86debug have ESIL implementation.
For this reason is needed do the same changes made for dr into ar command.
