### PR TITLE
Fix integer size in avr opcode type attribute

### DIFF
--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -35,7 +35,7 @@ typedef struct _opcodes_tag_ {
 	inst_handler_t handler;
 	int cycles;
 	int size;
-	int type;
+	ut64 type;
 } OPCODE_DESC;
 
 static int avr_op_analyze(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, CPU_MODEL *cpu);


### PR DESCRIPTION
When doing analysis of avr opcodes, the opcode "type" attribute is an int.

**anal_avr.c**
```c
typedef struct _opcodes_tag_ {
        const char *const name;
        int mask;
        int selector;
        inst_handler_t handler;
        int cycles;
        int size;
        int type;
} OPCODE_DESC;
```

But in the core RAnalOp struct, the type attribute is ut64.

**r_anal.h**
```c
typedef struct r_anal_op_t {
        char *mnemonic; /* mnemonic */
        ut64 addr;      /* address */
        ut64 type;      /* type of opcode */
        ....
} RAnalOp;
```

One problem caused by this is that non-conditional jumps do not draw reflines. In **reflines.c**, op->type is compared to R_ANAL_OP_TYPE_CJMP in the switch statement. The comparison fails due to the type difference.

The file I'm using for this test is here:
https://raw.githubusercontent.com/Riscure/RHme-2015/master/binary/ctf.hex

With this fix applied, conditional jumps should show reflines.