### PR TITLE
Bash on Ubuntu on Windows fix - remove ${LIB} from Makefile

### DIFF
--- a/shlr/bochs/Makefile
+++ b/shlr/bochs/Makefile
@@ -26,17 +26,17 @@ SRC_D=src
 SRC_C=$(wildcard $(SRC_D)/*.c)
 SRC_O=$(SRC_C:.c=.o)
 
-all: $(LIB)/$(LIBNAME).a
+all: lib/$(LIBNAME).a
 
-#$(LD) -shared -Wl,-soname,$(LIBNAME).so -o $(LIB)/$(LIBNAME).so $(SRC_O)
-$(LIB):
-	mkdir -p $(LIB)
+#$(LD) -shared -Wl,-soname,$(LIBNAME).so -o lib/$(LIBNAME).so $(SRC_O)
+lib:
+	mkdir -p lib
 
-$(LIB)/$(LIBNAME).a: $(LIB) $(SRC_O)
-	mkdir -p $(LIB)
-	$(LD) $(PIC_CFLAGS) $(LDFLAGS_SHARED) -o $(LIB)/$(LIBFILE) $(CFLAGS) $(SRC_O) $(LDFLAGS) $(LINK)
-	$(AR) rvs $(LIB)/$(LIBNAME).a $(SRC_O)
-	$(RANLIB) $(LIB)/$(LIBNAME).a
+lib/$(LIBNAME).a: lib $(SRC_O)
+	mkdir -p lib
+	$(LD) $(PIC_CFLAGS) $(LDFLAGS_SHARED) -o lib/$(LIBFILE) $(CFLAGS) $(SRC_O) $(LDFLAGS) $(LINK)
+	$(AR) rvs lib/$(LIBNAME).a $(SRC_O)
+	$(RANLIB) lib/$(LIBNAME).a
 
 clean:
 	-rm -f $(SRC_O)


### PR DESCRIPTION
Pull request to fix Bash on Ubuntu on Windows builds, as discussed in #5232.

(text below is from the commit)
r2 builds currently fail on Bash on Ubuntu on Windows due to the
${NAME} variable being defined in the environment (as the current
hostname), which meant that libbochs.a was being placed in an
unexpected location. This patch fixes the issue for BoUoW by replacing
use of the ${LIB} variable with a set value of 'lib'. It should be
noted that other build scripts (e.g. shlr/bochs/deps.mk) currently
assume that libbochs.a is located precisely at
shlr/bochs/lib/libbochs.a anyway (and as such, it is suspected that
the use of ${LIB} here may have been spurious to begin with).