### PR TITLE
Fix: regression in commit f0f54ad1c614f7f1a449844a123fb8f9299ee497

### DIFF
--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -1531,6 +1531,7 @@ bool linux_generate_corefile (RDebug *dbg, RBuffer *dest) {
 		free (proc_data);
 		return false;
 	}
+	elf_proc_note->n_threads = proc_data->per_process->num_threads;
 
 	/* Get NT_ process_wide: AUXV, MAPS, PRPSINFO */
 	/* NT_PRPSINFO */


### PR DESCRIPTION
Fixes a regression introduced by commit f0f54ad1c614f7f1a449844a123fb8f9299ee497

elf_proc_note->n_threads = proc_data->per_process->num_threads;

This assignment was deleted, but elf_proc_note->n_threads is being checked later in build_note_section in order to dump NT_PRSTATUS/FPREGSET/SIGINFO/X86_XSTATE structures per thread.

Before:

$ readelf -n test.core 

Displaying notes found at file offset 0x00000270 with length 0x000002cc:
  Owner                 Data size	Description
  CORE                 0x00000088	NT_PRPSINFO (prpsinfo structure)
  CORE                 0x00000130	NT_AUXV (auxiliary vector)
  CORE                 0x000000d6	NT_FILE (mapped files)


After this patch:

$ readelf -n newcore

Displaying notes found at file offset 0x00000270 with length 0x00000a2c:
  Owner                 Data size	Description
  CORE                 0x00000088	NT_PRPSINFO (prpsinfo structure)
  CORE                 0x00000150	NT_PRSTATUS (prstatus structure)
  CORE                 0x00000200	NT_FPREGSET (floating point registers)
  CORE                 0x00000080	NT_SIGINFO (siginfo_t data)
  LINUX                0x00000340	NT_X86_XSTATE (x86 XSAVE extended state)
  CORE                 0x00000130	NT_AUXV (auxiliary vector)
  CORE                 0x000000d6	NT_FILE (mapped files)