### PR TITLE
Anal

### DIFF
--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -98,8 +98,9 @@ R_API int r_anal_diff_fingerprint_fcn(RAnal *anal, RAnalFunction *fcn) {
 	r_list_foreach (fcn->bbs, iter, bb) {
 		len += bb->size;
 		fcn->fingerprint = realloc (fcn->fingerprint, len + 1);
-		if (!fcn->fingerprint)
+		if (!fcn->fingerprint) {
 			return 0;
+		}
 		memcpy (fcn->fingerprint+len-bb->size, bb->fingerprint, bb->size);
 	}
 	return len;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1722,11 +1722,17 @@ R_API ut32 r_anal_fcn_cost(RAnal *anal, RAnalFunction *fcn) {
 
 R_API ut64 r_anal_fcn_firstaddr(RAnalFunction *fcn) {
 	update_tinyrange_bbs (fcn);
-	return fcn->bbr.ranges[0];
+	if (fcn && fcn->bbr.ranges) {
+		return fcn->bbr.ranges[0];
+	}
+	return 0;
 }
 R_API ut64 r_anal_fcn_lastaddr(RAnalFunction *fcn) {
 	update_tinyrange_bbs (fcn);
-	return fcn->bbr.ranges[fcn->bbr.pairs + 1];
+	if (fcn && fcn->bbr.ranges) {
+		return fcn->bbr.ranges[fcn->bbr.pairs * 2 - 1];
+	}
+	return 0;
 }
 
 R_API ut32 r_anal_fcn_length(RAnalFunction *fcn) {

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -59,10 +59,15 @@ static int cmpaddr (const void *_a, const void *_b) {
 static void update_tinyrange_bbs(RAnalFunction *fcn) {
 	RAnalBlock *bb;
 	RListIter *iter;
-	r_list_sort (fcn->bbs, &cmpaddr);
-	r_tinyrange_fini (&fcn->bbr);
-	r_list_foreach (fcn->bbs, iter, bb) {
-		r_tinyrange_add (&fcn->bbr, bb->addr, bb->addr + bb->size);
+	//XXX TODO FIX as long as this is the only place bbs are sorted we can
+	//gain some time. Ideally a callback when a basic block is added may be a
+	//solution
+	if (!fcn->bbs->sorted) {
+		r_list_sort (fcn->bbs, &cmpaddr);
+		r_tinyrange_fini (&fcn->bbr);
+		r_list_foreach (fcn->bbs, iter, bb) {
+			r_tinyrange_add (&fcn->bbr, bb->addr, bb->addr + bb->size);
+		}
 	}
 }
 
@@ -73,7 +78,6 @@ R_API int r_anal_fcn_resize(RAnalFunction *fcn, int newsize) {
 	if (!fcn || newsize < 1) {
 		return false;
 	}
-	r_anal_fcn_set_size (fcn, newsize);
 	eof = fcn->addr + r_anal_fcn_size (fcn);
 	r_list_foreach_safe (fcn->bbs, iter, iter2, bb) {
 		if (bb->addr >= eof) {
@@ -100,9 +104,6 @@ R_API RAnalFunction *r_anal_fcn_new() {
 	if (!fcn) {
 		return NULL;
 	}
-	/* Function return type */
-	fcn->rets = 0;
-	fcn->_size = 0;
 	/* Function qualifier: static/volatile/inline/naked/virtual */
 	fcn->fmod = R_ANAL_FQUALIFIER_NONE;
 	/* Function calling convention: cdecl/stdcall/fastcall/etc */
@@ -135,7 +136,6 @@ R_API void r_anal_fcn_free(void *_fcn) {
 	if (!_fcn) {
 		return;
 	}
-	fcn->_size = 0;
 	free (fcn->name);
 	free (fcn->attr);
 	r_tinyrange_fini (&fcn->bbr);
@@ -255,14 +255,6 @@ static RAnalBlock* appendBasicBlock (RAnal *anal, RAnalFunction *fcn, ut64 addr)
 	}
 	return bb;
 }
-
-#define FITFCNSZ() {\
-	st64 n = bb->addr + bb->size-fcn->addr; \
-	if (n >= 0 && r_anal_fcn_size (fcn) <n) {r_anal_fcn_set_size (fcn, n); } } \
-	if (r_anal_fcn_size (fcn) > MAX_FCN_SIZE) { \
-		/* eprintf ("Function too big at 0x%"PFMT64x" + %d\n", bb->addr, fcn->size); */ \
-		r_anal_fcn_set_size (fcn, 0); \
-		return R_ANAL_RET_ERROR; }
 
 #define VARPREFIX "local"
 #define ARGPREFIX "arg"
@@ -587,7 +579,6 @@ repeat:
 		}
 		r_anal_op_fini (&op);
 		if (isInvalidMemory (buf + idx, len - idx)) {
-			FITFCNSZ();
 			VERBOSE_ANAL eprintf ("FFFF opcode at 0x%08"PFMT64x"\n", addr+idx);
 			return R_ANAL_RET_ERROR;
 		}
@@ -614,8 +605,6 @@ repeat:
 			r_anal_bb_set_offset (bb, bb->ninstr++, addr + idx - bb->addr);
 			bb->size += oplen;
 			fcn->ninstr++;
-		//	FITFCNSZ(); // defer this, in case this instruction is a branch delay entry
-		//	fcn->size += oplen; /// XXX. must be the sum of all the bblocks
 		}
 		idx += oplen;
 		delay.un_idx = idx;
@@ -657,7 +646,6 @@ repeat:
 				fcn->ninstr--;
 				VERBOSE_DELAY eprintf ("Correct for branch delay @ %08"PFMT64x " bb.addr=%08"PFMT64x " corrected.bb=%d f.uncorr=%d\n",
 						addr + idx - oplen, bb->addr, bb->size, r_anal_fcn_size (fcn));
-				FITFCNSZ();
 			}
 			// Next time, we go to the opcode after the delay count
 			// Take care not to use this below, use delay.un_idx instead ...
@@ -758,7 +746,6 @@ repeat:
 					op.type = R_ANAL_OP_TYPE_RET;
 				}
 			}
-			FITFCNSZ ();
 			r_anal_op_fini (&op);
 			gotoBeach (R_ANAL_RET_END);
 			break;
@@ -772,7 +759,6 @@ repeat:
 					goto repeat;
 				}
 			}
-			FITFCNSZ ();
 			r_anal_op_fini (&op);
 			return R_ANAL_RET_END;
 		case R_ANAL_OP_TYPE_NOP:
@@ -807,7 +793,6 @@ repeat:
 			break;
 		case R_ANAL_OP_TYPE_JMP:
 			if (op.jump == UT64_MAX) {
-				FITFCNSZ ();
 				r_anal_op_fini (&op);
 				return R_ANAL_RET_END;
 			}
@@ -815,12 +800,10 @@ repeat:
 				(void) r_anal_fcn_xref_add (anal, fcn, op.addr, op.jump, R_ANAL_REF_TYPE_CODE);
 			}
 			if (!anal->opt.jmpabove && (op.jump < fcn->addr)) {
-				FITFCNSZ ();
 				r_anal_op_fini (&op);
 				return R_ANAL_RET_END;
 			}
 			if (r_anal_noreturn_at (anal, op.jump)) {
-				FITFCNSZ ();
 				r_anal_op_fini (&op);
 				return R_ANAL_RET_END;
 			}
@@ -832,7 +815,6 @@ repeat:
 					must_eob = s != d;
 				}
 				if (must_eob) {
-					FITFCNSZ();
 					op.jump = UT64_MAX;
 					recurseAt (op.jump);
 					recurseAt (op.fail);
@@ -844,7 +826,6 @@ repeat:
 #if FIX_JMP_FWD
 				bb->jump = op.jump;
 				bb->fail = UT64_MAX;
-				FITFCNSZ();
 				return R_ANAL_RET_END;
 #else
 				if (!overlapped) {
@@ -852,7 +833,6 @@ repeat:
 					bb->fail = UT64_MAX;
 				}
 				recurseAt (op.jump);
-				FITFCNSZ();
 				gotoBeachRet ();
 #endif
 			} else {
@@ -867,14 +847,11 @@ repeat:
 							bb->jump = op.jump;
 							bb->fail = UT64_MAX;
 						}
-						FITFCNSZ();
 						return R_ANAL_RET_END;
 #else
 						// hardcoded jmp size // must be checked at the end wtf?
-						// always fitfcnsz and retend
 						if (r_anal_fcn_is_in_offset (fcn, op.jump)) {
 							/* jump inside the same function */
-							FITFCNSZ();
 							return R_ANAL_RET_END;
 #if JMP_IS_EOB_RANGE > 0
 						} else {
@@ -894,7 +871,6 @@ repeat:
 								bb->jump = op.jump;
 								bb->fail = UT64_MAX;
 							}
-							FITFCNSZ();
 							return R_ANAL_RET_END;
 						}
 					}
@@ -921,7 +897,6 @@ repeat:
 						bb->jump = op.jump;
 						bb->fail = UT64_MAX;
 					}
-					FITFCNSZ();
 					recurseAt (op.jump);
 					recurseAt (op.fail);
 					return R_ANAL_RET_END;
@@ -931,7 +906,6 @@ repeat:
 					if (op.jump > fcn->addr + JMP_IS_EOB_RANGE) {
 						recurseAt (op.fail);
 						/* jump inside the same function */
-						FITFCNSZ();
 						return R_ANAL_RET_END;
 #if JMP_IS_EOB_RANGE > 0
 					} else {
@@ -955,7 +929,6 @@ repeat:
 							bb->jump = op.jump;
 							bb->fail = UT64_MAX;
 						}
-						FITFCNSZ();
 						return R_ANAL_RET_END;
 					}
 				}
@@ -975,7 +948,6 @@ repeat:
 		case R_ANAL_OP_TYPE_IRCALL:
 			/* call [dst] */
 			if (op.ptr != UT64_MAX && r_anal_noreturn_at (anal, op.ptr)) {
-				FITFCNSZ ();
 				r_anal_op_fini (&op);
 				return R_ANAL_RET_END;
 			}
@@ -986,7 +958,6 @@ repeat:
 		case R_ANAL_OP_TYPE_CALL:
 			/* call dst */
 			if (r_anal_noreturn_at (anal, op.jump)) {
-				FITFCNSZ ();
 				r_anal_op_fini (&op);
 				return R_ANAL_RET_END;
 			}
@@ -1041,7 +1012,6 @@ repeat:
 					}
 				}
 			}
-			FITFCNSZ ();
 			r_anal_op_fini (&op);
 			return R_ANAL_RET_END;
 river:
@@ -1069,7 +1039,6 @@ river:
 					VERBOSE_ANAL eprintf ("RET 0x%08"PFMT64x". %d %d %d\n",
 							addr + delay.un_idx-oplen, overlapped,
 							bb->size, r_anal_fcn_size (fcn));
-					FITFCNSZ ();
 					r_anal_op_fini (&op);
 					return R_ANAL_RET_END;
 				}
@@ -1082,7 +1051,6 @@ river:
 	}
 beach:
 	r_anal_op_fini (&op);
-	FITFCNSZ ();
 	return ret;
 }
 
@@ -1174,7 +1142,6 @@ R_API void r_anal_trim_jmprefs(RAnalFunction *fcn) {
 
 R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 len, int reftype) {
 	int ret;
-	r_anal_fcn_set_size (fcn, 0);
 	/* defines fcn. or loc. prefix */
 	fcn->type = (reftype == R_ANAL_REF_TYPE_CODE)
 		? R_ANAL_FCN_TYPE_LOC
@@ -1194,42 +1161,6 @@ R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 
 	update_tinyrange_bbs (fcn);
 
 	if (ret == R_ANAL_RET_END && r_anal_fcn_size (fcn)) {	// cfg analysis completed
-		RListIter *iter;
-		RAnalBlock *bb;
-		ut64 endaddr = fcn->addr;
-		ut64 overlapped = -1;
-		RAnalFunction *fcn1 = NULL;
-
-		// set function size as length of continuous sequence of bbs
-		r_list_sort (fcn->bbs, &cmpaddr);
-		r_list_foreach (fcn->bbs, iter, bb) {
-			if (endaddr == bb->addr) {
-				endaddr += bb->size;
-			} else if (endaddr < bb->addr &&
-				   bb->addr - endaddr <
-					   anal->opt.bbs_alignment &&
-				   !(bb->addr &
-				     (anal->opt.bbs_alignment - 1))) {
-				endaddr = bb->addr + bb->size;
-			} else {
-				break;
-			}
-		}
-#if !JAYRO_04
-		r_anal_fcn_resize (fcn, endaddr - fcn->addr);
-
-		// resize function if overlaps
-		r_list_foreach (anal->fcns, iter, fcn1) {
-			if (fcn1->addr >= (fcn->addr) && fcn1->addr < (fcn->addr + r_anal_fcn_size (fcn))) {
-				if (overlapped > fcn1->addr) {
-					overlapped = fcn1->addr;
-				}
-			}
-		}
-		if (overlapped != -1) {
-			r_anal_fcn_resize (fcn, overlapped - fcn->addr);
-		}
-#endif
 		r_anal_trim_jmprefs (fcn);
 	}
 	return ret;
@@ -1273,7 +1204,6 @@ R_API int r_anal_fcn_add(RAnal *a, ut64 addr, ut64 size, const char *name, int t
 	fcn->addr = addr;
 	fcn->cc = r_anal_cc_default (a);
 	fcn->bits = a->bits;
-	r_anal_fcn_set_size (fcn, size);
 	free (fcn->name);
 	if (!name) {
 		fcn->name = r_str_newf ("fcn.%08"PFMT64x, fcn->addr);
@@ -1661,9 +1591,13 @@ R_API RList* r_anal_fcn_get_bbs (RAnalFunction *anal) {
 }
 
 R_API int r_anal_fcn_is_in_offset(RAnalFunction *fcn, ut64 addr) {
-	if (r_list_empty (fcn->bbs)) {
-		// r_anal_fcn_size (fcn);
-		return addr >= fcn->addr && addr < fcn->addr + fcn->_size;
+	int num_bbs = r_list_length (fcn->bbs);
+	if (!num_bbs) {
+		return addr >= fcn->addr && addr < fcn->addr + r_anal_fcn_symsize (fcn);
+	}
+	if (num_bbs == 1) {
+		//we only have just one bbs
+		return addr >= fcn->addr && addr < r_anal_fcn_lastaddr (fcn);
 	}
 	if (r_anal_fcn_in (fcn, addr)) {
 		return true;
@@ -1671,7 +1605,7 @@ R_API int r_anal_fcn_is_in_offset(RAnalFunction *fcn, ut64 addr) {
 	return false;
 }
 
-R_API int r_anal_fcn_count (RAnal *anal, ut64 from, ut64 to) {
+R_API int r_anal_fcn_count(RAnal *anal, ut64 from, ut64 to) {
 	int n = 0;
 	RAnalFunction *fcni;
 	RListIter *iter;
@@ -1709,22 +1643,22 @@ R_API bool r_anal_fcn_bbadd(RAnalFunction *fcn, RAnalBlock *bb) {
 }
 
 /* directly set the size of the function */
-R_API void r_anal_fcn_set_size(RAnalFunction *fcn, ut32 size) {
+R_API void r_anal_fcn_set_symsize(RAnalFunction *fcn, ut32 size) {
 	if (fcn) {
-		fcn->_size = size;
+		fcn->symsize = size;
 	}
 }
 
 /* returns the size of the function.
  * IMPORTANT: this will change, one day, because it doesn't have much sense */
-R_API ut32 r_anal_fcn_size(const RAnalFunction *fcn) {
-	return fcn ? fcn->_size : 0;
+R_API ut32 r_anal_fcn_symsize(const RAnalFunction *fcn) {
+	return fcn ? fcn->symsize : 0;
 }
 
 /* return the "real" size of the function, that is the sum of the size of the
  * basicblocks this function is composed of.
  * IMPORTANT: this will become, one day, the only size of a function */
-R_API ut32 r_anal_fcn_realsize(const RAnalFunction *fcn) {
+R_API ut32 r_anal_fcn_size(const RAnalFunction *fcn) {
 	RListIter *iter, *fiter;
 	RAnalBlock *bb;
 	RAnalFunction *f;
@@ -1785,3 +1719,19 @@ R_API ut32 r_anal_fcn_cost(RAnal *anal, RAnalFunction *fcn) {
 	}
 	return totalCycles;
 }
+
+R_API ut64 r_anal_fcn_firstaddr(RAnalFunction *fcn) {
+	update_tinyrange_bbs (fcn);
+	return fcn->bbr.ranges[0];
+}
+R_API ut64 r_anal_fcn_lastaddr(RAnalFunction *fcn) {
+	update_tinyrange_bbs (fcn);
+	return fcn->bbr.ranges[fcn->bbr.pairs + 1];
+}
+
+R_API ut32 r_anal_fcn_length(RAnalFunction *fcn) {
+	return r_anal_fcn_lastaddr (fcn) - r_anal_fcn_firstaddr (fcn);
+}
+
+
+

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -479,7 +479,7 @@ static int analyze_from_code_buffer(RAnal *anal, RAnalFunction *fcn, ut64 addr, 
 
 	fcn->name = strdup (gen_name);
 	fcn->dsc = strdup ("unknown");
-	r_anal_fcn_set_size (fcn, code_length);
+	r_anal_fcn_set_symsize (fcn, code_length);
 	fcn->type = R_ANAL_FCN_TYPE_FCN;
 	fcn->addr = addr;
 	state = r_anal_state_new (addr, (ut8*) code_buf, code_length);
@@ -491,7 +491,7 @@ static int analyze_from_code_buffer(RAnal *anal, RAnalFunction *fcn, ut64 addr, 
 	r_list_foreach (fcn->bbs, bb_iter, bb) {
 		actual_size += bb->size;
 	}
-	r_anal_fcn_set_size (fcn, state->bytes_consumed);
+	r_anal_fcn_set_symsize (fcn, state->bytes_consumed);
 	result = state->anal_ret_val;
 	r_list_free (nodes->cfg_node_addrs);
 	free (nodes);
@@ -500,7 +500,8 @@ static int analyze_from_code_buffer(RAnal *anal, RAnalFunction *fcn, ut64 addr, 
 	if (r_anal_fcn_size (fcn) != code_length) {
 		eprintf ("WARNING Analysis of %s Incorrect: Code Length: 0x%"PFMT64x", Function size reported 0x%x\n", fcn->name, code_length, r_anal_fcn_size(fcn));
 		eprintf ("Deadcode detected, setting code length to: 0x%"PFMT64x"\n", code_length);
-		r_anal_fcn_set_size (fcn, code_length);
+		//XXX FIX
+		r_anal_fcn_set_symsize (fcn, code_length);
 	}
 	return result;
 }
@@ -515,7 +516,7 @@ static int analyze_from_code_attr (RAnal *anal, RAnalFunction *fcn, RBinJavaFiel
 	if (!code_attr) {
 		fcn->name = strdup ("sym.UNKNOWN");
 		fcn->dsc = strdup ("unknown");
-		r_anal_fcn_set_size (fcn, code_length);
+		r_anal_fcn_set_symsize (fcn, code_length);
 		fcn->type = R_ANAL_FCN_TYPE_FCN;
 		fcn->addr = 0;
 		return R_ANAL_RET_ERROR;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1869,7 +1869,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 	char *name = get_fcn_name (core, fcn);
 	r_cons_printf ("{\"offset\":%"PFMT64d",\"name\":\"%s\",\"size\":%d",
 			fcn->addr, name, r_anal_fcn_size (fcn));
-	r_cons_printf (",\"realsz\":%d", r_anal_fcn_size (fcn));
+	r_cons_printf (",\"symsz\":%d", r_anal_fcn_symsize (fcn));
 	r_cons_printf (",\"cc\":%d", r_anal_fcn_cc (fcn));
 	r_cons_printf (",\"cost\":%d", r_anal_fcn_cost (core->anal, fcn));
 	r_cons_printf (",\"nbbs\":%d", r_list_length (fcn->bbs));

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -956,6 +956,17 @@ static int cb_rows(void *user, void *data) {
 	return true;
 }
 
+static int cb_hexcompact(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	if (node->i_value) {
+		core->print->flags |= R_PRINT_FLAGS_COMPACT;
+	} else {
+		core->print->flags &= (~R_PRINT_FLAGS_COMPACT);
+	}
+	return true;
+}
+
 static int cb_hexpairs(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -2054,6 +2065,7 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* hexdump */
 	SETCB("hex.pairs", "true", &cb_hexpairs, "Show bytes paired in 'px' hexdump");
+	SETCB("hex.compact", "false", &cb_hexcompact, "Show smallest 16 byte col hexdump (60 columns)");
 	SETI("hex.flagsz", 0, "If non zero, overrides the flag size in pxa");
 	SETICB("hex.cols", 16, &cb_hexcols, "Number of columns in hexdump");
 	SETI("hex.depth", 5, "Maximal level of recurrence while telescoping memory");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -28,7 +28,7 @@ static int compareType(const RAnalFunction *a, const RAnalFunction *b) {
 
 static int compareSize(const RAnalFunction *a, const RAnalFunction *b) {
 	// return a && b && a->_size < b->_size;
-	return a && b && r_anal_fcn_realsize (a) > r_anal_fcn_realsize (b);
+	return a && b && r_anal_fcn_size (a) > r_anal_fcn_size (b);
 }
 
 static int compareDist(const RAnalFunction *a, const RAnalFunction *b) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4918,7 +4918,7 @@ static int compute_coverage(RCore *core) {
 	RAnalFunction *fcn;
 	int cov = 0;
 	r_list_foreach (core->anal->fcns, iter, fcn) {
-		cov += r_anal_fcn_realsize (fcn);
+		cov += r_anal_fcn_size (fcn);
 	}
 	return cov;
 }

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3010,7 +3010,6 @@ static int cmd_print(void *data, const char *input) {
 						R_ANAL_FCN_TYPE_FCN | R_ANAL_FCN_TYPE_SYM);
 				if (f) {
 					ut32 bsz = core->blocksize;
-					// int fsz = r_anal_fcn_realsize (f);
 					int fsz = r_anal_fcn_size (f); // we want max-min here
 					r_core_block_size (core, fsz);
 					r_core_print_disasm_instructions (core, fsz, 0);
@@ -3198,7 +3197,7 @@ static int cmd_print(void *data, const char *input) {
 				}
 				if (f && input[2] == 'j') { // "pdfj"
 					ut8 *func_buf = NULL, *loc_buf = NULL;
-					ut32 fcn_size = r_anal_fcn_realsize (f);
+					ut32 fcn_size = r_anal_fcn_size (f);
 					cont_size = tmp_get_contsize (f);
 					r_cons_printf ("{");
 					r_cons_printf ("\"name\":\"%s\"", f->name);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -158,7 +158,7 @@ static int cmd_zign(void *data, const char *input) {
 				if (r_cons_is_breaked ()) {
 					break;
 				}
-				len = r_anal_fcn_realsize (fcni);
+				len = r_anal_fcn_size (fcni);
 				if (!(buf = calloc (1, len))) {
 					r_cons_break_pop ();
 					return false;
@@ -356,7 +356,7 @@ static int cmd_zign(void *data, const char *input) {
 				return false;
 			}
 			fcni = (RAnalFunction*)it->data;
-			len = r_anal_fcn_realsize (fcni);
+			len = r_anal_fcn_size (fcni);
 			if (!(buf = malloc (len))) {
 				return false;
 			}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -531,7 +531,7 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 			if (fcn) {
 				switch (str[2]) {
 				case 'B': return fcn->addr; // begin
-				case 'E': return fcn->addr + fcn->_size; // end
+				case 'E': return fcn->addr + r_anal_fcn_size (fcn); // end
 				case 'S': return r_anal_fcn_size (fcn);
 				case 'I': return fcn->ninstr;
 				/* basic blocks */

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1084,8 +1084,8 @@ static int var_comparator(const RAnalVar *a, const RAnalVar *b){
 }
 
 //TODO: this function is a temporary fix. All analysis should be based on realsize. However, now for same architectures realisze is not used
-static ut32 tmp_get_realsize (RAnalFunction *f) {
-	ut32 size = r_anal_fcn_realsize (f);
+static ut32 tmp_get_realsize(RAnalFunction *f) {
+	ut32 size = r_anal_fcn_size (f);
 	return (size > 0) ? size : r_anal_fcn_size (f);
 }
 

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -46,8 +46,7 @@ R_API int r_core_gdiff(RCore *c, RCore *c2) {
 		}
 		/* Fingerprint fcn */
 		r_list_foreach (cores[i]->anal->fcns, iter, fcn) {
-			int newsize = r_anal_diff_fingerprint_fcn (cores[i]->anal, fcn);
-			r_anal_fcn_set_size (fcn, newsize);
+			(void)r_anal_diff_fingerprint_fcn (cores[i]->anal, fcn);
 		}
 	}
 	/* Diff functions */

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -2001,7 +2001,7 @@ static ut64 var_functions_show(RCore *core, int idx, int show) {
 				r_cons_printf ("%c%c 0x%08"PFMT64x" %4d %s\n",
 					(seek == fcn->addr)?'>':' ',
 					(idx==i)?'*':' ',
-					fcn->addr, r_anal_fcn_realsize (fcn), fcn->name);
+					fcn->addr, r_anal_fcn_size (fcn), fcn->name);
 		}
 		i++;
 	}
@@ -2063,7 +2063,6 @@ static void r_core_visual_anal_refresh_column (RCore *core, int colpos) {
 		: var_functions_show (core, option, 0);
 	// RAnalFunction* fcn = r_anal_get_fcn_in(core->anal, addr, R_ANAL_FCN_TYPE_NULL);
 	int h, w = r_cons_get_size (&h);
-	// int sz = (fcn)? R_MIN (r_anal_fcn_size (fcn), h * 15) : 16; // max instr is 15 bytes.
 
 	const char *cmd, *printCmds[lastPrintMode] = {
 		"pdf", "afi", "pds", "pdc", "pdr"
@@ -2785,25 +2784,22 @@ repeat:
 		break;
 	case 'f':
 		{
-			int funsize = 0;
 			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
 			if (fcn) {
 				r_anal_fcn_resize (fcn, core->offset - fcn->addr);
 			}
 			//int depth = r_config_get_i (core->config, "anal.depth");
+#if 0
 			if (core->print->cur_enabled) {
 				if (core->print->ocur != -1) {
 					funsize = 1 + R_ABS (core->print->cur - core->print->ocur);
 				}
 				//depth = 0;
 			}
+#endif
 			r_cons_break_push (NULL, NULL);
 			r_core_cmdf (core, "af @ 0x%08" PFMT64x, off); // required for thumb autodetection
 			r_cons_break_pop ();
-			if (funsize) {
-				RAnalFunction *f = r_anal_get_fcn_in (core->anal, off, -1);
-				r_anal_fcn_set_size (f, funsize);
-			}
 		}
 		break;
 	case 'Q':

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -270,7 +270,9 @@ typedef struct r_anal_fcn_meta_t {
 typedef struct r_anal_type_function_t {
 	char* name;
 	char* dsc; // For producing nice listings
-	ut32 _size;
+	ut32 size; //sum bbs
+	ut32 symsize; //info coming from RBin
+	ut32 length; //max-min addr from bbs
 	int bits; // ((> bits 0) (set-bits bits))
 	int type;
 	/*item_list *rets; // Type of return value */
@@ -1282,6 +1284,10 @@ R_API int r_anal_fcn_del_locs(RAnal *anal, ut64 addr);
 R_API int r_anal_fcn_add_bb(RAnal *anal, RAnalFunction *fcn,
 		ut64 addr, ut64 size,
 		ut64 jump, ut64 fail, int type, RAnalDiff *diff);
+R_API ut64 r_anal_fcn_firstaddr(RAnalFunction *fcn);
+R_API ut64 r_anal_fcn_lastaddr(RAnalFunction *fcn);
+R_API ut32 r_anal_fcn_length(RAnalFunction *fcn);
+R_API ut32 r_anal_fcn_symsize(const RAnalFunction *fcn);
 R_API bool r_anal_check_fcn(RAnal *anal, ut8 *buf, ut16 bufsz, ut64 addr, ut64 low, ut64 high);
 
 /* locals */
@@ -1309,9 +1315,8 @@ R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind, int type);
 /* vars // globals. not here  */
 R_API bool r_anal_var_display(RAnal *anal, int delta, char kind, const char *type);
 R_API ut32 r_anal_fcn_size(const RAnalFunction *fcn);
-R_API void r_anal_fcn_set_size(RAnalFunction *fcn, ut32 size);
+R_API void r_anal_fcn_set_symsize(RAnalFunction *fcn, ut32 size);
 R_API ut32 r_anal_fcn_contsize(const RAnalFunction *fcn);
-R_API ut32 r_anal_fcn_realsize(const RAnalFunction *fcn);
 R_API int r_anal_fcn_cc(RAnalFunction *fcn);
 R_API int r_anal_fcn_split_bb(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bb, ut64 addr);
 R_API int r_anal_fcn_bb_overlaps(RAnalFunction *fcn, RAnalBlock *bb);

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -22,6 +22,7 @@ extern "C" {
 #define R_PRINT_FLAGS_DIFFOUT 0x00000100 /* only show different rows in `cc` hexdiffing */
 #define R_PRINT_FLAGS_ADDRDEC 0x00000200
 #define R_PRINT_FLAGS_COMMENT 0x00000400
+#define R_PRINT_FLAGS_COMPACT 0x00000800
 
 typedef int (*RPrintZoomCallback)(void *user, int mode, ut64 addr, ut8 *bufz, ut64 size);
 typedef const char *(*RPrintNameCallback)(void *user, ut64 addr);


### PR DESCRIPTION
Initial attempt to fix fcn->_size and related. 

I removed some checks in r_anal_fcn when overlapping, is that ok?

Thoughts about removing r_anal_fcn_set_size and the command af+? I think the way to define function by hand should be through basic blocks. Its used in FITFCNSZ for example as well.

I checked against dll from https://github.com/radare/radare2/issues/5718 and it seems there is an improvement with the frames. This is not meant to be merged since there will be many thing to test and fix (RAnalFunction still has _size parameter) ... just food for thought.