### PR TITLE
grep: Fix ~[x] with x higher than the total number of columns

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -574,7 +574,7 @@ R_API int r_cons_grep_line(char *buf, int len) {
 					if (!(*out)) {
 						free (in);
 						free (out);
-						return -1;
+						return 0;
 					} else {
 						break;
 					}


### PR DESCRIPTION
For example, "ii~[2]" didn't filter anything at all because the first row only has one column