### PR TITLE
Organize string macros

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -35,7 +35,7 @@ static inline ut64 genmask(int bits) {
 
 static bool isnum(RAnalEsil *esil, const char *str, ut64 *num) {
 	if (!esil || !str) return false;
-	if (*str >= '0' && *str <= '9') {
+	if (IS_DIGIT(*str)) {
 		if (num) *num = r_num_get (NULL, str);
 		return true;
 	}
@@ -414,10 +414,10 @@ R_API int r_anal_esil_get_parm_type(RAnalEsil *esil, const char *str) {
 	}
 	if (!strncmp (str, "0x", 2))
 		return R_ANAL_ESIL_PARM_NUM;
-	if (!((str[0] >= '0' && str[0] <= '9') || str[0] == '-'))
+	if (!((IS_DIGIT(str[0])) || str[0] == '-'))
 		goto not_a_number;
 	for (i = 1; i < len; i++)
-		if (!(str[i] >= '0' && str[i] <= '9'))
+		if (!(IS_DIGIT(str[i])))
 			goto not_a_number;
 	return R_ANAL_ESIL_PARM_NUM;
 not_a_number:

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -721,7 +721,7 @@ R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf) {
 					isavrseparator (*ptr_start); ptr_start++);
 			} else {
 				for (ptr_start = buf_token; *ptr_start &&
-					isseparator (*ptr_start); ptr_start++);
+					ISSEPARATOR (*ptr_start); ptr_start++);
 			}
 			if (!strncmp (ptr_start, "/*", 2)) {
 				if (!strstr (ptr_start + 2, "*/")) {

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -768,7 +768,7 @@ static void get_protocol_list_t(mach0_ut p, RBinFile *arch, RBinClass *klass) {
 }
 
 static const char *skipnum(const char *s) {
-	while (IS_NUMBER (*s)) s++;
+	while (IS_DIGIT (*s)) s++;
 	return s;
 }
 

--- a/libr/bin/mangling/swift-sd.c
+++ b/libr/bin/mangling/swift-sd.c
@@ -231,7 +231,7 @@ char *r_bin_demangle_swift(const char *s, int syscmd) {
 	q = getnum (p, NULL);
 	
 	// _TF or __TW
-	if (IS_NUMBER (*p) || *p == 'v' || *p == 'I' || *p == 'o' || *p == 'T' || *p == 'V' || *p == 'M' || *p == 'C' || *p == 'F' || *p == 'W') {
+	if (IS_DIGIT (*p) || *p == 'v' || *p == 'I' || *p == 'o' || *p == 'T' || *p == 'V' || *p == 'M' || *p == 'C' || *p == 'F' || *p == 'W') {
 		if (!strncmp (p+1, "SS", 2)) {
 			strcat (out, "Swift.String.init (");
 			p += 3;
@@ -395,7 +395,7 @@ char *r_bin_demangle_swift(const char *s, int syscmd) {
 				case 'T':
 				case 'I':
 					p = resolve (types, q + 0, &attr); // type
-					if (p && *p && IS_NUMBER (p[1])) {
+					if (p && *p && IS_DIGIT (p[1])) {
 						p--;
 					}
 					break;

--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -51,7 +51,7 @@ R_API void r_config_list(RConfig *cfg, const char *str, int rad) {
 	const char *pfx = "";
 	int len = 0;
 
-	if (!strnull (str)) {
+	if (!STRNULL (str)) {
 		str = r_str_chop_ro (str);
 		len = strlen (str);
 	}
@@ -120,7 +120,7 @@ R_API void r_config_list(RConfig *cfg, const char *str, int rad) {
 }
 
 R_API RConfigNode *r_config_node_get(RConfig *cfg, const char *name) { 
-	if (strnull (name)) {
+	if (STRNULL (name)) {
 		return NULL;
 	}
 	return r_hashtable_lookup (cfg->ht, r_str_hash (name));
@@ -229,7 +229,7 @@ R_API RConfigNode *r_config_set(RConfig *cfg, const char *name, const char *valu
 	RConfigNode *node;
 	char *ov = NULL;
 	ut64 oi;
-	if (!cfg || strnull (name)) return NULL;
+	if (!cfg || STRNULL (name)) return NULL;
 	node = r_config_node_get (cfg, name);
 	if (node) {
 		if (node->flags & CN_RO) {
@@ -256,7 +256,7 @@ R_API RConfigNode *r_config_set(RConfig *cfg, const char *name, const char *valu
 			} else {
 				free (node->value);
 				node->value = strdup (value);
-				if (*value >= '0' && *value <= '9') {
+				if (IS_DIGIT(*value)) {
 					if (strchr (value, '/')) {
 						node->i_value = r_num_get (cfg->num, value);
 					} else {

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -106,7 +106,7 @@ R_API void r_cons_grep(const char *str) {
 				cons->grep.sort_invert = false;
 			}
 			cons->grep.sort = atoi (str);
-			while (IS_NUMBER (*str)) {
+			while (IS_DIGIT (*str)) {
 				str++;
 			}
 			if (*str == ':') {
@@ -283,7 +283,7 @@ static int cmp (const void *a, const void *b) {
 		ca = (colsa > sorted_column) ? r_str_word_get0 (da, sorted_column): "";
 		cb = (colsb > sorted_column) ? r_str_word_get0 (db, sorted_column): "";
 	}
-	if (IS_NUMBER (*ca) && IS_NUMBER (*cb)) {
+	if (IS_DIGIT (*ca) && IS_DIGIT (*cb)) {
 		ut64 na = r_num_get (NULL, ca);
 		ut64 nb = r_num_get (NULL, cb);
 		int ret = na > nb;

--- a/libr/cons/utf8.c
+++ b/libr/cons/utf8.c
@@ -171,7 +171,7 @@ static int cursor_position(const int tty, int *const rowptr, int *const colptr) 
 		/* Parse rows. */
 		rows = 0;
 		res = rd(tty);
-		while (res >= '0' && res <= '9') {
+		while (IS_DIGIT(res)) {
 			rows = 10 * rows + res - '0';
 			res = rd(tty);
 		}
@@ -184,7 +184,7 @@ static int cursor_position(const int tty, int *const rowptr, int *const colptr) 
 		res = rd(tty);
 		if (res==-1)
 			break;
-		while (res >= '0' && res <= '9') {
+		while (IS_DIGIT(res)) {
 			cols = 10 * cols + res - '0';
 			res = rd(tty);
 		}

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2011-2017 - earada, pancake */
 
 #include <r_core.h>
+#include "r_util.h"
 
 #define is_in_range(at, from, sz) ((at) >= (from) && (at) < ((from) + (sz)))
 
@@ -156,7 +157,7 @@ static bool string_filter(RCore *core, const char *str) {
 			bo[i] = 0;
 		}
 		for (i = 0; str[i]; i++) {
-			if (str[i] >= '0' && str[i] <= '9') {
+			if (IS_DIGIT(str[i])) {
 				nm++;
 			} else if (str[i]>='a' && str[i]<='z') {
 				lo++;
@@ -258,7 +259,7 @@ static bool string_filter(RCore *core, const char *str) {
 			bool prevd = false;
 			for (i = 0; str[i]; i++) {
 				char ch = str[i];
-				if (ch >= '0' && ch <= '9') {
+				if (IS_DIGIT(ch)) {
 					segmentsum = segmentsum*10 + (ch - '0');
 					if (segment == 3) {
 						return true;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1315,7 +1315,7 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 		colon = NULL;
 	}
 	if (rep > 0) {
-		while (*cmd >= '0' && *cmd <= '9') {
+		while (IS_DIGIT(*cmd)) {
 			cmd++;
 		}
 		// do not repeat null cmd
@@ -1662,7 +1662,7 @@ next:
 		/* r_cons_flush() handles interactive output (to the terminal)
 		 * differently (e.g. asking about too long output). This conflicts
 		 * with piping to a file. Disable it while piping. */
-		if (ptr > (cmd + 1) && iswhitechar (ptr[-2])) {
+		if (ptr > (cmd + 1) && ISWHITECHAR (ptr[-2])) {
 			char *fdnum = ptr - 1;
 			if (*fdnum == 'H') {
 				scr_html = r_config_get_i (core->config, "scr.html");
@@ -1670,7 +1670,7 @@ next:
 				pipecolor = true;
 				*fdnum = 0;
 			} else {
-				if (*fdnum >= '0' && *fdnum <= '9') {
+				if (IS_DIGIT(*fdnum)) {
 					fdn = *fdnum - '0';
 				}
 				*fdnum = 0;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -361,7 +361,7 @@ static int var_cmd(RCore *core, const char *str) {
 		if (str[2] == '*') {
 			r_anal_var_delete_all (core->anal, fcn->addr, type);
 		} else {
-			if (IS_NUMBER (str[2])) {
+			if (IS_DIGIT (str[2])) {
 				r_anal_var_delete (core->anal, fcn->addr,
 						type, 1, (int)r_num_math (core->num, str + 1));
 			} else {
@@ -2730,7 +2730,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 		r_list_pop (stats->regread);
 		R_FREE (oldregread)
 	}
-	if (!IS_NUMBER (*name)) {
+	if (!IS_DIGIT (*name)) {
 		if (!contains (stats->regs, name)) {
 			r_list_push (stats->regs, strdup (name));
 		}
@@ -2743,7 +2743,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 
 static int myregread(RAnalEsil *esil, const char *name, ut64 *val, int *len) {
 	AeaStats *stats = esil->user;
-	if (!IS_NUMBER (*name)) {
+	if (!IS_DIGIT (*name)) {
 		if (!contains (stats->regs, name)) {
 			r_list_push (stats->regs, strdup (name));
 		}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1195,7 +1195,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 			case 2: // get section name
 				sectname = r_str_word_get0 (ptr, 1);
 			case 1: // get addr|libname
-				if (IS_NUMBER (*ptr)) {
+				if (IS_DIGIT (*ptr)) {
 					const char *a0 = r_str_word_get0 (ptr, 0);
 					addr = r_num_math (core->num, a0);
 				} else {

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -248,7 +248,7 @@ static int cmd_help(void *data, const char *input) {
 				}
 				free (ops);
 			}
-		} else if (input[1] && !IS_NUMBER (input[2])) {
+		} else if (input[1] && !IS_DIGIT (input[2])) {
 			r_cons_printf ("%d\n", r_asm_mnemonics_byname (core->assembler, input + 2));
 		} else {
 			bool json = false;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -754,7 +754,7 @@ static void cmd_print_format(RCore *core, const char *_input, int len) {
 	} else {
 		/* This make sure the structure will be printed entirely */
 		char *fmt = input + 1;
-		while (*fmt && iswhitechar (*fmt)) fmt++;
+		while (*fmt && ISWHITECHAR (*fmt)) fmt++;
 		int size = r_print_format_struct_size (fmt, core->print, mode)+10;
 		if (size > core->blocksize) {
 			r_core_block_size (core, size);

--- a/libr/core/cmd_quit.c
+++ b/libr/core/cmd_quit.c
@@ -7,7 +7,7 @@ static int cmd_Quit(void *data, const char *input) {
 	if (input[0] == '!') {
 		r_config_set (core->config, "scr.histsave", "false");
 	}
-	if (IS_NUMBER (input[0]) || input[0] == ' ') {
+	if (IS_DIGIT (input[0]) || input[0] == ' ') {
 		core->num->value = r_num_math (core->num, input);
 	} else {
 		core->num->value = -1;

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -478,7 +478,7 @@ static int __cb_hit(RSearchKeyword *kw, void *user, ut64 addr) {
 		const char *flag = sdb_fmt (0, "%s%d_%d", searchprefix, kw->kwidx, kw->count);
 		r_flag_set (core->flags, flag, base_addr + addr, kw->keyword_length);
 	}
-	if (!strnull (cmdhit)) {
+	if (!STRNULL (cmdhit)) {
 		ut64 here = core->offset;
 		r_core_seek (core, base_addr + addr, true);
 		r_core_cmd (core, cmdhit, 0);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -502,7 +502,7 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 			}
 			return 0LL;
 		case 'D':
-			if (IS_NUMBER (str[2])) {
+			if (IS_DIGIT (str[2])) {
 				return getref (core, atoi (str + 2), 'r', R_ANAL_REF_TYPE_DATA);
 			} else {
 				RDebugMap *map;

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -24,7 +24,7 @@ static bool is_valid_project_name (const char *name) {
 		if (name[i] >= 'A' && name[i] <= 'Z') {
 			continue;
 		}
-		if (name[i] >= '0' && name[i] <= '9') {
+		if (IS_DIGIT(name[i])) {
 			continue;
 		}
 		return false;

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -979,7 +979,7 @@ R_API void r_core_rtr_add(RCore *core, const char *_input) {
 		proto = RTR_PROT_RAP;
 		host = input;
 	}
-	while (*host && iswhitechar (*host))
+	while (*host && ISWHITECHAR (*host))
 		host++;
 
 	if (!(ptr = strchr (host, ':'))) {
@@ -1166,7 +1166,7 @@ R_API void r_core_rtr_add(RCore *core, const char *_input) {
 R_API void r_core_rtr_remove(RCore *core, const char *input) {
 	int fd, i;
 
-	if (input[0] >= '0' && input[0] <= '9') {
+	if (IS_DIGIT(input[0])) {
 		fd = r_num_math (core->num, input);
 		for (i = 0; i < RTR_MAX_HOSTS; i++)
 			if (rtr_host[i].fd && rtr_host[i].fd->fd == fd) {
@@ -1195,7 +1195,7 @@ R_API void r_core_rtr_session(RCore *core, const char *input) {
 	int fd;
 
 	prompt[0] = 0;
-	if (input[0] >= '0' && input[0] <= '9') {
+	if (IS_DIGIT(input[0])) {
 		fd = r_num_math (core->num, input);
 		for (rtr_n = 0; rtr_host[rtr_n].fd \
 			&& rtr_host[rtr_n].fd->fd != fd \

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -824,7 +824,7 @@ repeat:
 			r_core_cmdf (core, "s 0x%"PFMT64x, refi->addr);
 			ret = 1;
 		}
-	} else if (ch >= '0' && ch <= '9') {
+	} else if (IS_DIGIT(ch)) {
 		refi = r_list_get_n (xrefs, ch - 0x30);
 		if (refi) {
 			r_core_cmdf (core, "s 0x%"PFMT64x, refi->addr);
@@ -886,7 +886,7 @@ R_API int r_core_visual_xrefs_X (RCore *core) {
 	}
 	ch = r_cons_readchar ();
 	if (fun && fun->refs) {
-		if (ch >= '0' && ch <= '9') {
+		if (IS_DIGIT(ch)) {
 			refi = r_list_get_n (fun->refs, ch-0x30);
 			if (refi) {
 				r_core_cmdf (core, "s 0x%"PFMT64x, refi->addr);

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2009-2017 - pancake */
 
 #include "r_core.h"
+#include "r_util.h"
 
 #include <string.h>
 
@@ -2801,7 +2802,7 @@ repeat:
 	case 'Q':
 	case 'q':
 	default:
-		if (ch >= '0' && ch <= '9') {
+		if (IS_DIGIT(ch)) {
 			if (rep < 0) {
 				rep = 0;
 			}

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -1,6 +1,9 @@
 #ifndef R2_TYPES_H
 #define R2_TYPES_H
 
+// defines like IS_DIGIT, etc'
+#include "r_util/r_str_util.h"
+
 // TODO: fix this to make it crosscompile-friendly: R_SYS_OSTYPE ?
 /* operating system */
 #undef __BSD__
@@ -228,11 +231,6 @@ typedef void (*PrintfCallback)(const char *str, ...);
 #define R_NEW(x) (x*)malloc(sizeof(x))
 // TODO: Make R_NEW_COPY be 1 arg, not two
 #define R_NEW_COPY(x,y) x=(void*)malloc(sizeof(y));memcpy(x,y,sizeof(y))
-#define IS_PRINTABLE(x) (x>=' '&&x<='~')
-#define IS_NUMBER(x) (x>='0'&&x<='9')
-#define IS_WHITESPACE(x) (x==' '||x=='\t')
-#define IS_UPPER(c) ((c) >= 'A' && (c) <= 'Z')
-#define IS_LOWER(c) ((c) >= 'a' && (c) <= 'z')
 #define R_MEM_ALIGN(x) ((void *)(size_t)(((ut64)(size_t)x) & 0xfffffffffffff000LL))
 #define R_ARRAY_SIZE(x) (sizeof (x) / sizeof (x[0]))
 

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -1,16 +1,9 @@
 #ifndef R_STR_H
 #define R_STR_H
 
-typedef int (*RStrRangeCallback) (void *, int);
+#include "r_str_util.h"
 
-/* TODO ..use as uppercase maybe? they are macros! */
-#define strnull(x) (!x||!*x)
-#define iswhitechar(x) ((x)==' '||(x)=='\t'||(x)=='\n'||(x)=='\r')
-#define iswhitespace(x) ((x)==' '||(x)=='\t')
-#define isseparator(x) ((x)==' '||(x)=='\t'||(x)=='\n'||(x)=='\r'||(x)==' '|| \
-		(x)==','||(x)==';'||(x)==':'||(x)=='['||(x)==']'|| \
-		(x)=='('||(x)==')'||(x)=='{'||(x)=='}')
-#define ishexchar(x) ((x>='0'&&x<='9') ||  (x>='a'&&x<='f') ||  (x>='A'&&x<='F'))
+typedef int (*RStrRangeCallback) (void *, int);
 
 static inline void r_str_rmch(char *s, char ch) {
 	for (;*s; s++) {

--- a/libr/include/r_util/r_str_util.h
+++ b/libr/include/r_util/r_str_util.h
@@ -1,0 +1,17 @@
+#ifndef R_STR_UTIL_H
+#define R_STR_UTIL_H
+ 
+#define STRNULL(x) (!x||!*x)
+#define ISWHITECHAR(x) ((x)==' '||(x)=='\t'||(x)=='\n'||(x)=='\r')
+#define ISWHITESPACE(x) ((x)==' '||(x)=='\t')
+#define ISSEPARATOR(x) ((x)==' '||(x)=='\t'||(x)=='\n'||(x)=='\r'||(x)==' '|| \
+		(x)==','||(x)==';'||(x)==':'||(x)=='['||(x)==']'|| \
+		(x)=='('||(x)==')'||(x)=='{'||(x)=='}')
+#define ISHEXCHAR(x) ((x>='0'&&x<='9') ||  (x>='a'&&x<='f') ||  (x>='A'&&x<='F'))
+#define IS_PRINTABLE(x) (x>=' '&&x<='~')
+#define IS_DIGIT(x) (x>='0'&&x<='9')
+#define IS_WHITESPACE(x) (x==' '||x=='\t')
+#define IS_UPPER(c) ((c) >= 'A' && (c) <= 'Z')
+#define IS_LOWER(c) ((c) >= 'a' && (c) <= 'z')
+
+#endif //  R_STR_UTIL_H

--- a/libr/parse/p/parse_6502_pseudo.c
+++ b/libr/parse/p/parse_6502_pseudo.c
@@ -78,7 +78,7 @@ static int replace(int argc, const char *argv[], char *newstr, ADDR_TYPE type) {
 		}
 		if (!strcmp(ops[i].op, argv[0])) {
 			for (j = k = 0; ops[i].str[j] != '\0'; j++, k++) {
-				if (ops[i].str[j] >= '0' && ops[i].str[j] <= '9') {
+				if (IS_DIGIT(ops[i].str[j])) {
 					const char *w = argv[ops[i].str[j] - '0'];
 					if (w != NULL) {
 						strcpy(newstr + k, w);

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -125,7 +125,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		}
 		if (!strcmp (ops[i].op, argv[0])) {
 			for (j = k = 0; ops[i].str[j] != '\0'; j++, k++) {
-				if (ops[i].str[j] >= '0' && ops[i].str[j] <= '9') {
+				if (IS_DIGIT(ops[i].str[j])) {
 					int idx = ops[i].str[j]-'0';
 					if (idx < argc) {
 						const char *w = argv[idx];

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -139,7 +139,7 @@ static char *findNextNumber(char *op) {
 				if (!is_space) {
 					is_space = (p != op && (*o == ' ' || *o == ',' || *o == '['));
 				}
-				if (is_space && *p >= '0' && *p <= '9') {
+				if (is_space && IS_DIGIT(*p)) {
 					return p;
 				}
 				o = p++;
@@ -174,7 +174,7 @@ static int filter(RParse *p, RFlag *f, char *data, char *str, int len, bool big_
 		if (x86) {
 			for (ptr2 = ptr; *ptr2 && !isx86separator (*ptr2); ptr2++);
 		} else {
-			for (ptr2 = ptr; *ptr2 && (*ptr2 != ']' && (*ptr2 != '\x1b') && !isseparator (*ptr2)); ptr2++);
+			for (ptr2 = ptr; *ptr2 && (*ptr2 != ']' && (*ptr2 != '\x1b') && !ISSEPARATOR (*ptr2)); ptr2++);
 		}
 		off = r_num_math (NULL, ptr);
 		if (off > 0xff) {
@@ -238,7 +238,7 @@ static int filter(RParse *p, RFlag *f, char *data, char *str, int len, bool big_
 				pnum += 2;
 			}
 			for (; *pnum; pnum++) {
-				if ((is_hex && ishexchar(*pnum)) || IS_NUMBER(*pnum)) {
+				if ((is_hex && ISHEXCHAR(*pnum)) || IS_DIGIT(*pnum)) {
 					continue;
 				}
 				break;

--- a/libr/util/calc.c
+++ b/libr/util/calc.c
@@ -207,7 +207,7 @@ static int cin_get_num(RNum *num, RNumCalc *nc, RNumCalcValue *n) {
 	}
 	str[i] = 0;
 	*n = Nset (r_num_get (num, str));
-	if (*str >= '0' && *str <= '9' && strchr (str, '.')) { 
+	if (IS_DIGIT(*str) && strchr (str, '.')) { 
 		if (sscanf (str, "%lf", &d) < 1) {
 			return 0;
 		}

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -6,7 +6,7 @@
 
 /* int c; ret = hex_to_byte(&c, 'c'); */
 R_API int r_hex_to_byte(ut8 *val, ut8 c) {
-	if (c >= '0' && c <= '9') {
+	if (IS_DIGIT(c)) {
 		*val = (ut8)(*val) * 16 + (c - '0');
 	} else if (c >= 'A' && c <= 'F') {
 		*val = (ut8)(*val) * 16 + (c - 'A' + 10);
@@ -69,7 +69,7 @@ R_API char *r_hex_from_c(const char *code) {
 					for (code++;*code; code++) {
 						if (IS_WHITESPACE (*code))
 							continue;
-						if (IS_NUMBER (*code)) {
+						if (IS_DIGIT (*code)) {
 							parse_on = true;
 							break;
 						} else {
@@ -85,7 +85,7 @@ R_API char *r_hex_from_c(const char *code) {
 				if (!comma) comma = strchr (code, '}');
 				if (comma) {
 					char *word = r_str_ndup (code, comma - code);
-					if (IS_NUMBER (*word)) {
+					if (IS_DIGIT (*word)) {
 						ut8 n = (ut8)r_num_math (NULL, word);
 						*out++ = abc[(n >> 4) & 0xf];
 						*out++ = abc[n & 0xf];
@@ -274,7 +274,7 @@ R_API int r_hex_str_is_valid(const char* str) {
 		str += 2;
 	}
 	for (i = 0; str[i] != '\0' && str[i] != ' '; i++) {
-		if (ishexchar (str[i])) {
+		if (ISHEXCHAR (str[i])) {
 			continue;
 		}
 		return -1; //if we're here, then str isnt valid

--- a/libr/util/name.c
+++ b/libr/util/name.c
@@ -3,7 +3,7 @@
 #include <r_util.h>
 
 R_API int r_name_validate_char(const char ch) {
-	if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9'))
+	if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (IS_DIGIT(ch)))
 		return true;
 	switch (ch) {
 	case ':':
@@ -18,7 +18,7 @@ R_API int r_name_check(const char *name) {
 	if (!name || !*name)
 		return false;
 	/* Cannot start by number */
-	if (*name >= '0' && *name <= '9')
+	if (IS_DIGIT(*name))
 		return false;
 	/* Cannot contain non-alphanumeric chars + [:._] */
 	for (; *name != '\0'; name++)

--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -1238,8 +1238,8 @@ int r_print_format_struct_size(const char *f, RPrint *p, int mode) {
 	}
 
 	i = 0;
-	if (fmt[i] >= '0' && fmt[i] <= '9') {
-		while (fmt[i] >= '0' && fmt[i] <= '9') {
+	if (IS_DIGIT(fmt[i])) {
+		while (IS_DIGIT(fmt[i])) {
 			i++;
 		}
 	}
@@ -1478,7 +1478,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 	if (!fmt) {
 		fmt = formatname;
 	}
-	while (*fmt && iswhitechar (*fmt)) fmt++;
+	while (*fmt && ISWHITECHAR (*fmt)) fmt++;
 	argend = fmt + strlen (fmt);
 	arg = fmt;
 
@@ -1501,7 +1501,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 	/* get times */
 	otimes = times = atoi (arg);
 	if (times > 0) {
-		while (*arg >= '0' && *arg <= '9') {
+		while (IS_DIGIT(*arg)) {
 			arg++;
 		}
 	}

--- a/libr/util/punycode.c
+++ b/libr/util/punycode.c
@@ -62,7 +62,7 @@ static ut32 encode_var_int(const ut32 bias, const ut32 delta, char *dst) {
 }
 
 static char decode_digit(char v) {
-	if (v >= '0' && v <= '9') {
+	if (IS_DIGIT(v)) {
 		return v - 22;
 	}
 	if (v >= 'a' && v <= 'z') {

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -553,15 +553,15 @@ R_API int r_str_char_count(const char *string, char ch) {
 }
 
 // Counts the number of words (separted by separator charactors: newlines, tabs,
-// return, space). See r_util.h for more details of the isseparator macro.
+// return, space). See r_util.h for more details of the ISSEPARATOR macro.
 R_API int r_str_word_count(const char *string) {
 	const char *text, *tmp;
 	int word;
 
-	for (text = tmp = string; *text && isseparator (*text); text++);
+	for (text = tmp = string; *text && ISSEPARATOR (*text); text++);
 	for (word = 0; *text; word++) {
-		for (;*text && !isseparator (*text); text++);
-		for (tmp = text; *text && isseparator (*text); text++);
+		for (;*text && !ISSEPARATOR (*text); text++);
+		for (tmp = text; *text && ISSEPARATOR (*text); text++);
 	}
 	return word;
 }
@@ -634,7 +634,7 @@ R_API const char *r_str_nstr(const char *from, const char *to, int size) {
 // TODO: rewrite in macro?
 R_API const char *r_str_chop_ro(const char *str) {
 	if (str) {
-		while (*str && iswhitechar (*str)) {
+		while (*str && ISWHITECHAR (*str)) {
 			str++;
 		}
 	}
@@ -711,13 +711,13 @@ R_API char *r_str_chop(char *str) {
 	if (!str) {
 		return NULL;
 	}
-	while (*str && iswhitechar (*str)) {
+	while (*str && ISWHITECHAR (*str)) {
 		memmove (str, str + 1, strlen (str + 1) + 1);
 	}
 	len = strlen (str);
 	if (len > 0) {
 		for (ptr = str + len-1; ptr != str; ptr--) {
-			if (!iswhitechar (*ptr)) {
+			if (!ISWHITECHAR (*ptr)) {
 				break;
 			}
 			*ptr = '\0';
@@ -729,7 +729,7 @@ R_API char *r_str_chop(char *str) {
 // Returns a pointer to the first non-whitespace character of str.
 R_API const char *r_str_trim_const(const char *str) {
 	if (str) {
-		for (; *str && iswhitechar (*str); str++);
+		for (; *str && ISWHITECHAR (*str); str++);
 	}
 	return str;
 }
@@ -743,7 +743,7 @@ R_API char *r_str_trim_head(char *str) {
 		return NULL;
 	}
 
-	for (p = str; *p && iswhitechar (*p); p++)
+	for (p = str; *p && ISWHITECHAR (*p); p++)
 		;
 
 	/* Take the trailing null into account */
@@ -766,7 +766,7 @@ R_API char *r_str_trim_tail(char *str) {
 	}
 
 	while (length--) {
-		if (iswhitechar (str[length])) {
+		if (ISWHITECHAR (str[length])) {
 			str[length] = '\0';
 		} else {
 			break;
@@ -832,7 +832,7 @@ R_API int r_str_ccpy(char *dst, char *src, int ch) {
 R_API char *r_str_word_get_first(const char *text) {
 	char *ret;
 	int len = 0;
-	for (;*text && isseparator (*text); text++);
+	for (;*text && ISSEPARATOR (*text); text++);
 	/* strdup */
 	len = strlen (text);
 	ret = (char *)malloc (len + 1);
@@ -1104,12 +1104,12 @@ R_API char *r_str_clean(char *str) {
 	int len;
 	char *ptr;
 	if (str) {
-		while (*str && iswhitechar (*str)) {
+		while (*str && ISWHITECHAR (*str)) {
 			str++;
 		}
 		if ((len = strlen (str)) > 0 )
 			for (ptr = str + len - 1; ptr != str; ptr = ptr - 1) {
-				if (iswhitechar (*ptr)) {
+				if (ISWHITECHAR (*ptr)) {
 					*ptr = '\0';
 				} else {
 					break;
@@ -1664,7 +1664,7 @@ R_API char **r_str_argv(const char *cmdline, int *_argc) {
 		int doublequoted = 0;
 
 		// Seek the beginning of next argument (skip whitespaces)
-		while (cmdline[cmdline_current] != '\0' && iswhitechar (cmdline[cmdline_current])) {
+		while (cmdline[cmdline_current] != '\0' && ISWHITECHAR (cmdline[cmdline_current])) {
 			cmdline_current++;
 		}
 
@@ -2058,7 +2058,7 @@ R_API int r_print_format_length (const char *fmt) {
 	int viewflags = 0;
 	nargs = endian = i = j = 0;
 
-	while (*arg && iswhitechar (*arg)) {
+	while (*arg && ISWHITECHAR (*arg)) {
 		arg++;
 	}
 	/* get times */
@@ -2509,10 +2509,10 @@ R_API bool r_str_isnumber (const char *str) {
 	if (!*str) {
 		return false;
 	}
-	bool isnum = IS_NUMBER (*str) || *str == '-';
+	bool isnum = IS_DIGIT (*str) || *str == '-';
 	str++;
 	while (*str++) {
-		if (!IS_NUMBER (*str) || *str == '-') {
+		if (!IS_DIGIT (*str) || *str == '-') {
 			isnum = false;
 		}
 	}

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -323,7 +323,7 @@ R_API ut64 r_num_math(RNum *num, const char *str) {
 }
 
 R_API int r_num_is_float(RNum *num, const char *str) {
-	return (IS_NUMBER (*str) && (strchr (str, '.') || str[strlen (str) - 1] == 'f'));
+	return (IS_DIGIT (*str) && (strchr (str, '.') || str[strlen (str) - 1] == 'f'));
 }
 
 R_API double r_num_get_float(RNum *num, const char *str) {
@@ -521,7 +521,7 @@ R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex) {
 	if (p) {
 		strcpy (p, "0x");
 		strcpy (p+2, hex);
-		if (hex[0] >= '0' && hex[0] <= '9') {
+		if (IS_DIGIT(hex[0])) {
 			n = r_num_math (num, p);
 		} else {
 			eprintf ("Invalid argument\n");


### PR DESCRIPTION
Merge after #6700, needs

https://github.com/radare/radare2/pull/6700/commits/12758e2ed42e6c450ae6972f120b83f4eaea3ec8 "Rename IS_NUMBER to IS_DIGIT" 

- Move lowercase macros from r_str.h to `r_str_util.h` and uppercase them
- Move related macros like IS_DIGIT, IS_WHITESPACE from r_types.h to `r_str_util.h`
- Fixup all the use locations
- Convert all cases of `( c>= '0' && c <= '9')` to use IS_DIGIT, but left "external code" unchanged.
