### PR TITLE
Ensure ARM LDR literal instruction base addresses are word-aligned

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -794,7 +794,7 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 	case ARM_INS_LDREXD:
 	case ARM_INS_LDREXH:
 	case ARM_INS_LDR:
-		addr &= ~1LL;
+		addr &= ~3LL;
 		if (MEMDISP(1) < 0) {
 			const char *pc = "$$";
 			if (REGBASE(1) == ARM_REG_PC) {


### PR DESCRIPTION
The ARM Architecture Reference Manual states that the base address for a LDR literal instruction is the 4-byte aligned PC. 2-Byte aligned instructions can be found on Thumb, but literals are still word-aligned.

This caused a bad literal lookup wherein an instruction was referencing across word literal boundaries in a binary I was analyzing.

I couldn't figure out how to put together a concise testcase for radare-regressions, since this really just effects the ESIL interpretation of the instruction, and is dependent on file offsets. Happy to do it if you have suggestions on how to do so. :)