### PR TITLE
SNES: try to tell apart register lengths

### DIFF
--- a/libr/anal/p/anal_6502.c
+++ b/libr/anal/p/anal_6502.c
@@ -291,7 +291,7 @@ static int _6502_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	const int buffsize = sizeof (addrbuf) - 1;
 
 	memset (op, '\0', sizeof (RAnalOp));
-	op->size = snes_op_get_size (8, &snes_op[data[0]]);	//snes-arch is similiar to nes/6502
+	op->size = snes_op_get_size (1, 1, &snes_op[data[0]]);	//snes-arch is similiar to nes/6502
 	op->addr = addr;
 	op->type = R_ANAL_OP_TYPE_UNK;
 	op->id = data[0];

--- a/libr/asm/arch/6502/6502dis.c
+++ b/libr/asm/arch/6502/6502dis.c
@@ -174,5 +174,5 @@ static int _6502Disass (ut64 pc, RAsmOp *op, const ut8 *buf, ut64 len) {
 		}
 	}
 beach:
-	return snesDisass (8, pc, op, buf, len);
+	return snesDisass (1, 1, pc, op, buf, len);
 }

--- a/libr/asm/arch/snes/snes_op_table.h
+++ b/libr/asm/arch/snes/snes_op_table.h
@@ -7,20 +7,22 @@ enum {
 	SNES_OP_16BIT,
 	SNES_OP_24BIT,
 	SNES_OP_32BIT,
-	SNES_OP_IMM // 8- or 16-bit immediate depending on X or M flag
+	SNES_OP_IMM_M, // 8- or 16-bit immediate depending on M flag
+	SNES_OP_IMM_X // 8- or 16-bit immediate depending on X flag
 };
-
 
 typedef struct {
 	const char *name;
 	ut8 len;
+	ut8 flags;
 } snes_op_t;
 
-static int snes_op_get_size(int bits, snes_op_t* op) {
-	if (op->len == SNES_OP_IMM) {
-		return bits == 8 ? SNES_OP_16BIT : SNES_OP_24BIT;
-	} else {
-		return op->len;
+static int snes_op_get_size(int M_flag, int X_flag, snes_op_t* op) {
+
+	switch(op->len) {
+		case SNES_OP_IMM_M: return M_flag ? SNES_OP_16BIT : SNES_OP_24BIT;
+		case SNES_OP_IMM_X: return X_flag ? SNES_OP_16BIT : SNES_OP_24BIT;
+		default: return op->len;
 	}
 }
 
@@ -34,7 +36,7 @@ static snes_op_t snes_op[]={
 {"asl 0x%02x",		SNES_OP_16BIT},
 {"ora [0x%02x]",	SNES_OP_16BIT},
 {"php",			SNES_OP_8BIT},
-{"ora",			SNES_OP_IMM},
+{"ora",			SNES_OP_IMM_M},
 {"asl a",		SNES_OP_8BIT},
 {"phd",			SNES_OP_8BIT},
 {"tsb 0x%04x",		SNES_OP_24BIT},
@@ -66,7 +68,7 @@ static snes_op_t snes_op[]={
 {"rol 0x%02x",		SNES_OP_16BIT},
 {"and [0x%02x]",	SNES_OP_16BIT},
 {"plp",			SNES_OP_8BIT},
-{"and",			SNES_OP_IMM},
+{"and",			SNES_OP_IMM_M},
 {"rol a",		SNES_OP_8BIT},
 {"pld",			SNES_OP_8BIT},
 {"bit 0x%04x",		SNES_OP_24BIT},
@@ -98,7 +100,7 @@ static snes_op_t snes_op[]={
 {"lsr 0x%02x",		SNES_OP_16BIT},
 {"eor [0x%02x]",	SNES_OP_16BIT},
 {"pha",			SNES_OP_8BIT},
-{"eor",			SNES_OP_IMM},
+{"eor",			SNES_OP_IMM_M},
 {"lsr a",		SNES_OP_8BIT},
 {"phk",			SNES_OP_8BIT},
 {"jmp 0x%04x",		SNES_OP_24BIT},
@@ -130,7 +132,7 @@ static snes_op_t snes_op[]={
 {"ror 0x%02x",		SNES_OP_16BIT},
 {"adc [0x%02x]",	SNES_OP_16BIT},
 {"pla",			SNES_OP_8BIT},
-{"adc",			SNES_OP_IMM},
+{"adc",			SNES_OP_IMM_M},
 {"ror a",		SNES_OP_8BIT},
 {"rtl",			SNES_OP_8BIT},
 {"jmp (0x%04x)",	SNES_OP_24BIT},
@@ -162,7 +164,7 @@ static snes_op_t snes_op[]={
 {"stx 0x%02x",		SNES_OP_16BIT},
 {"sta [0x%02x]",	SNES_OP_16BIT},
 {"dey",			SNES_OP_8BIT},
-{"bit",			SNES_OP_IMM},
+{"bit",			SNES_OP_IMM_M},
 {"txa",			SNES_OP_8BIT},
 {"phb",			SNES_OP_8BIT},
 {"sty 0x%04x",		SNES_OP_24BIT},
@@ -185,16 +187,16 @@ static snes_op_t snes_op[]={
 {"sta 0x%04x,x",	SNES_OP_24BIT},
 {"stz 0x%04x,x",	SNES_OP_24BIT},
 {"sta 0x%06x,x",	SNES_OP_32BIT},
-{"ldy",			SNES_OP_IMM},
+{"ldy",			SNES_OP_IMM_X},
 {"lda (0x%02x,x)",	SNES_OP_16BIT},
-{"ldx",			SNES_OP_IMM},
+{"ldx",			SNES_OP_IMM_X},
 {"lda 0x%02x,s",	SNES_OP_16BIT},
 {"ldy 0x%02x",		SNES_OP_16BIT},
 {"lda 0x%02x",		SNES_OP_16BIT},
 {"ldx 0x%02x",		SNES_OP_16BIT},
 {"lda [0x%02x]",	SNES_OP_16BIT},
 {"tay",			SNES_OP_8BIT},
-{"lda",			SNES_OP_IMM},
+{"lda",			SNES_OP_IMM_M},
 {"tax",			SNES_OP_8BIT},
 {"plb",			SNES_OP_8BIT},
 {"ldy 0x%04x",		SNES_OP_24BIT},
@@ -217,7 +219,7 @@ static snes_op_t snes_op[]={
 {"lda 0x%04x,x",	SNES_OP_24BIT},
 {"ldx 0x%04x,y",	SNES_OP_24BIT},
 {"lda 0x%06x,x",	SNES_OP_32BIT},
-{"cpy",			SNES_OP_IMM},
+{"cpy",			SNES_OP_IMM_X},
 {"cmp (0x%02x,x)",	SNES_OP_16BIT},
 {"rep #0x%02x",		SNES_OP_16BIT},
 {"cmp 0x%02x,s",	SNES_OP_16BIT},
@@ -226,7 +228,7 @@ static snes_op_t snes_op[]={
 {"dec 0x%02x",		SNES_OP_16BIT},
 {"cmp [0x%02x]",	SNES_OP_16BIT},
 {"iny",			SNES_OP_8BIT},
-{"cmp",			SNES_OP_IMM},
+{"cmp",			SNES_OP_IMM_M},
 {"dex",			SNES_OP_8BIT},
 {"wai",			SNES_OP_8BIT},
 {"cpy 0x%04x",		SNES_OP_24BIT},
@@ -249,7 +251,7 @@ static snes_op_t snes_op[]={
 {"cmp 0x%04x,x",	SNES_OP_24BIT},
 {"dec 0x%04x,x",	SNES_OP_24BIT},
 {"cmp 0x%06x,x",	SNES_OP_32BIT},
-{"cpx",			SNES_OP_IMM},
+{"cpx",			SNES_OP_IMM_X},
 {"sbc (0x%02x,x)",	SNES_OP_16BIT},
 {"sep #0x%02x",		SNES_OP_16BIT},
 {"sbc 0x%02x,s",	SNES_OP_16BIT},
@@ -258,7 +260,7 @@ static snes_op_t snes_op[]={
 {"inc 0x%02x",		SNES_OP_16BIT},
 {"sbc [0x%02x]",	SNES_OP_16BIT},
 {"inx",			SNES_OP_8BIT},
-{"sbc",			SNES_OP_IMM},
+{"sbc",			SNES_OP_IMM_M},
 {"nop",			SNES_OP_8BIT},
 {"swa",			SNES_OP_8BIT},
 {"cpx 0x%04x",		SNES_OP_24BIT},

--- a/libr/asm/arch/snes/snesdis.c
+++ b/libr/asm/arch/snes/snesdis.c
@@ -7,9 +7,9 @@
 #include <string.h>
 #include "snes_op_table.h"
 
-static int snesDisass(int bits, ut64 pc, RAsmOp *op, const ut8 *buf, int len){
+static int snesDisass(int M_flag, int X_flag, ut64 pc, RAsmOp *op, const ut8 *buf, int len){
 	snes_op_t *s_op = &snes_op[buf[0]];
-	int op_len = snes_op_get_size(bits, s_op);
+	int op_len = snes_op_get_size(M_flag, X_flag, s_op);
 	if (len < op_len)
 		return 0;
 	switch (s_op->len) {
@@ -35,8 +35,17 @@ static int snesDisass(int bits, ut64 pc, RAsmOp *op, const ut8 *buf, int len){
 	case SNES_OP_32BIT:
 		snprintf (op->buf_asm, sizeof (op->buf_asm), s_op->name, buf[1]|buf[2]<<8|buf[3]<<16);
 		break;
-	case SNES_OP_IMM:
-		if (bits == 8) {
+	case SNES_OP_IMM_M:
+		if (M_flag) {
+			snprintf (op->buf_asm, sizeof (op->buf_asm), "%s #0x%02x",
+				s_op->name, buf[1]);
+		} else {
+			snprintf (op->buf_asm, sizeof (op->buf_asm), "%s #0x%04x",
+				s_op->name, ut8p_bw (buf+1));
+		}
+		break;
+	case SNES_OP_IMM_X:
+		if (X_flag) {
 			snprintf (op->buf_asm, sizeof (op->buf_asm), "%s #0x%02x",
 				s_op->name, buf[1]);
 		} else {

--- a/libr/asm/p/asm_snes.c
+++ b/libr/asm/p/asm_snes.c
@@ -5,11 +5,33 @@
 #include <r_asm.h>
 #include <r_lib.h>
 #include "../arch/snes/snesdis.c"
+#include "asm_snes.h"
+
+struct snes_asm_flags* snesflags = NULL;
+
+bool snes_asm_init (void* user) {
+	if (!snesflags) snesflags = malloc(sizeof( struct snes_asm_flags ));
+	memset(snesflags,0,sizeof (struct snes_asm_flags));
+	return 0;
+}
+
+bool snes_asm_fini (void* user) {
+	free(snesflags);
+	snesflags = NULL;
+	return 0;
+}
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
-	int dlen = snesDisass (a->bits, a->pc, op, buf, len);
+	int dlen = snesDisass (snesflags->M, snesflags->X, a->pc, op, buf, len);
 	if (dlen<0) dlen=0;
 	op->size = dlen;
+	if (buf[0] == 0xc2) { //REP
+		if ( buf[1] & 0x10 ) snesflags->X = 0;
+		if ( buf[1] & 0x20 ) snesflags->M = 0;
+	} else if (buf[0] == 0xe2) { //SEP
+		if ( buf[1] & 0x10 ) snesflags->X = 1;
+		if ( buf[1] & 0x20 ) snesflags->M = 1;
+	}
 	return dlen;
 }
 
@@ -18,6 +40,8 @@ RAsmPlugin r_asm_plugin_snes = {
 	.desc = "SuperNES CPU",
 	.arch = "snes",
 	.bits = 8|16,
+	.init = snes_asm_init,
+	.fini = snes_asm_fini,
 	.endian = R_SYS_ENDIAN_LITTLE,
 	.license = "LGPL3",
 	.disassemble = &disassemble

--- a/libr/asm/p/asm_snes.h
+++ b/libr/asm/p/asm_snes.h
@@ -1,0 +1,9 @@
+#ifndef ASM_P_ASM_SNES_H
+#define ASM_P_ASM_SNES_H
+
+struct snes_asm_flags {
+	unsigned char M; 
+	unsigned char X;
+};
+
+#endif


### PR DESCRIPTION
This (admittedly very hacky) pull request tries to make sure the disassembler and analyzer handles X and M flags, which determine whether the X/Y registers and the accumulator are 8 or 16 bits long, properly.

Whenever either the disassembler or the analyzer sees a "rep" or "sep" instruction that would have modified the X and M flags on a real 65816 CPU, it sets an internal flag that makes sure the following instructions are processed with proper register length.

This is especially important when handling instructions that load data with immediate addressing (the value is specified in bytes following the opcode) or when comparing registers with an immediate value, as length of these instructions is influenced by the flags' values.