### PR TITLE
fix -H

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -424,7 +424,7 @@ int main(int argc, char **argv, char **envp) {
 		return 0;
 	}
 
-	while ((c = getopt (argc, argv, "=0AMCwfF:hH::m:e:nk:o:Ndqs:p:b:B:a:Lui:I:l:P:R:c:D:vVSzu"
+	while ((c = getopt (argc, argv, "=0AMCwfF:hH:m:e:nk:o:Ndqs:p:b:B:a:Lui:I:l:P:R:c:D:vVSzu"
 #if USE_THREADS
 "t"
 #endif


### PR DESCRIPTION
the getopt '::' option is a GNU extension and, as such, does not work on all systems. For this reason I have already implemented before a check for single '-H' parameter where main_print_var is explicitly called with NULL argument. Also, on my system, the '::' is causing buggy behaviour. As such, I propose to revert back the '::' change.