### PR TITLE
New callback 'RAnalEsilCallbacks::hook_reg_change()'

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -540,6 +540,16 @@ R_API int r_anal_esil_get_parm(RAnalEsil *esil, const char *str, ut64 *num) {
 
 R_API int r_anal_esil_reg_write(RAnalEsil *esil, const char *dst, ut64 num) {
 	int ret = 0;
+	if (esil->cb.hook_reg_change) {
+		ut64 new_value;
+		if (esil->cb.hook_reg_change (esil, dst, &new_value)) {
+			IFDBG {
+				eprintf ("Hook changed %s (0x%" PFMT64x " => 0x%" PFMT64x ")\n",
+						dst, num, new_value);
+			}
+			num = new_value;
+		}
+	}
 	IFDBG { eprintf ("%s=0x%" PFMT64x "\n", dst, num); }
 	if (esil->cb.hook_reg_write) {
 		ret = esil->cb.hook_reg_write (esil, dst, num);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -956,6 +956,7 @@ typedef struct r_anal_esil_callbacks_t {
 	int (*reg_read)(ESIL *esil, const char *name, ut64 *res, int *size);
 	int (*hook_reg_write)(ESIL *esil, const char *name, ut64 val);
 	int (*reg_write)(ESIL *esil, const char *name, ut64 val);
+	int (*hook_reg_change)(ESIL *esil, const char *name, ut64 *val);
 } RAnalEsilCallbacks;
 
 typedef struct r_anal_esil_t {


### PR DESCRIPTION
Another possible solution to problem described in PR _Support for modifying incoming value when writing on ESIL register_ https://github.com/radare/radare2/pull/5950 and PR https://github.com/radare/radare2/pull/5977

In this PR we propose creating a new callback `hook_reg_change` that is called when writing the value of a register.