### PR TITLE
Fix #4554 stackptr calculation on pdr and graph

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -71,6 +71,7 @@ R_API RAnal *r_anal_new() {
 	r_flag_bind_init (anal->flb);
 	anal->reg = r_reg_new ();
 	anal->last_disasm_reg = NULL;
+	anal->stackptr = 0;
 	anal->bits_ranges = r_list_newf (free);
 	anal->lineswidth = 0;
 	anal->fcns = r_anal_fcn_list_new ();

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -3,6 +3,7 @@
 #include <r_anal.h>
 #include <r_util.h>
 #include <r_list.h>
+#include <limits.h>
 
 #define DFLT_NINSTR 3
 
@@ -23,6 +24,8 @@ R_API RAnalBlock *r_anal_bb_new() {
 	bb->op_pos = R_NEWS0 (ut16, DFLT_NINSTR);
 	bb->op_pos_size = DFLT_NINSTR;
 	bb->parent_reg_arena = NULL;
+	bb->stackptr = 0;
+	bb->parent_stackptr = INT_MAX;
 	return bb;
 }
 

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -13,6 +13,7 @@
 #define JAYRO_04 0
 
 // 16 KB is the maximum size for a basic block
+// this is not exactly true.. but it is underperforming by doing lot of memcpys
 #define MAXBBSIZE 16 * 1024
 #define MAX_FLG_NAME_SIZE 64
 
@@ -1018,19 +1019,22 @@ repeat:
 				RIOSection *s = anal->iob.section_vget (anal->iob.io, addr);
 				if (s && s->name) {
 					bool in_plt = strstr (s->name, ".plt") != NULL;
-					if (!in_plt && strstr (s->name, "_stubs") != NULL) {
+					if (!in_plt && strstr (s->name, "_stub") != NULL) {
 						/* for mach0 */
 						in_plt = true;
 					}
-					if (anal->cur->arch && strstr (anal->cur->arch, "arm")) {
-						if (anal->bits == 64) {
-							if (!in_plt) goto river;
-						}
+					if (!in_plt) {
+						goto river;
+					}
+#if 0
+					if (anal->bits == 64) {
 					} else {
+						/* uh? */
 						if (in_plt) {
 							goto river;
 						}
 					}
+#endif
 				}
 			}
 			FITFCNSZ ();

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -312,20 +312,20 @@ static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut
 	anal->iob.read_at (anal->iob.io, ptr, jmptbl, MAX_JMPTBL_SIZE);
 	for (offs = 0; offs + sz - 1 < MAX_JMPTBL_SIZE; offs += sz) {
 		switch (sz) {
-		case 1: 
-			jmpptr = r_read_le8 (jmptbl + offs); 
+		case 1:
+			jmpptr = r_read_le8 (jmptbl + offs);
 			break;
-		case 2: 
-			jmpptr = r_read_le16 (jmptbl + offs); 
+		case 2:
+			jmpptr = r_read_le16 (jmptbl + offs);
 			break;
-		case 4: 
-			jmpptr = r_read_le32 (jmptbl + offs); 
+		case 4:
+			jmpptr = r_read_le32 (jmptbl + offs);
 			break;
-		case 8: 
-			jmpptr = r_read_le32 (jmptbl + offs); 
+		case 8:
+			jmpptr = r_read_le32 (jmptbl + offs);
 			break; // XXX
-		default: 
-			jmpptr = r_read_le64 (jmptbl + offs); 
+		default:
+			jmpptr = r_read_le64 (jmptbl + offs);
 			break;
 		}
 		if (!anal->iob.is_valid_offset (anal->iob.io, jmpptr, 0)) {
@@ -672,6 +672,10 @@ repeat:
 			if (fcn->stack > 0 && (int)op.val > 0) {
 				fcn->maxstack = fcn->stack;
 			}
+			bb->stackptr += op.stackptr;
+			break;
+		case R_ANAL_STACK_RESET:
+			bb->stackptr = 0;
 			break;
 		// TODO: use fcn->stack to know our stackframe
 		case R_ANAL_STACK_SET:

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1023,18 +1023,25 @@ repeat:
 						/* for mach0 */
 						in_plt = true;
 					}
-					if (!in_plt) {
-						goto river;
-					}
-#if 0
 					if (anal->bits == 64) {
+						if (!in_plt) {
+/* on arm64 and x86-64 the plt/stub is just a ujmp */
+							goto river;
+						}
 					} else {
-						/* uh? */
+#if 0
+/* on x86-32 the plt is ujmp,push,jmp */
+┌ (fcn) sym.imp.__cxa_finalize 6
+│   sym.imp.__cxa_finalize ();
+│     ↑↑↑      ; CALL XREF from 0x0000055e (sym.__do_global_dtors_aux)
+│     |||   0x00000420      ffa30c000000   Jmp  dword [ebx + 0xc]
+│     |||   0x00000426      6800000000     Push 0
+└     └───< 0x0000042b      e9e0ffffff     Jmp  0x410
+#endif
 						if (in_plt) {
 							goto river;
 						}
 					}
-#endif
 				}
 			}
 			FITFCNSZ ();

--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -191,10 +191,11 @@ R_API RList *r_anal_type_list_new() {
 }
 
 R_API void r_anal_type_header (RAnal *anal, const char *hdr) {
+	/* return */
 }
 
 R_API void r_anal_type_define (RAnal *anal, const char *key, const char *value) {
-
+	/* return */
 }
 
 R_API int r_anal_type_link(RAnal *anal, const char *type, ut64 addr) {
@@ -235,10 +236,10 @@ R_API char *r_anal_type_format(RAnal *anal, const char *t) {
 	snprintf (var, sizeof (var), "%s.%s", kind, t);
 	if (!strcmp (kind, "type")) {
 		const char *fmt = sdb_const_get (DB, var, NULL);
-		if (fmt)
+		if (fmt) {
 			return strdup (fmt);
-	} else
-	if (!strcmp (kind, "struct")) {
+		}
+	} else if (!strcmp (kind, "struct")) {
 		// assumes var list is sorted by offset.. should do more checks here
 		for (n = 0; (p = sdb_array_get (DB, var, n, NULL)); n++) {
 			const char *tfmt;
@@ -323,6 +324,7 @@ R_API char *r_anal_type_format(RAnal *anal, const char *t) {
 	}
 	return NULL;
 }
+
 // Function prototypes api
 R_API int r_anal_type_func_exist(RAnal *anal, const char *func_name) {
 	const char *fcn = sdb_const_get (anal->sdb_types, func_name, 0);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -360,7 +360,7 @@ static void ds_comment_esil(RDisasmState *ds, bool up, bool end, const char *for
 		if (up) {
 			ds_comment_lineup (ds);
 		}
-	} 
+	}
 	r_cons_printf_list (format, ap);
 	va_end (ap);
 
@@ -944,7 +944,7 @@ static void ds_show_xrefs(RDisasmState *ds) {
 			}
 			ds_pre_xrefs (ds);
 			//those extra space to align
-			ds_comment (ds, false, "   %s; %s XREF from 0x%08"PFMT64x" (%s)%s\n", 
+			ds_comment (ds, false, "   %s; %s XREF from 0x%08"PFMT64x" (%s)%s\n",
 			  	COLOR (ds, pal_comment), r_anal_xrefs_type_tostring (refi->type),
 				refi->addr, name, COLOR_RESET (ds));
 			R_FREE (name);
@@ -1162,7 +1162,7 @@ static void ds_show_functions(RDisasmState *ds) {
 	if (ds->show_fcnlines) {
 		ds->pre = r_str_concat (ds->pre, " ");
 	}
-	ds->stackptr = 0;
+	ds->stackptr = core->anal->stackptr;
 	if (ds->show_vars) {
 		char spaces[32];
 		RAnalVar *var;
@@ -3123,10 +3123,10 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 						ds_comment_esil (ds, true, false, ds->pal_comment);
 					}
 					ds_align_comment (ds);
-					ds_comment_esil (ds, ds->show_color? false : true, false, 
-					  		"; %s%s%s(", r_str_get (fcn_type), (fcn_type && *fcn_type &&
+					ds_comment_esil (ds, ds->show_color? false : true, false,
+							"; %s%s%s(", r_str_get (fcn_type), (fcn_type && *fcn_type &&
 							fcn_type[strlen (fcn_type) - 1] == '*') ? "" : " ",
-					  		r_str_get (key));
+							r_str_get (key));
 					if (!nargs) {
 						ds_comment_esil (ds, false, true, "void)");
 						break;
@@ -3209,8 +3209,8 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 						}
 						if (fmt) {
 							//it may need ds_comment_esil
-							print_fcn_arg (core, arg_orig_c_type, arg_name, 
-							  	fmt, arg_addr, on_stack);
+							print_fcn_arg (core, arg_orig_c_type, arg_name,
+								fmt, arg_addr, on_stack);
 							ds_comment_esil (ds, false, false, i!=(nargs - 1)?", ":")");
 						}
 						free (arg_orig_c_type);
@@ -3439,6 +3439,7 @@ toro:
 		len = ds->l = core->blocksize;
 	}
 
+	ds->stackptr = core->anal->stackptr;
 	r_cons_break_push (NULL, NULL);
 	r_anal_build_range_on_hints (core->anal);
 	for (i = idx = ret = 0; idx < len && ds->lines < ds->l; idx += inc, i++, ds->index += inc, ds->lines++) {
@@ -4254,6 +4255,7 @@ R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int 
 	ds->len = r_anal_fcn_size (fcn);
 	ds->addr = fcn->addr;
 	ds->fcn = fcn;
+	ds->stackptr = core->anal->stackptr;
 
 	r_list_foreach (fcn->bbs, bb_iter, bb) {
 		r_list_add_sorted (bb_list, bb, cmpaddr);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -647,6 +647,7 @@ typedef struct r_anal_t {
 	//RList *noreturn;
 	RList /*RAnalRange*/ *bits_ranges;
 	RListComparator columnSort;
+	int stackptr;
 } RAnal;
 
 typedef RAnalFunction *(* RAnalGetFcnIn)(RAnal *anal, ut64 addr, int type);
@@ -789,6 +790,8 @@ typedef struct r_anal_bb_t {
 	struct r_anal_bb_t *jumpbb;
 	RList /*struct r_anal_bb_t*/ *cases;
 	ut8 *parent_reg_arena;
+	int stackptr;
+	int parent_stackptr;
 } RAnalBlock;
 
 typedef enum {


### PR DESCRIPTION
- blocks have their stackptr
- inherit from parent when visited hierarchically (in pdr and graph)
- add the global anal->stackptr as a starting value for disasm, defaults to 0

Should fix https://github.com/radare/radare2/issues/4554

I added the stackptr calculation for single blocks in `fcn_recurse()` in `fcn.c` because apparently it's where blocks are really created and analyzed, while `r_anal_bb()` in `bb.c` is never reached: is this deprecated?

added also a test https://github.com/radare/radare2-regressions/pull/688 (to be merged after this PR)