### PR TITLE
Add reverse singlestep command 'dsb'

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -660,7 +660,7 @@ static int cmd_debug_map_snapshot(RCore *core, const char *input) {
 		r_debug_snap (core->dbg, r_num_math (core->num, input + 1));
 		break;
 	case 'A':
-		r_debug_snap_set (core->dbg, atoi (input + 1));
+		r_debug_snap_set_idx (core->dbg, atoi (input + 1));
 		break;
 	case 'C':
 		r_debug_snap_comment (core->dbg, atoi (input + 1), strchr (input, ' '));
@@ -3449,6 +3449,29 @@ static int cmd_debug(void *data, const char *input) {
 		case 'g': // "dtg"
 			dot_trace_traverse (core, core->dbg->tree, input[2]);
 			break;
+		case 's': // "dts"
+			switch (input[1]) {
+			case 0:
+				r_debug_session_list (core->dbg);
+				break;
+			case '+':
+				r_debug_session_add (core->dbg);
+				break;
+			case 'A':
+				r_debug_session_set (core->dbg, atoi (input + 2));
+				break;
+			default:
+				{
+				const char *help_msg[] = {
+					"Usage:", "ats[*]", "",
+					"dts", "", "List all trace sessions",
+					"dts+", "", "Add trace session",
+					"dtsA", " id", "Apply trace session",
+					NULL };
+				r_core_cmd_help (core, help_msg);
+				}
+			}
+			break;
 		case '-':
 			r_tree_reset (core->dbg->tree);
 			r_debug_trace_free (core->dbg->trace);
@@ -3469,6 +3492,7 @@ static int cmd_debug(void *data, const char *input) {
 					"dtg", "", "Graph call/ret trace",
 					"dtg*", "", "Graph in agn/age commands. use .dtg*;aggi for visual",
 					"dtgi", "", "Interactive debug trace",
+					"dts", "[?]", "trace sessions",
 					"dt-", "", "Reset traces (instruction/calls)",
 					NULL
 				};

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3255,6 +3255,7 @@ static int cmd_debug_step (RCore *core, const char *input) {
 		"Usage: ds", "", "Step commands",
 		"ds", "", "Step one instruction",
 		"ds", " <num>", "Step <num> instructions",
+		"dsb", "", "Step back one instruction",
 		"dsf", "", "Step until end of frame",
 		"dsi", " <cond>", "Continue until condition matches",
 		"dsl", "", "Step one source line",
@@ -3386,6 +3387,13 @@ static int cmd_debug_step (RCore *core, const char *input) {
 			if (bpi) r_core_cmd0 (core, delb);
 			break;
 		}
+	case 'b': // "dsb"
+		{
+			if (!r_debug_step_back (core->dbg)) {
+				eprintf ("cannot step back\n");
+			}
+			break;
+		}
 	case 'l': // "dsl"
 		r_reg_arena_swap (core->dbg->reg, true);
 		step_line (core, times);
@@ -3458,7 +3466,7 @@ static int cmd_debug(void *data, const char *input) {
 				r_debug_session_add (core->dbg);
 				break;
 			case 'A':
-				r_debug_session_set (core->dbg, atoi (input + 2));
+				r_debug_session_set_idx (core->dbg, atoi (input + 2));
 				break;
 			default:
 				{

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3450,7 +3450,7 @@ static int cmd_debug(void *data, const char *input) {
 			dot_trace_traverse (core, core->dbg->tree, input[2]);
 			break;
 		case 's': // "dts"
-			switch (input[1]) {
+			switch (input[2]) {
 			case 0:
 				r_debug_session_list (core->dbg);
 				break;
@@ -3463,7 +3463,7 @@ static int cmd_debug(void *data, const char *input) {
 			default:
 				{
 				const char *help_msg[] = {
-					"Usage:", "ats[*]", "",
+					"Usage:", "dts[*]", "",
 					"dts", "", "List all trace sessions",
 					"dts+", "", "Add trace session",
 					"dtsA", " id", "Apply trace session",

--- a/libr/debug/Makefile
+++ b/libr/debug/Makefile
@@ -1,7 +1,7 @@
 include ../config.mk
 
 NAME=r_debug
-DEPS=r_reg r_anal r_bp r_io r_parse r_cons r_syscall r_hash r_flag r_util 
+DEPS=r_reg r_anal r_bp r_io r_parse r_cons r_syscall r_hash r_flag r_util
 DEPS+=r_socket
 CFLAGS+=-DCORELIB
 
@@ -23,8 +23,8 @@ CFLAGS+=-DXNU_USE_PTRACE=$(XNU_USE_PTRACE)
 
 STATIC_OBJS=$(subst ..,p/..,$(subst debug_,p/debug_,$(STATIC_OBJ)))
 
-OBJS=signal.o map.o trace.o arg.o debug.o plugin.o snap.o
-OBJS+=pid.o dreg.o ddesc.o esil.o ${STATIC_OBJS} 
+OBJS=signal.o map.o trace.o arg.o debug.o plugin.o snap.o session.o
+OBJS+=pid.o dreg.o ddesc.o esil.o ${STATIC_OBJS}
 
 ifeq (${OSTYPE},darwin)
 ifneq (${NATIVE_OBJS},)
@@ -39,7 +39,7 @@ endif
 
 ifneq (${COREDUMP_OBJS},)
 ifeq ($(OSTYPE),$(filter $(OSTYPE),gnulinux))
-OBJS+= p/${COREDUMP_OBJS}	
+OBJS+= p/${COREDUMP_OBJS}
 endif
 endif
 

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -302,6 +302,7 @@ R_API RDebug *r_debug_new(int hard) {
 	dbg->trace_execs = 0;
 	dbg->anal = NULL;
 	dbg->snaps = r_list_newf (r_debug_snap_free);
+	dbg->sessions = r_list_newf (r_debug_session_free);
 	dbg->pid = -1;
 	dbg->bpsize = 1;
 	dbg->tid = -1;
@@ -345,6 +346,7 @@ R_API RDebug *r_debug_free(RDebug *dbg) {
 		r_bp_free (dbg->bp);
 		//r_reg_free(&dbg->reg);
 		r_list_free (dbg->snaps);
+		r_list_free (dbg->sessions);
 		r_list_free (dbg->maps);
 		r_list_free (dbg->maps_user);
 		r_list_free (dbg->threads);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -907,6 +907,43 @@ R_API int r_debug_step_over(RDebug *dbg, int steps) {
 	return steps_taken;
 }
 
+R_API int r_debug_step_back(RDebug *dbg) {
+	ut64 pc, end;
+	ut8 buf[32];
+	RAnalOp op;
+	RDebugSession *before;
+	if (r_debug_is_dead (dbg)) {
+		return 0;
+	}
+	if (!dbg->anal || !dbg->reg)
+		return 0;
+
+	end = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+	/* rollback to previous state */
+	before = r_debug_session_get (dbg, end);
+	if (!before) {
+		return 0;
+	}
+	//eprintf ("before session (%d) 0x%08"PFMT64x"\n", before->key.id, before->key.addr);
+	r_debug_session_set (dbg, before);
+	pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+	//eprintf ("execute from 0x%08"PFMT64x" to 0x%08"PFMT64x"\n", pc, end);
+
+	for (;;) {
+		if (r_debug_is_dead (dbg))
+			break;
+		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+		r_io_read_at (dbg->iob.io, pc, buf, sizeof (buf));
+		r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf));
+		//eprintf ("executing [0x%08"PFMT64x",0x%08"PFMT64x"]\n", pc, pc + op.size);
+		if (pc + op.size == end)
+			return 1;
+		if (!r_debug_step (dbg, 1))
+			break;
+	}
+	return 0;
+}
+
 R_API int r_debug_continue_kill(RDebug *dbg, int sig) {
 	RDebugReasonType reason, ret = false;
 	RBreakpointItem *bp = NULL;

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -335,4 +335,3 @@ R_API ut64 r_debug_num_callback(RNum *userptr, const char *str, int *ok) {
 	// resolve using regnu
 	return r_debug_reg_get_err (dbg, str, ok, NULL);
 }
-

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -1,114 +1,122 @@
 /* radare - LGPL - Copyright 2017 - rkx1209 */
 #include <r_debug.h>
 
-R_API void r_debug_session_free (void *p) {
-  free (p);
+R_API void r_debug_session_free(void *p) {
+	free (p);
 }
 
-static int r_debug_session_lastid (RDebug *dbg) {
-  return r_list_length (dbg->sessions);
+static int r_debug_session_lastid(RDebug *dbg) {
+	return r_list_length (dbg->sessions);
 }
 
-R_API void r_debug_session_list (RDebug *dbg) {
-  const char *comment;
-  ut32 count = 0;
-  RListIter *iterse, *itersn;
-  RDebugSnap *snap;
-  RDebugSession *session;
-  r_list_foreach (dbg->sessions, iterse, session) {
-    count = 0;
-    dbg->cb_printf ("session:%2d\tat:0x%08"PFMT64x"\n", session->key.id, session->key.addr);
-    r_list_foreach (session->memlist, itersn, snap) {
-      comment = "";
-      if (snap->comment && *snap->comment)
-        comment = snap->comment;
-        dbg->cb_printf ("%d 0x%08"PFMT64x" - 0x%08"PFMT64x" size: %d crc: %x  --  %s\n",
-                      count, snap->addr, snap->addr_end, snap->size, snap->crc, comment);
-      count++;
-    }
-  }
+R_API void r_debug_session_list(RDebug *dbg) {
+	const char *comment;
+	ut32 count = 0;
+	RListIter *iterse, *itersn;
+	RDebugSnap *snap;
+	RDebugSession *session;
+	r_list_foreach (dbg->sessions, iterse, session) {
+		count = 0;
+		dbg->cb_printf ("session:%2d\tat:0x%08"PFMT64x "\n", session->key.id, session->key.addr);
+		r_list_foreach (session->memlist, itersn, snap) {
+			comment = "";
+			if (snap->comment && *snap->comment) {
+				comment = snap->comment;
+			}
+			dbg->cb_printf ("%d 0x%08"PFMT64x " - 0x%08"PFMT64x " size: %d crc: %x  --  %s\n",
+				count, snap->addr, snap->addr_end, snap->size, snap->crc, comment);
+			count++;
+		}
+	}
 }
 
-R_API bool r_debug_session_add (RDebug *dbg) {
-  RDebugSession *session;
-  RDebugSnap *snap;
-  RListIter *iter, *start, *iterr;
-  ut64 addr;
-  int i;
-  session = R_NEW0 (RDebugSession);
-  if (!session) return false;
+R_API bool r_debug_session_add(RDebug *dbg) {
+	RDebugSession *session;
+	RDebugSnap *snap;
+	RListIter *iter, *start, *iterr;
+	ut64 addr;
+	int i;
+	session = R_NEW0 (RDebugSession);
+	if (!session) {
+		return false;
+	}
 
-  addr = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
-  session->key = (RDebugKey) { addr, r_debug_session_lastid (dbg) };
+	addr = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+	session->key = (RDebugKey) {
+		addr, r_debug_session_lastid (dbg)
+	};
 
-  /* save current registers */
-  r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 0);
-  for (i = 0; i < R_REG_TYPE_LAST; i++) {
-    session->reg[i] = r_list_tail (dbg->reg->regset[i].pool);
-  }
-  r_reg_arena_push (dbg->reg);
+	/* save current registers */
+	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 0);
+	for (i = 0; i < R_REG_TYPE_LAST; i++) {
+		session->reg[i] = r_list_tail (dbg->reg->regset[i].pool);
+	}
+	r_reg_arena_push (dbg->reg);
 
-  /* save memory snapshots */
-  session->memlist = r_list_newf (r_debug_snap_free);
-  start = r_list_tail (dbg->snaps);
-  r_debug_snap_all (dbg, R_IO_RW);
-  if (!start) {
-    start = r_list_head (dbg->snaps);
-  } else {
-    start = start->n;
-  }
-  //XXX
-  for (iter = start; iter && (snap = iter->data); iter = iter->n) {
-    r_list_append (session->memlist, snap);
-  }
+	/* save memory snapshots */
+	session->memlist = r_list_newf (r_debug_snap_free);
+	start = r_list_tail (dbg->snaps);
+	r_debug_snap_all (dbg, R_IO_RW);
+	if (!start) {
+		start = r_list_head (dbg->snaps);
+	} else {
+		start = start->n;
+	}
+	// XXX
+	for (iter = start; iter && (snap = iter->data); iter = iter->n) {
+		r_list_append (session->memlist, snap);
+	}
 
-  r_list_append (dbg->sessions, session);
-  return true;
+	r_list_append (dbg->sessions, session);
+	return true;
 }
 
-R_API void r_debug_session_set (RDebug *dbg, RDebugSession *session) {
-  RDebugSnap *snap;
-  RRegArena *arena;
-  RListIter *iter, *iterr;
-  int i;
-  /* Restore all regsiter values from the stack area pointed by session */
-  r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 0);
-  for (i = 0; i < R_REG_TYPE_LAST; i++) {
-    iterr = session->reg[i];
-    arena = iterr->data;
-    memcpy (dbg->reg->regset[i].arena->bytes, arena->bytes, arena->size);
-  }
-  r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
+R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session) {
+	RDebugSnap *snap;
+	RRegArena *arena;
+	RListIter *iter, *iterr;
+	int i;
+	/* Restore all regsiter values from the stack area pointed by session */
+	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 0);
+	for (i = 0; i < R_REG_TYPE_LAST; i++) {
+		iterr = session->reg[i];
+		arena = iterr->data;
+		memcpy (dbg->reg->regset[i].arena->bytes, arena->bytes, arena->size);
+	}
+	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
 
-  /* Restore all memory values from memory snapshots*/
-  r_list_foreach (session->memlist, iter, snap) {
-    r_debug_snap_set (dbg, snap);
-  }
+	/* Restore all memory values from memory snapshots*/
+	r_list_foreach (session->memlist, iter, snap) {
+		r_debug_snap_set (dbg, snap);
+	}
 }
 
-R_API bool r_debug_session_set_idx (RDebug *dbg, int idx) {
-  RDebugSession *session;
-  RListIter *iter;
-  ut32 count = 0;
+R_API bool r_debug_session_set_idx(RDebug *dbg, int idx) {
+	RDebugSession *session;
+	RListIter *iter;
+	ut32 count = 0;
 
-  if (!dbg || idx < 0)
-    return false;
+	if (!dbg || idx < 0) {
+		return false;
+	}
 
-  r_list_foreach (dbg->sessions, iter, session) {
-    if (count == idx) {
-      r_debug_session_set (dbg, session);
-      return true;
-    }
-    count++;
-  }
-  return false;
+	r_list_foreach (dbg->sessions, iter, session) {
+		if (count == idx) {
+			r_debug_session_set (dbg, session);
+			return true;
+		}
+		count++;
+	}
+	return false;
 }
 
-R_API RDebugSession* r_debug_session_get (RDebug *dbg, ut64 addr) {
-  RDebugSession *session;
-  RListIter *iter;
-  r_list_foreach_prev (dbg->sessions, iter, session) {
-    if (session->key.addr != addr) return session;
-  }
-  return NULL;
+R_API RDebugSession *r_debug_session_get(RDebug *dbg, ut64 addr) {
+	RDebugSession *session;
+	RListIter *iter;
+	r_list_foreach_prev (dbg->sessions, iter, session) {
+		if (session->key.addr != addr) {
+			return session;
+		}
+	}
+	return NULL;
 }

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -52,7 +52,7 @@ R_API int r_debug_session_add (RDebug *dbg) {
   /* save memory snapshots */
   session->memlist = r_list_newf (r_debug_snap_free);
   start = r_list_tail (dbg->snaps);
-  r_debug_snap_all (dbg, 0);
+  r_debug_snap_all (dbg, R_IO_RW);
   if (!start) {
     start = r_list_head (dbg->snaps);
   } else {

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -1,0 +1,93 @@
+/* radare - LGPL - Copyright 2017 - rkx1209 */
+#include <r_debug.h>
+
+R_API void r_debug_session_free (void *p) {
+	RDebugSession *session = (RDebugSession*)p;
+	free (session);
+}
+
+static int r_debug_session_lastid (RDebug *dbg) {
+  return r_list_length (dbg->sessions);
+}
+
+R_API int r_debug_session_list (RDebug *dbg) {
+  const char *comment;
+  ut32 count = 0;
+	RListIter *iterse, *itersn;
+	RDebugSnap *snap;
+  RDebugSession *session;
+	r_list_foreach (dbg->sessions, iterse, session) {
+    count = 0;
+    dbg->cb_printf ("session:%2d\tat:0x%08"PFMT64x"\n", session->key.id, session->key.addr);
+	  r_list_foreach (session->memlist, itersn, snap) {
+		  comment = "";
+		  if (snap->comment && *snap->comment)
+			  comment = snap->comment;
+		  dbg->cb_printf ("%d 0x%08"PFMT64x" - 0x%08"PFMT64x" size: %d crc: %x  --  %s\n",
+		                  count, snap->addr, snap->addr_end, snap->size, snap->crc, comment);
+		  count++;
+    }
+	}
+}
+
+R_API int r_debug_session_add (RDebug *dbg) {
+	RDebugSession *session;
+  RDebugSnap *snap;
+  RListIter *iter, *start, *iterr;
+  ut64 addr;
+  int i;
+	session = R_NEW0 (RDebugSession);
+  if (!session) return 0;
+
+  addr = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+  session->key = (RDebugKey) { addr, r_debug_session_lastid (dbg) };
+
+  /* save current registers */
+  r_reg_arena_push (dbg->reg);
+  for (i = 0; i < R_REG_TYPE_LAST; i++) {
+    iterr = r_list_tail (dbg->reg->regset[i].pool);
+    session->reg[i] = iterr->data;
+  }
+
+  /* save memory snapshots */
+  session->memlist = r_list_newf (r_debug_snap_free);
+  start = r_list_tail (dbg->snaps);
+  r_debug_snap_all (dbg, 0);
+  if (!start) {
+    start = r_list_head (dbg->snaps);
+  } else {
+    start = start->n;
+  }
+  //XXX
+  for (iter = start; iter && (snap = iter->data); iter = iter->n) {
+    r_list_append (session->memlist, snap);
+  }
+
+  r_list_append (dbg->sessions, session);
+  return 1;
+}
+
+R_API int r_debug_session_set (RDebug *dbg, int idx) {
+  RDebugSession *session;
+  RDebugSnap *snap;
+  RListIter *iterse, *itersn;
+  int i;
+  ut32 count = 0;
+
+	if (!dbg || idx < 0)
+		return 0;
+	r_list_foreach (dbg->sessions, iterse, session) {
+		if (count == idx) {
+      for (i = 0; i < R_REG_TYPE_LAST; i++) {
+        dbg->reg->regset[i].arena = session->reg[i];
+      }
+      r_debug_reg_sync (dbg, -1, 1);
+      r_list_foreach (session->memlist, itersn, snap) {
+        r_debug_snap_set (dbg, snap);
+      }
+      return 1;
+    }
+    count++;
+  }
+  return 0;
+}

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -43,6 +43,7 @@ R_API int r_debug_session_add (RDebug *dbg) {
   session->key = (RDebugKey) { addr, r_debug_session_lastid (dbg) };
 
   /* save current registers */
+  r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 0);
   for (i = 0; i < R_REG_TYPE_LAST; i++) {
     session->reg[i] = r_list_tail (dbg->reg->regset[i].pool);
   }
@@ -72,12 +73,13 @@ R_API int r_debug_session_set (RDebug *dbg, RDebugSession *session) {
   RListIter *iter, *iterr;
   int i;
   /* Restore all regsiter values from the stack area pointed by session */
+  r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 0);
   for (i = 0; i < R_REG_TYPE_LAST; i++) {
     iterr = session->reg[i];
     arena = iterr->data;
     memcpy (dbg->reg->regset[i].arena->bytes, arena->bytes, arena->size);
   }
-  r_debug_reg_sync (dbg, -1, 1);
+  r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
 
   /* Restore all memory values from memory snapshots*/
   r_list_foreach (session->memlist, iter, snap) {

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -79,8 +79,14 @@ R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr) {
 }
 
 R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap) {
+	RListIter *iter;
+	RDebugMap *map;
 	eprintf ("Writing %d bytes to 0x%08"PFMT64x"...\n", snap->size, snap->addr);
-	dbg->iob.write_at (dbg->iob.io, snap->addr, snap->data, snap->size);
+	r_list_foreach (dbg->maps, iter, map) {
+		if (snap->addr <= map->addr && map->addr_end <= snap->addr_end) {
+			dbg->iob.write_at (dbg->iob.io, map->addr, snap->data, map->addr_end - map->addr);
+		}
+	}
 	return 1;
 }
 

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -78,7 +78,13 @@ R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr) {
 	return NULL;
 }
 
-R_API int r_debug_snap_set (RDebug *dbg, int idx) {
+R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap) {
+	eprintf ("Writing %d bytes to 0x%08"PFMT64x"...\n", snap->size, snap->addr);
+	dbg->iob.write_at (dbg->iob.io, snap->addr, snap->data, snap->size);
+	return 1;
+}
+
+R_API int r_debug_snap_set_idx (RDebug *dbg, int idx) {
 	RDebugSnap *snap;
 	RListIter *iter;
 	ut32 count = 0;
@@ -86,8 +92,7 @@ R_API int r_debug_snap_set (RDebug *dbg, int idx) {
 		return 0;
 	r_list_foreach (dbg->snaps, iter, snap) {
 		if (count == idx) {
-			eprintf ("Writing %d bytes to 0x%08"PFMT64x"...\n", snap->size, snap->addr);
-			dbg->iob.write_at (dbg->iob.io, snap->addr, snap->data, snap->size);
+			r_debug_snap_set (dbg, snap);
 			break;
 		}
 		count++;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -170,7 +170,7 @@ typedef struct r_debug_key {
 
 typedef struct r_debug_session_t {
 	RDebugKey key;
-	RRegArena *reg[R_REG_TYPE_LAST];
+	RListIter *reg[R_REG_TYPE_LAST];
 	RList *memlist; // <RDebugSnap*>
 } RDebugSession;
 
@@ -518,7 +518,9 @@ R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
 R_API void r_debug_session_free (void *p) ;
 R_API int r_debug_session_list (RDebug *dbg);
 R_API int r_debug_session_add (RDebug *dbg);
-R_API int r_debug_session_set (RDebug *dbg, int idx);
+R_API int r_debug_session_set (RDebug *dbg, RDebugSession *session);
+R_API int r_debug_session_set_idx (RDebug *dbg, int idx);
+R_API RDebugSession* r_debug_session_get (RDebug *dbg, ut64 addr);
 
 /* plugin pointers */
 extern RDebugPlugin r_debug_plugin_native;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -163,6 +163,17 @@ typedef struct r_debug_snap_t {
 	char *comment;
 } RDebugSnap;
 
+typedef struct r_debug_key {
+	ut64 addr;
+	int id;
+} RDebugKey;
+
+typedef struct r_debug_session_t {
+	RDebugKey key;
+	RRegArena *reg[R_REG_TYPE_LAST];
+	RList *memlist; // <RDebugSnap*>
+} RDebugSession;
+
 typedef struct r_debug_trace_t {
 	RList *traces;
 	int count;
@@ -240,6 +251,7 @@ typedef struct r_debug_t {
 	RList *maps; // <RDebugMap>
 	RList *maps_user; // <RDebugMap>
 	RList *snaps; // <RDebugSnap>
+	RList *sessions; // <RDebugSession>
 	Sdb *sgnls;
 	RCoreBind corebind;
 	// internal use only
@@ -499,7 +511,14 @@ R_API int r_debug_snap(RDebug *dbg, ut64 addr);
 R_API int r_debug_snap_comment (RDebug *dbg, int idx, const char *msg);
 R_API int r_debug_snap_all(RDebug *dbg, int perms);
 R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr);
-R_API int r_debug_snap_set (RDebug *dbg, int idx);
+R_API int r_debug_snap_set_idx (RDebug *dbg, int idx);
+R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
+
+/* debug session */
+R_API void r_debug_session_free (void *p) ;
+R_API int r_debug_session_list (RDebug *dbg);
+R_API int r_debug_session_add (RDebug *dbg);
+R_API int r_debug_session_set (RDebug *dbg, int idx);
 
 /* plugin pointers */
 extern RDebugPlugin r_debug_plugin_native;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -516,10 +516,10 @@ R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
 
 /* debug session */
 R_API void r_debug_session_free (void *p) ;
-R_API int r_debug_session_list (RDebug *dbg);
-R_API int r_debug_session_add (RDebug *dbg);
-R_API int r_debug_session_set (RDebug *dbg, RDebugSession *session);
-R_API int r_debug_session_set_idx (RDebug *dbg, int idx);
+R_API void r_debug_session_list (RDebug *dbg);
+R_API bool r_debug_session_add (RDebug *dbg);
+R_API void r_debug_session_set (RDebug *dbg, RDebugSession *session);
+R_API bool r_debug_session_set_idx (RDebug *dbg, int idx);
 R_API RDebugSession* r_debug_session_get (RDebug *dbg, ut64 addr);
 
 /* plugin pointers */

--- a/libr/include/r_reg.h
+++ b/libr/include/r_reg.h
@@ -100,6 +100,7 @@ typedef struct r_reg_set_t {
 	RRegArena *arena;
 	RList *pool;      /* RRegArena */
 	RList *regs;      /* RRegItem */
+	RListIter *cur;
 	int maskregstype; /* which type of regs have this reg set (logic mask with RRegisterType  R_REG_TYPE_XXX) */
 } RRegSet;
 

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -185,12 +185,12 @@ R_API void r_reg_arena_free(RRegArena* ra) {
 }
 
 R_API void r_reg_arena_swap(RReg* reg, int copy) {
-	// XXX this api should be deprecated
+	/* XXX: swap current arena to head(previous arena) */
 	int i;
 	for (i = 0; i < R_REG_TYPE_LAST; i++) {
 		if (r_list_length (reg->regset[i].pool) > 1) {
-			RListIter* ia = reg->regset[i].pool->tail;
-			RListIter* ib = reg->regset[i].pool->tail->p;
+			RListIter* ia = reg->regset[i].cur;
+			RListIter* ib = reg->regset[i].pool->head;
 			void* tmp = ia->data;
 			ia->data = ib->data;
 			ib->data = tmp;
@@ -200,10 +200,6 @@ R_API void r_reg_arena_swap(RReg* reg, int copy) {
 			break;
 		}
 	}
-#if 0
-	int index = (++reg->iters) % 2;
-	r_reg_arena_set (reg, index, copy);
-#endif
 }
 
 R_API void r_reg_arena_pop(RReg* reg) {
@@ -218,6 +214,7 @@ R_API void r_reg_arena_pop(RReg* reg) {
 		a = reg->regset[i].pool->tail->data;
 		if (a) {
 			reg->regset[i].arena = a;
+			reg->regset[i].cur = reg->regset[i].pool->tail;
 		}
 	}
 }
@@ -241,6 +238,7 @@ R_API int r_reg_arena_push(RReg* reg) {
 		}
 		r_list_push (reg->regset[i].pool, b);
 		reg->regset[i].arena = b;
+		reg->regset[i].cur = reg->regset[i].pool->tail;
 	}
 	return r_list_length (reg->regset[0].pool);
 }

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -232,6 +232,9 @@ R_API RReg* r_reg_new() {
 		reg->regset[i].arena = arena;
 	}
 	r_reg_arena_push (reg);
+	for (i = 0; i < R_REG_TYPE_LAST; i++) {
+		reg->regset[i].cur = r_list_tail (reg->regset[i].pool);
+	}
 	return reg;
 }
 


### PR DESCRIPTION
Add new reverse single step command 'dsb'.
To execute it, firstly we need save trace session using 'dts+' command.
'dts' command manages trace sessions which have each register and memory state at the moment.
After that, 'dsb' command seeks program counter to backward. (i.e. reverse single step)
Internally, 'dsb' command finds previous trace session and restore all status and then, 
execute forward until desired point.
This implementation is same as that of mozilla's rr. ( https://mail.mozilla.org/pipermail/rr-dev/2017-March/000473.html )

future work
- More optimization
- Read session log that created by other tools
(but, qira has hard-coded address in log, and rr has no deterministic inputs in log. What should I do?)
- Page permission problem
(when dsb command execute to backward across mprotect function, page permission must be changed,
because memory snapshot cannot apply to the area that is changed to 'read-only' by mprotect.
