### PR TITLE
Add support for `it` thumb instruction in esil FIX #3486

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -80,8 +80,7 @@ static RAnalVar *get_used_var(RAnal *anal, RAnalOp *op) {
 R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
 	int ret = 0;
 	RAnalVar *tmp;
-
-	//len will end up in memcmp so check for negative	
+	//len will end up in memcmp so check for negative
 	if (!anal || len < 0) {
 		return -1;
 	}


### PR DESCRIPTION
Fix for #3486
Also fixes the flags in the register profile
r2r PR: radare/radare2-regressions#632