### PR TITLE
added r_str_startswith to header

### DIFF
--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -128,5 +128,6 @@ R_API bool r_str_glob(const char *str, const char *glob);
 R_API int r_str_binstr2bin(const char *str, ut8 *out, int outlen);
 R_API char *r_str_between(const char *str, const char *prefix, const char *suffix);
 R_API bool r_str_startswith(const char *str, const char *needle);
+R_API bool r_str_endswith(const char *str, const char *needle);
 
 #endif //  R_STR_H

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -127,5 +127,6 @@ R_API char *r_hex_from_c(const char *code);
 R_API bool r_str_glob(const char *str, const char *glob);
 R_API int r_str_binstr2bin(const char *str, ut8 *out, int outlen);
 R_API char *r_str_between(const char *str, const char *prefix, const char *suffix);
+R_API bool r_str_startswith(const char *str, const char *needle);
 
 #endif //  R_STR_H


### PR DESCRIPTION
Was not declared in the r_str.h header and therefore only implicit declared by the compiler