### PR TITLE
integrating asm.calls with function types database

### DIFF
--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -285,6 +285,11 @@ R_API int r_anal_type_func_exist(RAnal *anal, const char *func_name) {
 	return fcn && !strcmp (fcn, "func");
 }
 
+R_API const char *r_anal_type_func_ret(RAnal *anal, const char *func_name){
+	char *query = sdb_fmt (-1, "func.%s.ret", func_name);
+	return sdb_const_get (anal->sdb_types, query, 0);
+}
+
 R_API const char *r_anal_type_func_cc(RAnal *anal, const char *func_name) {
 	char *query = sdb_fmt (-1, "func.%s.cc", func_name);
 	return sdb_const_get (anal->sdb_types, query, 0);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2818,7 +2818,31 @@ beach:
 		}
 	}
 }
-
+static void ds_print_calls_hints(RDisasmState *ds) {
+	RAnal *anal = ds->core->anal;
+	RAnalFunction *fcn = r_anal_get_fcn_in (anal, ds->analop.jump, -1);
+	char *name;
+	if (!fcn) {
+		return;
+	}
+	if (r_anal_type_func_exist (anal, fcn->name)) {
+		name = strdup (fcn->name);
+	} else if (!(name = r_anal_type_func_guess (anal, fcn->name))) {
+		return;
+	}
+	if (ds->show_color) {
+		r_cons_strcat (ds->pal_comment);
+	}
+	ds_align_comment (ds);
+	r_cons_printf ("; %s %s(", r_anal_type_func_ret (anal, name), name);
+	int i, arg_max = r_anal_type_func_args_count (anal, name);
+	for (i = 0; i < arg_max; i++) {
+		r_cons_printf (" %s %s%s", r_anal_type_func_args_type (anal, name, i),
+			r_anal_type_func_args_name (anal, name, i),
+			i == arg_max - 1 ? ");\n": ",");
+	}
+	free (name);
+}
 static void ds_print_comments_right(RDisasmState *ds) {
 	char *desc = NULL;
 	RCore *core = ds->core;
@@ -2862,6 +2886,9 @@ static void ds_print_comments_right(RDisasmState *ds) {
 		}
 	}
 	free (desc);
+	if (ds->analop.type == R_ANAL_OP_TYPE_CALL && ds->show_calls) {
+		ds_print_calls_hints (ds);
+	}
 }
 
 #if 0

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1135,6 +1135,7 @@ R_API char *r_anal_type_format (RAnal *anal, const char *t);
 R_API int r_anal_type_set(RAnal *anal, ut64 at, const char *field, ut64 val);
 R_API int r_anal_type_func_exist(RAnal *anal, const char *func_name);
 R_API const char *r_anal_type_func_cc(RAnal *anal, const char *func_name);
+ R_API const char *r_anal_type_func_ret(RAnal *anal, const char *func_name);
 R_API int r_anal_type_func_args_count(RAnal *anal, const char *func_name);
 R_API char *r_anal_type_func_args_type(RAnal *anal, const char *func_name, int i);
 R_API char *r_anal_type_func_args_name(RAnal *anal, const char *func_name, int i);


### PR DESCRIPTION
Current unfixed issues:
	works with aa, aaa,aaaa but never worked with af