### PR TITLE
fix command do in windows, fix dr command to get segments registers, …

### DIFF
--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -114,13 +114,19 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 		eprintf ("Cannot reopen\n");
 	}
 	if (isdebug) {
+		int newtid = newpid;
 		// XXX - select the right backend
 		if (core->file && core->file->desc) {
 			newpid = core->file->desc->fd;
+#if __WINDOWS__
+			newpid = core->io->winpid;
+			newtid = core->io->wintid;
+			r_debug_select(core->dbg, newpid, newtid);
+#endif
 		}
 		//reopen and attach
 		r_core_setup_debugger (core, "native", true);
-		r_debug_select (core->dbg, newpid, newpid);
+		r_debug_select (core->dbg, newpid, newtid);
 		//
 	}
 

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -121,7 +121,7 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 #if __WINDOWS__
 			newpid = core->io->winpid;
 			newtid = core->io->wintid;
-			r_debug_select(core->dbg, newpid, newtid);
+			r_debug_select (core->dbg, newpid, newtid);
 #endif
 		}
 		//reopen and attach

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -649,6 +649,8 @@ static int windows_reg_write (RDebug *dbg, int type, const ut8* buf, int size) {
 	ctx.ContextFlags = CONTEXT_FULL | CONTEXT_DEBUG_REGISTERS;
 	GetThreadContext (thread, &ctx);
 	if (type == R_REG_TYPE_DRX || type == R_REG_TYPE_GPR || type == R_REG_TYPE_SEG) {
+		if (sizeof(CONTEXT) < size)
+			size = sizeof(CONTEXT);
 		memcpy (&ctx, buf, size);
 		ret = SetThreadContext (thread, &ctx)? true: false;
 	}

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -756,7 +756,7 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 #else
 		//eprintf ("TODO: No support for write DRX registers\n");
 #if __WINDOWS__ && !__CYGWIN__
-		return windows_reg_write(dbg, type, buf, size);
+		return windows_reg_write (dbg, type, buf, size);
 #endif
 		return false;
 #endif

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -535,7 +535,7 @@ static int w32_dbg_wait(RDebug *dbg, int pid) {
 	/* handle debug events */
 	do {
 		/* do not continue when already exited but still open for examination */
-		if (exited_already) {
+		if (exited_already == pid) {
 			return -1;
 		}
 		if (WaitForDebugEvent (&de, INFINITE) == 0) {
@@ -563,7 +563,7 @@ static int w32_dbg_wait(RDebug *dbg, int pid) {
 				(int)de.u.ExitProcess.dwExitCode);
 			//debug_load();
 			next_event = 0;
-			exited_already = 1;
+			exited_already = pid;
 			ret = R_DEBUG_REASON_EXIT_PID;
 			break;
 		case CREATE_THREAD_DEBUG_EVENT:

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -151,6 +151,8 @@ typedef struct r_io_t {
 	int autofd;
 	int aslr;
 	ut64 winbase;
+	int wintid;
+	int winpid;
 	ut64 maxalloc;
 	char *runprofile;
 	char *args;

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -168,6 +168,8 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 
 	eprintf ("Spawned new process with pid %d, tid = %d\n", pid, tid);
 	io->winbase = de.u.CreateProcessInfo.lpBaseOfImage;
+	io->wintid = tid;
+	io->winpid = pid;
         return pid;
 
 err_fork:

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -170,7 +170,7 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 	io->winbase = de.u.CreateProcessInfo.lpBaseOfImage;
 	io->wintid = tid;
 	io->winpid = pid;
- 	return pid;
+	return pid;
 
 err_fork:
 	eprintf ("ERRFORK\n");

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -170,7 +170,7 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 	io->winbase = de.u.CreateProcessInfo.lpBaseOfImage;
 	io->wintid = tid;
 	io->winpid = pid;
-        return pid;
+ 	return pid;
 
 err_fork:
 	eprintf ("ERRFORK\n");


### PR DESCRIPTION
fixed 'do' command  (windows 32 debugger)
fixed 'dr' command to get segment register (ll plataform)
fixed  'r_debug_reg_sync' function:
* the loop was buggy i++ are comparing value before increment, i think must be ++i, or increment out of condition.
* if stament for reg read are always getting the value of full register and dont take in mind the type and get correct size for this type of regs.

fixed native_debug for windows to work correctly with profile reg.