### PR TITLE
Fix setting flag length with fl command

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -403,12 +403,12 @@ eprintf ("WTF 'f .xxx' adds a variable to the function? ?!!?(%s)\n");
 			if (p) {
 				*p++ = 0;
 				item = r_flag_get_i (core->flags,
-					r_num_math (core->num, str));
+					r_num_math (core->num, arg));
 				if (item)
 					item->size = r_num_math (core->num, p);
 			} else {
 				item = r_flag_get_i (core->flags,
-					r_num_math (core->num, str));
+					r_num_math (core->num, arg));
 				if (item)
 					r_cons_printf ("0x%08"PFMT64x"\n", item->size);
 			}


### PR DESCRIPTION
The command `fl` was wrongly passing `str` instead of `arg` to the flag lookup.

This caused the flag lookup to miss (as it gets passed both the flag name and the new value, prefixed with a space), and `fl` to always fail (silently) when changing the length of a flag.

This commit fixes that.