### PR TITLE
Added e var asm.cmtrefs. Fix #5571

### DIFF
--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1599,6 +1599,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("asm.describe", "false", "Show opcode description");
 	SETPREF("asm.hints", "false", "Show hints for magic numbers in disasm");
 	SETPREF("asm.marks", "true", "Show marks before the disassembly");
+	SETPREF("asm.cmtrefs", "false", "Show flag and comments from refs in disasm");
 	SETCB("bin.strpurge", "false", &cb_strpurge, "Try to purge false positive strings");
 	SETPREF("bin.libs", "false", "Try to load libraries after loading main binary");
 	SETCB("bin.strfilter", "", &cb_strfilter, "Filter strings (?:help, a:scii, e:mail, p:ath, u:rl, 8:utf8)");


### PR DESCRIPTION
Disabled by default. When enabled, it shows the flag and comment that is
at the ref of the current instruction.

Test for this: https://github.com/radare/radare2-regressions/pull/522