### PR TITLE
Fix for xtensa analysis of beqz.n and bnez.n  

### DIFF
--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -34,8 +34,6 @@ static inline ut64 xtensa_imm18s (ut64 addr, const ut8 *buf) {
 
 static inline ut64 xtensa_imm6s (ut64 addr, const ut8 *buf) {
 	ut8 imm6 = (buf[1] >> 4) | (buf[0] & 0x30);
-	if (imm6 & 0x20)
-		return (addr + 4 + imm6 - 0x40);
 	return (addr + 4 + imm6);
 }
 


### PR DESCRIPTION
Fix https://github.com/radare/radare2/issues/6227

Immediate of **beqz.n** and **bnez.n** is unsigned. So, it can jump only forward.

>The target instruction address of the branch is given by the address of the BEQZ.N in-
struction, plus the zero-extended 6-bit imm6 field of the instruction plus four. Because
the offset is unsigned, this instruction can only be used to branch forward. If register as
is not equal to zero, execution continues with the next sequential instruction.