### PR TITLE
fix visual mark target address

### DIFF
--- a/libr/core/vmarks.c
+++ b/libr/core/vmarks.c
@@ -30,7 +30,7 @@ R_API void r_core_visual_mark_set(RCore *core, ut8 ch, ut64 addr) {
 	if (!marks_init) {
 		r_core_visual_mark_reset(core);
 	}
-	marks[ch] = core->offset;
+	marks[ch] = addr;
 }
 
 R_API void r_core_visual_mark(RCore *core, ut8 ch) {


### PR DESCRIPTION
Visual marks do not respect the specified addresses but uses always the current seek.