### PR TITLE
fixed detach debugger on windows at radare2 exit

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -1213,7 +1213,11 @@ int main(int argc, char **argv, char **envp) {
 							if (r_config_get_i (r.config, "dbg.exitkills") &&
 									r_cons_yesno ('y', "Do you want to kill the process? (Y/n)")) {
 								r_debug_kill (r.dbg, 0, false, 9); // KILL
+#if __WINDOWS__
+							} else {
+								r_debug_detach (r.dbg, r.dbg->pid);
 							}
+#endif
 						} else continue;
 					}
 				}

--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -1216,8 +1216,8 @@ int main(int argc, char **argv, char **envp) {
 #if __WINDOWS__
 							} else {
 								r_debug_detach (r.dbg, r.dbg->pid);
-							}
 #endif
+							}
 						} else continue;
 					}
 				}


### PR DESCRIPTION
- Fixed detach from debugger on windows when u tell to radare2 dont kill process on exit #7040
- Only work for process debugged via attaching pid (see comment at #7040)