### PR TITLE
Fixed some issues from #5718

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -467,7 +467,7 @@ R_API void r_cons_flush() {
 		return;
 	}
 	r_cons_filter ();
-	if (I.is_interactive) {
+	if (I.is_interactive && I.fdout == 1) {
 		/* Use a pager if the output doesn't fit on the terminal window. */
 		if (I.pager && *I.pager && I.buffer_len > 0
 				&& r_str_char_count (I.buffer, '\n') >= I.rows) {

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -146,7 +146,7 @@ static int cmd_zign(void *data, const char *input) {
 							}
 							r_cons_newline ();
 						} else {
-							r_cons_printf ("%s zignature is too small\n", name);
+							fprintf (stderr, "%s zignature is too small\n", name);
 						}
 					} else {
 						eprintf ("Unnamed function at 0x%08"PFMT64x"\n", fcni->addr);
@@ -204,7 +204,7 @@ static int cmd_zign(void *data, const char *input) {
 		{
 			// TODO: parse arg0 and arg1
 			ut8 *buf;
-			int len, idx;
+			int len, idx, old_fs;
 			ut64 ini, fin;
 			RSignItem *si;
 			RIOSection *s;
@@ -242,6 +242,7 @@ static int cmd_zign(void *data, const char *input) {
 			if (buf != NULL) {
 				int count = 0;
 				eprintf ("Ranges are: 0x%08"PFMT64x" 0x%08"PFMT64x"\n", ini, fin);
+				old_fs = core->flags->space_idx;
 				r_cons_printf ("fs sign\n");
 				r_cons_break (NULL, NULL);
 				if (r_io_read_at (core->io, ini, buf, len) == len) {
@@ -256,6 +257,7 @@ static int cmd_zign(void *data, const char *input) {
 						}
 					}
 				} else eprintf ("Cannot read %d bytes at 0x%08"PFMT64x"\n", len, ini);
+				r_cons_printf ("fs %s\n", (old_fs == -1) ? "*" : core->flags->spaces[old_fs]);
 				r_cons_break_end ();
 				free (buf);
 				core->sign->matches = count;
@@ -299,6 +301,7 @@ static int cmd_zign(void *data, const char *input) {
 			RSignItem *si;
 			int len = 0;
 			int count = 0;
+			int old_fs;
 			RListIter *it;
 			ut8 *buf;
 
@@ -320,9 +323,11 @@ static int cmd_zign(void *data, const char *input) {
 					len) == len) {
 				si = r_sign_check (core->sign, buf, len);
 				if (si) {
+					old_fs = core->flags->space_idx;
 					r_cons_printf ("fs sign\n");
 					count++;
 					fcn_zig_add (si, count, (unsigned char *)fcni->addr);
+					r_cons_printf ("fs %s\n", (old_fs == -1) ? "*" : core->flags->spaces[old_fs]);
 				}
 			}
 			free (buf);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -146,7 +146,7 @@ static int cmd_zign(void *data, const char *input) {
 							}
 							r_cons_newline ();
 						} else {
-							fprintf (stderr, "%s zignature is too small\n", name);
+							eprintf ("%s zignature is too small\n", name);
 						}
 					} else {
 						eprintf ("Unnamed function at 0x%08"PFMT64x"\n", fcni->addr);


### PR DESCRIPTION
- Confirmation message for number of lines to print will not appear
anymore if the output is redirected to a file.
- "signature too small" message will be printed to stderr instead of
stdout, so will not appear on zignature file.
- Previous flagspace will be restored after running `.z` or `z/`
commands.