### PR TITLE
Fix #5642 - Update documentation for afb

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1332,7 +1332,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 				" .afbr-*     - undo the above operation\n"
 				" afbj        - show basic blocks information in JSON\n"
 				" afB [bits]  - define asm.bits for given function\n"
-				" afb [addr]  - list basic blocks of function (see afbq, afbj, afb*)\n"
+				" afb         - list basic blocks of function (see afbq, afbj, afb*)\n"
 				" afb+ fcn_at bbat bbsz [jump] [fail] ([type] ([diff]))  add bb to function @ fcnaddr\n");
 			break;
 		}


### PR DESCRIPTION
Was unsure if I should add the optional [@offset] hint to the documentation or not as it seems to be a common optional argument. 