### PR TITLE
Refactoring CMS/PKCS#7 and better use of the memory

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -1903,13 +1903,15 @@ static void bin_pe_get_certificate (struct PE_ (r_bin_pe_obj_t) * bin) {
 	con = r_pkcs7_parse_cms (data, size);
 	bin->pkcs7 = r_pkcs7_cms_dump (con);
 	if (bin->pkcs7) {
-		ut64 length = strlen (bin->pkcs7);
-		char *c = (char*) malloc (length);
-		if (c) {
-			memcpy (c, bin->pkcs7, length);
-			c[length-1] = '\0';
-			free ((char*)bin->pkcs7);
-			bin->pkcs7 = c;
+		int length = strlen (bin->pkcs7);
+		if (length > 0) {
+			char *c = (char*) malloc (length);
+			if (c) {
+				memcpy (c, bin->pkcs7, length);
+				c[length - 1] = '\0';
+				free ((char*)bin->pkcs7);
+				bin->pkcs7 = c;
+			}
 		}
 	}
 	r_pkcs7_free_cms (con);

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -1903,12 +1903,12 @@ static void bin_pe_get_certificate (struct PE_ (r_bin_pe_obj_t) * bin) {
 	con = r_pkcs7_parse_cms (data, size);
 	bin->pkcs7 = r_pkcs7_cms_dump (con);
 	if (bin->pkcs7) {
-		ut64 length = strlen(bin->pkcs7);
-		char *c = (char*) malloc(length);
+		ut64 length = strlen (bin->pkcs7);
+		char *c = (char*) malloc (length);
 		if (c) {
-			memcpy(c, bin->pkcs7, length);
+			memcpy (c, bin->pkcs7, length);
 			c[length-1] = '\0';
-			free((char*)bin->pkcs7);
+			free ((char*)bin->pkcs7);
 			bin->pkcs7 = c;
 		}
 	}

--- a/libr/include/r_util/r_pkcs7.h
+++ b/libr/include/r_util/r_pkcs7.h
@@ -65,9 +65,9 @@ typedef struct r_pkcs7_container_t {
 	RPKCS7SignedData signedData;
 } RCMS;
 
-R_API RCMS *r_pkcs7_parse_cms (const ut8 *buffer, ut32 length);
-R_API void r_pkcs7_free_cms (RCMS* container);
-R_API char* r_pkcs7_cms_dump (RCMS* container);
+R_API RCMS *r_pkcs7_parse_cms(const ut8 *buffer, ut32 length);
+R_API void r_pkcs7_free_cms(RCMS* container);
+R_API char* r_pkcs7_cms_dump(RCMS* container);
 
 #endif /* R_PKCS7_H */
 

--- a/libr/include/r_util/r_pkcs7.h
+++ b/libr/include/r_util/r_pkcs7.h
@@ -63,11 +63,11 @@ typedef struct r_pkcs7_signeddata_t {
 typedef struct r_pkcs7_container_t {
 	RASN1String *contentType;
 	RPKCS7SignedData signedData;
-} RPKCS7Container;
+} RCMS;
 
-R_API RPKCS7Container *r_pkcs7_parse_container (const ut8 *buffer, ut32 length);
-R_API void r_pkcs7_free_container (RPKCS7Container* container);
-R_API char* r_pkcs7_container_dump (RPKCS7Container* container);
+R_API RCMS *r_pkcs7_parse_cms (const ut8 *buffer, ut32 length);
+R_API void r_pkcs7_free_cms (RCMS* container);
+R_API char* r_pkcs7_cms_dump (RCMS* container);
 
 #endif /* R_PKCS7_H */
 

--- a/libr/include/r_util/r_x509.h
+++ b/libr/include/r_util/r_x509.h
@@ -104,14 +104,14 @@ typedef struct r_x509_certificaterevocationlist {
 	RX509CRLEntry **revokedCertificates;
 } RX509CertificateRevocationList;
 
-R_API RX509CertificateRevocationList* r_x509_parse_crl (RASN1Object *object);
-R_API void r_x509_free_crl (RX509CertificateRevocationList *crl);
-R_API char* r_x509_crl_dump (RX509CertificateRevocationList *crl, char* buffer, ut32 length, const char* pad);
+R_API RX509CertificateRevocationList* r_x509_parse_crl(RASN1Object *object);
+R_API void r_x509_free_crl(RX509CertificateRevocationList *crl);
+R_API char* r_x509_crl_dump(RX509CertificateRevocationList *crl, char* buffer, ut32 length, const char* pad);
 
-R_API RX509Certificate *r_x509_parse_certificate (RASN1Object *object);
-R_API RX509Certificate *r_x509_parse_certificate2 (const ut8 *buffer, ut32 length);
-R_API void r_x509_free_certificate (RX509Certificate* certificate);
-R_API char* r_x509_certificate_dump (RX509Certificate* certificate, char* buffer, ut32 length, const char* pad);
+R_API RX509Certificate *r_x509_parse_certificate(RASN1Object *object);
+R_API RX509Certificate *r_x509_parse_certificate2(const ut8 *buffer, ut32 length);
+R_API void r_x509_free_certificate(RX509Certificate* certificate);
+R_API char* r_x509_certificate_dump(RX509Certificate* certificate, char* buffer, ut32 length, const char* pad);
 
 
 #ifdef __cplusplus

--- a/libr/util/r_pkcs7.c
+++ b/libr/util/r_pkcs7.c
@@ -283,17 +283,17 @@ void r_pkcs7_free_signeddata (RPKCS7SignedData* sd) {
 	}
 }
 
-RPKCS7Container *r_pkcs7_parse_container (const ut8 *buffer, ut32 length) {
+RCMS *r_pkcs7_parse_cms (const ut8 *buffer, ut32 length) {
 	RASN1Object *object;
-	RPKCS7Container *container;
+	RCMS *container;
 	if (!buffer || !length) {
 		return NULL;
 	}
-	container = (RPKCS7Container*) malloc (sizeof (RPKCS7Container));
+	container = (RCMS*) malloc (sizeof (RCMS));
 	if (!container) {
 		return NULL;
 	}
-	memset (container, 0, sizeof (RPKCS7Container));
+	memset (container, 0, sizeof (RCMS));
 	object = r_asn1_create_object (buffer, length);
 	if (!object || object->list.length != 2 || object->list.objects[1]->list.length != 1) {
 		free (container);
@@ -305,7 +305,7 @@ RPKCS7Container *r_pkcs7_parse_container (const ut8 *buffer, ut32 length) {
 	return container;
 }
 
-void r_pkcs7_free_container (RPKCS7Container* container) {
+void r_pkcs7_free_cms (RCMS* container) {
 	if (container) {
 		r_asn1_free_string (container->contentType);
 		r_pkcs7_free_signeddata (&container->signedData);
@@ -494,11 +494,12 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 		return NULL;
 	}
 
-	if ((o = si->encryptedDigest)) s = r_asn1_stringify_bytes (o->sector, o->length);
-	else s = NULL;
-	r = snprintf (buffer + p, length - p, "%sEncrypted Digest: %u bytes\n%s\n", pad2, o ? o->length : 0, s ? s->string : "Missing");
-	p += (unsigned) r;
-	r_asn1_free_string (s);
+//	if ((o = si->encryptedDigest)) s = r_asn1_stringify_bytes (o->sector, o->length);
+//	else s = NULL;
+//	r = snprintf (buffer + p, length - p, "%sEncrypted Digest: %u bytes\n%s\n", pad2, o ? o->length : 0, s ? s->string : "Missing");
+//	p += (unsigned) r;
+//	r_asn1_free_string (s);
+	r = snprintf (buffer + p, length - p, "%sEncrypted Digest: %u bytes\n", pad2, o ? o->length : 0);
 	if (r < 0) {
 		free (pad3);
 		return NULL;
@@ -524,7 +525,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 	return buffer + p;
 }
 
-char *r_pkcs7_container_dump (RPKCS7Container* container) {
+char *r_pkcs7_cms_dump (RCMS* container) {
 	RPKCS7SignedData *sd;
 	ut32 i, length, p;
 	int r;
@@ -534,7 +535,7 @@ char *r_pkcs7_container_dump (RPKCS7Container* container) {
 	}
 	sd = &container->signedData;
 	p = 0;
-	length = 1024 + (container->signedData.certificates.length * 4096);
+	length = 2048 + (container->signedData.certificates.length * 1024);
 	buffer = (char*) malloc (length);
 	if (!buffer) return NULL;
 	memset (buffer, 0, length);

--- a/libr/util/r_pkcs7.c
+++ b/libr/util/r_pkcs7.c
@@ -394,7 +394,7 @@ char* r_pkcs7_signerinfos_dump (RX509CertificateRevocationList *crl, char* buffe
 	next = crl->nextUpdate;
 	r = snprintf (buffer, length, "%sCRL:\n%sSignature:\n%s%s\n%sIssuer\n",
 				pad, pad2, pad3, algo ? algo->string : "", pad2);
-	p = (unsigned) r;
+	p = (ut32) r;
 	if (r < 0 || !(tmp = r_x509_name_dump (&crl->issuer, buffer + p, length - p, pad3))) {
 		free (pad3);
 		return NULL;
@@ -407,7 +407,7 @@ char* r_pkcs7_signerinfos_dump (RX509CertificateRevocationList *crl, char* buffe
 	r = snprintf (buffer + p, length - p, "%sLast Update: %s\n%sNext Update: %s\n%sRevoked Certificates:\n",
 				pad2, last ? last->string : "Missing",
 				pad2, next ? next->string : "Missing", pad2);
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0) {
 		free (pad3);
 		return NULL;
@@ -442,7 +442,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 
 
 	r = snprintf (buffer, length, "%sSignerInfo:\n%sVersion: v%u\n%sIssuer\n", pad, pad2, si->version + 1, pad2);
-	p = (unsigned) r;
+	p = (ut32) r;
 	if (r < 0) {
 		free (pad3);
 		return NULL;
@@ -459,7 +459,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 		s = NULL;
 	}
 	r = snprintf (buffer + p, length - p, "%sSerial Number:\n%s%s\n", pad2, pad3, s ? s->string : "Missing");
-	p += (unsigned) r;
+	p += (ut32) r;
 	r_asn1_free_string (s);
 	if (r < 0) {
 		free (pad3);
@@ -469,7 +469,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 	s = si->digestAlgorithm.algorithm;
 	r = snprintf (buffer + p, length - p, "%sDigest Algorithm:\n%s%s\n%sAuthenticated Attributes:\n",
 				pad2, pad3, s ? s->string : "Missing", pad2);
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0) {
 		free (pad3);
 		return NULL;
@@ -479,7 +479,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 		if (!attr) continue;
 		r = snprintf (buffer + p, length - p, "%s%s: %u bytes\n",
 					pad3, attr->oid ? attr->oid->string : "Missing", attr->data ? attr->data->length : 0);
-		p += (unsigned) r;
+		p += (ut32) r;
 		if (r < 0) {
 			free (pad3);
 			return NULL;
@@ -488,7 +488,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 	s = si->digestEncryptionAlgorithm.algorithm;
 	r = snprintf (buffer + p, length - p, "%sDigest Encryption Algorithm\n%s%s\n",
 				pad2, pad3, s ? s->string : "Missing");
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0) {
 		free (pad3);
 		return NULL;
@@ -497,7 +497,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 //	if ((o = si->encryptedDigest)) s = r_asn1_stringify_bytes (o->sector, o->length);
 //	else s = NULL;
 //	r = snprintf (buffer + p, length - p, "%sEncrypted Digest: %u bytes\n%s\n", pad2, o ? o->length : 0, s ? s->string : "Missing");
-//	p += (unsigned) r;
+//	p += (ut32) r;
 //	r_asn1_free_string (s);
 	r = snprintf (buffer + p, length - p, "%sEncrypted Digest: %u bytes\n", pad2, o ? o->length : 0);
 	if (r < 0) {
@@ -505,7 +505,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 		return NULL;
 	}
 	r = snprintf (buffer + p, length - p, "%sUnauthenticated Attributes:\n", pad2);
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0) {
 		free (pad3);
 		return NULL;
@@ -516,7 +516,7 @@ char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, c
 		o = attr->data;
 		r = snprintf (buffer + p, length - p, "%s%s: %u bytes\n",
 					pad3, attr->oid ? attr->oid->string : "Missing", o ? o->length : 0);
-		p += (unsigned) r;
+		p += (ut32) r;
 		if (r < 0) {
 			free (pad3);
 			return NULL;
@@ -540,7 +540,7 @@ char *r_pkcs7_cms_dump (RCMS* container) {
 	if (!buffer) return NULL;
 	memset (buffer, 0, length);
 	r = snprintf (buffer, length, "signedData\n  Version: %u\n  Digest Algorithms:\n", sd->version);
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0) {
 		free (buffer);
 		return NULL;
@@ -549,7 +549,7 @@ char *r_pkcs7_cms_dump (RCMS* container) {
 		for (i = 0; i < container->signedData.digestAlgorithms.length; ++i) {
 			if (container->signedData.digestAlgorithms.elements[i]) {
 				r = snprintf (buffer + p, length - p, "    %s\n", container->signedData.digestAlgorithms.elements[i]->algorithm->string);
-				p += (unsigned) r;
+				p += (ut32) r;
 				if (r < 0 || length <= p) {
 					free (buffer);
 					return NULL;
@@ -558,7 +558,7 @@ char *r_pkcs7_cms_dump (RCMS* container) {
 		}
 	}
 	r = snprintf (buffer + p, length - p, "  Certificates: %u\n", container->signedData.certificates.length);
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0 || length <= p) {
 		free (buffer);
 		return NULL;
@@ -580,7 +580,7 @@ char *r_pkcs7_cms_dump (RCMS* container) {
 	}
 	p = tmp - buffer;
 	r = snprintf (buffer + p, length - p, "  SignerInfos:\n");
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0 || length <= p) {
 		free (buffer);
 		return NULL;

--- a/libr/util/r_x509.c
+++ b/libr/util/r_x509.c
@@ -448,7 +448,7 @@ char* r_x509_validity_dump (RX509Validity* validity, char* buffer, ut32 length, 
 	const char* b = validity->notBefore ? validity->notBefore->string : "Missing";
 	const char* a = validity->notAfter ? validity->notAfter->string : "Missing";
 	p = snprintf (buffer, length, "%sNot Before: %s\n%sNot After: %s\n", pad, b, pad, a);
-	return p < 0 ? NULL : buffer + (unsigned) p;
+	return p < 0 ? NULL : buffer + (ut32) p;
 }
 
 char* r_x509_name_dump (RX509Name* name, char* buffer, ut32 length, const char* pad) {
@@ -494,7 +494,7 @@ char* r_x509_subjectpublickeyinfo_dump (RX509SubjectPublicKeyInfo* spki, char* b
 				pad, spki->subjectPublicKeyExponent->length - 1);
 	r_asn1_free_string (m);
 //	r_asn1_free_string (e);
-	return r < 0 ? NULL : buffer + (unsigned) r;
+	return r < 0 ? NULL : buffer + (ut32) r;
 }
 
 char* r_x509_extensions_dump (RX509Extensions* exts, char* buffer, ut32 length, const char* pad) {
@@ -549,7 +549,7 @@ char* r_x509_tbscertificate_dump (RX509TBSCertificate* tbsc, char* buffer, ut32 
 				pad, pad, tbsc->serialNumber->string,
 				pad, pad, tbsc->signature.algorithm->string,
 				pad);
-	p = (unsigned) r;
+	p = (ut32) r;
 	if (r < 0 || length <= p || !(tmp = r_x509_name_dump (&tbsc->issuer, buffer + p, length - p, pad2))) {
 		free (pad2);
 		return NULL;
@@ -633,7 +633,7 @@ char* r_x509_certificate_dump (RX509Certificate* certificate, char* buffer, ut32
 	pad2 = r_str_newf ("%s  ", pad);
 	if (!pad2) return NULL;
 	if ((r = snprintf (buffer, length, "%sTBSCertificate:\n", pad)) < 0) return NULL;
-	p = (unsigned) r;
+	p = (ut32) r;
 	tbsc = r_x509_tbscertificate_dump (&certificate->tbsCertificate, buffer + p, length - p, pad2);
 	p = tbsc - buffer;
 	if (length <= p) {
@@ -651,7 +651,7 @@ char* r_x509_certificate_dump (RX509Certificate* certificate, char* buffer, ut32
 		free (pad2);
 		return NULL;
 	}
-	p += (unsigned) r;
+	p += (ut32) r;
 	free (pad2);
 //	r_asn1_free_string (signature);
 	return buffer + p;
@@ -676,7 +676,7 @@ char* r_x509_crlentry_dump (RX509CRLEntry *crle, char* buffer, ut32 length, cons
 				pad, pad, id ? id->string : "Missing",
 				pad, pad, utc ? utc->string : "Missing");
 
-	return r < 0 ? NULL : buffer + (unsigned) r;
+	return r < 0 ? NULL : buffer + (ut32) r;
 }
 
 char* r_x509_crl_dump (RX509CertificateRevocationList *crl, char* buffer, ut32 length, const char* pad) {
@@ -698,7 +698,7 @@ char* r_x509_crl_dump (RX509CertificateRevocationList *crl, char* buffer, ut32 l
 	next = crl->nextUpdate;
 	r = snprintf (buffer, length, "%sCRL:\n%sSignature:\n%s%s\n%sIssuer\n",
 				pad, pad2, pad3, algo ? algo->string : "", pad2);
-	p = (unsigned) r;
+	p = (ut32) r;
 	if (r < 0 || !(tmp = r_x509_name_dump (&crl->issuer, buffer + p, length - p, pad3))) {
 		free (pad3);
 		return NULL;
@@ -711,7 +711,7 @@ char* r_x509_crl_dump (RX509CertificateRevocationList *crl, char* buffer, ut32 l
 	r = snprintf (buffer + p, length - p, "%sLast Update: %s\n%sNext Update: %s\n%sRevoked Certificates:\n",
 				pad2, last ? last->string : "Missing",
 				pad2, next ? next->string : "Missing", pad2);
-	p += (unsigned) r;
+	p += (ut32) r;
 	if (r < 0) {
 		free (pad3);
 		return NULL;

--- a/libr/util/r_x509.c
+++ b/libr/util/r_x509.c
@@ -487,11 +487,13 @@ char* r_x509_subjectpublickeyinfo_dump (RX509SubjectPublicKeyInfo* spki, char* b
 		pad = "";
 	a = spki->algorithm.algorithm->string;
 	RASN1String* m = r_asn1_stringify_integer (spki->subjectPublicKeyModule->sector, spki->subjectPublicKeyModule->length);
-	RASN1String* e = r_asn1_stringify_bytes (spki->subjectPublicKeyExponent->sector, spki->subjectPublicKeyExponent->length);
-	r = snprintf (buffer, length, "%sAlgorithm: %s\n%sModule: %s\n%sExponent: %u bytes\n%s\n", pad, a, pad, m->string,
-				pad, spki->subjectPublicKeyExponent->length - 1, e->string);
+//	RASN1String* e = r_asn1_stringify_bytes (spki->subjectPublicKeyExponent->sector, spki->subjectPublicKeyExponent->length);
+//	r = snprintf (buffer, length, "%sAlgorithm: %s\n%sModule: %s\n%sExponent: %u bytes\n%s\n", pad, a, pad, m->string,
+//				pad, spki->subjectPublicKeyExponent->length - 1, e->string);
+	r = snprintf (buffer, length, "%sAlgorithm: %s\n%sModule: %s\n%sExponent: %u bytes\n", pad, a, pad, m->string,
+				pad, spki->subjectPublicKeyExponent->length - 1);
 	r_asn1_free_string (m);
-	r_asn1_free_string (e);
+//	r_asn1_free_string (e);
 	return r < 0 ? NULL : buffer + (unsigned) r;
 }
 
@@ -617,7 +619,8 @@ char* r_x509_tbscertificate_dump (RX509TBSCertificate* tbsc, char* buffer, ut32 
 }
 
 char* r_x509_certificate_dump (RX509Certificate* certificate, char* buffer, ut32 length, const char* pad) {
-	RASN1String *signature, *algo;
+//	RASN1String *signature,
+	RASN1String *algo;
 	ut32 p;
 	int r;
 	char *tbsc, *pad2;
@@ -638,17 +641,19 @@ char* r_x509_certificate_dump (RX509Certificate* certificate, char* buffer, ut32
 		return NULL;
 	}
 	algo = certificate->algorithmIdentifier.algorithm;
-	signature = r_asn1_stringify_bytes (certificate->signature->sector, certificate->signature->length);
-	r = snprintf (buffer + p, length - p, "%sAlgorithm:\n%s%s\n%sSignature: %u bytes\n%s\n",
-				pad, pad2, algo ? algo->string : "",
-				pad, certificate->signature->length, signature ? signature->string : "");
+//	signature = r_asn1_stringify_bytes (certificate->signature->sector, certificate->signature->length);
+//	r = snprintf (buffer + p, length - p, "%sAlgorithm:\n%s%s\n%sSignature: %u bytes\n%s\n",
+//				pad, pad2, algo ? algo->string : "",
+//				pad, certificate->signature->length, signature ? signature->string : "");
+	r = snprintf (buffer + p, length - p, "%sAlgorithm:\n%s%s\n%sSignature: %u bytes\n",
+				pad, pad2, algo ? algo->string : "", pad, certificate->signature->length);
 	if (r < 0) {
 		free (pad2);
 		return NULL;
 	}
 	p += (unsigned) r;
 	free (pad2);
-	r_asn1_free_string (signature);
+//	r_asn1_free_string (signature);
 	return buffer + p;
 }
 


### PR DESCRIPTION
@Maijin it fixes the `signature.exe` cms data `iC` output (and also any 4096 bits signatures)