### PR TITLE
Add: Initial support for bFLT #6129

### DIFF
--- a/libr/bin/format/bflt/bflt.c
+++ b/libr/bin/format/bflt/bflt.c
@@ -5,7 +5,7 @@
 
 #include "bflt.h"
 
-#define READ(x, i)	r_read_be32(x + i); i += 4;
+#define READ(x, i) r_read_be32 (x + i); i += 4;
 
 RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin) {
         RBinAddr *addr = R_NEW0 (RBinAddr);
@@ -90,7 +90,7 @@ struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf) {
 }	
 
 void r_bin_bflt_free(struct r_bin_bflt_obj *obj) {
-        free (obj->hdr);
+	free (obj->hdr);
 	R_FREE (obj->b);
-        R_FREE (obj);
+	R_FREE (obj);
 }

--- a/libr/bin/format/bflt/bflt.c
+++ b/libr/bin/format/bflt/bflt.c
@@ -1,0 +1,96 @@
+/* radare - LGPL - Copyright 2016 - Oscar Salvador */
+
+#include <r_util.h>
+#include <r_types.h>
+
+#include "bflt.h"
+
+#define READ(x, i)	r_read_be32(x + i); i += 4;
+
+RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin) {
+        RBinAddr *addr = R_NEW0 (RBinAddr);
+
+        if (!addr) {
+                return NULL;
+        }
+        addr->paddr = bin->hdr->entry;
+        return addr;
+}
+
+static int bflt_init_hdr (struct r_bin_bflt_obj *bin) {
+	struct bflt_hdr *p_hdr;
+	ut8 bhdr[BFLT_HDR_SIZE] = {0};
+	int i, len;
+	
+	len = r_buf_read_at (bin->b, 0, bhdr, sizeof (struct bflt_hdr));
+	if (len < 1) {
+		eprintf ("Warning: read bFLT hdr failed\n");
+		goto fail;
+	}
+	
+	if (strncmp ((const char *)bhdr, "bFLT", 4)) {
+		eprintf ("Warning: wrong magic number in bFLT file\n");
+		goto fail;
+	}
+	p_hdr = R_NEW0 (struct bflt_hdr);
+	if (!p_hdr) {
+		eprintf ("Warning: couldn't allocate memory\n");
+		goto fail;
+	}
+	
+	i += 4;
+	p_hdr->rev = READ (bhdr, i);
+	p_hdr->entry = READ (bhdr, i);
+	p_hdr->data_start = READ (bhdr, i);
+	p_hdr->data_end = READ (bhdr, i);
+	p_hdr->bss_end = READ (bhdr, i);
+	p_hdr->stack_size = READ (bhdr, i);
+	p_hdr->reloc_start = READ (bhdr, i);
+	p_hdr->reloc_count = READ (bhdr, i);
+	p_hdr->flags = READ (bhdr, i);
+	p_hdr->build_date = READ (bhdr, i);
+
+	if (p_hdr->rev != FLAT_VERSION) {
+		eprintf ("Warning: wrong flat version\n");
+		R_FREE (p_hdr);
+		goto fail;
+	}
+	bin->hdr = p_hdr;
+
+	return true;
+fail:
+	return false;
+}
+
+static int r_bin_bflt_init (struct r_bin_bflt_obj *obj, RBuffer *buf) {
+	obj->b = r_buf_new ();
+	obj->size = buf->length;
+	obj->endian = false;
+	if(!r_buf_set_bytes (obj->b, buf->buf, obj->size)) {
+		r_buf_free (obj->b);
+		return false;
+	}
+	if (!bflt_init_hdr (obj)) {
+		return false;
+	}
+	return true;
+}
+
+struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf) {
+	struct r_bin_bflt_obj *bin = R_NEW0 (struct r_bin_bflt_obj);
+	if (!bin) {
+		return NULL;
+	}
+	if (r_bin_bflt_init (bin, buf)) {
+		return bin;
+	} else {
+		free (bin);
+		return NULL;
+	}
+}	
+
+void r_bin_bflt_free(struct r_bin_bflt_obj *obj) {
+        free (obj->hdr);
+	R_FREE (obj->b);
+        R_FREE (obj);
+}

--- a/libr/bin/format/bflt/bflt.h
+++ b/libr/bin/format/bflt/bflt.h
@@ -14,6 +14,7 @@
 #define FLAT_RELOC_TYPE_DATA	0x1
 #define FLAT_RELOC_TYPE_BSS	0x2
 
+/*
 struct bflt_relocation {
 #if defined(__BIG_ENDIAN_BITFIELD)
         ut32 type : 2;
@@ -23,6 +24,7 @@ struct bflt_relocation {
         ut32 type : 2;
 #endif
 };
+*/
 /* */
 
 /* Version 4 */

--- a/libr/bin/format/bflt/bflt.h
+++ b/libr/bin/format/bflt/bflt.h
@@ -1,0 +1,72 @@
+/* radare - LGPL - Copyright 2016 - Oscar Salvador */
+
+#ifndef BFLT_H
+#define BFLT_H
+
+#include <r_types.h>
+#include <r_util.h>
+#include <r_lib.h>
+#include <r_bin.h>
+
+/* Version 2 */
+#define OLD_FLAT_VERSION	0x00000002L
+#define FLAT_RELOC_TYPE_TEXT	0x0
+#define FLAT_RELOC_TYPE_DATA	0x1
+#define FLAT_RELOC_TYPE_BSS	0x2
+
+struct bflt_relocation {
+#if defined(__BIG_ENDIAN_BITFIELD)
+        ut32 type : 2;
+        signed long offset : 30;
+#elif defined(__LITTLE_ENDIAN_BITFIELD)
+        signed long offset : 30;
+        ut32 type : 2;
+#endif
+};
+/* */
+
+/* Version 4 */
+#define FLAT_VERSION            0x00000004L
+#define FLAT_FLAG_RAM		0x1	/* load program entirely into RAM */
+#define FLAT_FLAG_GOTPIC 	0x2 	/* program is PIC with GOT */
+#define FLAT_FLAG_GZIP   	0x4	/* all but the header is compressed */
+#define FLAT_FLAG_GZDATA	0x8	/* only data/relocs are compressed (for XIP) */
+#define FLAT_FLAG_KTRACE	0x10	/* output useful kernel trace for debugging */
+
+struct bflt_hdr {
+	char magic[4];
+	ut32 rev;
+	ut32 entry;
+	ut32 data_start;
+	ut32 data_end;
+	ut32 bss_end;
+	ut32 stack_size;
+	ut32 reloc_start;
+	ut32 reloc_count;
+	ut32 flags;
+	ut32 build_date;
+	ut32 filler[5];
+};
+
+struct bflt_relocation_t {
+	ut32 addr_to_patch;
+	ut32 data;
+};
+
+struct r_bin_bflt_obj {
+	struct bflt_hdr *hdr;
+	struct bflt_relocation_t *bflt_reloc_table;
+	RBuffer *b;
+	Sdb *kv;
+	ut8 endian;
+	size_t size;
+};
+
+#define BFLT_HDR_SIZE		sizeof (struct bflt_hdr)
+#define VALID_GOT_ENTRY(x)	(x != 0xFFFFFFFF)
+
+RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin);
+struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf);
+void r_bin_bflt_free(struct r_bin_bflt_obj *obj);
+
+#endif

--- a/libr/bin/p/Makefile
+++ b/libr/bin/p/Makefile
@@ -13,7 +13,7 @@ FORMATS=any.mk elf.mk elf64.mk pe.mk pe64.mk te.mk mach0.mk
 FORMATS+=bios.mk mach064.mk fatmach0.mk dyldcache.mk java.mk
 FORMATS+=dex.mk fs.mk ningb.mk coff.mk ningba.mk xbe.mk zimg.mk
 FORMATS+=omf.mk cgc.mk dol.mk nes.mk mbn.mk psxexe.mk spc700.mk
-FORMATS+=vsf.mk nin3ds.mk xtr_dyldcache.mk
+FORMATS+=vsf.mk nin3ds.mk xtr_dyldcache.mk bflt.mk
 include $(FORMATS)
 
 all: ${ALL_TARGETS}

--- a/libr/bin/p/bflt.mk
+++ b/libr/bin/p/bflt.mk
@@ -1,0 +1,11 @@
+OBJ_BFLT=bin_bflt.o
+OBJ_BFLT+=../format/bflt/bflt.o
+
+STATIC_OBJ+=${OBJ_BFLT}
+TARGET_BFLT=bin_coff.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_BFLT}
+
+${TARGET_BFLT}: ${OBJ_BFLT}
+	${CC} $(call libname,bin_bflt) ${CFLAGS} \
+		$(OBJ_BFLT) $(LINK) $(LDFLAGS)

--- a/libr/bin/p/bflt.mk
+++ b/libr/bin/p/bflt.mk
@@ -2,7 +2,7 @@ OBJ_BFLT=bin_bflt.o
 OBJ_BFLT+=../format/bflt/bflt.o
 
 STATIC_OBJ+=${OBJ_BFLT}
-TARGET_BFLT=bin_coff.${EXT_SO}
+TARGET_BFLT=bin_bflt.${EXT_SO}
 
 ALL_TARGETS+=${TARGET_BFLT}
 

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -1,0 +1,303 @@
+#include <r_types.h>
+#include <r_util.h>
+#include <r_lib.h>
+#include <r_bin.h>
+#include <r_io.h>
+
+#include "bflt/bflt.h"
+
+static void *load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *sdb) {
+	struct r_bin_bflt_obj *res;
+	RBuffer *tbuf = NULL;
+
+	if (!buf || !sz || sz == UT64_MAX) {
+		return NULL;
+	}
+	tbuf = r_buf_new ();
+	r_buf_set_bytes (tbuf, buf, sz);
+	res = r_bin_bflt_new_buf (tbuf);
+	r_buf_free (tbuf);
+	return res;
+}
+
+static int load(RBinFile *arch) {
+	const ut8 *bytes = r_buf_buffer (arch->buf);
+	ut64 sz = r_buf_size (arch->buf);
+
+	arch->o->bin_obj = load_bytes (arch, bytes, sz, arch->o->loadaddr, arch->sdb);
+	return arch->o->bin_obj ? true : false;
+}
+
+static RList *entries(RBinFile *arch) {
+	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj*)arch->o->bin_obj;
+	RList *ret;
+	RBinAddr *ptr;
+
+	if (!(ret = r_list_newf (free))) {
+		return NULL;
+	}
+	ptr = r_bflt_get_entry (obj);
+	if (!ptr) {
+		return NULL;
+	}
+	r_list_append (ret, ptr);
+	return ret;
+}
+
+static void __patch_reloc (RBuffer *r_buf, struct bflt_relocation_t *reloc) {
+	char s[32];
+	int len, ret;
+	ut8 *buf;
+	ut32 val;
+
+	val = reloc->data;
+	snprintf (s, sizeof (s), "%08x", val);
+	buf = calloc (strlen (s), 1);
+
+	if (!buf) {
+		return;
+	}
+	len = r_hex_str2bin (s, buf);
+	ret = r_buf_write_at (r_buf, reloc->addr_to_patch, buf, len);
+	if (ret == -1) {
+		eprintf ("Error\n");
+	}
+	free (buf);
+}
+
+static RList *patch_relocs(RBin *b) {
+	struct r_bin_bflt_obj *bin;
+	struct bflt_relocation_t *reloc_table;
+	RList *list;
+	RBinReloc *reloc;
+	RBinObject *obj;
+	int i;
+	
+	obj = r_bin_cur_object (b);
+	if (!obj) {
+		return NULL;
+	}
+	bin = obj->bin_obj;
+	reloc_table = bin->bflt_reloc_table;
+	list = r_list_new ();
+	if (!list) {
+		return NULL;
+	}
+	
+	for(i = 0; i < bin->hdr->reloc_count; i++) {
+		__patch_reloc (bin->b, &reloc_table[i]);
+		RBinReloc *reloc = R_NEW0 (RBinReloc);
+		reloc->type = R_BIN_RELOC_32;
+		reloc->paddr = reloc_table[i].addr_to_patch;
+		reloc->vaddr = reloc->paddr;
+		r_list_append (list, reloc);	
+	}
+	
+	free (reloc_table);
+	return list;
+}
+
+static int get_ngot_entries(struct r_bin_bflt_obj *obj) {
+	int i, len;
+
+	for (i = 0 ;; i++) {
+		ut32 entry;
+		len = r_buf_read_at (obj->b, obj->hdr->data_start + (i * 4), (ut8 *)&entry, sizeof (ut32));
+		if (len != sizeof (ut32)) {
+			goto fail;
+		
+		}
+		entry = r_swap_ut32 (entry);
+		if (!VALID_GOT_ENTRY (entry)) {
+			break;
+		}
+	}
+	return i;
+fail:
+	return 0;
+}
+
+static RList *relocs(RBinFile *arch) {
+	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj*)arch->o->bin_obj;
+	struct bflt_relocation_t *bflt_reloc_table = NULL;
+	RList *list;
+	int i, len, n_got = 0, n_reloc = 0;
+	
+	list = r_list_new ();
+	if (!list || !obj) {
+		r_list_free (list);
+		return NULL;
+	}
+	n_reloc = obj->hdr->reloc_count;
+	if (obj->hdr->flags & FLAT_FLAG_GOTPIC) {
+		n_got = get_ngot_entries (obj);
+		n_reloc += n_got;
+	}
+	bflt_reloc_table = calloc (1, n_reloc * sizeof (struct bflt_relocation_t));
+	if (!bflt_reloc_table) {
+		return list;
+	}
+	if (obj->hdr->flags & FLAT_FLAG_GOTPIC) {
+		ut32 offset;
+		for (offset = 0, i = 0; i < n_got; i++, offset += 4) {
+			ut32 got_entry;
+			len = r_buf_read_at (obj->b, obj->hdr->data_start + offset, (ut8 *)&got_entry, sizeof (ut32));
+			got_entry = r_swap_ut32 (got_entry);
+			if (VALID_GOT_ENTRY (got_entry)) {
+				bflt_reloc_table[i].addr_to_patch = got_entry;
+				bflt_reloc_table[i].data = got_entry + BFLT_HDR_SIZE;
+			} else {
+				break;
+			}
+		}
+	}
+
+	for(i = 0; i < obj->hdr->reloc_count; i++) {
+		ut32 reloc_pointer;
+
+		len = r_buf_read_at (obj->b, obj->hdr->reloc_start + (i * 4), (ut8 *)&reloc_pointer, 4);
+		if (len != 4) {
+			return list;
+		}
+
+		reloc_pointer = r_swap_ut32 (reloc_pointer);
+		ut32 reloc_offset = reloc_pointer + BFLT_HDR_SIZE;
+
+		if (reloc_offset < obj->hdr->bss_end) {
+			ut32 reloc_fixed;
+			ut32 reloc_data_offset;
+
+			len = r_buf_read_at (obj->b, reloc_offset, (ut8 *)&reloc_fixed, 4);
+			reloc_data_offset = reloc_fixed + BFLT_HDR_SIZE;
+
+			bflt_reloc_table[n_got + i].addr_to_patch = reloc_offset;
+			bflt_reloc_table[n_got + i].data = reloc_data_offset;
+
+			RBinReloc *reloc = R_NEW0 (RBinReloc);
+			reloc->type = R_BIN_RELOC_32;
+			reloc->paddr = bflt_reloc_table[n_got + i].addr_to_patch;
+			reloc->vaddr = reloc->paddr;
+			r_list_append (list, reloc);			
+		}
+
+	}
+	obj->bflt_reloc_table = bflt_reloc_table;
+	return list;
+}
+
+static RBinInfo *info(RBinFile *arch) {
+	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj*)arch->o->bin_obj;
+	RBinInfo *info = R_NEW0(RBinInfo);
+
+	if (!info) {
+		return NULL;
+	}
+	info->file = arch->file ? strdup (arch->file) : NULL;
+	info->rclass = strdup ("bflt");
+	info->bclass = strdup ("bflt" );
+	info->type = strdup ("bFLT (Executable file)");
+	info->os = strdup ("Linux");
+	info->subsystem = strdup ("Linux");
+	info->arch = strdup ("arm");
+	info->big_endian = obj->endian;
+	info->bits = 32;
+	info->has_va = false;
+	info->dbg_info = 0;
+	info->machine = strdup ("unknown");
+
+	return info;
+}
+
+static int check_bytes(const ut8 *buf, ut64 length) {
+	return true;
+}
+
+static int check(RBinFile *arch) {
+	/*const ut8 *bytes = arch ? r_buf_buffer (arch->buf) : NULL;
+	ut64 sz = arch ? r_buf_size (arch->buf): 0; */
+	return true;
+}
+
+static Sdb* get_sdb(RBinObject *o) {
+	if (!o) {
+		return NULL;
+	}
+	struct r_bin_bflt_obj *bin = (struct r_bin_bflt_obj *) o->bin_obj;
+	if (bin->kv) {
+		return bin->kv;
+	}
+
+	return NULL;
+}
+
+static int destroy(RBinFile *arch) {
+	r_bin_bflt_free ((struct r_bin_bflt_obj*)arch->o->bin_obj);
+	return true;
+}
+
+static ut64 baddr(RBinFile *arch) {
+	return 0;
+}
+
+static RList *sections(RBinFile *arch) {
+	return NULL;
+}
+
+static RList *symbols(RBinFile *arch) {
+	return NULL;
+}
+
+static RList *fields(RBinFile *arch) {
+	return NULL;
+}
+
+static ut64 size(RBinFile *arch) {
+	return 0;
+}
+
+static RBinAddr *binsym(RBinFile *arch, int sym) {
+	return NULL;
+}
+
+static RList *imports(RBinFile *arch) {
+	return NULL;
+}
+
+static RList *libs(RBinFile *arch) {
+	return NULL;
+}
+
+RBinPlugin r_bin_plugin_bflt = {
+	.name = "bflt",
+	.desc = "bFLT format r_bin plugin",
+	.license = "LGPL3",
+	.get_sdb = &get_sdb,
+	.load = &load,
+	.load_bytes = &load_bytes,
+	.destroy = &destroy,
+	.check = &check,
+	.check_bytes = &check_bytes,
+	.baddr = &baddr,
+	.binsym = &binsym,
+	.entries = &entries,
+	.sections = &sections,
+	.symbols = &symbols,
+	.imports = &imports,
+	.info = &info,
+	.fields = &fields,
+	.size = &size,
+	.libs = &libs,
+	.relocs = &relocs,
+//	.relocs = NULL,
+//	.patch_relocs = NULL,
+	.patch_relocs = &patch_relocs,
+	.write = NULL,
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_BIN,
+	.data = &r_bin_plugin_bflt,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -636,6 +636,7 @@ extern RBinPlugin r_bin_plugin_ningba;
 extern RBinPlugin r_bin_plugin_ninds;
 extern RBinPlugin r_bin_plugin_nin3ds;
 extern RBinPlugin r_bin_plugin_xbe;
+extern RBinPlugin r_bin_plugin_bflt;
 extern RBinXtrPlugin r_bin_xtr_plugin_fatmach0;
 extern RBinXtrPlugin r_bin_xtr_plugin_xtr_dyldcache;
 extern RBinPlugin r_bin_plugin_zimg;

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -103,6 +103,7 @@ asm.pic18c
 bin.any
 bin.art
 bin.bf
+bin.bflt
 bin.bios
 bin.bootimg
 bin.cgc


### PR DESCRIPTION
Hi, this an initial support for bFLT. 
So far, bFLT get loaded on the entry address. 

But there are still weird things. f.i:

```
.LC0:
	.ascii	"a: %d %d\012\000"
	.text
	.align	2
	.global	main
	.type	main, %function
main:
	@ Function supports interworking.
	@ args = 0, pretend = 0, frame = 16
	@ frame_needed = 1, uses_anonymous_args = 0
	stmfd	sp!, {fp, lr}
	add	fp, sp, #4
	sub	sp, sp, #16
	str	r0, [fp, #-16]
	str	r1, [fp, #-20]
	ldr	r3, .L3
	str	r3, [fp, #-8]
	ldr	r3, .L3+4
	str	r3, [fp, #-12]
	ldr	r2, [fp, #-12]
	ldr	r1, [fp, #-8]
	ldr	r0, .L3+8
	bl	printf
	mov	r3, #0
	mov	r0, r3
	sub	sp, fp, #4
	@ sp needed
	ldmfd	sp!, {fp, lr}
	bx	lr
.L4:
	.align	2
.L3:
	.word	-559038737
	.word	57005
	.word	.LC0
	.size	main, .-main
	.ident	"GCC: (GNU) 5.4.0"
```

```
l@bananapi:~$ r2 ./test
 -- rax2 -s 20e296b20ae296b220e296b20
[0x00000044]> pd 10 @0x0000015c
            0x0000015c      10000be5       str r0, [fp, -0x10]
            0x00000160      14100be5       str r1, [fp, -0x14]
            0x00000164      2c309fe5       ldr r3, [0x00000198]        ; [0x198:4]=0xdeadbeef
            0x00000168      08300be5       str r3, [fp, -8]
            0x0000016c      28309fe5       ldr r3, [0x0000019c]        ; [0x19c:4]=0xdead
            0x00000170      0c300be5       str r3, [fp, -0xc]
            0x00000174      0c201be5       ldr r2, [fp, -0xc]
            0x00000178      08101be5       ldr r1, [fp, -8]
            0x0000017c      1c009fe5       ldr r0, [0x000001a0]        ; [0x1a0:4]=0xc0440000
            0x00000180      070000eb       bl 0x1a4
[0x00000044]>
```

At 0x180 should jump to printf, but...:

```
[0x00000044]> pd 10 @0x000001a4
            0x000001a4      0f002de9       push {r0, r1, r2, r3}
            0x000001a8      07402de9       push {r0, r1, r2, lr}
            0x000001ac      20309fe5       ldr r3, [0x000001d4]        ; [0x1d4:4]=0x50490000
            0x000001b0      14208de2       add r2, sp, 0x14
            0x000001b4      10109de5       ldr r1, [sp, 0x10]
            0x000001b8      000093e5       ldr r0, [r3]
            0x000001bc      04208de5       str r2, [sp, 4]
            0x000001c0      340000eb       bl 0x298
            0x000001c4      0cd08de2       add sp, sp, 0xc
            0x000001c8      04e09de4       pop {lr}
[0x00000044]>
```

Something got messed I think (maybe because of relocations).

This is why I would like that someone could take a look at this, because I "think" I'm not doing anything wrong (actually the relocation calculation seems pretty simple), but it must be.

I've uploaded the files I'm using:

$ file test
test: BFLT executable - version 4 ram




[files.zip](https://github.com/radare/radare2/files/643188/files.zip)

