### PR TITLE
fix memory leak in r_asm_mdisassemble

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -562,11 +562,10 @@ R_API RAsmCode* r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len) {
 		return r_asm_code_free (acode);
 	}
 	r_hex_bin2str (buf, len, acode->buf_hex);
-	if (!(acode->buf_asm = malloc (4))) {
+	if (!(buf_asm = r_strbuf_new (NULL))) {
 		return r_asm_code_free (acode);
 	}
-	buf_asm = r_strbuf_new (NULL);
-	for (idx = ret = slen = 0, acode->buf_asm[0] = '\0'; idx < len; idx += ret) {
+	for (idx = ret = slen = 0; idx < len; idx += ret) {
 		r_asm_set_pc (a, pc + idx);
 		ret = r_asm_disassemble (a, &op, buf + idx, len - idx);
 		if (ret < 1) {


### PR DESCRIPTION
buf_asm was redundantly allocated with malloc, then overwritten from a strbuf.