### PR TITLE
x86.nz fixes enhancements

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1063,9 +1063,10 @@ static int oplea(RAsm *a, ut8 *data, const Opcode op){
 	    op.operands[1].type & OT_MEMORY) {
 		data[l++] = 0x8d;
 		if (op.operands[1].regs[0] == X86R_UNDEFINED) {
+			int high = 0xff00 & op.operands[1].offset;
 			data[l++] = op.operands[0].reg << 3 | 5;
 			data[l++] = op.operands[1].offset;
-			data[l++] = op.operands[1].offset >> 6;
+			data[l++] = high >> 8;
 			data[l++] = op.operands[1].offset >> 16;
 			data[l++] = op.operands[1].offset >> 24;
 			return l;

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -661,6 +661,32 @@ static int opcmov(RAsm *a, ut8 *data, const Opcode op) {
 	return l;
 }
 
+static int opmovx(RAsm *a, ut8 *data, const Opcode op) {
+	int l = 0;
+	int word = 0;
+	char *movx = op.mnemonic + 3;
+
+	if (!(op.operands[0].type & OT_REGTYPE && op.operands[1].type & OT_MEMORY)) {
+		return -1;
+	}
+	if (op.operands[1].type & OT_WORD) {
+		word = 1;
+	}
+
+	data[l++] = 0x0f;
+	if (!strcmp (movx, "zx")) {
+		data[l++] = 0xb6 + word;
+	} else if (!strcmp (movx, "sx")) {
+		data[l++] = 0xbe + word;
+	}
+	data[l++] = op.operands[0].reg << 3 | op.operands[1].regs[0];
+	if (op.operands[1].regs[0] == X86R_ESP) {
+		data[l++] = 0x24;
+	}
+
+	return l;
+}
+
 static int opaam(RAsm *a, ut8 *data, const Opcode op) {
 	int l = 0;
 	int immediate = op.operands[0].immediate * op.operands[0].sign;
@@ -1916,6 +1942,8 @@ LookupTable oplookup[] = {
 	{"movsb", NULL, 0xa4, 1},
 	{"movsd", NULL, 0xa5, 1},
 	{"movsw", NULL, 0x66a5, 2},
+	{"movzx", &opmovx, 0},
+	{"movsx", &opmovx, 0},
 	{"mwait", NULL, 0x0f01c9, 3},
 	{"nop", NULL, 0x90, 1},
 	{"or", &opor, 0},

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -333,6 +333,9 @@ static int process_1byte_op(RAsm *a, ut8 *data, const Opcode op, int op1) {
 				if (offset < ST8_MIN || offset > ST8_MAX) {
 					mod_byte = 2;
 				}
+			} else if (op.operands[0].regs[1] != X86R_UNDEFINED) {
+				rm = 4;
+				offset = op.operands[0].regs[1] << 3;
 			}
 		}
 	} else if (op.operands[0].type & OT_REGALL) {
@@ -391,7 +394,8 @@ static int process_1byte_op(RAsm *a, ut8 *data, const Opcode op, int op1) {
 		}
 	}
 	data[l++] = mod_byte << 6 | reg << 3 | rm;
-	if ((mod_byte > 0 && mod_byte < 3) || mem_ref) {
+	if (offset || mem_ref) {
+	//if ((mod_byte > 0 && mod_byte < 3) || mem_ref) {
 		data[l++] = offset;
 		if (mod_byte == 2 || mem_ref) {
 			data[l++] = offset >> 8;


### PR DESCRIPTION
Fixes group 1 instructions with memory refs are operand 1
Fixes mov instruction to support register based offsets
Fix lea with large values as second operand
Add movsx and movzx ops

FIX #6689 

Regressions: radare/radare2-regressions#698