### PR TITLE
Introducing WebAssembly

### DIFF
--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -1,0 +1,33 @@
+ifeq (${_INCLUDE_MK_GCC_},)
+_INCLUDE_MK_GCC_=1
+EXT_EXE=.wasm
+EXT_SO=.wasm
+EXT_AR=a
+CC=emcc
+AR=emar
+LINK=
+RANLIB=emranlib
+ONELIB=0
+CC_AR=emar q ${LIBAR}
+PIC_CFLAGS=-fPIC
+CFLAGS+=-MD
+CFLAGS_INCLUDE=-I
+LDFLAGS_LINK=-l
+LDFLAGS_LINKPATH=-L
+CFLAGS_OPT0=-O0
+CFLAGS_OPT1=-O1
+CFLAGS_OPT2=-O2
+CFLAGS_OPT3=-O3
+CFLAGS_DEBUG=-g
+
+WASM=1
+SIDE_MODULE=1
+
+ifeq ($(OSTYPE),auto)
+OSTYPE=$(shell uname | tr 'A-Z' 'a-z')
+endif
+LDFLAGS_LIB=-shared
+LDFLAGS_SONAME=-Wl,-soname=
+
+CC_LIB=${CC} ${LDFLAGS_LIB} -o ${LIBSO}
+endif

--- a/sys/wasm.sh
+++ b/sys/wasm.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# find root
+cd `dirname $PWD/$0` ; cd ..
+#TODO: add support for ccache
+
+# XXX. fails with >1
+[ -z "${MAKE_JOBS}" ] && MAKE_JOBS=8
+
+OLD_LDFLAGS="${LDFLAGS}"
+unset LDFLAGS
+
+export CC="emcc -Os -s WASM=1 -s SIDE_MODULE=1"
+export AR="emar"
+
+CFGFLAGS="./configure --prefix=/usr --disable-debugger --with-compiler=wasm --without-pic --with-nonpic"
+
+make mrproper
+cp -f plugins.emscripten.cfg plugins.cfg
+./configure-plugins
+
+./configure ${CFGFLAGS} --host=wasm && \
+	make -s -j ${MAKE_JOBS} DEBUG=0


### PR DESCRIPTION
Via dockcross/asmjs/emscripten one should be able to compile WASM almost right away, according to this short article:

https://hackernoon.com/how-to-get-a-performance-boost-using-webassembly-8844ec6dd665#.s5oa3sisk

Unfortunately the portable emsdk bundled with dockcross is not yet at the edge for this:

```
[romanvg:/work] $ emcc fibonacci.c -Os -s WASM=1 -s SIDE_MODULE=1 -o fibonacci.wasm
WARNING:root:output file "fibonacci.wasm" has a wasm suffix, but we cannot emit wasm by itself. specify an output file with suffix .js or .html, and a wasm file will be created on the side
[romanvg:/work] 1 $ emcc fibonacci.c -Os -s WASM=1 -s SIDE_MODULE=1 -o fibonacci.js  
ERROR:root:fibonacci.c: No such file or directory ("fibonacci.c" was expected to be an input file, based on the commandline arguments provided)
[romanvg:/work] 1 $ emcc fibonnaci.c -Os -s WASM=1 -s SIDE_MODULE=1 -o fibonnaci.js
WARNING:root:retrieving port: binaryen from https://github.com/WebAssembly/binaryen/archive/version_18.zip
WARNING:root:unpacking port: binaryen
Traceback (most recent call last):
  File "/emsdk_portable/emscripten/tag-1.36.14/emcc", line 13, in <module>
    emcc.run()
  File "/emsdk_portable/emscripten/tag-1.36.14/emcc.py", line 2028, in run
    subprocess.check_call(cmd, stdout=open(wasm_text_target, 'w'))
  File "/usr/lib/python2.7/subprocess.py", line 535, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

@dockcross does not facilitate an in-docker upgrade either:

```
$ emsdk update
Traceback (most recent call last):
  File "/emsdk_portable/emsdk", line 2076, in <module>
    sys.exit(main())
  File "/emsdk_portable/emsdk", line 1980, in main
    update_emsdk()
  File "/emsdk_portable/emsdk", line 1447, in update_emsdk
    download_and_unzip(urljoin(emsdk_packages_url, 'emsdk_unix_update.tar.gz'), emsdk_path(), download_even_if_exists=True)
  File "/emsdk_portable/emsdk", line 838, in download_and_unzip
    dst_file = download_file(urljoin(emsdk_packages_url, zipfile), 'zips/', download_even_if_exists, filename_prefix)
  File "/emsdk_portable/emsdk", line 405, in download_file
    mkdir_p(os.path.dirname(file_name))
  File "/emsdk_portable/emsdk", line 279, in mkdir_p
    os.makedirs(path)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 13] Permission denied: '/emsdk_portable/zips'
```

And therefore a chain of github repos and dockerhubs need to be updated:

https://github.com/dockcross/dockcross/blob/master/browser-asmjs/Dockerfile.in#L1
https://hub.docker.com/r/trzeci/emscripten/
https://github.com/juj/emsdk

@asRIA, could you please refresh your emscripten docker container with the latest version so that dockcross has WebAssembly support? :)