### PR TITLE
Fixed newline color issue on windows

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -874,6 +874,9 @@ R_API void r_cons_newline() {
 	if (!I.null) {
 		r_cons_strcat ("\n");
 	}
+#if __WINDOWS__
+	r_cons_reset_colors();
+#endif
 	//if (I.is_html) r_cons_strcat ("<br />\n");
 }
 

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2851,6 +2851,9 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 				r_cons_newline ();
 			}
 		}
+#if __WINDOWS__
+		r_cons_reset_colors();
+#endif
 	}
 	free (msg);
 	return 0;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2851,9 +2851,6 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 				r_cons_newline ();
 			}
 		}
-#if __WINDOWS__
-		r_cons_reset_colors();
-#endif
 	}
 	free (msg);
 	return 0;


### PR DESCRIPTION
The line wasn't resetted to white on windows, that resulted to have the last color on the new line.