### PR TITLE
handle better data references

### DIFF
--- a/libr/anal/Makefile
+++ b/libr/anal/Makefile
@@ -4,7 +4,7 @@ EXTRA_TARGETS+=do
 EXTRA_CLEAN=doclean
 
 NAME=r_anal
-DEPS=r_util r_reg r_syscall
+DEPS=r_util r_reg r_syscall r_cons
 CFLAGS+=-DCORELIB -Iarch -I$(TOP)/shlr
 CFLAGS+=-I$(LTOP)/asm/arch/include
 

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -482,7 +482,6 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 	}
 
 	if (depth < 1) {
-		eprintf ("That's too deep\n");
 		return R_ANAL_RET_ERROR; // MUST BE TOO DEEP
 	}
 
@@ -519,7 +518,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 	ut64 last_push_addr = UT64_MAX;
 	while (idx < len) {
 		if (anal->limit) {
-			if ((addr + idx)<anal->limit->from || (addr + idx + 1) >anal->limit->to) {
+			if ((addr + idx) < anal->limit->from || (addr + idx + 1) >anal->limit->to) {
 				break;
 			}
 		}
@@ -536,7 +535,7 @@ repeat:
 		// check if opcode is in another basic block
 		// in that case we break
 		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + idx, len - idx)) < 1) {
-			VERBOSE_ANAL eprintf ("Unknown opcode at 0x%08"PFMT64x"\n", addr+idx);
+			VERBOSE_ANAL eprintf ("Unknown opcode at 0x%08"PFMT64x"\n", addr + idx);
 			if (!idx) {
 				gotoBeach (R_ANAL_RET_END);
 			} else {
@@ -561,7 +560,7 @@ repeat:
 		}
 		idx += oplen;
 		delay.un_idx = idx;
-		if (op.delay > 0 && delay.pending == 0) {
+		if (op.delay > 0 && !delay.pending) {
 			// Handle first pass through a branch delay jump:
 			// Come back and handle the current instruction later.
 			// Save the location of it in `delay.idx`
@@ -975,9 +974,8 @@ river:
 		case R_ANAL_OP_TYPE_PUSH:
 			last_is_push = true;
 			last_push_addr = op.val;
-			/* consider DATA refs to code as CODE referencs */
 			if (anal->iob.is_valid_offset (anal->iob.io, op.val, 1)) {
-				(void)r_anal_fcn_xref_add (anal, fcn, op.addr, op.val, R_ANAL_REF_TYPE_CODE);
+				(void)r_anal_fcn_xref_add (anal, fcn, op.addr, op.val, R_ANAL_REF_TYPE_DATA);
 			}
 			break;
 		case R_ANAL_OP_TYPE_RET:

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2009-2016 - pancake, nibble */
 
 #include <r_anal.h>
+#include <r_cons.h>
 #include <sdb.h>
 
 #define DB anal->sdb_xrefs
@@ -188,11 +189,15 @@ static bool xrefs_list_cb_json(RAnal *anal, bool is_first, const char *k, const 
 }
 
 static int xrefs_list_cb_plain(RAnal *anal, const char *k, const char *v) {
+	if (r_cons_is_breaked ()) {
+		return 0;
+	}
 	anal->cb_printf ("%s=%s\n", k, v);
 	return 1;
 }
 
 R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
+	r_cons_break_push (NULL, NULL);
 	switch (rad) {
 	case 1:
 	case '*':
@@ -213,6 +218,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 		sdb_foreach (DB, (SdbForeachCallback)xrefs_list_cb_plain, anal);
 		break;
 	}
+	r_cons_break_pop ();
 }
 
 R_API const char *r_anal_xrefs_type_tostring (char type) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -413,7 +413,7 @@ R_API char *cmd_syscall_dostr(RCore *core, int n) {
 	char str[64];
 	if (n == -1) {
 		n = (int)r_debug_reg_get (core->dbg, "oeax");
-		if (n == 0 || n == -1) {
+		if (!n || n == -1) {
 			const char *a0 = r_reg_get_name (core->anal->reg, R_REG_NAME_SN);
 			n = (int)r_debug_reg_get (core->dbg, a0);
 		}
@@ -3354,7 +3354,7 @@ static void cmd_anal_calls(RCore *core, const char *input) {
 			if (op.type == R_ANAL_OP_TYPE_CALL) {
 #if JAYRO_03
 				if (!anal_is_bad_call (core, from, to, addr, buf, bufi)) {
-					fcn = r_anal_get_fcn_in(core->anal, op.jump, R_ANAL_FCN_TYPE_ROOT);
+					fcn = r_anal_get_fcn_in (core->anal, op.jump, R_ANAL_FCN_TYPE_ROOT);
 					if (!fcn) {
 						r_core_anal_fcn (core, op.jump, addr,
 								R_ANAL_REF_TYPE_NULL, depth);
@@ -3607,8 +3607,9 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case '-': { // "ax-"
 		const char *inp;
 		ut64 a, b;
-		for (inp = input + 1; *inp && IS_WHITESPACE (*inp); inp++)
-			;
+		for (inp = input + 1; *inp && IS_WHITESPACE (*inp); inp++) {
+			//nothing to see here
+		}
 		if (!strcmp (inp, "*")) {
 			r_anal_xrefs_init (core->anal);
 		} else {
@@ -3629,14 +3630,16 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case 'g': // "axg"
 		{
 			Sdb *db = sdb_new0();
-			anal_axg (core, input+2, 0, db);
+			anal_axg (core, input + 2, 0, db);
 			sdb_free (db);
 		}
 		break;
 	case 'k': // "axk"
 		if (input[1] == ' ') {
 			sdb_query (core->anal->sdb_xrefs, input + 2);
-		} else eprintf ("|ERROR| Usage: axk [query]\n");
+		} else {
+			eprintf ("|ERROR| Usage: axk [query]\n");
+		}
 		break;
 	case '\0': // "ax"
 	case 'j': // "axj"
@@ -4579,7 +4582,7 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 	from = to = 0;
 	ptr = r_str_trim_head (strdup (input));
 	n = r_str_word_set0 (ptr);
-	if (n == 0) {
+	if (!n) {
 		int rwx = R_IO_EXEC;
 		// get boundaries of current memory map, section or io map
 		if (cfg_debug) {
@@ -4601,7 +4604,7 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 			from = core->offset;
 			to = r_io_size (core->io) + (map? map->to: 0);
 		}
-		if (from == 0 && to == 0) {
+		if (!from && !to) {
 			eprintf ("Cannot determine xref search boundaries\n");
 		} else if (!(rwx & R_IO_EXEC)) {
 			eprintf ("Warning: Searching xrefs in non-executable region\n");
@@ -4617,7 +4620,7 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 	if (from == UT64_MAX && to == UT64_MAX) {
 		return false;
 	}
-	if (from == 0 && to == 0) {
+	if (!from && !to) {
 		return false;
 	}
 	if (to - from > r_io_size (core->io)) {

--- a/libr/flag/spaces.c
+++ b/libr/flag/spaces.c
@@ -75,7 +75,7 @@ R_API int r_flag_space_set(RFlag *f, const char *name) {
 	return f->space_idx;
 }
 
-R_API int r_flag_space_unset (RFlag *f, const char *fs) {
+R_API int r_flag_space_unset(RFlag *f, const char *fs) {
 	RListIter *iter;
 	RFlagItem *fi;
 	int i, count = 0;


### PR DESCRIPTION
Before

![image](https://cloud.githubusercontent.com/assets/3474042/20895939/e26bc104-bb1b-11e6-9f1e-30877f0cf2c4.png)


```
[0x1002cff0]> fs
0  744 . strings
1 1748 . symbols
2   10 . sections
3  649 . relocs
4  637 . imports
5  281 . functions
```
------
After

```
[0x101cf8ab]> fs
0 3202 . strings
1 1748 . symbols
2   10 . sections
3  649 . relocs
4  637 . imports
5  221 . functions
```

![image](https://cloud.githubusercontent.com/assets/3474042/20895958/e982dce8-bb1b-11e6-97d2-d1ca98c263fe.png)

Let see the tests