### PR TITLE
Fix: #6507

### DIFF
--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -122,6 +122,10 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 		// XXX - select the right backend
 		if (core->file && core->file->desc) {
 			newpid = core->file->desc->fd;
+#if __linux__
+			core->dbg->main_pid = newpid;
+			newtid = newpid;
+#endif
 #if __WINDOWS__
 			newpid = core->io->winpid;
 			newtid = core->io->wintid;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1117,14 +1117,16 @@ static int r_debug_native_kill (RDebug *dbg, int pid, int tid, int sig) {
 		}
 	} else {
 #endif
-#if __linux__
 	if (sig == SIGKILL && dbg->threads) {
 		r_list_free (dbg->threads);
 		dbg->threads = NULL;
 	}
-#endif
-	if ((r_sandbox_kill (pid, sig) != -1)) ret = true;
-	if (errno == 1) ret = -true; // EPERM
+	if ((r_sandbox_kill (pid, sig) != -1)) {
+		ret = true;
+	}
+	if (errno == 1) {
+		ret = -true; // EPERM
+	}
 #if 0
 //	}
 #endif

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1117,6 +1117,12 @@ static int r_debug_native_kill (RDebug *dbg, int pid, int tid, int sig) {
 		}
 	} else {
 #endif
+#if __linux__
+	if (sig == SIGKILL && dbg->threads) {
+		r_list_free (dbg->threads);
+		dbg->threads = NULL;
+	}
+#endif
 	if ((r_sandbox_kill (pid, sig) != -1)) ret = true;
 	if (errno == 1) ret = -true; // EPERM
 #if 0

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -425,6 +425,7 @@ RList *linux_thread_list(int pid, RList *list) {
 		return NULL;
 	}
 
+	list->free = (RListFree)&r_debug_pid_free;
 	/* if this process has a task directory, use that */
 	snprintf (buf, sizeof (buf), "/proc/%d/task", pid);
 	if (r_file_is_directory (buf)) {

--- a/libr/threads
+++ b/libr/threads
@@ -1,0 +1,1157 @@
+bp/io.c: * reflect all r_bp stuff in the process using dbg->bp_write or ->breakpoint
+bp/io.c: * reflect all r_bp stuff in the process using dbg->bp_write or ->breakpoint
+bp/plugin.c:		eprintf ("Cannot add plugin because dbg->bp is null and/or plugin is null\n");
+core/anal_tp.c:	r_reg_setv (core->dbg->reg, pc, fcn->addr);
+core/anal_tp.c:			r_reg_setv (core->dbg->reg, pc, addr);
+core/anal_tp.c:			r_reg_setv (core->dbg->reg, pc, addr);
+core/canal.c:	if (core->dbg && core->dbg->reg) {
+core/canal.c:		rs = r_reg_regset_get (core->dbg->reg, R_REG_TYPE_GPR);
+core/canal.c:				ut64 val = r_reg_getv(core->dbg->reg, r->name);
+core/canal.c:		r_list_foreach (core->dbg->maps, iter, map) {
+core/cconfig.c:	core->dbg->hitinfo = node->i_value;
+core/cconfig.c:	core->dbg->bpsize = node->i_value;
+core/cconfig.c:	core->dbg->btdepth = node->i_value;
+core/cconfig.c:			if (core->dbg->h && core->dbg->h->reg_profile) {
+core/cconfig.c:				core->dbg->bits = R_SYS_BITS_32;
+core/cconfig.c:				core->dbg->bits = R_SYS_BITS_64;
+core/cconfig.c:				char *rp = core->dbg->h->reg_profile (core->dbg);
+core/cconfig.c:				r_reg_set_profile_string (core->dbg->reg, rp);
+core/cconfig.c:			r_bp_use (core->dbg->bp, asmarch, core->anal->bits);
+core/cconfig.c:	// the big endian should also be assigned to dbg->bp->endian
+core/cconfig.c:	core->dbg->bp->endian = isbig;
+core/cconfig.c:			r_debug_select (core->dbg, core->dbg->pid,
+core/cconfig.c:					core->dbg->tid);
+core/cconfig.c:		if (core->dbg && core->dbg->h) {
+core/cconfig.c:			ioraw = core->dbg->h->keepio? 0: 1;
+core/cconfig.c:	free (core->dbg->btalgo);
+core/cconfig.c:	core->dbg->btalgo = strdup (node->value);
+core/cconfig.c:	free (core->dbg->glob_libs);
+core/cconfig.c:	core->dbg->glob_libs = strdup (node->value);
+core/cconfig.c:	free (core->dbg->glob_unlibs);
+core/cconfig.c:	core->dbg->glob_unlibs = strdup (node->value);
+core/cconfig.c:	core->dbg->trace_forks = node->i_value;
+core/cconfig.c:		r_debug_attach (core->dbg, core->dbg->pid);
+core/cconfig.c:	core->dbg->trace_execs = node->i_value;
+core/cconfig.c:		r_debug_attach (core->dbg, core->dbg->pid);
+core/cconfig.c:	core->dbg->trace_clone = node->i_value;
+core/cconfig.c:		r_debug_attach (core->dbg, core->dbg->pid);
+core/cconfig.c:	core->dbg->trace_aftersyscall = node->i_value;
+core/cconfig.c:		r_debug_attach (core->dbg, core->dbg->pid);
+core/cconfig.c:	core->dbg->regcols = c/4;
+core/cconfig.c:	core->dbg->regcols = n / 20;
+core/cconfig.c:	core->dbg->stop_all_threads = node->i_value;
+core/cconfig.c:	core->dbg->swstep = node->i_value;
+core/cconfig.c:	core->dbg->consbreak = node->i_value;
+core/cconfig.c:	core->dbg->trace->enabled = node->i_value;
+core/cconfig.c:	core->dbg->trace->tag = node->i_value;
+core/cconfig.c:	node->i_value = core->dbg->swstep;
+core/cmd.c:		if (dbg && dbg->h && dbg->h->threads) {
+core/cmd.c:			int origpid = dbg->pid;
+core/cmd.c:			list = dbg->h->threads (dbg, dbg->pid);
+core/cmd.c:				head = r_reg_get_list (dbg->reg, i);
+core/cmd.c:					value = r_reg_get_value (dbg->reg, item);
+core/cmd.c:			int pid = core->dbg->pid;
+core/cmd.c:			if (core->dbg->h && core->dbg->h->pids) {
+core/cmd.c:				RList *list = core->dbg->h->pids (core->dbg, R_MAX (0, pid));
+core/cmd_anal.c:	RReg *hack = core->dbg->reg;
+core/cmd_anal.c:	core->dbg->reg = core->anal->reg;
+core/cmd_anal.c:	core->dbg->reg = hack;
+core/cmd_anal.c:		ut8 *buf = r_reg_get_bytes (core->dbg->reg, type, &len);
+core/cmd_anal.c:				r = r_reg_cond_get (core->dbg->reg, name);
+core/cmd_anal.c:					RRegFlags *rf = r_reg_cond_retrieve (core->dbg->reg, NULL);
+core/cmd_anal.c:						int o = r_reg_cond_bits (core->dbg->reg, id, rf);
+core/cmd_anal.c:				RRegFlags *rf = r_reg_cond_retrieve (core->dbg->reg, NULL);
+core/cmd_anal.c:								r_reg_cond_bits (core->dbg->reg, i, rf));
+core/cmd_anal.c:								r_reg_cond_bits (core->dbg->reg, i, rf),
+core/cmd_anal.c:			r_reg_arena_pop (core->dbg->reg);
+core/cmd_anal.c:			r_reg_arena_push (core->dbg->reg);
+core/cmd_anal.c:						core->dbg->reg->regset[0].pool));
+core/cmd_anal.c:		name = r_reg_get_name (core->dbg->reg, r_reg_get_name_idx (str + 2));
+core/cmd_anal.c:		r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_anal.c:		r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_anal.c:			r = r_reg_get (core->dbg->reg, regname, -1);
+core/cmd_anal.c:					const char *alias = r_reg_get_name (core->dbg->reg, type);
+core/cmd_anal.c:					r = r_reg_get (core->dbg->reg, alias, -1);
+core/cmd_anal.c:				//	r_reg_get_value (core->dbg->reg, r));
+core/cmd_anal.c:				r_reg_set_value (core->dbg->reg, r,
+core/cmd_anal.c:				//	r_reg_get_value (core->dbg->reg, r));
+core/cmd_anal.c:			r = r_reg_get (core->dbg->reg, str + 1, -1);
+core/cmd_anal.c:					off = r_reg_get_value_big (core->dbg->reg, r, &value);
+core/cmd_anal.c:					off = r_reg_get_value (core->dbg->reg, r);
+core/cmd_anal.c:		if (core->dbg->trace->enabled) {
+core/cmd_anal.c:			RReg *reg = core->dbg->reg;
+core/cmd_anal.c:			core->dbg->reg = core->anal->reg;
+core/cmd_anal.c:			core->dbg->reg = reg;
+core/cmd_anal.c:	sp = r_reg_get_name (core->dbg->reg, R_REG_NAME_SP);
+core/cmd_anal.c:	sp = r_reg_get_name (core->dbg->reg, R_REG_NAME_BP);
+core/cmd_anal.c:		eprintf ("Current Tag: %d\n", core->dbg->trace->tag);
+core/cmd_anal.c:		r_debug_trace_free (core->dbg->trace);
+core/cmd_anal.c:		core->dbg->trace = r_debug_trace_new ();
+core/cmd_debug.c:	r_list_foreach (r->dbg->maps, iter, map) {
+core/cmd_debug.c:	r_list_foreach (r->dbg->maps, iter, map) {
+core/cmd_debug.c:	r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:	if (!core || !esilstr || !core->dbg || !core->dbg->anal \
+core/cmd_debug.c:			|| !core->dbg->anal->esil) {
+core/cmd_debug.c:		eprintf ("Selected: %d %d\n", core->dbg->pid, core->dbg->tid);
+core/cmd_debug.c:		r_debug_pid_list (core->dbg, core->dbg->pid, 0);
+core/cmd_debug.c:			r_debug_detach (core->dbg, core->dbg->pid);
+core/cmd_debug.c:		if (core->dbg->forked_pid != -1) {
+core/cmd_debug.c:				eprintf ("dp %d\n", core->dbg->forked_pid);
+core/cmd_debug.c:				r_debug_select (core->dbg, core->dbg->forked_pid, core->dbg->tid);
+core/cmd_debug.c:				core->dbg->forked_pid = -1;
+core/cmd_debug.c:				r_debug_thread_list (core->dbg, core->dbg->pid);
+core/cmd_debug.c:				r_debug_select (core->dbg, core->dbg->pid,
+core/cmd_debug.c:		r_debug_select (core->dbg, core->dbg->pid, core->dbg->tid);
+core/cmd_debug.c:				(core->dbg->h && !core->dbg->h->canstep));
+core/cmd_debug.c:		r_core_cmdf (core, "=!pid %d", core->dbg->pid);
+core/cmd_debug.c:			r_debug_select (core->dbg, core->file->desc->fd, core->dbg->tid);
+core/cmd_debug.c:				(int) r_num_math (core->num, input + 2), core->dbg->tid);
+core/cmd_debug.c:		r_debug_pid_list (core->dbg, core->dbg->pid, 'j');
+core/cmd_debug.c:			int pid = (input[2] == ' ')? atoi (input + 2): core->dbg->pid;
+core/cmd_debug.c:		r_bp_traptrace_list (core->dbg->bp);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_bp_traptrace_reset (core->dbg->bp, true);
+core/cmd_debug.c:		r_bp_traptrace_add (core->dbg->bp, core->offset, core->offset+len);
+core/cmd_debug.c:		r_bp_traptrace_enable (core->dbg->bp, true);
+core/cmd_debug.c:		} while (r_bp_traptrace_at (core->dbg->bp, addr, analop.size));
+core/cmd_debug.c:		r_bp_traptrace_enable (core->dbg->bp, false);
+core/cmd_debug.c:	r_list_foreach (dbg->snaps, iter, snap) {
+core/cmd_debug.c:			dbg->iob.read_at (dbg->iob.io, snap->addr, b , snap->size);
+core/cmd_debug.c:	int ret = r_list_empty(core->dbg->maps)? false: true;
+core/cmd_debug.c:	r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_debug.c:		r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_debug.c:				r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_debug.c:		r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_debug.c:			r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_debug.c:		r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_debug.c:		value = r_reg_get_value (core->dbg->reg, r);
+core/cmd_debug.c:		if (core->dbg->reg->reg_profile_str) {
+core/cmd_debug.c:			r_cons_println (core->dbg->reg->reg_profile_str);
+core/cmd_debug.c:		r_reg_set_profile (core->dbg->reg, str+2);
+core/cmd_debug.c:			RRegSet *rs = r_reg_regset_get (core->dbg->reg, R_REG_TYPE_GPR);
+core/cmd_debug.c:			RRegSet *rs = r_reg_regset_get (core->dbg->reg, R_REG_TYPE_GPR);
+core/cmd_debug.c:			RRegSet *rs = r_reg_regset_get (core->dbg->reg, R_REG_TYPE_GPR);
+core/cmd_debug.c:				if (core->dbg->reg->name[i]) {
+core/cmd_debug.c:							core->dbg->reg->name[i]);
+core/cmd_debug.c:				r_list_foreach (core->dbg->reg->regset[i].regs, iter, r) {
+core/cmd_debug.c:	int bits = (core->dbg->bits & R_SYS_BITS_64)? 64: 32;
+core/cmd_debug.c:		if (core->dbg->reg->reg_profile_cmt) {
+core/cmd_debug.c:			r_cons_println (core->dbg->reg->reg_profile_cmt);
+core/cmd_debug.c:			//		r = r_reg_get (core->dbg->reg, str+1, 0);
+core/cmd_debug.c:			//r_reg_get_value (core->dbg->reg, r));
+core/cmd_debug.c:			RRegSet *rs = r_reg_regset_get (core->dbg->reg, R_REG_TYPE_GPR);
+core/cmd_debug.c:			ut8 *buf = r_reg_get_bytes (core->dbg->reg, type, &len);
+core/cmd_debug.c:				r = r_reg_cond_get (core->dbg->reg, name);
+core/cmd_debug.c:					RRegFlags* rf = r_reg_cond_retrieve (core->dbg->reg, NULL);
+core/cmd_debug.c:						int o = r_reg_cond_bits (core->dbg->reg, id, rf);
+core/cmd_debug.c:				RRegFlags *rf = r_reg_cond_retrieve (core->dbg->reg, NULL);
+core/cmd_debug.c:									r_reg_cond_bits (core->dbg->reg, i, rf));
+core/cmd_debug.c:									r_reg_cond_bits (core->dbg->reg, i, rf),
+core/cmd_debug.c:						core->dbg->reg->regset[0].pool));
+core/cmd_debug.c:			r_reg_arena_pop (core->dbg->reg);
+core/cmd_debug.c:			r_reg_arena_push (core->dbg->reg);
+core/cmd_debug.c:			RRegItem *item = r_reg_get (core->dbg->reg, name, -1);
+core/cmd_debug.c:					r_reg_set_pack (core->dbg->reg, item, word, size, val);
+core/cmd_debug.c:					ut64 res = r_reg_get_pack (core->dbg->reg, item, word, size);
+core/cmd_debug.c:			RRegItem *item = r_reg_get (core->dbg->reg, name, -1);
+core/cmd_debug.c:					r_reg_set_double (core->dbg->reg, item, val);
+core/cmd_debug.c:					long double res = r_reg_get_double (core->dbg->reg, item);
+core/cmd_debug.c:					const char *regname = r_reg_get_name (core->dbg->reg, role);
+core/cmd_debug.c:							size = core->dbg->bits * 8;
+core/cmd_debug.c:			name = r_reg_get_name (core->dbg->reg, r_reg_get_name_idx (foo));
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_debug.c:				} //else eprintf ("Cannot retrieve registers from pid %d\n", core->dbg->pid);
+core/cmd_debug.c:				RReg *orig = core->dbg->reg;
+core/cmd_debug.c:				core->dbg->reg = core->anal->reg;
+core/cmd_debug.c:				core->dbg->reg = orig;
+core/cmd_debug.c:		r_core_debug_rr (core, core->dbg->reg);
+core/cmd_debug.c:		} else eprintf ("Cannot retrieve registers from pid %d\n", core->dbg->pid);
+core/cmd_debug.c:			regname = r_reg_get_name (core->dbg->reg, r_reg_get_name_idx (string));
+core/cmd_debug.c:			r = r_reg_get (core->dbg->reg, regname, -1); //R_REG_TYPE_GPR);
+core/cmd_debug.c:							r_reg_get_value (core->dbg->reg, r));
+core/cmd_debug.c:					r_reg_set_bvalue (core->dbg->reg, r, arg+1);
+core/cmd_debug.c:							r_reg_get_value (core->dbg->reg, r));
+core/cmd_debug.c:							r_reg_get_value (core->dbg->reg, r));
+core/cmd_debug.c:					r_reg_set_value (core->dbg->reg, r,
+core/cmd_debug.c:							r_reg_get_value (core->dbg->reg, r));
+core/cmd_debug.c:	r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_debug.c:			bpi = r_bp_get_at (core->dbg->bp, core->offset);
+core/cmd_debug.c:					r_bp_set_trace_all (core->dbg->bp,true);
+core/cmd_debug.c:				} else if (!r_bp_set_trace (core->dbg->bp, addr, true)) {
+core/cmd_debug.c:					r_bp_set_trace_all (core->dbg->bp,false);
+core/cmd_debug.c:				} else if (!r_bp_set_trace (core->dbg->bp, addr, false)) {
+core/cmd_debug.c:				bpi = r_bp_get_at (core->dbg->bp, addr);
+core/cmd_debug.c:					if (core->dbg->bits & R_SYS_BITS_64) {
+core/cmd_debug.c:					} else if (core->dbg->bits & R_SYS_BITS_32) {
+core/cmd_debug.c:			core->dbg->bp->delta = (st64)r_num_math (core->num, input + 2);
+core/cmd_debug.c:			r_cons_printf ("%"PFMT64d"\n", core->dbg->bp->delta);
+core/cmd_debug.c:	case 'j': r_bp_list (core->dbg->bp, 'j'); break;
+core/cmd_debug.c:	case '*': r_bp_list (core->dbg->bp, 1); break;
+core/cmd_debug.c:	case '\0': r_bp_list (core->dbg->bp, 0); break;
+core/cmd_debug.c:		if (input[2] == '*') r_bp_del_all (core->dbg->bp);
+core/cmd_debug.c:		else r_bp_del (core->dbg->bp, r_num_math (core->num, input + 2));
+core/cmd_debug.c:					bpi = r_bp_get_at (core->dbg->bp, addr);
+core/cmd_debug.c:					bpi = r_bp_get_at (core->dbg->bp, addr);
+core/cmd_debug.c:		bpi = r_bp_get_at (core->dbg->bp, addr);
+core/cmd_debug.c:			r_bp_del (core->dbg->bp, addr);
+core/cmd_debug.c:		r_bp_enable (core->dbg->bp, r_num_math (core->num, input + 2), 0);
+core/cmd_debug.c:		bpi = r_bp_get_at (core->dbg->bp, core->offset);
+core/cmd_debug.c:		if (*p == '*') r_bp_enable_all (core->dbg->bp,true);
+core/cmd_debug.c:		else r_bp_enable (core->dbg->bp, r_num_math (core->num, input + 2), true);
+core/cmd_debug.c:		if (*p == '*') r_bp_enable_all (core->dbg->bp, false);
+core/cmd_debug.c:		r_bp_enable (core->dbg->bp, r_num_math (core->num, input + 2), false);
+core/cmd_debug.c:				r_bp_plugin_list (core->dbg->bp);
+core/cmd_debug.c:				if (!r_bp_use (core->dbg->bp, input + 3, core->anal->bits))
+core/cmd_debug.c:				r_bp_del (core->dbg->bp, r_num_math (core->num, p + 1));
+core/cmd_debug.c:			for (i = 0;i < core->dbg->bp->bps_idx_count; i++) {
+core/cmd_debug.c:				if ((bpi = core->dbg->bp->bps_idx[i])) {
+core/cmd_debug.c:				if (p && (bpi = r_bp_get_index (core->dbg->bp, addr))) {
+core/cmd_debug.c:			if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
+core/cmd_debug.c:			if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
+core/cmd_debug.c:			if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
+core/cmd_debug.c:				if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
+core/cmd_debug.c:				if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
+core/cmd_debug.c:				if ((bpi = r_bp_get_index (core->dbg->bp, addr))) {
+core/cmd_debug.c:	Sdb *tracenodes = core->dbg->tracenodes;
+core/cmd_debug.c:	RTree *tr = core->dbg->tree;
+core/cmd_debug.c:	int t = core->dbg->trace->enabled;
+core/cmd_debug.c:	core->dbg->trace->enabled = 0;
+core/cmd_debug.c:	r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_bp_del (core->dbg->bp, final_addr);
+core/cmd_debug.c:	trace_traverse (core->dbg->tree);
+core/cmd_debug.c:	core->dbg->trace->enabled = t;
+core/cmd_debug.c:			r_debug_kill (core->dbg, core->dbg->pid, core->dbg->tid, sig);
+core/cmd_debug.c:		eprintf ("Continue until 0x%08"PFMT64x" using %d bpsize\n", addr, core->dbg->bpsize);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_bp_add_sw (core->dbg->bp, addr, core->dbg->bpsize, R_BP_PROT_EXEC);
+core/cmd_debug.c:		r_bp_del (core->dbg->bp, addr);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		old_pid = core->dbg->pid;
+core/cmd_debug.c:		main_pid = core->dbg->main_pid;
+core/cmd_debug.c:		if (core->dbg->threads) {
+core/cmd_debug.c:			list = core->dbg->threads;
+core/cmd_debug.c:			if (core->dbg->h && core->dbg->h->threads) {
+core/cmd_debug.c:				list = core->dbg->h->threads (core->dbg, core->dbg->pid);
+core/cmd_debug.c:		r_debug_select (core->dbg, old_pid, core->dbg->tid);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:			int old_pid = core->dbg->pid;
+core/cmd_debug.c:			int old_tid = core->dbg->tid;
+core/cmd_debug.c:			int t = core->dbg->trace->enabled;
+core/cmd_debug.c:			core->dbg->trace->enabled = 0;
+core/cmd_debug.c:			core->dbg->trace->enabled = t;
+core/cmd_debug.c:		old_pid = core->dbg->pid;
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_debug_select (core->dbg, pid, core->dbg->tid);
+core/cmd_debug.c:		r_debug_select (core->dbg, old_pid, core->dbg->tid);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:			r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:			RBreakpointItem *bpi = r_bp_get_at (core->dbg->bp, addr);
+core/cmd_debug.c:			r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:			RBreakpointItem *bpi = r_bp_get_at (core->dbg->bp, addr);
+core/cmd_debug.c:			r_bp_del (core->dbg->bp, addr);
+core/cmd_debug.c:			r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:		r_reg_arena_swap (core->dbg->reg, true);
+core/cmd_debug.c:					dot_trace_traverse (core, core->dbg->tree, input[2]);
+core/cmd_debug.c:					r_tree_reset (core->dbg->tree);
+core/cmd_debug.c:					r_debug_trace_free (core->dbg->trace);
+core/cmd_debug.c:					core->dbg->trace = r_debug_trace_new ();
+core/cmd_debug.c:							const char *s = r_debug_signal_resolve_i (core->dbg, core->dbg->reason.signum);
+core/cmd_debug.c:							P ("type=%s\n", r_debug_reason_to_string (core->dbg->reason.type));
+core/cmd_debug.c:							P ("signum=%d\n", core->dbg->reason.signum);
+core/cmd_debug.c:							P ("sigpid=%d\n", core->dbg->reason.tid);
+core/cmd_debug.c:							P ("addr=0x%"PFMT64x"\n", core->dbg->reason.addr);
+core/cmd_debug.c:							P ("bp_addr=0x%"PFMT64x"\n", core->dbg->reason.bp_addr);
+core/cmd_debug.c:							P ("inbp=%s\n", r_str_bool (core->dbg->reason.bp_addr));
+core/cmd_debug.c:							const char *s = r_debug_signal_resolve_i (core->dbg, core->dbg->reason.signum);
+core/cmd_debug.c:							P ("\"type\":\"%s\",", r_debug_reason_to_string (core->dbg->reason.type));
+core/cmd_debug.c:							P ("\"signum\":%d,", core->dbg->reason.signum);
+core/cmd_debug.c:							P ("\"sigpid\":%d,", core->dbg->reason.tid);
+core/cmd_debug.c:							P ("\"addr\":%"PFMT64d",", core->dbg->reason.addr);
+core/cmd_debug.c:							P ("\"inbp\":%s,", r_str_bool (core->dbg->reason.bp_addr));
+core/cmd_debug.c:							r_reg_arena_push (core->dbg->reg);
+core/cmd_debug.c:							r_reg_arena_pop (core->dbg->reg);
+core/cmd_debug.c:						r_reg_arena_push (core->dbg->reg);
+core/cmd_debug.c:						r_reg_arena_pop (core->dbg->reg);
+core/cmd_debug.c:					r_reg_arena_push (core->dbg->reg);
+core/cmd_debug.c:					r_reg_arena_pop (core->dbg->reg);
+core/cmd_debug.c:				//int opid = core->dbg->pid = pid;
+core/cmd_debug.c:			if (core->dbg->h && core->dbg->h->gcore) {
+core/cmd_debug.c:				if (core->dbg->pid == -1) {
+core/cmd_debug.c:				char *corefile = get_corefile_name (input + 1, core->dbg->pid);
+core/cmd_debug.c:					if (!core->dbg->h->gcore (core->dbg, dst)) {
+core/cmd_print.c:	core->print->reg = core->dbg->reg;
+core/cmd_print.c:			RList *pids = (core->dbg->h && core->dbg->h->pids)
+core/cmd_print.c:				? core->dbg->h->pids (core->dbg, 0): NULL;
+core/cmd_search.c:				r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_search.c:				r_list_foreach (core->dbg->maps, iter, map) {
+core/cmd_search_rop.c:	regs = r_reg_get_list (core->dbg->reg, 0);
+core/cmd_search_rop.c:		r_reg_arena_pop (core->dbg->reg);
+core/cmd_search_rop.c:		r_reg_set_value (core->dbg->reg, reg_item, nr);
+core/cmd_search_rop.c:		r_reg_arena_push (core->dbg->reg);
+core/cmd_search_rop.c:		head = r_reg_get_list (core->dbg->reg, 0);
+core/cmd_search_rop.c:		head = r_reg_get_list (core->dbg->reg, 0);
+core/cmd_search_rop.c:			value_dst = r_reg_get_value (core->dbg->reg, item_dst);
+core/cmd_search_rop.c:			r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:			diff_dst = r_reg_get_value (core->dbg->reg, item_dst);
+core/cmd_search_rop.c:			r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:			r_reg_set_value (core->dbg->reg, item_dst, diff_dst);
+core/cmd_search_rop.c:		head = r_reg_get_list (core->dbg->reg, 0);
+core/cmd_search_rop.c:		head = r_reg_get_list (core->dbg->reg, 0);
+core/cmd_search_rop.c:			value_dst = r_reg_get_value (core->dbg->reg, item_dst);
+core/cmd_search_rop.c:			r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:			diff_dst = r_reg_get_value (core->dbg->reg, item_dst);
+core/cmd_search_rop.c:			r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:				value_src = r_reg_get_value (core->dbg->reg, item_src);
+core/cmd_search_rop.c:				r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:				diff_src = r_reg_get_value (core->dbg->reg, item_src);
+core/cmd_search_rop.c:				r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:				r_reg_set_value (core->dbg->reg, item_src, diff_src);
+core/cmd_search_rop.c:		head = r_reg_get_list (core->dbg->reg, 0);
+core/cmd_search_rop.c:				value_src1 = r_reg_get_value (core->dbg->reg, item_src1);
+core/cmd_search_rop.c:				r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:				diff_src1 = r_reg_get_value (core->dbg->reg, item_src1);
+core/cmd_search_rop.c:				r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:					value_src2 = r_reg_get_value (core->dbg->reg, item_src2);
+core/cmd_search_rop.c:					r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:					diff_src2 = r_reg_get_value (core->dbg->reg, item_src2);
+core/cmd_search_rop.c:						value_dst = r_reg_get_value (core->dbg->reg, item_dst);
+core/cmd_search_rop.c:						r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:		head = r_reg_get_list (core->dbg->reg, 0);
+core/cmd_search_rop.c:				value_src1 = r_reg_get_value (core->dbg->reg, item_src1);
+core/cmd_search_rop.c:				r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:				diff_src1 = r_reg_get_value (core->dbg->reg, item_src1);
+core/cmd_search_rop.c:				r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:					value_dst = r_reg_get_value (core->dbg->reg, item_dst);
+core/cmd_search_rop.c:					r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_search_rop.c:					diff_dst = r_reg_get_value (core->dbg->reg, item_dst);
+core/cmd_search_rop.c:					r_reg_arena_swap (core->dbg->reg, false);
+core/cmd_seek.c:				RReg *orig = core->dbg->reg;
+core/cmd_seek.c:				core->dbg->reg = core->anal->reg;
+core/cmd_seek.c:				core->dbg->reg = orig;
+core/core.c:		case 'P': return (core->dbg->pid > 0)? core->dbg->pid: 0;
+core/core.c:				r_list_foreach (core->dbg->maps, iter, map) {
+core/core.c:	if (core->dbg->sgnls) {
+core/core.c:		core->dbg->sgnls->refs++;
+core/core.c:		sdb_ns_set (d, "signals", core->dbg->sgnls);
+core/core.c:				r_list_foreach (core->dbg->maps, iter, map) {
+core/core.c:	r_core_bind (core, &core->dbg->corebind);
+core/core.c:	core->dbg->cb_printf = (PrintfCallback)r_cons_printf;
+core/core.c:	core->dbg->anal = core->anal; // XXX: dupped instance.. can cause lost pointerz
+core/core.c://	r_reg_arena_push (core->dbg->reg); // create a 2 level register state stack
+core/core.c://	core->dbg->anal->reg = core->anal->reg; // XXX: dupped instance.. can cause lost pointerz
+core/core.c:	core->dbg->cb_printf = r_cons_printf;
+core/core.c:	core->dbg->bp->cb_printf = r_cons_printf;
+core/core.c:	r_bp_use (core->dbg->bp, R_SYS_ARCH, core->anal->bits);
+core/disasm.c:		r_list_foreach (core->dbg->maps, iter, map) {
+core/disasm.c:	p = r_bp_get_at (core->dbg->bp, ds->at);
+core/file.c:		r_debug_kill (core->dbg, core->dbg->pid, core->dbg->tid, 9); // KILL
+core/file.c:			core->dbg->main_pid = newpid;
+core/file.c:	r_list_foreach (core->dbg->maps, iter, map) {
+core/file.c:	r_list_foreach (core->dbg->maps, iter, map) {
+core/file.c:	bp = r_bp_add_sw (r->dbg->bp, fi->offset, 1, R_BP_PROT_EXEC);
+core/file.c:		r_debug_select (r->dbg, r->dbg->pid, r->dbg->tid);
+core/file.c:		if (r->dbg->h && r->dbg->h->canstep) {
+core/graph.c:		const char *pc = r_reg_get_name (core->dbg->reg, R_REG_NAME_PC);
+core/graph.c:		RRegItem *r = r_reg_get (core->dbg->reg, pc, -1);
+core/graph.c:		ut64 addr = r_reg_get_value (core->dbg->reg, r);
+core/libs.c:CB (bp, dbg->bp)
+core/linux_heap_glibc.c:	r_list_foreach (core->dbg->maps, iter, map) {
+core/linux_heap_glibc.c:	if (!core || !core->dbg || !core->dbg->maps) {
+core/linux_heap_glibc.c:		r_list_foreach (core->dbg->maps, iter, map) {
+core/linux_heap_glibc.c:	if (!core || !core->dbg || !core->dbg->maps) {
+core/linux_heap_glibc.c:	if (!core || !core->dbg || !core->dbg->maps) {
+core/linux_heap_glibc.c:	if (!core || !core->dbg || !core->dbg->maps) {
+core/linux_heap_glibc.c:	if (!core || !core->dbg || !core->dbg->maps) {
+core/linux_heap_glibc.c:	if (!core || !core->dbg || !core->dbg->maps) {
+core/linux_heap_glibc.c:	if (!core || !core->dbg || !core->dbg->maps){
+core/visual.c:		const int cols = core->dbg->regcols;
+core/visual.c:		const int cols = core->dbg->regcols;
+core/visual.c:				const char *creg = core->dbg->creg;
+core/visual.c:		RBreakpointItem *bp = r_bp_get_at (core->dbg->bp, addr);
+core/visual.c:			r_bp_del (core->dbg->bp, addr);
+core/visual.c:			r_bp_add_sw (core->dbg->bp, addr, 1, R_BP_PROT_EXEC);
+debug/arg.c:		if (dbg->bits == 64) {
+debug/arg.c:			dbg->iob.read_at (dbg->iob.io, sp, (ut8*)&n64, sizeof(ut64));
+debug/arg.c:			dbg->iob.read_at (dbg->iob.io, sp, (ut8*)&n32, sizeof(ut32));
+debug/ddesc.c:	if (dbg && dbg->h && dbg->h->desc.open)
+debug/ddesc.c:		return dbg->h->desc.open (path);
+debug/ddesc.c:	if (dbg && dbg->h && dbg->h->desc.close)
+debug/ddesc.c:		return dbg->h->desc.close (fd);
+debug/ddesc.c:	if (dbg && dbg->h && dbg->h->desc.dup)
+debug/ddesc.c:		return dbg->h->desc.dup (fd, newfd);
+debug/ddesc.c:	if (dbg && dbg->h && dbg->h->desc.read)
+debug/ddesc.c:		return dbg->h->desc.read (fd, addr, len);
+debug/ddesc.c:	if (dbg && dbg->h && dbg->h->desc.seek)
+debug/ddesc.c:		return dbg->h->desc.seek (fd, addr);
+debug/ddesc.c:	if (dbg && dbg->h && dbg->h->desc.write)
+debug/ddesc.c:		return dbg->h->desc.write (fd, addr, len);
+debug/ddesc.c:		if (dbg && dbg->cb_printf)
+debug/ddesc.c:			dbg->cb_printf ("TODO \n");
+debug/ddesc.c:		if (dbg && dbg->h && dbg->h->desc.list) {
+debug/ddesc.c:			list = dbg->h->desc.list (dbg->pid);
+debug/ddesc.c:				dbg->cb_printf ("%i 0x%"PFMT64x" %c%c%c %s\n", p->fd, p->off,
+debug/debug.c:	if (!dbg || !dbg->h || !dbg->h->info) {
+debug/debug.c:	return dbg->h->info (dbg, arg);
+debug/debug.c:	if (dbg->trace->enabled) {
+debug/debug.c:	if (!r_bp_restore (dbg->bp, false)) { // unset sw breakpoints
+debug/debug.c:	if (!dbg->swstep && dbg->recoil_mode != R_DBG_RECOIL_NONE) {
+debug/debug.c:		dbg->reason.bp_addr = 0;
+debug/debug.c:	b = r_bp_get_at (dbg->bp, pc);
+debug/debug.c:	b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
+debug/debug.c:	if (!r_reg_set_value (dbg->reg, pc_ri, pc)) {
+debug/debug.c:		dbg->reason.bp_addr = 0;
+debug/debug.c:	dbg->reason.bp_addr = b->addr;
+debug/debug.c:	if (dbg->hitinfo) {
+debug/debug.c:	if (dbg->corebind.core && dbg->corebind.bphit) {
+debug/debug.c:		dbg->corebind.bphit (dbg->corebind.core, b);
+debug/debug.c:	if (!r_bp_restore (dbg->bp, true))
+debug/debug.c:	dbg->recoil_mode = R_DBG_RECOIL_NONE;
+debug/debug.c:	if (!dbg->reason.bp_addr) {
+debug/debug.c:	if (dbg->recoil_mode != R_DBG_RECOIL_NONE) {
+debug/debug.c:		if (dbg->swstep) {
+debug/debug.c:			if (!r_bp_restore_except (dbg->bp, true, dbg->reason.bp_addr)) {
+debug/debug.c:	dbg->recoil_mode = rc_mode;
+debug/debug.c:	if (!dbg->reason.bp_addr && dbg->recoil_mode == R_DBG_RECOIL_STEP) {
+debug/debug.c:#define CMP_ARCH(x) strncmp (dbg->arch, (x), R_MIN (len_arch, strlen ((x))))
+debug/debug.c:	int bpsz , len_arch = strlen (dbg->arch);
+debug/debug.c:			addr = (ut64)r_num_math (dbg->num, module);
+debug/debug.c:		r_list_foreach (dbg->maps, iter, map) {
+debug/debug.c:		r_list_foreach (dbg->maps, iter, map) {
+debug/debug.c:		? r_bp_add_hw (dbg->bp, addr, bpsz, R_BP_PROT_EXEC)
+debug/debug.c:		: r_bp_add_sw (dbg->bp, addr, bpsz, R_BP_PROT_EXEC);
+debug/debug.c:	dbg->arch = strdup (R_SYS_ARCH);
+debug/debug.c:	dbg->bits = R_SYS_BITS;
+debug/debug.c:	dbg->trace_forks = 1;
+debug/debug.c:	dbg->forked_pid = -1;
+debug/debug.c:	dbg->trace_clone = 0;
+debug/debug.c:	dbg->trace_aftersyscall = true;
+debug/debug.c:	R_FREE (dbg->btalgo);
+debug/debug.c:	dbg->trace_execs = 0;
+debug/debug.c:	dbg->anal = NULL;
+debug/debug.c:	dbg->snaps = r_list_newf (r_debug_snap_free);
+debug/debug.c:	dbg->pid = -1;
+debug/debug.c:	dbg->bpsize = 1;
+debug/debug.c:	dbg->tid = -1;
+debug/debug.c:	dbg->tree = r_tree_new ();
+debug/debug.c:	dbg->tracenodes = sdb_new0 ();
+debug/debug.c:	dbg->swstep = 0;
+debug/debug.c:	dbg->stop_all_threads = false;
+debug/debug.c:	dbg->trace = r_debug_trace_new ();
+debug/debug.c:	dbg->cb_printf = (void *)printf;
+debug/debug.c:	dbg->reg = r_reg_new ();
+debug/debug.c:	dbg->num = r_num_new (r_debug_num_callback, r_debug_str_callback, dbg);
+debug/debug.c:	dbg->h = NULL;
+debug/debug.c:	dbg->threads = NULL;
+debug/debug.c:	dbg->hitinfo = 1;
+debug/debug.c:	dbg->maps = r_debug_map_list_new ();
+debug/debug.c:	dbg->maps_user = r_debug_map_list_new ();
+debug/debug.c:		dbg->bp = r_bp_new ();
+debug/debug.c:		dbg->bp->iob.init = false;
+debug/debug.c:	sdb_foreach (dbg->tracenodes, (SdbForeachCallback)free_tracenodes_entry, dbg);
+debug/debug.c:	sdb_reset (dbg->tracenodes);
+debug/debug.c:		r_bp_free (dbg->bp);
+debug/debug.c:		//r_reg_free(&dbg->reg);
+debug/debug.c:		r_list_free (dbg->snaps);
+debug/debug.c:		r_list_free (dbg->maps);
+debug/debug.c:		r_list_free (dbg->maps_user);
+debug/debug.c:		r_list_free (dbg->threads);
+debug/debug.c:		r_num_free (dbg->num);
+debug/debug.c:		sdb_free (dbg->sgnls);
+debug/debug.c:		r_tree_free (dbg->tree);
+debug/debug.c:		sdb_foreach (dbg->tracenodes, (SdbForeachCallback)free_tracenodes_entry, dbg);
+debug/debug.c:		sdb_free (dbg->tracenodes);
+debug/debug.c:		r_list_free (dbg->plugins);
+debug/debug.c:		free (dbg->btalgo);
+debug/debug.c:		r_debug_trace_free (dbg->trace);
+debug/debug.c:		dbg->trace = NULL;
+debug/debug.c:		free (dbg->arch);
+debug/debug.c:		free (dbg->glob_libs);
+debug/debug.c:		free (dbg->glob_unlibs);
+debug/debug.c:	if (dbg && dbg->h && dbg->h->attach) {
+debug/debug.c:		ret = dbg->h->attach (dbg, pid);
+debug/debug.c:			r_debug_select (dbg, pid, ret); //dbg->pid, dbg->tid);
+debug/debug.c:	if (dbg && dbg->h && dbg->h->stop) {
+debug/debug.c:		return dbg->h->stop (dbg);
+debug/debug.c:	if (arch && dbg && dbg->h) {
+debug/debug.c:		bool rc = r_sys_arch_match (dbg->h->arch, arch);
+debug/debug.c:				if (dbg->h->bits & R_SYS_BITS_32) {
+debug/debug.c:					dbg->bits = R_SYS_BITS_32;
+debug/debug.c:				dbg->bits = R_SYS_BITS_64;
+debug/debug.c:			if (!dbg->h->bits) {
+debug/debug.c:				dbg->bits = dbg->h->bits;
+debug/debug.c:			} else if (!(dbg->h->bits & dbg->bits)) {
+debug/debug.c:				dbg->bits = dbg->h->bits & R_SYS_BITS_64;
+debug/debug.c:				if (!dbg->bits) {
+debug/debug.c:					dbg->bits = dbg->h->bits & R_SYS_BITS_32;
+debug/debug.c:				if (!dbg->bits) {
+debug/debug.c:					dbg->bits = R_SYS_BITS_32;
+debug/debug.c:			free (dbg->arch);
+debug/debug.c:			dbg->arch = strdup (arch);
+debug/debug.c:	ripc = r_reg_get (dbg->reg, dbg->reg->name[R_REG_NAME_PC], R_REG_TYPE_GPR);
+debug/debug.c:	risp = r_reg_get (dbg->reg, dbg->reg->name[R_REG_NAME_SP], R_REG_TYPE_GPR);
+debug/debug.c:		orig = r_reg_get_bytes (dbg->reg, -1, &orig_sz);
+debug/debug.c:		rpc = r_reg_get_value (dbg->reg, ripc);
+debug/debug.c:		rsp = r_reg_get_value (dbg->reg, risp);
+debug/debug.c:		dbg->iob.read_at (dbg->iob.io, rpc, backup, len);
+debug/debug.c:		dbg->iob.read_at (dbg->iob.io, rsp, stackbackup, len);
+debug/debug.c:		r_bp_add_sw (dbg->bp, rpc+len, dbg->bpsize, R_BP_PROT_EXEC);
+debug/debug.c:		dbg->iob.write_at (dbg->iob.io, rpc, buf, len);
+debug/debug.c:		//r_bp_add_sw (dbg->bp, rpc+len, 4, R_BP_PROT_EXEC);
+debug/debug.c:		//r_bp_del (dbg->bp, rpc+len);
+debug/debug.c:		r_bp_del (dbg->bp, rpc+len);
+debug/debug.c:		dbg->iob.write_at (dbg->iob.io, rpc, backup, len);
+debug/debug.c:			dbg->iob.write_at (dbg->iob.io, rsp, stackbackup, len);
+debug/debug.c:		ri = r_reg_get (dbg->reg, dbg->reg->name[R_REG_NAME_A0], R_REG_TYPE_GPR);
+debug/debug.c:		ra0 = r_reg_get_value (dbg->reg, ri);
+debug/debug.c:			r_reg_read_regs (dbg->reg, orig, orig_sz);
+debug/debug.c:			r_reg_set_value (dbg->reg, ripc, rpc);
+debug/debug.c:	if (dbg->h && dbg->h->detach)
+debug/debug.c:		return dbg->h->detach (dbg, pid);
+debug/debug.c:		if (pid != dbg->pid || tid != dbg->tid) {
+debug/debug.c:		if (dbg->pid != -1)
+debug/debug.c:			eprintf ("Child %d is dead\n", dbg->pid);
+debug/debug.c:	if (dbg->h && dbg->h->select && !dbg->h->select (pid, tid))
+debug/debug.c:	r_io_system (dbg->iob.io, sdb_fmt (0, "pid %d", pid));
+debug/debug.c:	dbg->pid = pid;
+debug/debug.c:	dbg->tid = tid;
+debug/debug.c:	// return dbg->reason
+debug/debug.c:	return dbg->reason.type;
+debug/debug.c:	dbg->reason.type = R_DEBUG_REASON_UNKNOWN;
+debug/debug.c:	if (dbg->h && dbg->h->wait) {
+debug/debug.c:		reason = dbg->h->wait (dbg, dbg->pid);
+debug/debug.c:			pc_ri = r_reg_get (dbg->reg, dbg->reg->name[R_REG_NAME_PC], -1);
+debug/debug.c:			pc = r_reg_get_value (dbg->reg, pc_ri);
+debug/debug.c:			if (dbg->corebind.core && b && b->cond) {
+debug/debug.c:		dbg->reason.type = reason;
+debug/debug.c:		if (reason == R_DEBUG_REASON_SIGNAL && dbg->reason.signum != -1) {
+debug/debug.c:			int what = r_debug_signal_what (dbg, dbg->reason.signum);
+debug/debug.c:			const char *name = r_debug_signal_resolve_i (dbg, dbg->reason.signum);
+debug/debug.c:						dbg->reason.signum, name, what);
+debug/debug.c:	if (dbg->recoil_mode == R_DBG_RECOIL_NONE) {
+debug/debug.c:		dbg->recoil_mode = R_DBG_RECOIL_STEP;
+debug/debug.c:	pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/debug.c:	sp = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_SP]);
+debug/debug.c:	if (!dbg->iob.read_at) {
+debug/debug.c:	if (dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf)) < 0) {
+debug/debug.c:	if (!r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf))) {
+debug/debug.c:		dbg->iob.read_at (dbg->iob.io, sp, (ut8 *)&sp_top, 8);
+debug/debug.c:		next[0] = (dbg->bits == R_SYS_BITS_32) ? sp_top.r32[0] : sp_top.r64;
+debug/debug.c:		if (dbg->iob.read_at (dbg->iob.io, r, (ut8*)&memval, 8) <0 ) {
+debug/debug.c:			next[0] = (dbg->bits == R_SYS_BITS_32) ? memval.r32[0] : memval.r64;
+debug/debug.c:		if (dbg->iob.read_at (dbg->iob.io,
+debug/debug.c:			next[0] = (dbg->bits == R_SYS_BITS_32) ? memval.r32[0] : memval.r64;
+debug/debug.c:		RBreakpointItem *bpi = r_bp_add_sw (dbg->bp, next[i], dbg->bpsize, R_BP_PROT_EXEC);
+debug/debug.c:		r_bp_del (dbg->bp, next[i]);
+debug/debug.c:	dbg->reason.type = R_DEBUG_REASON_STEP;
+debug/debug.c:	if (dbg->recoil_mode == R_DBG_RECOIL_NONE) {
+debug/debug.c:		if (dbg->recoil_mode == R_DBG_RECOIL_STEP) {
+debug/debug.c:			dbg->recoil_mode = R_DBG_RECOIL_NONE;
+debug/debug.c:	if (!dbg->h->step (dbg)) {
+debug/debug.c:	if (!dbg || !dbg->h) {
+debug/debug.c:	dbg->reason.type = R_DEBUG_REASON_STEP;
+debug/debug.c:		if (dbg->swstep) {
+debug/debug.c:		dbg->steps++;
+debug/debug.c:		dbg->reason.type = R_DEBUG_REASON_STEP;
+debug/debug.c:	r_io_bind (io, &dbg->bp->iob);
+debug/debug.c:	r_io_bind (io, &dbg->iob);
+debug/debug.c:	if (dbg->h && dbg->h->step_over) {
+debug/debug.c:			if (!dbg->h->step_over (dbg))
+debug/debug.c:	if (!dbg->anal || !dbg->reg)
+debug/debug.c:	buf_pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/debug.c:	dbg->iob.read_at (dbg->iob.io, buf_pc, buf, sizeof (buf));
+debug/debug.c:		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/debug.c:			dbg->iob.read_at (dbg->iob.io, buf_pc, buf, sizeof (buf));
+debug/debug.c:		if (!r_anal_op (dbg->anal, &op, pc, buf + (pc - buf_pc), sizeof (buf) - (pc - buf_pc))) {
+debug/debug.c:	if (dbg->h && dbg->h->cont) {
+debug/debug.c:		ret = dbg->h->cont (dbg, dbg->pid, dbg->tid, sig);
+debug/debug.c:		//XXX(jjd): why? //dbg->reason.signum = 0;
+debug/debug.c:		if (dbg->corebind.core) {
+debug/debug.c:			RCore *core = (RCore *)dbg->corebind.core;
+debug/debug.c:				if (bp && bp->cond && dbg->corebind.cmd) {
+debug/debug.c:					dbg->corebind.cmd (dbg->corebind.core, bp->cond);
+debug/debug.c:			ret = dbg->tid;
+debug/debug.c:		r_debug_select (dbg, dbg->pid, ret);
+debug/debug.c:		if (dbg->reason.signum != -1) {
+debug/debug.c:			int what = r_debug_signal_what (dbg, dbg->reason.signum);
+debug/debug.c:				sig = dbg->reason.signum;
+debug/debug.c:				dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf));
+debug/debug.c:				r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf));
+debug/debug.c:					const char *signame = r_debug_signal_resolve_i (dbg, dbg->reason.signum);
+debug/debug.c:						dbg->reason.signum, signame);
+debug/debug.c:	return r_debug_continue_kill (dbg, 0); //dbg->reason.signum);
+debug/debug.c:	if (!dbg->anal || !dbg->reg) {
+debug/debug.c:		eprintf ("Undefined pointer at dbg->anal\n");
+debug/debug.c:	buf_pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/debug.c:	dbg->iob.read_at (dbg->iob.io, buf_pc, buf, sizeof (buf));
+debug/debug.c:		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/debug.c:			dbg->iob.read_at (dbg->iob.io, buf_pc, buf, sizeof (buf));
+debug/debug.c:		if (!r_anal_op (dbg->anal, &op, pc, buf + (pc - buf_pc), sizeof (buf) - (pc - buf_pc))) {
+debug/debug.c:	has_bp = r_bp_get_in (dbg->bp, addr, R_BP_PROT_EXEC) != NULL;
+debug/debug.c:		r_bp_add_sw (dbg->bp, addr, dbg->bpsize, R_BP_PROT_EXEC);
+debug/debug.c:		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/debug.c:		if (r_bp_get_at (dbg->bp, pc))
+debug/debug.c:		r_bp_del (dbg->bp, addr);
+debug/debug.c:	si = r_syscall_get (dbg->anal->syscall, reg, -1);
+debug/debug.c:	if (!dbg || !dbg->h || r_debug_is_dead (dbg)) {
+debug/debug.c:	if (!dbg->h->contsc) {
+debug/debug.c:		dbg->h->contsc (dbg, dbg->pid, 0); // TODO handle return value
+debug/debug.c:	if (dbg->h->contsc) {
+debug/debug.c:		ret = dbg->h->contsc (dbg, dbg->pid, num);
+debug/debug.c:	if (dbg->h && dbg->h->kill) {
+debug/debug.c:		return dbg->h->kill (dbg, pid, tid, sig);
+debug/debug.c:	if (dbg && dbg->h && dbg->h->frames) {
+debug/debug.c:		return dbg->h->frames (dbg, at);
+debug/debug.c:	//if (dbg && dbg->h && dbg->h->frames)
+debug/debug.c:		//return dbg->h->frames (dbg);
+debug/debug.c:	//if (dbg && dbg->h && dbg->h->frames)
+debug/debug.c:		//return dbg->h->frames (dbg);
+debug/debug.c:	int is_dead = (dbg->pid == -1);
+debug/debug.c:	if (!is_dead && dbg->h && dbg->h->kill) {
+debug/debug.c:		is_dead = !dbg->h->kill (dbg, dbg->pid, false, 0);
+debug/debug.c:		dbg->reason.type = R_DEBUG_REASON_DEAD;
+debug/debug.c:	if (dbg && dbg->h && dbg->h->map_protect) {
+debug/debug.c:		return dbg->h->map_protect (dbg, addr, size, perms);
+debug/debug.c:	if (dbg && dbg->h && dbg->h->drx) {
+debug/debug.c:		dbg->h->drx (dbg, 0, 0, 0, 0, 0);
+debug/debug.c:	if (dbg && dbg->h && dbg->h->drx) {
+debug/debug.c:		return dbg->h->drx (dbg, idx, addr, len, rwx, g);
+debug/debug.c:	if (dbg && dbg->h && dbg->h->drx) {
+debug/debug.c:		return dbg->h->drx (dbg, idx, 0, -1, 0, 0);
+debug/dreg.c:	if (!dbg || !dbg->reg || !dbg->h) {
+debug/dreg.c:	if (write && !dbg->h->reg_write) {
+debug/dreg.c:	if (!write && !dbg->h->reg_read) {
+debug/dreg.c:	if (i >= R_REG_TYPE_GPR && dbg->reg->regset[i].regs->length == 0) {
+debug/dreg.c:			int mask = dbg->reg->regset[n].maskregstype;
+debug/dreg.c:			ut8 *buf = r_reg_get_bytes (dbg->reg, i, &size);
+debug/dreg.c:			if (!buf || !dbg->h->reg_write (dbg, i, buf, size)) {
+debug/dreg.c:						"registers %d to %d\n", i, dbg->tid);
+debug/dreg.c:			// int bufsize = R_MAX (1024, dbg->reg->size*2); // i know. its hacky
+debug/dreg.c:			int bufsize = dbg->reg->size;
+debug/dreg.c:			//int bufsize = dbg->reg->regset[i].arena->size;
+debug/dreg.c:				//we have already checked dbg->h and dbg->h->reg_read above
+debug/dreg.c:				size = dbg->h->reg_read (dbg, i, buf, bufsize);
+debug/dreg.c:					r_reg_set_bytes (dbg->reg, i, buf, size); //R_MIN (size, bufsize));
+debug/dreg.c:	if (!dbg || !dbg->reg) {
+debug/dreg.c:	if (dbg->corebind.core) {
+debug/dreg.c:		pr = ((RCore*)dbg->corebind.core)->print;
+debug/dreg.c:	if (!(dbg->reg->bits & size)) {
+debug/dreg.c:	if (dbg->bits & R_SYS_BITS_64) {
+debug/dreg.c:		colwidth = dbg->regcols? 20: 25;
+debug/dreg.c:	if (dbg->regcols) {
+debug/dreg.c:		cols = dbg->regcols;
+debug/dreg.c:		dbg->cb_printf ("{");
+debug/dreg.c:	dbg->creg = NULL;
+debug/dreg.c:		head = r_reg_get_list (dbg->reg, i);
+debug/dreg.c:			bool is_arm = dbg->arch && strstr (dbg->arch, "arm");
+debug/dreg.c:					bool is_thumb = r_reg_get_value (dbg->reg, item);
+debug/dreg.c:					if (dbg->anal->bits != new_bits)
+debug/dreg.c:						dbg->cb_printf ("e asm.bits=%d\n", new_bits);
+debug/dreg.c:				value = r_reg_get_value (dbg->reg, item);
+debug/dreg.c:				r_reg_arena_swap (dbg->reg, false);
+debug/dreg.c:				diff = r_reg_get_value (dbg->reg, item);
+debug/dreg.c:				r_reg_arena_swap (dbg->reg, false);
+debug/dreg.c:				value = r_reg_get_value_big (dbg->reg, item, &valueBig);
+debug/dreg.c:				dbg->cb_printf ("%s\"%s\":%s",
+debug/dreg.c:				dbg->cb_printf ("f-%s\n", item->name);
+debug/dreg.c:				dbg->cb_printf ("f %s 1 0x%s\n",
+debug/dreg.c:						dbg->creg = item->name;
+debug/dreg.c:						dbg->cb_printf (use_color);
+debug/dreg.c:						str = r_reg_get_bvalue (dbg->reg, item);
+debug/dreg.c:						dbg->cb_printf (" %s%s%s %s%s", a, item->name, b,
+debug/dreg.c:						dbg->cb_printf (fmt2, a, item->name, b, strvalue,
+debug/dreg.c:						dbg->cb_printf (Color_INVERT_RESET);
+debug/dreg.c:						dbg->cb_printf (Color_RESET);
+debug/dreg.c:					dbg->cb_printf (fmt, item->name, strvalue, woot);
+debug/dreg.c:					dbg->cb_printf (use_color);
+debug/dreg.c:					dbg->cb_printf (fmt, item->name, strvalue, Color_RESET"\n");
+debug/dreg.c:					dbg->cb_printf (fmt, item->name, strvalue, "\n");
+debug/dreg.c:		dbg->cb_printf ("}\n");
+debug/dreg.c:		dbg->cb_printf ("\n");
+debug/dreg.c:	if (!dbg || !dbg->reg) {
+debug/dreg.c:		name = r_reg_get_name (dbg->reg, role);
+debug/dreg.c:	ri = r_reg_get (dbg->reg, name, R_REG_TYPE_ALL);
+debug/dreg.c:		r_reg_set_value (dbg->reg, ri, num);
+debug/dreg.c:	if (!dbg || !dbg->reg) {
+debug/dreg.c:		name = r_reg_get_name (dbg->reg, role);
+debug/dreg.c:	ri = r_reg_get (dbg->reg, name, R_REG_TYPE_ALL);
+debug/dreg.c:			ret = r_reg_get_value_big (dbg->reg, ri, value);
+debug/dreg.c:		    ret = r_reg_get_value (dbg->reg, ri);
+debug/esil.c:#define ESIL dbg->anal->esil
+debug/esil.c:		a = r_num_math (dbg->num, e);
+debug/esil.c:		b = r_num_math (dbg->num, p);
+debug/esil.c:		a = r_num_math (dbg->num, e);
+debug/esil.c:	pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/esil.c:			if (CURVAL >= r_num_math (dbg->num, p))
+debug/esil.c:			if (CURVAL <= r_num_math (dbg->num, p))
+debug/esil.c:			if (CURVAL <= r_num_math (dbg->num, p))
+debug/esil.c:			if (CURVAL < r_num_math (dbg->num, p))
+debug/esil.c:			if (CURVAL > r_num_math (dbg->num, p))
+debug/esil.c:				ut64 num = r_num_math (dbg->num, p);
+debug/esil.c:	opc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/esil.c:	dbg->iob.read_at (dbg->iob.io, opc, obuf, sizeof (obuf));
+debug/esil.c:	//dbg->iob.read_at (dbg->iob.io, npc, buf, sizeof (buf));
+debug/esil.c:	//dbg->anal->reg = dbg->reg; // hack
+debug/esil.c:		//	npc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/esil.c:	if (r_anal_op (dbg->anal, &op, opc, obuf, sizeof (obuf))) {
+debug/esil.c:			//	npc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+debug/esil.c:		dbg->cb_printf ("de %s %c %s\n", r_str_rwx_i (ew->rwx), ew->dev, ew->expr);
+debug/map.c:		dbg->cb_printf ("[");
+debug/map.c:		r_list_foreach (dbg->maps, iter, map) {
+debug/map.c:			if (notfirst) dbg->cb_printf (",");
+debug/map.c:			dbg->cb_printf ("{\"name\":\"%s\",",map->name);
+debug/map.c:				dbg->cb_printf ("\"file\":\"%s\",", map->file);
+debug/map.c:			dbg->cb_printf ("\"addr\":%"PFMT64u",", map->addr);
+debug/map.c:			dbg->cb_printf ("\"addr_end\":%"PFMT64u",", map->addr_end);
+debug/map.c:			dbg->cb_printf ("\"type\":\"%c\",", map->user?'u':'s');
+debug/map.c:			dbg->cb_printf ("\"perm\":\"%s\"}", r_str_rwx_i (map->perm));
+debug/map.c:		r_list_foreach (dbg->maps_user, iter, map) {
+debug/map.c:			if (notfirst) dbg->cb_printf (",");
+debug/map.c:			dbg->cb_printf ("{\"name\":\"%s\",", map->name);
+debug/map.c:				dbg->cb_printf ("\"file\":\"%s\",", map->file);
+debug/map.c:			dbg->cb_printf ("\"addr\":%"PFMT64u",", map->addr);
+debug/map.c:			dbg->cb_printf ("\"addr_end\":%"PFMT64u",", map->addr_end);
+debug/map.c:			dbg->cb_printf ("\"type\":\"%c\",", map->user?'u':'s');
+debug/map.c:			dbg->cb_printf ("\"perm\":\"%s\"}", r_str_rwx_i (map->perm));
+debug/map.c:		dbg->cb_printf ("]\n");
+debug/map.c:		r_list_foreach (dbg->maps, iter, map) {
+debug/map.c:			dbg->cb_printf ("f map.%s 0x%08"PFMT64x" 0x%08"PFMT64x"\n",
+debug/map.c:		r_list_foreach (dbg->maps_user, iter, map) {
+debug/map.c:			dbg->cb_printf ("f map.%s 0x%08"PFMT64x" 0x%08"PFMT64x"\n",
+debug/map.c:		r_list_foreach (dbg->maps, iter, map) {
+debug/map.c:			dbg->cb_printf ("0x%016"PFMT64x" - 0x%016"PFMT64x" %6s %5s %s\n",
+debug/map.c:		r_list_foreach (dbg->maps_user, iter, map) {
+debug/map.c:			dbg->cb_printf ("f map.%s 0x%08"PFMT64x" 0x%08"PFMT64x"\n",
+debug/map.c:		fmtstr = dbg->bits& R_SYS_BITS_64?
+debug/map.c:		r_list_foreach (dbg->maps, iter, map) {
+debug/map.c:			const char *flagname = dbg->corebind.getName
+debug/map.c:				? dbg->corebind.getName (dbg->corebind.core, map->addr) : NULL;
+debug/map.c:			dbg->cb_printf (fmtstr,
+debug/map.c:		fmtstr = dbg->bits& R_SYS_BITS_64?
+debug/map.c:		r_list_foreach (dbg->maps_user, iter, map) {
+debug/map.c:			dbg->cb_printf (fmtstr, buf, map->addr, map->addr_end,
+debug/map.c:		if (dbg->maps) {
+debug/map.c:			print_debug_map_ascii_art (dbg->maps, addr,
+debug/map.c:				use_color, dbg->cb_printf,
+debug/map.c:				dbg->bits, cons_cols);
+debug/map.c:		if (dbg->maps_user) {
+debug/map.c:			print_debug_map_ascii_art (dbg->maps_user,
+debug/map.c:				dbg->cb_printf, dbg->bits, cons_cols);
+debug/map.c:	return (dbg && dbg->h && dbg->h->modules_get)?
+debug/map.c:		dbg->h->modules_get (dbg): NULL;
+debug/map.c:	if (dbg && dbg->h && dbg->h->map_get) {
+debug/map.c:		RList *newmaps = dbg->h->map_get (dbg);
+debug/map.c:			r_list_free (dbg->maps);
+debug/map.c:			dbg->maps = newmaps;
+debug/map.c:	if (dbg && dbg->h && dbg->h->map_alloc) {
+debug/map.c:		map = dbg->h->map_alloc (dbg, addr, size);
+debug/map.c:	if (dbg && dbg->h && dbg->h->map_dealloc)
+debug/map.c:		if (dbg->h->map_dealloc (dbg, addr, map->size))
+debug/map.c:	r_list_foreach (dbg->maps, iter, map) {
+debug/p/debug_bf.c:	RIODesc *d = dbg->iob.io->desc;
+debug/p/debug_bf.c:	RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	if (!(dbg->iob.io) || !(dbg->iob.io->desc) || !(dbg->iob.io->desc->data))
+debug/p/debug_bf.c:	o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	//r_io_system (dbg->iob.io, "dr");
+debug/p/debug_bf.c:	if (!(dbg->iob.io) || !(dbg->iob.io->desc) || !(dbg->iob.io->desc->data))
+debug/p/debug_bf.c:	o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	//r_io_system (dbg->iob.io, "db");
+debug/p/debug_bf.c:	RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bf.c:	RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bochs.c:	//RIOBdescbg *o = dbg->iob.io->desc->data;
+debug/p/debug_bochs.c:	RIODesc *d = dbg->iob.io->desc;
+debug/p/debug_bochs.c:	dbg->swstep = false;
+debug/p/debug_bochs.c:			//int arch = r_sys_arch_id (dbg->arch);
+debug/p/debug_bochs.c:			// int bits = dbg->anal->bits;
+debug/p/debug_bochs.c:	int bits = dbg->anal->bits;
+debug/p/debug_esil.c:	RIODesc *d = dbg->iob.io->desc;
+debug/p/debug_esil.c:	dbg->iob.read_at (dbg->iob.io, pc, buf, 64);
+debug/p/debug_esil.c:	oplen = r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf));
+debug/p/debug_esil.c:			r_anal_esil_parse (dbg->anal->esil, R_STRBUF_SAFEGET (&op.esil));
+debug/p/debug_esil.c:	dbg->tid = dbg->pid = 1;
+debug/p/debug_esil.c:	o = dbg->iob.io->desc->data;
+debug/p/debug_esil.c:	if (!strcmp (dbg->arch, "bf")) {
+debug/p/debug_esil.c:	return r_anal_get_reg_profile (dbg->anal);
+debug/p/debug_esil.c:	//r_io_system (dbg->iob.io, "db");
+debug/p/debug_esil.c:	ut8 *bytes = r_reg_get_bytes (dbg->reg, type, &sz);
+debug/p/debug_gdb.c:	free (r_reg_get_bytes (dbg->reg, type, &buflen));
+debug/p/debug_gdb.c:	int bits = dbg->anal->bits;
+debug/p/debug_gdb.c:	const char *pcname = r_reg_get_name (dbg->anal->reg, R_REG_NAME_PC);
+debug/p/debug_gdb.c:	RRegItem *reg = r_reg_get (dbg->anal->reg, pcname, 0);
+debug/p/debug_gdb.c:		if (dbg->anal->bits != reg->size)
+debug/p/debug_gdb.c:	free (r_reg_get_bytes (dbg->reg, type, &buflen));
+debug/p/debug_gdb.c:		current = r_reg_next_diff (dbg->reg, type, reg_buf, buflen, current, bits);
+debug/p/debug_gdb.c:		ut64 val = r_reg_get_value (dbg->reg, current);
+debug/p/debug_gdb.c:	RIODesc *d = dbg->iob.io->desc;
+debug/p/debug_gdb.c:	dbg->swstep = false;
+debug/p/debug_gdb.c:			int arch = r_sys_arch_id (dbg->arch);
+debug/p/debug_gdb.c:			int bits = dbg->anal->bits;
+debug/p/debug_gdb.c:					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+debug/p/debug_gdb.c:					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+debug/p/debug_gdb.c:					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+debug/p/debug_gdb.c:					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+debug/p/debug_gdb.c:	int arch = r_sys_arch_id (dbg->arch);
+debug/p/debug_gdb.c:	int bits = dbg->anal->bits;
+debug/p/debug_gdb.c:		} else if (dbg->anal->bits == 64) {
+debug/p/debug_io.c:	dbg->iob.system (dbg->iob.io, "ds");
+debug/p/debug_io.c:	dbg->iob.system (dbg->iob.io, "dso");
+debug/p/debug_io.c:	dbg->iob.system (dbg->iob.io, "dm");
+debug/p/debug_io.c:	dbg->iob.system (dbg->iob.io, "drp");
+debug/p/debug_io.c:	return r_anal_get_reg_profile (dbg->anal);
+debug/p/debug_io.c:	dbg->iob.system (dbg->iob.io, "dr8");
+debug/p/debug_io.c:	dbg->iob.system (dbg->iob.io, "dc");
+debug/p/debug_io.c:	dbg->iob.system (dbg->iob.io, cmd);
+debug/p/debug_native.c:	r_debug_native_continue (dbg, dbg->pid, dbg->tid, dbg->reason.signum);
+debug/p/debug_native.c:	int ret = ptrace (PT_STEP, dbg->pid, (caddr_t)1, 0);
+debug/p/debug_native.c:	if (!dbg || pid == dbg->pid)
+debug/p/debug_native.c:		return dbg->tid;
+debug/p/debug_native.c:	r_debug_kill (dbg, dbg->pid, dbg->tid, SIGINT);
+debug/p/debug_native.c:	void *data = (void*)(size_t)((sig != -1) ? sig : dbg->reason.signum);
+debug/p/debug_native.c:	int contsig = dbg->reason.signum;
+debug/p/debug_native.c:	if (dbg->consbreak) {
+debug/p/debug_native.c:		case 'l': needle = dbg->glob_libs; break;
+debug/p/debug_native.c:		case 'u': needle = dbg->glob_unlibs; break;
+debug/p/debug_native.c:	reason = linux_dbg_wait (dbg, dbg->tid);
+debug/p/debug_native.c:			 * this might modify dbg->reason.signum
+debug/p/debug_native.c:			reason = dbg->reason.type;
+debug/p/debug_native.c:	dbg->reason.tid = pid;
+debug/p/debug_native.c:	dbg->reason.type = reason;
+debug/p/debug_native.c:	int pid = dbg->pid;
+debug/p/debug_native.c:	#warning dbg-native not supported for this platform
+debug/p/debug_native.c:		return (0 == ptrace (PT_SETDBREGS, dbg->pid,
+debug/p/debug_native.c:		int ret = ptrace (PTRACE_SETREGS, dbg->pid,
+debug/p/debug_native.c:	mib[3] = dbg->pid;
+debug/p/debug_native.c:	mib[2] = dbg->pid;
+debug/p/debug_native.c:	HANDLE process = w32_open_process (PROCESS_ALL_ACCESS, FALSE, dbg->pid);
+debug/p/debug_native.c:	HANDLE process = w32_open_process (PROCESS_ALL_ACCESS, FALSE, dbg->tid);
+debug/p/debug_native.c:	if (dbg->pid == -1) {
+debug/p/debug_native.c:	snprintf (path, sizeof (path), "/proc/%d/map", dbg->pid);
+debug/p/debug_native.c:	snprintf (path, sizeof (path), "/proc/%d/maps", dbg->pid);
+debug/p/debug_native.c:	if (pid == 0) pid = dbg->pid;
+debug/p/debug_native.c:		if (dbg->tid>0 && (ret = tgkill (dbg->pid, dbg->tid, sig))) {
+debug/p/debug_native.c:	if (sig == SIGKILL && dbg->threads) {
+debug/p/debug_native.c:		r_list_free (dbg->threads);
+debug/p/debug_native.c:		dbg->threads = NULL;
+debug/p/debug_native.c:	dbg->h->desc = r_debug_desc_plugin_native;
+debug/p/debug_native.c:#define R dbg->reg
+debug/p/debug_native.c:	HANDLE process = w32_open_process (PROCESS_ALL_ACCESS, FALSE, dbg->pid);
+debug/p/debug_qnx.c:	free (r_reg_get_bytes (dbg->reg, type, &buflen));
+debug/p/debug_qnx.c:	int bits = dbg->anal->bits;
+debug/p/debug_qnx.c:	const char *pcname = r_reg_get_name (dbg->anal->reg, R_REG_NAME_PC);
+debug/p/debug_qnx.c:	RRegItem *reg = r_reg_get (dbg->anal->reg, pcname, 0);
+debug/p/debug_qnx.c:		if (dbg->anal->bits != reg->size)
+debug/p/debug_qnx.c:	free (r_reg_get_bytes (dbg->reg, type, &buflen));
+debug/p/debug_qnx.c:		current = r_reg_next_diff (dbg->reg, type, reg_buf, buflen, current, bits);
+debug/p/debug_qnx.c:		ut64 val = r_reg_get_value (dbg->reg, current);
+debug/p/debug_qnx.c:		dbg->reason.signum = desc->signal;
+debug/p/debug_qnx.c:	RIODesc *d = dbg->iob.io->desc;
+debug/p/debug_qnx.c:	dbg->swstep = false;
+debug/p/debug_qnx.c:			int arch = r_sys_arch_id (dbg->arch);
+debug/p/debug_qnx.c:			int bits = dbg->anal->bits;
+debug/p/debug_qnx.c:						eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+debug/p/debug_qnx.c:						eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
+debug/p/debug_qnx.c:	dbg->pid = 0;
+debug/p/debug_qnx.c:	int arch = r_sys_arch_id (dbg->arch);
+debug/p/debug_qnx.c:	int bits = dbg->anal->bits;
+debug/p/debug_rap.c:	r_io_system (dbg->iob.io, "ds");
+debug/p/debug_rap.c:	r_io_system (dbg->iob.io, "dr");
+debug/p/debug_rap.c:	r_io_system (dbg->iob.io, "dc");
+debug/p/debug_rap.c:	RIODesc *d = dbg->iob.io->desc;
+debug/p/debug_rap.c:	r_io_system (dbg->iob.io, "drp");
+debug/p/debug_rap.c:	//r_io_system (dbg->iob.io, "db");
+debug/p/debug_wind.c:	r_reg_read_regs (dbg->reg, buf, ret);
+debug/p/debug_wind.c:	if (!dbg->reg) {
+debug/p/debug_wind.c:	ut8 *arena = r_reg_get_bytes (dbg->reg, R_REG_TYPE_ALL, &arena_size);
+debug/p/debug_wind.c:			dbg->reason.type = R_DEBUG_REASON_INT;
+debug/p/debug_wind.c:			dbg->reason.addr = stc->pc;
+debug/p/debug_wind.c:			dbg->reason.tid = stc->kthread;
+debug/p/debug_wind.c:			dbg->reason.signum = stc->state;
+debug/p/debug_wind.c:	RIODesc *desc = dbg->iob.io->desc;
+debug/p/debug_wind.c:	if (dbg->arch && strcmp (dbg->arch, "x86")) {
+debug/p/debug_wind.c:	dbg->pid = 0;
+debug/p/debug_wind.c:	if (dbg->arch && strcmp (dbg->arch, "x86"))
+debug/p/debug_wind.c:	if (dbg->bits == R_SYS_BITS_32) {
+debug/p/debug_wind.c:	} else if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/bt.c:		pcname = r_reg_get_name (dbg->reg, R_REG_NAME_PC);
+debug/p/native/bt.c:			ut64 addr = r_reg_getv (dbg->reg, pcname);
+debug/p/native/bt.c:	if (dbg->btalgo) {
+debug/p/native/bt.c:		if (!strcmp (dbg->btalgo, "fuzzy")) {
+debug/p/native/bt.c:		} else if (!strcmp (dbg->btalgo, "anal")) {
+debug/p/native/bt.c:			if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/bt.c:		if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/bt/fuzzy-all.c:	if (dbg->arch && !strcmp (dbg->arch, "x86")) {
+debug/p/native/bt/fuzzy-all.c:		(void)dbg->iob.read_at (dbg->iob.io, addr-5, buf, 5);
+debug/p/native/bt/fuzzy-all.c:		(void) dbg->iob.read_at (dbg->iob.io, addr-8, buf, 8);
+debug/p/native/bt/fuzzy-all.c:		(void) r_anal_op (dbg->anal, &op, addr-8, buf, 8);
+debug/p/native/bt/fuzzy-all.c:		(void) r_anal_op (dbg->anal, &op, addr-4, buf, 4);
+debug/p/native/bt/fuzzy-all.c:	int wordsize = dbg->bits; // XXX, dbg->bits is wordsize not bits
+debug/p/native/bt/fuzzy-all.c:	RIOBind *bio = &dbg->iob;
+debug/p/native/bt/fuzzy-all.c:		RReg *reg = dbg->reg;
+debug/p/native/bt/fuzzy-all.c:	for (i=0; i<dbg->btdepth; i++) {
+debug/p/native/bt/generic-x64.c:	RReg *reg = dbg->reg;
+debug/p/native/bt/generic-x64.c:	RIOBind *bio = &dbg->iob;
+debug/p/native/bt/generic-x64.c:	for (i=1; i<dbg->btdepth; i++) {
+debug/p/native/bt/generic-x64.c:	RReg *reg = dbg->reg;
+debug/p/native/bt/generic-x64.c:	RIOBind *bio = &dbg->iob;
+debug/p/native/bt/generic-x64.c:	fcn = r_anal_get_fcn_in (dbg->anal, _rip, R_ANAL_FCN_TYPE_NULL);
+debug/p/native/bt/generic-x64.c:	for (i=1; i<dbg->btdepth; i++) {
+debug/p/native/bt/generic-x64.c:		//fcn = r_anal_get_fcn_in (dbg->anal, ptr, R_ANAL_FCN_TYPE_NULL);
+debug/p/native/bt/generic-x86.c:	RReg *reg = dbg->reg;
+debug/p/native/bt/generic-x86.c:	RIOBind *bio = &dbg->iob;
+debug/p/native/bt/generic-x86.c:	for (i=0; i<dbg->btdepth; i++) {
+debug/p/native/bt/generic-x86.c:	RReg *reg = dbg->reg;
+debug/p/native/bt/generic-x86.c:	RIOBind *bio = &dbg->iob;
+debug/p/native/bt/generic-x86.c:	fcn = r_anal_get_fcn_in (dbg->anal, eip, R_ANAL_FCN_TYPE_NULL);
+debug/p/native/bt/generic-x86.c:	for (i=1; i<dbg->btdepth; i++) {
+debug/p/native/linux/linux_coredump.c:	p->pr_pid = mypid = dbg->pid;
+debug/p/native/linux/linux_coredump.c:	file = r_str_newf ("/proc/%d/smaps", dbg->pid);
+debug/p/native/linux/linux_coredump.c:	file = r_str_newf ("/proc/%d/maps", dbg->pid);
+debug/p/native/linux/linux_coredump.c:	r_list_foreach (dbg->maps, iter, map) {
+debug/p/native/linux/linux_coredump.c:	const char *file = sdb_fmt (0, "/proc/%d/auxv", dbg->pid);
+debug/p/native/linux/linux_coredump.c:		rbytes = dbg->iob.read_at (dbg->iob.io, p->start_addr, map_content, size);
+debug/p/native/linux/linux_coredump.c:	const char *file = sdb_fmt (0, "/proc/%d/stat", dbg->pid);
+debug/p/native/linux/linux_coredump.c:	file = sdb_fmt (0, "/proc/%d/status", dbg->pid);
+debug/p/native/linux/linux_coredump.c:	file = sdb_fmt (0, "/proc/%d/coredump_filter", dbg->pid);
+debug/p/native/linux/linux_coredump.c:	if (dbg->h) {
+debug/p/native/linux/linux_coredump.c:		list = dbg->h->threads (dbg, dbg->pid);
+debug/p/native/linux/linux_coredump.c:					if (th->pid != dbg->pid) {
+debug/p/native/linux/linux_coredump.c:		if (dbg->pid != thread_id[i]) {
+debug/p/native/linux/linux_coredump.c:			elf_proc_note->thread_note->prstatus = linux_get_prstatus (dbg->pid, thread_id[i], proc_data, elf_proc_note->thread_note->siginfo->si_signo);
+debug/p/native/linux/linux_coredump.c:	init_note_info_structure(dbg->pid, elf_proc_note->auxv->size);
+debug/p/native/linux/linux_coredump.c:	(void)dump_elf_map_content (dbg, dest, elf_proc_note->maps, dbg->pid);
+debug/p/native/linux/linux_debug.c:	if ((dbg->bits & R_SYS_BITS_32) && (dbg->bp->endian == 1)) {
+debug/p/native/linux/linux_debug.c:	if (dbg->bits & R_SYS_BITS_32) {
+debug/p/native/linux/linux_debug.c:	int ret = ptrace (PTRACE_GETSIGINFO, dbg->pid, 0, &siginfo);
+debug/p/native/linux/linux_debug.c:			dbg->reason.type = R_DEBUG_REASON_DEAD;
+debug/p/native/linux/linux_debug.c:		//ptrace (PTRACE_SETSIGINFO, dbg->pid, 0, &siginfo);
+debug/p/native/linux/linux_debug.c:		dbg->reason.type = R_DEBUG_REASON_SIGNAL;
+debug/p/native/linux/linux_debug.c:		dbg->reason.signum = siginfo.si_signo;
+debug/p/native/linux/linux_debug.c:		//dbg->stopaddr = siginfo.si_addr;
+debug/p/native/linux/linux_debug.c:		//dbg->errno = siginfo.si_errno;
+debug/p/native/linux/linux_debug.c:		switch (dbg->reason.signum) {
+debug/p/native/linux/linux_debug.c:				dbg->reason.type = R_DEBUG_REASON_BREAKPOINT;
+debug/p/native/linux/linux_debug.c:				dbg->reason.bp_addr = (ut64)siginfo.si_addr;
+debug/p/native/linux/linux_debug.c:				dbg->reason.type = R_DEBUG_REASON_ABORT;
+debug/p/native/linux/linux_debug.c:				dbg->reason.type = R_DEBUG_REASON_SEGFAULT;
+debug/p/native/linux/linux_debug.c:		if (dbg->reason.signum != SIGTRAP) {
+debug/p/native/linux/linux_debug.c:		if (dbg->trace_clone) {
+debug/p/native/linux/linux_debug.c:		if (dbg->trace_forks) {
+debug/p/native/linux/linux_debug.c:			dbg->forked_pid = data;
+debug/p/native/linux/linux_debug.c:	ret = ptrace (PTRACE_SINGLESTEP, dbg->pid, (void*)(size_t)addr, 0);
+debug/p/native/linux/linux_debug.c:	if (dbg->trace_forks) {
+debug/p/native/linux/linux_debug.c:	if (dbg->trace_clone) {
+debug/p/native/linux/linux_debug.c:	if (dbg->trace_execs) {
+debug/p/native/linux/linux_debug.c:	if (dbg->trace_aftersyscall) {
+debug/p/native/linux/linux_debug.c:				reason = dbg->reason.type;
+debug/p/native/linux/linux_debug.c:	r_list_append (dbg->threads, tid_info);
+debug/p/native/linux/linux_debug.c:	dbg->main_pid = main_pid;
+debug/p/native/linux/linux_debug.c:	if (!dbg->threads) {
+debug/p/native/linux/linux_debug.c:		dbg->threads = attach_to_pid_and_threads (dbg, pid);
+debug/p/native/linux/linux_debug.c:		if (dbg->threads && !r_list_find (dbg->threads, &pid, &match_pid)) {
+debug/p/native/linux/linux_debug.c:	if (dbg->threads) {
+debug/p/native/linux/linux_debug.c:		th_list = dbg->threads;
+debug/p/native/linux/linux_debug.c:			th_list = linux_thread_list (dbg->pid, th_list);
+debug/p/native/linux/linux_debug.c:		if (th->pid == dbg->pid) {
+debug/p/native/linux/linux_debug.c:	rdi->pid = dbg->pid;
+debug/p/native/linux/linux_debug.c:	rdi->tid = dbg->tid;
+debug/p/native/linux/linux_debug.c:	int pid = dbg->pid;
+debug/p/native/linux/linux_debug.c:			if (ptrace (PTRACE_POKEUSER, dbg->pid, r_offsetof (
+debug/p/native/linux/linux_debug.c:		int ret = ptrace (PTRACE_SETREGSET, dbg->pid, NT_PRSTATUS, &io);
+debug/p/native/linux/linux_debug.c:		int ret = ptrace (PTRACE_SETREGS, dbg->pid, buf, NULL);
+debug/p/native/linux/linux_debug.c:		int ret = ptrace (PTRACE_SETREGS, dbg->pid, 0, (void*)buf);
+debug/p/native/maps/darwin.c:	task_t task = pid_to_task (dbg->tid);
+debug/p/native/maps/darwin.c:	if (dbg->pid == 0) {
+debug/p/native/maps/darwin.c:			int ret = proc_regionfilename (dbg->pid, address,
+debug/p/native/maps/darwin.c:	task_t task = pid_to_task (dbg->pid);
+debug/p/native/maps/darwin.c:	kret = mach_vm_region (pid_to_task (dbg->pid), &address, &size, VM_REGION_BASIC_INFO_64,
+debug/p/native/maps/darwin.c:			int ret = proc_regionfilename (dbg->pid, address, module_name, sizeof (module_name));
+debug/p/native/maps/darwin.c:	const char *osname = dbg->anal->syscall->os;
+debug/p/native/maps/windows.c:	int pid = dbg->pid;
+debug/p/native/maps/windows.c:	//int tid = dbg->tid;
+debug/p/native/maps/windows.c:	int pid = dbg->pid;
+debug/p/native/reg.c:	if (dbg->bits & R_SYS_BITS_64) {
+debug/p/native/w32.c:		dbg->tid = tid;
+debug/p/native/w32.c:		dbg->pid = pid;
+debug/p/native/w32.c:	HANDLE process = w32_open_process (PROCESS_ALL_ACCESS, FALSE, dbg->pid);
+debug/p/native/w32.c:	int pid = dbg->pid;
+debug/p/native/w32.c:	int tid = dbg->tid;
+debug/p/native/w32.c:	thread = w32_open_thread (dbg->pid, dbg->tid);
+debug/p/native/w32.c:	rdi->pid = dbg->pid;
+debug/p/native/w32.c:	rdi->tid = dbg->tid;
+debug/p/native/xnu/trap_arm.c:		RIOBind *bio = &dbg->iob;
+debug/p/native/xnu/trap_arm.c:	if (dbg->bits == R_SYS_BITS_64)
+debug/p/native/xnu/trap_x86.c:	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
+debug/p/native/xnu/trap_x86.c:	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
+debug/p/native/xnu/trap_x86.c:	if (dbg->bits == R_SYS_BITS_64)
+debug/p/native/xnu/xnu_debug.c:/* XXX: right now it just returns the first thread, not the one selected in dbg->tid */
+debug/p/native/xnu/xnu_debug.c:	task_t t = pid_to_task (dbg->pid);
+debug/p/native/xnu/xnu_debug.c:	it = r_list_find (dbg->threads, (const void *)(size_t)&tid,
+debug/p/native/xnu/xnu_debug.c:	it = r_list_find (dbg->threads, (const void *)(size_t)&tid,
+debug/p/native/xnu/xnu_debug.c:	int ret = ptrace (PT_STEP, dbg->pid, (caddr_t)1, 0) == 0; //SIGINT
+debug/p/native/xnu/xnu_debug.c:	task_t task = pid_to_task (dbg->pid);
+debug/p/native/xnu/xnu_debug.c:		eprintf ("step failed on task %d for pid %d\n", task, dbg->tid);
+debug/p/native/xnu/xnu_debug.c:	dbg->pid = pid;
+debug/p/native/xnu/xnu_debug.c:	r_list_free (dbg->threads);
+debug/p/native/xnu/xnu_debug.c:	void *data = (void*)(size_t)((sig != -1) ? sig : dbg->reason.signum);
+debug/p/native/xnu/xnu_debug.c:	if (dbg->bits & R_SYS_BITS_32) {
+debug/p/native/xnu/xnu_debug.c:	} else if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/xnu/xnu_debug.c:	if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/xnu/xnu_debug.c:	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
+debug/p/native/xnu/xnu_debug.c:	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
+debug/p/native/xnu/xnu_debug.c:	kinfo_proc_error = xnu_get_kinfo_proc(dbg->pid, &kp);
+debug/p/native/xnu/xnu_debug.c:	rdi->pid = dbg->pid;
+debug/p/native/xnu/xnu_debug.c:	rdi->tid = dbg->tid;
+debug/p/native/xnu/xnu_debug.c:	#define CPU_PC (dbg->bits == R_SYS_BITS_64) ? \
+debug/p/native/xnu/xnu_debug.c:	#define CPU_PC (dbg->bits == R_SYS_BITS_64) ? \
+debug/p/native/xnu/xnu_debug.c:	r_list_foreach (dbg->threads, iter, thread) {
+debug/p/native/xnu/xnu_debug.c:	task_t task = pid_to_task (dbg->tid);
+debug/p/native/xnu/xnu_debug.c:	xnu_thread_t *th = get_xnu_thread (dbg, dbg->tid);
+debug/p/native/xnu/xnu_debug.c:	task_t task = pid_to_task (dbg->pid);
+debug/p/native/xnu/xnu_debug.c:	threads_list = xnu_thread_list (dbg, dbg->pid, r_list_new ());
+debug/p/native/xnu/xnu_debug.c:	segment_count = xnu_get_vmmap_entries_for_pid (dbg->pid);
+debug/p/native/xnu/xnu_debug.c:		r_list_length (threads_list), command_size, dbg->pid);
+debug/p/native/xnu/xnu_debug.c:	if (!dbg->maps) perror ("There are not loaded maps");
+debug/p/native/xnu/xnu_debug.c:	if (xnu_write_mem_maps_to_buffer (mem_maps_buffer, dbg->maps, round_page (header_size),
+debug/p/native/xnu/xnu_debug.c:	task_t task = pid_to_task (dbg->tid);
+debug/p/native/xnu/xnu_debug.c:		dbg->iob.read_at (dbg->iob.io, info.all_image_info_addr,
+debug/p/native/xnu/xnu_debug.c:		dbg->iob.read_at (dbg->iob.io, info.all_image_info_addr,
+debug/p/native/xnu/xnu_debug.c:	dbg->iob.read_at (dbg->iob.io, info_array_address,
+debug/p/native/xnu/xnu_debug.c:		dbg->iob.read_at (dbg->iob.io, file_path_address,
+debug/p/native/xnu/xnu_debug.c:	int tid = dbg->pid;
+debug/p/native/xnu/xnu_debug.c:	if (dbg->pid == 0) {
+debug/p/native/xnu/xnu_debug.h://(dbg->bits==64)?x86_THREAD_STATE:_STRUCT_X86_THREAD_STATE32
+debug/p/native/xnu/xnu_debug.h://#define R_DEBUG_STATE_SZ ((dbg->bits == R_SYS_BITS_64) ? 168 : 64)
+debug/p/native/xnu/xnu_debug.h:#define REG_PC ((dbg->bits == R_SYS_BITS_64) ? 16 : 10)
+debug/p/native/xnu/xnu_debug.h:#define REG_FL ((dbg->bits == R_SYS_BITS_64) ? 17 : 9)
+debug/p/native/xnu/xnu_excthreads.c:			RIOBind *bio = &dbg->iob;
+debug/p/native/xnu/xnu_excthreads.c:	if (pid_to_task (dbg->pid) != msg->task.name) {
+debug/p/native/xnu/xnu_excthreads.c:		dbg->pid = -1;
+debug/p/native/xnu/xnu_excthreads.c:	task_t task = pid_to_task (dbg->pid);
+debug/p/native/xnu/xnu_excthreads.c:        ret = xnu_save_exception_ports (dbg->pid);
+debug/p/native/xnu/xnu_excthreads.c:	kr = mach_port_request_notification (task_self, pid_to_task (dbg->pid),
+debug/p/native/xnu/xnu_threads.c:	thread->state_size = (dbg->bits == R_SYS_BITS_64)
+debug/p/native/xnu/xnu_threads.c:	if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/xnu/xnu_threads.c:	if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/xnu/xnu_threads.c:	if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/xnu/xnu_threads.c:	if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/xnu/xnu_threads.c:	if (dbg->bits == R_SYS_BITS_64) {
+debug/p/native/xnu/xnu_threads.c:	thread->state_size = (dbg->bits == R_SYS_BITS_64) ?
+debug/p/native/xnu/xnu_threads.c:	ret_proc = proc_pidinfo (dbg->pid, PROC_PIDTHREADINFO,
+debug/p/native/xnu/xnu_threads.c:	if (!dbg->threads) {
+debug/p/native/xnu/xnu_threads.c:		dbg->threads = r_list_newf ((RListFree)&xnu_thread_free);
+debug/p/native/xnu/xnu_threads.c:		if (!dbg->threads) {
+debug/p/native/xnu/xnu_threads.c:	task = pid_to_task (dbg->pid);
+debug/p/native/xnu/xnu_threads.c:	if (r_list_empty (dbg->threads)) {
+debug/p/native/xnu/xnu_threads.c:			if (!r_list_append (dbg->threads, thread)) {
+debug/p/native/xnu/xnu_threads.c:		r_list_foreach_safe (dbg->threads, iter, iter2, thread) {
+debug/p/native/xnu/xnu_threads.c:				r_list_delete (dbg->threads, iter);
+debug/p/native/xnu/xnu_threads.c:			iter = r_list_find (dbg->threads, &thread_list[i],
+debug/p/native/xnu/xnu_threads.c:			r_list_append (dbg->threads, t);
+debug/pid.c:	if (dbg && dbg->h && dbg->h->pids) {
+debug/pid.c:		return dbg->h->pids (dbg, pid);
+debug/pid.c:	if (dbg && dbg->h && dbg->h->pids) {
+debug/pid.c:		list = dbg->h->pids (dbg, R_MAX (0, pid));
+debug/pid.c:			dbg->cb_printf ("[");
+debug/pid.c:				dbg->cb_printf ("{\"pid\":%d,"
+debug/pid.c:				dbg->cb_printf (" %c %d %c %s\n",
+debug/pid.c:					dbg->pid==p->pid?'*':'-',
+debug/pid.c:			dbg->cb_printf ("]\n");
+debug/pid.c:	if (dbg && dbg->h && dbg->h->threads) {
+debug/pid.c:		list = dbg->h->threads (dbg, pid);
+debug/pid.c:			dbg->cb_printf ("[");
+debug/pid.c:				dbg->cb_printf ("{\"pid\":%d,"
+debug/pid.c:			dbg->cb_printf ("]\n");
+debug/pid.c:				dbg->cb_printf (" %c %d %c %s\n",
+debug/pid.c:						dbg->tid == p->pid ? '*' : '-',
+debug/plugin.c:	dbg->plugins = r_list_newf (free);
+debug/plugin.c:		r_list_foreach (dbg->plugins, iter, h) {
+debug/plugin.c:				dbg->h = h;
+debug/plugin.c:				if (dbg->anal && dbg->anal->cur)
+debug/plugin.c:					r_debug_set_arch (dbg, dbg->anal->cur->arch, dbg->bits);
+debug/plugin.c:				dbg->bp->breakpoint = dbg->h->breakpoint;
+debug/plugin.c:				dbg->bp->user = dbg;
+debug/plugin.c:	if (dbg->h && dbg->h->reg_profile) {
+debug/plugin.c:		char *p = dbg->h->reg_profile (dbg);
+debug/plugin.c:			r_reg_set_profile_string (dbg->reg, p);
+debug/plugin.c:			if (dbg->anal && dbg->reg != dbg->anal->reg) {
+debug/plugin.c:				r_reg_free (dbg->anal->reg);
+debug/plugin.c:				dbg->anal->reg = dbg->reg;
+debug/plugin.c:			if (dbg->h->init)
+debug/plugin.c:				dbg->h->init (dbg);
+debug/plugin.c:			r_reg_set_profile_string (dbg->reg, p);
+debug/plugin.c:			eprintf ("Cannot retrieve reg profile from debug plugin (%s)\n", dbg->h->name);
+debug/plugin.c:	return (dbg->h != NULL);
+debug/plugin.c:	r_list_foreach (dbg->plugins, iter, h) {
+debug/plugin.c:			dbg->cb_printf ("%s\n", h->name);
+debug/plugin.c:			dbg->cb_printf ("%d  %s  %s %s%s\n",
+debug/plugin.c:					count, (h == dbg->h)? "dbg": "---",
+debug/plugin.c:	r_list_append (dbg->plugins, foo);
+debug/signal.c:#define DB dbg->sgnls
+debug/signal.c:	int opt, mode = dbg->_mode;
+debug/signal.c:		if (dbg->_mode == 2) {
+debug/signal.c:			dbg->_mode = 0;
+debug/signal.c:	dbg->_mode = mode;
+debug/signal.c:	dbg->_mode = 0;
+debug/signal.c:	return r_sandbox_kill (dbg->pid, num);
+debug/signal.c:	if (dbg->h->kill_list)
+debug/signal.c:		return dbg->h->kill_list (dbg);
+debug/signal.c:	if (dbg->h->kill_setup)
+debug/signal.c:		return dbg->h->kill_setup (dbg, sig, action);
+debug/snap.c:		r_list_free (dbg->snaps);
+debug/snap.c:		dbg->snaps = r_list_newf (r_debug_snap_free);
+debug/snap.c:	r_list_foreach (dbg->snaps, iter, snap) {
+debug/snap.c:		r_list_delete (dbg->snaps, iter);
+debug/snap.c:		dbg->cb_printf ("[");
+debug/snap.c:	r_list_foreach (dbg->snaps, iter, snap) {
+debug/snap.c:			dbg->cb_printf ("{\"count\":%d,\"addr\":%"PFMT64d",\"size\":%d,\"crc\":%d,\"comment\":\"%s\"}%s",
+debug/snap.c:			dbg->cb_printf ("dms 0x%08"PFMT64x"\n", snap->addr);
+debug/snap.c:			dbg->cb_printf ("%d 0x%08"PFMT64x" - 0x%08"PFMT64x" size: %d crc: %x  --  %s\n",
+debug/snap.c:		dbg->cb_printf ("]\n");
+debug/snap.c:	r_list_foreach (dbg->snaps, iter, snap) {
+debug/snap.c:	dbg->iob.read_at (dbg->iob.io, snap->addr, snap->data, snap->size);
+debug/snap.c:	r_list_append (dbg->snaps, snap);
+debug/snap.c:	r_list_foreach (dbg->maps, iter, map) {
+debug/snap.c:	r_list_foreach (dbg->snaps, iter, snap) {
+debug/trace.c:	//if (tag>0 && tag<31) core->dbg->trace->tag = 1<<(sz-1);
+debug/trace.c:	return (dbg->trace->tag = (tag>0)? tag: UT32_MAX);
+debug/trace.c:	if (dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf)) != sizeof (buf)) {
+debug/trace.c:	if (r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf)) < 1) {
+debug/trace.c:	if (dbg->anal->esil && dbg->anal->trace) {
+debug/trace.c:		r_anal_esil_trace (dbg->anal->esil, &op);
+debug/trace.c:	free (dbg->trace->addresses);
+debug/trace.c:	dbg->trace->addresses = (str&&*str)? strdup (str): NULL;
+debug/trace.c:	Sdb *db = dbg->trace->db;
+debug/trace.c:	int tag = dbg->trace->tag;
+debug/trace.c:	r_list_foreach (dbg->trace->traces, iter, trace) {
+debug/trace.c:		if (tag != 0 && !(dbg->trace->tag & (1<<tag)))
+debug/trace.c:	int tag = dbg->trace->tag;
+debug/trace.c:	r_list_foreach (dbg->trace->traces, iter, trace) {
+debug/trace.c:				dbg->cb_printf ("at+ 0x%"PFMT64x" %d\n", trace->addr, trace->times);
+debug/trace.c:				dbg->cb_printf ("pd 1 @ 0x%"PFMT64x"\n", trace->addr);
+debug/trace.c:				dbg->cb_printf ("0x%"PFMT64x" ", trace->addr);
+debug/trace.c:				dbg->cb_printf ("0x%08"PFMT64x" size=%d count=%d times=%d tag=%d\n",
+debug/trace.c:	if (dbg->trace->addresses) {
+debug/trace.c:		if (!strstr (dbg->trace->addresses, addr_str))
+debug/trace.c:	int tag = dbg->trace->tag;
+debug/trace.c:	r_anal_trace_bb (dbg->anal, addr);
+debug/trace.c:		tp->count = ++dbg->trace->count;
+debug/trace.c:		r_list_append (dbg->trace->traces, tp);
+debug/trace.c:		sdb_num_set (dbg->trace->db, sdb_fmt (0, "trace.%d.%"PFMT64x, tag, addr),
+debug/trace.c:	RDebugTrace *t = dbg->trace;
+include/r_heap_glibc.h:#define SZ core->dbg->bits
+io/p/io_debug.c:	if (c && c->dbg && c->dbg->h) {
+io/p/io_w32dbg.c:        ReadProcessMemory (dbg->pi.hProcess, (void*)(size_t)addr, buf, len, &ret);
+io/p/io_w32dbg.c:	return 0 != WriteProcessMemory (dbg->pi.hProcess, (void *)(size_t)addr, buf, len, &ret)? len: 0;
+io/p/io_w32dbg.c:	dbg->pi.hProcess = OpenProcess (PROCESS_ALL_ACCESS, FALSE, dbg->pid);
+io/p/io_w32dbg.c:	if (!dbg->pi.hProcess) {
+io/p/io_w32dbg.c:	return dbg->pid;
+io/p/io_w32dbg.c:		dbg->pid = atoi (file + 9);
+io/p/io_w32dbg.c:		pidpath = r_sys_pid_to_path (dbg->pid);


### PR DESCRIPTION
Fixes bad behaviour with "doo" command.

```
$ r2 -d test
Process with PID 18765 started...
= attach 18765 18765
bin.baddr 0x00400000
USING 400000
Assuming filepath /home/oscar/lab/r2/6507/test
asm.bits 64
 -- Your project name should contain an uppercase letter, 8 vowels, some numbers, and the first 5 numbers of your private bitcoin key.
[0x7f292fa9a190]> dc
Selecting and continuing: 18765
da da da
PTRACE_EVENT_EXIT pid=18765, status=0x0
[0x7f292f7a82e9]> doo popeyemarino
Wait event received by different pid 18765
Process with PID 18766 started...
File dbg:///home/oscar/lab/r2/6507/test  popeyemarino reopened in read-write mode
= attach 18766 18766
Assuming filepath /home/oscar/lab/r2/6507/test
[0x7f6b81f52190]> dc
Selecting and continuing: 18766
popeyemarino
PTRACE_EVENT_EXIT pid=18766, status=0x0
```

