### PR TITLE
Fix ahi s regression

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -750,7 +750,7 @@ static void ds_build_op_str(RDisasmState *ds) {
 					core->parser->relsub_addr = num;
 				}
 			}
-			r_parse_filter (core->parser, core->flags, asm_str, ds->str, sizeof (ds->str), core->print->big_endian);
+			r_parse_filter (core->parser, core->flags, ds->opstr, ds->str, sizeof (ds->str), core->print->big_endian);
 			core->parser->flagspace = ofs;
 			free (ds->opstr);
 			ds->opstr = strdup (ds->str);


### PR DESCRIPTION
In radare/radare2@d9d83914 the fix for "r_parse_filter output for pc relative addrs when color is involved" broke the ahi command in some contexts.
This (tries to) fix #7315 