### PR TITLE
More zignature fixes

### DIFF
--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -89,7 +89,6 @@ static int cmd_zign(void *data, const char *input) {
 			int fdold = r_cons_singleton ()->fdout;
 			int minzlen = r_config_get_i (core->config, "cfg.minzlen");
 			int maxzlen = r_config_get_i (core->config, "cfg.maxzlen");
-			eprintf ("maxzlen: %d\n", maxzlen);
 			ptr = strchr (input + 2, ' ');
 			if (ptr) {
 				*ptr = '\0';

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1689,6 +1689,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("cfg.wseek", "false", "Seek after write");
 	SETCB("cfg.bigendian", "false", &cb_bigendian, "Use little (false) or big (true) endianness");
 	SETI("cfg.minzlen", 2, "Minimum zignature length to filter in 'zg'");
+	SETI("cfg.maxzlen", 500, "Maximum zignature length to filter in 'zg'");
 
 	/* diff */
 	SETI("diff.from", 0, "Set source diffing address for px (uses cc command)");


### PR DESCRIPTION
- Added cfg.maxzlen to filter out big zignatures (#5718)
- Changed r_anal_fcn_size to r_anal_fcn_realsize on `zg` and `z.`
(realsize makes more sense)