### PR TITLE
Support for 24 bit esil memory ops and bugfixed AVR flags

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1516,7 +1516,7 @@ static int esil_poke_n(RAnalEsil *esil, int bits) {
 				esil->lastsz = bits;
 				num = num & bitmask;
 			}
-			r_write_ble(b, num, esil->anal->big_endian, bits);
+			r_write_ble (b, num, esil->anal->big_endian, bits);
 			ret = r_anal_esil_mem_write (esil, addr, b, bytes);
 		}
 	}
@@ -1530,6 +1530,9 @@ static int esil_poke1(RAnalEsil *esil) {
 }
 static int esil_poke2(RAnalEsil *esil) {
 	return esil_poke_n (esil, 16);
+}
+static int esil_poke3(RAnalEsil *esil) {
+	return esil_poke_n (esil, 24);
 }
 static int esil_poke4(RAnalEsil *esil) {
 	return esil_poke_n (esil, 32);
@@ -1597,6 +1600,7 @@ static int esil_peek_n(RAnalEsil *esil, int bits) {
 		free (dst);
 		return 0;
 	}
+	//eprintf ("GONA PEEK %d dst:%s\n", bits, dst);
 	if (dst && isregornum (esil, dst, &addr)) {
 		ut64 bitmask = genmask (bits - 1);
 		ut8 a[sizeof(ut64)] = {0};
@@ -1618,6 +1622,9 @@ static int esil_peek1(RAnalEsil *esil) {
 }
 static int esil_peek2(RAnalEsil *esil) {
 	return esil_peek_n (esil, 16);
+}
+static int esil_peek3(RAnalEsil *esil) {
+	return esil_peek_n (esil, 24);
 }
 static int esil_peek4(RAnalEsil *esil) {
 	return esil_peek_n (esil, 32);
@@ -2613,6 +2620,7 @@ static void r_anal_esil_setup_ops(RAnalEsil *esil) {
 	OP ("=[]", esil_poke);
 	OP ("=[1]", esil_poke1);
 	OP ("=[2]", esil_poke2);
+	OP ("=[3]", esil_poke3);
 	OP ("=[4]", esil_poke4);
 	OP ("=[8]", esil_poke8);
 	OP ("|=[]", esil_mem_oreq);
@@ -2670,6 +2678,7 @@ static void r_anal_esil_setup_ops(RAnalEsil *esil) {
 	OP ("=[*]", esil_poke_some);
 	OP ("[1]", esil_peek1);
 	OP ("[2]", esil_peek2);
+	OP ("[3]", esil_peek3);
 	OP ("[4]", esil_peek4);
 	OP ("[8]", esil_peek8);
 	OP ("STACK", r_anal_esil_dumpstack);

--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -285,12 +285,16 @@ static void __generic_push(RAnalOp *op, int sz) {
 }
 
 static void __generic_math_update_flags(RAnalOp *op, char t_d, ut64 v_d, char t_rk, ut64 v_rk) {
-	RStrBuf *d, *rk;
+	RStrBuf *d_strbuf, *rk_strbuf;
+	char *d, *rk;
 
-	d = r_strbuf_new (NULL);
-	rk = r_strbuf_new (NULL);
-	r_strbuf_setf (d,  t_d  == 'r' ? "r%d" : "%" PFMT64x, v_d);
-	r_strbuf_setf (rk, t_rk == 'r' ? "r%d" : "%" PFMT64x, v_rk);
+	d_strbuf = r_strbuf_new (NULL);
+	rk_strbuf = r_strbuf_new (NULL);
+	r_strbuf_setf (d_strbuf,  t_d  == 'r' ? "r%d" : "%" PFMT64x, v_d);
+	r_strbuf_setf (rk_strbuf, t_rk == 'r' ? "r%d" : "%" PFMT64x, v_rk);
+
+	d = r_strbuf_get(d_strbuf);
+	rk = r_strbuf_get(rk_strbuf);
 
 	ESIL_A ("%s,0x08,&,!,!," "%s,0x08,&,!,!,"    "&,"	// H
 		"%s,0x08,&,!,!," "0,RPICK,0x08,&,!," "&,"
@@ -305,15 +309,15 @@ static void __generic_math_update_flags(RAnalOp *op, char t_d, ut64 v_d, char t_
 		d, rk, d, rk);
 	ESIL_A ("0,RPICK,0x80,&,!,!,nf,=,");			// N
 	ESIL_A ("0,RPICK,!,zf,=,");				// Z
-	ESIL_A ("%s,0x80,&,!,!," "r%s,0x80,&,!,!,"   "&,"	// C
+	ESIL_A ("%s,0x80,&,!,!," "%s,0x80,&,!,!,"    "&,"	// C
 		"%s,0x80,&,!,!," "0,RPICK,0x80,&,!," "&,"
 		"%s,0x80,&,!,!," "0,RPICK,0x80,&,!," "&,"
 		"|,|,cf,=,",
 		d, rk, rk, d);
 	ESIL_A ("vf,nf,^,sf,=,");				// S
 
-	r_strbuf_free (d);
-	r_strbuf_free (rk);
+	r_strbuf_free (d_strbuf);
+	r_strbuf_free (rk_strbuf);
 }
 
 static void __generic_math_update_flags_rr(RAnalOp *op, int d, int r) {

--- a/libr/include/r_endian.h
+++ b/libr/include/r_endian.h
@@ -74,6 +74,12 @@ static inline void r_write_be32(void *dest, ut32 val) {
 	r_write_at_be16 (dest, val >> 0, sizeof (ut16));
 }
 
+static inline void r_write_be24(void *dest, ut32 val) {
+	r_write_be8 (dest++, val >> 16);
+	r_write_be8 (dest++, val >> 8);
+	r_write_be8 (dest, val >> 0);
+}
+
 static inline void r_write_at_be32(void *dest, ut32 val, size_t offset) {
 	ut8 *d = (ut8*)dest + offset;
 	r_write_be32 (d, val);
@@ -136,6 +142,12 @@ static inline void r_write_le16(void *dest, ut16 val) {
 static inline void r_write_at_le16(void *dest, ut16 val, size_t offset) {
 	ut8 *d = (ut8 *)dest + offset;
 	r_write_le16 (d, val);
+}
+
+static inline void r_write_le24(void *dest, ut32 val) {
+	r_write_le8 (dest++, val >> 0);
+	r_write_le8 (dest++, val >> 8);
+	r_write_le8 (dest,   val >> 16);
 }
 
 static inline ut32 r_read_le32(const void *src) {
@@ -213,6 +225,10 @@ static inline void r_write_ble16(void *dest, ut16 val, bool big_endian) {
 	big_endian? r_write_be16 (dest, val): r_write_le16 (dest, val);
 }
 
+static inline void r_write_ble24(void *dest, ut32 val, bool big_endian) {
+	big_endian? r_write_be24 (dest, val): r_write_le24 (dest, val);
+}
+
 static inline void r_write_ble32(void *dest, ut32 val, bool big_endian) {
 	big_endian? r_write_be32 (dest, val): r_write_le32 (dest, val);
 }
@@ -228,6 +244,9 @@ static inline void r_write_ble(void *dst, ut64 val, bool big_endian, int size) {
 		break;
 	case 16:
 		r_write_ble16 (dst, (ut16) val, big_endian);
+		break;
+	case 24:
+		r_write_ble24 (dst, (ut32) val, big_endian);
 		break;
 	case 32:
 		r_write_ble32 (dst, (ut32) val, big_endian);

--- a/libr/util/mem.c
+++ b/libr/util/mem.c
@@ -180,6 +180,12 @@ R_API void r_mem_swapendian(ut8 *dest, const ut8 *orig, int size) {
 		dest[0] = orig[1];
 		dest[1] = buffer[0];
 		break;
+	case 3:
+		*buffer = *orig;
+		dest[0] = orig[2];
+		dest[1] = orig[1];
+		dest[2] = buffer[0];
+		break;
 	case 4:
 		memcpy (buffer, orig, 4);
 		dest[0] = buffer[3];


### PR DESCRIPTION
An initial support for 24 bit memory ops in esil (mov of 3 bytes, big and little endian).
AVR bugfixes.