### PR TITLE
Typos in help messages fixed

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -385,11 +385,11 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 	int pid, sig;
 	const char *ptr, *help_msg[] = {
 		"Usage:", "dp", " # Process commands",
-		"dp", "", "List current pid and childrens",
+		"dp", "", "List current pid and children",
 		"dp", " <pid>", "List children of pid",
 		"dp*", "", "List all attachable pids",
 		"dp=", "<pid>", "Select pid",
-		"dp-", " <pid>", "Dettach select pid",
+		"dp-", " <pid>", "Detach select pid",
 		"dpa", " <pid>", "Attach and select pid",
 		"dpc", "", "Select forked pid (see dbg.forks)",
 		"dpc*", "", "Display forked pid (see dbg.forks)",

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3713,7 +3713,7 @@ static int cmd_print(void *data, const char *input) {
 				"ps", "", "print string",
 				"psi", "", "print string inside curseek",
 				"psb", "", "print strings in current block",
-				"psx", "", "show string with scaped chars",
+				"psx", "", "show string with escaped chars",
 				"psz", "", "print zero terminated string",
 				"psp", "", "print pascal string",
 				"psu", "", "print utf16 unicode (json)",

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -27,7 +27,7 @@ static void show_help(RCore *core) {
 		"to", " -", "Open cfg.editor to load types",
 		"to", " <path>", "Load types from C header file",
 		"tos", " <path>", "Load types from parsed Sdb database",
-		"tp", " <type>  = <address>", "cast data at <adress> to <type> and print it",
+		"tp", " <type>  = <address>", "cast data at <address> to <type> and print it",
 		"ts", "[?]", "print loaded struct types",
 		"tu", "[?]", "print loaded union types",
 		//"| ts k=v k=v @ link.addr set fields at given linked type\n"
@@ -461,7 +461,7 @@ static int cmd_type(void *data, const char *input) {
 			const char *help_message[] = {
 				"Usage:", "", "",
 				"tl", "", "list all links in readable format",
-				"tl", "[typename]", "link a type to current adress.",
+				"tl", "[typename]", "link a type to current address.",
 				"tl", "[typename] = [address]", "link type to given address.",
 				"tls", "[address]", "show link at given address",
 				"tl-*", "", "delete all links.",


### PR DESCRIPTION
This simple PR fixes typos in help messages.

For the record, the following looks incorrect but I don't know how to fix it:

> afta  Setup memory and analyse do type matching analysis for all functions