### PR TITLE
Fix windows visualmode

### DIFF
--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -81,20 +81,18 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 		if (ptr[0] == 0xa) {
 			int ll = (size_t)(ptr - str) - 1;
 			lines--;
-			if (vmode && lines<0) {
+			if (vmode && lines < 0) {
 				break;
 			}
-			//if (ll < 1) {
 			if (ll < 0) {
 				continue;
 			}
 			if (vmode) {
 				// TODO: Fix utf8 chop
 				/* only chop columns if necessary */
-				if (/*ll != linelen && */ll+linelen >= cols) {
+				if (ll + linelen >= cols) {
 					// chop line if too long
-					ll = (cols-linelen)-1;
-					//if (ll < 1) {
+					ll = (cols - linelen) - 1;
 					if (ll < 0) {
 							continue;
 					}

--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -95,7 +95,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 					// chop line if too long
 					ll = (cols - linelen) - 1;
 					if (ll < 0) {
-							continue;
+						continue;
 					}
 				}
 			}

--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -79,27 +79,31 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 	if (ptr && hConsole)
 	for (; *ptr && ptr < ptr_end; ptr++) {
 		if (ptr[0] == 0xa) {
-			int ll = (size_t)(ptr - str);
+			int ll = (size_t)(ptr - str) - 1;
 			lines--;
 			if (vmode && lines<0) {
 				break;
 			}
-			if (ll < 1) {
+			//if (ll < 1) {
+			if (ll < 0) {
 				continue;
 			}
 			if (vmode) {
 				// TODO: Fix utf8 chop
 				/* only chop columns if necessary */
-				if (ll != linelen && ll+linelen >= cols) {
+				if (/*ll != linelen && */ll+linelen >= cols) {
 					// chop line if too long
 					ll = (cols-linelen)-1;
-					if (ll < 1) {
-						continue;
+					//if (ll < 1) {
+					if (ll < 0) {
+							continue;
 					}
 				}
 			}
-			write (1, str, ll);
-			linelen += ll;
+			if (ll > 0) {
+				write(1, str, ll);
+				linelen += ll;
+			}
 			esc = 0;
 			str = ptr+1;
 			if (vmode) {
@@ -137,8 +141,10 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 				if (linelen+ll>=cols) {
 					// chop line if too long
 					ll = (cols-linelen)-1;
-					// fix utf8 len here
-					ll = wrapline ((const char*)str, cols-linelen-1);
+					if (ll>0) {
+						// fix utf8 len here
+						ll = wrapline ((const char*)str, cols-linelen-1);
+					}
 				}
 			}
 			if (ll>0) {

--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -68,6 +68,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 	int ret = 0;
 	int inv = 0;
 	int linelen = 0;
+	int ll = 0;
 	int lines, cols = r_cons_get_size (&lines);
 	if (I->is_wine==-1) {
 		I->is_wine = r_file_is_directory ("/proc")? 1: 0;
@@ -79,12 +80,12 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 	if (ptr && hConsole)
 	for (; *ptr && ptr < ptr_end; ptr++) {
 		if (ptr[0] == 0xa) {
-			int ll = (size_t)(ptr - str) - 1;
+			ll = (size_t)(ptr - str);
 			lines--;
 			if (vmode && lines < 0) {
 				break;
 			}
-			if (ll < 0) {
+			if (ll < 1) {
 				continue;
 			}
 			if (vmode) {
@@ -103,7 +104,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 				linelen += ll;
 			}
 			esc = 0;
-			str = ptr+1;
+			str = ptr + 1;
 			if (vmode) {
 				int wlen = cols - linelen;
 				char white[1024];
@@ -117,7 +118,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 			continue;
 		}
 		if (ptr[0] == 0x1b) {
-			int ll = (size_t)(ptr-str);
+			ll = (size_t)(ptr-str);
 			if (str[0]=='\n') {
 				str++;
 				ll--;

--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -108,7 +108,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 			if (vmode) {
 				int wlen = cols - linelen;
 				char white[1024];
-				if (wlen>0 && wlen<sizeof (white)) {
+				if (wlen > 0 && wlen < sizeof (white)) {
 					memset (white, ' ', sizeof (white));
 					write (1, white, wlen-1);
 				}
@@ -119,14 +119,14 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 		}
 		if (ptr[0] == 0x1b) {
 			ll = (size_t)(ptr-str);
-			if (str[0]=='\n') {
+			if (str[0] == '\n') {
 				str++;
 				ll--;
 				if (vmode) {
-					int wlen = cols-linelen-1;
+					int wlen = cols - linelen - 1;
 					char white[1024];
 					//wlen = 5;
-					if (wlen>0) {
+					if (wlen > 0) {
 						memset (white, ' ', sizeof (white));
 						write (1, white, wlen);
 					}
@@ -137,16 +137,16 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 				linelen = 0;
 			}
 			if (vmode) {
-				if (linelen+ll>=cols) {
+				if (linelen + ll >= cols) {
 					// chop line if too long
-					ll = (cols-linelen)-1;
-					if (ll>0) {
+					ll = (cols-linelen) - 1;
+					if (ll > 0) {
 						// fix utf8 len here
-						ll = wrapline ((const char*)str, cols-linelen-1);
+						ll = wrapline ((const char*)str, cols - linelen - 1);
 					}
 				}
 			}
-			if (ll>0) {
+			if (ll > 0) {
 				write (1, str, ll);
 				linelen += ll;
 			}

--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -99,7 +99,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int vmode) {
 				}
 			}
 			if (ll > 0) {
-				write(1, str, ll);
+				write (1, str, ll);
 				linelen += ll;
 			}
 			esc = 0;

--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -116,10 +116,12 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 		RRegItem *r;
 		RListIter *iter;
 		r_list_foreach (rs->regs, iter, r) {
-			ut64 val = r_reg_getv (core->dbg->reg, r->name);
-			if (addr == val) {
-				types |= R_ANAL_ADDR_TYPE_REG;
-				break;
+			if (r->type == R_REG_TYPE_GPR) {
+				ut64 val = r_reg_getv(core->dbg->reg, r->name);
+				if (addr == val) {
+					types |= R_ANAL_ADDR_TYPE_REG;
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Fixed message 128 bits not implemented when anal try to read the gpr arena.
- Fixed isssues with visualmode in windows: The problem come when end line is processed, size of write dont is checked and can write invalid data.
- Fixed issues with visual mode when asm.emu is enabled, the variable "ll" dont its checked for values low to 0 and in some cases tell to the routine a print over the buffer.
