### PR TITLE
Fixing x86 16/32 bit LCALL

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -956,7 +956,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		}
 		break;
 	case X86_INS_CALL:
-	case X86_INS_LCALL:
 		{
 			char* arg = getarg (&gop, 0, 0, NULL);
 			esilprintf (op,
@@ -966,6 +965,21 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					"%s,%s,=",
 					pc, rs, sp, sp, arg, pc);
 			free (arg);
+		}
+		break;
+	case X86_INS_LCALL:
+		{
+			char* arg1 = getarg (&gop, 0, 0, NULL);
+			char* arg2 = getarg (&gop, 1, 0, NULL);
+			esilprintf (op,
+					"%s,"
+					"%d,%s,-=,%s,"
+					"=[],"
+					"%s,cs,=,"
+					"%s,%s,=",
+					pc, rs, sp, sp, arg1, arg2, pc);
+			free (arg1);
+			free (arg2);
 		}
 		break;
 	case X86_INS_JMP:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -973,11 +973,11 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			char* arg2 = getarg (&gop, 1, 0, NULL);
 			esilprintf (op,
 					"%s,"
-					"%d,%s,-=,%s,"
-					"=[],"
-					"%s,cs,=,"
-					"%s,%s,=",
-					pc, rs, sp, sp, arg1, arg2, pc);
+					"2,%s,-=,cs,=[2],"	// push CS
+					"%d,%s,-=,%s,=[],"	// push IP/EIP
+					"%s,cs,=,"		// set CS
+					"%s,%s,=",		// set IP/EIP
+					pc, sp, rs, sp, sp, arg1, arg2, pc);
 			free (arg1);
 			free (arg2);
 		}


### PR DESCRIPTION
It seems that capstone based ESIL of `call word/dword ptr16:addr16/32` was broken, because it didn't update the CS segment, and it used the segment address as jump offset.