### PR TITLE
Increase size of printed 'chunk data' in dmhc

### DIFF
--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -329,7 +329,7 @@ void GH(print_heap_chunk)(RCore *core) {
 	}
 
 	PRINT_GA (",\n}\n");
-	GHT size = ((cnk->size >> 3) << 3) - SZ * 2;
+	GHT size = ((cnk->size >> 3) << 3) - SZ;
 	if (size > SZ * 128) {
 		PRINT_GA ("chunk too big to be displayed\n");
 		size = SZ * 128;


### PR DESCRIPTION
This will increase the amount of printed `chunk data` to include the `nextchunk->prev_size` field. If the current chunk is allocated, then `nextchunk->prev_size` is part of the usable memory of the current chunk. 

Before patch, missing the last 8 bytes of `A`s:

```
:> dmhc @0x18df000
struct malloc_chunk @ 0x18df000 {
  prev_size = 0x0,
  size = 0xd1,
  flags: |N:0 |M:0 |P:1,
  fd = 0x4141414141414141,
  bk = 0x4141414141414141,
}
chunk data =
0x018df010  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df020  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df030  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df040  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df050  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df060  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df070  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df080  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df090  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df0a0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df0b0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x018df0c0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
```
```
:> px @0x018df010
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x018df010  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df020  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df030  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df040  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df050  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df060  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df070  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df080  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df090  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df0a0  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df0b0  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df0c0  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x018df0d0  4141 4141 4141 4141 d100 0000 0000 0000  AAAAAAAA........
```

After patch, allocated:

```
:> dmhc @0x946000
struct malloc_chunk @ 0x946000 {
  prev_size = 0x0,
  size = 0xd1,
  flags: |N:0 |M:0 |P:1,
  fd = 0x4141414141414141,
  bk = 0x4141414141414141,
}
chunk data =
0x00946010  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946020  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946030  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946040  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946050  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946060  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946070  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946080  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946090  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460a0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460b0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460c0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460d0  0x4141414141414141                       AAAAAAAA
:>
```

After patch, freed:

```
:> dmhc @0x946000
struct malloc_chunk @ 0x946000 {
  prev_size = 0x0,
  size = 0xd1,
  flags: |N:0 |M:0 |P:1,
  fd = 0x7f001d73c7b8,
  bk = 0x7f001d73c7b8,
}
chunk data =
0x00946010  0x00007f001d73c7b8  0x00007f001d73c7b8   ..s.......s.....
0x00946020  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946030  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946040  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946050  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946060  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946070  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946080  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x00946090  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460a0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460b0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460c0  0x4141414141414141  0x4141414141414141   AAAAAAAAAAAAAAAA
0x009460d0  0x00000000000000d0                       ........
:>
```

When the chunk is free, the last 8 bytes are now the `prev_size` field used by the next chunk. It could look a bit misleading to print this information here inside the `chunk data`. But then again, the `fd` and `bk` pointers are inside the `chunk data` as well.