### PR TITLE
Probably fixed: ax- not working (#6795)

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -133,6 +133,24 @@ R_API RList *r_anal_xrefs_get (RAnal *anal, ut64 to) {
 	return list;
 }
 
+R_API RList *r_anal_refs_get (RAnal *anal, ut64 from) {
+	RList *list = r_list_new ();
+	if (!list) {
+		return NULL;
+	}
+	list->free = NULL;
+	r_anal_xrefs_from (anal, list, "ref", R_ANAL_REF_TYPE_NULL, from);
+	r_anal_xrefs_from (anal, list, "ref", R_ANAL_REF_TYPE_CODE, from);
+	r_anal_xrefs_from (anal, list, "ref", R_ANAL_REF_TYPE_CALL, from);
+	r_anal_xrefs_from (anal, list, "ref", R_ANAL_REF_TYPE_DATA, from);
+	r_anal_xrefs_from (anal, list, "ref", R_ANAL_REF_TYPE_STRING, from);
+	if (r_list_empty (list)) {
+		r_list_free (list);
+		list = NULL;
+	}
+	return list;
+}
+
 R_API RList *r_anal_xrefs_get_from (RAnal *anal, ut64 to) {
 	RList *list = r_list_new ();
 	if (!list) {
@@ -215,7 +233,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 		anal->cb_printf ("}\n");
 		}
 		break;
-	default: 
+	default:
 		sdb_foreach (DB, (SdbForeachCallback)xrefs_list_cb_plain, anal);
 		break;
 	}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1586,7 +1586,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			}
 			}
 			break;
-		default: 
+		default:
 			{
 				const char *help_msg[] = {
 					"Usage:", "afn[sa]", " Analyze function names",
@@ -3533,7 +3533,7 @@ static void _anal_calls(RCore *core, ut64 addr, ut64 addr_end) {
 	}
 	bufi = 0;
 	if (addr_end - addr > 0xffffff) {
-		return;	
+		return;
 	}
 	while (addr < addr_end) {
 		if (r_cons_is_breaked ()) {
@@ -3865,24 +3865,31 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case '-': { // "ax-"
 		const char *inp;
 		ut64 a, b;
+		char *p;
+		RList *list;
+		RListIter *iter;
+		RAnalRef *ref;
 		for (inp = input + 1; *inp && IS_WHITESPACE (*inp); inp++) {
 			//nothing to see here
 		}
 		if (!strcmp (inp, "*")) {
 			r_anal_xrefs_init (core->anal);
 		} else {
-			char *p = strdup (inp);
-			char *q = strchr (p, ' ');
-			a = r_num_math (core->num, p);
-			if (q) {
-				*q++ = 0;
-				b = r_num_math (core->num, q);
+			p = strdup (inp);
+			if (p) {
+				b = r_num_math (core->num, p);
+				free (p);
 			} else {
 				//b = UT64_MAX;
 				b = core->offset;
 			}
-			r_anal_ref_del (core->anal, b, a);
-			free (p);
+			list = r_anal_refs_get (core->anal, b);
+			if (list) {
+				r_list_foreach (list, iter, ref) {
+					r_anal_ref_del (core->anal, ref->at, ref->addr);
+				}
+				r_list_free (list);
+			}
 		}
 	} break;
 	case 'g': // "axg"
@@ -4080,7 +4087,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case 'C': // "axC"
 	case 'c': // "axc"
 	case 'd': // "axd"
-	case ' ': 
+	case ' ':
 		{
 		char *ptr = strdup (r_str_trim_head ((char *)input + 1));
 		int n = r_str_word_set0 (ptr);
@@ -4099,7 +4106,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 		}
 		r_anal_ref_add (core->anal, addr, at, input[0]);
 		free (ptr);
-		} 
+		}
 	   	break;
 	default:
 	case '?':
@@ -5120,13 +5127,13 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			r_cons_break_timeout (r_config_get_i (core->config, "anal.timeout"));
 			r_core_anal_all (core);
 			rowlog_done (core);
-			char *dh_orig = core->dbg->h 
+			char *dh_orig = core->dbg->h
 					? strdup (core->dbg->h->name)
 					: strdup ("esil");
 			if (core->io && core->io->plugin && !core->io->plugin->isdbg) {
 				//use dh_origin if we are debugging
 				R_FREE (dh_orig);
-			}	
+			}
 			if (r_cons_is_breaked ()) {
 				goto jacuzzi;
 			}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1335,6 +1335,7 @@ R_API int r_anal_fcn_resize (RAnalFunction *fcn, int newsize);
 R_API int r_anal_xrefs_count(RAnal *anal);
 R_API const char *r_anal_xrefs_type_tostring (char type);
 R_API RList *r_anal_xrefs_get (RAnal *anal, ut64 to);
+R_API RList *r_anal_refs_get (RAnal *anal, ut64 to);
 R_API RList *r_anal_xrefs_get_from (RAnal *anal, ut64 from);
 R_API void r_anal_xrefs_list(RAnal *anal, int rad);
 R_API RList* r_anal_fcn_get_refs (RAnalFunction *anal);


### PR DESCRIPTION
Ref: #6795
The issue apparently was a strchr() in libr/core/cmd_anal.c which was making us skip past the supplied address.
Also needed to write a r_anal_refs_get() function in libr/anal/xrefs.c to get "refs" instead of "xrefs" for an address.