### PR TITLE
Add: dbg.libs/unlibs for linux

### DIFF
--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -312,7 +312,7 @@ static bool setbpint(RCore *r, const char *mode, const char *sym) {
 	if (bp) {
 		bp->internal = true;
 #if __linux__
-		bp->data = r_str_newf ("?e %s: %s;dd", mode, sym);
+		bp->data = r_str_newf ("?e %s: %s", mode, sym);
 #else
 		bp->data = r_str_newf ("?e %s: %s;ps@rdi", mode, sym);
 #endif
@@ -367,13 +367,12 @@ static int r_core_file_do_load_for_debug (RCore *r, ut64 baseaddr, const char *f
 	if (*r_config_get (r->config, "dbg.libs")) {
 		r_core_cmd0 (r, ".dmm*");
 #if __linux__
-		setbpint(r, "dbg.libs", "sym._dl_map_object_from_fd");
-		setbpint(r, "dbg.libs", "sym._dl_open");
-		setbpint(r, "dbg.unlibs", "sym._dl_unmap");
-		setbpint(r, "dbg.unlibs", "sym._dl_close");
+		setbpint (r, "dbg.libs", "sym.imp.dlopen");
+		setbpint (r, "dbg.libs", "sym.imp.dlmopen");
+		setbpint (r, "dbg.unlibs", "sym.imp.dlclose");
 #elif __APPLE__
-		setbpint(r, "dbg.libs", "sym._dlopen");
-		setbpint(r, "dbg.libs", "sym._dlclose");
+		setbpint (r, "dbg.libs", "sym._dlopen");
+		setbpint (r, "dbg.libs", "sym._dlclose");
 #endif
 	}
 	binfile = r_bin_cur (r->bin);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -604,8 +604,11 @@ R_API RDebugReasonType r_debug_wait(RDebug *dbg, RBreakpointItem **bp) {
 			return R_DEBUG_REASON_ERROR;
 		}
 
+		bool libs_bp = (dbg->glob_libs || dbg->glob_unlibs) ? true : false;
 		/* if the underlying stop reason is a breakpoint, call the handlers */
-		if (reason == R_DEBUG_REASON_BREAKPOINT || reason == R_DEBUG_REASON_STEP) {
+		if (reason == R_DEBUG_REASON_BREAKPOINT || reason == R_DEBUG_REASON_STEP || 
+			(libs_bp && 
+			((reason == R_DEBUG_REASON_NEW_LIB) || (reason == R_DEBUG_REASON_EXIT_LIB)))) {
 			RRegItem *pc_ri;
 			RBreakpointItem *b = NULL;
 			ut64 pc;


### PR DESCRIPTION
This commits adds internal breakpoints for **dlopen**, **dlmopen** and **dlclose**.
A proper return reason has been added in linux_dbg_wait , so when typing `di` we can see the reason.

Some things still have to be fixed:

* it prints twice the command stored in `bp->data`.
  First it prints the first part of the string (before ";"), and when it does a rcons_flush it prints everything (this issue was already here but i'll take a look).
* To know which library was unloaded more work should be done. We should keep a list of libraries like:

struct library {
 ut64 handler;
 char *name;
};

The handler field would be the value returned from dlopen/dlmopen (value in rax). Once r2 detects a dbg.unlibs, it should compare all handlers we got so far with the one we're gonna close with dlclose (value passed in rdi).

And then we could keep this list in a lib field within RDebug structure. 
So every time we unload a library, we can also print its name.



```
oscar@oscar:~/lab/r2/3462$ r2 -d loadlib
[0x7f4662fe3190]> db
0x00400590 - 0x00400591 1 --x sw break enabled cmd="?e dbg.libs: sym.imp.dlopen;ps@r:rdi" cond="" name="" module=""
0x004005c0 - 0x004005c1 1 --x sw break enabled cmd="?e dbg.libs: sym.imp.dlmopen;ps@r:rsi" cond="" name="" module=""
0x004005a0 - 0x004005a1 1 --x sw break enabled cmd="?e dbg.unlibs: sym.imp.dlclose" cond="" name="" module=""
[0x7f4662fe3190]> dc
Selecting and continuing: 9125
hit breakpoint at: 400590
dbg.libs: sym.imp.dlopen

dbg.libs: sym.imp.dlopen
libgvc.so.6.0.0
[0x00400590]> dc
Selecting and continuing: 9125
hit breakpoint at: 4005a0
dbg.unlibs: sym.imp.dlclose
dbg.unlibs: sym.imp.dlclose
[0x00400590]> di
type=exit-lib
signal=SIGTRAP
signum=5
sigpid=9125
addr=0x0
bp_addr=0x4005a0
......
[0x00400590]> dc
Selecting and continuing: 9125
hit breakpoint at: 4005c0
dbg.libs: sym.imp.dlmopen

dbg.libs: sym.imp.dlmopen
libgvc.so.6.0.0
[0x00400590]> di
type=new-lib
signal=SIGTRAP
signum=5
sigpid=9125
addr=0x0
bp_addr=0x4005c0
....
[0x00400590]>
```


