### PR TITLE
Support for modifying incoming value when writing on ESIL register

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -542,7 +542,7 @@ R_API int r_anal_esil_reg_write(RAnalEsil *esil, const char *dst, ut64 num) {
 	int ret = 0;
 	IFDBG { eprintf ("%s=0x%" PFMT64x "\n", dst, num); }
 	if (esil->cb.hook_reg_write) {
-		ret = esil->cb.hook_reg_write (esil, dst, num);
+		ret = esil->cb.hook_reg_write (esil, dst, &num);
 	}
 	if (!ret && dst[0] == ESIL_INTERNAL_PREFIX && dst[1]) {
 		ret = esil_internal_write (esil, dst, num);

--- a/libr/anal/esil_stats.c
+++ b/libr/anal/esil_stats.c
@@ -28,7 +28,7 @@ static int hook_reg_read(RAnalEsil *esil, const char *name, ut64 *res, int *size
 	return 0;
 }
 
-static int hook_reg_write(RAnalEsil *esil, const char *name, ut64 val) {
+static int hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	sdb_array_add (esil->stats, "reg.write", name, 0);
 	return 0;
 }

--- a/libr/anal/esil_trace.c
+++ b/libr/anal/esil_trace.c
@@ -36,11 +36,11 @@ static int trace_hook_reg_read(RAnalEsil *esil, const char *name, ut64 *res, int
 	return ret;
 }
 
-static int trace_hook_reg_write(RAnalEsil *esil, const char *name, ut64 val) {
+static int trace_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	int ret = 0;
-	//eprintf ("[ESIL] REG WRITE %s 0x%08"PFMT64x"\n", name, val);
+	//eprintf ("[ESIL] REG WRITE %s 0x%08"PFMT64x"\n", name, *val);
 	sdb_array_add (DB, KEY ("reg.write"), name, 0);
-	sdb_num_set (DB, KEYREG ("reg.write", name), val, 0);
+	sdb_num_set (DB, KEYREG ("reg.write", name), *val, 0);
 	if (ocbs.hook_reg_write) {
 		RAnalEsilCallbacks cbs = esil->cb;
 		esil->cb = ocbs;

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -426,13 +426,13 @@ static int i8051_hook_reg_read(RAnalEsil *esil, const char *name, ut64 *res, int
 	return ret;
 }
 
-static int i8051_hook_reg_write(RAnalEsil *esil, const char *name, ut64 val) {
+static int i8051_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	int ret = 0;
 	RI8015Reg *ri;
 	RAnalEsilCallbacks cbs = esil->cb;
 	if ((ri = i8051_reg_find (name))) {
 		ut8 offset = i8051_reg_get_offset(esil, ri);
-		ret = r_anal_esil_mem_write (esil, IRAM + offset, (ut8*)&val, ri->num_bytes);
+		ret = r_anal_esil_mem_write (esil, IRAM + offset, (ut8*)val, ri->num_bytes);
 	}
 	esil->cb = ocbs;
 	if (!ret && ocbs.hook_reg_write) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2360,7 +2360,7 @@ static bool contains(RList *list, const char *name) {
 
 static char *oldregread = NULL;
 
-static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
+static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 	AeaStats *stats = esil->user;
 	if (oldregread && !strcmp (name, oldregread)) {
 		r_list_pop (stats->regread);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2785,7 +2785,7 @@ static int mymemwrite1(RAnalEsil *esil, ut64 addr, const ut8 *buf, int len) {
 	return 1;
 }
 
-static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
+static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 	char str[64], *msg = NULL;
 	ut32 *n32 = (ut32*)str;
 	RDisasmState *ds = esil->user;
@@ -2798,7 +2798,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 	}
 
 	memset (str, 0, sizeof (str));
-	if (val != 0LL) {
+	if (*val != 0LL) {
 #if 0
 		RFlagItem *fi = r_flag_get_i (esil->anal->flb.f, val);
 		if (fi) {
@@ -2826,7 +2826,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 			msg = r_str_newf ("%s", str);
 		}
 #endif
-		(void)r_io_read_at (esil->anal->iob.io, val, (ut8*)str, sizeof (str)-1);
+		(void)r_io_read_at (esil->anal->iob.io, *val, (ut8*)str, sizeof (str)-1);
 		str[sizeof (str)-1] = 0;
 		if (*str && r_str_is_printable (str)) {
 			// do nothing
@@ -2843,7 +2843,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 				}
 			}
 		}
-		RFlagItem *fi = r_flag_get_i (esil->anal->flb.f, val);
+		RFlagItem *fi = r_flag_get_i (esil->anal->flb.f, *val);
 		if (fi) {
 			msg = r_str_concatf (msg, " %s", fi->name);
 		}
@@ -2853,7 +2853,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 val) {
 			r_cons_printf (" ; %s", msg);
 		}
 	} else {
-		r_cons_printf (" ; %s=0x%"PFMT64x" %s", name, val, msg? msg: "");
+		r_cons_printf (" ; %s=0x%"PFMT64x" %s", name, *val, msg? msg: "");
 	}
 	free (msg);
 	return 0;

--- a/libr/debug/esil.c
+++ b/libr/debug/esil.c
@@ -179,7 +179,7 @@ static int exprmatchreg (RDebug *dbg, const char *regname, const char *expr) {
 	return ret;
 }
 
-static int esilbreak_reg_write(RAnalEsil *esil, const char *regname, ut64 num) {
+static int esilbreak_reg_write(RAnalEsil *esil, const char *regname, ut64 *num) {
 	EsilBreak *ew;
 	RListIter *iter;
 	if (regname[0]>='0' && regname[0]<='9') {
@@ -187,7 +187,7 @@ static int esilbreak_reg_write(RAnalEsil *esil, const char *regname, ut64 num) {
 		//eprintf (Color_BLUE"IMM WRTE %s\n"Color_RESET, regname);
 		return 0;
 	}
-	eprintf (Color_MAGENTA"REG WRTE %s 0x%"PFMT64x"\n"Color_RESET, regname, num);
+	eprintf (Color_MAGENTA"REG WRTE %s 0x%"PFMT64x"\n"Color_RESET, regname, *num);
 	r_list_foreach (EWPS, iter, ew) {
 		if (ew->rwx & R_IO_WRITE && ew->dev == 'r') {
 			// XXX: support array of regs in expr

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -954,7 +954,7 @@ typedef struct r_anal_esil_callbacks_t {
 	int (*mem_write)(ESIL *esil, ut64 addr, const ut8 *buf, int len);
 	int (*hook_reg_read)(ESIL *esil, const char *name, ut64 *res, int *size);
 	int (*reg_read)(ESIL *esil, const char *name, ut64 *res, int *size);
-	int (*hook_reg_write)(ESIL *esil, const char *name, ut64 val);
+	int (*hook_reg_write)(ESIL *esil, const char *name, ut64 *val);
 	int (*reg_write)(ESIL *esil, const char *name, ut64 val);
 } RAnalEsilCallbacks;
 


### PR DESCRIPTION
Modification on operation hook_reg_write() in RAnalEsilCallbacks struct, for supporting modification of the incoming value,

This PR supersedes the previous PR https://github.com/radare/radare2/pull/5950/commits/d5eb782a6cfd2af01e956fae4f24a81dcbf94336
I don't know how to rebase, squash, smash, unmerge, patch, drop, pop, push and strock with GIT, so I have created a new clean branch and applied my patches on it.