### PR TITLE
"#4734 #4442 fix"

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -25,6 +25,7 @@ typedef struct {
 } HintListState;
 
 static void add_string_ref (RCore *core, ut64 xref_to);
+static int cmpfcn (const void *_a, const void *_b);
 
 static void loganal(ut64 from, ut64 to, int depth) {
 	r_cons_clear_line (1);
@@ -533,6 +534,16 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 				if (!ref) {
 					eprintf ("Error: new (xref)\n");
 					goto error;
+				}
+				if (fcn->type == R_ANAL_FCN_TYPE_LOC) {
+					RAnalFunction *f = r_anal_get_fcn_in (core->anal, from, -1);
+					if (f) {
+						if (!f->fcn_locs) {
+							f->fcn_locs = r_anal_fcn_list_new ();
+						}
+						r_list_append (f->fcn_locs, fcn);
+						r_list_sort (f->fcn_locs, &cmpfcn);
+					}
 				}
 				ref->addr = from;
 				ref->at = fcn->addr;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -923,6 +923,14 @@ static int var_comparator(const RAnalVar *a, const RAnalVar *b){
 	return false;
 }
 
+//TODO: this function is a temporary fix. All analysis should be based on realsize. However, now for same architectures realisze is not used
+static ut32 tmp_get_realsize (RAnalFunction *f)
+{
+	ut32 size = r_anal_fcn_realsize (f);
+	size = (size > 0) ? size : r_anal_fcn_size (f);
+	return (size < 0) ? 0 : size;
+}
+
 static void ds_show_functions(RDisasmState *ds) {
 	RAnalFunction *f;
 	RCore *core = ds->core;
@@ -988,12 +996,12 @@ static void ds_show_functions(RDisasmState *ds) {
 			ds_print_offset (ds);
 			r_cons_printf ("%s%s%s(%s) %s%s%s %d\n",
 					space, COLOR_RESET (ds), COLOR (ds, color_fname),
-					fcntype, fcn_name, cmt, COLOR_RESET (ds), r_anal_fcn_size (f));
+					fcntype, fcn_name, cmt, COLOR_RESET (ds), tmp_get_realsize (f));
 		} else {
 			r_cons_printf ("%s%s%s%s%s(%s) %s%s%s %d\n",
 					COLOR (ds, color_fline), ds->pre,
 					space, COLOR_RESET (ds), COLOR (ds, color_fname),
-					fcntype, fcn_name, cmt, COLOR_RESET (ds), r_anal_fcn_size (f));
+					fcntype, fcn_name, cmt, COLOR_RESET (ds), tmp_get_realsize (f));
 		}
 	}
 	if (sign)

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -276,6 +276,7 @@ typedef struct r_anal_type_function_t {
 	ut8 *fingerprint; // TODO: make is fuzzy and smarter
 	RAnalDiff *diff;
 	RList *locs; // list of local variables
+	RList *fcn_locs; //sorted list of a function *.loc refs
 	//RList *locals; // list of local labels -> moved to anal->sdb_fcns
 	RList *bbs;
 	RList *vars;
@@ -1273,6 +1274,7 @@ R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind, int type);
 
 R_API ut32 r_anal_fcn_size(const RAnalFunction *fcn);
 R_API void r_anal_fcn_set_size(RAnalFunction *fcn, ut32 size);
+R_API ut32 r_anal_fcn_contsize(const RAnalFunction *fcn);
 R_API ut32 r_anal_fcn_realsize(const RAnalFunction *fcn);
 R_API int r_anal_fcn_cc(RAnalFunction *fcn);
 R_API int r_anal_fcn_split_bb(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bb, ut64 addr);


### PR DESCRIPTION
This pull request fixes issue https://github.com/radare/radare2/issues/4442 and https://github.com/radare/radare2/issues/4734
The following bugs were fixed:
- `pdf` worked only with continuous functions. (which is wrong because funcs bbs could be aligned not continuously, example of such function can be found in issue #4743)
- `pdf` used size instead of realsize
- `pdr` locs print is added
- loc.* were not a part of a function. Now behavior is similar to the IDA behavior. Each functions includes locs and the function realsize calculated as size of bbs of a function + locs size