### PR TITLE
Uses correct TEXT section name as of Sierra, fixes #6797

### DIFF
--- a/binr/ragg2/ragg2-cc
+++ b/binr/ragg2/ragg2-cc
@@ -210,7 +210,8 @@ windows)
 	;;
 darwin)
 	#TEXT="__TEXT.__text"
-	TEXT="0.__text"
+	#TEXT="0.__text"
+	TEXT=0.__TEXT.__text
 	FMT=mach0
 	;;
 *|linux)


### PR DESCRIPTION
This might break OSX < Sierra. Works on MacOS 10.12.2, LLVM version 8.0.0 (clang-800.0.42.1) x86_64-apple-darwin16.3.0