### PR TITLE
remove leading comma when generating exports only json

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1705,7 +1705,7 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 				"\"type\":\"%s\","
 				"\"vaddr\":%"PFMT64d","
 				"\"paddr\":%"PFMT64d"}",
-				iter->p?",":"", str,
+				exponly?"":iter->p?",":"", str,
 				sn.demname? sn.demname: "",
 				sn.nameflag,
 				(int)symbol->size,


### PR DESCRIPTION
there is a bug in iEj, it outputs something like:

`[,{"name":...]`
The leading comma is obviously wrong. (r2pipe/json modules do not like it)
This patch intends to remove that comma when exponly is set.

