### PR TITLE
r_str_utf16_encode: escape backslash characters too

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2100,7 +2100,10 @@ R_API char *r_str_utf16_encode (const char *s, int len) {
 		return NULL;
 	}
 	for (i = 0; i < len; s++, i++) {
-		if ((*s >= 0x20) && (*s <= 126)) {
+		if (*s == '\\') {
+			*d++ = '\\';
+			*d++ = '\\';
+		} else if ((*s >= 0x20) && (*s <= 126)) {
 			*d++ = *s;
 		} else {
 			*d++ = '\\';


### PR DESCRIPTION
That function emits backslash escaped unicode sequences, so backslashes
should be escaped too. This fixes invalid json issues in /j

Fixes #7282 

Tests https://github.com/radare/radare2-regressions/pull/802