### PR TITLE
Use current project as default for Ps

### DIFF
--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -51,6 +51,9 @@ static int cmd_project(void *data, const char *input) {
 		r_core_project_delete (core, file);
 		break;
 	case 's':
+		if (!file || !file[0]) { /* if no argument specified use current project */
+			file = str;
+		}
 		if (r_core_project_save (core, file)) {
 			r_config_set (core->config, "prj.name", file);
 			r_cons_println (file);


### PR DESCRIPTION
That changes behavior of Ps such that if no argument specified, it uses the current project, so that the project is saved (instead of ignoring the command).

I vaguely remember that this used to be the behavior in the past? This tripped me up causing me to lose a few hours of progress :(
