### PR TITLE
cleanup unused variable in r_debruijn_offset()

### DIFF
--- a/libr/util/debruijn.c
+++ b/libr/util/debruijn.c
@@ -104,7 +104,7 @@ R_API char* r_debruijn_pattern(int size, int start, const char* charset) {
 // Host endian = 1 if little, 0 if big.
 R_API int r_debruijn_offset(ut64 value, int big_endian) {
 	char* needle, *pattern, buf[9];
-	int n, retval;
+	int retval;
 	char* pch;
 
 	if (value == 0) {
@@ -137,9 +137,6 @@ R_API int r_debruijn_offset(ut64 value, int big_endian) {
 	for (needle = buf; !*needle; needle++) {
 		/* do nothing here */
 	}
-	// we should not guess the endian. its already handled by other functions
-	// and configure by the user in cfg.bigendian
-	n = 1;
 
 	pch = strstr (pattern, needle);
 	retval = -1;


### PR DESCRIPTION
```
debruijn.c: In function ‘r_debruijn_offset’:
debruijn.c:107:6: warning: variable ‘n’ set but not used [-Wunused-but-set-variable]
  int n, retval;
      ^
```
(gcc 6.2.1)