### PR TITLE
Reworked in_function() to iterate over all bbs to check whether an ad…

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -11,12 +11,11 @@
 #define SLOW_IO 0
 #define HASNEXT_FOREVER 1
 
-static int in_function(RAnalFunction *fcn, ut64 addr) {
+static bool in_function(RAnalFunction *fcn, ut64 addr) {
 	RListIter *iter;
-	struct r_anal_bb_t *bbi;
+	RAnalBlock *bbi;
 	r_list_foreach (fcn->bbs, iter, bbi) {
-		if (addr >= bbi->addr && addr < bbi->addr + bbi->size)
-		{
+		if (addr >= bbi->addr && addr < bbi->addr + bbi->size) {
 			return true;
 		}
 	}

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -11,7 +11,17 @@
 #define SLOW_IO 0
 #define HASNEXT_FOREVER 1
 
-#define in_function(fn,y) ((y) >= (fn)->addr && (y) < ((fn)->addr + r_anal_fcn_size (fn)))
+static int in_function(RAnalFunction *fcn, ut64 addr) {
+	RListIter *iter;
+	struct r_anal_bb_t *bbi;
+	r_list_foreach (fcn->bbs, iter, bbi) {
+		if (addr >= bbi->addr && addr < bbi->addr + bbi->size)
+		{
+			return true;
+		}
+	}
+	return false;
+}
 
 #define HINTCMD_ADDR(hint,x,y) if(hint->x) \
 	r_cons_printf (y" @ 0x%"PFMT64x"\n", hint->x, hint->addr)


### PR DESCRIPTION
Changed in_function() to return true only if the address is in one of the BBs.
I think this is useful because otherwise it is not possible to obtain the output of the "ag" command for functions which are between two basic blocks of another function. I found this for a binary of ffmepg which i can provide if need be.