### PR TITLE
Make debugging work a bit better on OpenBSD: nudge get_base_from_maps…

### DIFF
--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -276,6 +276,13 @@ static ut64 get_base_from_maps(RCore *core, const char *file) {
 			//b = map->addr;
 		}
 	}
+	// fallback resolution copied from cmd_debug.c:r_debug_get_baddr
+	r_list_foreach (core->dbg->maps, iter, map) {
+		if (map->perm == 5) { // r-x
+			return map->addr;
+		}
+	}
+
 	return b;
 }
 #endif


### PR DESCRIPTION
…() so it does not return 0 on OpenBSD just because the memory mapping does not contain the file name.

Copied the fallback code from cmd_debug.c:r_debug_get_baddr().

getBaddrFromDebugger() from radare2.c also does the right thing. r_debug_get_baddr() probably should be exposed through the api so everyone can use one, maybe correct, version.

Before patch:

```
$ r2 -version
radare2 1.2.0-git 13429 @ openbsd-x86-64 git.1.1.0-142-g7595aad0a
commit: 7595aad0a4608abf26bd5a6032eb01b9f3007735 build: 2017-01-07
$ r2 -d ~/tmp/a.out
Process with PID 87025 started...
= attach 87025 87025
bin.baddr 0x8cd55000000
USING 8cd55000000
Assuming filepath /home/gk/tmp/a.out
asm.bits 64
 -- Documentation is for weak people.
[0x8cfb4a002b0]> aa
[Cannot find function 'entry0' at 0x000003c0 entry0 (aa)
[x] Analyze all flags starting with sym. and entry0 (aa)
[0x8cfb4a002b0]> f~main
0x0000058f 256 main
0x0000058f 44 sym.main
[0x8cfb4a002b0]> s main 
[0x0000058f]> pdf
p: Cannot find function at 0x0000058f
[0x0000058f]>
```

After patch:

```
$ r2 -d ~/tmp/a.out
Process with PID 4403 started...
= attach 4403 4403
bin.baddr 0x110b46f00000
USING 110b46f00000
Assuming filepath /home/gk/tmp/a.out
asm.bits 64
 -- -bash: r2: command not found
[0x110dc89002b0]> aa
[x] Analyze all flags starting with sym. and entry0 (aa)
[0x110dc89002b0]> f~main
0x110b46f0058f 256 main
0x110b46f0058f 44 sym.main
[0x110dc89002b0]> s main
[0x110b46f0058f]> pdf
            ;-- main:
/ (fcn) sym.main 44
|   sym.main ();
|              ; CALL XREF from 0x110b46f0041d (entry0)
|           0x110b46f0058f      55             push rbp
|           0x110b46f00590      4889e5         mov rbp, rsp
|           0x110b46f00593      4883ec10       sub rsp, 0x10
|           0x110b46f00597      b800000000     mov eax, 0
|           0x110b46f0059c      e8e3ffffff     call sym.lol
|           0x110b46f005a1      89c6           mov esi, eax
|           0x110b46f005a3      488d3d560410.  lea rdi, 0x110b47000a00 ; 0x110b47000a00 ; section..rodata ; "%d$
|           0x110b46f005aa      b800000000     mov eax, 0
|           0x110b46f005af      e8bcfdffff     call sym.imp.printf    ; sym.imp._csu_finish-0x20
|           0x110b46f005b4      b800000000     mov eax, 0
|           0x110b46f005b9      c9             leave
\           0x110b46f005ba      c3             ret
[0x110b46f0058f]>
```
