### PR TITLE
Coverititty is silly

### DIFF
--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -376,7 +376,7 @@ INST_HANDLER (adc) {	// ADC Rd, Rr
 	int d = ((buf[0] >> 4) & 0xf) | ((buf[1] & 1) << 4);
 	int r = (buf[0] & 0xf) | ((buf[1] & 2) << 3);
 	ESIL_A ("r%d,cf,+,r%d,+,", r, d);		// Rd + Rr + C
-	__generic_add_update_flags_rr(op, r, d);	// FLAGS
+	__generic_add_update_flags_rr(op, d, r);	// FLAGS
 	ESIL_A ("r%d,=,", d);				// Rd = result
 }
 
@@ -385,7 +385,7 @@ INST_HANDLER (add) {	// ADD Rd, Rr
 	int d = ((buf[0] >> 4) & 0xf) | ((buf[1] & 1) << 4);
 	int r = (buf[0] & 0xf) | ((buf[1] & 2) << 3);
 	ESIL_A ("r%d,r%d,+,", r, d);			// Rd + Rr
-	__generic_add_update_flags_rr(op, r, d);	// FLAGS
+	__generic_add_update_flags_rr(op, d, r);	// FLAGS
 	ESIL_A ("r%d,=,", d);				// Rd = result
 }
 


### PR DESCRIPTION
When adding numbers, factor order does not matter, but this patch will silence the warnings emitted by Coverity.