### PR TITLE
fix for debug command dbic <num> <cmd>

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2126,10 +2126,8 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					   case 'c': // "dbic"
 						   p = strchr (input + 3, ' ');
 						   if (p) {
-							   do {
-								   ++p;
-							   } while ( !IS_WHITESPACE(*p) );
-							   if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
+							   p = strchr (p + 1, ' ');
+							   if (p && (bpi = r_bp_get_index (core->dbg->bp, addr))) {
 								   bpi->data = strdup (p+1);
 							   } else eprintf ("Cannot set command\n");
 						   } else {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2126,6 +2126,9 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					   case 'c': // "dbic"
 						   p = strchr (input + 3, ' ');
 						   if (p) {
+							   do {
+								   ++p;
+							   } while ( isdigit (*p) );
 							   if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
 								   bpi->data = strdup (p+1);
 							   } else eprintf ("Cannot set command\n");

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2128,7 +2128,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 						   if (p) {
 							   do {
 								   ++p;
-							   } while ( isdigit (*p) );
+							   } while ( !IS_WHITESPACE(*p) );
 							   if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
 								   bpi->data = strdup (p+1);
 							   } else eprintf ("Cannot set command\n");


### PR DESCRIPTION
Example of issue:
db entry0
db entry0+2
dbic 1 dr
db
--> shows in cmd "1 dr", which cannot be executed!

This patch should solve this issue