### PR TITLE
section prefixes, debug maps, new debug mapped sections

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1993,10 +1993,17 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 			} else {
 				str[0] = 0;
 			}
-			r_cons_printf ("idx=%02i vaddr=0x%08"PFMT64x" paddr=0x%08"PFMT64x" sz=%"PFMT64d" vsz=%"PFMT64d" "
-				"perm=%s %s%sname=%s\n",
-				i, addr, section->paddr, section->size, section->vsize,
-				perms, str, hashstr ?hashstr : "", section->name);
+			if (r->bin->prefix) {
+				r_cons_printf ("idx=%02i vaddr=0x%08"PFMT64x" paddr=0x%08"PFMT64x" sz=%"PFMT64d" vsz=%"PFMT64d" "
+					"perm=%s %s%sname=%s.%s\n",
+					i, addr, section->paddr, section->size, section->vsize,
+					perms, str, hashstr ?hashstr : "", r->bin->prefix, section->name);
+			} else {
+				r_cons_printf ("idx=%02i vaddr=0x%08"PFMT64x" paddr=0x%08"PFMT64x" sz=%"PFMT64d" vsz=%"PFMT64d" "
+					"perm=%s %s%sname=%s\n",
+					i, addr, section->paddr, section->size, section->vsize,
+					perms, str, hashstr ?hashstr : "", section->name);
+			}
 			free (hashstr);
 		}
 		i++;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1397,7 +1397,6 @@ static int cb_binprefix(void *user, void *data) {
 	if (!core || !core->bin) {
 		return false;
 	}
-	R_FREE (core->bin->prefix);
 	if (node->value && *node->value) {
 		if (!strcmp (node->value, "auto")) {
 			if (!core->bin->file) {

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -57,7 +57,7 @@ R_API int r_debug_reg_sync(RDebug *dbg, int type, int write) {
 			int bufsize = dbg->reg->size;
 			//int bufsize = dbg->reg->regset[i].arena->size;
 			if (bufsize > 0) {
-				ut8 *buf = calloc (1, bufsize);
+				ut8 *buf = calloc (1 + 1, bufsize);
 				if (!buf) {
 					return false;
 				}


### PR DESCRIPTION
tests added here: https://github.com/radare/radare2-regressions/pull/622

* fix rabin2: get it to print prefixes for sections when the ```-r``` options isn't present

* new command ```dmS```. Like ```dmi``` but for sections. There is still an outstanding issue with the non-filtered invocation of ```dmS```. The second time it is called (without a library name specified) there will be a double-free error raised. I've added a test to trigger this condition. I haven't  reckoned how to resolve it yet.