### PR TITLE
Fix bad 64 bit assembly for group1 ops

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -210,7 +210,8 @@ static int process_group_1(RAsm *a, ut8 *data, const Opcode op) {
 	}
 
 	data[l++] = immediate;
-	if ((immediate > 127 || immediate < -128) && op.operands[0].type & OT_DWORD) {
+	if ((immediate > 127 || immediate < -128) &&
+	    ((op.operands[0].type & OT_DWORD) || (op.operands[0].type & OT_QWORD))) {
 		data[l++] = immediate >> 8;
 		data[l++] = immediate >> 16;
 		data[l++] = immediate >> 24;


### PR DESCRIPTION
For instructions with `rsp` reg as first operand

FIX #7137 