### PR TITLE
Fix off-by-one error in afx- handling

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1467,7 +1467,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			char *p;
 			ut64 a, b;
 			RAnalFunction *fcn;
-			char *mi = strdup (input + 2);
+			char *mi = strdup (input + 3);
 			if (mi && *mi == ' ' && (p = strchr (mi + 1, ' '))) {
 				*p = 0;
 				a = r_num_math (core->num, mi);


### PR DESCRIPTION
For `afx-`, input starts at `fx-`, so the added offset needs to be 3, not 2. Without this change, it will always print `Usage: afx- [src] [dst]` as `*mi==' '` will never match.