### PR TITLE
change r_sys_mkdir() from macro to function

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -24,12 +24,11 @@ R_API bool r_sys_arch_match(const char *archstr, const char *arch);
 R_API RList *r_sys_dir(const char *path);
 R_API void r_sys_perror_str(const char *fun);
 #if __WINDOWS__ && !defined(__CYGWIN__)
-#define r_sys_mkdir(x) (CreateDirectory(x,NULL)!=0)
 #define r_sys_mkdir_failed() (GetLastError () != ERROR_ALREADY_EXISTS)
 #else
-#define r_sys_mkdir(x) (mkdir(x,0755)!=-1)
 #define r_sys_mkdir_failed() (errno != EEXIST)
 #endif
+R_API bool r_sys_mkdir(const char *dir);
 R_API bool r_sys_mkdirp(const char *dir);
 R_API int r_sys_sleep(int secs);
 R_API int r_sys_usleep(int usecs);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -522,6 +522,17 @@ R_API char *r_sys_cmd_str(const char *cmd, const char *input, int *len) {
 	return NULL;
 }
 
+R_API bool r_sys_mkdir(const char *dir) {
+	if (r_sandbox_enable (0))
+		return false;
+
+#if __WINDOWS__ && !defined(__CYGWIN__)
+	return CreateDirectory (dir, NULL) != 0;
+#else
+	return mkdir (dir, 0755) != -1;
+#endif
+}
+
 R_API bool r_sys_mkdirp(const char *dir) {
 	bool ret = true;
 	char slash = R_SYS_DIR[0];


### PR DESCRIPTION
it permits to properly check sandbox mode before calling mkdir(2).
it is a better way to fix #5595 as the check is at a lower level.