### PR TITLE
Arch independent data in share

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,9 +201,9 @@ install love: install-doc install-man install-www
 		rm -f last ; ln -fs $(VERSION) last
 	cd "$(DESTDIR)$(DATADIR)/radare2/" ;\
 		rm -f last ; ln -fs $(VERSION) last
-	rm -rf "${DESTDIR}${LIBDIR}/radare2/${VERSION}/hud"
-	mkdir -p "${DESTDIR}${LIBDIR}/radare2/${VERSION}/hud"
-	cp -f doc/hud "${DESTDIR}${LIBDIR}/radare2/${VERSION}/hud/main"
+	rm -rf "${DESTDIR}${DATADIR}/radare2/${VERSION}/hud"
+	mkdir -p "${DESTDIR}${DATADIR}/radare2/${VERSION}/hud"
+	cp -f doc/hud "${DESTDIR}${DATADIR}/radare2/${VERSION}/hud/main"
 	mkdir -p "${DESTDIR}${DATADIR}/radare2/${VERSION}/"
 	sys/ldconfig.sh
 	./configure-plugins --rm-static $(DESTDIR)/$(LIBDIR)/radare2/last/
@@ -242,12 +242,12 @@ symstall install-symlink: install-man-symlink install-doc-symlink install-pkgcon
 		echo "$$DIR" ; \
 		${MAKE} install-symlink ); \
 	done
-	mkdir -p "${DESTDIR}${LIBDIR}/radare2/${VERSION}/hud"
+	mkdir -p "${DESTDIR}${DATADIR}/radare2/${VERSION}/hud"
 	cd "$(DESTDIR)$(LIBDIR)/radare2/" ;\
 		rm -f last ; ln -fs $(VERSION) last
 	cd "$(DESTDIR)$(DATADIR)/radare2/" ;\
 		rm -f last ; ln -fs $(VERSION) last
-	ln -fs "${PWD}/doc/hud" "${DESTDIR}${LIBDIR}/radare2/${VERSION}/hud/main"
+	ln -fs "${PWD}/doc/hud" "${DESTDIR}${DATADIR}/radare2/${VERSION}/hud/main"
 	mkdir -p "${DESTDIR}${DATADIR}/radare2/${VERSION}/"
 	sys/ldconfig.sh
 	./configure-plugins --rm-static $(DESTDIR)/$(LIBDIR)/radare2/last/

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -185,7 +185,7 @@ R_API bool r_anal_set_reg_profile(RAnal *anal) {
 }
 
 R_API bool r_anal_set_fcnsign(RAnal *anal, const char *name) {
-#define FCNSIGNPATH R2_LIBDIR"/radare2/"R2_VERSION"/fcnsign"
+#define FCNSIGNPATH R2_PREFIX "/share/radare2/" R2_VERSION "/fcnsign"
 	char *file = NULL;
 	const char *arch = (anal->cur && anal->cur->arch) ? anal->cur->arch : R_SYS_ARCH;
 	if (name && *name) {

--- a/libr/anal/d/Makefile
+++ b/libr/anal/d/Makefile
@@ -35,6 +35,8 @@ BUILD_EXT_EXE=
 endif
 SDB=$(SDBPATH)/sdb${BUILD_EXT_EXE}
 
+FCNSIGNPATH=${DESTDIR}${DATADIR}/radare2/${VERSION}/fcnsign
+
 all: ${SDB}
 	@$(MAKE) compile
 
@@ -64,14 +66,14 @@ ${SDB}:
 .PHONY: all clean install install-symlink symstall
 
 install: ${F_SDB}
-	-rm -rf "${DESTDIR}${LIBDIR}/radare2/${VERSION}/fcnsign"
-	mkdir -p "${DESTDIR}${LIBDIR}/radare2/${VERSION}/fcnsign"
-	cp -f *.sdb "${DESTDIR}${LIBDIR}/radare2/${VERSION}/fcnsign"
+	-rm -rf "${FCNSIGNPATH}"
+	mkdir -p "${FCNSIGNPATH}"
+	cp -f *.sdb "${FCNSIGNPATH}"
 
 CWD=$(shell pwd)
 symstall install-symlink: ${F_SDB}
-	mkdir -p "${DESTDIR}${LIBDIR}/radare2/${VERSION}/fcnsign"
-	for FILE in *.sdb ; do ln -fs "${CWD}/$$FILE" "${DESTDIR}${LIBDIR}/radare2/${VERSION}/fcnsign/$$FILE" ; done
+	mkdir -p "${FCNSIGNPATH}"
+	for FILE in *.sdb ; do ln -fs "${CWD}/$$FILE" "${FCNSIGNPATH}/$$FILE" ; done
 
 uninstall:
-	rm -rf "${DESTDIR}${LIBDIR}/radare2/fcnsign"
+	rm -rf "${FCNSIGNPATH}"

--- a/libr/asm/d/Makefile
+++ b/libr/asm/d/Makefile
@@ -16,7 +16,7 @@ clean:
 .PHONY: all clean install install-symlink symstall uninstall
 
 # XXX rmdblslash not defined, but doesnt warns about it
-OPDIR=${DESTDIR}${LIBDIR}/radare2/${VERSION}/opcodes
+OPDIR=${DESTDIR}${DATADIR}/radare2/${VERSION}/opcodes
 
 install: ${F_SDB}
 	-rm -rf "${OPDIR}"
@@ -30,4 +30,4 @@ symstall install-symlink: ${F_SDB}
 	for FILE in *.sdb ; do ln -fs "${CWD}/$$FILE" "${OPDIR}/$$FILE" ; done
 
 uninstall:
-	rm -rf "${DESTDIR}${LIBDIR}/radare2/opcodes"
+	rm -rf "${OPDIR}"

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -458,7 +458,7 @@ static int is_executable (RBinObject *obj) {
 	return false;
 }
 
-#define DBSPATH R2_LIBDIR"/radare2/"R2_VERSION"/fcnsign"
+#define DBSPATH R2_PREFIX "/share/radare2/" R2_VERSION "/fcnsign"
 static void sdb_concat_by_path (Sdb *s, const char *path) {
 	Sdb *db = sdb_new (0, path, 0);
 	sdb_merge (s, db);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -143,7 +143,7 @@ static int zoom = 0;
 
 R_API int r_core_visual_hud(RCore *core) {
 	const char *c = r_config_get (core->config, "hud.path");
-	const char *f = R2_LIBDIR"/radare2/"R2_VERSION"/hud/main";
+	const char *f = R2_PREFIX "/share/radare2/" R2_VERSION "/hud/main";
 	int use_color = core->print->flags & R_PRINT_FLAGS_COLOR;
 	char *homehud = r_str_home (R2_HOMEDIR"/hud");
 	char *res = NULL;

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -14,7 +14,7 @@ extern "C" {
 
 R_LIB_VERSION_HEADER(r_asm);
 
-#define R_ASM_OPCODES_PATH R2_LIBDIR "/radare2/" R2_VERSION "/opcodes"
+#define R_ASM_OPCODES_PATH R2_PREFIX "/share/radare2/" R2_VERSION "/opcodes"
 // XXX too big!
 // the 256th character is left for the null terminator
 #define R_ASM_BUFSIZE 255

--- a/libr/include/r_magic.h
+++ b/libr/include/r_magic.h
@@ -15,7 +15,7 @@ R_LIB_VERSION_HEADER(r_magic);
 #define MAGICFILE "/etc/magic"
 #endif
 
-#define R_MAGIC_PATH R2_LIBDIR "/radare2/" R2_VERSION "/magic"
+#define R_MAGIC_PATH R2_PREFIX "/share/radare2/" R2_VERSION "/magic"
 
 #if USE_LIB_MAGIC
 

--- a/libr/magic/d/Makefile
+++ b/libr/magic/d/Makefile
@@ -1,6 +1,7 @@
 include ../../config.mk
 
-MAGICDIR=${DESTDIR}${LIBDIR}/radare2/${VERSION}/magic
+MAGICDIR=${DESTDIR}${DATADIR}/radare2/${VERSION}/magic
+
 install: ${F_SDB}
 	-rm -rf "$(MAGICDIR)"
 	mkdir -p "$(MAGICDIR)"

--- a/libr/syscall/d/Makefile
+++ b/libr/syscall/d/Makefile
@@ -66,15 +66,17 @@ ${SDB}:
 
 .PHONY: all clean install install-symlink symstall
 
+SYSCALLPATH=${DESTDIR}${DATADIR}/radare2/${VERSION}/syscall
+
 install: ${F_SDB}
-	-rm -rf "${DESTDIR}${LIBDIR}/radare2/${VERSION}/syscall"
-	mkdir -p "${DESTDIR}${LIBDIR}/radare2/${VERSION}/syscall"
-	cp -f *.sdb "${DESTDIR}${LIBDIR}/radare2/${VERSION}/syscall"
+	-rm -rf "${SYSCALLPATH}"
+	mkdir -p "${SYSCALLPATH}"
+	cp -f *.sdb "${SYSCALLPATH}"
 
 CWD=$(shell pwd)
 symstall install-symlink: ${F_SDB}
-	mkdir -p "${DESTDIR}${LIBDIR}/radare2/${VERSION}/syscall"
-	for FILE in *.sdb ; do ln -fs "${CWD}/$$FILE" "${DESTDIR}${LIBDIR}/radare2/${VERSION}/syscall/$$FILE" ; done
+	mkdir -p "${SYSCALLPATH}"
+	for FILE in *.sdb ; do ln -fs "${CWD}/$$FILE" "${SYSCALLPATH}/$$FILE" ; done
 
 uninstall:
-	rm -rf "${DESTDIR}${LIBDIR}/radare2/syscall"
+	rm -rf "${SYSCALLPATH}"

--- a/libr/syscall/syscall.c
+++ b/libr/syscall/syscall.c
@@ -83,7 +83,7 @@ R_API int r_syscall_setup(RSyscall *s, const char *arch, const char *os, int bit
 		}
 	}
 
-#define SYSCALLPATH R2_LIBDIR"/radare2/"R2_VERSION"/syscall"
+#define SYSCALLPATH R2_PREFIX "/share/radare2/" R2_VERSION "/syscall"
 	file = sdb_fmt (0, "%s/%s-%s-%d.sdb",
 		SYSCALLPATH, os, arch, bits);
 	if (!r_file_exists (file)) {


### PR DESCRIPTION
Hi,

This moves all architecture independent data (ca. 2MB) from r2's LIBDIR to r2's DATADIR. This is interesting from a distribution's point of view, since for stuff in /usr/share one package is enough for all architectures. So instead of having 2MB of data in e.g. 10 different architecture-specific packages it's provided by one architecture-independent package saving ~20MB. It's also interesting for users installing the r2 libs for multiple architectures to save some memory & bandwidth.

-- Sebastian