### PR TITLE
Fix #6124 - ensure "#\t" doesn't get processed as a command

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1259,7 +1259,8 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	char *cmt, *colon = NULL, *icmd = strdup (cmd);
 	const char *cmdrep = NULL;
 	cmd = r_str_trim_head_tail (icmd);
-	if (!icmd || !strncmp (cmd, "# ", 2)) {
+	// lines starting with # are ignored (never reach cmd_hash()), except #! and #?
+	if (!icmd || (cmd[0] == '#' && cmd[1] != '!' && cmd[1] != '?')) {
 		goto beach;
 	}	
 	cmt = *icmd ? strchr (icmd+1, '#'): NULL;

--- a/libr/core/cmd_hash.c
+++ b/libr/core/cmd_hash.c
@@ -192,6 +192,7 @@ static int cmd_hash(void *data, const char *input) {
 		r_core_cmd_help (core, helpmsg3);
 		return false;
 	}
-	/* this is a comment - captain obvious */
+	/* this is a comment - captain obvious
+	   should not be reached, see r_core_cmd_subst() */
 	return 0;
 }


### PR DESCRIPTION
This whitelists #! and #? and considers every other line starting with #
as a command, handled at r_core_cmd_subst() instead of reaching
cmd_hash(), because if that happens, file redirections and other
modifiers may get processed too in lines that otherwise look like
comments.