### PR TITLE
Expose class method's flags

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -2803,3 +2803,54 @@ R_API void r_bin_field_free(void *_field) {
 	free (field->format);
 	free (field);
 }
+
+R_API const char *r_bin_get_meth_flag_string(ut64 flag, bool compact) {
+	switch (flag) {
+	case R_BIN_METH_CLASS:
+		return compact ? "c" : "class";
+	case R_BIN_METH_STATIC:
+		return compact ? "s" : "static";
+	case R_BIN_METH_PUBLIC:
+		return compact ? "p" : "public";
+	case R_BIN_METH_PRIVATE:
+		return compact ? "P" : "private";
+	case R_BIN_METH_PROTECTED:
+		return compact ? "r" : "protected";
+	case R_BIN_METH_INTERNAL:
+		return compact ? "i" : "internal";
+	case R_BIN_METH_OPEN:
+		return compact ? "o" : "open";
+	case R_BIN_METH_FILEPRIVATE:
+		return compact ? "e" : "fileprivate";
+	case R_BIN_METH_FINAL:
+		return compact ? "f" : "final";
+	case R_BIN_METH_VIRTUAL:
+		return compact ? "v" : "virtual";
+	case R_BIN_METH_CONST:
+		return compact ? "k" : "const";
+	case R_BIN_METH_MUTATING:
+		return compact ? "m" : "mutating";
+	case R_BIN_METH_ABSTRACT:
+		return compact ? "a" : "abstract";
+	case R_BIN_METH_SYNCHRONIZED:
+		return compact ? "y" : "synchronized";
+	case R_BIN_METH_NATIVE:
+		return compact ? "n" : "native";
+	case R_BIN_METH_BRIDGE:
+		return compact ? "b" : "bridge";
+	case R_BIN_METH_VARARGS:
+		return compact ? "g" : "varargs";
+	case R_BIN_METH_SYNTHETIC:
+		return compact ? "h" : "synthetic";
+	case R_BIN_METH_STRICT:
+		return compact ? "t" : "strict";
+	case R_BIN_METH_MIRANDA:
+		return compact ? "A" : "miranda";
+	case R_BIN_METH_CONSTRUCTOR:
+		return compact ? "C" : "constructor";
+	case R_BIN_METH_DECLARED_SYNCHRONIZED:
+		return compact ? "Y" : "declared_synchronized";
+	default:
+		return NULL;
+	}
+}

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -593,6 +593,9 @@ static void get_method_list_t(mach0_ut p, RBinFile *arch, char *class_name, RBin
 #endif
 		method->vaddr = m.imp;
 		method->type = is_static ? "FUNC" : "METH";
+        if (is_static) {
+            method->method_flags |= R_BIN_METH_CLASS;
+        }
 		if (is_thumb (arch)) {
 			if (method->vaddr & 1) {
 				method->vaddr >>= 1;
@@ -891,7 +894,7 @@ static void get_class_ro_t(mach0_ut p, RBinFile *arch, ut32 *is_meta_class, RBin
 #endif
 
 	if (cro.baseMethods > 0) {
-		get_method_list_t (cro.baseMethods, arch, klass->name, klass, false);
+		get_method_list_t (cro.baseMethods, arch, klass->name, klass, (cro.flags & RO_META) ? true : false);
 	}
 
 	if (cro.baseProtocols > 0) {

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -517,16 +517,20 @@ static int cmd_info(void *data, const char *input) {
 								r_cons_printf (",\"methods\":[");
 								r_list_foreach (cls->methods, iter2, sym) {
 									const char *comma = iter2->p? ",": "";
-									r_cons_printf ("%s{\"name\":\"%s\",\"vaddr\":%"PFMT64d "}",
-										comma, sym->name, sym->vaddr);
+									char *flags = r_core_bin_method_flags_str (sym, R_CORE_BIN_JSON);
+									r_cons_printf ("%s{\"name\":\"%s\",\"flags\":%s,\"vaddr\":%"PFMT64d "}",
+										comma, sym->name, flags, sym->vaddr);
+									R_FREE (flags);
 								}
 								r_cons_printf ("]");
 								break;
 							default:
 								r_cons_printf ("class %s\n", cls->name);
 								r_list_foreach (cls->methods, iter2, sym) {
-									r_cons_printf ("0x%08"PFMT64x " method %s %s\n",
-										sym->vaddr, cls->name, sym->name);
+									char *flags = r_core_bin_method_flags_str (sym, 0);
+									r_cons_printf ("0x%08"PFMT64x " method %s %s %s\n",
+										sym->vaddr, cls->name, flags, sym->name);
+									R_FREE (flags);
 								}
 								break;
 							}

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -800,6 +800,7 @@ static void *show_class(RCore *core, int mode, int idx, RBinClass *_c, const cha
 		r_cons_printf ("MethodsFor: %s\n\n", _c->name);
 		r_list_foreach (_c->methods, iter, m) {
 			const char *name = m->dname? m->dname: m->name;
+			char *mflags;
 			if (grep) {
 				if (!r_str_casestr (name, grep)) {
 					i++;
@@ -814,20 +815,26 @@ static void *show_class(RCore *core, int mode, int idx, RBinClass *_c, const cha
 					}
 				}
 			}
+
+			mflags = r_core_bin_method_flags_str (m, 0);
+
 			if (show_color) {
 				if (i == idx) {
 					const char *clr = Color_BLUE;
 					r_cons_printf (Color_GREEN ">>" Color_RESET " %02d %s0x%08"
-							PFMT64x Color_YELLOW "  %s\n" Color_RESET,
-						i, clr, m->vaddr, name);
+							PFMT64x Color_YELLOW " %s %s\n" Color_RESET,
+						i, clr, m->vaddr, mflags, name);
 				} else {
-					r_cons_printf ("-  %02d %s0x%08"PFMT64x Color_RESET"  %s\n",
-						i, core->cons->pal.offset, m->vaddr, name);
+					r_cons_printf ("-  %02d %s0x%08"PFMT64x Color_RESET" %s %s\n",
+						i, core->cons->pal.offset, m->vaddr, mflags, name);
 				}
 			} else {
-				r_cons_printf ("%s %02d 0x%08"PFMT64x"  %s\n",
-					(i==idx)? ">>": "- ", i, m->vaddr, name);
+				r_cons_printf ("%s %02d 0x%08"PFMT64x" %s %s\n",
+					(i==idx)? ">>": "- ", i, m->vaddr, mflags, name);
 			}
+
+			R_FREE (mflags);
+
 			if (i++ == idx) {
 				mur = m;
 			}
@@ -2796,7 +2803,7 @@ repeat:
 				}
 				is_wide = true;
 				j++;
-			} 
+			}
 		}
 		name[4 + n] = '\0';
 		//handle wide strings

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -65,6 +65,30 @@ R_LIB_VERSION_HEADER (r_bin);
 #define R_BIN_REQ_HEADER   0x2000000
 #define R_BIN_REQ_LISTPLUGINS   0x4000000
 
+/* RBinSymbol->method_flags : */
+#define R_BIN_METH_CLASS 0x0000000000000001L
+#define R_BIN_METH_STATIC 0x0000000000000002L
+#define R_BIN_METH_PUBLIC 0x0000000000000004L
+#define R_BIN_METH_PRIVATE 0x0000000000000008L
+#define R_BIN_METH_PROTECTED 0x0000000000000010L
+#define R_BIN_METH_INTERNAL 0x0000000000000020L
+#define R_BIN_METH_OPEN 0x0000000000000040L
+#define R_BIN_METH_FILEPRIVATE 0x0000000000000080L
+#define R_BIN_METH_FINAL 0x0000000000000100L
+#define R_BIN_METH_VIRTUAL 0x0000000000000200L
+#define R_BIN_METH_CONST 0x0000000000000400L
+#define R_BIN_METH_MUTATING 0x0000000000000800L
+#define R_BIN_METH_ABSTRACT 0x0000000000001000L
+#define R_BIN_METH_SYNCHRONIZED 0x0000000000002000L
+#define R_BIN_METH_NATIVE 0x0000000000004000L
+#define R_BIN_METH_BRIDGE 0x0000000000008000L
+#define R_BIN_METH_VARARGS 0x0000000000010000L
+#define R_BIN_METH_SYNTHETIC 0x0000000000020000L
+#define R_BIN_METH_STRICT 0x0000000000040000L
+#define R_BIN_METH_MIRANDA 0x0000000000080000L
+#define R_BIN_METH_CONSTRUCTOR 0x0000000000100000L
+#define R_BIN_METH_DECLARED_SYNCHRONIZED 0x0000000000200000L
+
 enum {
 	R_BIN_SYM_ENTRY,
 	R_BIN_SYM_INIT,
@@ -358,7 +382,7 @@ typedef struct r_bin_section_t {
 	int bits;
 	bool has_strings;
 	bool add; // indicates when you want to add the section to io `S` command
-	bool is_data;	
+	bool is_data;
 } RBinSection;
 
 typedef struct r_bin_class_t {
@@ -398,6 +422,8 @@ typedef struct r_bin_symbol_t {
 	ut32 ordinal;
 	ut32 visibility;
 	int bits;
+	/* see R_BIN_METH_* constants */
+	ut64 method_flags;
 } RBinSymbol;
 
 typedef struct r_bin_import_t {
@@ -539,6 +565,7 @@ R_API bool r_bin_lang_cxx(RBinFile *binfile);
 R_API bool r_bin_lang_msvc(RBinFile *binfile);
 R_API bool r_bin_lang_dlang(RBinFile *binfile);
 R_API bool r_bin_lang_rust(RBinFile *binfile);
+R_API const char *r_bin_get_meth_flag_string(ut64 flag, bool compact);
 
 R_API RList* r_bin_get_entries(RBin *bin);
 R_API RList* r_bin_get_fields(RBin *bin);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -485,6 +485,8 @@ typedef struct r_core_bin_filter_t {
 R_API int r_core_bin_info (RCore *core, int action, int mode, int va, RCoreBinFilter *filter, const char *chksum);
 R_API int r_core_bin_set_arch_bits (RCore *r, const char *name, const char * arch, ut16 bits);
 R_API int r_core_bin_update_arch_bits (RCore *r);
+R_API char *r_core_bin_method_flags_str(RBinSymbol *sym, int mode);
+
 /* rtr */
 R_API int r_core_rtr_cmds (RCore *core, const char *port);
 R_API char *r_core_rtr_cmds_query (RCore *core, const char *host, const char *port, const char *cmd);


### PR DESCRIPTION
- a superset of method flags is defined with R_BIN_METH_* constants
- a new field, RBinSymbol->method_flags holds them
- every parser can expose them
- they show up in `ic` commands and VB, either in compact form, JSON and r2 commands
- exposed them for objc and dex

This is meant to close https://github.com/radare/radare2/issues/5467

Added tests in https://github.com/radare/radare2-regressions/pull/796 (to be merged after this)

ObjC Example:

```
$ r2 bins/mach0/TestMethods
[0x100006af4]> icj ViewController~{}
{
  "class": "ViewController",
  "methods": [
    {
      "name": "viewDidLoad",
      "flags": [

      ],
      "vaddr": 4294993772
    },
    {
      "name": "didReceiveMemoryWarning",
      "flags": [

      ],
      "vaddr": 4294993872
    },
    {
      "name": "thisIsAClassMethod",
      "flags": [
        "class"
      ],
      "vaddr": 4294993852
    },
    {
      "name": "andAnotherOne",
      "flags": [
        "class"
      ],
      "vaddr": 4294993952
    }
  ]
}
[0x100006af4]> ic ViewController
class ViewController
0x10000676c method ViewController      viewDidLoad
0x1000067d0 method ViewController      didReceiveMemoryWarning
0x1000067bc method ViewController c    thisIsAClassMethod
0x100006820 method ViewController c    andAnotherOne

[0x100006af4]> ic*~ViewController
f class.ViewController = 0x10000676c
f method.ViewController.viewDidLoad = 0x10000676c
f method.ViewController.didReceiveMemoryWarning = 0x1000067d0
f method.class.ViewController.thisIsAClassMethod = 0x1000067bc
f method.class.ViewController.andAnotherOne = 0x100006820
```

DEX Example:

```
$ r2 bins/dex/Hello.dex
[0x000001c0]> icj~{}
[
  {
    "classname": "LHello",
    "addr": 372,
    "index": 0,
    "methods": [
      {
        "name": "LHello.method.<init>(Ljava/lang/String;)V",
        "flags": [
          "public",
          "constructor"
        ],
        "addr": 420
      },
      {
        "name": "LHello.method.main([Ljava/lang/String;)V",
        "flags": [
          "static",
          "public"
        ],
        "addr": 448
      },
      {
        "name": "LHello.method.say()V",
        "flags": [
          "public"
        ],
        "addr": 488
      }
    ]
  }
]
[0x000001c0]> ic
0x00000174 [0x000001a4 - 0x0000021e] (sz 122) class 0 LHello
0x000001a4 method 0 pC   LHello.method.<init>(Ljava/lang/String;)V
0x000001c0 method 1 sp   LHello.method.main([Ljava/lang/String;)V
0x000001e8 method 2 p    LHello.method.say()V

[0x000001c0]> ic*
fs classes
f class.LHello = 0x1a4
f method.public.constructor.LHello.LHello.method.<init>(Ljava/lang/String;)V = 0x1a4
f method.static.public.LHello.LHello.method.main([Ljava/lang/String;)V = 0x1c0
f method.public.LHello.LHello.method.say()V = 0x1e8
```