### PR TITLE
Fix "commment" typo

### DIFF
--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -792,7 +792,7 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 			/* print comment header*/
 			if (p->use_comments) {
 				printfmt (col == 1 ? "|" : " ");
-				printfmt (" commment ");
+				printfmt (" comment ");
 			}
 			printfmt (col == 2 ? "|\n" : "\n");
 		}


### PR DESCRIPTION
This fixes a typo in the hexdump view introduced in c176c48ffccd4d470add516c137a550dff241901.