### PR TITLE
[MIPS] Patched nonspaced instructions (like syscall)

### DIFF
--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -186,6 +186,8 @@ static int parse(RParse *p, const char *data, char *str) {
 					}
 				}
 			}
+		} else {
+			strncpy (w0, buf, WSZ - 1);
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4 };

--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -87,6 +87,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ "subu",  "1 = 2 - 3", 3},
 		{ "sub",  "1 = 2 - 3", 3},
 		{ "sw",  "[3 + 2] = 1", 3},
+		{ "syscall",  "syscall", 0},
 		{ "xor",  "1 = 2 ^ 3", 3},
 		{ "xori",  "1 = 2 ^ 3", 3},
 		{ NULL }


### PR DESCRIPTION
This should patch also https://github.com/radare/radare2/issues/6001