### PR TITLE
Add script to parse capstone arch files, map instr_id to name

### DIFF
--- a/sys/gen_capston_ins_table.py
+++ b/sys/gen_capston_ins_table.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+gen_capston_ins_table.py
+
+Parse capstone header file and dump JSON map for inst_id->name lookup.
+
+"""
+
+import sys
+import re
+import json
+from cffi import FFI
+
+
+def parse_definition(s):
+    r = re.finditer("^typedef\s+enum\s+(\w+_insn) \{", s, flags=re.MULTILINE)
+    m = next(r)
+    if not m:
+        raise RuntimeError("Failed to parse")
+    tpname = m.group(1)
+    ss = "typedef enum " + s.split(tpname, 1)[-1].split("//>")[0]
+    enum_prefix = ss.split("\n")[1].strip().rsplit("_", 1)[0]
+    if not enum_prefix or len(enum_prefix) > 10:
+        raise RuntimeError("Failed to parse")
+    return tpname, enum_prefix, ss
+
+
+def create_dict(filename, suffix="//>"):
+    with open(filename, "r") as f:
+        s = f.read()
+
+    ffi = FFI()
+    tpname, enum_prefix, enum = parse_definition(s)
+    ffi.cdef(enum)
+
+    x = ffi.new("%s*" % tpname)
+    c = ffi.dlopen('c')
+    d = {getattr(c, n): n for n in dir(c) if n.startswith(enum_prefix)}
+
+    return d
+
+
+def main():
+
+    if (len(sys.argv) != 2):
+        print("Usage: %s <path to capstone (x86.h|arm.h|...)>" % sys.argv[0])
+        return
+    d = create_dict(sys.argv[1])
+
+    print(json.dumps(d, indent=4))
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
```
$ r2  -qc 'wa mov eax, 0x00001234; ao 1~id:'  -  
id: 449
$ sys/gen_capston_ins_table.py ./shlr/capstone/include/capstone/x86.h | grep 449
    "449": "X86_INS_MOV", 
    "1449": "X86_INS_VCMPEQ_OSPS", 

$ sys/gen_capston_ins_table.py ./shlr/capstone/include/capstone/arm.h | head -n  10
{
    "0": "ARM_INS_INVALID", 
    "1": "ARM_INS_ADC", 
    "2": "ARM_INS_ADD", 
    "3": "ARM_INS_ADR", 
    "4": "ARM_INS_AESD", 
    "5": "ARM_INS_AESE", 
    "6": "ARM_INS_AESIMC", 
    "7": "ARM_INS_AESMC", 
    "8": "ARM_INS_AND", 
<...>
```
useful when chasing anal_bytes bugs, and can also easily use to generate tables to output name in `ao` output.

https://www.youtube.com/watch?v=GV0OC2I4L04