### PR TITLE
Fix aaa - let aac pass to run from $S

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5163,8 +5163,8 @@ static int cmd_anal_all(RCore *core, const char *input) {
 					goto jacuzzi;
 				}
 				rowlog (core, "Analyze function calls (aac)");
-				r_core_seek (core, curseek, 1);
 				(void) cmd_anal_calls (core, ""); // "aac"
+				r_core_seek (core, curseek, 1);
 				// rowlog (core, "Analyze data refs as code (LEA)");
 				// (void) cmd_anal_aad (core, NULL); // "aad"
 				rowlog_done (core);


### PR DESCRIPTION
It used to run from current offset, leading to different results of `aaa` depending on "where" it is run. In this way is more seek-independent.