### PR TITLE
Always build ds->opstr before comment

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2581,7 +2581,7 @@ static void ds_print_op_push_info(RDisasmState *ds){
 	case R_ANAL_OP_TYPE_PUSH:
 		if (ds->analop.val) {
 			RFlagItem *flag = r_flag_get_i (ds->core->flags, ds->analop.val);
-			if (flag && (!ds->opstr || !strstr(ds->opstr, flag->name))) {
+			if (flag && !strstr (ds->opstr, flag->name)) {
 				r_cons_printf (" ; %s", flag->name);
 			}
 		}
@@ -2659,7 +2659,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 				}
 				ALIGN;
 				if (!is_lea_str) {
-					if (ds->opstr && *flag && strstr (ds->opstr, flag)) {
+					if (*flag && strstr (ds->opstr, flag)) {
 						ds_comment (ds, true, "%s; 0x%" PFMT64x "%s", esc, refaddr, nl);
 					} else {
 						ds_comment (ds, true, "%s; 0x%" PFMT64x "%s%s%s", esc, refaddr,
@@ -3664,7 +3664,11 @@ toro:
 
 		if (ds->show_comments && !ds->show_comment_right) {
 			ds_show_refs (ds);
+			ds_build_op_str (ds);
 			ds_print_ptr (ds, len + 256, idx);
+			if (!ds->pseudo) {
+				R_FREE (ds->opstr);
+			}
 			ds_print_fcn_name (ds);
 			ds_print_color_reset (ds);
 			if (ds->show_emu) {


### PR DESCRIPTION
Fixed the agf segfault in #7125. This PR removes the ds->opstr checks of #7125 and #7140. Now flags are not repeated in comment if already in disasm even if asm.cmtright = false.