### PR TITLE
Fix wrong version after sys/build.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ distclean mrproper:
 	rm -f libr/libr.a
 	for DIR in libr binr shlr ; do ( cd "$$DIR" ; ${MAKE} mrproper) ; done
 	rm -f config-user.mk plugins.cfg libr/config.h
-	rm -f libr/include/r_userconf.h libr/config.mk
+	rm -f libr/include/r_userconf.h libr/include/r_version.h libr/config.mk
 	rm -f pkgcfg/*.pc
 
 pkgcfg:


### PR DESCRIPTION
Delete libr/include/r_version.h in distclean mrproper target so it will
be generated again with the current data