### PR TITLE
Fix for issue #4497

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -70,6 +70,7 @@ R_API RAnal *r_anal_new() {
 	r_io_bind_init (anal->iob);
 	r_flag_bind_init (anal->flb);
 	anal->reg = r_reg_new ();
+	anal->last_disasm_reg = NULL;
 	anal->bits_ranges = r_list_newf (free);
 	anal->lineswidth = 0;
 	anal->fcns = r_anal_fcn_list_new ();
@@ -116,6 +117,9 @@ R_API RAnal *r_anal_free(RAnal *a) {
 	if (a->esil) {
 		r_anal_esil_free (a->esil);
 		a->esil = NULL;
+	}
+	if (a->last_disasm_reg) {
+		free (a->last_disasm_reg);
 	}
 	memset (a, 0, sizeof (RAnal));
 	free (a);

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -118,9 +118,7 @@ R_API RAnal *r_anal_free(RAnal *a) {
 		r_anal_esil_free (a->esil);
 		a->esil = NULL;
 	}
-	if (a->last_disasm_reg) {
-		free (a->last_disasm_reg);
-	}
+	free (a->last_disasm_reg);
 	memset (a, 0, sizeof (RAnal));
 	free (a);
 	return NULL;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2755,7 +2755,7 @@ static int cmd_print(void *data, const char *input) {
 						if (emu) {
 							saved_gp = core->anal->gp;
 							saved_arena = r_reg_arena_peek (core->anal->reg);
-							local_state = r_hashtable64_new();
+							local_state = r_hashtable64_new ();
 							local_state->free = &free;
 						}
 
@@ -2784,7 +2784,7 @@ static int cmd_print(void *data, const char *input) {
 							core->anal->gp = saved_gp;
 							if (saved_arena) {
 								r_reg_arena_poke (core->anal->reg, saved_arena);
-								R_FREE(saved_arena);
+								R_FREE (saved_arena);
 							}
 						}
 						r_config_set_i (core->config, "asm.lines", asm_lines);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2104,8 +2104,6 @@ static void pdr_bb(RCore * core, RHashTable64* state, RAnalBlock * b, bool emu, 
 			r_hashtable64_remove (state, b->addr);
 			gp = r_reg_getv (core->anal->reg, "gp");
 			if (gp) {
-				r_cons_printf ("restoring GP=0x%08"PFMT64x, gp);
-				r_cons_newline ();
 				core->anal->gp = gp;
 			}
 		} else {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2094,14 +2094,13 @@ static ut32 tmp_get_contsize (RAnalFunction *f) {
 	return (size < 0) ? 0 : size;
 }
 
-static void pdr_bb(RCore * core, RHashTable64* state, RAnalBlock * b, bool emu, ut64 saved_gp, ut8 *saved_arena) {
+static void pdr_bb(RCore * core, RAnalFunction * fcn, RAnalBlock * b, bool emu, ut64 saved_gp, ut8 *saved_arena) {
 	core->anal->gp = saved_gp;
 	if (emu) {
-		ut8 *esil_arena = r_hashtable64_lookup (state, b->addr);
-		if (esil_arena) {
+		if (b->parent_reg_arena) {
 			ut64 gp;
-			r_reg_arena_poke (core->anal->reg, esil_arena);
-			r_hashtable64_remove (state, b->addr);
+			r_reg_arena_poke (core->anal->reg, b->parent_reg_arena);
+			R_FREE (b->parent_reg_arena);
 			gp = r_reg_getv (core->anal->reg, "gp");
 			if (gp) {
 				core->anal->gp = gp;
@@ -2114,18 +2113,18 @@ static void pdr_bb(RCore * core, RHashTable64* state, RAnalBlock * b, bool emu, 
 #if 1
 	if (b->jump != UT64_MAX) {
 		if (emu && core->anal->last_disasm_reg != NULL) {
-			ut8 *new_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
-			if (new_arena) {
-				r_hashtable64_insert (state, b->jump, new_arena);
+			RAnalBlock * jumpbb = r_anal_bb_get_jumpbb (fcn, b);
+			if (jumpbb) {
+				jumpbb->parent_reg_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
 			}
 		}
 		r_cons_printf ("| ----------- true: 0x%08"PFMT64x, b->jump);
 	}
 	if (b->fail != UT64_MAX) {
 		if (emu && core->anal->last_disasm_reg != NULL) {
-			ut8 *new_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
-			if (new_arena) {
-				r_hashtable64_insert (state, b->fail, new_arena);
+			RAnalBlock * failbb = r_anal_bb_get_failbb (fcn, b);
+			if (failbb) {
+				failbb->parent_reg_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
 			}
 		}
 		r_cons_printf ("  false: 0x%08"PFMT64x, b->fail);
@@ -2749,38 +2748,34 @@ static int cmd_print(void *data, const char *input) {
 						// TODO: sort by addr
 						bool asm_lines = r_config_get_i (core->config, "asm.lines");
 						bool emu = r_config_get_i (core->config, "asm.emu");
-						RHashTable64 *local_state;
 						ut64 saved_gp;
 						ut8 *saved_arena;
 						if (emu) {
 							saved_gp = core->anal->gp;
 							saved_arena = r_reg_arena_peek (core->anal->reg);
-							local_state = r_hashtable64_new ();
-							local_state->free = &free;
 						}
 
 						r_config_set_i (core->config, "asm.lines", 0);
 						for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
 							if (tmp_func->addr < f->addr) {
 								r_list_foreach (tmp_func->bbs, iter, b) {
-									pdr_bb (core, local_state, b, emu, saved_gp, saved_arena);
+									pdr_bb (core, tmp_func, b, emu, saved_gp, saved_arena);
 								}
 							} else {
 								break;
 							}
 						}
 						r_list_foreach (f->bbs, iter, b) {
-							pdr_bb (core, local_state, b, emu, saved_gp, saved_arena);
+							pdr_bb (core, f, b, emu, saved_gp, saved_arena);
 						}
 						for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
 							//this should be more advanced
 							r_list_foreach (tmp_func->bbs, iter, b) {
-								pdr_bb (core, local_state, b, emu, saved_gp, saved_arena);
+								pdr_bb (core, tmp_func, b, emu, saved_gp, saved_arena);
 							}
 						}
 
 						if (emu) {
-							r_hashtable64_free (local_state);
 							core->anal->gp = saved_gp;
 							if (saved_arena) {
 								r_reg_arena_poke (core->anal->reg, saved_arena);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2749,15 +2749,15 @@ static int cmd_print(void *data, const char *input) {
 						// TODO: sort by addr
 						bool asm_lines = r_config_get_i (core->config, "asm.lines");
 						bool emu = r_config_get_i (core->config, "asm.emu");
-                        RHashTable64 *local_state;
+						RHashTable64 *local_state;
 						ut64 saved_gp;
 						ut8 *saved_arena;
-                        if (emu) {
+						if (emu) {
 							saved_gp = core->anal->gp;
 							saved_arena = r_reg_arena_peek (core->anal->reg);
-                            local_state = r_hashtable64_new();
+							local_state = r_hashtable64_new();
 							local_state->free = &free;
-                        }
+						}
 
 						r_config_set_i (core->config, "asm.lines", 0);
 						for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -878,7 +878,7 @@ static void ds_atabs_option(RDisasmState *ds) {
 	if (!ds || !ds->atabs) {
 		return;
 	}
-	size = strlen (ds->asmop.buf_asm) * (ds->atabs + 1) * 4; 
+	size = strlen (ds->asmop.buf_asm) * (ds->atabs + 1) * 4;
 	if (size < 1 || size < strlen (ds->asmop.buf_asm)) {
 		return;
 	}
@@ -2697,7 +2697,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 					if (*msg) {
 						int i;
 						DOALIGN();
-						if (strlen (msg) == 1) {	
+						if (strlen (msg) == 1) {
 							r_cons_printf (" ; \"");
 							for (i = 0; i < len; i++) {
 								if (!msg[i]) {
@@ -2881,6 +2881,7 @@ static void ds_print_esil_anal_init(RDisasmState *ds) {
 	}
 	core->anal->esil->user = ds;
 	free (ds->esil_regstate);
+	R_FREE (core->anal->last_disasm_reg);
 	if (core->anal->gp) {
 		r_reg_setv (core->anal->reg, "gp", core->anal->gp);
 	}
@@ -2890,6 +2891,7 @@ static void ds_print_esil_anal_init(RDisasmState *ds) {
 static void ds_print_esil_anal_fini(RDisasmState *ds) {
 	if (ds->show_emu && ds->esil_regstate) {
 		RCore* core = ds->core;
+		core->anal->last_disasm_reg = r_reg_arena_peek (core->anal->reg);
 		const char *pc = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 		r_reg_arena_poke (core->anal->reg, ds->esil_regstate);
 		r_reg_setv (core->anal->reg, pc, ds->esil_old_pc);
@@ -2929,8 +2931,8 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 	}
 	{
 		const RAnalMetaItem *mi = r_meta_find (core->anal, ds->at, R_META_TYPE_ANY, 0);
-		if (mi) { 
-			goto beach; 
+		if (mi) {
+			goto beach;
 		}
 	}
 	if (ds->show_color) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -588,6 +588,7 @@ typedef struct r_anal_t {
 	RList *refs;
 	RList *vartypes;
 	RReg *reg;
+	ut8 *last_disasm_reg;
 	RSyscall *syscall;
 	struct r_anal_op_t *queued;
 	int diff_ops;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -772,10 +772,12 @@ typedef struct r_anal_bb_t {
 	struct r_anal_bb_t *head;
 	struct r_anal_bb_t *tail;
 	struct r_anal_bb_t *next;
+	/* these are used also in pdr: */
 	struct r_anal_bb_t *prev;
 	struct r_anal_bb_t *failbb;
 	struct r_anal_bb_t *jumpbb;
 	RList /*struct r_anal_bb_t*/ *cases;
+	ut8 *parent_reg_arena;
 } RAnalBlock;
 
 typedef enum {
@@ -1194,6 +1196,8 @@ R_API int r_anal_bb_is_in_offset(RAnalBlock *bb, ut64 addr);
 R_API bool r_anal_bb_set_offset(RAnalBlock *bb, int i, ut16 v);
 R_API ut16 r_anal_bb_offset_inst(RAnalBlock *bb, int i);
 R_API ut64 r_anal_bb_opaddr_at(RAnalBlock *bb, ut64 addr);
+R_API RAnalBlock *r_anal_bb_get_failbb(RAnalFunction *fcn, RAnalBlock *bb);
+R_API RAnalBlock *r_anal_bb_get_jumpbb(RAnalFunction *fcn, RAnalBlock *bb);
 
 /* op.c */
 R_API const char *r_anal_stackop_tostring (int s);

--- a/libr/include/r_reg.h
+++ b/libr/include/r_reg.h
@@ -198,6 +198,7 @@ R_API void r_reg_arena_zero(RReg *reg);
 
 R_API ut8 *r_reg_arena_peek(RReg *reg);
 R_API void r_reg_arena_poke(RReg *reg, const ut8 *buf);
+R_API ut8 *r_reg_arena_dup(RReg *reg, const ut8 *source);
 R_API const char *r_reg_cond_to_string(int n);
 R_API int r_reg_cond_from_string(const char *str);
 #endif

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -262,6 +262,16 @@ R_API void r_reg_arena_poke(RReg *reg, const ut8 *ret) {
 	memcpy (regset->arena->bytes, ret, regset->arena->size);
 }
 
+R_API ut8 *r_reg_arena_dup(RReg *reg, const ut8 *source) {
+	RRegSet *regset = r_reg_regset_get (reg, R_REG_TYPE_GPR);
+	if (!reg || !regset || !regset->arena || (regset->arena->size < 1)) {
+		return NULL;
+	}
+	ut8 *ret = malloc (regset->arena->size);
+	if (!ret) return NULL;
+	memcpy (ret, source, regset->arena->size);
+	return ret;
+}
 
 R_API int r_reg_arena_set_bytes(RReg *reg, const char* str) {
 	while (IS_WHITESPACE (*str)) {

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -250,15 +250,18 @@ R_API ut8 *r_reg_arena_peek(RReg *reg) {
 		return NULL;
 	}
 	ut8 *ret = malloc (regset->arena->size);
-	if (!ret) return NULL;
+	if (!ret) {
+		return NULL;
+	}
 	memcpy (ret, regset->arena->bytes, regset->arena->size);
 	return ret;
 }
 
 R_API void r_reg_arena_poke(RReg *reg, const ut8 *ret) {
 	RRegSet *regset = r_reg_regset_get (reg, R_REG_TYPE_GPR);
-	if (!ret || !regset || !regset->arena || !regset->arena->bytes)
+	if (!ret || !regset || !regset->arena || !regset->arena->bytes) {
 		return;
+	}
 	memcpy (regset->arena->bytes, ret, regset->arena->size);
 }
 
@@ -268,7 +271,9 @@ R_API ut8 *r_reg_arena_dup(RReg *reg, const ut8 *source) {
 		return NULL;
 	}
 	ut8 *ret = malloc (regset->arena->size);
-	if (!ret) return NULL;
+	if (!ret) {
+		return NULL;
+	}
 	memcpy (ret, source, regset->arena->size);
 	return ret;
 }


### PR DESCRIPTION
This should fix https://github.com/radare/radare2/issues/4497
- pdr with recursive esil status inheritance, use an hash table to keep the parent's register arena values
- added the `last_disasm_reg` on `core->anal`, this holds the final status of the last disassembly command, can be used to chain emulation status between subsequent disasm sessions (could be useful also in graphs)

let's discuss this!