### PR TITLE
Add &nbsp; to html output and fix <br />

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -652,11 +652,19 @@ R_API int r_cons_html_print(const char *ptr) {
 		return 0;
 	}
 	for (;ptr[0]; ptr = ptr + 1) {
-		if (0 && ptr[0] == '\n') {
-			printf ("<br />");
-			fflush (stdout);
-		}
-		if (ptr[0] == '<') {
+		if (ptr[0] == '\n') {                                                 
+			tmp = (int) (size_t) (ptr-str);                               
+			if (write (1, str, tmp) != tmp) {                             
+				eprintf ("r_cons_html_print: write: error\n");        
+			}                                                             
+			printf ("<br />");                                            
+			if (!ptr[1]) {                                                
+				// write new line if it's the end of the output       
+				printf ("\n");                                        
+			}                                                             
+			str = ptr + 1;                                                
+			continue;                                                     
+		} else if (ptr[0] == '<') {
 			tmp = (int) (size_t) (ptr-str);
 			if (write (1, str, tmp) != tmp) {
 				eprintf ("r_cons_html_print: write: error\n");
@@ -671,6 +679,15 @@ R_API int r_cons_html_print(const char *ptr) {
 				eprintf ("r_cons_html_print: write: error\n");
 			}
 			printf ("&gt;");
+			fflush (stdout);
+			str = ptr + 1;
+			continue;
+		} else if (ptr[0] == ' ') {
+			tmp = (int) (size_t) (ptr-str);
+			if (write (1, str, tmp) != tmp) {
+				eprintf ("r_cons_html_print: write: error\n");
+			}
+			printf ("&nbsp;");
 			fflush (stdout);
 			str = ptr + 1;
 			continue;


### PR DESCRIPTION
e scr.html=true doesn't print spaces as &nbsp; and thus it looks messy because the maximum spaces sequence allowed in html is 1. 
Therefore we should change every space to &nbsp;. 

In addition, fixed a problem with <br /> printing. \n (a new line) was printed instead and it doesn't consider as line-break in the majority of editors. Therefore now it avoids printing new line and prints <br /> instead.