### PR TITLE
Use HTTPS for Microsoft symbol server URL

### DIFF
--- a/doc/pdb/index.js
+++ b/doc/pdb/index.js
@@ -8,7 +8,7 @@ const INPUT_FOLDER_ARG = 2;
 const OUTPUT_FOLDER_ARG = 3;
 
 const SYMBOL_SERVER = 'Microsoft-Symbol-Server/6.11.0001.402';
-const DOWNLOABLE_LINK = 'http://msdl.microsoft.com/download/symbols';
+const DOWNLOABLE_LINK = 'https://msdl.microsoft.com/download/symbols';
 const GUID = 'guid';
 const DBG_FNAME = 'dbg_file';
 const CURL = 'curl';

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1713,7 +1713,7 @@ R_API int r_core_config_init(RCore *core) {
 	cfg->num = core->num;
 	/* pdb */
 	SETPREF("pdb.useragent", "Microsoft-Symbol-Server/6.11.0001.402", "User agent for Microsoft symbol server");
-	SETPREF("pdb.server", "http://msdl.microsoft.com/download/symbols", "Base URL for Microsoft symbol server");
+	SETPREF("pdb.server", "https://msdl.microsoft.com/download/symbols", "Base URL for Microsoft symbol server");
 	SETI("pdb.extract", 1, "Avoid extract of the pdb file, just download");
 
 	/* anal */


### PR DESCRIPTION
Update Microsoft symbol server URL to https://msdl.microsoft.com/download/symbols. This is the default sympath in WinDbg 10.0.14321.