### PR TITLE
Improve Windows search path for sdb

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -221,7 +221,12 @@ static int bin_pe_parse_imports(struct PE_(r_bin_pe_obj_t)* bin,
 						db = sdb_new (NULL, filename, 0);
 					} else {
 #if __WINDOWS__
-						filename = sdb_fmt (1, "share/radare2/"R2_VERSION "/format/dll/%s.sdb", symdllname);
+						char invoke_dir[MAX_PATH];
+						if (r_sys_get_src_dir_w32(invoke_dir)) {
+							filename = sdb_fmt (1, "%s/share/radare2/"R2_VERSION "/format/dll/%s.sdb", invoke_dir, symdllname);
+						} else {
+							filename = sdb_fmt (1, "share/radare2/"R2_VERSION "/format/dll/%s.sdb", symdllname);
+						}
 #else
 						filename = sdb_fmt (1, R2_PREFIX "/share/radare2/" R2_VERSION "/format/dll/%s.sdb", symdllname);
 #endif

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1129,7 +1129,12 @@ static void set_bin_relocs(RCore *r, RBinReloc *reloc, ut64 addr, Sdb **db, char
 						*db = sdb_new (NULL, filename, 0);
 					} else {
 #if __WINDOWS__
-						filename = sdb_fmt (1, "share/radare2/"R2_VERSION"/format/dll/%s.sdb", module);
+						char invoke_dir[MAX_PATH];
+						if (r_sys_get_src_dir_w32(invoke_dir)) {
+							filename = sdb_fmt (1, "%s/share/radare2/"R2_VERSION "/format/dll/%s.sdb", invoke_dir, module);
+						} else {
+							filename = sdb_fmt (1, "share/radare2/"R2_VERSION"/format/dll/%s.sdb", module);
+						}
 #else
 						filename = sdb_fmt (1, R2_PREFIX"/share/radare2/" R2_VERSION"/format/dll/%s.sdb", module);
 #endif

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -121,7 +121,7 @@ R_API int r_core_bin_set_cur(RCore *core, RBinFile *binfile) {
 	if (!binfile) {
 		// Find first available binfile
 		ut32 fd = r_core_file_cur_fd (core);
-		binfile = fd != (ut32)-1 
+		binfile = fd != (ut32)-1
 				  ? r_bin_file_find_by_fd (core->bin, fd)
 				  : NULL;
 		if (!binfile) {
@@ -168,7 +168,7 @@ static bool string_filter(RCore *core, const char *str) {
 			}
 			if (str[i]=='\\') {
 				ot++;
-			}	
+			}
 			if (str[i]==' ') {
 				sp++;
 			}
@@ -302,7 +302,7 @@ static bool string_filter(RCore *core, const char *str) {
 static void _print_strings(RCore *r, RList *list, int mode, int va) {
 	int minstr = r_config_get_i (r->config, "bin.minstr");
 	int maxstr = r_config_get_i (r->config, "bin.maxstr");
-	RBin *bin = r->bin;	
+	RBin *bin = r->bin;
 	RListIter *iter;
 	RBinString *string;
 	RBinSection *section;
@@ -406,7 +406,7 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 }
 
 static bool bin_raw_strings(RCore *r, int mode, int va) {
-	RBinFile *bf = r_bin_cur (r->bin);	
+	RBinFile *bf = r_bin_cur (r->bin);
 	if (!bf) {
 		const char *file = r->io->desc->uri;
 		r_sys_cmdf ("rabin2 -qzzz '%s'", file);
@@ -440,7 +440,7 @@ static bool bin_strings(RCore *r, int mode, int va) {
 	}
 	if (!plugin) {
 		return 0;
-	}		
+	}
 	if (plugin->info && plugin->name) {
 		if (strcmp (plugin->name, "any") == 0 && !rawstr) {
 			return false;
@@ -486,7 +486,7 @@ static void sdb_concat_by_path(Sdb *s, const char *path) {
 }
 
 R_API void r_core_anal_type_init(RCore *core) {
-	Sdb *types = NULL; 
+	Sdb *types = NULL;
 	const char *anal_arch = NULL, *os = NULL;
 	int bits = 0;
 	char *dbpath;
@@ -790,12 +790,12 @@ static int bin_dwarf(RCore *core, int mode) {
 	int lastFileLinesCount2 = 0;
 
 
-	const char *lf = NULL; 
-	int *lfl = NULL; 
+	const char *lf = NULL;
+	int *lfl = NULL;
 	char *lfc = NULL;
-	int lflc = 0; 
+	int lflc = 0;
 
-	//TODO we should need to store all this in sdb, or do a filecontentscache in libr/util 
+	//TODO we should need to store all this in sdb, or do a filecontentscache in libr/util
 	//XXX this whole thing has leaks
 	r_list_foreach (list, iter, row) {
 		if (r_cons_is_breaked ()) {
@@ -1774,7 +1774,7 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 		snFini (&sn);
 		i++;
 	}
-	
+
 	//handle thumb and arm for entry point since they are not present in symbols
 	if (is_arm) {
 		r_list_foreach (entries, iter, entry) {
@@ -2608,13 +2608,13 @@ static int bin_signature(RCore *r, int mode) {
 
 
 R_API void r_core_bin_export_info_rad(RCore *core) {
-	Sdb *db = NULL; 
+	Sdb *db = NULL;
 	char *flagname, *offset = NULL;
 	RBinFile *bf = r_core_bin_cur (core);
 	if (!bf) {
 		return;
 	}
-	db = sdb_ns (bf->sdb, "info", 0);; 
+	db = sdb_ns (bf->sdb, "info", 0);;
 	if (!db) {
 		return;
 	}
@@ -2652,7 +2652,7 @@ R_API void r_core_bin_export_info_rad(RCore *core) {
 				free (offset_key);
 				if (off) {
 					r_cons_printf ("Cf %d %s @ %s\n", fmtsize, v, off);
-				} 
+				}
 			}
 			free (dup);
 		}
@@ -2734,7 +2734,7 @@ R_API int r_core_bin_set_arch_bits(RCore *r, const char *name, const char * arch
 
 R_API int r_core_bin_update_arch_bits(RCore *r) {
 	RBinFile *binfile = NULL;
-	const char *name = NULL, *arch = NULL; 
+	const char *name = NULL, *arch = NULL;
 	ut16 bits = 0;
 	if (!r) {
 		return 0;
@@ -2744,7 +2744,7 @@ R_API int r_core_bin_update_arch_bits(RCore *r) {
 	   	if (r->assembler->cur) {
 			arch = r->assembler->cur->arch;
 		}
-	} 
+	}
 	binfile = r_core_bin_cur (r);
 	name = binfile ? binfile->file : NULL;
 	if (r && r->bin && r->bin->binxtrs) {

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -40,6 +40,7 @@ R_API char *r_sys_getdir(void);
 R_API int r_sys_chdir(const char *s);
 R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, int *len, char **sterr);
 #if __WINDOWS__
+R_API int r_sys_get_src_dir_w32(char *buf);
 R_API char *r_sys_cmd_str_w32(const char *cmd);
 #endif
 R_API int r_sys_truncate(const char *file, int sz);

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -2,8 +2,8 @@
 #include <r_util.h>
 
 #if __WINDOWS__
-#include <windows.h> 
-#include <stdio.h> 
+#include <windows.h>
+#include <stdio.h>
 #ifndef __CYGWIN__
 #include <tchar.h>
 #endif
@@ -13,7 +13,7 @@ void r_sys_perror_str(const char *fun);
 
 #define ErrorExit(x) { r_sys_perror(x); return NULL; }
 static int CreateChildProcess(const char *szCmdline, HANDLE out);
-char *ReadFromPipe(HANDLE fh); 
+char *ReadFromPipe(HANDLE fh);
 
 // HACKY
 static char *getexe(const char *str) {
@@ -25,80 +25,106 @@ static char *getexe(const char *str) {
 	return argv0;
 }
 
-R_API char *r_sys_cmd_str_w32(const char *cmd) { 
+R_API int r_sys_get_src_dir_w32(char *buf) {
+	int i = 0;
+	char fullpath[MAX_PATH + 1];
+
+	if (!GetModuleFileName(NULL, fullpath, MAX_PATH + 1)) {
+		return false;
+	}
+
+	if (!GetShortPathName(fullpath, buf, MAX_PATH+1)) {
+		return false;
+	}
+
+	i = strlen(buf);
+
+	while(i > 0 && buf[i-1] != '/' && buf[i-1] != '\\') {
+		buf[--i] = 0;
+	}
+
+	// Remove the last separator in the path.
+	if(i > 0) {
+		buf[--i] = 0;
+	}
+
+	return true;
+}
+
+R_API char *r_sys_cmd_str_w32(const char *cmd) {
 	char *ret = NULL;
 	HANDLE out = NULL;
 	HANDLE in = NULL;
-	SECURITY_ATTRIBUTES saAttr; 
+	SECURITY_ATTRIBUTES saAttr;
 	char *argv0 = getexe (cmd);
 
-	// Set the bInheritPlugin flag so pipe handles are inherited. 
-	saAttr.nLength = sizeof (SECURITY_ATTRIBUTES); 
-	saAttr.bInheritHandle = TRUE; 
-	saAttr.lpSecurityDescriptor = NULL; 
+	// Set the bInheritPlugin flag so pipe handles are inherited.
+	saAttr.nLength = sizeof (SECURITY_ATTRIBUTES);
+	saAttr.bInheritHandle = TRUE;
+	saAttr.lpSecurityDescriptor = NULL;
 	HANDLE fh;
 
-	// Create a pipe for the child process's STDOUT. 
-	if (!CreatePipe (&fh, &out, &saAttr, 0)) 
-		ErrorExit ("StdoutRd CreatePipe"); 
+	// Create a pipe for the child process's STDOUT.
+	if (!CreatePipe (&fh, &out, &saAttr, 0))
+		ErrorExit ("StdoutRd CreatePipe");
 
 	// Ensure the read handle to the pipe for STDOUT is not inherited.
 	if (!SetHandleInformation (fh, HANDLE_FLAG_INHERIT, 0) )
-		ErrorExit ("Stdout SetHandleInformation"); 
+		ErrorExit ("Stdout SetHandleInformation");
 
 	CreateChildProcess (cmd, out);
 
 	in = CreateFile (argv0,
-			GENERIC_READ, 
-			FILE_SHARE_READ, 
-			NULL, 
-			OPEN_EXISTING, 
-			FILE_ATTRIBUTE_READONLY, 
-			NULL); 
+			GENERIC_READ,
+			FILE_SHARE_READ,
+			NULL,
+			OPEN_EXISTING,
+			FILE_ATTRIBUTE_READONLY,
+			NULL);
 
 	if (in == INVALID_HANDLE_VALUE) {
 		eprintf ("CreateFile (%s)\n", argv0);
-		ErrorExit ("CreateFile"); 
+		ErrorExit ("CreateFile");
 	}
 
-	// Close the write end of the pipe before reading from the 
+	// Close the write end of the pipe before reading from the
 	// read end of the pipe, to control child process execution.
 	// The pipe is assumed to have enough buffer space to hold the
 	// data the child process has already written to it.
 	if (!CloseHandle (out))
-		ErrorExit ("StdOutWr CloseHandle"); 
+		ErrorExit ("StdOutWr CloseHandle");
 	ret = ReadFromPipe (fh);
 	free (argv0);
 
-	return ret; 
-} 
+	return ret;
+}
 
-static int CreateChildProcess(const char *szCmdline, HANDLE out) { 
-	PROCESS_INFORMATION piProcInfo; 
+static int CreateChildProcess(const char *szCmdline, HANDLE out) {
+	PROCESS_INFORMATION piProcInfo;
 	STARTUPINFO siStartInfo;
-	BOOL bSuccess = FALSE; 
+	BOOL bSuccess = FALSE;
 
 	ZeroMemory (&piProcInfo, sizeof (PROCESS_INFORMATION) );
 
-	// Set up members of the STARTUPINFO structure. 
+	// Set up members of the STARTUPINFO structure.
 	// This structure specifies the STDIN and STDOUT handles for redirection.
 	ZeroMemory (&siStartInfo, sizeof (STARTUPINFO) );
-	siStartInfo.cb = sizeof(STARTUPINFO); 
+	siStartInfo.cb = sizeof(STARTUPINFO);
 	siStartInfo.hStdError = out;
 	siStartInfo.hStdOutput = out;
 	siStartInfo.hStdInput = NULL;
 	siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
 
-	bSuccess = CreateProcess (NULL, 
-			(LPSTR)szCmdline,// command line 
-			NULL,          // process security attributes 
-			NULL,          // primary thread security attributes 
-			TRUE,          // handles are inherited 
-			0,             // creation flags 
-			NULL,          // use parent's environment 
-			NULL,          // use parent's current directory 
-			&siStartInfo,  // STARTUPINFO pointer 
-			&piProcInfo);  // receives PROCESS_INFORMATION 
+	bSuccess = CreateProcess (NULL,
+			(LPSTR)szCmdline,// command line
+			NULL,          // process security attributes
+			NULL,          // primary thread security attributes
+			TRUE,          // handles are inherited
+			0,             // creation flags
+			NULL,          // use parent's environment
+			NULL,          // use parent's current directory
+			&siStartInfo,  // STARTUPINFO pointer
+			&piProcInfo);  // receives PROCESS_INFORMATION
 
 	if (bSuccess) {
 		CloseHandle (piProcInfo.hProcess);
@@ -109,16 +135,16 @@ static int CreateChildProcess(const char *szCmdline, HANDLE out) {
 
 char *ReadFromPipe(HANDLE fh) {
 	DWORD dwRead;
-	CHAR chBuf[BUFSIZE]; 
+	CHAR chBuf[BUFSIZE];
 	BOOL bSuccess = FALSE;
 	char *str;
 	int strl = 0;
 	int strsz = BUFSIZE+1;
 
 	str = malloc (strsz);
-	for (;;) { 
+	for (;;) {
 		bSuccess = ReadFile (fh, chBuf, BUFSIZE, &dwRead, NULL);
-		if (! bSuccess || dwRead == 0) break; 
+		if (! bSuccess || dwRead == 0) break;
 		chBuf[dwRead] = '\0';
 		if (strl+dwRead>strsz) {
 			strsz += 4096;
@@ -128,8 +154,8 @@ char *ReadFromPipe(HANDLE fh) {
 		}
 		memcpy (str+strl, chBuf, dwRead);
 		strl += dwRead;
-	} 
+	}
 	str[strl] = 0;
 	return str;
-} 
+}
 #endif


### PR DESCRIPTION
This pull request fixes #5348. Instead of looking for r2's `share` directory in the working directory, r2 will now _additionally_ look for its `share` directory in the directory where the r2 binary lives. This fix only applies to Windows, which does not honor POSIX path conventions.