### PR TITLE
Support for modifying incoming value when writing on ESIL register

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -542,7 +542,7 @@ R_API int r_anal_esil_reg_write(RAnalEsil *esil, const char *dst, ut64 num) {
 	int ret = 0;
 	IFDBG { eprintf ("%s=0x%" PFMT64x "\n", dst, num); }
 	if (esil->cb.hook_reg_write) {
-		ret = esil->cb.hook_reg_write (esil, dst, num);
+		ret = esil->cb.hook_reg_write (esil, dst, &num);
 	}
 	if (!ret && dst[0] == ESIL_INTERNAL_PREFIX && dst[1]) {
 		ret = esil_internal_write (esil, dst, num);

--- a/libr/anal/esil_stats.c
+++ b/libr/anal/esil_stats.c
@@ -28,7 +28,7 @@ static int hook_reg_read(RAnalEsil *esil, const char *name, ut64 *res, int *size
 	return 0;
 }
 
-static int hook_reg_write(RAnalEsil *esil, const char *name, ut64 val) {
+static int hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	sdb_array_add (esil->stats, "reg.write", name, 0);
 	return 0;
 }

--- a/libr/anal/esil_trace.c
+++ b/libr/anal/esil_trace.c
@@ -36,11 +36,11 @@ static int trace_hook_reg_read(RAnalEsil *esil, const char *name, ut64 *res, int
 	return ret;
 }
 
-static int trace_hook_reg_write(RAnalEsil *esil, const char *name, ut64 val) {
+static int trace_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	int ret = 0;
-	//eprintf ("[ESIL] REG WRITE %s 0x%08"PFMT64x"\n", name, val);
+	//eprintf ("[ESIL] REG WRITE %s 0x%08"PFMT64x"\n", name, *val);
 	sdb_array_add (DB, KEY ("reg.write"), name, 0);
-	sdb_num_set (DB, KEYREG ("reg.write", name), val, 0);
+	sdb_num_set (DB, KEYREG ("reg.write", name), *val, 0);
 	if (ocbs.hook_reg_write) {
 		RAnalEsilCallbacks cbs = esil->cb;
 		esil->cb = ocbs;

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -432,7 +432,7 @@ static int i8051_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	RAnalEsilCallbacks cbs = esil->cb;
 	if ((ri = i8051_reg_find (name))) {
 		ut8 offset = i8051_reg_get_offset(esil, ri);
-		ret = r_anal_esil_mem_write (esil, IRAM + offset, (ut8*) val, ri->num_bytes);
+		ret = r_anal_esil_mem_write (esil, IRAM + offset, (ut8*)val, ri->num_bytes);
 	}
 	esil->cb = ocbs;
 	if (!ret && ocbs.hook_reg_write) {

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -426,13 +426,13 @@ static int i8051_hook_reg_read(RAnalEsil *esil, const char *name, ut64 *res, int
 	return ret;
 }
 
-static int i8051_hook_reg_write(RAnalEsil *esil, const char *name, ut64 val) {
+static int i8051_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	int ret = 0;
 	RI8015Reg *ri;
 	RAnalEsilCallbacks cbs = esil->cb;
 	if ((ri = i8051_reg_find (name))) {
 		ut8 offset = i8051_reg_get_offset(esil, ri);
-		ret = r_anal_esil_mem_write (esil, IRAM + offset, (ut8*)&val, ri->num_bytes);
+		ret = r_anal_esil_mem_write (esil, IRAM + offset, (ut8*) val, ri->num_bytes);
 	}
 	esil->cb = ocbs;
 	if (!ret && ocbs.hook_reg_write) {

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -66,9 +66,9 @@ static RI8015Reg registers[] = {
 #define emit(frag) r_strbuf_appendf(&op->esil, frag)
 #define emitf(...) r_strbuf_appendf(&op->esil, __VA_ARGS__)
 
-#define j(frag) emitf(frag, 1 & buf[0], buf[1], buf[2]);
-#define h(frag) emitf(frag, 7 & buf[0], buf[1], buf[2]);
-#define k(frag) emitf(frag, bitindex[buf[1]>>3], buf[1] & 7, buf[2]);
+#define j(frag) emitf(frag, 1 & buf[0], buf[1], buf[2])
+#define h(frag) emitf(frag, 7 & buf[0], buf[1], buf[2])
+#define k(frag) emitf(frag, bitindex[buf[1]>>3], buf[1] & 7, buf[2])
 
 // on 8051 the stack grows upward and lsb is pushed first meaning
 // that on little-endian esil vms =[2] works as indended
@@ -118,20 +118,20 @@ static RI8015Reg registers[] = {
 
 #define TEMPLATE_4(base, format, src4, arg1, arg2) \
 	case base + 0x4: \
-		h (format(0, src4, arg1, arg2)) break; \
+		h (format(0, src4, arg1, arg2)); break; \
 		\
 	case base + 0x5: \
-		h (format(1, IB1,  arg1, arg2)) break; \
+		h (format(1, IB1,  arg1, arg2)); break; \
 		\
 	case base + 0x6: \
 	case base + 0x7: \
-		j (format(0, R0I,  arg1, arg2)) break; \
+		j (format(0, R0I,  arg1, arg2)); break; \
 		\
 	case base + 0x8: case base + 0x9: \
 	case base + 0xA: case base + 0xB: \
 	case base + 0xC: case base + 0xD: \
 	case base + 0xE: case base + 0xF: \
-		h (format(0, R0,   arg1, arg2)) break;
+		h (format(0, R0,   arg1, arg2)); break;
 
 #define OP_GROUP_INPLACE_LHS_4(base, lhs, op) TEMPLATE_4(base, OP_GROUP_INPLACE_LHS_4_FMT, L1, lhs, op)
 #define OP_GROUP_INPLACE_LHS_4_FMT(databyte, rhs, lhs, op) XR(rhs) XI(lhs, op)
@@ -189,7 +189,7 @@ static void analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, const 
 	case 0x92: /* mov   */ /* TODO */ break;
 	case 0xA2: /* mov   */ /* TODO */ break;
 	case 0xB2: /* cpl   */
-		emitf("%d,1,<<,%d,^=[1]", a2, a1);
+		emitf ("%d,1,<<,%d,^=[1]", a2, a1);
 		break;
 	case 0xC2: /* clr   */ /* TODO */ break;
 
@@ -210,10 +210,11 @@ static void analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, const 
 	OP_GROUP_INPLACE_LHS_4(0x20, A, "+")
 
 	case 0x34:
-		h (XR(L1)  "C,+," XI(A, "+")) break;
+		h (XR(L1)  "C,+," XI(A, "+"));
+		 break;
 	case 0x35:
-		h (XR(IB1) "C,+," XI(A, "+")) break;
-
+		h (XR(IB1) "C,+," XI(A, "+")); 
+		break;
 	case 0x36: case 0x37:
 		j (XR(R0I) "C,+," XI(A, "+"));
 		break;
@@ -319,39 +320,51 @@ static void analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, const 
 		/* djnz */ h(XI(R0, "--") "," XR(R0) CJMP(L1, "2")); break;
 
 	case 0xE2: case 0xE3:
-		/* movx */ j(XRAM_BASE "r%0$d,+,[1]," XW(A)); break;
-
+		/* movx */ 
+		j(XRAM_BASE "r%0$d,+,[1]," XW(A)); 
+		break;
 	case 0xE4:
-		/* clr  */ emit("0,A,="); break;
+		/* clr  */ 
+		emit("0,A,="); 
+		break;
 	case 0xE5:
-		/* mov  */ h (XR(IB1) XW(A)) break;
-
+		/* mov  */ 
+		h (XR(IB1) XW(A)); 
+		break;
 	case 0xE6: case 0xE7:
-		/* mov  */ j (XR(R0I) XW(A)) break;
-
+		/* mov  */ 
+		j (XR(R0I) XW(A));
+		break;
 	case 0xE8: case 0xE9:
 	case 0xEA: case 0xEB:
 	case 0xEC: case 0xED:
 	case 0xEE: case 0xEF:
-		/* mov  */ h (XR(R0)  XW(A)) break;
-
+		/* mov  */ 
+		h (XR(R0)  XW(A));
+		break;
 	case 0xF2: case 0xF3:
-		/* movx */ j(XR(A) XRAM_BASE "r%0$d,+,=[1]");
+		/* movx */ 
+		j(XR(A) XRAM_BASE "r%0$d,+,=[1]");
 		break;
 	case 0xF4:
-		/* cpl  */ h ("255" XI(A, "^")) break;
+		/* cpl  */ 
+		h ("255" XI(A, "^")); 
+		break;
 	case 0xF5:
-		/* mov  */ h (XR(A) XW(IB1)) break;
-
+		/* mov  */ 
+		h (XR(A) XW(IB1)); 
+		break;
 	case 0xF6: case 0xF7:
-		/* mov  */ j (XR(A) XW(R0I)) break;
-
+		/* mov  */ 
+		j (XR(A) XW(R0I)); 
+		break;
 	case 0xF8: case 0xF9:
 	case 0xFA: case 0xFB:
 	case 0xFC: case 0xFD:
 	case 0xFE: case 0xFF:
-		/* mov  */ h (XR(A) XW(R0)) break;
-
+		/* mov  */ 
+		h (XR(A) XW(R0)); 
+		break;
 	default: break;
 	}
 }
@@ -527,16 +540,17 @@ static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	} else if (*buf_asm && !strncmp (buf_asm+1, "call", 4)) {
 		op->type = R_ANAL_OP_TYPE_CALL;
 		op->jump = o.addr;
-		op->fail = addr+o.length;
-	} else
+		op->fail = addr + o.length;
+	} else {
 		/* CJNE, DJNZ, JC, JNC, JZ, JB, JNB, LJMP, SJMP */
-	if (buf_asm[0]=='j' || (buf_asm[0] && buf_asm[1] == 'j')) {
-		op->type = R_ANAL_OP_TYPE_JMP;
-		if (o.operand == OFFSET) {
-			op->jump = o.addr+addr+o.length;
-		} else {
-			op->jump = o.addr;
-			op->fail = addr+o.length;
+		if (buf_asm[0]=='j' || (buf_asm[0] && buf_asm[1] == 'j')) {
+			op->type = R_ANAL_OP_TYPE_JMP;
+			if (o.operand == OFFSET) {
+				op->jump = o.addr + addr + o.length;
+			} else {
+				op->jump = o.addr;
+			}
+			op->fail = addr + o.length;
 		}
 	}
 	if (anal->decode) {

--- a/libr/asm/arch/8051/8051.c
+++ b/libr/asm/arch/8051/8051.c
@@ -170,10 +170,10 @@ r_8051_op r_8051_decode(const ut8 *buf, int len) {
 	return _{ "xxx", 0, 0 }; // XXX
 }
 
-static char *strdup_filter (const char *str, const ut8 *buf) {
+static char *strdup_filter(const char *str, const ut8 *buf) {
 	char *o;
 	int i, j, len;
-	if (!str || !buf) {
+	if (!str) {
 		return NULL;
 	}
 	len = strlen (str);
@@ -185,7 +185,7 @@ static char *strdup_filter (const char *str, const ut8 *buf) {
 		return NULL;
 	}
 	for (i = j = 0; i < len; i++) {
-		if (str[i] == '$') {
+		if (str[i] == '$' && buf) {
 			int n = str[i+1];
 			if (n >= '0' && n <= '9') {
 				n -= '0';
@@ -212,11 +212,15 @@ char *r_8051_disasm(r_8051_op op, ut32 addr, char *str, int len) {
 		*out = 0;
 	}
 	switch (op.operand) {
-	case NONE: strncpy (out, op.name, len-1); break;
+	case NONE: 
+		strncpy (out, op.name, len-1); 
+		break;
 	case ARG:
-		if (!strncmp (op.arg, "#imm", 4))
-		snprintf (out, len, "%s 0x%x", op.name, op.buf[1]);
-		else snprintf (out, len, "%s %s", op.name, op.arg);
+		if (!strncmp (op.arg, "#imm", 4)) {
+			snprintf (out, len, "%s 0x%x", op.name, op.buf[1]);
+		} else {
+			snprintf (out, len, "%s %s", op.name, op.arg);
+		}
 		break;
 	case ADDR11:
 	case ADDR16:

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2350,7 +2350,7 @@ static bool contains(RList *list, const char *name) {
 
 static char *oldregread = NULL;
 
-static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
+static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 	AeaStats *stats = esil->user;
 	if (oldregread && !strcmp (name, oldregread)) {
 		r_list_pop (stats->regread);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2785,7 +2785,7 @@ static int mymemwrite1(RAnalEsil *esil, ut64 addr, const ut8 *buf, int len) {
 	return 1;
 }
 
-static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
+static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 	char str[64], *msg = NULL;
 	ut32 *n32 = (ut32*)str;
 	RDisasmState *ds = esil->user;
@@ -2798,7 +2798,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 	}
 
 	memset (str, 0, sizeof (str));
-	if (val != 0LL) {
+	if (*val != 0LL) {
 #if 0
 		RFlagItem *fi = r_flag_get_i (esil->anal->flb.f, val);
 		if (fi) {
@@ -2826,7 +2826,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 			msg = r_str_newf ("%s", str);
 		}
 #endif
-		(void)r_io_read_at (esil->anal->iob.io, val, (ut8*)str, sizeof (str)-1);
+		(void)r_io_read_at (esil->anal->iob.io, *val, (ut8*)str, sizeof (str)-1);
 		str[sizeof (str)-1] = 0;
 		if (*str && r_str_is_printable (str)) {
 			// do nothing
@@ -2843,7 +2843,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 				}
 			}
 		}
-		RFlagItem *fi = r_flag_get_i (esil->anal->flb.f, val);
+		RFlagItem *fi = r_flag_get_i (esil->anal->flb.f, *val);
 		if (fi) {
 			msg = r_str_concatf (msg, " %s", fi->name);
 		}
@@ -2853,7 +2853,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 			r_cons_printf (" ; %s", msg);
 		}
 	} else {
-		r_cons_printf (" ; %s=0x%"PFMT64x" %s", name, val, msg? msg: "");
+		r_cons_printf (" ; %s=0x%"PFMT64x" %s", name, *val, msg? msg: "");
 	}
 	free (msg);
 	return 0;

--- a/libr/debug/esil.c
+++ b/libr/debug/esil.c
@@ -179,7 +179,7 @@ static int exprmatchreg (RDebug *dbg, const char *regname, const char *expr) {
 	return ret;
 }
 
-static int esilbreak_reg_write(RAnalEsil *esil, const char *regname, ut64 num) {
+static int esilbreak_reg_write(RAnalEsil *esil, const char *regname, ut64 *num) {
 	EsilBreak *ew;
 	RListIter *iter;
 	if (regname[0]>='0' && regname[0]<='9') {
@@ -187,7 +187,7 @@ static int esilbreak_reg_write(RAnalEsil *esil, const char *regname, ut64 num) {
 		//eprintf (Color_BLUE"IMM WRTE %s\n"Color_RESET, regname);
 		return 0;
 	}
-	eprintf (Color_MAGENTA"REG WRTE %s 0x%"PFMT64x"\n"Color_RESET, regname, num);
+	eprintf (Color_MAGENTA"REG WRTE %s 0x%"PFMT64x"\n"Color_RESET, regname, *num);
 	r_list_foreach (EWPS, iter, ew) {
 		if (ew->rwx & R_IO_WRITE && ew->dev == 'r') {
 			// XXX: support array of regs in expr

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -953,7 +953,7 @@ typedef struct r_anal_esil_callbacks_t {
 	int (*mem_write)(ESIL *esil, ut64 addr, const ut8 *buf, int len);
 	int (*hook_reg_read)(ESIL *esil, const char *name, ut64 *res, int *size);
 	int (*reg_read)(ESIL *esil, const char *name, ut64 *res, int *size);
-	int (*hook_reg_write)(ESIL *esil, const char *name, ut64 val);
+	int (*hook_reg_write)(ESIL *esil, const char *name, ut64 *val);
 	int (*reg_write)(ESIL *esil, const char *name, ut64 val);
 } RAnalEsilCallbacks;
 


### PR DESCRIPTION
Modification on operation `hook_reg_write()` in `RAnalEsilCallbacks` struct, for supporting modification of the incoming value,