### PR TITLE
Fix incorrect assignment in esil for x86 pop /m

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -904,10 +904,25 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case X86_INS_POP:
 		{
-			dst = getarg (&gop, 0, 0, NULL, DST_AR);
-			esilprintf (op,
-				"%s,[%d],%s,=,%d,%s,+=",
-				sp, rs, dst, rs, sp);
+			switch (INSOP(0).type) {
+			case X86_OP_MEM:
+				{
+					dst = getarg (&gop, 0, 1, NULL, DST_AR);
+					esilprintf (op,
+						"%s,[%d],%s,%d,%s,+=",
+						sp, rs, dst, rs, sp);
+					break;
+				}
+			case X86_OP_REG:
+			default:
+				{
+					dst = getarg (&gop, 0, 0, NULL, DST_AR);
+					esilprintf (op,
+						"%s,[%d],%s,=,%d,%s,+=",
+						sp, rs, dst, rs, sp);
+					break;
+				}
+			}
 		}
 		break;
 	case X86_INS_POPF:


### PR DESCRIPTION
`pop dword [eax]` produces esil like `esp,[4],eax,[4],=,4,esp,+=` on master, which isn't executable as it would have evaluated involving `num = num`.

It **should** produce `esp,[4],eax,=[4],4,esp,+=` when the destination is a mem operand.

This should be a solid fix, but I don't know if there are any tests to run and compare against. I didn't see an open issue for this either, so I figured just putting up a PR would be better :)