### PR TITLE
Fix mips emu function resolution in disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3051,8 +3051,11 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 			ut64 pcv = ds->analop.jump;
 			if (pcv == UT64_MAX) {
 				pcv = ds->analop.ptr; // call [reloc-addr] // windows style
-				if (pcv == UT64_MAX) {
-					pcv = r_reg_getv (core->anal->reg, pc);
+				if (pcv == UT64_MAX || pcv == 0) {
+					r_anal_esil_reg_read (esil, "$jt", &pcv, NULL);
+					if (pcv == UT64_MAX || pcv == 0) {
+						pcv = r_reg_getv (core->anal->reg, pc);
+					}
 				}
 			}
 			fcn = r_anal_get_fcn_at (core->anal, pcv, 0);


### PR DESCRIPTION
Make function and args resolution work in mips too, by leveraging internal ESIL `$jt` register to get the proper function address.

```
│ 0x004b36a4      8f858030       lw a1, -0x7fd0(gp)                    ; [0x924390:4]=0x7f0000 "160.6.10" ; a1=0x7f0000 "160.6.10"
│ 0x004b36a8      8f991b0c       lw t9, 0x1b0c(gp)                     ; [0x92de6c:4]=0x7e1790 sym.imp.strncmp ; t9=0x7e1790 -> 0x10809900 sym.imp.strncmp
│ 0x004b36ac      8fa40254       lw a0, 0x254(sp)                      ; a0=0x0
│ 0x004b36b0      24a5d424       addiu a1, a1, -0x2bdc                 ; a1=0x7ed424 "5.4.8.1.160.1" str.5.4.8.1.160.1
│ 0x004b36b4      0200c821       move t9, s0                           ; t9=0x7e1790 -> 0x10809900 sym.imp.strncmp
│ 0x004b36b8      0320f809       jalr t9                               ; int strncmp(const char * s1 : 0x00000000 = .ELF..., const char * s2 : 0x007ed424 = 5.4.8.1.160.1, size_t n : 0x00000011 = 33556480);
```