### PR TITLE
include debug symbols in windows releases

### DIFF
--- a/sys/mingw32.sh
+++ b/sys/mingw32.sh
@@ -41,7 +41,7 @@ fi
 make mrproper
 
 ./configure ${CFGFLAGS} --with-compiler=$C --host=$H && \
-	make -s -j ${MAKE_JOBS} CC="${C} -static-libgcc" && \
+	make -s -j ${MAKE_JOBS} CC="${C} -g -static-libgcc" && \
 	make w32dist
 
 LDFLAGS="${OLD_LDFLAGS}"

--- a/sys/mingw64.sh
+++ b/sys/mingw64.sh
@@ -18,5 +18,5 @@ fi
 
 make clean
 ./configure --without-gmp --with-compiler=x86_64-w64-mingw32-gcc --with-ostype=windows --host=x86_64-unknown-windows --without-ssl
-make -s -j ${MAKE_JOBS} CC="${C} -static-libgcc" && \
+make -s -j ${MAKE_JOBS} CC="${C} -g -static-libgcc" && \
 make w64dist


### PR DESCRIPTION
Users can use `cv2pdb` to get PDB symbols.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/radare/radare2/7218)
<!-- Reviewable:end -->
