### PR TITLE
Move ssp integration to libr/asm.c [FIX #6356]

### DIFF
--- a/binr/rasm2/Makefile
+++ b/binr/rasm2/Makefile
@@ -1,5 +1,4 @@
 BIN=rasm2
 BINDEPS=r_asm r_parse r_syscall r_anal r_reg
 BINDEPS+=r_flag r_cons r_lang r_util
-CFLAGS+=-I$(SHLR)/spp
 include ../rules.mk

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -45,7 +45,7 @@ R_LIB_VERSION_HEADER(r_asm);
 
 #define R_ASM_GET_NAME(x,y,z) \
 	(x && x->binb.bin && x->binb.get_name)? \
-		x->binb.get_name (x->binb.bin, y, z): NULL 
+		x->binb.get_name (x->binb.bin, y, z): NULL
 
 enum {
 	R_ASM_SYNTAX_NONE = 0,
@@ -160,6 +160,7 @@ R_API int r_asm_assemble(RAsm *a, RAsmOp *op, const char *buf);
 R_API RAsmCode* r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len);
 R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, const char *hexstr);
 R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf);
+R_API RAsmCode* r_asm_rasm_assemble(RAsm *a, const char *buf, bool use_spp);
 R_API RAsmCode* r_asm_assemble_file(RAsm *a, const char *file);
 R_API char *r_asm_to_string(RAsm *a, ut64 addr, const ut8 *b, int l);
 R_API ut8 *r_asm_from_string(RAsm *a, ut64 addr, const char *b, int *l);


### PR DESCRIPTION
Optionally run SPP over rasm2 assembly input with `-p`(reprocessor) argument

Adds a new function to ease the addition of the optional bool to the massemble function.

Removes SPP integration from rasm2 