### PR TITLE
Enforce pf syntax

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -764,13 +764,30 @@ static void cmd_print_format(RCore *core, const char *_input, int len) {
 		/* This make sure the structure will be printed entirely */
 		char *fmt = input + 1;
 		while (*fmt && ISWHITECHAR (*fmt)) fmt++;
-		int size = r_print_format_struct_size (fmt, core->print, mode)+10;
+		int size = r_print_format_struct_size (fmt, core->print, mode) + 10;
 		if (size > core->blocksize) {
 			r_core_block_size (core, size);
 		}
-		r_print_format (core->print, core->offset,
-			core->block, core->blocksize, fmt, mode, NULL, NULL);
+		/* check if fmt is '\d+ \d+<...>', common mistake due to usage string*/
+		bool syntax_ok = true;
+		char *args = strdup (fmt);
+		if(!args) {
+			r_cons_printf ("Error: Mem Allocation.");
+			free (args);
+			goto stage_left;
+		}
+		const char *arg1 = strtok (args," ");
+		if(arg1 && r_str_isnumber (arg1)) {
+			syntax_ok = false;
+			r_cons_printf ("Usage: pf [0|cnt][format-string]\n");
+		}
+		free (args);
+		if (syntax_ok) {
+			r_print_format (core->print, core->offset,
+			                core->block, core->blocksize, fmt, mode, NULL, NULL);
+		}
 	}
+stage_left:
 	free (input);
 	r_core_block_size (core, o_blocksize);
 }

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -455,7 +455,7 @@ static void print_format_help(RCore *core) {
 	"pf?", "fmt_name", "Show the definition of a named format",
 	"pfo", "", "List all format definition files (fdf)",
 	"pfo", " fdf_name", "Load a Format Definition File (fdf)",
-	"pf.", "fmt_name.size=33", "Set new value for the size field in obj",
+	"pf.", "fmt_name.field_name=33", "Set new value for the specified field in named format",
 	"pfv.", "fmt_name[.field]", "Print value(s) only for named format. Useful for one-liners",
 	"pfs", " fmt_name|fmt", "Print the size of (named) format in bytes",
 	NULL};

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2506,13 +2506,13 @@ R_API int *r_str_split_lines(char *str, int *count) {
 }
 
 R_API bool r_str_isnumber (const char *str) {
-	if (!*str) {
+	if (!str || !*str) {
 		return false;
 	}
-	bool isnum = IS_DIGIT (*str) || *str == '-';
-	str++;
-	while (*str++) {
-		if (!IS_DIGIT (*str) || *str == '-') {
+
+	bool isnum = !IS_DIGIT (*str) || *str == '-';
+	while (isnum && *++str) {
+		if (!IS_DIGIT (*str)) {
 			isnum = false;
 		}
 	}

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2509,8 +2509,7 @@ R_API bool r_str_isnumber (const char *str) {
 	if (!str || !*str) {
 		return false;
 	}
-
-	bool isnum = !IS_DIGIT (*str) || *str == '-';
+	bool isnum = IS_DIGIT (*str) || *str == '-';
 	while (isnum && *++str) {
 		if (!IS_DIGIT (*str)) {
 			isnum = false;


### PR DESCRIPTION
Half of fix for #6659 
Other half is #6684. 

Merge together with https://github.com/radare/radare2/issues/6681

New regression tests for this syntax check:
https://github.com/radare/radare2-regressions/pull/696

Before:
```
$ r2 - -qc 'pf 16 16' # or 'pf 16 xx'
0x00000000 [0] {
}
0x00000000 [1] {
}
0x00000000 [2] {
}
0x00000000 [3] {
}
0x00000000 [4] {
}
0x00000000 [5] {
}
0x00000000 [6] {
}
0x00000000 [7] {
}
0x00000000 [8] {
}
0x00000000 [9] {
}
0x00000000 [10] {
}
0x00000000 [11] {
}
0x00000000 [12] {
}
0x00000000 [13] {
}
0x00000000 [14] {
}
0x00000000 [15] {
}

```
After
```
$ r2 - -qc 'pf 16 16'
Usage: pf [0|cnt][format-string]    
$ r2 - -qc 'pf 16 xx'
Usage: pf [0|cnt][format-string] 
```

