### PR TITLE
fixed rap in win64

### DIFF
--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -33,7 +33,7 @@ WSACleanup: closes all network connections
 #define BUFFER_SIZE 4096
 
 R_API bool r_socket_is_connected (RSocket *s) {
-#if __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 	char buf[2];
 	r_socket_block_time (s, 0, 0);
 	ssize_t ret = recv (s->fd, (char*)&buf, 1, MSG_PEEK);
@@ -127,7 +127,7 @@ R_API RSocket *r_socket_new (int is_ssl) {
 }
 
 R_API bool r_socket_connect (RSocket *s, const char *host, const char *port, int proto, unsigned int timeout) {
-#if __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 	struct sockaddr_in sa;
 	struct hostent *he;
 	WSADATA wsadata;
@@ -289,7 +289,7 @@ R_API int r_socket_close (RSocket *s) {
 #if __UNIX__ || defined(__CYGWIN__)
 		shutdown (s->fd, SHUT_RDWR);
 #endif
-#if __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms740481(v=vs.85).aspx
 		shutdown (s->fd, SD_SEND);
 		do {
@@ -341,7 +341,7 @@ R_API bool r_socket_listen (RSocket *s, const char *port, const char *certfile) 
 	if (r_sandbox_enable (0)) {
 		return false;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 	WSADATA wsadata;
 	if (WSAStartup (MAKEWORD (1, 1), &wsadata) == SOCKET_ERROR) {
 		eprintf ("Error creating socket.");
@@ -463,7 +463,7 @@ R_API int r_socket_block_time (RSocket *s, int block, int sec) {
 			(flags | O_NONBLOCK));
 	if (ret < 0)
 		return false;
-#elif __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#elif __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 	// HACK: nonblocking io on w32 behaves strange
 	return true;
 	ioctlsocket (s->fd, FIONBIO, (u_long FAR*)&block);
@@ -499,7 +499,7 @@ R_API int r_socket_ready(RSocket *s, int secs, int usecs) {
 	fds[0].events = POLLIN | POLLPRI;
 	fds[0].revents = POLLNVAL | POLLHUP | POLLERR;
 	return poll ((struct pollfd *)&fds, 1, msecs);
-#elif __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#elif __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 	return 1;
 #if XXX_THIS_IS_NOT_WORKING_WELL
 	fd_set rfds;
@@ -520,7 +520,7 @@ R_API int r_socket_ready(RSocket *s, int secs, int usecs) {
 }
 
 R_API char *r_socket_to_string(RSocket *s) {
-#if __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 	char *str = malloc (32);
 	snprintf (str, 31, "fd%d", s->fd);
 	return str;
@@ -601,7 +601,7 @@ R_API int r_socket_read(RSocket *s, unsigned char *buf, int len) {
 		return SSL_read (s->sfd, buf, len);
 	}
 #endif
-#if __WINDOWS__ && !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
 rep:
 	{
 	int ret = recv (s->fd, (void *)buf, len, 0);


### PR DESCRIPTION
- Fixed RAP in windows x64.

PD: I dont understand who made the exclusion of socket under win64 .... win32/64 share same API for sockets