### PR TITLE
Fix invalid free() on teardown for io plugins

### DIFF
--- a/libr/core/libs.c
+++ b/libr/core/libs.c
@@ -12,9 +12,21 @@ static int __lib_##x##_cb(RLibPlugin *pl, void *user, void *data) { \
 }\
 static int __lib_##x##_dt(RLibPlugin *pl, void *p, void *u) { return true; }
 
+#define CB_COPY(x,y) \
+static int __lib_##x##_cb(RLibPlugin *pl, void *user, void *data) { \
+	struct r_##x##_plugin_t *hand = (struct r_##x##_plugin_t *)data; \
+	struct r_##x##_plugin_t *instance; \
+	RCore *core = (RCore *)user; \
+	instance = R_NEW (struct r_##x##_plugin_t); \
+	memcpy (instance, hand, sizeof (struct r_##x##_plugin_t)); \
+	r_##x##_add (core->y, instance); \
+	return true; \
+}\
+static int __lib_##x##_dt(RLibPlugin *pl, void *p, void *u) { return true; }
+
 // XXX api consistency issues
 #define r_io_add r_io_plugin_add
-CB (io, io)
+CB_COPY (io, io)
 #define r_core_add r_core_plugin_add
 CB (core, rcmd)
 #define r_debug_add r_debug_plugin_add


### PR DESCRIPTION
For example given a plugin defined like this:

```C
RIOPlugin r_io_plugin_foo = {
	.name = "foo",
	...snip...
};

#ifndef CORELIB
RLibStruct radare_plugin = {
	.type = R_LIB_TYPE_IO,
	.data = &r_io_plugin_foo,
	.version = R2_VERSION
};
#endif
```

We will try to `free (&r_io_plugin_foo)`, which was not allocated on the
heap. Static io plugins are OTOH allocated like this, so we need to do
the same for dynamically loaded io plugins. However, this is not the same
across the different plugin types, so we need to special-case io plugins
here.