### PR TITLE
Added ev and evj command

### DIFF
--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -170,9 +170,6 @@ R_API void r_config_list(RConfig *cfg, const char *str, int rad) {
 		pfx = "\"e ";
 		sfx = "\"";
 	/* fallthrou */
-	case 'v':
-		verbose = true;
-	/* fallthrou */
 	case 0:
 		r_list_foreach (cfg->nodes, iter, node) {
 			if (!str || (str && (!strncmp (str, node->name, len)))) {
@@ -187,6 +184,14 @@ R_API void r_config_list(RConfig *cfg, const char *str, int rad) {
 					cfg->cb_printf ("%20s: %s\n", node->name,
 						node->desc? node->desc: "");
 				}
+			}
+		}
+		break;
+	case 'v':
+		verbose = true;
+		r_list_foreach (cfg->nodes, iter, node) {
+			if (!str || (str && (!strncmp (str, node->name, len)))) {
+				config_print_node (cfg, node, pfx, sfx, verbose, json);
 			}
 		}
 		break;

--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -49,23 +49,23 @@ R_API void r_config_node_free(void *n) {
 
 static void config_print_value_json(RConfig *cfg, RConfigNode *node) {
 	const char *val = node->value;
+	if (!val) {
+		val = "0";
+	}
+	const char *sval = r_str_escape (val);
 	if (node->flags & CN_BOOL || node->flags & CN_INT || node->flags & CN_OFFT) {
-		if (!val) {
-			val = "0";
-		}
 		if (!strncmp (val, "0x", 2)) {
 			ut64 n = r_num_get (NULL, val);
 			cfg->cb_printf ("%"PFMT64d, n);
 		} else if (r_str_isnumber (val) || !strcmp (val, "true") || !strcmp (val, "false")) {
 			cfg->cb_printf ("%s", val);
 		} else {
-			char *sval = r_str_escape (val);
 			cfg->cb_printf ("\"%s\"", sval);
-			free (sval);
 		}
 	} else {
-		cfg->cb_printf ("\"%s\"", val);
+		cfg->cb_printf ("\"%s\"", sval);
 	}
+	free (sval);
 }
 
 static void config_print_node(RConfig *cfg, RConfigNode *node, const char *pfx, const char *sfx, bool verbose, bool json) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -5,11 +5,23 @@
 #define NODECB(w,x,y) r_config_set_cb(cfg,w,x,y)
 #define NODEICB(w,x,y) r_config_set_i_cb(cfg,w,x,y)
 #define SETDESC(x,y) r_config_node_desc(x,y)
-#define SETOPTION(x,y) r_list_append((x)->options,strdup(y))
+#define SETOPTIONS(x, ...) set_options(x, __VA_ARGS__)
 #define SETI(x,y,z) SETDESC(r_config_set_i(cfg,x,y), z);
 #define SETICB(w,x,y,z) SETDESC(NODEICB(w,x,y), z);
 #define SETPREF(x,y,z) SETDESC(r_config_set(cfg,x,y), z);
 #define SETCB(w,x,y,z) SETDESC(NODECB(w,x,y), z);
+
+static void set_options(RConfigNode *node, ...) {
+	va_list argp;
+	char *option = NULL;
+	va_start (argp, node);
+	option = va_arg (argp, char *);
+	while (option) {
+		r_list_append (node->options, strdup (option));
+		option = va_arg (argp, char *);
+	}
+	va_end (argp);
+}
 
 /* TODO: use loop here */
 /*------------------------------------------------------------------------------------------*/
@@ -2016,9 +2028,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB("dbg.forks", "false", &cb_dbg_forks, "Stop execution if fork() is done (see dbg.threads)");
 	n = NODECB("dbg.btalgo", "fuzzy", &cb_dbg_btalgo);
 	SETDESC(n, "Select backtrace algorithm");
-	SETOPTION(n, "default");
-	SETOPTION(n, "fuzzy");
-	SETOPTION(n, "anal");
+	SETOPTIONS(n, "default", "fuzzy", "anal", NULL);
 	SETCB("dbg.threads", "false", &cb_stopthreads, "Stop all threads when debugger breaks (see dbg.forks)");
 	SETCB("dbg.clone", "false", &cb_dbg_clone, "Stop execution if new thread is created");
 	SETCB("dbg.aftersyscall", "true", &cb_dbg_aftersc, "Stop execution before the syscall is executed (see dcs)");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2,10 +2,14 @@
 
 #include <r_core.h>
 
-#define SETI(x,y,z) r_config_node_desc(r_config_set_i(cfg,x,y), z);
-#define SETICB(w,x,y,z) r_config_node_desc(r_config_set_i_cb(cfg,w,x,y), z);
-#define SETPREF(x,y,z) r_config_node_desc(r_config_set(cfg,x,y), z);
-#define SETCB(w,x,y,z) r_config_node_desc(r_config_set_cb(cfg,w,x,y), z);
+#define NODECB(w,x,y) r_config_set_cb(cfg,w,x,y)
+#define NODEICB(w,x,y) r_config_set_i_cb(cfg,w,x,y)
+#define SETDESC(x,y) r_config_node_desc(x,y)
+#define SETOPTION(x,y) r_list_append((x)->options,strdup(y))
+#define SETI(x,y,z) SETDESC(r_config_set_i(cfg,x,y), z);
+#define SETICB(w,x,y,z) SETDESC(NODEICB(w,x,y), z);
+#define SETPREF(x,y,z) SETDESC(r_config_set(cfg,x,y), z);
+#define SETCB(w,x,y,z) SETDESC(NODECB(w,x,y), z);
 
 /* TODO: use loop here */
 /*------------------------------------------------------------------------------------------*/
@@ -788,7 +792,11 @@ static int cb_dbg_btalgo(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
 	if (*node->value == '?') {
-		r_cons_printf ("default\nfuzzy\nanal\n");
+		RListIter *iter;
+		char *option;
+		r_list_foreach (node->options, iter, option) {
+			r_cons_printf ("%s\n", option);
+		}
 		return false;
 	}
 	free (core->dbg->btalgo);
@@ -1740,6 +1748,7 @@ static char *getViewerPath() {
 R_API int r_core_config_init(RCore *core) {
 	int i;
 	char buf[128], *p, *tmpdir;
+	RConfigNode *n;
 	RConfig *cfg = core->config = r_config_new (core);
 	if (!cfg) {
 		return 0;
@@ -2005,7 +2014,11 @@ R_API int r_core_config_init(RCore *core) {
 
 	SETPREF("dbg.bpinmaps", "true", "Force breakpoints to be inside a valid map");
 	SETCB("dbg.forks", "false", &cb_dbg_forks, "Stop execution if fork() is done (see dbg.threads)");
-	SETCB("dbg.btalgo", "fuzzy", &cb_dbg_btalgo, "Select backtrace algorithm");
+	n = NODECB("dbg.btalgo", "fuzzy", &cb_dbg_btalgo);
+	SETDESC(n, "Select backtrace algorithm");
+	SETOPTION(n, "default");
+	SETOPTION(n, "fuzzy");
+	SETOPTION(n, "anal");
 	SETCB("dbg.threads", "false", &cb_stopthreads, "Stop all threads when debugger breaks (see dbg.forks)");
 	SETCB("dbg.clone", "false", &cb_dbg_clone, "Stop execution if new thread is created");
 	SETCB("dbg.aftersyscall", "true", &cb_dbg_aftersc, "Stop execution before the syscall is executed (see dcs)");

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -214,6 +214,24 @@ static int cmd_eval(void *data, const char *input) {
 	case 'j': // json
 		r_config_list (core->config, NULL, 'j');
 		break;
+	case 'v': // verbose
+		switch (input[1]) {
+		default:
+			if (strlen (input) > 2) {
+				r_config_list (core->config, input + 2, 'v');
+			} else {
+				r_config_list (core->config, NULL, 'v');
+			}
+			break;
+		case 'j':
+			if (strlen (input) > 3) {
+				r_config_list (core->config, input + 3, 'J');
+			} else {
+				r_config_list (core->config, NULL, 'J');
+			}
+			break;
+		}
+		break;
 	case 'q': // quiet list of eval keys
 		r_config_list (core->config, NULL, 'q');
 		break;
@@ -351,7 +369,6 @@ static int cmd_eval(void *data, const char *input) {
 		r_core_config_init (core);
 		//eprintf ("BUG: 'e-' command locks the eval hashtable. patches are welcome :)\n");
 		break;
-	case 'v': eprintf ("Invalid command '%s'. Use 'e?'\n", input); break;
 	case '*': r_config_list (core->config, NULL, 1); break;
 	case '?':
 		switch (input[1]) {
@@ -362,7 +379,7 @@ static int cmd_eval(void *data, const char *input) {
 			"Usage:", "e [var[=value]]", "Evaluable vars",
 			"e","?asm.bytes", "show description",
 			"e", "??", "list config vars with description",
-			"e", "", "list config vars",
+			"e|ej", "", "list config vars (in JSON)",
 			"e-", "", "reset config vars",
 			"e*", "", "dump config vars in r commands",
 			"e!", "a", "invert the boolean value of 'a' var",
@@ -370,6 +387,7 @@ static int cmd_eval(void *data, const char *input) {
 			"er", " [key]", "set config key as readonly. no way back",
 			"ec", " [k] [color]", "set color for given key (prompt, offset, ...)",
 			"et", " [key]", "show type of given config variable",
+			"ev|evj", " [key]", "list config vars in verbose format (in JSON)",
 			"e", " a", "get value of var 'a'",
 			"e", " a=b", "set var 'a' the 'b' value",
 			"e var=?", "", "print all valid values of var",

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -215,22 +215,7 @@ static int cmd_eval(void *data, const char *input) {
 		r_config_list (core->config, NULL, 'j');
 		break;
 	case 'v': // verbose
-		switch (input[1]) {
-		default:
-			if (strlen (input) > 2) {
-				r_config_list (core->config, input + 2, 'v');
-			} else {
-				r_config_list (core->config, NULL, 'v');
-			}
-			break;
-		case 'j':
-			if (strlen (input) > 3) {
-				r_config_list (core->config, input + 3, 'J');
-			} else {
-				r_config_list (core->config, NULL, 'J');
-			}
-			break;
-		}
+		r_config_list (core->config, input + 1, 'v');
 		break;
 	case 'q': // quiet list of eval keys
 		r_config_list (core->config, NULL, 'q');
@@ -379,7 +364,7 @@ static int cmd_eval(void *data, const char *input) {
 			"Usage:", "e [var[=value]]", "Evaluable vars",
 			"e","?asm.bytes", "show description",
 			"e", "??", "list config vars with description",
-			"e|ej", "", "list config vars (in JSON)",
+			"ej", "", "list config vars in JSON",
 			"e-", "", "reset config vars",
 			"e*", "", "dump config vars in r commands",
 			"e!", "a", "invert the boolean value of 'a' var",
@@ -387,7 +372,8 @@ static int cmd_eval(void *data, const char *input) {
 			"er", " [key]", "set config key as readonly. no way back",
 			"ec", " [k] [color]", "set color for given key (prompt, offset, ...)",
 			"et", " [key]", "show type of given config variable",
-			"ev|evj", " [key]", "list config vars in verbose format (in JSON)",
+			"ev", " [key]", "list config vars in verbose format",
+			"evj", " [key]", "list config vars in verbose format in JSON",
 			"e", " a", "get value of var 'a'",
 			"e", " a=b", "set var 'a' the 'b' value",
 			"e var=?", "", "print all valid values of var",

--- a/libr/include/r_config.h
+++ b/libr/include/r_config.h
@@ -30,6 +30,7 @@ typedef struct r_config_node_t {
 	RConfigCallback getter;
 	RConfigCallback setter;
 	char *desc;
+	RList *options;
 } RConfigNode;
 
 R_API const char *r_config_node_type(RConfigNode *node);


### PR DESCRIPTION
Added ev and evj command:

```
user@linuxdev radare2-dev $ ./binr/radare2/radare2 --
 -- Find hexpairs with '/x a0 cc 33'
[0x00000000]> ev dbg.bta
dbg.btalgo = fuzzy ; Select backtrace algorithm [default, fuzzy, anal]
[0x00000000]> e dbg.btalgo=?
default
fuzzy
anal
[0x00000000]> evj dbg.bt
[{"name":"dbg.btalgo","value":"fuzzy","type":"str","desc":"Select backtrace algorithm","ro":false,"options":["default","fuzzy","anal"]},{"name":"dbg.btdepth","value":128,"type":"int","desc":"Depth of backtrace","ro":false}]
[0x00000000]> e?
|Usage: e [var[=value]]Evaluable vars
| e?asm.bytes     show description
| e??             list config vars with description
| e|ej            list config vars (in JSON)
| e-              reset config vars
| e*              dump config vars in r commands
| e!a             invert the boolean value of 'a' var
| eevar           open editor to change the value of var
| er [key]        set config key as readonly. no way back
| ec [k] [color]  set color for given key (prompt, offset, ...)
| et [key]        show type of given config variable
| ev|evj [key]    list config vars in verbose format (in JSON)
| e a             get value of var 'a'
| e a=b           set var 'a' the 'b' value
| e var=?         print all valid values of var
| env [k[=v]]     get/set environment variable
[0x00000000]>
```

Also added `RList *options` to RConfigNode and reworked dbg.btalgo in cconfig.c.

If this gets merged I can also follow up with reworking the rest of cconfig!