### PR TITLE
Fixing nasty bug in CC implementation

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -464,7 +464,27 @@ R_API void r_core_anal_type_init(RCore *core) {
 	}
 }
 
+static int save_ptr(void *p, const char *k, const char *v) {
+	Sdb *sdbs[2];
+	sdbs[0] = ((Sdb**) p)[0];
+	sdbs[1] = ((Sdb**) p)[1];
+	if (!strncmp (v, "cc", strlen("cc") + 1)) {
+		const char *x = sdb_const_get (sdbs[1], sdb_fmt (-1, "cc.%s.name", k), 0);
+		char *tmp = sdb_fmt (-1, "0x%08"PFMT64x, (ut64)x);
+		sdb_set (sdbs[0], tmp, x, 0);
+	}
+	return 1;
+}
+
 R_API void r_core_anal_cc_init(RCore *core) {
+	Sdb *sdbs[2];
+	sdbs[0] = sdb_new0 ();
+	sdbs[1] = core->anal->sdb_cc;
+	//save pointers and values stored inside them
+	//to recover from freeing heeps
+	const char *defaultcc = sdb_const_get (sdbs[1], "default.cc", 0);
+	sdb_set (sdbs[0], sdb_fmt (-1, "0x%08"PFMT64x, defaultcc), defaultcc, 0);
+	sdb_foreach (core->anal->sdb_cc, save_ptr, sdbs);
 	sdb_reset ( core->anal->sdb_cc);
 	const char *anal_arch = r_config_get (core->config, "anal.arch");
 	char *dbpath = sdb_fmt (-1, DBSPATH"/cc-%s-%d.sdb", anal_arch,
@@ -472,6 +492,21 @@ R_API void r_core_anal_cc_init(RCore *core) {
 	if (r_file_exists (dbpath)) {
 		sdb_concat_by_path (core->anal->sdb_cc, dbpath);
 	}
+	//restore all freed CC or replace with new default cc
+	RListIter *it;
+	RAnalFunction *fcn;
+	r_list_foreach (core->anal->fcns, it, fcn) {
+		char *ptr = sdb_fmt (-1, "0x%08"PFMT64x, (ut64)fcn->cc);
+		const char *cc = sdb_const_get (sdbs[0], ptr, 0);
+		if (cc) {
+			fcn->cc = r_anal_cc_to_constant (core->anal, (char *)cc);
+		}
+		if (!fcn->cc) {
+			fcn->cc = r_anal_cc_default (core->anal);
+		}
+	}
+	sdb_close (sdbs[0]);
+	sdb_free (sdbs[0]);
 }
 #undef DBSPATH
 


### PR DESCRIPTION
That is not the kind of bug I see everyday
1- calling convention db is loaded
2- function cc types is initialized by project file, that string is only
one copy across the whole database for memory efficiency.
3- The db is reloaded due to change in arch or what ever, Old strings
are freed and new one is created with totally new address. Most cases it
just reload the same database.
4- Addresses in function cc types are not updates, they are already
freed at reloading db step

Solution implemented at db reloading step:
1- create new temp db with all possible available calling conventions and
the adresses in memory of these calling conventions
2- once db is reloaded, grab adress of cc from function, match it with
the name in the new temp db, then replace it with the constant value
from the newly loaded db