### PR TITLE
Reorder includes to provide missing BIGNUM definition

### DIFF
--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -12,6 +12,13 @@
 #include <r_th.h>
 #if !__WINDOWS__
 #include <dirent.h>
+#include <signal.h>
+#endif
+#ifdef HAVE_LIB_GMP
+#include <gmp.h>
+#endif
+#if HAVE_LIB_SSL
+#include <openssl/bn.h>
 #endif
 #include <sys/time.h>
 #include "r_util/r_big.h"
@@ -50,15 +57,6 @@
 #include "r_util/r_asn1.h"
 #include "r_util/r_x509.h"
 #include "r_util/r_pkcs7.h"
-#if __UNIX__
-#include <signal.h>
-#endif
-#ifdef HAVE_LIB_GMP
-#include <gmp.h>
-#endif
-#if HAVE_LIB_SSL
-#include <openssl/bn.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Since fa671b9a162cce32e13b0186066b709d7ce4734e the order of includes in `libr/includes/r_util.h` appears to break `--with-openssl` builds since `BIGNUM` is not already defined by the time it is used in `r_big.h`.

Edit: Not sure if build with OpenSSL is even useful or not, but PKGBUILD in ArchLinux AUR uses that flag.