### PR TITLE
fix #5940 in libr/anal/p/anal_x86_cs.c

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1228,7 +1228,7 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 				// TODO update flags & handle signedness
 				esilprintf (op, "%s,%s,*,%s,=", a2, a1, a0);
 			} else {
-				if (a1[0]) {
+				if (ISVALID(a1[0])) {
 					esilprintf (op, "%s,%s,*=", a1, a0);
 				} else {
 					esilprintf (op, "%s,%s,*=", a0, "rax");

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1337,7 +1337,7 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			char dstAdd[64];
 			getarg (&gop, 1, 0, NULL, src);
 			getarg (&gop, 0, 0, NULL, dst);
-			getarg ( &gop, 0, 1, "+", dstAdd);
+			getarg (&gop, 0, 1, "+", dstAdd);
 			if (INSOP(0).type == X86_OP_MEM) {
 				char dst1[64];
 				getarg (&gop, 0, 1, NULL, dst1);

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -76,31 +76,35 @@ static bool is_xmm_reg(cs_x86_op op) {
  * @param  n       Operand index
  * @param  set     if 1 it adds set (=) to the operand
  * @param  setoper Extra operation for the set (^, -, +, etc...)
- * @return         char* with the esil operand
+ * @param  out     Output
+ * @return         Void
  */
-static char *getarg(struct Getarg* gop, int n, int set, char *setop) {
+static void getarg(struct Getarg* gop, int n, int set, char *setop, char *out) {
 	char *setarg = setop ? setop : "";
 	cs_insn *insn = gop->insn;
 	csh handle = gop->handle;
 	char buf[64];
 	cs_x86_op op;
+	buf[0] = 0;
 
 	if (!insn->detail) {
-		return NULL;
+		out[0]=0;
+		return;
 	}
-	buf[0] = 0;
 	if (n < 0 || n >= INSOPS) {
-		return NULL;
+		out[0]=0;
+		return;
 	}
 	op = INSOP (n);
 	switch (op.type) {
 	case X86_OP_INVALID:
-		return strdup ("invalid");
+		strcpy (out, "invalid");
+		return;
 	case X86_OP_REG:
 		if (set == 1) {
-			snprintf (buf, sizeof (buf), "%s,%s=",
+			snprintf (out, 64, "%s,%s=",
 				cs_reg_name (handle, op.reg), setarg);
-			return strdup (buf);
+			return;
 		} else {
 			if (gop->bits == 64) {
 				switch (op.reg) {
@@ -117,14 +121,17 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop) {
 				default: break;
 				}
 			}
-			return strdup (cs_reg_name (handle, op.reg));
+			strcpy (out, cs_reg_name (handle, op.reg));
+			return;
 		}
 	case X86_OP_IMM:
 		if (set == 1) {
-			return r_str_newf ("%"PFMT64d",%s=[%d]",
+			snprintf (out, 64, "%"PFMT64d",%s=[%d]",
 				(ut64)op.imm, setarg, op.size);
+			return;
 		}
-		return r_str_newf ("%"PFMT64d, (ut64)op.imm);
+		snprintf (out, 64, "%"PFMT64d, (ut64)op.imm);
+		return;
 	case X86_OP_MEM:
 		{
 		// address = (base + (index * scale) + offset)
@@ -186,9 +193,11 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop) {
 
 		buf[sizeof (buf) - 1] = 0;
 		}
-		return strdup (buf);
+		strcpy (out, buf);
+		return;
 	}
-	return NULL;
+	out[0]=0;
+	return;
 }
 
 static csh handle = 0;
@@ -377,7 +386,8 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_SETE:
 	case X86_INS_SETGE:
 		{
-			char *dst = getarg (&gop, 0, 1, NULL);
+			char dst[64];
+			getarg (&gop, 0, 1, NULL, dst);
 			switch (insn->id) {
 			case X86_INS_SETE:  esilprintf (op, "zf,%s", dst); break;
 			case X86_INS_SETNE: esilprintf (op, "zf,!,%s", dst); break;
@@ -396,7 +406,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			case X86_INS_SETA:  esilprintf (op, "cf,zf,|,!,%s", dst); break;
 			case X86_INS_SETBE: esilprintf (op, "cf,zf,|,%s", dst); break;
 			}
-			free (dst);
 		}
 		break;
 	// cmov
@@ -426,8 +435,10 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_CMOVP:
 	case X86_INS_CMOVS: {
 		const char *conditional = NULL;
-		char *src = getarg (&gop, 1, 0, NULL);
-		char *dst = getarg (&gop, 0, 1, NULL);
+		char src[64];
+		char dst[64];
+		getarg (&gop, 1, 0, NULL, src);
+		getarg (&gop, 0, 1, NULL, dst);
 		switch (insn->id) {
 		case X86_INS_CMOVA:
 			// mov if CF = 0 *AND* ZF = 0
@@ -494,11 +505,9 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			conditional = "sf";
 			break;
 		}
-		if (src && dst && conditional) {
+		if (src[0] && dst[0] && conditional) {
 			esilprintf (op, "%s,?{,%s,%s,}", conditional, src, dst);
 		}
-		free (src);
-		free (dst);
 	}
 		break;
 	case X86_INS_STOSB:
@@ -544,13 +553,13 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_MOVSD:
 		// Handle "Move Scalar Double-Precision Floating-Point Value"
 		if (is_xmm_reg (INSOP(0)) || is_xmm_reg (INSOP(1))) {
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, NULL);
-			if (src && dst) {
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, NULL, dst);
+			if (src[0] && dst[0]) {
 				esilprintf (op, "%s,%s", src, dst);
 			}
-			if (src) free (src);
-			if (dst) free (dst);
 			break;
 		}
 	case X86_INS_MOVSB:
@@ -612,25 +621,25 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 						width, width, src, width, dst, width, src,
 						width, dst, counter, counter);
 			} else {
-				char *src = getarg (&gop, 1, 0, NULL);
-				char *dst = getarg (&gop, 0, 1, NULL);
+				char src[64];
+				char dst[64];
+				getarg (&gop, 1, 0, NULL, src);
+				getarg (&gop, 0, 1, NULL, dst);
 				esilprintf (op, "%s,%s", src, dst);
-				free (src);
-				free (dst);
 			}
 			break;
 		case X86_OP_REG:
 		default:
 			{
-				char *src = getarg (&gop, 1, 0, NULL);
-				char *dst = getarg (&gop, 0, 0, NULL);
+				char src[64];
+				char dst[64];
+				getarg (&gop, 1, 0, NULL, src);
+				getarg (&gop, 0, 0, NULL, dst);
 				const char *dst64 = r_reg_32_to_64 (a->reg, dst);
 				esilprintf (op, "%s,%s,=", src, dst);
 				if (a->bits == 64 && dst64) {
 					r_strbuf_appendf (&op->esil, ",0xffffffff,%s,&=", dst64);
 				}
-				free (src);
-				free (dst);
 				break;
 			}
 		}
@@ -641,11 +650,11 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		// TODO: RCL Still does not work as intended
 		//  - Set flags
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, dst);
 			esilprintf (op, "%s,%s,<<<,%s,=", src, dst, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_ROR:
@@ -653,11 +662,11 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		// TODO: RCR Still does not work as intended
 		//  - Set flags
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, dst);
 			esilprintf (op, "%s,%s,>>>,%s,=", src, dst, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_SHL:
@@ -668,32 +677,32 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		// number of bits shifted is greater than the size of the
 		// destination.
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "<<");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "<<", dst);
 			esilprintf (op, "%s,%s,$z,zf,=,$p,pf,=,$s,sf,=", src, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_SAR:
 	case X86_INS_SARX:
 		// TODO: Set CF. See case X86_INS_SHL for more details.
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, ">>");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, ">>", dst);
 			esilprintf (op, "%s,%s,$z,zf,=,$p,pf,=,$s,sf,=", src, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_SAL:
 		// TODO: Set CF: See case X86_INS_SAL for more details.
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "<<");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "<<", dst);
 			esilprintf (op, "%s,%s,$z,zf,=,$p,pf,=,$s,sf,=", src, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_SALC:
@@ -704,13 +713,13 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_SHRX:
 		// TODO: Set CF: See case X86_INS_SAL for more details.
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst_r = getarg (&gop, 0, 0, NULL);
-			char *dst_w = getarg (&gop, 0, 1, NULL);
+			char src[64];
+			char dst_r[64];
+			char dst_w[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, dst_r);
+			getarg (&gop, 0, 1, NULL, dst_w);
 			esilprintf (op, "0,cf,=,1,%s,-,1,<<,%s,&,?{,1,cf,=,},%s,%s,>>,%s,$z,zf,=,$p,pf,=,$s,sf,=", src, dst_r, src, dst_r, dst_w);
-			free (src);
-			free (dst_r);
-			free (dst_w);
 		}
 		break;
 	case X86_INS_CMP:
@@ -723,28 +732,28 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_CMPSS:
 	case X86_INS_TEST:
 		if (insn->id == X86_INS_TEST) {
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, dst);
 			esilprintf (op, "0,%s,%s,&,==,$z,zf,=,$p,pf,=,$s,sf,=,$0,cf,=,$0,of,=",
 				src, dst);
-			free (src);
-			free (dst);
 		} else {
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, dst);
 			esilprintf (op,  "%s,%s,==,$z,zf,=,$b%d,cf,=,$p,pf,=,$s,sf,=,$o,of,=",
 				src, dst, (INSOP(0).size*8));
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_LEA:
 		{
-			char *src = getarg (&gop, 1, 2, NULL);
-			char *dst = getarg (&gop, 0, 1, NULL);
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 2, NULL, src);
+			getarg (&gop, 0, 1, NULL, dst);
 			esilprintf (op, "%s,%s", src, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_PUSHAW:
@@ -776,10 +785,10 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_ENTER:
 	case X86_INS_PUSH:
 		{
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char dst[64];
+			getarg (&gop, 0, 0, NULL, dst);
 			esilprintf (op, "%s,%d,%s,-=,%s,=[%d]",
-				dst?dst:"eax", rs, sp, sp, rs);
-			free (dst);
+				dst[0]?dst:"eax", rs, sp, sp, rs);
 		}
 		break;
 	case X86_INS_PUSHF:
@@ -818,11 +827,11 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case X86_INS_POP:
 		{
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char dst[64];
+			getarg (&gop, 0, 0, NULL, dst);
 			esilprintf (op,
 				"%s,[%d],%s,=,%d,%s,+=",
 				sp, rs, dst, rs, sp);
-			free (dst);
 		}
 		break;
 	case X86_INS_POPF:
@@ -881,7 +890,8 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_LOOPNE:
 		{
 			const char *cnt = (a->bits==16)?"cx":(a->bits==32)?"ecx":"rcx";
-			char *dst = getarg (&gop, 0, 2, NULL);
+			char dst[64];
+			getarg (&gop, 0, 2, NULL, dst);
 			switch (insn->id) {
 			case X86_INS_JL:
 				esilprintf (op, "of,sf,^,?{,%s,%s,=,}", dst, pc);
@@ -952,26 +962,27 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					cnt, cnt, dst, pc);
 				break;
 			}
-			free (dst);
 		}
 		break;
 	case X86_INS_CALL:
 		{
-			char* arg = getarg (&gop, 0, 0, NULL);
+			char arg[64];
+			getarg (&gop, 0, 0, NULL, arg);
 			esilprintf (op,
 					"%s,"
 					"%d,%s,-=,%s,"
 					"=[],"
 					"%s,%s,=",
 					pc, rs, sp, sp, arg, pc);
-			free (arg);
 		}
 		break;
 	case X86_INS_LCALL:
 		{
-			char* arg1 = getarg (&gop, 0, 0, NULL);
-			char* arg2 = getarg (&gop, 1, 0, NULL);
-			if (arg2) {
+			char arg1[64];
+			char arg2[64];
+			getarg (&gop, 0, 0, NULL, arg1);
+			getarg (&gop, 1, 0, NULL, arg2);
+			if (arg2[0]) {
 				esilprintf (op,
 						"2,%s,-=,cs,%s,=[2],"	// push CS
 						"%d,%s,-=,%s,%s,=[],"	// push IP/EIP
@@ -984,16 +995,14 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 						"%s,%s,=",		// set IP/EIP
 						sp, sp, rs, sp, arg1, pc);
 			}
-			free (arg1);
-			free (arg2);
 		}
 		break;
 	case X86_INS_JMP:
 	case X86_INS_LJMP:
 		{
-			char *src = getarg (&gop, 0, 0, NULL);
+			char src[64];
+			getarg (&gop, 0, 0, NULL, src);
 			esilprintf (op, "%s,%s,=", src, pc);
-			free (src);
 		}
 		// TODO: what if UJMP?
 		switch (INSOP(0).type) {
@@ -1045,10 +1054,10 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			break;
 		case X86_OP_REG:
 			{
-			char *src = getarg (&gop, 0, 0, NULL);
+			char src[64];
+			getarg (&gop, 0, 0, NULL, src);
 			op->src[0] = r_anal_value_new ();
 			op->src[0]->reg = r_reg_get (a->reg, src, R_REG_TYPE_GPR);
-			free (src);
 			//XXX fallthrough
 			}
 		//case X86_OP_FP:
@@ -1082,8 +1091,10 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_PXOR:
 	case X86_INS_XOR:
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "^");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "^", dst);
 			char *p;
 			esilprintf (op, "%s,%s,$z,zf,=,$p,pf,=,$s,sf,=,$0,cf,=,$0,of,=", src, dst);
 			if ((a->bits == 64) && (p = strchr (dst, (int)','))) {
@@ -1092,8 +1103,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					r_strbuf_appendf (&op->esil, ",0xffffffff,%s,&=", p);
 				}
 			}
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_OR:
@@ -1106,30 +1115,30 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		// XXX: Fix the above issue in esil.c to ensure we never make this
 		// mistake.
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "|");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "|", dst);
 			esilprintf (op, "%s,%s,$s,sf,=,$z,zf,=,$p,pf,=,$0,of,=,$0,cf,=",
 					src, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_INC:
 		// The CF flag is not affected. The OF, SF, ZF, AF, and PF flags
 		// are set according to the result.
 		{
-			char *src = getarg (&gop, 0, 1, "++");
+			char src[64];
+			getarg (&gop, 0, 1, "++", src);
 			esilprintf (op, "%s,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=", src);
-			free (src);
 		}
 		break;
 	case X86_INS_DEC:
 		// The CF flag is not affected. The OF, SF, ZF, AF, and PF flags
 		// are set according to the result.
 		{
-			char *src = getarg (&gop, 0, 1, "--");
+			char src[64];
+			getarg (&gop, 0, 1, "--", src);
 			esilprintf (op, "%s,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=", src);
-			free (src);
 		}
 		break;
 	case X86_INS_PSUBB:
@@ -1141,36 +1150,36 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_PSUBUSB:
 	case X86_INS_PSUBUSW:
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "-");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "-", dst);
 			esilprintf (op, "%s,%s", src, dst);
-			free(src);
-			free(dst);
 		}
 		break;
 	case X86_INS_SUB:
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "-");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "-", dst);
 			ut64 size = INSOP(0).size;
 			// Set OF, SF, ZF, AF, PF, and CF flags.
 			// We use $b rather than $c here as the carry flag really
 			// represents a "borrow"
 			esilprintf (op, "%s,%s,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b%d,cf,=",
 				src, dst, size);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_SBB:
 		// dst = dst - (src + cf)
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, dst);
 			ut64 size = INSOP(0).size;
 			esilprintf (op, "cf,%s,+,%s,-=,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b%d,cf,=", src, dst, size);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_LIDT:
@@ -1206,8 +1215,10 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_ANDNPD:
 	case X86_INS_ANDNPS:
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "&");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "&", dst);
 			char *p;
 			esilprintf (op, "%s,%s,$0,of,=,$0,cf,=,$z,zf,=,$s,sf,=,$o,pf,=", src, dst);
 			if ((a->bits == 64) && (p = strchr (dst, (int)','))) {
@@ -1216,17 +1227,18 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					r_strbuf_appendf (&op->esil, ",0xffffffff,%s,&=", p);
 				}
 			}
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_IDIV:
 		{
-			char *a0 = getarg (&gop, 0, 0, NULL);
-			char *a1 = getarg (&gop, 1, 0, NULL);
-			char *a2 = getarg (&gop, 2, 0, NULL);
+			char a0[64];
+			char a1[64];
+			char a2[64];
+			getarg (&gop, 0, 0, NULL, a0);
+			getarg (&gop, 1, 0, NULL, a1);
+			getarg (&gop, 2, 0, NULL, a2);
 			// TODO update flags & handle signedness
-			if (!a2 && !a1) {
+			if (!a2[0] && !a1[0]) {
 				// TODO: IDIV rbx not implemented. this is just a workaround
 // http://www.tptp.cc/mirrors/siyobik.info/instruction/IDIV.html
 // Divides (signed) the value in the AX, DX:AX, or EDX:EAX registers (dividend) by the source operand (divisor) and stores the result in the AX (AH:AL), DX:AX, or EDX:EAX registers. The source operand can be a general-purpose register or a memory location. The action of this instruction depends on the operand size (dividend/divisor), as shown in the following table:
@@ -1235,47 +1247,45 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			} else {
 				esilprintf (op, "%s,%s,/,%s,=", a2, a1, a0);
 			}
-			free (a0);
-			free (a1);
-			free (a2);
 		}
 		break;
 	case X86_INS_DIV:
 		{
 			int width = INSOP(0).size;
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char dst[64];
+			getarg (&gop, 0, 0, NULL, dst);
 			const char *r_ax = (width==2)?"ax": (width==4)?"eax":"rax";
 			const char *r_dx = (width==2)?"dx": (width==4)?"edx":"rdx";
 			// TODO update flags & handle signedness
 			esilprintf (op, "%s,%s,%%,%s,=,%s,%s,/,%s,=",
 				dst, r_ax, r_dx, dst, r_ax, r_ax);
-			free (dst);
 		}
 		break;
 	case X86_INS_IMUL:
 		{
-			char *a0 = getarg (&gop, 0, 0, NULL);
-			char *a1 = getarg (&gop, 1, 0, NULL);
-			char *a2 = getarg (&gop, 2, 0, NULL);
-			if (a2) {
+			char a0[64];
+			char a1[64];
+			char a2[64];
+			getarg (&gop, 0, 0, NULL, a0);
+			getarg (&gop, 1, 0, NULL, a1);
+			getarg (&gop, 2, 0, NULL, a2);
+			if (a2[0]) {
 				// TODO update flags & handle signedness
 				esilprintf (op, "%s,%s,*,%s,=", a2, a1, a0);
-				free (a2);
 			} else {
-				if (a1) {
+				if (a1[0]) {
 					esilprintf (op, "%s,%s,*=", a1, a0);
 				} else {
 					esilprintf (op, "%s,%s,*=", a0, "rax");
 				}
 			}
-			free (a0);
-			free (a1);
 		}
 		break;
 	case X86_INS_MUL:
 		{
-			char *src = getarg (&gop, 0, 0, NULL);
-			if (src) {
+			char src[64];
+			getarg (&gop, 0, 0, NULL, src);
+			if (src[0]) {
 				switch (src[0]) {
 				case 'r':
 					esilprintf (op, "%s,rax,*=", src);
@@ -1287,7 +1297,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					esilprintf (op, "%s,al,*=", src);
 					break;
 				}
-				free (src);
 			} else {
 				/* should never happen */
 			}
@@ -1299,40 +1308,41 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case X86_INS_MULSD:
 	case X86_INS_MULSS:
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "*");
-			if (!src && dst) {
+			char src[64];
+			char *srcp = src;
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "*", dst);
+			if (!src[0] && dst[0]) {
 				switch (dst[0]) {
 				case 'r':
-					src = strdup ("rax");
+					srcp = "rax";
 					break;
 				case 'e':
-					src = strdup ("eax");
+					srcp = "eax";
 					break;
 				default:
-					src = strdup ("al");
+					srcp = "al";
 					break;
 				}
 			}
-			esilprintf (op, "%s,%s", src, dst);
-			free (src);
-			free (dst);
+			esilprintf (op, "%s,%s", srcp, dst);
 		}
 		break;
 	case X86_INS_NEG:
 		{
-			char *src = getarg (&gop, 0, 0, NULL);
-			char *dst = getarg(&gop, 0, 1, NULL);
+			char src[64];
+			char dst[64];
+			getarg (&gop, 0, 0, NULL, src);
+			getarg(&gop, 0, 1, NULL, dst);
 			esilprintf (op, "0,cf,=,0,%s,>,?{,1,cf,=,},%s,0,-,%s,$z,zf,=,0,of,=,$s,sf,=,$o,pf,=", src, src, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_NOT:
 		{
-			char *dst = getarg (&gop, 0, 1, "^");
+			char dst[64];
+			getarg (&gop, 0, 1, "^", dst);
 			esilprintf (op, "-1,%s", dst);
-			free (dst);
 		}
 		break;
 	case X86_INS_PACKSSDW:
@@ -1349,10 +1359,13 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case X86_INS_XCHG:
 		{
-			char *src = getarg (&gop, 1, 0, NULL); // x
-			char *dst = getarg (&gop, 0, 0, NULL); // y
+			char src[64]; // x
+			char dst[64]; // y
+			getarg (&gop, 0, 0, NULL, dst);
+			getarg (&gop, 1, 0, NULL, src);
 			if (INSOP(0).type == X86_OP_MEM) {
-				char *dst1 = getarg (&gop, 0, 1, NULL);
+				char dst1[64];
+				getarg (&gop, 0, 1, NULL, dst1);
 				esilprintf (op,
 					"%s,%s,^,%s,=,"
 					"%s,%s,^,%s,"
@@ -1360,7 +1373,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					dst, src, src,	// x = x ^ y
 					src, dst, dst1,	// y = y ^ x
 					dst, src, src); // x = x ^ y
-				free (dst1);
 			} else {
 				esilprintf (op,
 					"%s,%s,^,%s,=,"
@@ -1371,17 +1383,19 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					dst, src, src); // x = x ^ y
 				//esilprintf (op, "%s,%s,%s,=,%s", src, dst, src, dst);
 			}
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_XADD: /* xchg + add */
 		{
-			char *src = getarg (&gop, 1, 0, NULL); // x
-			char *dst = getarg (&gop, 0, 0, NULL); // y
-			char *dstAdd = getarg ( &gop, 0, 1, "+");
+			char src[64]; // x
+			char dst[64]; // y
+			char dstAdd[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, dst);
+			getarg ( &gop, 0, 1, "+", dstAdd);
 			if (INSOP(0).type == X86_OP_MEM) {
-				char *dst1 = getarg (&gop, 0, 1, NULL);
+				char dst1[64];
+				getarg (&gop, 0, 1, NULL, dst1);
 				esilprintf (op,
 					"%s,%s,^,%s,=,"
 					"%s,%s,^,%s,"
@@ -1391,7 +1405,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					src, dst, dst1,	// y = y ^ x
 					dst, src, src,  // x = x ^ y
 					src, dstAdd);
-				free (dst1);
 			} else {
 				esilprintf (op,
 					"%s,%s,^,%s,=,"
@@ -1404,9 +1417,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 					src, dstAdd);
 				//esilprintf (op, "%s,%s,%s,=,%s", src, dst, src, dst);
 			}
-			free (src);
-			free (dst);
-			free (dstAdd);
 		}
 		break;
 	case X86_INS_FADD:
@@ -1421,37 +1431,39 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		// The OF, SF, ZF, AF, CF, and PF flags are set according to the
 		// result.
 		if (INSOP(0).type == X86_OP_MEM) {
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *src2 = getarg (&gop, 0, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, NULL);
+			char src[64];
+			char src2[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 0, NULL, src2);
+			getarg (&gop, 0, 1, NULL, dst);
 			esilprintf (op, "%s,%s,+,%s", src, src2, dst);
-			free (src);
-			free (src2);
-			free (dst);
 		} else {
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "+");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "+", dst);
 			esilprintf (op, "%s,%s", src, dst);
-			free (src);
-			free (dst);
 		}
 		break;
 	case X86_INS_ADD:
 		// The OF, SF, ZF, AF, CF, and PF flags are set according to the
 		// result.
 		{
-		char *src = getarg (&gop, 1, 0, NULL);
-		char *dst = getarg (&gop, 0, 1, "+");
+		char src[64];
+		char dst[64];
+		getarg (&gop, 1, 0, NULL, src);
+		getarg (&gop, 0, 1, "+", dst);
 		int carry_out_bit = (INSOP(0).size * 8) - 1;
 		esilprintf (op, "%s,%s,$o,of,=,$s,sf,=,$z,zf,=,$c%d,cf,=,$p,pf,=", src, dst, carry_out_bit);
-		free (src);
-		free (dst);
 		}
 		break;
 	case X86_INS_ADC:
 		{
-			char *src = getarg (&gop, 1, 0, NULL);
-			char *dst = getarg (&gop, 0, 1, "+");
+			char src[64];
+			char dst[64];
+			getarg (&gop, 1, 0, NULL, src);
+			getarg (&gop, 0, 1, "+", dst);
 			int carry_out_bit = (INSOP(0).size * 8) - 1;
 			// dst = dst + src + cf
 			// NOTE: We would like to add the carry first before adding the
@@ -1460,8 +1472,6 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			// that adds carry (as esil only keeps track of the last
 			// addition to set the flags).
 			esilprintf (op, "cf,%s,+,%s,$o,of,=,$s,sf,=,$z,zf,=,$c%d,cf,=,$p,pf,=", src, dst, carry_out_bit);
-			free (src);
-			free (dst);
 		}
 		break;
 		/* Direction flag */
@@ -1772,14 +1782,14 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 			break;
 		case X86_OP_REG:
 			{
-			char *dst = getarg (&gop, 0, 0, NULL);
+			char dst[64];
+			getarg (&gop, 0, 0, NULL, dst);
 			//op->dst = r_anal_value_new ();
 			op->dst->reg = r_reg_get (a->reg, dst, R_REG_TYPE_GPR);
 			//op->src[0] = r_anal_value_new ();
 			if (INSOP(1).type == X86_OP_MEM) {
 				op->src[0]->delta = INSOP(1).mem.disp;
 			}
-			free (dst);
 			}
 		default:
 			break;


### PR DESCRIPTION
Patched ``getarg()`` function and removed ``return strdup()``/``return r_str_newf()`` from it.
Patched ``anop_esil()`` and ``anop()`` functions to make it work with patched ``getarg()``