### PR TITLE
Assemble 64bit byte mov correctly [FIX #6042]

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1013,7 +1013,9 @@ static int opmov(RAsm *a, ut8 *data, const Opcode op) {
 				}
 			}
 		} else if (op.operands[0].type & OT_MEMORY) {
-			if (a->bits == 64 && !(op.operands[0].type & OT_QWORD)) {
+			if (a->bits == 64 &&
+				!(op.operands[0].type & OT_BYTE) &&
+				!(op.operands[0].type & OT_QWORD)) {
 				data[l++] = 0x67;
 			}
 			if (op.operands[0].type & (OT_DWORD | OT_QWORD)) {


### PR DESCRIPTION
Fix for #6042 
```
$ rasm2 -a x86 -b 64 'mov byte [rbp - 0x100], 2'
c68500ffffff02
```

Oddly this also compiles correctly before this patch with keystone installed. Not sure as to why yet.