### PR TITLE
asm.emu emulate also when meta is there

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1727,6 +1727,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("asm.emu", "false", "Run ESIL emulation analysis on disasm");
 	SETCB("asm.emustr", "false", &cb_emustr, "Show only strings if any in the asm.emu output");
 	SETPREF("asm.emuwrite", "false", "Allow asm.emu to modify memory (WARNING)");
+	SETPREF("asm.emuskip", "ds", "Skip metadata of given types in asm.emu (default: d=data, s=string)");
 	SETPREF("asm.filter", "true", "Replace numeric values by flags (e.g. 0x4003e0 -> sym.imp.printf)");
 	SETPREF("asm.fcnlines", "true", "Show function boundary lines");
 	SETPREF("asm.flags", "true", "Show flags");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -486,6 +486,18 @@ static int cb_emustr(void *user, void *data) {
 	return true;
 }
 
+static int cb_emuskip(void *user, void *data) {
+	RConfigNode *node = (RConfigNode*) data;
+	if (*node->value == '?') {
+		r_cons_printf ("Concatenation of meta types encoded as characters:\n" \
+				"'d': data\n'c': code\n's': string\n'f': format\n'm': magic\n" \
+				"'h': hide\n'C': comment\n'r': run\n" \
+				"(default is 'ds' to skip data and strings)\n");
+		return false;
+	}
+	return true;
+}
+
 static int cb_asm_invhex(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -1727,7 +1739,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("asm.emu", "false", "Run ESIL emulation analysis on disasm");
 	SETCB("asm.emustr", "false", &cb_emustr, "Show only strings if any in the asm.emu output");
 	SETPREF("asm.emuwrite", "false", "Allow asm.emu to modify memory (WARNING)");
-	SETPREF("asm.emuskip", "ds", "Skip metadata of given types in asm.emu (default: d=data, s=string)");
+	SETCB("asm.emuskip", "ds", &cb_emuskip, "Skip metadata of given types in asm.emu (see e asm.emuskip=?)");
 	SETPREF("asm.filter", "true", "Replace numeric values by flags (e.g. 0x4003e0 -> sym.imp.printf)");
 	SETPREF("asm.fcnlines", "true", "Show function boundary lines");
 	SETPREF("asm.flags", "true", "Show flags");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2873,7 +2873,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 		} else {
 			r_cons_printf (" ; %s=0x%"PFMT64x" %s", name, *val, msg? msg: "");
 		}
-	} 
+	}
 	free (msg);
 	return 0;
 }
@@ -2993,11 +2993,11 @@ static char * resolve_fcn_name(RAnal *anal, const char * func_name) {
 	return r_anal_type_func_guess (anal, (char*)func_name);
 }
 
-static bool can_emulate_metadata(RAnal * a, ut64 at) {
+static bool can_emulate_metadata(RCore * core, ut64 at) {
 	const char *infos;
-	const char *emuskipmeta = "ds";
+	const char *emuskipmeta = r_config_get (core->config, "asm.emuskip");
 	char key[32];
-	Sdb *s = a->sdb_meta;
+	Sdb *s = core->anal->sdb_meta;
 	snprintf (key, sizeof (key)-1, "meta.0x%"PFMT64x, at);
 	infos = sdb_const_get (s, key, 0);
 	if (!infos) {
@@ -3030,7 +3030,7 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 	if (!ds->show_comments || !ds->show_emu) {
 		goto beach;
 	}
-	if (!can_emulate_metadata (core->anal, at)) {
+	if (!can_emulate_metadata (core, at)) {
 		goto beach;
 	}
 	if (ds->show_color) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2993,6 +2993,29 @@ static char * resolve_fcn_name(RAnal *anal, const char * func_name) {
 	return r_anal_type_func_guess (anal, (char*)func_name);
 }
 
+static bool can_emulate_metadata(RAnal * a, ut64 at) {
+	const char *infos;
+	const char *emuskipmeta = "ds";
+	char key[32];
+	Sdb *s = a->sdb_meta;
+	snprintf (key, sizeof (key)-1, "meta.0x%"PFMT64x, at);
+	infos = sdb_const_get (s, key, 0);
+	if (!infos) {
+		/* no metadata: let's emulate this */
+		return true;
+	}
+	for (; *infos; infos++) {
+		/*
+		 * don't emulate if at least one metadata type
+		 * can't be emulated
+		 */
+		if (*infos != ',' && strchr(emuskipmeta, *infos)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 // modifies anal register state
 static void ds_print_esil_anal(RDisasmState *ds) {
 	RCore *core = ds->core;
@@ -3007,18 +3030,15 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 	if (!ds->show_comments || !ds->show_emu) {
 		goto beach;
 	}
-	{
-		const RAnalMetaItem *mi = r_meta_find (core->anal, at, R_META_TYPE_ANY, 0);
-		if (mi) {
-			goto beach;
-		}
+	if (!can_emulate_metadata (core->anal, at)) {
+		goto beach;
 	}
 	if (ds->show_color) {
 		r_cons_strcat (ds->pal_comment);
 	}
+	ds_align_comment (ds);
 	ioc = r_config_get_i (core->config, "io.cache");
 	r_config_set (core->config, "io.cache", "true");
-	ds_align_comment (ds);
 	esil = core->anal->esil;
 	pc = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 	r_reg_setv (core->anal->reg, pc, at + ds->analop.size);


### PR DESCRIPTION
- emulate silently, to avoid skipping calculating values
which could be used in subsequent instructions

also made a test for this: https://github.com/radare/radare2-regressions/pull/612