### PR TITLE
gdb: use simple packets instead of vCont for single-threaded

### DIFF
--- a/shlr/gdb/src/core.c
+++ b/shlr/gdb/src/core.c
@@ -698,7 +698,7 @@ int send_vcont(libgdbr_t* g, const char* command, int thread_id) {
 	int ret;
 	if (!g) return -1;
 	if (thread_id < 0) {
-		ret = snprintf (tmp, sizeof (tmp) - 1, "%s;%s", CMD_C, command);
+		ret = snprintf (tmp, sizeof (tmp) - 1, "%s", command);
 	} else {
 		ret = snprintf (tmp, sizeof (tmp) - 1, "%s;%s:%x", CMD_C, command, thread_id);
 	}


### PR DESCRIPTION
When debugging a single-threaded application via GDB Serial protocol
some GDB servers (notably OpenOCD) do not support vCont command, so
neither step nor continue work. Even though current protocol
description deprecates plain "s" and "c" it does so only for
multi-threading cases.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>