### PR TITLE
Windows debugger: Added dce command. Fixed dmm commands.

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -793,7 +793,7 @@ show_help:
 				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
 						fn, map->addr);
 #if __WINDOWS__
-				/* Single quotes break the generated rabin2 command on Windows */
+				/* Use double quotes around the file path on Windows to generate valid commands */
 				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
 						map->addr, map->file);
 #else
@@ -824,7 +824,7 @@ show_help:
 						fn, map->addr);
 
 #if __WINDOWS__
-				/* Single quotes break the generated rabin2 command on Windows */
+				/* Use double quotes around the file path on Windows to generate valid commands */
 				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
 						map->addr, map->file);
 #else
@@ -3000,7 +3000,9 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 		"dca", " [sym] [sym].", "Continue at every hit on any given symbol",
 		"dcc", "", "Continue until call (use step into)",
 		"dccu", "", "Continue until unknown call (call reg)",
+#if __WINDOWS__
 		"dce", "", "Continue execution (pass exception to program)",
+#endif
 		"dcf", "", "Continue until fork (TODO)",
 		"dck", " <signal> <pid>", "Continue sending signal to process",
 		"dco", " <num>", "Step over <num> instructions",
@@ -3063,10 +3065,12 @@ beach:
 	case 'a': // "dca"
 		eprintf ("TODO: dca\n");
 		break;
+#if __WINDOWS__
 	case 'e': // "dce"
 		r_reg_arena_swap (core->dbg->reg, true);
 		r_debug_continue_pass_exception (core->dbg);
 		break;
+#endif
 	case 'f': // "dcf"
 		eprintf ("[+] Running 'dcs vfork fork clone' behind the scenes...\n");
 		// we should stop in fork and vfork syscalls

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -792,8 +792,14 @@ show_help:
 				//r_cons_printf ("fs+module_%s\n", fn);
 				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
 						fn, map->addr);
+#if __WINDOWS__
+				/* Single quotes break the generated rabin2 command on Windows */
+				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
+						map->addr, map->file);
+#else
 				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" '%s'\n",
 						map->addr, map->file);
+#endif
 				//r_cons_printf ("fs-\n");
 				free (fn);
 			}
@@ -816,8 +822,15 @@ show_help:
 				//r_cons_printf ("fs+module_%s\n", fn);
 				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
 						fn, map->addr);
+
+#if __WINDOWS__
+				/* Single quotes break the generated rabin2 command on Windows */
+				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
+						map->addr, map->file);
+#else
 				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" '%s'\n",
 						map->addr, map->file);
+#endif
 				//r_cons_printf ("fs-\n");
 				free (fn);
 			}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -812,7 +812,7 @@ show_help:
 			}
 			break;
 		case 'j':
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
 			{
 				/* Single backslashes cause issues when parsing JSON output, so escape them */
 				char *escaped_path = r_str_escape (map->file);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3000,6 +3000,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 		"dca", " [sym] [sym].", "Continue at every hit on any given symbol",
 		"dcc", "", "Continue until call (use step into)",
 		"dccu", "", "Continue until unknown call (call reg)",
+		"dce", "", "Continue execution (pass exception to program)",
 		"dcf", "", "Continue until fork (TODO)",
 		"dck", " <signal> <pid>", "Continue sending signal to process",
 		"dco", " <num>", "Step over <num> instructions",
@@ -3061,6 +3062,10 @@ beach:
 		break;
 	case 'a': // "dca"
 		eprintf ("TODO: dca\n");
+		break;
+	case 'e': // "dce"
+		r_reg_arena_swap (core->dbg->reg, true);
+		r_debug_continue_pass_exception (core->dbg);
 		break;
 	case 'f': // "dcf"
 		eprintf ("[+] Running 'dcs vfork fork clone' behind the scenes...\n");

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -787,21 +787,28 @@ show_help:
 			break;
 		case ':':
 			if (addr >= map->addr && addr < map->addr_end) {
+#if __WINDOWS__
+				/* Escape backslashes in the file path on Windows */
+				char *escaped_path = r_str_escape (map->file);
+				char *escaped_name = r_str_escape (map->name);
+				r_name_filter (escaped_name, 0);
+				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
+						escaped_name, map->addr);
+				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \'%s\'\n",
+						map->addr, escaped_path);
+				free (escaped_path);
+				free (escaped_name);
+#else
 				char *fn = strdup (map->file);
 				r_name_filter (fn, 0);
 				//r_cons_printf ("fs+module_%s\n", fn);
 				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
 						fn, map->addr);
-#if __WINDOWS__
-				/* Use double quotes around the file path on Windows to generate valid commands */
-				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
-						map->addr, map->file);
-#else
 				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" '%s'\n",
 						map->addr, map->file);
-#endif
 				//r_cons_printf ("fs-\n");
 				free (fn);
+#endif
 			}
 			break;
 		case '.':
@@ -816,9 +823,11 @@ show_help:
 			{
 				/* Single backslashes cause issues when parsing JSON output, so escape them */
 				char *escaped_path = r_str_escape (map->file);
+				char *escaped_name = r_str_escape (map->name);
 				r_cons_printf ("{\"address\":%"PFMT64d",\"name\":\"%s\",\"file\":\"%s\"}%s",
-						map->addr, map->name, escaped_path, iter->n?",":"");
+						map->addr, escaped_name, escaped_path, iter->n?",":"");
 				free (escaped_path);
+				free (escaped_name);
 			}
 #else
 			r_cons_printf ("{\"address\":%"PFMT64d",\"name\":\"%s\",\"file\":\"%s\"}%s",
@@ -827,21 +836,29 @@ show_help:
 			break;
 		case '*':
 			{
+#if __WINDOWS__
+				/* Escape backslashes in the file path on Windows */
+				char *escaped_path = r_str_escape (map->file);
+				char *escaped_name = r_str_escape (map->name);
+				r_name_filter (escaped_name, 0);
+				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
+						escaped_name, map->addr);
+				/* Use double quotes around the file path on Windows to generate valid commands */
+				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
+						map->addr, escaped_path);
+				free (escaped_path);
+				free (escaped_name);
+#else
 				char *fn = strdup (map->file);
 				r_name_filter (fn, 0);
 				//r_cons_printf ("fs+module_%s\n", fn);
 				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
 						fn, map->addr);
-#if __WINDOWS__
-				/* Use double quotes around the file path on Windows to generate valid commands */
-				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
-						map->addr, map->file);
-#else
 				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" '%s'\n",
 						map->addr, map->file);
-#endif
 				//r_cons_printf ("fs-\n");
 				free (fn);
+#endif
 			}
 			break;
 		default:

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -791,11 +791,13 @@ show_help:
 				/* Escape backslashes in the file path on Windows */
 				char *escaped_path = r_str_escape (map->file);
 				char *escaped_name = r_str_escape (map->name);
-				r_name_filter (escaped_name, 0);
-				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
-						escaped_name, map->addr);
-				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \'%s\'\n",
-						map->addr, escaped_path);
+				if (escaped_path && escaped_name) {
+					r_name_filter (escaped_name, 0);
+					r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
+							escaped_name, map->addr);
+					r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \'%s\'\n",
+							map->addr, escaped_path);
+				}
 				free (escaped_path);
 				free (escaped_name);
 #else
@@ -824,8 +826,10 @@ show_help:
 				/* Single backslashes cause issues when parsing JSON output, so escape them */
 				char *escaped_path = r_str_escape (map->file);
 				char *escaped_name = r_str_escape (map->name);
-				r_cons_printf ("{\"address\":%"PFMT64d",\"name\":\"%s\",\"file\":\"%s\"}%s",
-						map->addr, escaped_name, escaped_path, iter->n?",":"");
+				if (escaped_path && escaped_name) {
+					r_cons_printf ("{\"address\":%"PFMT64d",\"name\":\"%s\",\"file\":\"%s\"}%s",
+							map->addr, escaped_name, escaped_path, iter->n?",":"");
+				}
 				free (escaped_path);
 				free (escaped_name);
 			}
@@ -840,12 +844,14 @@ show_help:
 				/* Escape backslashes in the file path on Windows */
 				char *escaped_path = r_str_escape (map->file);
 				char *escaped_name = r_str_escape (map->name);
-				r_name_filter (escaped_name, 0);
-				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
-						escaped_name, map->addr);
-				/* Use double quotes around the file path on Windows to generate valid commands */
-				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
-						map->addr, escaped_path);
+				if (escaped_path && escaped_name) {
+					r_name_filter (escaped_name, 0);
+					r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
+							escaped_name, map->addr);
+					/* Use double quotes around the file path on Windows to generate valid commands */
+					r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",
+							map->addr, escaped_path);
+				}
 				free (escaped_path);
 				free (escaped_name);
 #else

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -787,7 +787,7 @@ show_help:
 			break;
 		case ':':
 			if (addr >= map->addr && addr < map->addr_end) {
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
 				/* Escape backslashes in the file path on Windows */
 				char *escaped_path = r_str_escape (map->file);
 				char *escaped_name = r_str_escape (map->name);
@@ -836,7 +836,7 @@ show_help:
 			break;
 		case '*':
 			{
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
 				/* Escape backslashes in the file path on Windows */
 				char *escaped_path = r_str_escape (map->file);
 				char *escaped_name = r_str_escape (map->name);
@@ -3026,7 +3026,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 		"dca", " [sym] [sym].", "Continue at every hit on any given symbol",
 		"dcc", "", "Continue until call (use step into)",
 		"dccu", "", "Continue until unknown call (call reg)",
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
 		"dce", "", "Continue execution (pass exception to program)",
 #endif
 		"dcf", "", "Continue until fork (TODO)",
@@ -3091,7 +3091,7 @@ beach:
 	case 'a': // "dca"
 		eprintf ("TODO: dca\n");
 		break;
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
 	case 'e': // "dce"
 		r_reg_arena_swap (core->dbg->reg, true);
 		r_debug_continue_pass_exception (core->dbg);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -812,8 +812,18 @@ show_help:
 			}
 			break;
 		case 'j':
+#if __WINDOWS__
+			{
+				/* Single backslashes cause issues when parsing JSON output, so escape them */
+				char *escaped_path = r_str_escape (map->file);
+				r_cons_printf ("{\"address\":%"PFMT64d",\"name\":\"%s\",\"file\":\"%s\"}%s",
+						map->addr, map->name, escaped_path, iter->n?",":"");
+				free (escaped_path);
+			}
+#else
 			r_cons_printf ("{\"address\":%"PFMT64d",\"name\":\"%s\",\"file\":\"%s\"}%s",
 					map->addr, map->name, map->file, iter->n?",":"");
+#endif
 			break;
 		case '*':
 			{
@@ -822,7 +832,6 @@ show_help:
 				//r_cons_printf ("fs+module_%s\n", fn);
 				r_cons_printf ("f mod.%s = 0x%08"PFMT64x"\n",
 						fn, map->addr);
-
 #if __WINDOWS__
 				/* Use double quotes around the file path on Windows to generate valid commands */
 				r_cons_printf (".!rabin2 -rsB 0x%08"PFMT64x" \"%s\"\n",

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1024,6 +1024,15 @@ R_API int r_debug_continue(RDebug *dbg) {
 	return r_debug_continue_kill (dbg, 0); //dbg->reason.signum);
 }
 
+R_API int r_debug_continue_pass_exception(RDebug *dbg) {
+#if __WINDOWS__ && !__CYGWIN__
+	return r_debug_continue_kill (dbg, 1); // TODO: Passing in 0 and 1 is stupid
+#else
+	eprintf ("Not implemented for this platform\n");
+	return false;
+#endif
+}
+
 R_API int r_debug_continue_until_nontraced(RDebug *dbg) {
 	eprintf ("TODO\n");
 	return false;

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1024,14 +1024,11 @@ R_API int r_debug_continue(RDebug *dbg) {
 	return r_debug_continue_kill (dbg, 0); //dbg->reason.signum);
 }
 
+#if __WINDOWS__
 R_API int r_debug_continue_pass_exception(RDebug *dbg) {
-#if __WINDOWS__ && !__CYGWIN__
-	return r_debug_continue_kill (dbg, 1); // TODO: Passing in 0 and 1 is stupid
-#else
-	eprintf ("Not implemented for this platform\n");
-	return false;
-#endif
+	return r_debug_continue_kill (dbg, DBG_EXCEPTION_NOT_HANDLED);
 }
+#endif
 
 R_API int r_debug_continue_until_nontraced(RDebug *dbg) {
 	eprintf ("TODO\n");

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1024,7 +1024,7 @@ R_API int r_debug_continue(RDebug *dbg) {
 	return r_debug_continue_kill (dbg, 0); //dbg->reason.signum);
 }
 
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
 R_API int r_debug_continue_pass_exception(RDebug *dbg) {
 	return r_debug_continue_kill (dbg, DBG_EXCEPTION_NOT_HANDLED);
 }

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -230,12 +230,8 @@ static void r_debug_native_stop(RDebug *dbg) {
 static int r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
 #if __WINDOWS__ && !__CYGWIN__
 	/* Honor the Windows-specific signal that instructs threads to process exceptions */
-	DWORD continue_status;
-	if (sig == DBG_EXCEPTION_NOT_HANDLED ) {
-		continue_status = DBG_EXCEPTION_NOT_HANDLED;
-	} else {
-		continue_status = DBG_CONTINUE;
-	}
+	DWORD continue_status = (sig == DBG_EXCEPTION_NOT_HANDLED)
+		? DBG_EXCEPTION_NOT_HANDLED : DBG_CONTINUE;
 	if (ContinueDebugEvent (pid, tid, continue_status) == 0) {
 		print_lasterr ((char *)__FUNCTION__, "ContinueDebugEvent");
 		eprintf ("debug_contp: error\n");

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -229,7 +229,16 @@ static void r_debug_native_stop(RDebug *dbg) {
 /* TODO: must return true/false */
 static int r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
 #if __WINDOWS__ && !__CYGWIN__
-	if (ContinueDebugEvent (pid, tid, DBG_CONTINUE) == 0) {
+	DWORD continue_status;
+
+	if (sig == 1) {
+		continue_status = DBG_EXCEPTION_NOT_HANDLED;
+	} else {
+		continue_status = DBG_CONTINUE;
+	}
+
+	if (ContinueDebugEvent (pid, tid, continue_status) == 0) {
+//	if (ContinueDebugEvent (pid, tid, DBG_CONTINUE) == 0) {
 		print_lasterr ((char *)__FUNCTION__, "ContinueDebugEvent");
 		eprintf ("debug_contp: error\n");
 		return false;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -228,9 +228,9 @@ static void r_debug_native_stop(RDebug *dbg) {
 /* TODO: specify thread? */
 /* TODO: must return true/false */
 static int r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
+	/* Honor the Windows-specific signal that instructs threads to process exceptions */
 	DWORD continue_status;
-    /* Honor the Windows-specific signal that instructs threads to process exceptions */
 	if (sig == DBG_EXCEPTION_NOT_HANDLED ) {
 		continue_status = DBG_EXCEPTION_NOT_HANDLED;
 	} else {

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -228,17 +228,15 @@ static void r_debug_native_stop(RDebug *dbg) {
 /* TODO: specify thread? */
 /* TODO: must return true/false */
 static int r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	DWORD continue_status;
-
-	if (sig == 1) {
+    /* Honor the Windows-specific signal that instructs threads to process exceptions */
+	if (sig == DBG_EXCEPTION_NOT_HANDLED ) {
 		continue_status = DBG_EXCEPTION_NOT_HANDLED;
 	} else {
 		continue_status = DBG_CONTINUE;
 	}
-
 	if (ContinueDebugEvent (pid, tid, continue_status) == 0) {
-//	if (ContinueDebugEvent (pid, tid, DBG_CONTINUE) == 0) {
 		print_lasterr ((char *)__FUNCTION__, "ContinueDebugEvent");
 		eprintf ("debug_contp: error\n");
 		return false;

--- a/libr/debug/p/native/maps/windows.c
+++ b/libr/debug/p/native/maps/windows.c
@@ -27,9 +27,6 @@ static RList *w32_dbg_modules(RDebug *dbg) {
 			if (mr->file != NULL)
 				r_list_append (list, mr);
 		}
-		memset (&me32, 0, sizeof (me32));
-		me32.dwSize = sizeof (me32);
-
 	} while(Module32Next (hModuleSnap, &me32));
 	CloseHandle (hModuleSnap);
 	CloseHandle (hProcess);

--- a/libr/debug/p/native/maps/windows.c
+++ b/libr/debug/p/native/maps/windows.c
@@ -1,25 +1,3 @@
-/* Replace single backslashes with double backslashes */
-static char *replace_backslashes(const char *orig) {
-	char *replaced = NULL;
-	int i, j;
-
-	replaced = malloc (MAX_PATH);
-	if (!replaced)
-		return NULL;
-	memset (replaced, 0, MAX_PATH);
-	for (i = 0, j = 0; i < strlen (orig); i++, j++) {
-		replaced[j] = orig[i];
-		if (orig[i] == '\\') {
-			j++;
-			replaced[j] = '\\';
-		}
-		if (j >= MAX_PATH) {
-			free (replaced);
-			return NULL;
-		}
-	}
-	return replaced;
-}
 
 static RList *w32_dbg_modules(RDebug *dbg) {
 	HANDLE hProcess = 0;
@@ -45,9 +23,7 @@ static RList *w32_dbg_modules(RDebug *dbg) {
 		ut64 baddr = (ut64)(size_t)me32.modBaseAddr;
 		mr = r_debug_map_new (me32.szModule, baddr, baddr + me32.modBaseSize, 0, 0);
 		if (mr != NULL) {
-            /* Single backslashes can cause issues when parsing JSON output,
-             * so we replace them with double backslashes */
-			mr->file = replace_backslashes (me32.szExePath);
+			mr->file = strdup (me32.szExePath);
 			if (mr->file != NULL)
 				r_list_append (list, mr);
 		}

--- a/libr/debug/p/native/maps/windows.c
+++ b/libr/debug/p/native/maps/windows.c
@@ -45,6 +45,8 @@ static RList *w32_dbg_modules(RDebug *dbg) {
 		ut64 baddr = (ut64)(size_t)me32.modBaseAddr;
 		mr = r_debug_map_new (me32.szModule, baddr, baddr + me32.modBaseSize, 0, 0);
 		if (mr != NULL) {
+            /* Single backslashes can cause issues when parsing JSON output,
+             * so we replace them with double backslashes */
 			mr->file = replace_backslashes (me32.szExePath);
 			if (mr->file != NULL)
 				r_list_append (list, mr);

--- a/libr/debug/p/native/maps/windows.c
+++ b/libr/debug/p/native/maps/windows.c
@@ -26,7 +26,6 @@ static RList *w32_dbg_modules(RDebug *dbg) {
 	HANDLE hModuleSnap = 0;
 	MODULEENTRY32 me32;
 	RDebugMap *mr;
-	char *mapname = NULL;
 	int pid = dbg->pid;
 	RList *list = r_list_new ();
 

--- a/libr/debug/p/native/maps/windows.c
+++ b/libr/debug/p/native/maps/windows.c
@@ -1,3 +1,25 @@
+/* Replace single backslashes with double backslashes */
+static char *replace_backslashes(const char *orig) {
+	char *replaced = NULL;
+	int i, j;
+
+	replaced = malloc (MAX_PATH);
+	if (!replaced)
+		return NULL;
+	memset (replaced, 0, MAX_PATH);
+	for (i = 0, j = 0; i < strlen (orig); i++, j++) {
+		replaced[j] = orig[i];
+		if (orig[i] == '\\') {
+			j++;
+			replaced[j] = '\\';
+		}
+		if (j >= MAX_PATH) {
+			free (replaced);
+			return NULL;
+		}
+	}
+	return replaced;
+}
 
 static RList *w32_dbg_modules(RDebug *dbg) {
 	HANDLE hProcess = 0;
@@ -22,14 +44,15 @@ static RList *w32_dbg_modules(RDebug *dbg) {
 	hProcess = w32_openprocess (PROCESS_QUERY_INFORMATION |PROCESS_VM_READ,FALSE, pid );
 	do {
 		ut64 baddr = (ut64)(size_t)me32.modBaseAddr;
-		mapname = (char *)malloc(MAX_PATH);
-		snprintf (mapname, MAX_PATH, "%s\\%s", me32.szExePath, me32.szModule);
-		mr = r_debug_map_new (mapname, baddr, baddr + me32.modBaseSize, 0, 0);
+		mr = r_debug_map_new (me32.szModule, baddr, baddr + me32.modBaseSize, 0, 0);
 		if (mr != NULL) {
-			mr->file=strdup(mapname);
-			r_list_append (list, mr);
+			mr->file = replace_backslashes (me32.szExePath);
+			if (mr->file != NULL)
+				r_list_append (list, mr);
 		}
-		free(mapname);
+		memset (&me32, 0, sizeof (me32));
+		me32.dwSize = sizeof (me32);
+
 	} while(Module32Next (hModuleSnap, &me32));
 	CloseHandle (hModuleSnap);
 	CloseHandle (hProcess);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -367,7 +367,7 @@ R_API int r_debug_continue_syscall(RDebug *dbg, int sc);
 R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc);
 R_API int r_debug_continue(RDebug *dbg);
 R_API int r_debug_continue_kill(RDebug *dbg, int signal);
-#if __WINDOWS__
+#if __WINDOWS__ && !__CYGWIN__
 R_API int r_debug_continue_pass_exception(RDebug *dbg);
 #endif
 

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -367,7 +367,9 @@ R_API int r_debug_continue_syscall(RDebug *dbg, int sc);
 R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc);
 R_API int r_debug_continue(RDebug *dbg);
 R_API int r_debug_continue_kill(RDebug *dbg, int signal);
+#if __WINDOWS__
 R_API int r_debug_continue_pass_exception(RDebug *dbg);
+#endif
 
 /* process/thread handling */
 R_API int r_debug_select(RDebug *dbg, int pid, int tid);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -367,6 +367,7 @@ R_API int r_debug_continue_syscall(RDebug *dbg, int sc);
 R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc);
 R_API int r_debug_continue(RDebug *dbg);
 R_API int r_debug_continue_kill(RDebug *dbg, int signal);
+R_API int r_debug_continue_pass_exception(RDebug *dbg);
 
 /* process/thread handling */
 R_API int r_debug_select(RDebug *dbg, int pid, int tid);


### PR DESCRIPTION
This PR is to pay for the pizza at r2con. Thanks pancake :)

Added new command on Windows:
`dce`: Continue execution (pass exception to program)

Fixed the following commands on Windows:
`.dmm*`
`dmm` (now reports sane paths)
`dmmj` (when used from e.g. r2pipe)

The `dce` command will instruct the debugged process to handle the raised exception (similar to `shift+F9` in OllyDbg). This is especially useful when debugging protected executables and malware that make use of anti-debugging techniques.

`dmm*` did not generate valid commands on Windows. I have found it extremely useful to quickly get the exports of all loaded DLLs by using `.dmm*`.

The `dmm` command worked but its output would include the name of the executable twice.

The `dmmj` command was problematic when scripting r2 from e.g. Python via r2pipe, because the backspaces in the paths were not properly escaped.