### PR TITLE
Add Pnx command for project notes

### DIFF
--- a/libr/core/Makefile
+++ b/libr/core/Makefile
@@ -11,7 +11,7 @@ OBJS+=hack.o vasm.o patch.o cbin.o log.o rtr.o cmd_api.o
 OBJS+=canal.o project.o gdiff.o asm.o vmenus.o disasm.o plugin.o
 OBJS+=help.o task.o panels.o pseudo.o vmarks.o anal_tp.o blaze.o
 
-CFLAGS+=-DCORELIB
+CFLAGS+=-DCORELIB -I../../shlr
 LDFLAGS+=${DL_LIBS}
 
 ifeq ($(shell uname),OpenBSD)

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -3,7 +3,6 @@
 #include "r_config.h"
 #include "r_core.h"
 #include "r_print.h"
-#include "spp/spp.h"
 
 static int cmd_project(void *data, const char *input) {
 	RCore *core = (RCore *)data;
@@ -160,25 +159,7 @@ static int cmd_project(void *data, const char *input) {
 			}
 			break;
 		case 'x':
-			char *str = r_core_project_notes_file (core, fileproject);
-			char *data = r_file_slurp (str, NULL);
-			Output out;
-			out.fout = NULL;
-			out.cout = r_strbuf_new ("");
-			r_strbuf_init (out.cout);
-			struct Proc proc;
-			spp_proc_set (&proc, "spp", 1);
-			spp_eval (data, &out);
-			free (data);
-			data = strdup (r_strbuf_get (out.cout));
-			char *bol = strtok (data, "\n");
-			while (bol) {
-				if (bol[0] == ':') {
-					r_core_cmd0(core, bol + 1);
-				}
-				bol = strtok (NULL, "\n");
-			}
-			free (data);
+			r_core_project_execute_cmds (core, fileproject);
 			break;
 		case 0:
 			{

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -160,7 +160,6 @@ static int cmd_project(void *data, const char *input) {
 			}
 			break;
 		case 'x':
-			printf ("Execute project note commands\n");
 			char *str = r_core_project_notes_file (core, fileproject);
 			char *data = r_file_slurp (str, NULL);
 			Output out;
@@ -169,18 +168,13 @@ static int cmd_project(void *data, const char *input) {
 			r_strbuf_init (out.cout);
 			struct Proc proc;
 			spp_proc_set (&proc, "spp", 1);
-			printf ("1\n");
 			spp_eval (data, &out);
 			free (data);
-			printf ("2\n");
 			data = strdup (r_strbuf_get (out.cout));
 			char *bol = strtok (data, "\n");
-			printf ("3\n");
 			while (bol) {
-				printf ("%s\n", bol);
 				if (bol[0] == ':') {
-					printf ("execute\n");
-
+					r_core_cmd0(core, bol + 1);
 				}
 				bol = strtok (NULL, "\n");
 			}

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -3,6 +3,7 @@
 #include "r_config.h"
 #include "r_core.h"
 #include "r_print.h"
+#include "spp/spp.h"
 
 static int cmd_project(void *data, const char *input) {
 	RCore *core = (RCore *)data;
@@ -158,6 +159,33 @@ static int cmd_project(void *data, const char *input) {
 				eprintf ("Usage: `Pnj` or `Pnj ...`\n");
 			}
 			break;
+		case 'x':
+			printf ("Execute project note commands\n");
+			char *str = r_core_project_notes_file (core, fileproject);
+			char *data = r_file_slurp (str, NULL);
+			Output out;
+			out.fout = NULL;
+			out.cout = r_strbuf_new ("");
+			r_strbuf_init (out.cout);
+			struct Proc proc;
+			spp_proc_set (&proc, "spp", 1);
+			printf ("1\n");
+			spp_eval (data, &out);
+			free (data);
+			printf ("2\n");
+			data = strdup (r_strbuf_get (out.cout));
+			char *bol = strtok (data, "\n");
+			printf ("3\n");
+			while (bol) {
+				printf ("%s\n", bol);
+				if (bol[0] == ':') {
+					printf ("execute\n");
+
+				}
+				bol = strtok (NULL, "\n");
+			}
+			free (data);
+			break;
 		case 0:
 			{
 			char *str = r_core_project_notes_file (core, fileproject);
@@ -177,6 +205,7 @@ static int cmd_project(void *data, const char *input) {
 					"Pn", " -", "edit notes with cfg.editor",
 					"Pn-", "", "delete notes",
 					"Pn-", "str", "delete lines matching /str/ in notes",
+					"Pnx", "", "run project note commands",
 					"Pnj", "", "show notes in base64",
 					"Pnj", " [base64]", "set notes in base64",
 					NULL};


### PR DESCRIPTION
`Pnx` will parse the current project notes with SPP and execute any line starting with `:` interpreting them as r2 commands.