### PR TITLE
asm_m68k_cs: Add missing CORELIB check

### DIFF
--- a/libr/asm/p/asm_m68k_cs.c
+++ b/libr/asm/p/asm_m68k_cs.c
@@ -134,9 +134,12 @@ RAsmPlugin r_asm_plugin_m68k_cs = {
 	.endian = R_SYS_ENDIAN_LITTLE | R_SYS_ENDIAN_BIG,
 };
 
+#ifndef CORELIB
 RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ASM,
 	.data = &r_asm_plugin_m68k_cs,
 	.version = R2_VERSION
 };
+#endif
+
 #endif


### PR DESCRIPTION
radare_plugin should not be defined for builtin plugins.