### PR TITLE
Use the defined structure for r_debug_plugin_t

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -733,7 +733,7 @@ static int r_debug_gdb_breakpoint (RBreakpointItem *bp, int set, void *user) {
 	return !ret;
 }
 
-struct r_debug_plugin_t r_debug_plugin_gdb = {
+RDebugPlugin r_debug_plugin_gdb = {
 	.name = "gdb",
 	/* TODO: Add support for more architectures here */
 	.license = "LGPL3",


### PR DESCRIPTION
This should change nothing, just bring some consistency in
the codebase with others debug plugins.