### PR TITLE
reorganizing opcode for arm

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -834,8 +834,8 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 								  -disp, MEMBASE(1), MEMBASE(1));
 					}					
 				} else {
-					r_strbuf_appendf (&op->esil, "%s,%s,0x%"PFMT64x",+,0xffffffff,&,=[4]",
-							  REG(0), MEMBASE(1), (ut64)disp);
+					r_strbuf_appendf (&op->esil, "%s,0x%"PFMT64x",%s,+,0xffffffff,&,=[4]",
+							  REG(0), (ut64)disp, MEMBASE(1));
 					if (insn->detail->arm.writeback) {
 						r_strbuf_appendf (&op->esil, ",%d,%s,+,%s,=",
 								  disp, MEMBASE(1), MEMBASE(1));


### PR DESCRIPTION
This should make afva recognise arm variables again
tests fixed here too 
https://github.com/radare/radare2-regressions/pull/677