### PR TITLE
Fix findNextNumber() in r_parse when scr.color=false

### DIFF
--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -137,7 +137,7 @@ static char *findNextNumber(char *op) {
 				bool is_space = ansi_found;
 				ansi_found = false;
 				if (!is_space) {
-					is_space = (p != op && (*o == ' ' || *o == ',' || *o == '['));
+					is_space = (p == op || *o == ' ' || *o == ',' || *o == '[');
 				}
 				if (is_space && IS_DIGIT(*p)) {
 					return p;


### PR DESCRIPTION
Fix #6752