### PR TITLE
get_pc_from_stack for computed refs

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -606,7 +606,6 @@ R_API void r_anal_build_range_on_hints(RAnal *a) {
 			} else {
 				//remove this hint is not needed
 				r_anal_hint_unset_bits (a, hint->addr);
-				
 			}
 			range_bits = hint->bits;
 			r_anal_hint_free (hint);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3365,10 +3365,6 @@ static void getpcfromstack_x86(RCore *core, RAnalEsil *esil) {
 	if (!esil) {
 		return;
 	}
-	// Only for x86 as of now
-	if (strncmp (core->anal->cur->arch, "x86", 3)) {
-		return;
-	}
 
 	memcpy (&esil_cpy, esil, sizeof (esil_cpy));
 	addr = cur = esil_cpy.cur;
@@ -3607,7 +3603,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 				if ((target && op.ptr == ntarget) || !target) {
 					if (core->anal->cur && strcmp (core->anal->cur->arch, "arm")) {
 						if (cfg_anal_strings) {
-							if (CHECKREF(ESIL->cur)) {
+							if (CHECKREF (ESIL->cur)) {
 								r_anal_ref_add (core->anal, ESIL->cur, cur, 'd');
 								if ((target && ESIL->cur == ntarget) || !target) {
 									add_string_ref (core, ESIL->cur);
@@ -3622,7 +3618,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 				if (core->anal->bits == 64 && core->anal->cur && !strcmp (core->anal->cur->arch, "arm")) {
 					ut64 dst = ESIL->cur;
 					if ((target && dst == ntarget) || !target) {
-						if (CHECKREF(dst)) {
+						if (CHECKREF (dst)) {
 							r_anal_ref_add (core->anal, dst, cur, 'd');
 						}
 					}
@@ -3641,7 +3637,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 						if (dst > 0xffff && op.src[1] && (dst & 0xffff) == (op.src[1]->imm & 0xffff) && myvalid (mycore->io, dst)) {
 							RFlagItem *f;
 							char *str;
-							if (CHECKREF(dst) || CHECKREF(cur)) {
+							if (CHECKREF (dst) || CHECKREF (cur)) {
 								r_anal_ref_add (core->anal, dst, cur, 'd');
 								if (cfg_anal_strings) {
 									add_string_ref (core, dst);
@@ -3661,7 +3657,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 			case R_ANAL_OP_TYPE_LOAD:
 				{
 					ut64 dst = esilbreak_last_read;
-					if (dst != UT64_MAX && CHECKREF(dst)) {
+					if (dst != UT64_MAX && CHECKREF (dst)) {
 						if (myvalid (mycore->io, dst)) {
 							r_anal_ref_add (core->anal, dst, cur, 'd');
 							if (cfg_anal_strings) {
@@ -3670,7 +3666,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 						}
 					}
 					dst = esilbreak_last_data;
-					if (dst != UT64_MAX && CHECKREF(dst)) {
+					if (dst != UT64_MAX && CHECKREF (dst)) {
 						if (myvalid (mycore->io, dst)) {
 							r_anal_ref_add (core->anal, dst, cur, 'd');
 							if (cfg_anal_strings) {
@@ -3683,7 +3679,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 			case R_ANAL_OP_TYPE_JMP:
 				{
 					ut64 dst = op.jump;
-					if (CHECKREF(dst)) {
+					if (CHECKREF (dst)) {
 						if (myvalid (core->io, dst)) {
 							r_anal_ref_add (core->anal, dst, cur, 'c');
 						}
@@ -3697,8 +3693,11 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 						if (myvalid (core->io, dst)) {
 							r_anal_ref_add (core->anal, dst, cur, 'C');
 						}
-						ESIL->old = cur + op.size;
-						getpcfromstack_x86(core, ESIL);
+						// Only for x86 as of now
+						if (!strncmp (core->anal->cur->arch, "x86", 3)) {
+							ESIL->old = cur + op.size;
+							getpcfromstack_x86 (core, ESIL);
+						}
 					}
 				}
 				break;
@@ -3713,7 +3712,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 					if (dst == UT64_MAX) {
 						dst = r_reg_getv (core->anal->reg, pcname);
 					}
-					if (CHECKREF(dst)) {
+					if (CHECKREF (dst)) {
 						if (myvalid (core->io, dst)) {
 							RAnalRefType ref =
 								(op.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_UCALL

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3362,7 +3362,7 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 	int tmp_esil_str_len;
 	const char *esilstr;
 	const int maxaddrlen = 20;
-	char *spname = NULL;
+	const char *spname = NULL;
 	if (!esil) {
 		return;
 	}
@@ -3424,7 +3424,8 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 	    return;
 	}
 
-	snprintf (tmp_esil_str, tmp_esil_str_len - 1, "%llu%s", esil_cpy.old, &esilstr[strlen (spname) + 4]);
+	snprintf (tmp_esil_str, tmp_esil_str_len - 1, "%20" PFMT64u "%s", esil_cpy.old, &esilstr[strlen (spname) + 4]);
+	tmp_esil_str = r_str_trim_head_tail (tmp_esil_str);
 	idx += op.size;
 	r_anal_esil_set_pc (&esil_cpy, cur);
 	r_anal_esil_parse (&esil_cpy, tmp_esil_str);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3410,7 +3410,7 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 	    free (buf);
 	    return;
 	}
-	tmp_esil_str_len = strlen (esilstr) + strlen (spname);
+	tmp_esil_str_len = strlen (esilstr) + strlen (spname) + maxaddrlen;
 	tmp_esil_str = (char*) malloc (tmp_esil_str_len);
 	tmp_esil_str[tmp_esil_str_len - 1] = '\0';
 	if (!tmp_esil_str) {
@@ -3424,7 +3424,7 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 	    return;
 	}
 
-	snprintf (tmp_esil_str, tmp_esil_str_len - 1, "%llu%s", esil_cpy.old, &esilstr[strlen (spname)]);
+	snprintf (tmp_esil_str, tmp_esil_str_len - 1, "%llu%s", esil_cpy.old, &esilstr[strlen (spname) + 4]);
 	idx += op.size;
 	r_anal_esil_set_pc (&esil_cpy, cur);
 	r_anal_esil_parse (&esil_cpy, tmp_esil_str);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3966,6 +3966,9 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 				char *comment;
 				bool asm_varsub = r_config_get_i (core->config, "asm.varsub");
 				core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
+				if (core->parser->relsub) {
+					core->parser->relsub_addr = addr;
+				}
 				r_list_foreach (list, iter, ref) {
 					r_core_read_at (core, ref->addr, buf, size);
 					r_asm_set_pc (core->assembler, ref->addr);

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -150,11 +150,12 @@ static char *findNextNumber(char *op) {
 }
 
 static int filter(RParse *p, RFlag *f, char *data, char *str, int len, bool big_endian) {
-	char *ptr = data, *ptr2;
+	char *ptr = data, *ptr2, *ptr_backup;
 	RAnalFunction *fcn;
 	RFlagItem *flag;
 	ut64 off;
 	bool x86 = false;
+	bool computed = false;
 	if (p && p->cur && p->cur->name) {
 		if (strstr (p->cur->name, "x86")) x86 = true;
 		if (strstr (p->cur->name, "m68k")) x86 = true;
@@ -194,9 +195,11 @@ static int filter(RParse *p, RFlag *f, char *data, char *str, int len, bool big_
 				RFlagItem *flag2;
 				flag = r_flag_get_i2 (f, off);
 				if (!flag) {
+					computed = false;
 					flag = r_flag_get_i (f, off);
 				}
 				if (p->relsub_addr) {
+					computed = true;
 					flag2 = r_flag_get_i2 (f, p->relsub_addr);
 					if (!flag2) {
 						flag2 = r_flag_get_i (f, p->relsub_addr);
@@ -215,12 +218,22 @@ static int filter(RParse *p, RFlag *f, char *data, char *str, int len, bool big_
 						ptr = ptr2;
 						continue;
 					}
-					*ptr = 0;
 					// hack to realign pointer for colours
 					ptr2--;
 					if (*ptr2 != 0x1b) {
 						ptr2++;
 					}
+					ptr_backup = ptr;
+					if (computed && ptr != ptr2 && *ptr) {
+						if (*ptr2 == ']') {
+							ptr2++;
+							for (ptr--; ptr > data && *ptr != '['; ptr--);
+							if (ptr == data) {
+								ptr = ptr_backup;
+							}
+						}
+					}
+					*ptr = 0;
 					snprintf (str, len, "%s%s%s", data, flag->name,
 							(ptr != ptr2) ? ptr2 : "");
 					return true;

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -194,8 +194,8 @@ static int filter(RParse *p, RFlag *f, char *data, char *str, int len, bool big_
 			if (f) {
 				RFlagItem *flag2;
 				flag = r_flag_get_i2 (f, off);
+				computed = false;
 				if (!flag) {
-					computed = false;
 					flag = r_flag_get_i (f, off);
 				}
 				if (p->relsub_addr) {


### PR DESCRIPTION
Work in progress, need comments.
With some work, this would fix #6402 and #6819.
Is this the right way to go though? Or should this check be inserted in another place?

Obvious issues/ caveats with the code right now -
1) Only supports x86 / x86_64
3) Output for bins/elf/redpill is currently as below. Will look into how r2 understands these are strings.
```
$ r2 redpill
[0x00000f40]> e anal.strings = true
[0x00000f40]> aa
[0x00000f40]> aae
...
[0x00000f40]> axt 0x00001d89
data 0x00001457 lea eax, [esi - 0x2277] in main
[0x00000f40]> axt 0x00001da0
data 0x0000148e lea eax, [esi - 0x2260] in main
...
```
4) Line 3421 in canal.c and the part before that. Using this temporary solution because values pushed on stack (like PC) during ESIL emulation are not really stored...