### PR TITLE
Add mxe+dockcross support for docker-windows builds

### DIFF
--- a/mk/i686-w64-mingw32.static-gcc.mk
+++ b/mk/i686-w64-mingw32.static-gcc.mk
@@ -1,0 +1,21 @@
+ifeq (${_INCLUDE_MK_GCC_},)
+_INCLUDE_MK_GCC_=1
+CC=i686-w64-mingw32.static-gcc
+RANLIB=i686-w64-mingw32.static-ranlib
+ONELIB=0
+OSTYPE=windows
+LINK=
+CC_AR=i686-w64-mingw32.static-ar -r ${LIBAR}
+PICFLAGS=
+CFLAGS+=${PICFLAGS} -MD -D__WINDOWS__=1
+CC_LIB=${CC} -shared -o
+CFLAGS_INCLUDE=-I
+LDFLAGS+=-static-libgcc
+LDFLAGS_LINK=-l
+LDFLAGS_LINKPATH=-L
+CFLAGS_OPT0=-O0
+CFLAGS_OPT1=-O1
+CFLAGS_OPT2=-O2
+CFLAGS_OPT3=-O3
+CFLAGS_DEBUG=-g
+endif

--- a/mk/x86_64-w64-mingw32.static-gcc.mk
+++ b/mk/x86_64-w64-mingw32.static-gcc.mk
@@ -1,0 +1,18 @@
+PREFIX=/usr/src/mxe/usr/
+CC=x86_64-w64-mingw32.static-gcc
+RANLIB=x86_64-w64-mingw32.static-ranlib
+ONELIB=0
+OSTYPE=windows
+LINK=
+CC_AR=x86_64-w64-mingw32.static-ar -r ${LIBAR}
+PICFLAGS=
+CFLAGS+=${PICFLAGS} -MD -D__WINDOWS__=1
+CC_LIB=${CC} -shared -o
+CFLAGS_INCLUDE=-I
+LDFLAGS_LINK=-l
+LDFLAGS_LINKPATH=-L
+CFLAGS_OPT0=-O0
+CFLAGS_OPT1=-O1
+CFLAGS_OPT2=-O2
+CFLAGS_OPT3=-O3
+CFLAGS_DEBUG=-g


### PR DESCRIPTION
Support for dockcross+mxe, which requires `.static` toolchain on mxe path:

https://github.com/mxe/mxe
https://github.com/dockcross/dockcross

Complements with PR: https://github.com/radare/radare2-release/pull/1