### PR TITLE
Virtual marks cleanup & added to project file

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -388,6 +388,8 @@ R_API bool r_core_project_save_rdb(RCore *core, const char *file, int opts) {
 		r_str_write (fd, "# meta\n");
 		r_meta_list (core->anal, R_META_TYPE_ANY, 1);
 		r_cons_flush ();
+		r_core_cmd (core, "fV*", 0);
+		r_cons_flush ();
 	}
 	if (opts & R_CORE_PRJ_XREFS) {
 		r_core_cmd (core, "ax*", 0);

--- a/libr/core/vmarks.c
+++ b/libr/core/vmarks.c
@@ -18,19 +18,15 @@ R_API void r_core_visual_mark_dump(RCore *core) {
 	if (!marks_init)
 		return;
 	for (i=0; i<UT8_MAX; i++) {
-		if (marks[i]) {
+		if (marks[i] != UT64_MAX) {
 			r_cons_printf ("fV %d 0x%"PFMT64x"\n", i, marks[i]);
 		}
-		marks[i] = 0;
 	}
 }
 
 R_API void r_core_visual_mark_set(RCore *core, ut8 ch, ut64 addr) {
 	if (!marks_init) {
-		int i;
-		for (i=0; i<UT8_MAX; i++)
-			marks[i] = 0;
-		marks_init = true;
+		r_core_visual_mark_reset(core);
 	}
 	marks[ch] = core->offset;
 }


### PR DESCRIPTION
removing deletion of marks after dump and using UT64_MAX as an unset flag throughout the code.