### PR TITLE
Fix BL for arm thumb

### DIFF
--- a/libr/asm/arch/arm/armass.c
+++ b/libr/asm/arch/arm/armass.c
@@ -494,13 +494,17 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		return 4;
 	} else
 	if (!strcmpnull (ao->op, "bl")) {
-		int reg = getreg (ao->a[0]);
-		ao->o = 0x47;
-		if (reg == -1) {
-			ao->o |= getnum (ao->a[0]) << 8;
-		} else {
-			return 0;
-		}
+		int high, low;
+		high = low = (getnum (ao->a[0]) - 4);
+		high &= 0x7FFFFF;
+		high >>= 12;
+		high |= 0xF000;
+		low &= 0xFFF;
+		low >>= 1;
+		low |= 0xF800;
+		ao->o = low;
+		ao->o |= (high << 16);
+		thumb_swap (&ao->o);
 		// XXX: length = 4
 		return 4;
 	} else


### PR DESCRIPTION
I've re-implemented the `BL` opcode in Thumb mode according to this document here: [THUMB Instruction Set](https://ece.uwaterloo.ca/~ece222/ARM/ARM7-TDMI-manual-pt3.pdf) at section __5.19__ where it described the *long branch with link*.

Now if we do:

```
rasm2 -aarm -b16 "bl -0x2a"
```

We finally get `fff7e9ff` instead of `ffffd647`