### PR TITLE
conf: enable graph.nodejmps by default

### DIFF
--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -1935,7 +1935,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("graph.gv.edge", "", "Graphviz edge style. (arrowhead=\"vee\")");
 	SETPREF("graph.gv.graph", "", "Graphviz global style attributes. (bgcolor=white)");
 	SETPREF("graph.gv.current", "false", "Highlight the current node in graphviz graph.");
-	SETPREF("graph.nodejmps", "false", "Enables shortcuts for every node.");
+	SETPREF("graph.nodejmps", "true", "Enables shortcuts for every node.");
 	/* hud */
 	SETPREF("hud.path", "", "Set a custom path for the HUD file");
 


### PR DESCRIPTION
I feel like nodejmps is a natural extension of the shortcuts used in graph mode and when they are not enabled it seems to me like there's something missing...

what about enabling it by default?