### PR TITLE
fix ia command for normal output

### DIFF
--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -468,7 +468,7 @@ static int cmd_info(void *data, const char *input) {
 			case R_CORE_BIN_RADARE: cmd_info (core, "i*IiecsSmz"); break;
 			case R_CORE_BIN_JSON: cmd_info (core, "ijIiecsSmz"); break;
 			case R_CORE_BIN_SIMPLE: cmd_info (core, "iqIiecsSmz"); break;
-			default: cmd_info (core, "iIiecsSmz"); break;
+			default: cmd_info (core, "IiEecsSmz"); break;
 			}
 			break;
 		case '?': {


### PR DESCRIPTION
R2R PR: https://github.com/radare/radare2-regressions/pull/652

New output, now the second import is a export:
```
[0x1000011e0]> ia
havecode true
pic      true
canary   true
nx       false
crypto   false
va       true
intrp    /usr/lib/dyld
bintype  mach0
class    MACH064
lang     c
arch     x86
bits     64
machine  x86 64 all
os       osx
minopsz  1
maxopsz  16
pcalign  0
subsys   darwin
endian   little
stripped false
static   false
linenum  false
lsyms    false
relocs   false
binsz    38624
[Imports]
ordinal=000 plt=0x00000000 bind=NONE type=FUNC name=_DefaultRuneLocale
ordinal=001 plt=0x10000443e bind=NONE type=FUNC name=__assert_rtn
ordinal=002 plt=0x100004444 bind=NONE type=FUNC name=__bzero
ordinal=003 plt=0x10000444a bind=NONE type=FUNC name=__error
[....]

82 imports
[Exports]
vaddr=0x100000000 paddr=0x00000000 ord=000 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=__mh_execute_header

1 exports
[Entrypoints]
vaddr=0x1000011e0 paddr=0x000011e0 baddr=0x100000000 laddr=0x00000000 haddr=0x00000648 type=program

1 entrypoints
[Symbols]
vaddr=0x100000000 paddr=0x00000000 ord=000 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=__mh_execute_header
vaddr=0x05614542 paddr=0x05614542 ord=001 fwd=NONE sz=0 bind=LOCAL type=FUNC name=radr://5614542
vaddr=0x10000443e paddr=0x0000443e ord=002 fwd=NONE sz=0 bind=LOCAL type=FUNC name=imp.__assert_rtn
vaddr=0x100004444 paddr=0x00004444 ord=003 fwd=NONE sz=0 bind=LOCAL type=FUNC name=imp.__bzero
[....]

114 symbols
[Sections]
idx=00 vaddr=0x100000f00 paddr=0x00000f00 sz=13599 vsz=13599 perm=m-r-x name=0.__TEXT.__text
idx=01 vaddr=0x100004420 paddr=0x00004420 sz=456 vsz=456 perm=m-r-x name=1.__TEXT.__stubs
idx=02 vaddr=0x1000045e8 paddr=0x000045e8 sz=776 vsz=776 perm=m-r-x name=2.__TEXT.__stub_helper
[....]

13 sections
[Memory]

vaddr=0x1000048f0 paddr=0x000048f0 ordinal=000 sz=67 len=66 section=3.__TEXT.__const type=ascii string=$FreeBSD: src/bin/ls/cmp.c,v 1.12 2002/06/30 05:13:54 obrien Exp $
[....]
```