### PR TITLE
fixed array types in parsing routines + added special case for char[]

### DIFF
--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -230,20 +230,21 @@ R_API char *r_anal_type_format(RAnal *anal, const char *t) {
 					}
 				} else {
 					elements = sdb_array_get_num (DB, var2, 2, NULL);
-					snprintf (var3, sizeof (var3), "type.%s", type);
-					tfmt = sdb_const_get (DB, var3, NULL);
+					// special case for char[]. Use char* format type without *
+					if (!strncmp (type, "char", 5) && elements > 0) {
+						tfmt = sdb_const_get (DB, "type.char *", NULL);
+						if (tfmt && *tfmt == '*')
+							tfmt++;
+					} else {
+						snprintf (var3, sizeof (var3), "type.%s", type);
+						tfmt = sdb_const_get (DB, var3, NULL);
+					}
 					if (tfmt) {
 						filter_type (type);
 						if (elements > 0) {
 							fmt = r_str_concatf (fmt, "[%d]", elements);
-							if (*tfmt == '*') { // is not pointer but local array
-								fmt = r_str_concat (fmt, tfmt+1);
-							} else {
-								fmt = r_str_concat (fmt, tfmt);
-							}
-						} else {
-							fmt = r_str_concat (fmt, tfmt);
 						}
+						fmt = r_str_concat (fmt, tfmt);
 						vars = r_str_concat (vars, p);
 						vars = r_str_concat (vars, " ");
 					} else eprintf ("Cannot resolve type '%s'\n", var3);

--- a/shlr/tcc/tccgen.c
+++ b/shlr/tcc/tccgen.c
@@ -661,10 +661,14 @@ static void type_to_str(char *buf, int buf_size,
         goto no_var;
     case VT_PTR:
         s = type->ref;
-        pstrcpy(buf1, sizeof(buf1), "*");
-        if (varstr)
-            pstrcat(buf1, sizeof(buf1), varstr);
-        type_to_str(buf, buf_size, &s->type, buf1);
+        if (t & VT_ARRAY) {
+            type_to_str(buf, buf_size, &s->type, NULL);
+        } else {
+            pstrcpy(buf1, sizeof(buf1), "*");
+            if (varstr)
+                pstrcat(buf1, sizeof(buf1), varstr);
+            type_to_str(buf, buf_size, &s->type, buf1);
+        }
         goto no_var;
     }
     if (varstr) {


### PR DESCRIPTION
Interpret char[] as char* in the pf format (use z instead of c).