### PR TITLE
Fix sdb update

### DIFF
--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -94,7 +94,7 @@ R_API int r_anal_type_get_size(RAnal *anal, const char *type) {
 
 R_API RList *r_anal_type_fcn_list(RAnal *anal) {
 	SdbList *sdb_list = sdb_foreach_match (anal->sdb_types, "=^func$", false);
-	RList *list = r_list_new ();
+	RList *list = r_list_newf ((RListFree)r_anal_fcn_free);
 	char *name, *value;
 	const char *key;
 	SdbListIter *sdb_iter;
@@ -126,8 +126,11 @@ R_API RList *r_anal_type_fcn_list(RAnal *anal) {
 			continue;
 		}
 		//XXX we should handle as much calling conventions
-		//for as much architectures as we want here as we want here
-		fcn->vars = r_list_new ();
+		//for as much architectures as we want here
+		fcn->vars = r_list_newf ((RListFree)r_anal_var_free);
+		if (!fcn->vars) {
+			continue;
+		}
 		for (i = 0; i < args_n; i++) {
 			key = r_str_newf ("func.%s.arg.%d", kv->key, i);
 			value = sdb_get (anal->sdb_types, key, 0);
@@ -144,7 +147,7 @@ R_API RList *r_anal_type_fcn_list(RAnal *anal) {
 			}
 		}
 	}
-	ls_destroy (sdb_list);
+	ls_free (sdb_list);
 	if (r_list_empty (list)) {
 		r_list_free (list);
 		return NULL;

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -225,7 +225,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 	case ',': // "CC,"
 		if (input[2]=='?') {
 			eprintf ("Usage: CC, [file]\n");
-		} else if (input[2]==' ') {
+		} else if (input[2] == ' ') {
 			const char *fn = input+2;
 			char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
 			while (*fn== ' ')fn++;

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -172,7 +172,7 @@ static int linklist_readable (void *p, const char *k, const char *v) {
 	return 1;
 
 }
-static int typelist (void *p, const char *k, const char *v) {
+static int typelist(void *p, const char *k, const char *v) {
 	r_cons_printf ("tk %s=%s\n", k, v);
 #if 0
 	if (!strcmp (v, "func")) {


### PR DESCRIPTION
This doesn't fix the metadata test that are currently broken but as far I am concerned I would update the test and go ahead. Isn't important to get metadata info in order of insertion. However, is convenience if the key just at beginning use the direction, in that case the output will be sorted by offsets and is "less" or "grep" friendly and help you to locate stuff more quickly. But it doesn't work quite well or I screwed it up. Will check with time

```
0x080496b4 CCu "[25] va=0x080496b4 pa=0x000006b4 sz=4 vsz=4 rwx=--rw- .bss"
0x08049690 data Cd 4
0x080496a0 data Cd 4
0x080496a4 data Cd 4
0x080496a8 data Cd 4
0x080484b0 string[13] "Hello_world_"
```

The other change while reading your changes @radare are memleaks that I hope won't break anything else but you never know.