### PR TITLE
x86 anal puts value of immediate in ao->val not ao->ptr

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -719,6 +719,8 @@ repeat:
 		if (op.ptr && op.ptr != UT64_MAX && op.ptr != UT32_MAX) {
 			// swapped parameters wtf
 			r_anal_fcn_xref_add (anal, fcn, op.addr, op.ptr, R_ANAL_REF_TYPE_DATA);
+		} else if (op.val && op.val != UT64_MAX && op.val != UT32_MAX) {
+			r_anal_fcn_xref_add (anal, fcn, op.addr, op.val, R_ANAL_REF_TYPE_DATA);
 		}
 
 		switch (op.type & R_ANAL_OP_TYPE_MASK) {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1767,8 +1767,9 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 				}
 				break;
 			case X86_OP_IMM:
-				if (INSOP(1).imm > 10)
-					op->ptr = INSOP(1).imm;
+				if (INSOP(1).imm > 10) {
+					op->val = INSOP(1).imm;
+				}
 				break;
 			default:
 				break;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2586,7 +2586,7 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 		i = 0;
 		while (at + i < to && i < ret-OPSZ && !r_cons_is_breaked ()) {
 			RAnalRefType type;
-			ut64 xref_from, xref_to;
+			ut64 xref_from, xref_to = UT64_MAX;
 			xref_from = at + i;
 			r_anal_op_fini (&op);
 			ret = r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i);
@@ -2632,6 +2632,9 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 				if (op.ptr != -1) {
 					type = R_ANAL_REF_TYPE_DATA;
 					xref_to = op.ptr;
+				} else if (op.val != -1) {
+					type = R_ANAL_REF_TYPE_DATA;
+					xref_to = op.val;
 				}
 				break;
 			}
@@ -2680,7 +2683,9 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 					free (str_string);
 				}
 				// Add to SDB
-				r_anal_xrefs_set (core->anal, type, xref_from, xref_to);
+				if ( xref_to != UT64_MAX ) {
+					r_anal_xrefs_set (core->anal, type, xref_from, xref_to);
+				}
 			} else if (rad == 'j') {
 				// Output JSON
 				if (count > 0) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2554,6 +2554,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 	char *esc = ds->show_comment_right? " ": "";
 	char *nl = ds->show_comment_right? "" : "\n";
 	bool string_found = false;
+	bool v_consumed = false;
 	if (!ds->show_comments || !ds->show_slow) {
 		return;
 	}
@@ -2561,8 +2562,12 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 		char ch = v;
 		ALIGN;
 		ds_comment (ds, true, "%s; '%c'%s", esc, ch, nl);
+		v_consumed = true;
 	}
 	bool flag_printed = false;
+	if (!v_consumed && p == UT64_MAX && v != UT64_MAX) {
+		p = v; // use immediate as possible ptr
+	}
 	if (p == UT64_MAX) {
 		/* do nothing */
 	} else if (((st64)p) > 0) {
@@ -2765,9 +2770,10 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 					}
 				} else if (!strcmp (kind, "invalid")) {
 					int *n = (int*)&p;
-					ut64 p = ds->analop.val;
-					if (p == UT64_MAX || p == UT32_MAX) {
-						p = ds->analop.ptr;
+					ut64 p = ds->analop.ptr;
+					ut64 v = ds->analop.val;
+					if (p == UT64_MAX && v != UT64_MAX) {
+						p = v; // use immediate as possible ptr
 					}
 					/* avoid double ; -1 */
 					if (p != UT64_MAX && p != UT32_MAX) {


### PR DESCRIPTION
* Xref falls back to op.val
* Fix ds_print_ptr, consider immed as possible ptr
* Fix ds_print_ptr, consider immed as literal value
* Make fcn_recurse consider immediate for fcn xref
* Fix compiler warning