### PR TITLE
Fix JSON printing of exports

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1598,6 +1598,7 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 	RListIter *iter;
 	RList *symbols;
 	const char *lang;
+	bool firstexp = true;
 	int i = 0, is_arm, lastfs = 's',
 	    bin_demangle = r_config_get_i (r->config, "bin.demangle");
 	if (!info) {
@@ -1727,7 +1728,7 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 				"\"type\":\"%s\","
 				"\"vaddr\":%"PFMT64d","
 				"\"paddr\":%"PFMT64d"}",
-				iter->p?",":"", str,
+				(exponly && firstexp) ? "" : (iter->p ? "," : ""), str,
 				sn.demname? sn.demname: "",
 				sn.nameflag,
 				(int)symbol->size,
@@ -1799,6 +1800,9 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 		}
 		snFini (&sn);
 		i++;
+		if (exponly && firstexp) {
+			firstexp = false;
+		}
 	}
 
 	//handle thumb and arm for entry point since they are not present in symbols


### PR DESCRIPTION
Bug fix when printing exports.

If the first exported symbol occurs *after* a non-exported symbol (i.e. `exponly && !isAnExport (symbol)` returns `true`), then `iter->p` will be non-`NULL`. This causes a "," to be printed *before* the first element of the JSON list, which is not valid JSON.