### PR TITLE
Add: coredump refactoring + RDebugMap offset field

### DIFF
--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -77,7 +77,6 @@ int linux_handle_signals (RDebug *dbg, bool self_signalled) {
 						char *p = strstr (b->data, "dbg.");
 						if (p) {
 							if (r_str_startswith (p, "dbg.libs")) {
-								char str[80];
 								const char *name;
 								if (strstr (b->data, "sym.imp.dlopen")) {
 									name = r_reg_get_name (dbg->reg, R_REG_NAME_A0);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -133,6 +133,7 @@ typedef struct r_debug_map_t {
 	ut64 addr;
 	ut64 addr_end;
 	ut64 size;
+	ut64 offset;
 	char *file;
 	int perm;
 	int user;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -14,6 +14,8 @@ extern "C" {
 #define R_IO_WRITE (1 << 1)
 #define R_IO_READ  (1 << 2)
 #define R_IO_MAP   (1 << 4)
+#define R_IO_PRIV  (1 << 5)
+#define R_IO_SHAR  (1 << 6)
 #define R_IO_RW    (R_IO_READ | R_IO_WRITE)
 
 #define R_IO_SEEK_SET 0


### PR DESCRIPTION
I've cleaned up the code of linux_coredump.c, and I've added an offset field for `RDebugMap` structure.
I've also changed a little bit the code of `r_debug_native_map_get` function in order to get the offset and if a map is private/shared.
Since I need this info for generating a coredump, and since it might come in handy for some other things, I thought it's fine.