### PR TITLE
Fixed IJMP, ICALL, EIJMP and EICALL

### DIFF
--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -1790,8 +1790,6 @@ static int esil_avr_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val)
 		*val = cpu->pc > 8
 			? *val & MASK (cpu->pc - 8)
 			: 0;
-	} else {
-		eprintf ("Modifying register '%s' with value 0x%08"PFMT64x"\n", name, *val);
 	}
 
 	return 0;


### PR DESCRIPTION
As Javier noted during an exciting debugging session in the Christmas loneliness of him home, my implementation of IJMP, ICALL, EIJMP and EICALL were utterly broken.

These fixes are some untested random changes for trying to improve the AVR emulator.