### PR TITLE
Show full address while executing `s`

### DIFF
--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -485,6 +485,6 @@ static int cmd_seek(void *data, const char *input) {
 		}
 			break;
 		}
-	} else r_cons_printf ("0x%"PFMT64x"\n", core->offset);
+	} else r_cons_printf ("0x%08"PFMT64x"\n", core->offset);
 	return 0;
 }


### PR DESCRIPTION
According to "pantikal" suggestion on Telegram few days ago, now `s` command will print the full address and not partial address:
e.g 
```
[0x0001ce3a]> s
0x0001ce3a
```

instead of:
```
[0x0001ce3a]> s
0x1ce3a
```