### PR TITLE
Fixed tricore byte copy. (FIX #6882)

### DIFF
--- a/libr/asm/p/asm_tricore.c
+++ b/libr/asm/p/asm_tricore.c
@@ -18,8 +18,8 @@ static ut8 bytes[128];
 
 static int tricore_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
 	int delta = memaddr - Offset;
-	if (delta >= 0 && length > delta && length < sizeof(bytes)) {
-		memcpy (myaddr, bytes + delta, length - delta);
+	if (delta >= 0 && length + delta < sizeof(bytes)) {
+		memcpy (myaddr, bytes + delta, length);
 	}
 	return 0;
 }


### PR DESCRIPTION
something was still wrong, but finally works.