### PR TITLE
r_cons_push/pop: Defined malloc(0) exactly

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -528,10 +528,10 @@ R_API void r_cons_push() {
 				free (data);
 				return;
 			}
+			memcpy (data->buf, I.buffer, I.buffer_len);
 		} else {
 			data->buf = NULL;
 		}
-		memcpy (data->buf, I.buffer, I.buffer_len);
 		data->buf_len = I.buffer_len;
 		data->buf_size = I.buffer_sz;
 		data->grep = R_NEW0 (RConsGrep);
@@ -568,11 +568,11 @@ R_API void r_cons_pop() {
 			}
 			free (I.buffer);
 			I.buffer = tmp;
+			memcpy (I.buffer, data->buf, data->buf_len);
 		} else {
 			free (I.buffer);
 			I.buffer = NULL;
 		}
-		memcpy (I.buffer, data->buf, data->buf_len);
 		I.buffer_len = data->buf_len;
 		I.buffer_sz = data->buf_size;
 		if (data->grep) {

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -521,14 +521,15 @@ R_API void r_cons_filter() {
 
 R_API void r_cons_push() {
 	if (I.cons_stack) {
-		if (I.buffer_len < 1) {
-			return;
-		}
 		RConsStack *data = R_NEW0 (RConsStack);
-		data->buf = malloc (I.buffer_len);
-		if (!data->buf) {
-			free (data);
-			return;
+		if (I.buffer_len > 0) {
+			data->buf = malloc (I.buffer_len);
+			if (!data->buf) {
+				free (data);
+				return;
+			}
+		} else {
+			data->buf = NULL;
 		}
 		memcpy (data->buf, I.buffer, I.buffer_len);
 		data->buf_len = I.buffer_len;
@@ -555,17 +556,22 @@ R_API void r_cons_pop() {
 		if (!data) {
 			return;
 		}
-		if (!data->buf || data->buf_size < 1 || data->buf_len < 1) {
+		if ((!data->buf && data->buf_len > 0) || data->buf_len > data->buf_size) {
 			free (data);
 			return;
 		}
-		tmp = malloc (data->buf_size);
-		if (!tmp) {
-			cons_stack_free ((void *)data);
-			return;
+		if (data->buf_size > 0) {
+			tmp = malloc (data->buf_size);
+			if (!tmp) {
+				cons_stack_free ((void *)data);
+				return;
+			}
+			free (I.buffer);
+			I.buffer = tmp;
+		} else {
+			free (I.buffer);
+			I.buffer = NULL;
 		}
-		free (I.buffer);
-		I.buffer = tmp;
 		memcpy (I.buffer, data->buf, data->buf_len);
 		I.buffer_len = data->buf_len;
 		I.buffer_sz = data->buf_size;


### PR DESCRIPTION
I think it is better to define `malloc(0)` exactly. Unbreaks the tests.