### PR TITLE
s/struct r_anal_plugin_t/RAnalPlugin

### DIFF
--- a/libr/anal/p/anal_arm_gnu.c
+++ b/libr/anal/p/anal_arm_gnu.c
@@ -455,7 +455,7 @@ static int archinfo(RAnal *anal, int q) {
 	return 4; // XXX
 }
 
-struct r_anal_plugin_t r_anal_plugin_arm_gnu = {
+RAnalPlugin r_anal_plugin_arm_gnu = {
 	.name = "arm.gnu",
 	.arch = "arm",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_bf.c
+++ b/libr/anal/p/anal_bf.c
@@ -121,7 +121,7 @@ static char *get_reg_profile(RAnal *anal) {
 	);
 }
 
-struct r_anal_plugin_t r_anal_plugin_bf = {
+RAnalPlugin r_anal_plugin_bf = {
 	.name = "bf",
 	.desc = "brainfuck code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_cr16.c
+++ b/libr/anal/p/anal_cr16.c
@@ -123,7 +123,7 @@ static int cr16_op(RAnal *anal, RAnalOp *op, ut64 addr,
 	return ret;
 }
 
-struct r_anal_plugin_t r_anal_plugin_cr16 = {
+RAnalPlugin r_anal_plugin_cr16 = {
 	.name = "cr16",
 	.desc = "CR16 code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_ebc.c
+++ b/libr/anal/p/anal_ebc.c
@@ -161,7 +161,7 @@ static int ebc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 	return ret;
 }
 
-struct r_anal_plugin_t r_anal_plugin_ebc = {
+RAnalPlugin r_anal_plugin_ebc = {
 	.name = "ebc",
 	.desc = "EBC code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_gb.c
+++ b/libr/anal/p/anal_gb.c
@@ -1451,7 +1451,7 @@ static int esil_gb_fini (RAnalEsil *esil) {
 	return true;
 }
 
-struct r_anal_plugin_t r_anal_plugin_gb = {
+RAnalPlugin r_anal_plugin_gb = {
 	.name = "gb",
 	.desc = "Gameboy CPU code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_h8300.c
+++ b/libr/anal/p/anal_h8300.c
@@ -718,7 +718,7 @@ static int set_reg_profile(RAnal *anal) {
 	return r_reg_set_profile_string (anal->reg, p);
 }
 
-struct r_anal_plugin_t r_anal_plugin_h8300 = {
+RAnalPlugin r_anal_plugin_h8300 = {
 	.name = "h8300",
 	.desc = "H8300 code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_i8080.c
+++ b/libr/anal/p/anal_i8080.c
@@ -188,7 +188,7 @@ static int i8080_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	return op->size = ilen;
 }
 
-struct r_anal_plugin_t r_anal_plugin_i8080 = {
+RAnalPlugin r_anal_plugin_i8080 = {
 	.name = "i8080",
 	.desc = "I8080 CPU code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_malbolge.c
+++ b/libr/anal/p/anal_malbolge.c
@@ -37,7 +37,7 @@ static int mal_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	return false;
 }
 
-struct r_anal_plugin_t r_anal_plugin_malbolge = {
+RAnalPlugin r_anal_plugin_malbolge = {
 	.name = "malbolge",
 	.desc = "Malbolge analysis plugin",
 	.arch = "malbolge",

--- a/libr/anal/p/anal_mips_gnu.c
+++ b/libr/anal/p/anal_mips_gnu.c
@@ -524,7 +524,7 @@ static int archinfo(RAnal *anal, int q) {
 	return 4;
 }
 
-struct r_anal_plugin_t r_anal_plugin_mips_gnu = {
+RAnalPlugin r_anal_plugin_mips_gnu = {
 	.name = "mips.gnu",
 	.desc = "MIPS code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_msp430.c
+++ b/libr/anal/p/anal_msp430.c
@@ -71,7 +71,7 @@ static int msp430_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	return ret;
 }
 
-struct r_anal_plugin_t r_anal_plugin_msp430 = {
+RAnalPlugin r_anal_plugin_msp430 = {
 	.name = "msp430",
 	.desc = "TI MSP430 code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_nios2.c
+++ b/libr/anal/p/anal_nios2.c
@@ -88,7 +88,7 @@ static int nios2_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) 
 	return op->size;
 }
 
-struct r_anal_plugin_t r_anal_plugin_nios2 = {
+RAnalPlugin r_anal_plugin_nios2 = {
 	.name = "nios2",
 	.desc = "NIOS II code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_null.c
+++ b/libr/anal/p/anal_null.c
@@ -10,7 +10,7 @@ static int null_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int l
 	return op->size = 1;
 }
 
-struct r_anal_plugin_t r_anal_plugin_null = {
+RAnalPlugin r_anal_plugin_null = {
 	.name = "null",
 	.desc = "Fallback/Null analysis plugin",
 	.arch = "none",

--- a/libr/anal/p/anal_pic18c.c
+++ b/libr/anal/p/anal_pic18c.c
@@ -398,7 +398,7 @@ static int set_reg_profile(RAnal *esil) {
 
 	return r_reg_set_profile_string (esil->reg, p);
 }
-struct r_anal_plugin_t r_anal_plugin_pic18c = {
+RAnalPlugin r_anal_plugin_pic18c = {
 	.name = "pic18c",
 	.desc = "PIC 18c analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_ppc_gnu.c
+++ b/libr/anal/p/anal_ppc_gnu.c
@@ -139,7 +139,7 @@ static int archinfo(RAnal *anal, int q) {
 	return 4; /* :D */
 }
 
-struct r_anal_plugin_t r_anal_plugin_ppc_gnu = {
+RAnalPlugin r_anal_plugin_ppc_gnu = {
 	.name = "ppc.gnu",
 	.desc = "PowerPC analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_propeller.c
+++ b/libr/anal/p/anal_propeller.c
@@ -102,7 +102,7 @@ static int propeller_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int
 	return ret;
 }
 
-struct r_anal_plugin_t r_anal_plugin_propeller = {
+RAnalPlugin r_anal_plugin_propeller = {
 	.name = "propeller",
 	.desc = "Parallax propeller code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -156,7 +156,7 @@ static int set_reg_profile(RAnal *anal) {
 }
 #endif
 
-struct r_anal_plugin_t r_anal_plugin_riscv = {
+RAnalPlugin r_anal_plugin_riscv = {
 	.name = "riscv",
 	.desc = "RISC-V analysis plugin",
 	.license = "GPL",

--- a/libr/anal/p/anal_rsp.c
+++ b/libr/anal/p/anal_rsp.c
@@ -685,7 +685,7 @@ static int archinfo(RAnal *anal, int q) {
 	return 4;
 }
 
-struct r_anal_plugin_t r_anal_plugin_rsp = {
+RAnalPlugin r_anal_plugin_rsp = {
 	.name = "rsp",
 	.desc = "RSP code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_sh.c
+++ b/libr/anal/p/anal_sh.c
@@ -808,7 +808,7 @@ static int archinfo(RAnal *anal, int q) {
 	return 2; /* :) */
 }
 
-struct r_anal_plugin_t r_anal_plugin_sh = {
+RAnalPlugin r_anal_plugin_sh = {
 	.name = "sh",
 	.desc = "SH-4 code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_snes.c
+++ b/libr/anal/p/anal_snes.c
@@ -219,7 +219,7 @@ static int snes_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int l
 	return op->size;
 }
 
-struct r_anal_plugin_t r_anal_plugin_snes = {
+RAnalPlugin r_anal_plugin_snes = {
 	.name = "snes",
 	.desc = "SNES analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_tms320.c
+++ b/libr/anal/p/anal_tms320.c
@@ -98,7 +98,7 @@ static int tms320_fini(void * unused) {
 	return tms320_dasm_fini (&engine);
 }
 
-struct r_anal_plugin_t r_anal_plugin_tms320 = {
+RAnalPlugin r_anal_plugin_tms320 = {
 	.name = "tms320",
 	.arch = "tms320",
 	.bits = 32,

--- a/libr/anal/p/anal_v810.c
+++ b/libr/anal/p/anal_v810.c
@@ -426,7 +426,7 @@ static int set_reg_profile(RAnal *anal) {
 	return r_reg_set_profile_string (anal->reg, p);
 }
 
-struct r_anal_plugin_t r_anal_plugin_v810 = {
+RAnalPlugin r_anal_plugin_v810 = {
 	.name = "v810",
 	.desc = "V810 code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_v850.c
+++ b/libr/anal/p/anal_v850.c
@@ -107,7 +107,7 @@ static int v850_op(RAnal *anal, RAnalOp *op, ut64 addr,
 	return ret;
 }
 
-struct r_anal_plugin_t r_anal_plugin_v850 = {
+RAnalPlugin r_anal_plugin_v850 = {
 	.name = "V850",
 	.desc = "V850 code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_ws.c
+++ b/libr/anal/p/anal_ws.c
@@ -131,7 +131,7 @@ static int ws_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 	return op->size;
 }
 
-struct r_anal_plugin_t r_anal_plugin_ws = {
+RAnalPlugin r_anal_plugin_ws = {
 	.name = "ws",
 	.desc = "Space, tab and linefeed analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_xap.c
+++ b/libr/anal/p/anal_xap.c
@@ -203,7 +203,7 @@ static int xap_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *bytes, int len
 	return op->size;
 }
 
-struct r_anal_plugin_t r_anal_plugin_xap = {
+RAnalPlugin r_anal_plugin_xap = {
 	.name = "xap",
 	.desc = "XAP code analysis plugin",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -1995,7 +1995,7 @@ static char *get_reg_profile(RAnal *anal) {
 	);
 }
 
-struct r_anal_plugin_t r_anal_plugin_xtensa = {
+RAnalPlugin r_anal_plugin_xtensa = {
 	.name = "xtensa",
 	.desc = "Xtensa disassembler",
 	.license = "LGPL3",

--- a/libr/anal/p/anal_z80.c
+++ b/libr/anal/p/anal_z80.c
@@ -362,7 +362,7 @@ static int z80_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int
 	return ilen;
 }
 
-struct r_anal_plugin_t r_anal_plugin_z80 = {
+RAnalPlugin r_anal_plugin_z80 = {
 	.name = "z80",
 	.arch = "z80",
 	.license = "LGPL3",


### PR DESCRIPTION
Grep fail:
```
$ grep -R "struct r_anal_plugin_t" .        
./anal/p/anal_pic18c.c:struct r_anal_plugin_t r_anal_plugin_pic18c = {
./anal/p/anal_propeller.c:struct r_anal_plugin_t r_anal_plugin_propeller = {
./anal/p/anal_mips_gnu.c:struct r_anal_plugin_t r_anal_plugin_mips_gnu = {
./anal/p/anal_z80.c:struct r_anal_plugin_t r_anal_plugin_z80 = {
./anal/p/anal_ebc.c:struct r_anal_plugin_t r_anal_plugin_ebc = {
./anal/p/anal_arm_gnu.c:struct r_anal_plugin_t r_anal_plugin_arm_gnu = {
./anal/p/anal_msp430.c:struct r_anal_plugin_t r_anal_plugin_msp430 = {
./anal/p/anal_snes.c:struct r_anal_plugin_t r_anal_plugin_snes = {
./anal/p/anal_sh.c:struct r_anal_plugin_t r_anal_plugin_sh = {
./anal/p/anal_v810.c:struct r_anal_plugin_t r_anal_plugin_v810 = {
./anal/p/anal_i8080.c:struct r_anal_plugin_t r_anal_plugin_i8080 = {
./anal/p/anal_v850.c:struct r_anal_plugin_t r_anal_plugin_v850 = {
./anal/p/anal_xap.c:struct r_anal_plugin_t r_anal_plugin_xap = {
./anal/p/anal_riscv.c:struct r_anal_plugin_t r_anal_plugin_riscv = {
./anal/p/anal_xtensa.c:struct r_anal_plugin_t r_anal_plugin_xtensa = {
./anal/p/anal_tms320.c:struct r_anal_plugin_t r_anal_plugin_tms320 = {
./anal/p/anal_bf.c:struct r_anal_plugin_t r_anal_plugin_bf = {
./anal/p/anal_malbolge.c:struct r_anal_plugin_t r_anal_plugin_malbolge = {
./anal/p/anal_null.c:struct r_anal_plugin_t r_anal_plugin_null = {
./anal/p/anal_cr16.c:struct r_anal_plugin_t r_anal_plugin_cr16 = {
./anal/p/anal_rsp.c:struct r_anal_plugin_t r_anal_plugin_rsp = {
./anal/p/anal_ws.c:struct r_anal_plugin_t r_anal_plugin_ws = {
./anal/p/anal_h8300.c:struct r_anal_plugin_t r_anal_plugin_h8300 = {
./anal/p/anal_gb.c:struct r_anal_plugin_t r_anal_plugin_gb = {
./anal/p/anal_ppc_gnu.c:struct r_anal_plugin_t r_anal_plugin_ppc_gnu = {
./anal/p/anal_nios2.c:struct r_anal_plugin_t r_anal_plugin_nios2 = {

$ grep -R "RAnalPlugin r_anal_pl" .  
./anal/p/anal_m68k_cs.c:RAnalPlugin r_anal_plugin_m68k_cs = {
./anal/p/anal_m68k_cs.c:RAnalPlugin r_anal_plugin_m68k_cs = {
./anal/p/anal_dalvik.c:RAnalPlugin r_anal_plugin_dalvik = {
./anal/p/anal_cris.c:RAnalPlugin r_anal_plugin_cris = {
./anal/p/anal_ppc_cs.c:RAnalPlugin r_anal_plugin_ppc_cs = {
./anal/p/anal_arc.c:RAnalPlugin r_anal_plugin_arc = {
./anal/p/anal_arm_cs.c:RAnalPlugin r_anal_plugin_arm_cs = {
./anal/p/anal_vax.c:RAnalPlugin r_anal_plugin_vax = {
./anal/p/anal_mips_cs.c:RAnalPlugin r_anal_plugin_mips_cs = {
./anal/p/anal_sysz.c:RAnalPlugin r_anal_plugin_sysz = {
./anal/p/anal_avr.c:RAnalPlugin r_anal_plugin_avr = {
./anal/p/anal_8051.c:RAnalPlugin r_anal_plugin_8051 = {
./anal/p/anal_java.c:RAnalPlugin r_anal_plugin_java = {
./anal/p/anal_java.c:RAnalPlugin r_anal_plugin_java_ls = {
./anal/p/anal_6502.c:RAnalPlugin r_anal_plugin_6502 = {
./anal/p/anal_xcore_cs.c:RAnalPlugin r_anal_plugin_xcore_cs = {
./anal/p/anal_sparc_gnu.c:RAnalPlugin r_anal_plugin_sparc_gnu = {
./anal/p/anal_x86_udis.c:RAnalPlugin r_anal_plugin_x86_udis = {
./anal/p/anal_x86_cs.c:RAnalPlugin r_anal_plugin_x86_cs = {
./anal/p/anal_sparc_cs.c:RAnalPlugin r_anal_plugin_sparc_cs = {
./anal/p/anal_i4004.c:RAnalPlugin r_anal_plugin_i4004 = {
```

in radare's name cause is fake news.