### PR TITLE
Small fixes

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -76,7 +76,7 @@ static void r_debug_native_stop(RDebug *dbg);
 #   define WIFCONTINUED(s) ((s) == 0xffff)
 #  endif
 # endif
-#if (__x86_64__ || __i386__) && !defined(__ANDROID__)
+#if (__x86_64__ || __i386__ || __arm__ || __arm64__) && !defined(__ANDROID__)
 #include "native/linux/linux_coredump.h"
 #endif
 #else // OS

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -40,6 +40,7 @@
 #if __linux__ && !__ANDROID__
 #include <sys/personality.h>
 #include <pty.h>
+#include <utmp.h>
 #endif
 #if defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <util.h>


### PR DESCRIPTION
Here are the first few fixes for issue #6394. Still missing is correct pty header include in run. c for kfreebsd and the int64 offset to pointer cast in cmd_zign.c.