### PR TITLE
's' result should be formatted as prompt

### DIFF
--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -489,6 +489,6 @@ static int cmd_seek(void *data, const char *input) {
 		}
 			break;
 		}
-	} else r_cons_printf ("0x%"PFMT64x"\n", core->offset);
+	} else r_cons_printf ("0x%08"PFMT64x"\n", core->offset);
 	return 0;
 }


### PR DESCRIPTION
Apparently there is demand for this:

![demand](https://cloud.githubusercontent.com/assets/12002672/23094421/9115d9ae-f633-11e6-958e-86e1754d9d4e.png)

The old 's' behavior can be emulated by:
```
? $$~[1]
```