### PR TITLE
Fix various memory leaks 

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -788,6 +788,7 @@ int main(int argc, char **argv, char **envp) {
 				}
 			}
 			if (optind < argc) {
+				R_FREE (pfile);
 				while (optind < argc) {
 					pfile = argv[optind++];
 					fh = r_core_file_open (&r, pfile, perms, mapaddr);

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -111,6 +111,7 @@ R_API RAnal *r_anal_free(RAnal *a) {
 	r_list_free (a->types);
 	r_reg_free (a->reg);
 	r_anal_op_free (a->queued);
+	r_list_free (a->bits_ranges);
 	a->sdb = NULL;
 	r_syscall_free (a->syscall);
 	sdb_ns_free (a->sdb);

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -644,7 +644,9 @@ static int r_bin_object_set_items(RBinFile *binfile, RBinObject *o) {
 		o->lines = cp->lines (binfile);
 	}
 	if (cp->get_sdb) {
-		o->kv = cp->get_sdb (o);
+		Sdb* new_kv = cp->get_sdb (o);
+		if (new_kv != o->kv) sdb_free (o->kv);
+		o->kv = new_kv;
 	}
 	if (cp->mem)  {
 		o->mem = cp->mem (binfile);

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -645,7 +645,9 @@ static int r_bin_object_set_items(RBinFile *binfile, RBinObject *o) {
 	}
 	if (cp->get_sdb) {
 		Sdb* new_kv = cp->get_sdb (o);
-		if (new_kv != o->kv) sdb_free (o->kv);
+		if (new_kv != o->kv) {
+			sdb_free (o->kv);
+		}
 		o->kv = new_kv;
 	}
 	if (cp->mem)  {

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -304,7 +304,7 @@ static void get_strings_range(RBinFile *arch, RList *list, int min, ut64 from, u
 		ut64 size = to - from;
 		// in case of dump ignore here
 		if (size != 0 && size > arch->rbin->maxstrbuf) {
-			eprintf ("WARNING: bin_strings buffer is too big (0x%08" PFMT64x ")." 
+			eprintf ("WARNING: bin_strings buffer is too big (0x%08" PFMT64x ")."
 					" Use -zzz or set bin.maxstrbuf (RABIN2_MAXSTRBUF) in r2 (rabin2)\n", size);
 			return;
 		}
@@ -1350,6 +1350,7 @@ static void plugin_free(RBinPlugin *p) {
 	if (p && p->fini) {
 		p->fini (NULL);
 	}
+	R_FREE (p);
 }
 
 // rename to r_bin_plugin_add like the rest

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -527,6 +527,7 @@ static void r_bin_object_free(void /*RBinObject*/ *o_) {
 	}
 	r_bin_info_free (o->info);
 	r_bin_object_delete_items (o);
+	R_FREE (o);
 }
 
 // XXX - change this to RBinObject instead of RBinFile
@@ -997,9 +998,9 @@ static void r_bin_file_free(void /*RBinFile*/ *bf_) {
 		a->sdb_addrinfo = NULL;
 	}
 	free (a->file);
+	a->o = NULL;
 	r_list_free (a->objs);
 	r_list_free (a->xtr_data);
-	r_bin_object_free (a->o);
 	memset (a, 0, sizeof (RBinFile));
 	free (a);
 }

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -350,7 +350,7 @@ R_API RDebug *r_debug_free(RDebug *dbg) {
 		r_tree_free (dbg->tree);
 		sdb_foreach (dbg->tracenodes, (SdbForeachCallback)free_tracenodes_entry, dbg);
 		sdb_free (dbg->tracenodes);
-		//r_debug_plugin_free();
+		r_list_free (dbg->plugins);
 		free (dbg->btalgo);
 		r_debug_trace_free (dbg->trace);
 		dbg->trace = NULL;

--- a/libr/debug/plugin.c
+++ b/libr/debug/plugin.c
@@ -35,8 +35,8 @@ R_API bool r_debug_use(RDebug *dbg, const char *str) {
 		char *p = dbg->h->reg_profile (dbg);
 		if (p) {
 			r_reg_set_profile_string (dbg->reg, p);
-			if (dbg->anal) {
-				//r_reg_free (dbg->anal->reg);
+			if (dbg->anal && dbg->reg != dbg->anal->reg) {
+				r_reg_free (dbg->anal->reg);
 				dbg->anal->reg = dbg->reg;
 			}
 			if (dbg->h->init)

--- a/libr/debug/plugin.c
+++ b/libr/debug/plugin.c
@@ -9,7 +9,7 @@ static RDebugPlugin *debug_static_plugins[] = {
 
 R_API void r_debug_plugin_init(RDebug *dbg) {
 	int i;
-	dbg->plugins = r_list_new ();
+	dbg->plugins = r_list_newf (free);
 	for (i = 0; debug_static_plugins[i]; i++) {
 		RDebugPlugin *p = R_NEW (RDebugPlugin);
 		memcpy (p, debug_static_plugins[i], sizeof (RDebugPlugin));

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -80,7 +80,7 @@ R_API int r_io_write_buf(RIO *io, struct r_buf_t *b) {
 
 R_API RIO *r_io_free(RIO *io) {
 	if (!io) return NULL;
-	R_FREE (io->plugin_default);
+	free(io->plugin_default);
 	r_list_free (io->plugins);
 	r_list_free (io->sections);
 	r_list_free (io->maps);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -80,6 +80,7 @@ R_API int r_io_write_buf(RIO *io, struct r_buf_t *b) {
 
 R_API RIO *r_io_free(RIO *io) {
 	if (!io) return NULL;
+	free(io->plugin_default);
 	r_list_free (io->plugins);
 	r_list_free (io->sections);
 	r_list_free (io->maps);
@@ -798,7 +799,7 @@ R_API ut64 r_io_seek(RIO *io, ut64 offset, int whence) {
 		io->off = (whence == R_IO_SEEK_SET)
 			? offset // HACKY FIX linux-arm-32-bs at 0x10000
 			: ret;
-			io->off = offset; 
+			io->off = offset;
 		ret = (!io->debug && io->va && !r_list_empty (io->sections))
 			? r_io_section_maddr_to_vaddr (io, io->off)
 			: io->off;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -80,7 +80,7 @@ R_API int r_io_write_buf(RIO *io, struct r_buf_t *b) {
 
 R_API RIO *r_io_free(RIO *io) {
 	if (!io) return NULL;
-	free(io->plugin_default);
+	R_FREE (io->plugin_default);
 	r_list_free (io->plugins);
 	r_list_free (io->sections);
 	r_list_free (io->maps);

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -224,6 +224,8 @@ R_API RReg *r_reg_new() {
 		}
 		reg->regset[i].pool = r_list_newf ((RListFree)r_reg_arena_free);
 		reg->regset[i].regs = r_list_newf ((RListFree)r_reg_item_free);
+		// 'reg->regset[i].poll->tail->data' should point to the current 'arena'
+		r_list_push (reg->regset[i].pool, arena);
 		reg->regset[i].arena = arena;
 	}
 	r_reg_arena_push (reg);

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -204,6 +204,7 @@ R_API void r_reg_free(RReg *reg) {
 		r_list_free (reg->regset[i].pool);
 		reg->regset[i].pool = NULL;
 	}
+	r_list_free (reg->allregs);
 	r_reg_free_internal (reg, false);
 	free (reg);
 }


### PR DESCRIPTION
Running radare2 inside valgrind I obtained a series of memory leaks, these commits should fix every one of them.

Radare2 was executed without analysis, I just opened an executable with "valgrind r2 hello" and then closed immediately with a ^D. The [hello.zip](https://github.com/radare/radare2/files/622733/hello.zip) executable is attacked to this request.

I run my patches against the test suite and it produces exactly the same errors.

Let me know if there is any change that should be made or if there is something that is not clear.