### PR TITLE
Support writing PE32/PE32+ section permissions

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -683,8 +683,9 @@ static int bin_pe_init_sections(struct PE_(r_bin_pe_obj_t)* bin) {
 		r_sys_perror ("malloc (section header)");
 		goto out_error;
 	}
-	if (r_buf_read_at (bin->b, bin->dos_header->e_lfanew + 4 + sizeof (PE_(image_file_header)) +
-		bin->nt_headers->file_header.SizeOfOptionalHeader,
+	bin->section_header_offset = bin->dos_header->e_lfanew + 4 + sizeof (PE_(image_file_header)) +
+		bin->nt_headers->file_header.SizeOfOptionalHeader;
+	if (r_buf_read_at (bin->b, bin->section_header_offset,
 		(ut8*) bin->section_header, sections_size) == -1) {
 		bprintf ("Warning: read (sections)\n");
 		R_FREE (bin->section_header);

--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -84,6 +84,7 @@ struct PE_(r_bin_pe_obj_t) {
 
 	// these values define the real offset into the untouched binary
 	ut64 nt_header_offset;
+	ut64 section_header_offset;
 	ut64 import_directory_offset;
 	ut64 export_directory_offset;
 	ut64 resource_directory_offset;
@@ -145,3 +146,4 @@ void PE_(r_bin_pe_check_sections)(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_
 struct r_bin_pe_addr_t *PE_(check_unknow) (struct PE_(r_bin_pe_obj_t) *bin);
 struct r_bin_pe_addr_t *PE_(check_msvcseh) (struct PE_(r_bin_pe_obj_t) *bin);
 struct r_bin_pe_addr_t *PE_(check_mingw) (struct PE_(r_bin_pe_obj_t) *bin);
+bool PE_(r_bin_pe_section_perms)(struct PE_(r_bin_pe_obj_t) *bin, const char *name, int perms);

--- a/libr/bin/format/pe/pe64_write.c
+++ b/libr/bin/format/pe/pe64_write.c
@@ -1,0 +1,4 @@
+/* radare - LGPL - Copyright 2008-2017 nibble, pancake */
+
+#define R_BIN_PE64 1
+#include "pe_write.c"

--- a/libr/bin/format/pe/pe_write.c
+++ b/libr/bin/format/pe/pe_write.c
@@ -1,0 +1,55 @@
+/* radare - LGPL - Copyright 2010-2017 pancake, nibble */
+
+#include <r_types.h>
+#include <r_util.h>
+#include "pe.h"
+
+bool PE_(r_bin_pe_section_perms)(struct PE_(r_bin_pe_obj_t) *bin, const char *name, int perms) {
+	PE_(image_section_header) *shdr = bin->section_header;
+	int i;
+
+	if (!shdr) {
+		return false;
+	}
+
+	for (i = 0; i < bin->num_sections; i++) {
+		const char *sname = (const char*) shdr[i].Name;
+		if (!strncmp (name, sname, PE_IMAGE_SIZEOF_SHORT_NAME)) {
+			int patchoff;
+			ut32 newperms = shdr[i].Characteristics;
+			ut32 newperms_le;
+
+			/* Apply permission flags */
+			if (perms & R_BIN_SCN_EXECUTABLE) {
+				newperms |=  PE_IMAGE_SCN_MEM_EXECUTE;
+			} else {
+				newperms &= ~PE_IMAGE_SCN_MEM_EXECUTE;
+			}
+			if (perms & R_BIN_SCN_WRITABLE) {
+				newperms |=  PE_IMAGE_SCN_MEM_WRITE;
+			} else {
+				newperms &= ~PE_IMAGE_SCN_MEM_WRITE;
+			}
+			if (perms & R_BIN_SCN_READABLE) {
+				newperms |=  PE_IMAGE_SCN_MEM_READ;
+			} else {
+				newperms &= ~PE_IMAGE_SCN_MEM_READ;
+			}
+			if (perms & R_BIN_SCN_SHAREABLE) {
+				newperms |=  PE_IMAGE_SCN_MEM_SHARED;
+			} else {
+				newperms &= ~PE_IMAGE_SCN_MEM_SHARED;
+			}
+
+
+			patchoff = bin->section_header_offset;
+			patchoff += i * sizeof (PE_(image_section_header));
+			patchoff += r_offsetof (PE_(image_section_header), Characteristics);
+			r_write_le32 (&newperms_le, newperms);
+			printf ("wx %02x @ 0x%x\n", newperms_le, patchoff);
+			r_buf_write_at (bin->b, patchoff, (ut8*)&newperms_le, sizeof (newperms_le));
+			return true;
+		}
+	}
+	return false;
+}

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -761,6 +761,8 @@ static void header(RBinFile *arch) {
 	}
 }
 
+extern struct r_bin_write_t r_bin_write_pe;
+
 RBinPlugin r_bin_plugin_pe = {
 	.name = "pe",
 	.desc = "PE bin plugin",
@@ -785,7 +787,8 @@ RBinPlugin r_bin_plugin_pe = {
 	.relocs = &relocs,
 	.minstrlen = 4,
 	.create = &create,
-	.get_vaddr = &get_vaddr
+	.get_vaddr = &get_vaddr,
+	.write = &r_bin_write_pe
 };
 
 #ifndef CORELIB

--- a/libr/bin/p/bin_pe64.c
+++ b/libr/bin/p/bin_pe64.c
@@ -22,6 +22,8 @@ static bool check(RBinFile *arch) {
 	return check_bytes (bytes, sz);
 }
 
+extern struct r_bin_write_t r_bin_write_pe64;
+
 RBinPlugin r_bin_plugin_pe64 = {
 	.name = "pe64",
 	.desc = "PE64 (PE32+) bin plugin",
@@ -42,6 +44,7 @@ RBinPlugin r_bin_plugin_pe64 = {
 	.libs = &libs,
 	.relocs = &relocs,
 	.get_vaddr = &get_vaddr,
+	.write = &r_bin_write_pe64
 };
 
 #ifndef CORELIB

--- a/libr/bin/p/bin_write_pe.c
+++ b/libr/bin/p/bin_write_pe.c
@@ -1,0 +1,20 @@
+/* radare - LGPL - Copyright 2009-2017 - pancake, nibble */
+
+#include <r_types.h>
+#include <r_bin.h>
+#include "pe/pe.h"
+
+static bool scn_perms(RBinFile *arch, const char *name, int perms) {
+	struct PE_(r_bin_pe_obj_t) *obj = arch->o->bin_obj;
+	bool ret = PE_(r_bin_pe_section_perms) (arch->o->bin_obj, name, perms);
+	r_buf_free (arch->buf);
+	arch->buf = obj->b;
+	obj->b = NULL;
+	return ret;
+}
+
+#if !R_BIN_PE64
+RBinWrite r_bin_write_pe = {
+	.scn_perms = &scn_perms
+};
+#endif

--- a/libr/bin/p/bin_write_pe64.c
+++ b/libr/bin/p/bin_write_pe64.c
@@ -1,0 +1,8 @@
+/* radare - LGPL - Copyright 2009-2017 pancake */
+
+#define R_BIN_PE64 1
+#include "bin_write_pe.c"
+
+RBinWrite r_bin_write_pe64 = {
+	.scn_perms = &scn_perms
+};

--- a/libr/bin/p/pe.mk
+++ b/libr/bin/p/pe.mk
@@ -1,4 +1,4 @@
-OBJ_PE=bin_pe.o ../format/pe/pe.o
+OBJ_PE=bin_pe.o bin_write_pe.o ../format/pe/pe.o ../format/pe/pe_write.o
 
 STATIC_OBJ+=${OBJ_PE}
 TARGET_PE=bin_pe.${EXT_SO}

--- a/libr/bin/p/pe64.mk
+++ b/libr/bin/p/pe64.mk
@@ -1,4 +1,4 @@
-OBJ_PE64=bin_pe64.o ../format/pe/pe64.o
+OBJ_PE64=bin_pe64.o bin_write_pe64.o ../format/pe/pe64.o ../format/pe/pe64_write.o
 
 STATIC_OBJ+=${OBJ_PE64}
 TARGET_PE64=bin_pe64.${EXT_SO}


### PR DESCRIPTION
Hi,

I'm working on adding support for writing PE32(+) section permissions (see #921).

The patch works fine so far (it's mostly adapted from the ELF code), but I've seen that sections that do not have a name get one auto-assigned. `bins/pe/normal64.exe` is an example of this:
```
[Sections]
idx=00 vaddr=0x00401000 paddr=0x00000200 sz=512 vsz=4096 perm=m--wx name=sect_0
```
Here `sect_0` was autogenerated and is not actually in the file. This is a problem when trying to modify the section permissions, as the code checks the raw names from the binary and not the ones radare "sees". So to change the permissions one would have to invoke rabin2 like this: `rabin2 -O p//x normal64.exe` (i.e. with empty section name). It works, but it's not pretty and also fails when there are multiple unnamed sections. How could this be handled better? I can't use the parsed section info for looking up the name since that can't be mapped back to the right section in the binary (sections might get dropped during parsing under certain circumstances so the indices could differ).