### PR TITLE
Update README for r2pm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,15 @@ To start to use it for the first time you need to initialize packages:
 
 And to refresh packages before installation/updating a new one:
 
-    $ r2pm refresh
+    $ r2pm update
 
-To install/update package use the command
+To install package use the command
 
     $ r2pm install [package name]
+
+To update package use the command
+
+    $ r2pm update [package name]
 
 # Bindings
 


### PR DESCRIPTION
Apart examples with `install/update [package-name]` looks a bit clear for me. Should it be inlined instead?