### PR TITLE
added support for escape sequences in r_num_as_string

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -366,7 +366,7 @@ static int rax (char *str, int len, int last) {
 			return false;
 		}
 		n32 = (ut32)(n & UT32_MAX);
-		asnum  = r_num_as_string (NULL, n);
+		asnum  = r_num_as_string (NULL, n, false);
 		memcpy (&f, &n32, sizeof (f));
 		memcpy (&d, &n, sizeof (d));
 

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -225,7 +225,7 @@ static int cmd_help(void *data, const char *input) {
 			if (core->num->dbz) {
 				eprintf ("RNum ERROR: Division by Zero\n");
 			}
-			asnum  = r_num_as_string (NULL, n);
+			asnum  = r_num_as_string (NULL, n, false);
 
 			/* decimal, hexa, octal */
 			s = n>>16<<12;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3148,7 +3148,7 @@ static void handle_print_refptr_meta_infos(RCore *core, RDisasmState *ds, ut64 w
 #endif
 
 static void ds_print_as_string(RDisasmState *ds) {
-	char *str = r_num_as_string (NULL, ds->analop.ptr);
+	char *str = r_num_as_string (NULL, ds->analop.ptr, true);
 	if (str) {
 		ds_align_comment (ds);
 		r_cons_printf (" %s; \"%s\"%s", COLOR (ds, pal_comment),

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -52,7 +52,7 @@ R_API const char *r_num_calc_index(RNum *num, const char *p);
 R_API ut64 r_num_chs(int cylinder, int head, int sector, int sectorsize);
 R_API int r_num_is_valid_input(RNum *num, const char *input_value);
 R_API ut64 r_num_get_input_value(RNum *num, const char *input_value);
-R_API char* r_num_as_string(RNum *___, ut64 n);
+R_API char* r_num_as_string(RNum *___, ut64 n, bool printable_only);
 R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex);
 R_API void r_num_minmax_swap(ut64 *a, ut64 *b);
 R_API void r_num_minmax_swap_i(int *a, int *b); // XXX this can be a cpp macro :??

--- a/libr/util/num.c
+++ b/libr/util/num.c
@@ -435,22 +435,23 @@ R_API char* r_num_as_string(RNum *___, ut64 n, bool printable_only) {
 	str[stri=0] = 0;
 	while (len--) {
 		char ch = (num & 0xff);
-		if (ch>=32 && ch <127) {
+		if (ch >= 32 && ch < 127) {
 			str[stri++] = ch;
 			str[stri] = 0;
-		} else if(!printable_only && (off = escape_char (str + stri, ch)) != 0) {
+		} else if (!printable_only && (off = escape_char (str + stri, ch)) != 0) {
 			stri += off;
 		} else {
 			if (ch)
 				return NULL;
 		}
-		ret |= (num&0xff);
+		ret |= (num & 0xff);
 		num >>= 8;
 	}
-	if (ret)
+	if (ret) {
 		return strdup (str);
-	else if (!printable_only)
+	} else if (!printable_only) {
 		return strdup ("\\0");
+	}
 	return NULL;
 }
 

--- a/libr/util/num.c
+++ b/libr/util/num.c
@@ -6,6 +6,7 @@
 
 #include <r_util.h>
 #define R_NUM_USE_CALC 1
+#define R_NUM_AS_STRING_ESCAPES 1
 
 R_API void r_num_irand() {
 	srand (r_sys_now ());
@@ -408,17 +409,54 @@ R_API ut64 r_num_get_input_value(RNum *num, const char *input_value) {
 	return value;
 }
 
+#define NIBBLE_TO_HEX(n) (((n) & 0xf) > 9 ? 'a' + ((n) & 0xf) - 10 : '0' + ((n) & 0xf))
 R_API char* r_num_as_string(RNum *___, ut64 n) {
-	char str[10];
+	char str[34]; // 8 byte * 4 chars in \x?? format
 	int stri, ret = 0;
 	int len = sizeof (ut64);
 	ut64 num = n;
 	str[stri=0] = 0;
 	while (len--) {
 		char ch = (num & 0xff);
-		if (ch>=33 && ch <127) {
+		if (ch>=32 && ch <127) {
 			str[stri++] = ch;
 			str[stri] = 0;
+#ifdef R_NUM_AS_STRING_ESCAPES
+		} else if (ch == 7) {
+			str[stri++] = '\\';
+			str[stri++] = 'a';
+			str[stri] = 0;
+		} else if (ch == 8) {
+			str[stri++] = '\\';
+			str[stri++] = 'b';
+			str[stri] = 0;
+		} else if (ch == 9) {
+			str[stri++] = '\\';
+			str[stri++] = 't';
+			str[stri] = 0;
+		} else if (ch == 10) {
+			str[stri++] = '\\';
+			str[stri++] = 'n';
+			str[stri] = 0;
+		} else if (ch == 11) {
+			str[stri++] = '\\';
+			str[stri++] = 'v';
+			str[stri] = 0;
+		} else if (ch == 12) {
+			str[stri++] = '\\';
+			str[stri++] = 'f';
+			str[stri] = 0;
+		} else if (ch == 13) {
+			str[stri++] = '\\';
+			str[stri++] = 'r';
+			str[stri] = 0;
+		} else if (ch) {
+			str[stri++] = '\\';
+			str[stri++] = 'x';
+			str[stri++] = NIBBLE_TO_HEX (ch >> 4);
+			str[stri++] = NIBBLE_TO_HEX (ch);
+			str[stri] = 0;
+#endif
 		} else {
 			if (ch)
 				return NULL;


### PR DESCRIPTION
consists of 2 changes:

1. allow space in the original implementation as character
2. support escape sequences for nonprintable chars (uses currently hardcoded compile flag)

see #5896