### PR TITLE
r_core_anal_fcn fix

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -49,6 +49,7 @@ R_API RAnal *r_anal_new() {
 	anal->esil_goto_limit = R_ANAL_ESIL_GOTO_LIMIT;
 	anal->limit = NULL;
 	anal->opt.nopskip = true; // skip nops in code analysis
+	anal->opt.hpskip = false; // skip `mov reg,reg` and `lea reg,[reg]`
 	anal->decode = true; // slow slow if not used
 	anal->gp = 0LL;
 	anal->sdb = sdb_new0 ();

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -1166,6 +1166,10 @@ R_API int r_core_anal_esil_fcn(RCore *core, ut64 at, ut64 from, int reftype, int
  * If the function has been already analyzed, it adds a
  * reference to that fcn */
 R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth) {
+	if (from == UT64_MAX && r_anal_get_fcn_in (core->anal, at, 0)) {
+		return 0;
+	}
+
 	bool use_esil = r_config_get_i (core->config, "anal.esil");
 	RAnalFunction *fcn;
 	RListIter *iter;

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -121,6 +121,13 @@ static int cb_analnopskip (void *user, void *data) {
 	return true;
 }
 
+static int cb_analhpskip (void *user, void *data) {
+	RCore *core = (RCore*) user;
+	RConfigNode *node = (RConfigNode*) data;
+	core->anal->opt.hpskip = node->i_value;
+	return true;
+}
+
 static int cb_analbbsplit (void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
@@ -1519,6 +1526,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("anal.vinfun", "false",  "Search values in functions (aav) (false by default to only find on non-code)");
 	SETPREF("anal.vinfunrange", "false",  "Search values outside function ranges (requires anal.vinfun=false)\n");
 	SETCB("anal.nopskip", "true", &cb_analnopskip, "Skip nops at the beginning of functions");
+	SETCB("anal.hpskip", "false", &cb_analhpskip, "Skip `mov reg, reg` and `lea reg, [reg] at the beginning of functions");
 	SETCB("anal.bbsplit", "true", &cb_analbbsplit, "Use the experimental basic block split for JMPs");
 	SETCB("anal.noncode", "false", &cb_analnoncode, "Analyze data as code");
 	SETCB("anal.arch", R_SYS_ARCH, &cb_analarch, "Specify the anal.arch to use");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1825,6 +1825,7 @@ static void ds_instruction_mov_lea(RDisasmState *ds, int idx) {
 					r_core_read_at (core, ptr, b, src->memref);
 					off = r_mem_get_num (b, src->memref);
 					item = r_flag_get_i (core->flags, off);
+					//TODO: introduce env for this print?
 					r_cons_printf ("; MOV %s = [0x%"PFMT64x"] = 0x%"PFMT64x" %s\n",
 							dst->reg->name, ptr, off, item?item->name: "");
 				}
@@ -1847,11 +1848,11 @@ static void ds_instruction_mov_lea(RDisasmState *ds, int idx) {
 				r_core_read_at (core, ptr, b, sizeof (b)); //memref);
 				off = r_mem_get_num (b, memref);
 				item = r_flag_get_i (core->flags, off);
-				{
-				char s[64];
-				r_str_ncpy (s, (const char *)b, sizeof (s));
-				r_cons_printf ("; LEA %s = [0x%"PFMT64x"] = 0x%"PFMT64x" \"%s\"\n",
-						dst->reg->name, ptr, off, item?item->name: s);
+				if (ds->show_leahints) {
+					char s[64];
+					r_str_ncpy (s, (const char *)b, sizeof (s));
+					r_cons_printf ("; LEA %s = [0x%"PFMT64x"] = 0x%"PFMT64x" \"%s\"\n",
+							dst->reg->name, ptr, off, item?item->name: s);
 				}
 			}
 		}

--- a/libr/flags/flags.c
+++ b/libr/flags/flags.c
@@ -251,6 +251,26 @@ static RFlagItem *evalFlag(RFlag *f, RFlagItem *item) {
 	return item;
 }
 
+/* return true if flag.* exist at offset. Otherwise, false is returned.
+ * For example (f, "sym", 3, 0x1000)*/
+R_API bool r_flag_exist_at(RFlag *f, const char *flag_prefix, ut16 fp_size, ut64 off) {
+	RListIter *iter = NULL;
+	RFlagItem *item = NULL;
+	if (!f) {
+		return false;
+	}
+	RList *list = r_hashtable64_lookup (f->ht_off, XOROFF (off));
+	if (!list) {
+		return false;
+	}
+	r_list_foreach (list, iter, item) {
+		if (item->name && !strncmp (item->name, flag_prefix, fp_size)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 /* return the flag item with name "name" in the RFlag "f", if it exists.
  * Otherwise, NULL is returned. */
 R_API RFlagItem *r_flag_get(RFlag *f, const char *name) {
@@ -569,6 +589,7 @@ R_API const char *r_flag_color(RFlag *f, RFlagItem *it, const char *color) {
 // BIND
 R_API int r_flag_bind(RFlag *f, RFlagBind *fb) {
 	fb->f = f;
+	fb->exist_at = r_flag_exist_at;
 	fb->get = r_flag_get;
 	fb->get_at = r_flag_get_at;
 	fb->set = r_flag_set;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -556,6 +556,7 @@ typedef struct r_anal_options_t {
 	int bbsplit;
 	int noncode;
 	int nopskip; // skip nops at the beginning of functions
+	int hpskip; // skip `mov reg,reg` and `lea reg,[reg]`
 	int jmptbl; // analyze jump tables
 	bool pushret; // analyze push+ret as jmp
 } RAnalOptions;

--- a/libr/include/r_flags.h
+++ b/libr/include/r_flags.h
@@ -43,6 +43,7 @@ typedef struct r_flag_t {
 
 /* compile time dependency */
 
+typedef bool (*RFlagExistAt)(RFlag *f, const char *flag_prefix, ut16 fp_size, ut64 off);
 typedef RFlagItem* (*RFlagGet)(RFlag *f, const char *name);
 typedef RFlagItem* (*RFlagGetAt)(RFlag *f, ut64 addr);
 typedef RFlagItem* (*RFlagSet)(RFlag *f, const char *name, ut64 addr, ut32 size);
@@ -51,6 +52,7 @@ typedef int (*RFlagSetSpace)(RFlag *f, const char *name);
 typedef struct r_flag_bind_t {
 	int init;
 	RFlag *f;
+	RFlagExistAt exist_at;
 	RFlagGet get;
 	RFlagGetAt get_at;
 	RFlagSet set;
@@ -64,6 +66,7 @@ R_API int r_flag_bind(RFlag *io, RFlagBind *bnd);
 R_API RFlag * r_flag_new(void);
 R_API RFlag * r_flag_free(RFlag *f);
 R_API void r_flag_list(RFlag *f, int rad, const char *pfx);
+R_API bool r_flag_exist_at(RFlag *f, const char *flag_prefix, ut16 fp_size, ut64 off);
 R_API RFlagItem *r_flag_get(RFlag *f, const char *name);
 R_API RFlagItem *r_flag_get_i(RFlag *f, ut64 off);
 R_API RFlagItem *r_flag_get_i2(RFlag *f, ut64 off);


### PR DESCRIPTION
If an analysed address belongs to some function we simply skip all further analysis.

Theoretically this fix should significantly decrease number of false positives, also it solves this issue - https://github.com/radare/radare2/issues/4783.