### PR TITLE
Fix #7193 : R2PM_ETCD has an extra "radare2" path

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -58,7 +58,7 @@ TRAVIS_TYPE=XX
 TRAVIS_JOB=86948888
 IS_SYSPKG=0
 R2PM_USRDIR="${HOME}/.config/radare2/r2pm"
-R2PM_ETCD="${R2HOMEDIR}/radare2/radare2rc.d"
+R2PM_ETCD="${R2HOMEDIR}/radare2rc.d"
 IS_LOCAL=0
 
 # TODO. support system plugin installs R2PM_PLUGDIR="${R2PM_PREFIX}/lib/radare2/last"


### PR DESCRIPTION
Fixes alias in radare2rc at r2pm packages like esilburner