### PR TITLE
RiscV improvements

### DIFF
--- a/libr/asm/arch/riscv/riscv.c
+++ b/libr/asm/arch/riscv/riscv.c
@@ -309,6 +309,7 @@ riscv_disassemble(RAsm *a, RAsmOp *rop, insn_t word, int xlen) {
 		if (op->name && op->args) {
 			snprintf (rop->buf_asm, sizeof (rop->buf_asm), "%s", op->name);
 			get_insn_args (rop->buf_asm, op->args, word, a->pc);
+			return 0;
 		} else {
 			sprintf (rop->buf_asm, "invalid word(%"PFMT64x")", (ut64)word);
 			return -1;

--- a/libr/asm/arch/riscv/riscv.c
+++ b/libr/asm/arch/riscv/riscv.c
@@ -327,5 +327,5 @@ riscv_dis(RAsm *a, RAsmOp *rop, const ut8 *buf, ut64 len) {
 	memcpy (&insn, buf, 4);
 	riscv_disassemble (a, rop, insn, a->bits);
 
-	return 4;
+	return riscv_insn_length(insn);
 }


### PR DESCRIPTION
- Return actual instruction length: Support instructions of varying length. Addresses #6849.
- Choose first match while disassembling. The opcodes table is sorted with the preferred instructions with a certain encoding first. This means "c.jr ra" will be chosen before "c.mv ra, zero" for example.

Result after this patch for the same function that I disassembled in #6849:
```
            ;-- sulp:
            0x00010074      4111           c.addi sp, -16              ; [1] va=0x00010074 pa=0x00000074 sz=204598 vsz=204598 rwx=--r-x .text
            0x00010076      26c2           c.swsp s1, 4(sp)
            0x00010078      4ac0           c.swsp s2, 0(sp)
            0x0001007a      06c6           c.swsp ra, 12(sp)
            0x0001007c      22c4           c.swsp s0, 8(sp)
            0x0001007e      ae84           c.mv s1, a1                 ; (null)/newlib/libc/include/sy:1
            0x00010080      3289           c.mv s2, a2
            0x00010082      ef90b255       jal ra, sym.__ulp
            0x00010086      2a88           c.mv a6, a0
            0x00010088      ae88           c.mv a7, a1
            0x0001008a      63050902       beq s2, zero, 0x100b4
            0x0001008e      93d74401       srli a5, s1, 0x14
            0x00010092      13f7f77f       andi a4, a5, 2047
            0x00010096      9307b006       addi a5, zero, 107
            0x0001009a      998f           invalid
            0x0001009c      635cf000       bge zero, a5, 0x100b4
            0x000100a0      d207           c.slli a5, 0x14
            0x000100a2      3707f03f       lui a4, 0x3ff00
            0x000100a6      0146           c.li a2, 0
            0x000100a8      b386e700       add a3, a5, a4
            0x000100ac      ef00b31d       jal ra, sym.__muldf3
            0x000100b0      2a88           c.mv a6, a0
            0x000100b2      ae88           c.mv a7, a1
            0x000100b4      b240           c.lwsp ra, 12(sp)
            0x000100b6      4285           c.mv a0, a6
            0x000100b8      c685           c.mv a1, a7
            0x000100ba      2244           c.lwsp s0, 8(sp)
            0x000100bc      9244           c.lwsp s1, 4(sp)
            0x000100be      0249           c.lwsp s2, 0(sp)
            0x000100c0      4101           c.addi sp, 16
            0x000100c2      8280           c.jr ra
```
It's still somewhat different compared to the objdump output (why is `998f` invalid? why is `c.jr ra` not recognized as `ret`?), but it comes a lot closer.