### PR TITLE
Add: Initial support for bFLT v4

### DIFF
--- a/libr/bin/format/bflt/bflt.c
+++ b/libr/bin/format/bflt/bflt.c
@@ -1,0 +1,99 @@
+/* radare - LGPL - Copyright 2016 - Oscar Salvador */
+
+#include <r_util.h>
+#include <r_types.h>
+
+#include "bflt.h"
+
+#define READ(x, i) r_read_be32 (x + i); i += 4;
+
+RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin) {
+        RBinAddr *addr = R_NEW0 (RBinAddr);
+
+        if (!addr) {
+                return NULL;
+        }
+        addr->paddr = bin->hdr->entry;
+        return addr;
+}
+
+static int bflt_init_hdr (struct r_bin_bflt_obj *bin) {
+	struct bflt_hdr *p_hdr;
+	ut8 bhdr[BFLT_HDR_SIZE] = {0};
+	int i, len;
+	
+	len = r_buf_read_at (bin->b, 0, bhdr, BFLT_HDR_SIZE);
+	if (len < 1) {
+		eprintf ("Warning: read bFLT hdr failed\n");
+		goto fail;
+	}
+	
+	if (strncmp ((const char *)bhdr, "bFLT", 4)) {
+		eprintf ("Warning: wrong magic number in bFLT file\n");
+		goto fail;
+	}
+	p_hdr = R_NEW0 (struct bflt_hdr);
+	if (!p_hdr) {
+		eprintf ("Warning: couldn't allocate memory\n");
+		goto fail;
+	}
+	
+	i += 4;
+	p_hdr->rev = READ (bhdr, i);
+	p_hdr->entry = READ (bhdr, i);
+	p_hdr->data_start = READ (bhdr, i);
+	p_hdr->data_end = READ (bhdr, i);
+	p_hdr->bss_end = READ (bhdr, i);
+	p_hdr->stack_size = READ (bhdr, i);
+	p_hdr->reloc_start = READ (bhdr, i);
+	p_hdr->reloc_count = READ (bhdr, i);
+	p_hdr->flags = READ (bhdr, i);
+	p_hdr->build_date = READ (bhdr, i);
+
+	if (p_hdr->rev != FLAT_VERSION) {
+		eprintf ("Warning: only v4 is supported!\n");
+		R_FREE (p_hdr);
+		goto fail;
+	}
+	bin->hdr = p_hdr;
+
+	return true;
+fail:
+	return false;
+}
+
+static int r_bin_bflt_init (struct r_bin_bflt_obj *obj, RBuffer *buf) {
+	obj->b = r_buf_new ();
+	obj->size = buf->length;
+	obj->endian = false;
+	obj->reloc_table = NULL;
+	obj->got_table = NULL;
+	obj->n_got = 0;
+	obj->hdr = NULL;
+
+	if(!r_buf_set_bytes (obj->b, buf->buf, obj->size)) {
+		r_buf_free (obj->b);
+		return false;
+	}
+	if (!bflt_init_hdr (obj)) {
+		return false;
+	}
+	return true;
+}
+
+struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf) {
+	struct r_bin_bflt_obj *bin = R_NEW0 (struct r_bin_bflt_obj);
+	if (bin) {
+		if (r_bin_bflt_init (bin, buf)) {
+			return bin;
+		}
+	}
+
+	return NULL;
+}	
+
+void r_bin_bflt_free(struct r_bin_bflt_obj *obj) {
+	R_FREE (obj->hdr);
+	R_FREE (obj->b);
+	R_FREE (obj);
+}

--- a/libr/bin/format/bflt/bflt.c
+++ b/libr/bin/format/bflt/bflt.c
@@ -9,11 +9,9 @@
 
 RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin) {
         RBinAddr *addr = R_NEW0 (RBinAddr);
-
-        if (!addr) {
-                return NULL;
+        if (addr) {
+        	addr->paddr = bin->hdr->entry;
         }
-        addr->paddr = bin->hdr->entry;
         return addr;
 }
 
@@ -83,12 +81,9 @@ static int r_bin_bflt_init (struct r_bin_bflt_obj *obj, RBuffer *buf) {
 
 struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf) {
 	struct r_bin_bflt_obj *bin = R_NEW0 (struct r_bin_bflt_obj);
-	if (bin) {
-		if (r_bin_bflt_init (bin, buf)) {
-			return bin;
-		}
+	if (bin && r_bin_bflt_init (bin, buf)) {
+		return bin;
 	}
-
 	return NULL;
 }	
 

--- a/libr/bin/format/bflt/bflt.h
+++ b/libr/bin/format/bflt/bflt.h
@@ -9,10 +9,10 @@
 #include <r_bin.h>
 
 /* Version 4 */
-#define FLAT_VERSION            0x00000004L
+#define	FLAT_VERSION		0x00000004L
 #define FLAT_FLAG_RAM		0x1	/* load program entirely into RAM */
-#define FLAT_FLAG_GOTPIC 	0x2 	/* program is PIC with GOT */
-#define FLAT_FLAG_GZIP   	0x4	/* all but the header is compressed */
+#define FLAT_FLAG_GOTPIC	0x2 	/* program is PIC with GOT */
+#define FLAT_FLAG_GZIP		0x4	/* all but the header is compressed */
 #define FLAT_FLAG_GZDATA	0x8	/* only data/relocs are compressed (for XIP) */
 #define FLAT_FLAG_KTRACE	0x10	/* output useful kernel trace for debugging */
 

--- a/libr/bin/format/bflt/bflt.h
+++ b/libr/bin/format/bflt/bflt.h
@@ -1,0 +1,58 @@
+/* radare - LGPL - Copyright 2016 - Oscar Salvador */
+
+#ifndef BFLT_H
+#define BFLT_H
+
+#include <r_types.h>
+#include <r_util.h>
+#include <r_lib.h>
+#include <r_bin.h>
+
+/* Version 4 */
+#define FLAT_VERSION            0x00000004L
+#define FLAT_FLAG_RAM		0x1	/* load program entirely into RAM */
+#define FLAT_FLAG_GOTPIC 	0x2 	/* program is PIC with GOT */
+#define FLAT_FLAG_GZIP   	0x4	/* all but the header is compressed */
+#define FLAT_FLAG_GZDATA	0x8	/* only data/relocs are compressed (for XIP) */
+#define FLAT_FLAG_KTRACE	0x10	/* output useful kernel trace for debugging */
+
+struct bflt_hdr {
+	char magic[4];
+	ut32 rev;
+	ut32 entry;
+	ut32 data_start;
+	ut32 data_end;
+	ut32 bss_end;
+	ut32 stack_size;
+	ut32 reloc_start;
+	ut32 reloc_count;
+	ut32 flags;
+	ut32 build_date;
+	ut32 filler[5];
+};
+
+//typedef reloc_struct_t
+
+struct reloc_struct_t {
+	ut32 addr_to_patch;
+	ut32 data_offset;
+};
+
+struct r_bin_bflt_obj {
+	struct bflt_hdr *hdr;
+	struct reloc_struct_t *reloc_table;
+	struct reloc_struct_t *got_table;
+	RBuffer *b;
+	ut8 endian;
+	size_t size;
+	uint32_t n_got;
+};
+
+#define BFLT_HDR_SIZE		sizeof (struct bflt_hdr)
+#define VALID_GOT_ENTRY(x)	(x != 0xFFFFFFFF)
+
+RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin);
+struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf);
+void r_bin_bflt_free(struct r_bin_bflt_obj *obj);
+
+#endif

--- a/libr/bin/p/Makefile
+++ b/libr/bin/p/Makefile
@@ -13,7 +13,7 @@ FORMATS=any.mk elf.mk elf64.mk pe.mk pe64.mk te.mk mach0.mk
 FORMATS+=bios.mk mach064.mk fatmach0.mk dyldcache.mk java.mk
 FORMATS+=dex.mk fs.mk ningb.mk coff.mk ningba.mk xbe.mk zimg.mk
 FORMATS+=omf.mk cgc.mk dol.mk nes.mk mbn.mk psxexe.mk spc700.mk
-FORMATS+=vsf.mk nin3ds.mk xtr_dyldcache.mk
+FORMATS+=vsf.mk nin3ds.mk xtr_dyldcache.mk bflt.mk
 include $(FORMATS)
 
 all: ${ALL_TARGETS}

--- a/libr/bin/p/bflt.mk
+++ b/libr/bin/p/bflt.mk
@@ -1,0 +1,11 @@
+OBJ_BFLT=bin_bflt.o
+OBJ_BFLT+=../format/bflt/bflt.o
+
+STATIC_OBJ+=${OBJ_BFLT}
+TARGET_BFLT=bin_bflt.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_BFLT}
+
+${TARGET_BFLT}: ${OBJ_BFLT}
+	${CC} $(call libname,bin_bflt) ${CFLAGS} \
+		$(OBJ_BFLT) $(LINK) $(LDFLAGS)

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -47,8 +47,6 @@ static RList *entries(RBinFile *arch) {
 
 static void __patch_reloc (RBuffer *buf, ut32 addr_to_patch, ut32 data_offset) {
 	ut32 val = data_offset;
-
-	eprintf ("__patch_reloc: patching 0x%x with 0x%x\n", addr_to_patch, val);
 	r_buf_write_at (buf, addr_to_patch, (void *)&val, 4);
 }
 
@@ -242,7 +240,7 @@ out:
 
 static RBinInfo *info(RBinFile *arch) {
 	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj*)arch->o->bin_obj;
-	RBinInfo *info = R_NEW0(RBinInfo);
+	RBinInfo *info = R_NEW0 (RBinInfo);
 
 	if (!info) {
 		return NULL;
@@ -285,25 +283,15 @@ RBinPlugin r_bin_plugin_bflt = {
 	.name = "bflt",
 	.desc = "bFLT format r_bin plugin",
 	.license = "LGPL3",
-	.get_sdb = NULL,
 	.load = &load,
 	.load_bytes = &load_bytes,
 	.destroy = &destroy,
 	.check = &check,
 	.check_bytes = &check_bytes,
-	.baddr = NULL,
-	.binsym = NULL,
 	.entries = &entries,
-	.sections = NULL,
-	.symbols = NULL,
-	.imports = NULL,
 	.info = &info,
-	.fields = NULL,
-	.size = NULL,
-	.libs = NULL,
 	.relocs = &relocs,
 	.patch_relocs = &patch_relocs,
-	.write = NULL,
 };
 
 #ifndef CORELIB

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -1,0 +1,315 @@
+/* radare - LGPL - Copyright 2016 - Oscar Salvador */
+#include <r_types.h>
+#include <r_util.h>
+#include <r_lib.h>
+#include <r_bin.h>
+#include <r_io.h>
+
+#include "bflt/bflt.h"
+
+static void *load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *sdb) {
+	struct r_bin_bflt_obj *res;
+	RBuffer *tbuf = NULL;
+
+	if (!buf || !sz || sz == UT64_MAX) {
+		return NULL;
+	}
+	tbuf = r_buf_new ();
+	r_buf_set_bytes (tbuf, buf, sz);
+	res = r_bin_bflt_new_buf (tbuf);
+	r_buf_free (tbuf);
+	return res ? res : NULL;
+}
+
+static int load(RBinFile *arch) {
+	const ut8 *bytes = r_buf_buffer (arch->buf);
+	ut64 sz = r_buf_size (arch->buf);
+
+	arch->o->bin_obj = load_bytes (arch, bytes, sz, arch->o->loadaddr, arch->sdb);
+	return arch->o->bin_obj ? true : false;
+}
+
+static RList *entries(RBinFile *arch) {
+	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj*)arch->o->bin_obj;
+	RList *ret;
+	RBinAddr *ptr;
+
+	if (!(ret = r_list_newf (free))) {
+		return NULL;
+	}
+	ptr = r_bflt_get_entry (obj);
+	if (!ptr) {
+		return NULL;
+	}
+	r_list_append (ret, ptr);
+	return ret;
+}
+
+static void __patch_reloc (RBuffer *buf, ut32 addr_to_patch, ut32 data_offset) {
+	ut32 val = data_offset;
+
+	eprintf ("__patch_reloc: patching 0x%x with 0x%x\n", addr_to_patch, val);
+	r_buf_write_at (buf, addr_to_patch, (void *)&val, 4);
+}
+
+static int search_old_relocation (struct reloc_struct_t *reloc_table, ut32 addr_to_patch, int n_reloc) {
+	int i;
+
+	for (i = 0; i < n_reloc; i++) {
+		if (addr_to_patch == reloc_table[i].data_offset) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static RList *patch_relocs(RBin *b) {
+	struct r_bin_bflt_obj *bin;
+	RList *list;
+	RBinObject *obj;
+	RIO *io;
+	int i;
+
+	list = r_list_new ();
+	if (!list) {
+		return NULL;
+	}
+
+	io = b->iob.get_io (&b->iob);
+	if (!io || !io->desc) {
+		return NULL;
+	}
+	if (!io->cached) {
+		eprintf ("Warning: please run r2 with -e io.cache=true to patch relocations\n");
+		return list;
+	}
+	
+	obj = r_bin_cur_object (b);
+	if (!obj) {
+		return NULL;
+	}
+	bin = obj->bin_obj;
+
+	if (bin->got_table) {
+		struct reloc_struct_t *got_table = bin->got_table;
+		for (i = 0; i < bin->n_got; i++) {
+			__patch_reloc (bin->b, got_table[i].addr_to_patch,
+						got_table[i].data_offset);
+			RBinReloc *reloc = R_NEW0 (RBinReloc);
+			if (reloc) {
+				reloc->type = R_BIN_RELOC_32;
+				reloc->paddr = got_table[i].addr_to_patch;
+				reloc->vaddr = reloc->paddr;
+				r_list_append (list, reloc);
+			}
+		}
+		R_FREE (bin->got_table);
+	}
+
+	if (bin->reloc_table) {
+		struct reloc_struct_t *reloc_table = bin->reloc_table;
+		for (i = 0; i < bin->hdr->reloc_count; i++) {
+			int found = search_old_relocation (reloc_table, 
+						reloc_table[i].addr_to_patch, 
+						bin->hdr->reloc_count);
+			if (found != -1) {
+				__patch_reloc (bin->b, reloc_table[found].addr_to_patch, 
+							reloc_table[i].data_offset);
+			} else {
+				__patch_reloc (bin->b, reloc_table[i].addr_to_patch,
+							reloc_table[i].data_offset);
+			}
+			RBinReloc *reloc = R_NEW0 (RBinReloc);
+			if (reloc) {
+				reloc->type = R_BIN_RELOC_32;
+				reloc->paddr = reloc_table[i].addr_to_patch;
+				reloc->vaddr = reloc->paddr;
+				r_list_append (list, reloc);
+			}
+		}
+		R_FREE (bin->reloc_table);
+	}
+
+	RIOBind *iob = &b->iob;
+	iob->write_at (iob->io, bin->b->base, bin->b->buf, bin->b->length);
+	
+	return list;
+}
+
+static int get_ngot_entries(struct r_bin_bflt_obj *obj) {
+	ut32 data_size = obj->hdr->data_end - obj->hdr->data_start;
+	int i, n_got;
+
+	for (i = 0, n_got = 0; i < data_size ; i+= 4, n_got++) {
+		ut32 entry;
+		int len = r_buf_read_at (obj->b, obj->hdr->data_start + i, (ut8 *)&entry, sizeof (ut32));
+		if (len != sizeof (ut32)) {
+			return 0;
+		}
+		if (!VALID_GOT_ENTRY (entry)) {
+			break;
+		}
+	}
+
+	return n_got;
+}
+
+static RList *relocs(RBinFile *arch) {
+	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj*)arch->o->bin_obj;
+	RList *list = r_list_new ();
+	int i, len;
+
+	if (!list || !obj) {
+		r_list_free (list);
+		return NULL;
+	}
+
+	if (obj->hdr->flags & FLAT_FLAG_GOTPIC) {
+		int n_got = get_ngot_entries (obj);
+		if (n_got) {
+			struct reloc_struct_t *got_table = calloc (1, n_got * sizeof (ut32));
+			if (got_table) {
+				ut32 offset = 0;
+				for (i = 0; i < n_got ; offset +=4, i++) {
+					ut32 got_entry;
+					len = r_buf_read_at (obj->b, obj->hdr->data_start + offset,
+								(ut8 *)&got_entry, sizeof (ut32));
+					if (!VALID_GOT_ENTRY (got_entry)) {
+						break;
+					} else {
+						got_table[i].addr_to_patch = got_entry;
+						got_table[i].data_offset = got_entry + BFLT_HDR_SIZE;
+					}
+				}
+				obj->n_got = n_got;
+				obj->got_table = got_table;
+			}
+		}
+	}
+
+	if (obj->hdr->reloc_count > 0) {
+		int n_reloc = obj->hdr->reloc_count; 
+		ut32 *reloc_pointer_table = calloc (n_reloc, sizeof (ut32));
+		if (!reloc_pointer_table) {
+			goto out;
+		}
+
+		struct reloc_struct_t *reloc_table = calloc (n_reloc, sizeof (struct reloc_struct_t));
+		if (!reloc_table) {
+			goto out;
+		}
+	
+		len = r_buf_read_at (obj->b, obj->hdr->reloc_start, (ut8 *)reloc_pointer_table, n_reloc * sizeof (ut32));
+		if (len != n_reloc * sizeof (ut32)) {
+			goto out;
+		}
+	
+		for (i = 0; i < obj->hdr->reloc_count; i++) {
+			ut32 reloc_offset = r_swap_ut32 (reloc_pointer_table[i]) + BFLT_HDR_SIZE;
+	
+			if (reloc_offset < obj->hdr->bss_end) {
+				ut32 reloc_fixed;
+				ut32 reloc_data_offset;
+	
+				len = r_buf_read_at (obj->b, reloc_offset, (ut8 *)&reloc_fixed, sizeof (ut32));
+				if (len != sizeof (ut32)) {
+					eprintf ("problem while reading relocation entries\n");
+					goto out;
+				}
+				reloc_data_offset = r_swap_ut32 (reloc_fixed) + BFLT_HDR_SIZE;
+	
+				reloc_table[i].addr_to_patch = reloc_offset;
+				reloc_table[i].data_offset = reloc_data_offset;
+	
+	
+				RBinReloc *reloc = R_NEW0 (RBinReloc);
+				if (reloc) {
+					reloc->type = R_BIN_RELOC_32;
+					reloc->paddr = reloc_table[i].addr_to_patch;
+					reloc->vaddr = reloc->paddr;
+					r_list_append (list, reloc);
+				}
+			}
+		}
+		free (reloc_pointer_table);
+		obj->reloc_table = reloc_table;
+	}
+
+out:
+	return list;
+}
+
+static RBinInfo *info(RBinFile *arch) {
+	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj*)arch->o->bin_obj;
+	RBinInfo *info = R_NEW0(RBinInfo);
+
+	if (!info) {
+		return NULL;
+	}
+	info->file = arch->file ? strdup (arch->file) : NULL;
+	info->rclass = strdup ("bflt");
+	info->bclass = strdup ("bflt" );
+	info->type = strdup ("bFLT (Executable file)");
+	info->os = strdup ("Linux");
+	info->subsystem = strdup ("Linux");
+	info->arch = strdup ("arm");
+	info->big_endian = obj->endian;
+	info->bits = 32;
+	info->has_va = false;
+	info->dbg_info = 0;
+	info->machine = strdup ("unknown");
+
+	return info;
+}
+
+static int check_bytes(const ut8 *buf, ut64 length) {
+	return length > 4 && !memcmp (buf, "bFLT", 4);
+}
+
+static int check(RBinFile *arch) {
+	const ut8 *bytes = arch ? r_buf_buffer (arch->buf) : NULL;
+	ut64 sz = arch ? r_buf_size (arch->buf): 0; 
+	if (!bytes || !sz) {
+		return false;
+	}
+	return check_bytes (bytes, sz);
+}
+
+static int destroy(RBinFile *arch) {
+	r_bin_bflt_free ((struct r_bin_bflt_obj*)arch->o->bin_obj);
+	return true;
+}
+
+RBinPlugin r_bin_plugin_bflt = {
+	.name = "bflt",
+	.desc = "bFLT format r_bin plugin",
+	.license = "LGPL3",
+	.get_sdb = NULL,
+	.load = &load,
+	.load_bytes = &load_bytes,
+	.destroy = &destroy,
+	.check = &check,
+	.check_bytes = &check_bytes,
+	.baddr = NULL,
+	.binsym = NULL,
+	.entries = &entries,
+	.sections = NULL,
+	.symbols = NULL,
+	.imports = NULL,
+	.info = &info,
+	.fields = NULL,
+	.size = NULL,
+	.libs = NULL,
+	.relocs = &relocs,
+	.patch_relocs = &patch_relocs,
+	.write = NULL,
+};
+
+#ifndef CORELIB
+RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_BIN,
+	.data = &r_bin_plugin_bflt,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -636,6 +636,7 @@ extern RBinPlugin r_bin_plugin_ningba;
 extern RBinPlugin r_bin_plugin_ninds;
 extern RBinPlugin r_bin_plugin_nin3ds;
 extern RBinPlugin r_bin_plugin_xbe;
+extern RBinPlugin r_bin_plugin_bflt;
 extern RBinXtrPlugin r_bin_xtr_plugin_fatmach0;
 extern RBinXtrPlugin r_bin_xtr_plugin_xtr_dyldcache;
 extern RBinPlugin r_bin_plugin_zimg;

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -103,6 +103,7 @@ asm.pic18c
 bin.any
 bin.art
 bin.bf
+bin.bflt
 bin.bios
 bin.bootimg
 bin.cgc


### PR DESCRIPTION
Once again, this times relocations are fixed:

```
$ file test2
test2: BFLT executable - version 4 ram
$ r2 -e io.cache=true ./test2
[0x00000044]> s 0x00000160
[0x00000160]> pd 10
            0x00000160      14100be5       str r1, [fp, -0x14]
            0x00000164      30309fe5       ldr r3, [0x0000019c]        ; [0x19c:4]=0xdeadbeef
            0x00000168      08300be5       str r3, [fp, -8]
            0x0000016c      2c009fe5       ldr r0, [0x000001a0]        ; [0x1a0:4]=0x4668 str.Hola
            0x00000170      0d0000eb       bl 0x1ac
            0x00000174      28309fe5       ldr r3, [0x000001a4]        ; [0x1a4:4]=0x4660 str.Adios
            0x00000178      003093e5       ldr r3, [r3]
            0x0000017c      0310a0e1       mov r1, r3
            0x00000180      20009fe5       ldr r0, [0x000001a8]        ; [0x1a8:4]=0x4670 str._s_n
            0x00000184      1a0000eb       bl 0x1f4
[0x00000160]>
```

More should be needed, but so far is ok I think.
I'll see if i manage do install uClinux.

Another thing is that this plugin is able to manage bFLT version 4, but I'll port to v2 too.