### PR TITLE
libr2.so: fix soname version

### DIFF
--- a/binr/preload/Makefile
+++ b/binr/preload/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OSTYPE),android)
 LDFLAGS+=${DL_LIBS} -lm
 endif
 ifeq ($(OSTYPE),gnulinux)
-LDFLAGS+=-Wl,-soname,libr2.${EXT_SO}.${VERSION}
+LDFLAGS+=-Wl,-soname,libr2.${EXT_SO}.${LIBVERSION}
 endif
 include ../../libr/socket/deps.mk
 include ../../shlr/zip/deps.mk


### PR DESCRIPTION
I packaged 1.0.2 for debian using --with-libversion=1.0, as it should be ABI compatible. While this mostly worked, libr2.so has been generated with 1.0.2 as soname. This fixes the behaviour.