### PR TITLE
fix flags duplication

### DIFF
--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1727,6 +1727,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB("bin.rawstr", "false", &cb_rawstr, "Load strings from raw binaries");
 	SETPREF("bin.strings", "true", "Load strings from rbin on startup");
 	SETPREF("bin.classes", "true", "Load classes from rbin on startup");
+	SETPREF("bin.mergeflags", "true", "Merge symbols with the same name into the same flag");
 
 	/* cfg */
 	SETPREF("cfg.plugins", "true", "Load plugins at startup");


### PR DESCRIPTION
R2R's PR: https://github.com/radare/radare2-regressions/pull/571

In R2 flags come from symbols and classes, if a class also contains methods this symbol will be duplicate (from symbols and classes->methods). This affects Dalvik an ObjC, maybe more formats too.
In order to fix that we can add a "if (flag_exists (r->flags, sym->name))" to check if the flag is already defined.
I'm not sure if "flag_exists" function exists or if it should be defined elsewhere.

This fix seems to also fix https://github.com/radare/radare2/issues/5886.