### PR TITLE
anal: fix aae command arguments handling

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -2959,6 +2959,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 	RAsmOp asmop;
 	RAnalOp op = {0};
 	ut8 *buf = NULL;
+	bool end_address_set = false;
 	int i, iend;
 	int minopsize = 4; // XXX this depends on asm->mininstrsize
 	ut64 addr = core->offset;
@@ -2982,19 +2983,23 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 		if (fcn) {
 			addr = fcn->addr;
 			end = fcn->addr + r_anal_fcn_size (fcn);
+			end_address_set = true;
 		}
 	}
-	if (str[0] == ' ') {
-		end = addr + r_num_math (core->num, str + 1);
-	} else {
-		RIOSection *sect = r_io_section_vget (core->io, addr);
-		if (sect) {
-			end = sect->vaddr + sect->size;
+
+	if (!end_address_set) {
+		if (str[0] == ' ') {
+			end = addr + r_num_math (core->num, str + 1);
 		} else {
-			if (!end)
+			RIOSection *sect = r_io_section_vget (core->io, addr);
+			if (sect) {
+				end = sect->vaddr + sect->size;
+			} else {
 				end = addr + core->blocksize;
+			}
 		}
 	}
+
 	iend = end - addr;
 	if (iend < 0) {
 		return;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4536,16 +4536,13 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		break;
 	}
 	case 'e': // "aae"
-		if (input[1] == ' ') {
-			char *len = strdup (input + 2);
-			if (len) {
-				char *addr = strchr (len, ' ');
-				if (addr) {
-					*addr++ = 0;
-				}
-				r_core_anal_esil (core, len, addr);
-				free (len);
+		if (input[1] != '\0') {
+			char *len = (char *) &input[1];
+			char *addr = strchr (&input[2], ' ');
+			if (addr) {
+				*addr++ = 0;
 			}
+			r_core_anal_esil (core, len, addr);
 		} else {
 			ut64 at = core->offset;
 			ut64 from = r_num_get (core->num, "$S");


### PR DESCRIPTION
Commands like `aae?`, `aaef` and `aae [len] [addr]` weren't working.