### PR TITLE
fpu/mm/xmm improves

### DIFF
--- a/libr/include/r_types_base.h
+++ b/libr/include/r_types_base.h
@@ -13,6 +13,14 @@
 #define ut8 unsigned char
 #define st8 signed char
 #define boolt int
+typedef struct _ut128 {
+	ut64 Low;
+	st64 High;
+} ut128;
+typedef struct _ut80 {
+	ut64 Low;
+	ut16 High;
+} ut80;
 
 #include <stdbool.h>
 


### PR DESCRIPTION
- Add ut128 and ut80 types to manage FPU registers
- Get correct order of MMx register
- YMM registers implemented
- Win32/64 code to get context removed from debug_native and moved to w32.c

Note:
   This code dont show nothig also you change the showfpu to true at line 915. But now all registers are retrieve by the correct way.

TODO: Add this info to registers profiles x32/64 and check if in x32 the rreg api can get x64 values.
  

