### PR TITLE
single stepping of JMP/CALL with indirect memory operand

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1911,6 +1911,13 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 			op->type = R_ANAL_OP_TYPE_UCALL;
 			op->jump = UT64_MAX;
 			op->ptr = INSOP(0).mem.disp;
+			op->disp = INSOP(0).mem.disp;
+			if (INSOP(0).mem.index==X86_REG_INVALID) {
+				op->ireg = NULL;
+			} else {
+				op->ireg = cs_reg_name(*handle, INSOP(0).mem.index);
+				op->scale = INSOP(0).mem.scale;
+			}
 			if (INSOP(0).mem.base == X86_REG_RIP) {
 				op->ptr += addr + insn->size;
 				op->refptr = 8;
@@ -1934,6 +1941,13 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 			// op->type = R_ANAL_OP_TYPE_UJMP;
 			op->type = R_ANAL_OP_TYPE_MJMP;
 			op->ptr = INSOP(0).mem.disp;
+			op->disp = INSOP(0).mem.disp;
+			if (INSOP(0).mem.index==X86_REG_INVALID) {
+				op->ireg = NULL;
+			} else {
+				op->ireg = cs_reg_name(*handle, INSOP(0).mem.index);
+				op->scale = INSOP(0).mem.scale;
+			}
 			if (INSOP(0).mem.base == X86_REG_RIP) {
 				op->ptr += addr + insn->size;
 				op->refptr = 8;

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1910,15 +1910,15 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		case X86_OP_MEM:
 			op->type = R_ANAL_OP_TYPE_UCALL;
 			op->jump = UT64_MAX;
-			op->ptr = INSOP(0).mem.disp;
-			op->disp = INSOP(0).mem.disp;
-			if (INSOP(0).mem.index==X86_REG_INVALID) {
+			op->ptr = INSOP (0).mem.disp;
+			op->disp = INSOP (0).mem.disp;
+			if (INSOP (0).mem.index == X86_REG_INVALID) {
 				op->ireg = NULL;
 			} else {
-				op->ireg = cs_reg_name(*handle, INSOP(0).mem.index);
+				op->ireg = cs_reg_name (*handle, INSOP (0).mem.index);
 				op->scale = INSOP(0).mem.scale;
 			}
-			if (INSOP(0).mem.base == X86_REG_RIP) {
+			if (INSOP (0).mem.base == X86_REG_RIP) {
 				op->ptr += addr + insn->size;
 				op->refptr = 8;
 			}
@@ -1940,13 +1940,13 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		case X86_OP_MEM:
 			// op->type = R_ANAL_OP_TYPE_UJMP;
 			op->type = R_ANAL_OP_TYPE_MJMP;
-			op->ptr = INSOP(0).mem.disp;
-			op->disp = INSOP(0).mem.disp;
-			if (INSOP(0).mem.index==X86_REG_INVALID) {
+			op->ptr = INSOP (0).mem.disp;
+			op->disp = INSOP (0).mem.disp;
+			if (INSOP (0).mem.index == X86_REG_INVALID) {
 				op->ireg = NULL;
 			} else {
-				op->ireg = cs_reg_name(*handle, INSOP(0).mem.index);
-				op->scale = INSOP(0).mem.scale;
+				op->ireg = cs_reg_name (*handle, INSOP (0).mem.index);
+				op->scale = INSOP (0).mem.scale;
 			}
 			if (INSOP(0).mem.base == X86_REG_RIP) {
 				op->ptr += addr + insn->size;

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -668,11 +668,11 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 		br = 2;
 		break;
 	case R_ANAL_OP_TYPE_MJMP:
-		if (op.ireg==NULL) {
+		if (!op.ireg) {
 			next[0] = op.jump;
 			br = 1;
 		} else {
-			r = r_debug_reg_get(dbg,op.ireg);
+			r = r_debug_reg_get (dbg,op.ireg);
 			if (dbg->iob.read_at (dbg->iob.io, r*op.scale + op.disp, (ut8*)&memval, 8) <0 ) {
 				next[0] = op.addr + op.size;
 				br = 1;
@@ -688,7 +688,7 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 		br = 1;
 		break;
 	case R_ANAL_OP_TYPE_UCALL:
-		r = r_debug_reg_get(dbg,op.ireg);
+		r = r_debug_reg_get (dbg,op.ireg);
 		if (dbg->iob.read_at (dbg->iob.io, r*op.scale + op.disp, (ut8*)&memval, 8) <0 ) {
 			next[0] = op.addr + op.size;
 			br = 1;

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -621,8 +621,9 @@ R_API RDebugReasonType r_debug_wait(RDebug *dbg) {
 
 R_API int r_debug_step_soft(RDebug *dbg) {
 	ut8 buf[32];
-	ut64 pc, sp;
+	ut64 pc, sp, r;
 	ut64 next[2];
+	ut64 memval;
 	RAnalOp op;
 	int br, i, ret;
 	union {
@@ -666,9 +667,34 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 		next[1] = op.fail;
 		br = 2;
 		break;
+	case R_ANAL_OP_TYPE_MJMP:
+		if (op.ireg==NULL) {
+			next[0] = op.jump;
+			br = 1;
+		} else {
+			r = r_debug_reg_get(dbg,op.ireg);
+			if (dbg->iob.read_at (dbg->iob.io, r*op.scale + op.disp, (ut8*)&memval, 8) <0 ) {
+				next[0] = op.addr + op.size;
+				br = 1;
+				break;
+			}
+			next[0] = memval;
+			br = 1;
+		}
+		break;
 	case R_ANAL_OP_TYPE_CALL:
 	case R_ANAL_OP_TYPE_JMP:
 		next[0] = op.jump;
+		br = 1;
+		break;
+	case R_ANAL_OP_TYPE_UCALL:
+		r = r_debug_reg_get(dbg,op.ireg);
+		if (dbg->iob.read_at (dbg->iob.io, r*op.scale + op.disp, (ut8*)&memval, 8) <0 ) {
+			next[0] = op.addr + op.size;
+			br = 1;
+			break;
+		}
+		next[0] = memval;
 		br = 1;
 		break;
 	default:

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -706,6 +706,9 @@ typedef struct r_anal_op_t {
 	struct r_anal_op_t *next; // TODO deprecate
 	RStrBuf esil;
 	const char *reg; /* destination register */
+	const char *ireg; /* register used for indirect memory computation*/
+	int scale;
+	ut64 disp;
 	RAnalSwitchOp *switch_op;
 } RAnalOp;
 


### PR DESCRIPTION
these changes should allow single stepping of instructions like "call qword [rax*8 + 0x6008a8]" and "jmp qword [rbx*8 + 0x6004e0]" to work properly.