### PR TITLE
Adds the ability to print filtered strings in the disassembly that are not flags and contain newlines

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2602,10 +2602,12 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 					(void)r_io_read_at (ds->core->io, ds->analop.ptr,
 							    (ut8 *)str + 1, sizeof (str) - 1);
 					str[sizeof (str) - 1] = 0;
-					if (str[1] && r_str_is_printable (str + 1)) {
+					if (str[1] && r_str_is_printable_incl_newlines (str + 1)) {
 						str[0] = '"';
 						flag = str;
 						strcpy (str + strlen (str), "\"");
+						//Filter out remaining non printable characters, e.g. \n \r
+						r_str_filter (flag, 0);
 						string_found = true;
 					}
 				}

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1399,7 +1399,7 @@ R_API int r_str_is_printable(const char *str) {
 	return 1;
 }
 
-R_API int r_str_is_printable_incl_newlines(const char *str) {
+R_API bool r_str_is_printable_incl_newlines(const char *str) {
 	while (*str) {
 		int ulen = r_utf8_decode ((const ut8*)str, strlen (str), NULL);
 		if (ulen > 1) {
@@ -1407,14 +1407,13 @@ R_API int r_str_is_printable_incl_newlines(const char *str) {
 			continue;
 		}
 		if (!IS_PRINTABLE (*str)) {
-			//Further check to see if it's a \n or \r
-			if (!(*str == 0x0a || *str == 0x0d)) {
-				return 0;
+			if (!(*str == '\r' || *str == '\n')) {
+				return false;
 			}
 		}
 		str++;
 	}
-	return 1;
+	return true;
 }
 
 // Length in chars of a wide string (find better name?)

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1399,6 +1399,24 @@ R_API int r_str_is_printable(const char *str) {
 	return 1;
 }
 
+R_API int r_str_is_printable_incl_newlines(const char *str) {
+	while (*str) {
+		int ulen = r_utf8_decode ((const ut8*)str, strlen (str), NULL);
+		if (ulen > 1) {
+			str += ulen;
+			continue;
+		}
+		if (!IS_PRINTABLE (*str)) {
+			//Further check to see if it's a \n or \r
+			if (!(*str == 0x0a || *str == 0x0d)) {
+				return 0;
+			}
+		}
+		str++;
+	}
+	return 1;
+}
+
 // Length in chars of a wide string (find better name?)
 R_API int r_wstr_clen (const char *s) {
 	int len = 0;


### PR DESCRIPTION
This improves the printing of strings in the disassembly that contain newlines in them and are not flags.  

While analysing 2 different ARM firmware images I found that important strings that contained newlines were not showing up in the disassembly. This code replaces the newline characters of a string that is not a flag with dots using the existing r_str_filter function. I chose to replicate the r_str_is_printable function in str.c (rather than modify it) with a further check for the newline characters and then filter them out in disasm.c. I felt this would have the smallest impact on the codebase for any potentially unexpected results. I have also written a regression test in the arm_16 test as that is where I had triggered this issue.

This also relates to an already merged pull request (#6890) which correctly resolved strings in ARM thumb mode ADR instructions. With this pull requests all strings will now show up in ARM thumb code that uses the ADR instruction to reference strings. This makes analysing ARM firmware much more effective.

e.g.

```bash
[0x00000000]> px 23
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x00000000  10b5 01a0 00bf 00bf 5261 6461 7265 3220  ........Radare2 
0x00000010  7465 7374 0d0a 00                        test...
[0x00000000]> pd 4
            0x00000000      10b5           push {r4, lr}
            0x00000002      01a0           adr r0, 4                   ; 0x8 ; "Radare2 test.."
            0x00000004      00bf           nop
            0x00000006      00bf           nop
[0x00000000]> 
```