### PR TITLE
Fixed SIGSEGV, fixed heap buffer overflow, heap use after free

### DIFF
--- a/libr/include/r_util/r_asn1.h
+++ b/libr/include/r_util/r_asn1.h
@@ -88,7 +88,7 @@ R_API RASN1String *r_asn1_stringify_oid (const ut8* buffer, ut32 length);
 R_API RASN1String *r_asn1_stringify_tag (RASN1Object *object);
 R_API RASN1String *r_asn1_stringify_object (RASN1Object *object);
 
-void r_asn1_free_object (RASN1Object *object);
+void r_asn1_free_object (RASN1Object **object);
 void r_asn1_free_string (RASN1String *string);
 
 

--- a/libr/util/r_asn1.c
+++ b/libr/util/r_asn1.c
@@ -15,7 +15,10 @@ ut32 ascii_len(const char *s, ut32 len) {
 		return 0;
 	}
 	const char* e = s;
-	while (s < (e + len) && *s >= 0x20 && *s <= 0x7E) s++;
+	len++;
+	while (s < (e + len) && *s >= 0x20 && *s <= 0x7E) {
+		s++;
+	}
 	return s - e;
 }
 

--- a/libr/util/r_asn1.c
+++ b/libr/util/r_asn1.c
@@ -2,6 +2,7 @@
 
 #include <r_util.h>
 #include "r_oids.h"
+#include <r_types.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -10,17 +11,17 @@
 
 const char* _hex = "0123456789abcdef";
 
-static char* sanitize(char *s, ut32 len) {
+static char *sanitize(char *s, ut32 len) {
 	if (!s) {
 		return NULL;
 	}
 	char* e = s;
 	while (s <= (e + len)) {
-		if(*s < 0x20 || *s > 0x7E)
+		if (!IS_PRINTABLE(*s))
 			*s = '.';
 		s++;
 	}
-	return s - e;
+	return e;
 }
 
 RASN1String *r_asn1_create_string (const char *string, bool allocated, ut32 length) {
@@ -76,7 +77,7 @@ RASN1String *r_asn1_stringify_string (const ut8 *buffer, ut32 length) {
 		return NULL;
 	}
 	memcpy (str, buffer, length);
-	sanitize(str, length + 1);
+	sanitize (str, length + 1);
 	str[length] = '\0';
 	return r_asn1_create_string (str, true, length);
 }
@@ -255,12 +256,10 @@ RASN1String *r_asn1_stringify_oid (const ut8* buffer, ut32 length) {
 		return NULL;
 	}
 
-	str = (char*) malloc (ASN1_OID_LEN);
+	str = (char*) calloc (1, ASN1_OID_LEN);
 	if (!str) {
 		return NULL;
 	}
-
-	memset (str, 0, ASN1_OID_LEN);
 
 	end = buffer + length;
 	t = str;
@@ -321,11 +320,10 @@ RASN1Object *asn1_parse_header (const ut8 *buffer, ut32 length) {
 		return NULL;
 	}
 
-	object = (RASN1Object*) malloc (sizeof (RASN1Object));
+	object = R_NEW0 (RASN1Object);
 	if (!object) {
 		return NULL;
 	}
-	memset (object, 0, sizeof(RASN1Object));
 	head = buffer[0];
 	object->klass = head & ASN1_CLASS;
 	object->form = head & ASN1_FORM;

--- a/libr/util/r_asn1.c
+++ b/libr/util/r_asn1.c
@@ -392,9 +392,7 @@ ut32 r_asn1_count_objects (const ut8 *buffer, ut32 length) {
 	while (next >= buffer && next < end) {
 		object = asn1_parse_header (next, end - next);
 		if (!object || next == object->sector) {
-			if (object) {
-				R_FREE(object);
-			}
+			R_FREE(object);
 			break;
 		}
 		next = object->sector + object->length;
@@ -426,9 +424,7 @@ RASN1Object *r_asn1_create_object (const ut8 *buffer, ut32 length) {
 				object->list.objects[i] = NULL;
 				inner = r_asn1_create_object (next, end - next);
 				if (!inner || next == inner->sector) {
-					if (inner) {
-						R_FREE(inner);
-					}
+					R_FREE(inner);
 					break;
 				}
 				next = inner->sector + inner->length;
@@ -446,7 +442,7 @@ void r_asn1_free_object (RASN1Object **object) {
 		return;
 	}
 	if (*object) {
-		eprintf("PTR: %p\n  tag: %02x\nklass: %02x\nform: %02x\n", *object, 
+		eprintf("PTR: %p\n  tag: %02x\nklass: %02x\nform: %02x\n", *object,
 			(*object)->tag, (*object)->klass, (*object)->form);
 		//this shall not be freed. it's a pointer into the buffer.
 		(*object)->sector = 0;

--- a/libr/util/r_asn1.c
+++ b/libr/util/r_asn1.c
@@ -321,7 +321,7 @@ RASN1Object *asn1_parse_header (const ut8 *buffer, ut32 length) {
 	if (!object) {
 		return NULL;
 	}
-	memset(object, 0, sizeof(RASN1Object));
+	memset (object, 0, sizeof(RASN1Object));
 	head = buffer[0];
 	object->klass = head & ASN1_CLASS;
 	object->form = head & ASN1_FORM;
@@ -373,7 +373,7 @@ RASN1Object *asn1_parse_header (const ut8 *buffer, ut32 length) {
 	}
 	if (object->length > length) {
 		// Malformed object - overflow from data ptr
-		R_FREE(object);
+		R_FREE (object);
 	}
 	return object;
 }
@@ -392,12 +392,12 @@ ut32 r_asn1_count_objects (const ut8 *buffer, ut32 length) {
 	while (next >= buffer && next < end) {
 		object = asn1_parse_header (next, end - next);
 		if (!object || next == object->sector) {
-			R_FREE(object);
+			R_FREE (object);
 			break;
 		}
 		next = object->sector + object->length;
 		counter++;
-		R_FREE(object);
+		R_FREE (object);
 	}
 	return counter;
 }
@@ -424,7 +424,7 @@ RASN1Object *r_asn1_create_object (const ut8 *buffer, ut32 length) {
 				object->list.objects[i] = NULL;
 				inner = r_asn1_create_object (next, end - next);
 				if (!inner || next == inner->sector) {
-					R_FREE(inner);
+					R_FREE (inner);
 					break;
 				}
 				next = inner->sector + inner->length;
@@ -442,8 +442,6 @@ void r_asn1_free_object (RASN1Object **object) {
 		return;
 	}
 	if (*object) {
-		eprintf("PTR: %p\n  tag: %02x\nklass: %02x\nform: %02x\n", *object,
-			(*object)->tag, (*object)->klass, (*object)->form);
 		//this shall not be freed. it's a pointer into the buffer.
 		(*object)->sector = 0;
 		if ((*object)->list.objects) {
@@ -452,11 +450,12 @@ void r_asn1_free_object (RASN1Object **object) {
 					r_asn1_free_object (&(*object)->list.objects[i]);
 				}
 			}
-			R_FREE((*object)->list.objects);
+			R_FREE ((*object)->list.objects);
 		}
 		(*object)->list.objects = NULL;
 		(*object)->list.length = 0;
 		free (*object);
+		*object = NULL;
 	}
 }
 

--- a/libr/util/r_asn1.c
+++ b/libr/util/r_asn1.c
@@ -10,13 +10,14 @@
 
 const char* _hex = "0123456789abcdef";
 
-ut32 ascii_len(const char *s, ut32 len) {
+static char* sanitize(char *s, ut32 len) {
 	if (!s) {
-		return 0;
+		return NULL;
 	}
-	const char* e = s;
-	len++;
-	while (s < (e + len) && *s >= 0x20 && *s <= 0x7E) {
+	char* e = s;
+	while (s <= (e + len)) {
+		if(*s < 0x20 || *s > 0x7E)
+			*s = '.';
 		s++;
 	}
 	return s - e;
@@ -70,13 +71,13 @@ RASN1String *r_asn1_stringify_string (const ut8 *buffer, ut32 length) {
 	if (!buffer || !length) {
 		return NULL;
 	}
-	length = ascii_len(buffer, length + 1);
-	str = (char*) malloc (length);
+	str = (char*) malloc (length + 1);
 	if (!str) {
 		return NULL;
 	}
 	memcpy (str, buffer, length);
-	str[length - 1] = '\0';
+	sanitize(str, length + 1);
+	str[length] = '\0';
 	return r_asn1_create_string (str, true, length);
 }
 
@@ -457,8 +458,7 @@ void r_asn1_free_object (RASN1Object **object) {
 		}
 		(*object)->list.objects = NULL;
 		(*object)->list.length = 0;
-		free (*object);
-		*object = NULL;
+		R_FREE ((*object));
 	}
 }
 

--- a/libr/util/r_pkcs7.c
+++ b/libr/util/r_pkcs7.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <r_util.h>
+#include <r_types.h>
 #include "r_x509_internal.h"
 #include "r_pkcs7_internal.h"
 
@@ -540,10 +541,13 @@ char *r_pkcs7_cms_dump (RCMS* container) {
 	p = 0;
 	buffer = NULL;
 	length = 2048 + (container->signedData.certificates.length * 1024);
-	if(!length) return NULL;
-	buffer = (char*) malloc (length);
-	if (!buffer) return NULL;
-	memset (buffer, 0, length);
+	if(!length) {
+		return NULL;
+	}
+	buffer = (char*) calloc (1, length);
+	if (!buffer) {
+		return NULL;
+	}
 	r = snprintf (buffer, length, "signedData\n  Version: %u\n  Digest Algorithms:\n", sd->version);
 	p += (ut32) r;
 	if (r < 0) {

--- a/libr/util/r_pkcs7.c
+++ b/libr/util/r_pkcs7.c
@@ -378,7 +378,7 @@ void r_pkcs7_free_attributes (RPKCS7Attributes* attributes) {
 }
 
 char* r_pkcs7_signerinfos_dump (RX509CertificateRevocationList *crl, char* buffer, ut32 length, const char* pad) {
-	RASN1String *algo, *last, *next;
+	RASN1String *algo = NULL, *last = NULL, *next = NULL;
 	ut32 i, p;
 	int r;
 	char *tmp, *pad2, *pad3;
@@ -428,8 +428,8 @@ char* r_pkcs7_signerinfos_dump (RX509CertificateRevocationList *crl, char* buffe
 }
 
 char* r_x509_signedinfo_dump (RPKCS7SignerInfo *si, char* buffer, ut32 length, const char* pad) {
-	RASN1String *s;
-	RASN1Object *o;
+	RASN1String *s = NULL;
+	RASN1Object *o = NULL;
 	ut32 i, p;
 	int r;
 	char *tmp, *pad2, *pad3;

--- a/libr/util/r_x509.c
+++ b/libr/util/r_x509.c
@@ -135,7 +135,6 @@ bool r_x509_parse_extension (RX509Extension *ext, RASN1Object *object) {
 	if (!ext || !object || object->list.length < 2) {
 		return false;
 	}
-	memset (ext, 0, sizeof (RX509Extension));
 	o = object->list.objects[0];
 	if (o && o->tag == TAG_OID) {
 		ext->extnID = r_asn1_stringify_oid (o->sector, o->length);
@@ -149,7 +148,7 @@ bool r_x509_parse_extension (RX509Extension *ext, RASN1Object *object) {
 			ext->extnValue = o;
 			if (o == object->list.objects[1]) {
 				object->list.objects[1] = NULL;
-			} else if (object->list.length > 3 &&
+			} else if (object->list.length > 2 &&
 					o == object->list.objects[2]) {
 				object->list.objects[2] = NULL;
 			}
@@ -170,9 +169,10 @@ bool r_x509_parse_extensions (RX509Extensions *ext, RASN1Object * object) {
 	}
 	ext->length = object->list.length;
 	for (i = 0; i < object->list.length; ++i) {
-		ext->extensions[i] = (RX509Extension*) malloc (sizeof (RX509Extension));
+		ext->extensions[i] = R_NEW0 (RX509Extension);
 		if (!r_x509_parse_extension (ext->extensions[i], object->list.objects[i])) {
-			R_FREE (ext->extensions[i]);
+			r_x509_free_extension(ext->extensions[i]);
+			ext->extensions[i] = NULL;
 		}
 	}
 	return true;

--- a/libr/util/r_x509.c
+++ b/libr/util/r_x509.c
@@ -635,7 +635,7 @@ char* r_x509_tbscertificate_dump (RX509TBSCertificate* tbsc, char* buffer, ut32 
 
 char* r_x509_certificate_dump (RX509Certificate* certificate, char* buffer, ut32 length, const char* pad) {
 //	RASN1String *signature,
-	RASN1String *algo;
+	RASN1String *algo = NULL;
 	ut32 p;
 	int r;
 	char *tbsc, *pad2;
@@ -673,7 +673,7 @@ char* r_x509_certificate_dump (RX509Certificate* certificate, char* buffer, ut32
 }
 
 char* r_x509_crlentry_dump (RX509CRLEntry *crle, char* buffer, ut32 length, const char* pad) {
-	RASN1String *id = NULL, *utc;
+	RASN1String *id = NULL, *utc = NULL;
 	int r;
 	if (!crle || !buffer || !length) {
 		return NULL;
@@ -695,7 +695,7 @@ char* r_x509_crlentry_dump (RX509CRLEntry *crle, char* buffer, ut32 length, cons
 }
 
 char* r_x509_crl_dump (RX509CertificateRevocationList *crl, char* buffer, ut32 length, const char* pad) {
-	RASN1String *algo, *last, *next;
+	RASN1String *algo = NULL, *last = NULL, *next = NULL;
 	ut32 i, p;
 	int r;
 	char *tmp, *pad2, *pad3;

--- a/libr/util/r_x509.c
+++ b/libr/util/r_x509.c
@@ -3,11 +3,11 @@
 #include <r_util.h>
 #include <stdlib.h>
 #include <string.h>
+#include <r_types.h>
 
 #include "r_x509_internal.h"
 
-#define MOVE_PTR(dst, src)			((dst) = (src)); \
-									(src) = NULL;
+#define MOVE_PTR(dst, src) { ((dst) = (src)); (src) = NULL; }
 
 bool r_x509_parse_validity (RX509Validity *validity, RASN1Object *object) {
 	RASN1Object *o;
@@ -172,7 +172,7 @@ bool r_x509_parse_extensions (RX509Extensions *ext, RASN1Object * object) {
 	for (i = 0; i < object->list.length; ++i) {
 		ext->extensions[i] = (RX509Extension*) malloc (sizeof (RX509Extension));
 		if (!r_x509_parse_extension (ext->extensions[i], object->list.objects[i])) {
-			R_FREE(ext->extensions[i]);
+			R_FREE (ext->extensions[i]);
 		}
 	}
 	return true;


### PR DESCRIPTION
Fixed bugs (#6908 #6909 #6911)

Here is the list of the binaries tested:

```
heap-buffer-overflow-2ce-030-5a6
heap-buffer-overflow-657-030-5a6
heap-buffer-overflow-657-26e-dc4
heap-buffer-overflow-ad2-d00-020
heap-buffer-overflow-fc3-0b5-0a6
heap-buffer-overflow-fc3-183-0a6
heap-buffer-overflow-fc3-220-6d2
heap-use-after-free-c05-e7c-e7c
SEGV-341-892-d00
SEGV-8f6-98a-f0e
SEGV-989-98a-f0e
SEGV-a94-0b5-0a6
SEGV-a94-220-6d2
SEGV-b7b-c17-f10
SEGV-b7b-c17-f10
SEGV-d26-f76-98a
SEGV-d8f-f76-98a

```