### PR TITLE
Fix: avoid modifying symbol names in bin/filter

### DIFF
--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -67,14 +67,7 @@ R_API void r_bin_filter_sym(Sdb *db, ut64 vaddr, RBinSymbol *sym) {
 	if (vaddr) {
 		//hashify (name, vaddr);
 	}
-	if (count > 1) {
-		char *nstr = r_str_newf ("%s_%d", sym->name, count - 1);
-		//this leaks but for security reasons until refactored
-		//the problem is only with ELF's relocs though 
-		//complains go to alvarofe
-		//free (sym->name);
-		sym->name = nstr;
-	}
+    sym->dup_count = count - 1;
 }
 
 R_API void r_bin_filter_symbols(RList *list) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1564,7 +1564,11 @@ static void snInit(RCore *r, SymName *sn, RBinSymbol *sym, const char *lang) {
 	if (!r || !sym || !sym->name) return;
 	pfx = getPrefixFor (sym->type);
 	sn->name = strdup (sym->name);
-	sn->nameflag = r_str_newf ("%s.%s", pfx, sym->name);
+	if (sym->dup_count) {
+		sn->nameflag = r_str_newf ("%s.%s_%d", pfx, sym->name, sym->dup_count);
+	} else {
+		sn->nameflag = r_str_newf ("%s.%s", pfx, sym->name);
+	}
 	r_name_filter (sn->nameflag, MAXFLAG_LEN);
 	if (sym->classname && sym->classname[0]) {
 		sn->classname = strdup (sym->classname);
@@ -1780,11 +1784,21 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 				lastfs = 's';
 			}
 			if (r->bin->prefix) {
-				r_cons_printf ("f %s.sym.%s %u 0x%08"PFMT64x"\n",
+				if (symbol->dup_count) {
+					r_cons_printf ("f %s.sym.%s_%d %u 0x%08"PFMT64x"\n",
+						r->bin->prefix, name, symbol->dup_count, symbol->size, addr);
+				} else {
+					r_cons_printf ("f %s.sym.%s %u 0x%08"PFMT64x"\n",
 						r->bin->prefix, name, symbol->size, addr);
+				}
 			} else {
-				r_cons_printf ("f sym.%s %u 0x%08"PFMT64x"\n",
+				if (symbol->dup_count) {
+					r_cons_printf ("f sym.%s_%d %u 0x%08"PFMT64x"\n",
+						name, symbol->dup_count, symbol->size, addr);
+				} else {
+					r_cons_printf ("f sym.%s %u 0x%08"PFMT64x"\n",
 						name, symbol->size, addr);
+				}
 			}
 			binfile = r_core_bin_cur (r);
 			plugin = r_bin_file_cur_plugin (binfile);

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -422,6 +422,7 @@ typedef struct r_bin_symbol_t {
 	int bits;
 	/* see R_BIN_METH_* constants */
 	ut64 method_flags;
+	int dup_count;
 } RBinSymbol;
 
 typedef struct r_bin_import_t {


### PR DESCRIPTION
- the duplication count is stored in RBinSymbol and used when emitting flags
- for class method names this duplication count is ignored, since the flag generation already prepends the class name to account for uniqueness
- bring back the duplication count for obj. / loc. / sym. flags and in is*
- in all other places (lists, midflags, ic, etc) the "real" names are shown instead

Related test changes: https://github.com/radare/radare2-regressions/pull/831