### PR TITLE
fixed issue #7168

### DIFF
--- a/libr/io/p/io_w32dbg.c
+++ b/libr/io/p/io_w32dbg.c
@@ -73,7 +73,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 			return NULL;
 		}
 		pidpath = r_sys_pid_to_path (dbg->pid);
-		RETURN_IO_DESC_NEW (&r_io_plugin_w32dbg, -1,
+		RETURN_IO_DESC_NEW (&r_io_plugin_w32dbg, dbg->pid,
 			pidpath, rw | R_IO_EXEC, mode, dbg);
 	}
 	return NULL;


### PR DESCRIPTION
-Solved issue #7168

When IO for win32 dbg is created, the fd always is passed to -1, this can cause problems when reloadfile try to locate previous fd, and made wrong selection of pid via "dpa" command.