### PR TITLE
Fix escaping of JSON unicode literals

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -52,7 +52,7 @@ static void pair_str(const char *a, const char *b, int mode, int last) {
 		if (!b) {
 			b = "";
 		}
-		char *eb = r_str_escape (b);
+		char *eb = r_str_utf16_encode (b, -1);
 		if (eb) {
 			pair (a, sdb_fmt (0, "\"%s\"", eb), mode, last);
 			free (eb);

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -101,7 +101,7 @@ static void r_core_file_info(RCore *core, int mode) {
 			}
 		}
 		{
-			char *escapedFile = r_str_escape (uri);
+			char *escapedFile = r_str_utf16_encode (uri, -1);
 			r_cons_printf (",\"file\":\"%s\"", escapedFile);
 			free (escapedFile);
 		}

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -395,12 +395,8 @@ static int __cb_hit(RSearchKeyword *kw, void *user, ut64 addr) {
 			if (!first_hit) {
 				r_cons_printf (",");
 			}
-			char *es = r_str_escape (s);
-			if (es) {
-				r_cons_printf ("{\"offset\": %"PFMT64d ",\"id:\":%d,\"type\":\"%s\",\"data\":\"%s\"}",
-					base_addr + addr, kw->kwidx, type, es);
-				free (es);
-			}
+			r_cons_printf ("{\"offset\": %"PFMT64d ",\"id:\":%d,\"type\":\"%s\",\"data\":\"%s\"}",
+				base_addr + addr, kw->kwidx, type, s);
 		} else {
 			r_cons_printf ("0x%08"PFMT64x " %s%d_%d %s\n",
 				base_addr + addr, searchprefix, kw->kwidx, kw->count, s);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1213,12 +1213,8 @@ static char *r_str_escape_(const char *buf, const int dot_nl) {
 			*q++ = 'r';
 			break;
 		case '\\':
-			if (p[1] == 'u') {
-				*q++ = *p;
-			} else {
-				*q++ = '\\';
-				*q++ = '\\';
-			}
+			*q++ = '\\';
+			*q++ = '\\';
 			break;
 		case '\t':
 			*q++ = '\\';
@@ -2103,7 +2099,10 @@ R_API char *r_str_utf16_encode (const char *s, int len) {
 		return NULL;
 	}
 	for (i = 0; i < len; s++, i++) {
-		if (((*s >= 0x20) && (*s <= 126)) || (*s == '\\' && s[1] == 'u')) {
+		if (*s == '\\') {
+			*d++ = '\\';
+			*d++ = '\\';
+		} else if ((*s >= 0x20) && (*s <= 126)) {
 			*d++ = *s;
 		} else {
 			*d++ = '\\';


### PR DESCRIPTION
- revert 5f1efc9d (which adds double escaping with r_str_escape),
- re-apply 1c6a3138 (my previous commit)
- fix the recent commits 69a7e122 and 04ad4dcf to use `r_str_utf16_encode` instead of `r_str_escape` since the former produces "\u0000" and the latter produces "\x00" which is not valid JSON

-----

See this comment for the full rationale https://github.com/radare/radare2/issues/7282#issuecomment-294408136

Behavior of /j with this PR (same as my previous PR, #7288):

```
[0x00000000]> wx 005c
[0x00000000]> /j \x00\\
[{"offset": 0,"id:":0,"data":"\u0000\\"}]
```

Behavior of /j without this PR (current master, wrong)

```
[0x00000000]> wx 005c
[0x00000000]> /j \x00\\
[{"offset": 0,"id:":0,"data":"\\u0000\\"}]
```

Detail on the "not valid JSON" comment above, using node 7.7.1:

```
> JSON.parse('"\\x00"')
SyntaxError: Unexpected token x in JSON at position 2

> JSON.parse('"\\u0000"')
'\u0000'
```