### PR TITLE
Fix #5556 - prints all hashes, even if have gap between the bits

### DIFF
--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -271,10 +271,12 @@ static void algolist() {
 	ut64 bits;
 	int i;
 	eprintf ("Available Hashes: \n");
-	for (i = 0; i < 64; i++) {
-		bits = ((ut64)1) << i;
+	for (i = 0; i < R_HASH_NBITS; i++) {
+		bits = 1LL << i;
 		const char *name = r_hash_name (bits);
-		if (name && *name) printf ("  %s\n", name);
+		if (name && *name) {
+			 printf ("  %s\n", name);
+		}
 	}
 	eprintf ("\n");
 	eprintf ("Available Encoders/Decoders: \n");

--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -272,7 +272,7 @@ static void algolist() {
 	int i;
 	eprintf ("Available Hashes: \n");
 	for (i = 0; i < R_HASH_NBITS; i++) {
-		bits = 1LL << i;
+		bits = 1ULL << i;
 		const char *name = r_hash_name (bits);
 		if (name && *name) {
 			 printf ("  %s\n", name);

--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -271,11 +271,10 @@ static void algolist() {
 	ut64 bits;
 	int i;
 	eprintf ("Available Hashes: \n");
-	for (i = 0; ; i++) {
+	for (i = 0; i < 64; i++) {
 		bits = ((ut64)1) << i;
 		const char *name = r_hash_name (bits);
-		if (!name || !*name) break;
-		printf ("  %s\n", name);
+		if (name && *name) printf ("  %s\n", name);
 	}
 	eprintf ("\n");
 	eprintf ("Available Encoders/Decoders: \n");

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1590,11 +1590,12 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 
 static void algolist(int mode) {
 	int i;
-	for (i = 0; i < 64 ; i++) {
-		ut64 bits = ((ut64)1) << i;
+	for (i = 0; i < R_HASH_NBITS ; i++) {
+		ut64 bits = 1LL << i;
 		const char *name = r_hash_name (bits);
-		if (name && *name)
+		if (name && *name) {
 			r_cons_println (name);
+		}
 	}
 	if (!mode) r_cons_newline ();
 }

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1591,7 +1591,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 static void algolist(int mode) {
 	int i;
 	for (i = 0; i < R_HASH_NBITS ; i++) {
-		ut64 bits = 1LL << i;
+		ut64 bits = 1ULL << i;
 		const char *name = r_hash_name (bits);
 		if (name && *name) {
 			r_cons_println (name);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1590,11 +1590,11 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 
 static void algolist(int mode) {
 	int i;
-	for (i = 0; ; i++) {
+	for (i = 0; i < 64 ; i++) {
 		ut64 bits = ((ut64)1) << i;
 		const char *name = r_hash_name (bits);
-		if (!name || !*name) break;
-		r_cons_println (name);
+		if (name && *name)
+			r_cons_println (name);
 	}
 	if (!mode) r_cons_newline ();
 }

--- a/libr/include/r_hash.h
+++ b/libr/include/r_hash.h
@@ -80,6 +80,8 @@ typedef struct r_hash_seed_t {
 #define R_HASH_SIZE_HAMDIST 1
 #define R_HASH_SIZE_LUHN 1
 
+#define R_HASH_NBITS (8*sizeof(ut64))
+
 #define R_HASH_NONE 0
 #define R_HASH_MD5 1
 #define R_HASH_SHA1 2


### PR DESCRIPTION
The fix for issue #5007 has caused a gap between the bits in the hash_name_bytes structure. As such, the for loops to print the available hashes stop at the first gap. This fix allows to have any number of gaps in the bits. Since ut64 is a 64bit word, the for loops are hard-coded with the number 64.