### PR TITLE
Fix issues in emuwrite call args in disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3086,22 +3086,29 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 						const char *arg_name, *fmt, *cc_source;
 						char *arg_orig_c_type, *arg_c_type;
 						ut64 arg_size;
-						int on_stack=0;
+						int on_stack=0, warning=0;
 						get_fcn_args_info (core->anal, key, i, cc, &arg_name, &arg_orig_c_type, &arg_c_type, &fmt, &arg_size, &cc_source);
 						if (!strcmp (cc_source, "stack_rev")) {
 							int j;
 							free (arg_orig_c_type);
 							on_stack = 1;
 							for (j = nargs-1; j >= i; j--) {
+								warning = 0;
 								get_fcn_args_info (core->anal, key, j, cc, &arg_name, &arg_orig_c_type, &arg_c_type, &fmt, &arg_size, &cc_source);
 								arg_addr = spv;
 								if (arg_size == 0) {
-									r_cons_printf ("\nWARNING: missing size for type '%s'\n", arg_c_type);
+									r_cons_printf ("%s: unk_size", arg_c_type);
+									warning = 1;
 									arg_size = s_width;
 								}
-								spv += s_width;
+								spv += arg_size;
 								if (!fmt) {
-									r_cons_printf ("\nWARNING: no format for type '%s'\n", arg_c_type);
+									if (!warning) {
+										r_cons_printf ("%s : unk_format", arg_c_type);
+									} else {
+										r_cons_printf ("_format");
+									}
+									r_cons_printf (j!=i?", ":");");
 									free (arg_orig_c_type);
 									continue;
 								}
@@ -3116,16 +3123,22 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 						if (!strncmp (cc_source, "stack", 5)) {
 							arg_addr = spv;
 							if (arg_size == 0) {
-								r_cons_printf ("\nWARNING: missing size for type '%s'\n", arg_c_type);
+								r_cons_printf ("%s: unk_size", arg_c_type);
+								warning = 1;
 								arg_size = s_width;
 							}
-							spv += s_width;
+							spv += arg_size;
 							on_stack = 1;
 						} else {
 							arg_addr = r_reg_getv (core->anal->reg, cc_source);
 						}
 						if (!fmt) {
-							r_cons_printf ("\nWARNING: no format for type '%s'\n", arg_c_type);
+							if (!warning) {
+								r_cons_printf ("%s : unk_format", arg_c_type);
+							} else {
+								r_cons_printf ("_format");
+							}
+							r_cons_printf (i!=(nargs-1)?", ":");");
 							free (arg_orig_c_type);
 							continue;
 						}


### PR DESCRIPTION
- actually use arg_size to advance the stack pointer
- nice error display: unk_size, unk_format or unk_size_format