### PR TITLE
fix build on FreeBSD

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -804,7 +804,7 @@ static RList *r_debug_native_sysctl_map (RDebug *dbg) {
 	if (sysctl (mib, 4, NULL, &len, NULL, 0) != 0) return NULL;
 	len = len * 4 / 3;
 	buf = malloc(len);
-	if (!buf) {return NULL};
+	if (!buf) {return NULL;};
 	if (sysctl (mib, 4, buf, &len, NULL, 0) != 0) {
 		free (buf);
 		return NULL;
@@ -1425,7 +1425,7 @@ static RList *r_debug_desc_native_list (int pid) {
 	if (sysctl (mib, 4, NULL, &len, NULL, 0) != 0) return NULL;
 	len = len * 4 / 3;
 	buf = malloc(len);
-	if (!buf) {return NULL};
+	if (!buf) {return NULL;};
 	if (sysctl (mib, 4, buf, &len, NULL, 0) != 0) {
 		free (buf);
 		return NULL;


### PR DESCRIPTION
Since 0.10.6 build on FreeBSD fails with:
p/debug_native.c:1428:24: error: expected ';' after return statement
        if (!buf) {return NULL};

This is simple small fix to resolve build issues.