### PR TITLE
Fix pds string references

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1959,7 +1959,12 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 			} else {
 				string2 = strdup (str + 1);
 			}
-			if (!string && string2) {
+			if (string2) {
+				/* the str.* flag will win over naked "string",
+				 * since it's generally more accurate */
+				if (string) {
+					R_FREE (string);
+				}
 				string = string2;
 				string2 = NULL;
 			}


### PR DESCRIPTION
Prefer references to `str.*` flags than naked strings when both are present, because the latter might have been guessed incorrectly from ascii-looking bytes in stored pointers.

This breaks few tests, fixed in https://github.com/radare/radare2-regressions/pull/764