### PR TITLE
Fix double slash at the 'db' symlink path

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -97,7 +97,7 @@ init|up|update)
 		rm -f "${R2PM_DBDIR}"
 	fi
 
-	ln -fs "${R2PM_USRDIR}"/git/radare2-pm/db "${R2PM_DBDIR}" || exit 1
+	ln -fs "${R2PM_USRDIR}"git/radare2-pm/db "${R2PM_DBDIR}" || exit 1
 	if [ "$1" = "init" ]; then
 		echo "r2pm database initialized. Use 'r2pm update' to update"
 	fi


### PR DESCRIPTION
After installing radare2 on Bash on Windows 10 machine and executing `r2pm init && r2pm update`, I get `Cannot find /home/<user_name>/.config/radare2/r2pm/db/<plugin_name>` every time I try to install plugin using `r2pm -i <plugin_name>`.

I checked deeper and found that the `symlink` that is created under `~/.config/radare2/r2pm/db` is pointing to `~/.config/radare2/r2pm//git/radare2-pm/db`, you can see that there are two slashes between the folders `r2pm` and `git`.

I went to the source code and indeed there are two slashes:

Line 53: `R2PM_USRDIR="${HOME}/.config/radare2/r2pm/"`
...
Line 100: `ln -fs "${R2PM_USRDIR}"/git/radare2-pm/db "${R2PM_DBDIR}" || exit 1`

Notice that R2PM_USRDIR variable ends with '/' and then concatenated with a string that starts with '/'.

I then edited manually the symlnk path to be `~/.config/radare2/r2pm/git/radare2-pm/db` with only one slash and then all worked.

I checked this also in Kali-Linux and although the symlink there is also with double slash, all works fine. Seems like double slash in symlinks on Linux machines is working fine, but not on 'Bash on windows' (the collaboration between Microsoft and Canonical).

In this pull-request I edited Line 100 from:
`ln -fs "${R2PM_USRDIR}"/git/radare2-pm/db "${R2PM_DBDIR}" || exit 1`
to
`ln -fs "${R2PM_USRDIR}"git/radare2-pm/db "${R2PM_DBDIR}" || exit 1`

I checked it on both Windows (Bash) and Kali (Bash) and it now works just fine.