### PR TITLE
Fix cmtright handling in graphs

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -1726,7 +1726,7 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 	}
 	r_config_save_num (hc, "asm.fcnlines", "asm.lines", "asm.bytes",
 		"asm.cmtcol", "asm.marks", "asm.marks", "asm.offset",
-		"asm.comments", NULL);
+		"asm.comments", "asm.cmtright", NULL);
 	const bool o_comments = r_config_get_i (core->config, "graph.comments");
 	const bool o_cmtright = r_config_get_i (core->config, "graph.cmtright");
 	int o_cursor = core->print->cur_enabled;
@@ -1738,7 +1738,7 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 	r_config_set_i (core->config, "asm.lines", false);
 	r_config_set_i (core->config, "asm.cmtcol", 0);
 	r_config_set_i (core->config, "asm.marks", false);
-	r_config_set_i (core->config, "asm.cmtright", o_cmtright);
+	r_config_set_i (core->config, "asm.cmtright", (opts & BODY_SUMMARY) || o_cmtright);
 	r_config_set_i (core->config, "asm.comments", (opts & BODY_SUMMARY) || o_comments);
 	core->print->cur_enabled = false;
 


### PR DESCRIPTION
- keep it true in summary mode, to avoid killing "pds" strings parsing
- restore it back to its original value