### PR TITLE
cmd_help: Remove # [algo] [len] from main help (it's ph now)

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -787,7 +787,6 @@ static int cmd_help(void *data, const char *input) {
 		"="," [cmd]", "Run this command via rap://",
 		"/","", "Search for bytes, regexps, patterns, ..",
 		"!"," [cmd]", "Run given command as in system(3)",
-		"#"," [algo] [len]", "Calculate hash checksum of current block",
 		"#","!lang [..]", "Hashbang to run an rlang script",
 		"a","[?]", "Perform analysis of code",
 		"b","[?]", "Get or change block size",


### PR DESCRIPTION
It was renamed by 5683e45cb2a7c60b422aa7943a049616ec1607d7, which just missed removing it from here.