### PR TITLE
fix radare_plugin redundantly defined

### DIFF
--- a/libr/asm/p/asm_z80.c
+++ b/libr/asm/p/asm_z80.c
@@ -27,8 +27,10 @@ RAsmPlugin r_asm_plugin_z80 = {
 	.assemble = &do_assemble,
 };
 
+#ifndef CORELIB
 struct r_lib_struct_t radare_plugin = {
 	.type = R_LIB_TYPE_ASM,
 	.data = &r_asm_plugin_z80,
 	.version = R2_VERSION
 };
+#endif


### PR DESCRIPTION
without these guards the linker complains:

p/asm_z80.o:(.data.rel+0x0): multiple definition of `radare_plugin'
p/asm_m68k_cs.o:(.data.rel+0x0): first defined here
collect2: error: ld returned 1 exit status