### PR TITLE
Allow multiple calls of cdb_init without leaking or failing

### DIFF
--- a/shlr/sdb/src/sdb.c
+++ b/shlr/sdb/src/sdb.c
@@ -30,6 +30,7 @@ SDB_API Sdb* sdb_new0 () {
 SDB_API Sdb* sdb_new (const char *path, const char *name, int lock) {
 	Sdb* s = R_NEW0 (Sdb);
 	if (!s) return NULL;
+	s->db.fd = -1;
 	s->fd = -1;
 	s->refs = 1;
 	if (path && !*path) {


### PR DESCRIPTION
Backported sdb fixes wrt multiple cdb_init calls (i.e. https://github.com/radare/sdb/commit/fe5c7938615062853a0c31f3216379aa9fb7f962, https://github.com/radare/sdb/commit/cafbe0cd88343fdd3414611720e32fd563804479, https://github.com/radare/sdb/commit/964f7e41c358c937e8d02950643668783354c6db).

Figured you'd be busy so I did it for you.