### PR TITLE
Removing unused args from sdb_remove and sdb_uncat (#3481)

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -92,7 +92,7 @@ R_API RBinXtrData *r_bin_xtrdata_new(RBuffer *buf, ut64 offset, ut64 size, ut32 
 R_API void r_bin_xtrdata_free(void /*RBinXtrData*/ *data_) {
 	RBinXtrData *data = data_;
 	if (data) {
-		sdb_remove (data->sdb, sdb_fmt (0, "%d", data->offset), 0);
+		sdb_remove (data->sdb, sdb_fmt (0, "%d", data->offset));
 		if (data->metadata) {
 			free (data->metadata->libname);
 			free (data->metadata->arch);

--- a/libr/include/sdb/sdb.h
+++ b/libr/include/sdb/sdb.h
@@ -124,7 +124,7 @@ char *sdb_querys (Sdb* s, char *buf, size_t len, const char *cmd);
 char *sdb_querysf (Sdb* s, char *buf, size_t buflen, const char *fmt, ...);
 int  sdb_query_file(Sdb *s, const char* file);
 int  sdb_exists (Sdb*, const char *key);
-int  sdb_remove (Sdb*, const char *key, ut32 cas);
+int  sdb_remove (Sdb*, const char *key);
 int  sdb_unset (Sdb*, const char *key, ut32 cas);
 int  sdb_unset_like(Sdb *s, const char *k);
 char** sdb_like(Sdb *s, const char *k, const char *v, SdbForeachCallback cb);

--- a/libr/include/sdb/sdb.h
+++ b/libr/include/sdb/sdb.h
@@ -135,7 +135,7 @@ const char *sdb_const_get_len (Sdb* s, const char *key, int *vlen, ut32 *cas);
 int  sdb_set (Sdb*, const char *key, const char *data, ut32 cas);
 int  sdb_set_owned (Sdb* s, const char *key, char *val, ut32 cas);
 int  sdb_concat(Sdb *s, const char *key, const char *value, ut32 cas);
-int  sdb_uncat(Sdb *s, const char *key, const char *value, ut32 cas);
+int  sdb_uncat(Sdb *s, const char *key, const char *value);
 int  sdb_add (Sdb* s, const char *key, const char *val, ut32 cas);
 void sdb_list(Sdb*);
 int  sdb_sync (Sdb*);

--- a/shlr/sdb/src/query.c
+++ b/shlr/sdb/src/query.c
@@ -402,7 +402,7 @@ next_quote:
 				if (*cmd=='+') {
 					sdb_concat (s, cmd+1, val, 0);
 				} else {
-					sdb_uncat (s, cmd+1, val, 0);
+					sdb_uncat (s, cmd+1, val);
 				}
 			}
 		} else {

--- a/shlr/sdb/src/sdb.c
+++ b/shlr/sdb/src/sdb.c
@@ -251,9 +251,8 @@ SDB_API int sdb_remove(Sdb *s, const char *key) {
 }
 
 // alias for '-key=str'.. '+key=str' concats
-SDB_API int sdb_uncat(Sdb *s, const char *key, const char *value, ut32 cas) {
+SDB_API int sdb_uncat(Sdb *s, const char *key, const char *value) {
 	// remove 'value' from current key value.
-	// TODO: cas is ignored here
 	int vlen = 0;
 	char *p, *v = sdb_get_len (s, key, &vlen, NULL);
 	int mod = 0;

--- a/shlr/sdb/src/sdb.c
+++ b/shlr/sdb/src/sdb.c
@@ -238,7 +238,7 @@ SDB_API int sdb_unset (Sdb* s, const char *key, ut32 cas) {
 }
 
 /* remove from memory */
-SDB_API int sdb_remove(Sdb *s, const char *key, ut32 cas) {
+SDB_API int sdb_remove(Sdb *s, const char *key) {
 	SdbHashEntry *e;
 	ut32 hash = sdb_hash (key);
 	e = ht_search (s->ht, hash);
@@ -604,7 +604,7 @@ SDB_API int sdb_sync (Sdb* s) {
 			if (sdb_disk_insert (s, kv->key, kv->value)) {
 				it.n = iter->n;
 				//sdb_unset (s, kv->key, 0);
-				sdb_remove (s, kv->key, 0);
+				sdb_remove (s, kv->key);
 				iter = &it;
 			}
 		}

--- a/shlr/sdb/src/sdb.h
+++ b/shlr/sdb/src/sdb.h
@@ -124,7 +124,7 @@ char *sdb_querys (Sdb* s, char *buf, size_t len, const char *cmd);
 char *sdb_querysf (Sdb* s, char *buf, size_t buflen, const char *fmt, ...);
 int  sdb_query_file(Sdb *s, const char* file);
 int  sdb_exists (Sdb*, const char *key);
-int  sdb_remove (Sdb*, const char *key, ut32 cas);
+int  sdb_remove (Sdb*, const char *key);
 int  sdb_unset (Sdb*, const char *key, ut32 cas);
 int  sdb_unset_like(Sdb *s, const char *k);
 char** sdb_like(Sdb *s, const char *k, const char *v, SdbForeachCallback cb);

--- a/shlr/sdb/src/sdb.h
+++ b/shlr/sdb/src/sdb.h
@@ -135,7 +135,7 @@ const char *sdb_const_get_len (Sdb* s, const char *key, int *vlen, ut32 *cas);
 int  sdb_set (Sdb*, const char *key, const char *data, ut32 cas);
 int  sdb_set_owned (Sdb* s, const char *key, char *val, ut32 cas);
 int  sdb_concat(Sdb *s, const char *key, const char *value, ut32 cas);
-int  sdb_uncat(Sdb *s, const char *key, const char *value, ut32 cas);
+int  sdb_uncat(Sdb *s, const char *key, const char *value);
 int  sdb_add (Sdb* s, const char *key, const char *val, ut32 cas);
 void sdb_list(Sdb*);
 int  sdb_sync (Sdb*);


### PR DESCRIPTION
Starting off small with the pedantic cleaning up, title should be self explanatory. Please let me know if this is too small, or I've blundered somewhere.