### PR TITLE
Fixed what caused #7268

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3687,7 +3687,7 @@ toro:
 
 		if (ds->show_comments && !ds->show_comment_right) {
 			ds_show_refs (ds);
-			// ds_build_op_str (ds);
+			ds_build_op_str (ds);
 			ds_print_ptr (ds, len + 256, idx);
 			if (!ds->pseudo) {
 				R_FREE (ds->opstr);

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1659,6 +1659,7 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 			for (++i; p[i] && p[i] != 'm'; i++) {
 				o[j] = p[i];
 			}
+			j--;
 			continue;
 #else
 			/* copy until 'm' */


### PR DESCRIPTION
`j` should stay put despite the `continue`.