### PR TITLE
Add internal flags setting for esil_sub

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1049,10 +1049,10 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 	case ARM64_INS_CMN: // cmp w8, 0xd
 		// update esil, cpu flags
 		if (ISIMM64(1)) {
-			r_strbuf_setf (&op->esil, "%"PFMT64d",%s,-,$z,zf,=,$s,nf,=,$b%d,cf,=,$o,vf,=", IMM64(1), REG64(0), 64);
+			r_strbuf_setf (&op->esil, "%"PFMT64d",%s,-,$z,zf,=,$s,nf,=,$b%d,cf,=,$o,vf,=", IMM64(1), REG64(0), arm64_reg_width(insn->id));
 		} else {
 			// cmp w10, w11
-			r_strbuf_setf (&op->esil, "%s,%s,-,$z,zf,=,$s,nf,=,$b%d,cf,=,$o,vf,=", REG64(1), REG64(0), 32);
+			r_strbuf_setf (&op->esil, "%s,%s,-,$z,zf,=,$s,nf,=,$b%d,cf,=,$o,vf,=", REG64(1), REG64(0), arm64_reg_width(insn->id));
 		}
 		break;
 	case ARM64_INS_FCSEL:


### PR DESCRIPTION
I did this because https://github.com/radare/radare2/commit/7c96bca8095ca380e9770b02b53ddbc3a5cddedd broke my `csel` test (https://github.com/radare/radare2-regressions/blob/master/t.esil/arm-64#L553) and it turns out the reason is `esil_sub` didn't set `esil->cur` and `esil->lastsz` properly.

/cc @XVilka 