### PR TITLE
Fix spelling of 'Lua' (from 'LUA')

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ code, debugging programs, attaching to remote gdb servers, ..
    w64, Solaris, Haiku, FirefoxOS
 
    * **Bindings:**
-	* Vala/Genie, Python (2, 3), NodeJS, LUA, Go, Perl,
+	* Vala/Genie, Python (2, 3), NodeJS, Lua, Go, Perl,
    Guile, php5, newlisp, Ruby, Java, OCaml, ...
 
 # Dependencies


### PR DESCRIPTION
Lua is not an acronym. Its spelling in README.md should be updated to reflect the official spelling.