### PR TITLE
fix radare2-regressions/t.archos/Linux-x86_64/dbg_bps regressions

### DIFF
--- a/libr/debug/reg.c
+++ b/libr/debug/reg.c
@@ -30,8 +30,8 @@ R_API int r_debug_reg_sync(RDebug *dbg, int type, int write) {
 			}
 		} else {
 			// int bufsize = R_MAX (1024, dbg->reg->size*2); // i know. its hacky
-			//int bufsize = dbg->reg->size;
-			int bufsize = dbg->reg->regset[i].arena->size;
+			int bufsize = dbg->reg->size;
+			//int bufsize = dbg->reg->regset[i].arena->size;
 			if (bufsize > 0) {
 				ut8 *buf = calloc (1, bufsize);
 				if (!buf) {


### PR DESCRIPTION
Commit 12a6469bbd4fc7 broke some regressions.
How to reproduce?
  cd radare2-regressions/t.archos/Linux-x86_64
  r2 -AAd ../../bins/elf/x86-helloworld-gcc

==> Will randomly crash with segmentation fault.

Reason looks like the dbg->reg->regset[i].arena->size is giving some strange values, e.g.
    i=3, dbg->reg->size=296, dbg->reg->regset[i].arena->size=1

The size of 1 byte from arena->size seems to be causing the crash.
This commit reverts back the line.
Probably a better fix is to look at where, in the codebase, these values are (or should) be initialized.