### PR TITLE
Optimize ELF Symbol loading

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -936,10 +936,6 @@ R_API int r_bin_load_io_at_offset_as_sz (RBin *bin, RIODesc *desc, ut64 baseaddr
 				totalsz += sz;
 			}
 			sz = totalsz;
-		} else {
-			free (buf_bytes);
-			iob->desc_seek (io, desc, seekaddr);
-			buf_bytes = iob->desc_read (io, desc, &sz);
 		}
 	}
 

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2550,6 +2550,7 @@ static RBinElfSymbol* get_symbols_from_phdr(ELFOBJ *bin, int type) {
 		ret_ctr++;
 	}
 done:
+	ret[ret_ctr].last = 1;
 	// Size everything down to only what is used
 	{
 		nsym = i > 0 ? i : 1;
@@ -2567,7 +2568,6 @@ done:
 		}
 		ret = p;
 	}
-	ret[ret_ctr].last = 1;
 	if (type == R_BIN_ELF_IMPORTS && !bin->imports_by_ord_size) {
 		bin->imports_by_ord_size = ret_ctr + 1;
 		if (ret_ctr > 0) {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2422,7 +2422,7 @@ static RBinElfSymbol* get_symbols_from_phdr(ELFOBJ *bin, int type) {
 		return NULL;
 	}
 	for (j = 0; j < bin->dyn_entries; j++) {
-	    switch (bin->dyn_buf[j].d_tag) {
+		switch (bin->dyn_buf[j].d_tag) {
 		case (DT_SYMTAB):
 			addr_sym_table = Elf_(r_bin_elf_v2p) (bin, bin->dyn_buf[j].d_un.d_ptr);
 			break;
@@ -2457,7 +2457,7 @@ static RBinElfSymbol* get_symbols_from_phdr(ELFOBJ *bin, int type) {
 	size_t capacity1 = 4096;
 	size_t capacity2 = 4096;
 	sym = (Elf_(Sym)*) calloc (capacity1, sym_size);
-	ret = (RBinElfSymbol*) calloc (capacity2, sizeof (struct r_bin_elf_symbol_t));
+	ret = (RBinElfSymbol *) calloc (capacity2, sizeof (struct r_bin_elf_symbol_t));
 	if (!sym || !ret) {
 		goto beach;
 	}
@@ -2511,11 +2511,11 @@ static RBinElfSymbol* get_symbols_from_phdr(ELFOBJ *bin, int type) {
 			}
 			tsize = 16;
 		} else if (type == R_BIN_ELF_SYMBOLS &&
-				sym[i].st_shndx != STN_UNDEF &&
-				ELF_ST_TYPE(sym[i].st_info) != STT_SECTION &&
-				ELF_ST_TYPE(sym[i].st_info) != STT_FILE) {
+		           sym[i].st_shndx != STN_UNDEF &&
+		           ELF_ST_TYPE (sym[i].st_info) != STT_SECTION &&
+		           ELF_ST_TYPE (sym[i].st_info) != STT_FILE) {
 			tsize = sym[i].st_size;
-			toffset = (ut64)sym[i].st_value;
+			toffset = (ut64) sym[i].st_value;
 		} else {
 			continue;
 		}
@@ -2553,7 +2553,7 @@ done:
 	// Size everything down to only what is used
 	{
 		nsym = i > 0 ? i : 1;
-		Elf_ (Sym) * temp_sym = (Elf_ (Sym)*)realloc (sym, (nsym * GROWTH_FACTOR) * sym_size);
+		Elf_ (Sym) * temp_sym = (Elf_ (Sym)*) realloc (sym, (nsym * GROWTH_FACTOR) * sym_size);
 		if (!temp_sym) {
 			goto beach;
 		}
@@ -2561,7 +2561,7 @@ done:
 	}
 	{
 		ret_ctr = ret_ctr > 0 ? ret_ctr : 1;
-		RBinElfSymbol *p = (RBinElfSymbol*)realloc (ret, (ret_ctr + 1) * sizeof (RBinElfSymbol));
+		RBinElfSymbol *p = (RBinElfSymbol *) realloc (ret, (ret_ctr + 1) * sizeof (RBinElfSymbol));
 		if (!p) {
 			goto beach;
 		}
@@ -2571,14 +2571,14 @@ done:
 	if (type == R_BIN_ELF_IMPORTS && !bin->imports_by_ord_size) {
 		bin->imports_by_ord_size = ret_ctr + 1;
 		if (ret_ctr > 0) {
-			bin->imports_by_ord = (RBinImport**)calloc (ret_ctr + 1, sizeof (RBinImport*));
+			bin->imports_by_ord = (RBinImport * *) calloc (ret_ctr + 1, sizeof (RBinImport*));
 		} else {
 			bin->imports_by_ord = NULL;
 		}
 	} else if (type == R_BIN_ELF_SYMBOLS && !bin->symbols_by_ord_size && ret_ctr) {
 		bin->symbols_by_ord_size = ret_ctr + 1;
 		if (ret_ctr > 0) {
-			bin->symbols_by_ord = (RBinSymbol**)calloc (ret_ctr + 1, sizeof (RBinSymbol*));
+			bin->symbols_by_ord = (RBinSymbol * *) calloc (ret_ctr + 1, sizeof (RBinSymbol*));
 		}else {
 			bin->symbols_by_ord = NULL;
 		}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -353,7 +353,7 @@ static int init_dynamic_section(struct Elf_(r_bin_elf_obj_t) *bin) {
 	int entries;
 	int i, j, len, r;
 	ut8 sdyn[sizeof (Elf_(Dyn))] = {0};
-	ut32 dyn_size;
+	ut32 dyn_size = 0;
 
 	if (!bin || !bin->phdr || !bin->ehdr.e_phnum) {
 		return false;
@@ -2415,7 +2415,7 @@ static RBinElfSymbol* get_symbols_from_phdr(ELFOBJ *bin, int type) {
 	ut8 s[sizeof (Elf_(Sym))] = {0};
 	RBinElfSymbol *ret = NULL;
 	int i, j, k, r, tsize, nsym, ret_ctr;
-	ut64 toffset, tmp_offset;
+	ut64 toffset = 0, tmp_offset;
 	ut32 size, sym_size = 0;
 
 	if (!bin || !bin->phdr || !bin->ehdr.e_phnum) {
@@ -2670,7 +2670,7 @@ static int Elf_(fix_symbols)(ELFOBJ *bin, int nsym, int type, RBinElfSymbol **sy
 
 static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type) {
 	ut32 shdr_size;
-	int tsize, nsym, ret_ctr, i, j, r, k, newsize;
+	int tsize, nsym, ret_ctr = 0, i, j, r, k, newsize;
 	ut64 toffset;
 	ut32 size = 0;
 	RBinElfSymbol  *ret = NULL;


### PR DESCRIPTION
Dent in https://github.com/radare/radare2/issues/6642.

- Keep memory ∝ |symbols|, not file size
- Fuse loops
- Don't do Realloc on (Almost) every iteration
- Realloc when finisihed to release extra mem
- Avoid an extra read of entire (1GB) file.

Still 100x too slow from practical and still takes 4x memory than is needed.

this remove allocation that is size of file that live only very short time, instead only allocate what is needed for symbol table parse.

 

