### PR TITLE
Fix dcu regression

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2996,8 +2996,7 @@ static bool cmd_dcu (RCore *core, const char *input) {
 		return false;
 	}
 	if (to == UT64_MAX) {
-		eprintf ("Cannot continue upto address 0\n");
-		return false;
+		to = from;
 	}
 	if (dcu_range) {
 		r_cons_break_push (NULL, NULL);


### PR DESCRIPTION
My bad, wrong fix for uninit var warning.
closes https://github.com/radare/radare2/issues/6733

r2r:
https://github.com/radare/radare2-regressions/pull/701