### PR TITLE
Fixing debugging problems at MIPS (32bits)

### DIFF
--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -473,10 +473,6 @@ R_API int r_cons_yesno(int def, const char *fmt, ...) {
 		key = 'y';
 	r_cons_set_raw (0);
 	if (key=='\n' || key=='\r')
-		/* I don't know why but with this eprintf
-		 * the Y/N functionality works properly at MIPS
-		 */
-		eprintf("");
 		key = def;
 	return key=='y';
 }

--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -473,6 +473,10 @@ R_API int r_cons_yesno(int def, const char *fmt, ...) {
 		key = 'y';
 	r_cons_set_raw (0);
 	if (key=='\n' || key=='\r')
+		/* I don't know why but with this eprintf
+		 * the Y/N functionality works properly at MIPS
+		 */
+		eprintf("");
 		key = def;
 	return key=='y';
 }

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -69,7 +69,13 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 	}
 
 	/* The MIPS ptrace has a different behaviour */
-# if !(__MIPS__ || __mips__)
+# if __mips__
+	/* see if we really have a breakpoint here... */
+	b = r_bp_get_at (dbg->bp, pc);
+	if (!b) { /* we don't. nothing left to do */
+		return true;
+	}
+# else
 	/* see if we really have a breakpoint here... */
 	b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
 	if (!b) { /* we don't. nothing left to do */
@@ -85,12 +91,6 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 	if (!r_debug_reg_sync (dbg, R_REG_TYPE_GPR, true)) {
 		eprintf ("cannot set registers!\n");
 		return false;
-	}
-# else
-	/* see if we really have a breakpoint here... */
-	b = r_bp_get_at (dbg->bp, pc);
-	if (!b) { /* we don't. nothing left to do */
-		return true;
 	}
 # endif
 

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -68,12 +68,13 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 		return true;
 	}
 
+	/* The MIPS ptrace has a different behaviour */
+# if !(__MIPS__ || __mips__)
 	/* see if we really have a breakpoint here... */
 	b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
 	if (!b) { /* we don't. nothing left to do */
 		return true;
 	}
-	*pb = b;
 
 	/* set the pc value back */
 	pc -= b->size;
@@ -85,6 +86,15 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 		eprintf ("cannot set registers!\n");
 		return false;
 	}
+# else
+	/* see if we really have a breakpoint here... */
+	b = r_bp_get_at (dbg->bp, pc);
+	if (!b) { /* we don't. nothing left to do */
+		return true;
+	}
+# endif
+
+	*pb = b;
 
 	/* if we are on a software stepping breakpoint, we hide what is going on... */
 	if (b->swstep) {

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -20,7 +20,7 @@ const char *linux_reg_profile (RDebug *dbg) {
 #elif __arm64__ || __aarch64__
 #include "reg/linux-arm64.h"
 #elif __MIPS__ || __mips__
-	if ((dbg->bits & R_SYS_BITS_32) && (dbg->bp->endian == R_TRUE)) {
+	if ((dbg->bits & R_SYS_BITS_32) && (dbg->bp->endian == true)) {
 #include "reg/linux-mips.h"
 	} else {
 #include "reg/linux-mips64.h"

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -20,7 +20,11 @@ const char *linux_reg_profile (RDebug *dbg) {
 #elif __arm64__ || __aarch64__
 #include "reg/linux-arm64.h"
 #elif __MIPS__ || __mips__
+	if ((dbg->bits & R_SYS_BITS_32) && (dbg->bp->endian == R_TRUE)) {
 #include "reg/linux-mips.h"
+	} else {
+#include "reg/linux-mips64.h"
+	}
 #elif (__i386__ || __x86_64__)
 	if (dbg->bits & R_SYS_BITS_32) {
 #if __x86_64__

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -20,7 +20,7 @@ const char *linux_reg_profile (RDebug *dbg) {
 #elif __arm64__ || __aarch64__
 #include "reg/linux-arm64.h"
 #elif __MIPS__ || __mips__
-	if ((dbg->bits & R_SYS_BITS_32) && (dbg->bp->endian == true)) {
+	if ((dbg->bits & R_SYS_BITS_32) && (dbg->bp->endian == 1)) {
 #include "reg/linux-mips.h"
 	} else {
 #include "reg/linux-mips64.h"

--- a/libr/debug/p/native/linux/reg/linux-mips.h
+++ b/libr/debug/p/native/linux/reg/linux-mips.h
@@ -28,51 +28,65 @@ PC = 272
 #endif
 
 #endif
+
+/* IMPORTANT - MIPS ptrace always returns the registers in 64bits format,
+   so this register table has been modified from 64 bits to 32 bits.
+   Example:
+	Originals (64 bits):
+	  "gpr    at      .64     8       0\n"
+	  "gpr    v0      .64     16      0\n"
+	Modified to (32 bits):
+          "gpr    at      .32     12      0\n"
+          "gpr    v0      .32     20      0\n"
+
+   It is using the same arena->size, but we are only using the last 4 bytes
+   (LITTLE ENDIAN PROBLEMS?)
+*/
 	return strdup (
-	"=PC	pc\n"
-	"=SP	sp\n"
-	"=BP	fp\n"
-	"=A0	a0\n"
-	"=A1	a1\n"
-	"=A2	a2\n"
-	"=A3	a3\n"
-	"gpr	zero	.64	0	0\n"
-	// XXX DUPPED CAUSES FAILURE "gpr	at	.32	8	0\n"
-	"gpr	at	.64	8	0\n"
-	"gpr	v0	.64	16	0\n"
-	"gpr	v1	.64	24	0\n"
-	/* args */
-	"gpr	a0	.64	32	0\n"
-	"gpr	a1	.64	40	0\n"
-	"gpr	a2	.64	48	0\n"
-	"gpr	a3	.64	56	0\n"
-	/* tmp */
-	"gpr	t0	.64	64	0\n"
-	"gpr	t1	.64	72	0\n"
-	"gpr	t2	.64	80	0\n"
-	"gpr	t3	.64	88	0\n"
-	"gpr	t4	.64	96	0\n"
-	"gpr	t5	.64	104	0\n"
-	"gpr	t6	.64	112	0\n"
-	"gpr	t7	.64	120	0\n"
-	/* saved */
-	"gpr	s0	.64	128	0\n"
-	"gpr	s1	.64	136	0\n"
-	"gpr	s2	.64	144	0\n"
-	"gpr	s3	.64	152	0\n"
-	"gpr	s4	.64	160	0\n"
-	"gpr	s5	.64	168	0\n"
-	"gpr	s6	.64	176	0\n"
-	"gpr	s7	.64	184	0\n"
-	"gpr	s8	.64	192	0\n"
-	"gpr	s9	.64	200	0\n"
-	/* special */
-	"gpr	k0	.64	208	0\n"
-	"gpr	k1	.64	216	0\n"
-	"gpr	gp	.64	224	0\n"
-	"gpr	sp	.64	232	0\n"
-	"gpr	fp	.64	240	0\n"
-	"gpr	ra	.64	248	0\n"
-	/* extra */
-	"gpr	pc	.64	272	0\n"
+        "=PC    pc\n"
+        "=SP    sp\n"
+        "=BP    fp\n"
+        "=A0    a0\n"
+        "=A1    a1\n"
+        "=A2    a2\n"
+        "=A3    a3\n"
+        "gpr    zero    .32     4       0\n"
+        // XXX DUPPED CAUSES FAILURE "gpr       at      .32     8       0\n"
+        "gpr    at      .32     12      0\n"
+        "gpr    v0      .32     20      0\n"
+        "gpr    v1      .32     28      0\n"
+        /* args */
+        "gpr    a0      .32     36      0\n"
+        "gpr    a1      .32     44      0\n"
+        "gpr    a2      .32     52      0\n"
+        "gpr    a3      .32     60      0\n"
+        /* tmp */
+        "gpr    t0      .32     68      0\n"
+        "gpr    t1      .32     76      0\n"
+        "gpr    t2      .32     84      0\n"
+        "gpr    t3      .32     92      0\n"
+        "gpr    t4      .32     100     0\n"
+        "gpr    t5      .32     108     0\n"
+        "gpr    t6      .32     116     0\n"
+        "gpr    t7      .32     124     0\n"
+        /* saved */
+        "gpr    s0      .32     132     0\n"
+        "gpr    s1      .32     140     0\n"
+        "gpr    s2      .32     148     0\n"
+        "gpr    s3      .32     156     0\n"
+        "gpr    s4      .32     164     0\n"
+        "gpr    s5      .32     172     0\n"
+        "gpr    s6      .32     180     0\n"
+        "gpr    s7      .32     188     0\n"
+        "gpr    s8      .32     196     0\n"
+        "gpr    s9      .32     204     0\n"
+        /* special */
+        "gpr    k0      .32     212     0\n"
+        "gpr    k1      .32     220     0\n"
+        "gpr    gp      .32     228     0\n"
+        "gpr    sp      .32     236     0\n"
+        "gpr    fp      .32     244     0\n"
+        "gpr    ra      .32     252     0\n"
+        /* extra */
+        "gpr    pc      .32     276     0\n"
 	);

--- a/libr/debug/p/native/linux/reg/linux-mips64.h
+++ b/libr/debug/p/native/linux/reg/linux-mips64.h
@@ -1,0 +1,78 @@
+// XXX wtf
+#if 0
+	reg      name    usage
+	---+-----------+-------------
+	0        zero   always zero
+	1         at    reserved for assembler
+	2-3     v0-v1   expression evaluation, result of function
+	4-7     a0-a3   arguments for functions
+	8-15    t0-t7   temporary (not preserved across calls)
+	16-23   s0-s7   saved temporary (preserved across calls)
+	24-25   t8-t9   temporary (not preserved across calls)
+	26-27   k0-k1   reserved for OS kernel
+	28      gp      points to global area
+	29      sp      stack pointer
+	30      fp      frame pointer
+	31      ra      return address
+#if 0
+16 /* 0 - 31 are integer registers, 32 - 63 are fp registers.  */
+PC = 272
+17 #define FPR_BASE        32
+18 #define PC              64
+19 #define CAUSE           65
+20 #define BADVADDR        66
+21 #define MMHI            67
+22 #define MMLO            68
+23 #define FPC_CSR         69
+24 #define FPC_EIR         70
+#endif
+
+#endif
+	return strdup (
+	"=PC	pc\n"
+	"=SP	sp\n"
+	"=BP	fp\n"
+	"=A0	a0\n"
+	"=A1	a1\n"
+	"=A2	a2\n"
+	"=A3	a3\n"
+	"gpr	zero	.64	0	0\n"
+	// XXX DUPPED CAUSES FAILURE "gpr	at	.32	8	0\n"
+	"gpr	at	.64	8	0\n"
+	"gpr	v0	.64	16	0\n"
+	"gpr	v1	.64	24	0\n"
+	/* args */
+	"gpr	a0	.64	32	0\n"
+	"gpr	a1	.64	40	0\n"
+	"gpr	a2	.64	48	0\n"
+	"gpr	a3	.64	56	0\n"
+	/* tmp */
+	"gpr	t0	.64	64	0\n"
+	"gpr	t1	.64	72	0\n"
+	"gpr	t2	.64	80	0\n"
+	"gpr	t3	.64	88	0\n"
+	"gpr	t4	.64	96	0\n"
+	"gpr	t5	.64	104	0\n"
+	"gpr	t6	.64	112	0\n"
+	"gpr	t7	.64	120	0\n"
+	/* saved */
+	"gpr	s0	.64	128	0\n"
+	"gpr	s1	.64	136	0\n"
+	"gpr	s2	.64	144	0\n"
+	"gpr	s3	.64	152	0\n"
+	"gpr	s4	.64	160	0\n"
+	"gpr	s5	.64	168	0\n"
+	"gpr	s6	.64	176	0\n"
+	"gpr	s7	.64	184	0\n"
+	"gpr	s8	.64	192	0\n"
+	"gpr	s9	.64	200	0\n"
+	/* special */
+	"gpr	k0	.64	208	0\n"
+	"gpr	k1	.64	216	0\n"
+	"gpr	gp	.64	224	0\n"
+	"gpr	sp	.64	232	0\n"
+	"gpr	fp	.64	240	0\n"
+	"gpr	ra	.64	248	0\n"
+	/* extra */
+	"gpr	pc	.64	272	0\n"
+	);


### PR DESCRIPTION
\* A new MIPS profile (32 bits) has been created
\* MIPS (32 bits) registers could be read/written properly (LE is still using the old 64bits profile) 
\* breakpoint (soft) stepping is now working (even with a bp at the same addr)
\* ds, drr, dbc, etc. are working properly

! dS is not working yet

\+ I have tested this patch on x64LE, x86LE with basic functions (ds, dS drr, dbc, etc.) and it works well. It seems nothing is broken.