### PR TITLE
Do not fail if vFile:fstat is not implemented on the remote side

### DIFF
--- a/shlr/gdb/src/messages.c
+++ b/shlr/gdb/src/messages.c
@@ -120,7 +120,13 @@ int handle_fOpen(libgdbr_t *g) {
 }
 
 int handle_fstat(libgdbr_t *g) {
-	if (!*g->data || g->data[0] != 'F' || g->data[1] == '-') {
+	// no data just mean this is not supported by gdb
+	if (!*g->data) {
+        send_ack (g);
+        return 0;
+    }
+
+    if (g->data[0] != 'F' || g->data[1] == '-') {
 		send_ack (g);
 		return -1;
 	}


### PR DESCRIPTION
See handle_vFile in ./gdb/gdbserver/hostio.c in gdb git, and the documentation
https://sourceware.org/gdb/onlinedocs/gdb/Host-I_002fO-Packets.html#Host-I_002fO-Packets

         An empty response indicates that this operation is not recognized.

vFile:fstat is not supported by gdb 7.6.1, shipped on RHEL 7, for example.