### PR TITLE
Overhauled STR, fixed arm reg profile

### DIFF
--- a/libr/include/r_endian.h
+++ b/libr/include/r_endian.h
@@ -1,6 +1,8 @@
 #ifndef R_ENDIAN_H
 #define R_ENDIAN_H
 
+extern "C" {
+
 /* Endian agnostic functions working on single byte. */
 
 static inline ut8 r_read_ble8(const void *src) {
@@ -74,7 +76,8 @@ static inline void r_write_be32(void *dest, ut32 val) {
 	r_write_at_be16 (dest, val >> 0, sizeof (ut16));
 }
 
-static inline void r_write_be24(void *dest, ut32 val) {
+static inline void r_write_be24(void *_dest, ut32 val) {
+	ut8 *dest = (ut8*)_dest;
 	r_write_be8 (dest++, val >> 16);
 	r_write_be8 (dest++, val >> 8);
 	r_write_be8 (dest, val >> 0);
@@ -144,9 +147,10 @@ static inline void r_write_at_le16(void *dest, ut16 val, size_t offset) {
 	r_write_le16 (d, val);
 }
 
-static inline void r_write_le24(void *dest, ut32 val) {
-	r_write_le8 (dest++, val >> 0);
-	r_write_le8 (dest++, val >> 8);
+static inline void r_write_le24(void *_dest, ut32 val) {
+	ut8* dest = (ut8*)_dest;
+        r_write_le8 (dest++, val >> 0);
+        r_write_le8 (dest++, val >> 8);
 	r_write_le8 (dest,   val >> 16);
 }
 
@@ -270,35 +274,34 @@ static inline void r_write_ble(void *dst, ut64 val, bool big_endian, int size) {
 
 /*swap*/
 static inline ut16 r_swap_ut16(ut16 val) {
-    return (val << 8) | (val >> 8 );
+	return (val << 8) | (val >> 8 );
 }
 
 static inline st16 r_swap_st16(st16 val) {
-    val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
-    return (val << 16) | (val >> 16);
+	val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
+	return (val << 16) | (val >> 16);
 }
 
 static inline ut32 r_swap_ut32(ut32 val) {
-    val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
-    return (val << 16) | (val >> 16);
+	val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
+	return (val << 16) | (val >> 16);
 }
 
 static inline st32 r_swap_st32(st32 val) {
-    val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF );
-    return (val << 16) | ((val >> 16) & 0xFFFF);
+	val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF );
+	return (val << 16) | ((val >> 16) & 0xFFFF);
 }
 
-
 static inline ut64 r_swap_ut64(ut64 val) {
-    val = ((val << 8) & 0xFF00FF00FF00FF00ULL ) | ((val >> 8) & 0x00FF00FF00FF00FFULL );
-    val = ((val << 16) & 0xFFFF0000FFFF0000ULL ) | ((val >> 16) & 0x0000FFFF0000FFFFULL );
-    return (val << 32) | (val >> 32);
+	val = ((val << 8) & 0xFF00FF00FF00FF00ULL ) | ((val >> 8) & 0x00FF00FF00FF00FFULL );
+	val = ((val << 16) & 0xFFFF0000FFFF0000ULL ) | ((val >> 16) & 0x0000FFFF0000FFFFULL );
+	return (val << 32) | (val >> 32);
 }
 
 static inline st64 r_swap_st64(st64 val) {
-    val = ((val << 8) & 0xFF00FF00FF00FF00ULL ) | ((val >> 8) & 0x00FF00FF00FF00FFULL );
-    val = ((val << 16) & 0xFFFF0000FFFF0000ULL ) | ((val >> 16) & 0x0000FFFF0000FFFFULL );
-    return (val << 32) | ((val >> 32) & 0xFFFFFFFFULL);
+	val = ((val << 8) & 0xFF00FF00FF00FF00ULL ) | ((val >> 8) & 0x00FF00FF00FF00FFULL );
+	val = ((val << 16) & 0xFFFF0000FFFF0000ULL ) | ((val >> 16) & 0x0000FFFF0000FFFFULL );
+	return (val << 32) | ((val >> 32) & 0xFFFFFFFFULL);
 }
 
 /* Some "secured" functions, to do basic operation (mul, sub, add...) on integers */
@@ -396,6 +399,8 @@ static inline int UT8_SUB(ut8 *r, ut8 a, ut8 b) {
 	if(r != NULL)
 		*r = a - b;
 	return 1;
+}
+
 }
 
 #endif


### PR DESCRIPTION
Made STR significantly more functional (there's always more that can be done). Fixed the cpsr bit fields, but a strange problem occurred when cpsr was the last register, so there's a hack for now to add a ghost register. This seemed better than having it not work and breaking everything. Also, many conditionals in ARM ESIL were wrong, so I fixed those (some invalid ESIL [missing commas], some the logic incorrect such as != which takes one argument vs. ==, ! which does the "C" !=). Hopefully I can continue to improve the state of ESIL emulation for ARM.