### PR TITLE
Fix:  fix segfault for really big processes while dumping it (coredump)

### DIFF
--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -707,7 +707,7 @@ static void *get_ntfile_data(linux_map_entry_t *head) {
 	pp += sizeof (n_segments) + sizeof (n_pag);
 
 	for (p = head; p; p = p->n) {
-		if (!is_a_kernel_mapping (p->name)) {
+		if (p->file_backed && !is_a_kernel_mapping (p->name)) {
 			memcpy (pp, &p->start_addr, sizeof (p->start_addr));
 			pp += sizeof (p->start_addr);
 			memcpy (pp, &p->end_addr, sizeof (p->end_addr));
@@ -717,7 +717,7 @@ static void *get_ntfile_data(linux_map_entry_t *head) {
 		}
 	}
 	for (p = head; p; p = p->n) {
-		if (!is_a_kernel_mapping (p->name)) {
+		if (p->file_backed && !is_a_kernel_mapping (p->name)) {
 			strncpy (pp, p->name, size - (pp - maps_data));
 			pp += strlen (p->name) + 1;
 		}


### PR DESCRIPTION
I don't how this happened but for some reason in the function where we're writing the files-backed maps I forgot to check if the map was actually a file-backed map.
This didn't hurt small processes, so I guess this is why I didn't spot it, but with big processes like firefox this causes a segfault.

This fixes it.