### PR TITLE
Remove #if __EMSCRIPTEN__ and fix !rax2 -s in r2

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -179,9 +179,7 @@ static int rax (char *str, int len, int last) {
 			memset (buf, '\0', n);
 			n = r_hex_str2bin (str, (ut8*)buf);
 			if (n > 0) fwrite (buf, n, 1, stdout);
-#if __EMSCRIPTEN__
 			puts ("");
-#endif
 			fflush (stdout);
 			free (buf);
 		}


### PR DESCRIPTION
Remove #if __EMSCRIPTEN__ and fix !rax2 -s in r2