### PR TITLE
Add r_buf_set_bytes_steal to eliminate copying

### DIFF
--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -38,6 +38,7 @@ R_API bool r_buf_dump (RBuffer *buf, const char *file);
 /* methods */
 R_API int r_buf_set_bits(RBuffer *b, int bitoff, int bitsize, ut64 value);
 R_API int r_buf_set_bytes(RBuffer *b, const ut8 *buf, ut64 length);
+R_API int r_buf_set_bytes_steal(RBuffer *b, const ut8 *buf, ut64 length);
 R_API int r_buf_append_string(RBuffer *b, const char *str);
 R_API bool r_buf_append_buf(RBuffer *b, RBuffer *a);
 R_API bool r_buf_append_bytes(RBuffer *b, const ut8 *buf, int length);

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -287,6 +287,18 @@ R_API int r_buf_set_bytes(RBuffer *b, const ut8 *buf, ut64 length) {
 	if (!(b->buf = malloc (length)))
 		return false;
 	memmove (b->buf, buf, length);
+
+	b->length = length;
+	b->empty = 0;
+	return true;
+}
+
+R_API int r_buf_set_bytes_steal(RBuffer *b, const ut8 *buf, ut64 length) {
+	if (length <= 0 || !buf) {
+		return false;
+	}
+	free (b->buf);
+	b->buf = (ut8*) buf;
 	b->length = length;
 	b->empty = 0;
 	return true;


### PR DESCRIPTION
https://github.com/radare/radare2/issues/6642
https://github.com/radare/radare2/pull/6719

reduce peak maximum mem during load. This introduces R_API function. 
For 1GB file:

before
![before](https://cloud.githubusercontent.com/assets/25528402/22724521/9cf6ed08-edbe-11e6-99c7-2d169e0e50e3.png)
After
![after](https://cloud.githubusercontent.com/assets/25528402/22724520/9ce88074-edbe-11e6-954f-1e9bef9c35b3.png)

steal too copies too many...