### PR TITLE
anal: fix 'axf string ref' tests

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3437,7 +3437,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 		ut8 buf[12];
 		RAsmOp asmop;
 		char *buf_asm = NULL;
-		RList *list;
+		RList *list, *list_;
 		RAnalRef *ref;
 		RListIter *iter;
 		char *space = strchr (input, ' ');
@@ -3447,12 +3447,13 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 		} else {
 			addr = core->offset;
 		}
-#if 0
-		list = r_anal_xrefs_get_from (core->anal, addr);
-#else
-		RAnalFunction * fcn = r_anal_get_fcn_in (core->anal, addr, 0);
-		list = fcn? fcn->refs: NULL;
-#endif
+		list = list_ = r_anal_xrefs_get_from (core->anal, addr);
+
+		if (!list) {
+			RAnalFunction * fcn = r_anal_get_fcn_in (core->anal, addr, 0);
+			list = fcn? fcn->refs: NULL;
+		}
+
 		if (list) {
 			if (input[1] == 'q') { // axfq
 				r_list_foreach (list, iter, ref) {
@@ -3503,7 +3504,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 					free (buf_asm);
 				}
 			}
-			// r_list_free (list);
+			r_list_free (list_);
 		}
 	} break;
 	case 'F':


### PR DESCRIPTION
Complements commmit 637e6db by reverting to the old axf behavior of
showing xrefs from a single address instead of the whole function,
but only if that specific address has xrefs. Otherwise it shows the
xrefs of the whole function

References #5113