### PR TITLE
Radiff graph

### DIFF
--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -124,7 +124,7 @@ R_API bool r_anal_diff_bb(RAnal *anal, RAnalFunction *fcn, RAnalFunction *fcn2) 
 		ot = 0;
 		mbb = mbb2 = NULL;
 		r_list_foreach (fcn2->bbs, iter2, bb2) {
-			if (bb2->diff==NULL || bb2->diff->type == R_ANAL_DIFF_TYPE_NULL) {
+			if (!bb2->diff || bb2->diff->type == R_ANAL_DIFF_TYPE_NULL) {
 				r_diff_buffers_distance (NULL, bb->fingerprint, bb->size,
 						bb2->fingerprint, bb2->size, NULL, &t);
 				if (t > anal->diff_thbb && t > ot) {

--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -124,7 +124,7 @@ R_API bool r_anal_diff_bb(RAnal *anal, RAnalFunction *fcn, RAnalFunction *fcn2) 
 		ot = 0;
 		mbb = mbb2 = NULL;
 		r_list_foreach (fcn2->bbs, iter2, bb2) {
-			if (bb2->diff && bb2->diff->type == R_ANAL_DIFF_TYPE_NULL) {
+			if (bb2->diff==NULL || bb2->diff->type == R_ANAL_DIFF_TYPE_NULL) {
 				r_diff_buffers_distance (NULL, bb->fingerprint, bb->size,
 						bb2->fingerprint, bb2->size, NULL, &t);
 				if (t > anal->diff_thbb && t > ot) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1115,7 +1115,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 			if (opts & R_CORE_ANAL_GRAPHDIFF) {
 				const char *difftype = bbi->diff? (\
 					bbi->diff->type==R_ANAL_DIFF_TYPE_MATCH? "lightgray":
-					bbi->diff->type==R_ANAL_DIFF_TYPE_UNMATCH? "yellow": "red"): "gray";
+					bbi->diff->type==R_ANAL_DIFF_TYPE_UNMATCH? "yellow": "red"): "orange";
 				const char *diffname = bbi->diff? (\
 					bbi->diff->type==R_ANAL_DIFF_TYPE_MATCH? "match":
 					bbi->diff->type==R_ANAL_DIFF_TYPE_UNMATCH? "unmatch": "new"): "unk";

--- a/libr/util/diff.c
+++ b/libr/util/diff.c
@@ -291,10 +291,10 @@ R_API bool r_diff_buffers_distance_levenstein(RDiff *d, const ut8 *a, ut32 la, c
 		// the final distance is the last byte we processed in the inner loop.
 		// v0 is used instead of v1 because we switched the pointers before exiting the outer loop
 		*distance = v0[stop];
-		if (similarity) {
-			double diff = (double) (*distance) / (double) (R_MAX (aLen, bLen));
-			*similarity = (double)1 - diff;
-		}
+	}
+	if (similarity) {
+		double diff = (double) (v0[stop]) / (double) (R_MAX (aLen, bLen));
+		*similarity = (double)1 - diff;
 	}
 	free (v0);
 	free (v1);


### PR DESCRIPTION
Appears to address #3614, reenables actual comparison for radiff2 -g. This appears to have been broken since May. 