### PR TITLE
fix msvc

### DIFF
--- a/libr/bin/format/coff/coff_specs.h
+++ b/libr/bin/format/coff/coff_specs.h
@@ -129,6 +129,7 @@
 #define COFF_SYM_CLASS_WEAK_EXTERNAL	105
 #define COFF_SYM_CLASS_CLR_TOKEN	107
 
+R_PACKED(
 struct coff_hdr {
 	ut16 f_magic;	/* Magic number */	
 	ut16 f_nscns;	/* Number of Sections */
@@ -137,8 +138,9 @@ struct coff_hdr {
 	ut32 f_nsyms;	/* Number of Symbols */
 	ut16 f_opthdr;	/* sizeof(Optional Header) */
 	ut16 f_flags;	/* Flags */
-} __attribute__((packed));
+});// __attribute__ ((packed));
 
+R_PACKED (
 struct coff_opt_hdr {
 	ut16 magic;			/* Magic Number                    */
 	ut16 vstamp;		/* Version stamp                   */
@@ -148,8 +150,9 @@ struct coff_opt_hdr {
 	ut32 entry;			/* Entry point                     */
 	ut32 text_start;	/* Base of Text used for this file */
 	ut32 data_start;	/* Base of Data used for this file */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct coff_scn_hdr {
 	char s_name[8];	/* Section Name */
 	ut32 s_paddr;	/* Physical Address */
@@ -161,8 +164,9 @@ struct coff_scn_hdr {
 	ut16 s_nreloc;	/* Number of Relocation table entries */
 	ut16 s_nlnno;	/* Number of Line Number table entries */
 	ut32 s_flags;	/* Flags for this section */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct coff_symbol {
 	char n_name[8];	/* Symbol Name */
 	ut32 n_value;	/* Value of Symbol */
@@ -170,12 +174,12 @@ struct coff_symbol {
 	ut16 n_type;	/* Symbol Type */
 	ut8 n_sclass;	/* Storage Class */
 	ut8 n_numaux;	/* Auxiliary Count */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct coff_reloc {
 	ut32 r_vaddr;	/* Reference Address */
 	ut32 r_symndx;	/* Symbol index */
 	ut16 r_type;	/* Type of relocation */
-} __attribute__((packed));
-
+});
 #endif /* COFF_SPECS_H */

--- a/libr/bin/format/nes/nes_specs.h
+++ b/libr/bin/format/nes/nes_specs.h
@@ -61,7 +61,8 @@
 #define JOYPAD_PORT1                        0x4016
 #define JOYPAD_PORT2                        0x4017
 
-typedef struct __attribute__((__packed__)) {
+R_PACKED (
+typedef struct  {
 	char id[0x4];					// NES\x1A
 	ut8 prg_page_count_16k;				 // number of PRG-ROM pages
 	ut8 chr_page_count_8k;				// number of CHR-ROM pages
@@ -69,6 +70,6 @@ typedef struct __attribute__((__packed__)) {
 	ut8 rom_control_byte_1;				 // flags describing ROM image
 	ut8 ram_bank_count_8k;				// size of PRG RAM
 	ut8 reserved[7];				// zero filled
-} ines_hdr;
+}) ines_hdr;
 
 #endif // _NES_H

--- a/libr/bin/format/nin/n3ds.h
+++ b/libr/bin/format/nin/n3ds.h
@@ -8,7 +8,7 @@ More formats to support: https://www.3dbrew.org/wiki/Category:File_formats
 #define NIN_N3DS_H
 
 #include <r_types_base.h>
-
+R_PACKED (
 struct n3ds_firm_sect_hdr
 {
 	ut32 offset;
@@ -16,8 +16,9 @@ struct n3ds_firm_sect_hdr
 	ut32 size;
 	ut32 type; /* ('0'=ARM9/'1'=ARM11) */
 	ut8 sha256[0x20];
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct n3ds_firm_hdr
 {
 	ut8 magic[4];
@@ -27,7 +28,7 @@ struct n3ds_firm_hdr
 	ut8 reserved2[0x30];
 	struct n3ds_firm_sect_hdr sections[4];
 	ut8 rsa2048[0x100];
-} __attribute__((packed));
+});
 
 #endif /* NIN_N3DS_H */
 

--- a/libr/bin/format/nin/nds.h
+++ b/libr/bin/format/nin/nds.h
@@ -9,6 +9,7 @@ http://sourceforge.net/p/devkitpro/ndstool/ci/master/tree/source/header.h
 
 #include <r_types_base.h>
 
+R_PACKED (
 struct nds_hdr
 {
     st8 title[0xC];
@@ -68,7 +69,7 @@ struct nds_hdr
     ut16 logo_crc;
     ut16 header_crc;
 
-} __attribute__((packed));
+});
 
 #endif /* NIN_NDS_H */
 

--- a/libr/bin/format/sfc/sfc_specs.h
+++ b/libr/bin/format/sfc/sfc_specs.h
@@ -42,7 +42,8 @@
 #define EXTRAM_START_ADDRESS		    0x7E8000
 #define EXTRAM_SIZE			    0x18000
 
-typedef struct __attribute__((__packed__)) {
+R_PACKED (
+typedef struct {
 	char name[0x15];	//game title.
 	ut8 rom_setup;		//ROM setup (LoROM/HiROM, etc.)
 	ut8 rom_type;	
@@ -53,6 +54,6 @@ typedef struct __attribute__((__packed__)) {
 	ut8 rom_version;
 	ut16 comp_check;	//should be equal to ~checksum
 	ut16 checksum;
-} sfc_int_hdr;
+}) sfc_int_hdr;
 
 #endif // _SFC_SPECS_H

--- a/libr/bin/format/spc700/spc_specs.h
+++ b/libr/bin/format/spc700/spc_specs.h
@@ -23,7 +23,8 @@ typedef enum {
 	SNES9X,
 } emulator_used;
 
-typedef struct __attribute__((__packed__)) { //SNES9x
+R_PACKED(
+typedef struct { //SNES9x
 	char	song_title [32];
 	char	game_title [32];
 	char	name_of_dumper [16];
@@ -35,9 +36,10 @@ typedef struct __attribute__((__packed__)) { //SNES9x
 	bool default_channel_disabled;
 	emulator_used emulator_used[1];
 	ut8 reserved[1];
-} id666_tag_text;
+}) id666_tag_text;
 
-typedef struct __attribute__((__packed__)) { //ZSNES
+R_PACKED (
+typedef struct { //ZSNES
 	char	song_title [32];
 	char	game_title [32];
 	char	name_of_dumper [16];
@@ -49,30 +51,35 @@ typedef struct __attribute__((__packed__)) { //ZSNES
 	char	artist_song [32];
 	bool default_channel_disabled;
 	ut8 reserved[1];
-} id666_tag_binary;
+}) id666_tag_binary;
 
-typedef struct __attribute__((__packed__))	{
+R_PACKED (
+typedef struct 	{
 	char	signature [33];
 	ut8	 signature2 [2];
 	ut8 has_id666;
 	ut8 version;
-} spc_hdr;
+}) spc_hdr;
 
-typedef struct __attribute__((__packed__))	{
-	ut8 pcl, pch;
+R_PACKED (
+typedef struct {
+	ut8 pcl;
+	ut8 pch;
 	ut8 a;
 	ut8 x;
 	ut8 y;
 	ut8 psw;
 	ut8 sp;
-	ut8 reserved_1, reserved_2;
-} spc_reg;
+	ut8 reserved_1;
+	ut8 reserved_2;
+}) spc_reg;
 
-typedef struct __attribute__((__packed__))	{
+R_PACKED (
+typedef struct {
 	ut8 ram [0x10000];
 	ut8 dsp [128];
 	ut8 unused [0x40];
 	ut8 ipl_rom [0x40];
-} spc_data;
+}) spc_data;
 
 #endif // _SPC_H

--- a/libr/bin/format/vsf/vsf_specs.h
+++ b/libr/bin/format/vsf/vsf_specs.h
@@ -8,20 +8,24 @@
 #include <r_bin.h>
 
 /* Snapshot format for VICE: http://vice-emu.sourceforge.net/ */
+
+R_PACKED (
 struct vsf_hdr {
 	char id[19];		/* "VICE Snapshot File" */
 	char major;
 	char minor;
 	char machine[16];	/* "C64" or "C128" or... */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct vsf_module {
 	char module_name[16];	/* looking for "C64MEM", ... */
 	char major;
 	char minor;
 	ut32 length;		/* little endian */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct vsf_maincpu {
 	ut32 clk;		/* CPU clock value */
 	ut8 ac;			/* A */
@@ -32,34 +36,37 @@ struct vsf_maincpu {
 	ut8 st;			/* Status register */
 	ut32 lastopcode;	/* ? */
 	ut32 ba_low_flags;	/* ? */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct vsf_c64mem {
 	ut8 cpudata;		/* CPU port data byte */
 	ut8 cpudir;		/* CPU port direction byte */
 	ut8 exrom;		/* state of the EXROM line (?) */
 	ut8 game;		/* state of the GAME line (?) */
 	ut8 ram[1024 * 64];	/* 64k RAM dump */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct vsf_c64rom {
 	ut8 kernal[1024 * 8];	/* Kernal ROM */
 	ut8 basic[1024 * 8];	/* BASIC  ROM */
 	ut8 chargen[1024 * 4];	/* Charset */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct vsf_c128mem {
 	ut8 mmu[12];		/* dump of the 12 MMU registers */
 	ut8 ram[1024 * 128];	/* 128k RAM dump: banks 0 and 1 */
-} __attribute__((packed));
+});
 
+R_PACKED (
 struct vsf_c128rom {
 	ut8 kernal[1024 * 8];	/* Kernal ROM */
 	ut8 basic[1024 * 32];	/* BASIC  ROM */
 	ut8 editor[1024 * 4];	/* Dump of the editor ROM */
 	ut8 chargen[1024 * 4];	/* Charset */
-} __attribute__((packed));
-
+});
 
 /* Internal structure */
 struct r_bin_vsf_obj {

--- a/libr/bin/format/xbe/xbe.h
+++ b/libr/bin/format/xbe/xbe.h
@@ -11,7 +11,7 @@
 #define XBE_KP_CHIHIRO 0x2290059D
 
 #define XBE_MAX_THUNK 378
-
+R_PACKED(
 typedef struct {
 	ut32 magic;
 	ut8  signature[0x100];
@@ -37,12 +37,13 @@ typedef struct {
 	ut32 kernel_lib_addr;
 	ut32 xapi_lib_addr;
 	ut32 shit[2];
-} __attribute__((packed)) xbe_header;
+}) xbe_header;
+
 
 #define SECT_FLAG_X 0x00000004
 #define SECT_FLAG_W 0x00000001
-
-typedef struct {
+R_PACKED (
+typedef struct  {
 	ut32 flags;
 	ut32 vaddr;
 	ut32 vsize;
@@ -52,13 +53,16 @@ typedef struct {
 	ut32 refcount;
 	ut32 shit[2];
 	ut8  digest[20];
-} __attribute__((packed)) xbe_section;
+}) xbe_section;
 
-typedef struct {
-	char name[8];
-	ut16 major, minor, build;
+R_PACKED (
+typedef struct  {
+	ut8 name[8];
+	ut16 major;
+	ut16 minor;
+	ut16 build;
 	ut16 flags;
-} __attribute__((packed)) xbe_lib;
+}) xbe_lib;
 
 typedef struct {
 	xbe_header *header;

--- a/libr/bin/mangling/cxx/cp-demangle.c
+++ b/libr/bin/mangling/cxx/cp-demangle.c
@@ -5520,8 +5520,13 @@ d_demangle_callback (const char *mangled, int options,
     di.comps = comps;
     di.subs = subs;
 #else
+#ifdef _MSC_VER
+	  di.comps = calloc (di.num_comps * sizeof (*di.comps),1);
+	  di.subs = calloc (di.num_subs * sizeof (*di.subs),1);
+#else
     di.comps = alloca (di.num_comps * sizeof (*di.comps));
     di.subs = alloca (di.num_subs * sizeof (*di.subs));
+#endif	
 #endif
 
     switch (type)
@@ -5799,8 +5804,13 @@ is_ctor_or_dtor (const char *mangled,
     di.comps = comps;
     di.subs = subs;
 #else
-    di.comps = alloca (di.num_comps * sizeof (*di.comps));
-    di.subs = alloca (di.num_subs * sizeof (*di.subs));
+#ifdef _MSC_VER
+	  di.comps = calloc (di.num_comps * sizeof (*di.comps), 1);
+	  di.subs = calloc (di.num_subs * sizeof (*di.subs), 1);
+#else
+	  di.comps = alloca (di.num_comps * sizeof (*di.comps));
+	  di.subs = alloca (di.num_subs * sizeof (*di.subs));
+#endif	
 #endif
 
     dc = cplus_demangle_mangled_name (&di, 1);

--- a/libr/bin/p/bin_bootimg.c
+++ b/libr/bin/p/bin_bootimg.c
@@ -13,6 +13,7 @@ typedef struct boot_img_hdr BootImage;
 #define BOOT_ARGS_SIZE 512
 #define BOOT_EXTRA_ARGS_SIZE 1024
 
+R_PACKED (
 struct boot_img_hdr {
 	ut8 magic[BOOT_MAGIC_SIZE];
 
@@ -35,7 +36,7 @@ struct boot_img_hdr {
 	/* Supplemental command line data; kept here to maintain
 	 * binary compatibility with older versions of mkbootimg */
 	ut8 extra_cmdline[BOOT_EXTRA_ARGS_SIZE];
-} __attribute__((packed));
+});
 
 typedef struct {
 	Sdb *kv;

--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -23,7 +23,8 @@
 #define N_TEXT 7
 #define N_DATA 11
 
-typedef struct __attribute__((packed)) {
+R_PACKED (
+typedef struct {
 	ut32 text_paddr[N_TEXT];
 	ut32 data_paddr[N_DATA];
 	ut32 text_vaddr[N_TEXT];
@@ -35,7 +36,7 @@ typedef struct __attribute__((packed)) {
 	ut32 entrypoint;
 	ut32 padding[10];
 	// 0x100 -- start of data section
-} DolHeader;
+}) DolHeader;
 
 static bool check_bytes(const ut8 *buf, ut64 length) {
 	if (!buf || length < 6) {

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -9,12 +9,15 @@
 
 #define APP_NAME_BYTES 32
 #define COMPANY_NAME_BYTES 32
-typedef struct __attribute__((__packed__)) {
+
+R_PACKED (
+typedef struct  {
 	ut8 major; //!< "compatibility" version number
 	ut8 minor;
-} Version;
+}) Version;
 
-typedef struct __attribute__((__packed__)) {
+R_PACKED (
+typedef struct  {
 	char header[8];                   //!< Sentinal value, should always be 'PBLAPP\0\0'
 	Version struct_version;           //!< version of this structure's format
 	Version sdk_version;              //!< version of the SDK used to build this app
@@ -30,7 +33,7 @@ typedef struct __attribute__((__packed__)) {
 	ut32 reloc_list_start;        //!< The offset of the address relocation list
 	ut32 num_reloc_entries;       //!< The number of entries in the address relocation list
 	ut8 uuid[16];
-} PebbleAppInfo;
+}) PebbleAppInfo;
 
 static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (length > 7 && !memcmp (buf, "PBLAPP\x00\x00", 8));

--- a/libr/bin/p/bin_vsf.c
+++ b/libr/bin/p/bin_vsf.c
@@ -127,10 +127,6 @@ static RList *mem(RBinFile *arch) {
 }
 
 static RList* sections(RBinFile* arch) {
-#ifdef _MSC_VER
-#pragma message ("Windows: WARNING: vsf_sections bypassed !")
-	return NULL;
-#else
 	struct r_bin_vsf_obj* vsf_obj = (struct r_bin_vsf_obj*) arch->o->bin_obj;
 	if (!vsf_obj) {
 		return NULL;
@@ -154,9 +150,9 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "BASIC");
-			ptr->paddr = (vsf_obj->rom +
+			ptr->paddr = ((char *)vsf_obj->rom +
 				      r_offsetof (struct vsf_c64rom, basic)) -
-				     (void *)arch->buf->buf;
+				     (char *)arch->buf->buf;
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xa000;
 			ptr->vsize = 1024 * 8;	// BASIC size (8k)
@@ -169,9 +165,9 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "KERNAL");
-			ptr->paddr = (vsf_obj->rom +
+			ptr->paddr = ((char *)vsf_obj->rom +
 				      r_offsetof (struct vsf_c64rom, kernal)) -
-				     (void *)arch->buf->buf;
+				     (char *)arch->buf->buf;
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8;	// KERNAL size (8k)
@@ -187,9 +183,9 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "BASIC");
-			ptr->paddr = (vsf_obj->rom +
+			ptr->paddr = ((char *)vsf_obj->rom +
 				      r_offsetof (struct vsf_c128rom, basic)) -
-				     (void *)arch->buf->buf;
+				     (char *)arch->buf->buf;
 			ptr->size = 1024 * 28; // (28k)
 			ptr->vaddr = 0x4000;
 			ptr->vsize = 1024 * 28;	// BASIC size (28k)
@@ -203,9 +199,9 @@ static RList* sections(RBinFile* arch) {
 			}
 			strcpy (ptr->name, "MONITOR");
 			// skip first 28kb  since "BASIC" and "MONITOR" share the same section in VSF
-			ptr->paddr = (vsf_obj->rom +
+			ptr->paddr = ((char *)vsf_obj->rom +
 				      r_offsetof (struct vsf_c128rom, basic)) +
-				     1024 * 28 - (void *)arch->buf->buf;
+				     1024 * 28 - (char *)arch->buf->buf;
 			ptr->size = 1024 * 4; // (4k)
 			ptr->vaddr = 0xb000;
 			ptr->vsize = 1024 * 4;	// BASIC size (4k)
@@ -218,9 +214,9 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "EDITOR");
-			ptr->paddr = (vsf_obj->rom +
+			ptr->paddr = ((char *)vsf_obj->rom +
 				      r_offsetof (struct vsf_c128rom, editor)) -
-				     (void *)arch->buf->buf;
+				     (char *)arch->buf->buf;
 			ptr->size = 1024 * 4; // (4k)
 			ptr->vaddr = 0xc000;
 			ptr->vsize = 1024 * 4;	// BASIC size (4k)
@@ -233,9 +229,9 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "KERNAL");
-			ptr->paddr = (vsf_obj->rom +
+			ptr->paddr = ((char *)vsf_obj->rom +
 				      r_offsetof (struct vsf_c128rom, kernal)) -
-				     (void *)arch->buf->buf;
+				     (char *)arch->buf->buf;
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8;	// KERNAL size (8k)
@@ -256,7 +252,7 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "RAM");
-			ptr->paddr = (vsf_obj->mem + offset) - (void*) arch->buf->buf;
+			ptr->paddr = ((char *)vsf_obj->mem + offset) - (char*) arch->buf->buf;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
@@ -273,7 +269,7 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "RAM BANK 0");
-			ptr->paddr = (vsf_obj->mem + offset) - (void*) arch->buf->buf;
+			ptr->paddr = ((char *)vsf_obj->mem + offset) - (char*) arch->buf->buf;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
@@ -285,7 +281,7 @@ static RList* sections(RBinFile* arch) {
 				return ret;
 			}
 			strcpy (ptr->name, "RAM BANK 1");
-			ptr->paddr = (vsf_obj->mem + offset) + size - (void*) arch->buf->buf;
+			ptr->paddr = ((char *)vsf_obj->mem + offset) + size - (char*) arch->buf->buf;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
@@ -296,7 +292,6 @@ static RList* sections(RBinFile* arch) {
 	}
 
 	return ret;
-#endif
 }
 
 static RBinInfo* info(RBinFile *arch) {
@@ -499,12 +494,8 @@ static RList* symbols(RBinFile *arch) {
 		strncpy (ptr->name, _symbols[i].symbol_name, R_BIN_SIZEOF_STRINGS);
 		ptr->vaddr = _symbols[i].address;
 		ptr->size = 2;
-#ifdef _MSC_VER
-#pragma message("Windows: WARNING (TODO): vsf symbols bypassed")
-#else
-		ptr->paddr = (vsf_obj->mem + offset) - (void *)arch->buf->buf +
+		ptr->paddr = ((char *)vsf_obj->mem + offset) - (char *)arch->buf->buf +
 			     _symbols[i].address;
-#endif
 		ptr->ordinal = i;
 		r_list_append (ret, ptr);
 	}
@@ -532,11 +523,7 @@ static RList* entries(RBinFile *arch) {
 	if (!(ptr = R_NEW0 (RBinAddr))) {
 		return ret;
 	}
-#ifdef _MSC_VER
-#pragma message("Windows: WARNING (TODO): vsf entries bypassed")
-#else
-	ptr->paddr = (vsf_obj->mem + offset) - (void*) arch->buf->buf;
-#endif
+	ptr->paddr = ((char *)vsf_obj->mem + offset) - (char*) arch->buf->buf;
 	ptr->vaddr = vsf_obj->maincpu ? vsf_obj->maincpu->pc : 0;
 	r_list_append (ret, ptr);
 

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -947,7 +947,6 @@ R_API bool r_cons_isatty() {
 // XXX: if this function returns <0 in rows or cols expect MAYHEM
 R_API int r_cons_get_size(int *rows) {
 #if __WINDOWS__ && !__CYGWIN__
-	char buffer[1024];
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 	GetConsoleScreenBufferInfo (GetStdHandle (STD_OUTPUT_HANDLE), &csbi);
 	I.columns = (csbi.srWindow.Right - csbi.srWindow.Left) - 1;

--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -279,7 +279,6 @@ static int readchar_win() {
 	DWORD mode, out;
 	HANDLE h;
 	INPUT_RECORD irInBuf[128];
-	int dir;
 	int i;
 do_it_again:
 	h = GetStdHandle (STD_INPUT_HANDLE);
@@ -448,7 +447,6 @@ R_API int r_cons_readchar() {
 	HANDLE h = GetStdHandle (STD_INPUT_HANDLE);
 	GetConsoleMode (h, &mode);
 	SetConsoleMode (h, 0); // RAW
-ignore:
 	ret = ReadConsole (h, buf, 1, &out, NULL);
 	FlushConsoleInputBuffer(h);
 	if (!ret)

--- a/libr/cons/rgb.c
+++ b/libr/cons/rgb.c
@@ -173,7 +173,7 @@ R_API char *r_cons_rgb_str (char *outstr, ut8 r, ut8 g, ut8 b, int is_bg) {
 R_API void r_cons_rgb (ut8 r, ut8 g, ut8 b, int is_bg) {
 #if __WINDOWS__ && !__CYGWIN__
 #ifdef _MSC_VER
-#pragma message "r_cons_rgb not yet supported on windows"
+#pragma message ("r_cons_rgb not yet supported on windows")
 #else
 #warning r_cons_rgb not yet supported on windows
 #endif

--- a/libr/crypto/p/crypto_aes_algo.c
+++ b/libr/crypto/p/crypto_aes_algo.c
@@ -41,7 +41,12 @@ void aes_expkey (const struct aes_state *st, ut32 ***expkey)
 	// ut32 expkey[2][st->rounds + 1][Nb];
 	// memcpy (&expkey, _expkey, 2 * (st->rounds + 1) * Nb);
 	int ROUND_KEY_COUNT = 4 * (1 + st->rounds);
-	ut32 tk[st->columns], tt;
+#ifdef _MSC_VER
+	ut32 *tk = (ut32*)malloc (sizeof (ut32) * st->columns);
+#else
+	ut32 tk[st->columns];
+#endif
+	ut32 tt;
 	st32 idx = 0, t = 0;
 	const ut8 *key = st->key;
 	st32 i, j, r;
@@ -106,6 +111,9 @@ void aes_expkey (const struct aes_state *st, ut32 ***expkey)
 				U2[(ut8)(tt >> 8)] ^ U3[(ut8)tt];
 		}
 	}
+#ifdef _MSC_VER
+	free (tk);
+#endif
 }
 
 // Convenience method to encrypt exactly one block of plaintext, assuming
@@ -113,7 +121,11 @@ void aes_expkey (const struct aes_state *st, ut32 ***expkey)
 // in         - The plaintext
 // result     - The ciphertext generated from a plaintext using the key
 void aes_encrypt (struct aes_state *st, ut8 *in, ut8 *result) {
+#ifdef _MSC_VER
+	ut32 expkey[2][(6 + (256 / 4)) + 1][Nb];
+#else
 	ut32 expkey[2][st->rounds + 1][Nb];
+#endif
 	aes_expkey(st, expkey);
 
 	ut32 t0, t1, t2, t3, tt;
@@ -191,7 +203,12 @@ void aes_encrypt (struct aes_state *st, ut8 *in, ut8 *result) {
 // in         - The ciphertext.
 // result     - The plaintext generated from a ciphertext using the session key.
 void aes_decrypt (struct aes_state *st, ut8 *in, ut8 *result) {
+#ifdef _MSC_VER
+	ut32 expkey[2][(6 + (256 / 4)) + 1][Nb];
+#else
 	ut32 expkey[2][st->rounds + 1][Nb];
+#endif
+	
 	aes_expkey(st, expkey);
 
 	ut32 t0, t1, t2, t3, tt;

--- a/libr/crypto/p/crypto_rc6.c
+++ b/libr/crypto/p/crypto_rc6.c
@@ -29,7 +29,11 @@ static bool rc6_init(struct rc6_state *const state, const ut8 *key, int keylen, 
 	int u = w / 8;
 	int c = keylen / u;
 	int t = 2 * r + 4;
-	ut32 *L = (ut32*) calloc (c, sizeof (ut32));
+#ifdef _MSC_VER
+	ut32 *L = (ut32*) malloc (sizeof (ut32) * c);
+#else
+	ut32 L[c];
+#endif
 	ut32 A = 0, B = 0, k = 0, j = 0;
 	ut32 v = 3 * t; //originally v = 2 * ((c > t) ? c : t);
 
@@ -55,7 +59,9 @@ static bool rc6_init(struct rc6_state *const state, const ut8 *key, int keylen, 
 	}
 	
 	state->key_size = keylen/8;
+#ifdef _MSC_VER
 	free (L);
+#endif
 	return true;
 }
 

--- a/libr/hash/hash.c
+++ b/libr/hash/hash.c
@@ -1,7 +1,9 @@
 /* radare - LGPL - Copyright 2007-2017 pancake */
 
 #include <r_hash.h>
-
+#ifdef _MSC_VER
+#define strcasecmp stricmp
+#endif
 R_LIB_VERSION (r_hash);
 
 struct {

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -234,6 +234,8 @@ typedef void (*PrintfCallback)(const char *str, ...);
 #else
   #if defined(__GNUC__) && __GNUC__ >= 4
     #define R_API __attribute__((visibility("default")))
+  #elif defined(_MSC_VER)
+    #define R_API __declspec(dllexport)
   #else
     #define R_API
   #endif

--- a/libr/include/r_types_base.h
+++ b/libr/include/r_types_base.h
@@ -14,10 +14,6 @@
 #define st8 signed char
 #define boolt int
 
-#ifdef _MSC_VER
-#define __attribute__(x)
-#endif
-
 typedef struct _ut80 {
 	ut64 Low;
 	ut16 High;
@@ -133,5 +129,9 @@ typedef struct _utX{
 #if !defined(NAN)
 #define NAN (0.0f/0.0f)
 #endif
-
+#ifdef _MSC_VER
+#define R_PACKED( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+#elif defined(__GNUC__)
+#define R_PACKED( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#endif
 #endif

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -20,6 +20,10 @@
 #if HAVE_LIB_SSL
 #include <openssl/bn.h>
 #endif
+#ifdef _MSC_VER
+#include <windows.h>
+int gettimeofday (struct timeval* p, void* tz);
+#endif
 #include <sys/time.h>
 #include "r_util/r_big.h"
 #include "r_util/r_base64.h"

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -95,8 +95,8 @@ err_enable:
 
 static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 	PROCESS_INFORMATION pi;
-        STARTUPINFO si = { sizeof (si) };
-        DEBUG_EVENT de;
+    STARTUPINFOA si = { sizeof (si) };
+    DEBUG_EVENT de;
 	int pid, tid;
 	HANDLE th = INVALID_HANDLE_VALUE;
 	if (!*cmd) return -1;
@@ -143,7 +143,7 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 	}
 	cmdline[cmd_i] = '\0';
 
-        if (!CreateProcess (argv[0], cmdline, NULL, NULL, FALSE,
+        if (!CreateProcessA (argv[0], cmdline, NULL, NULL, FALSE,
 			CREATE_NEW_CONSOLE | DEBUG_ONLY_THIS_PROCESS,
 			NULL, NULL, &si, &pi)) {
 		r_sys_perror ("CreateProcess");

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -3,9 +3,6 @@
 #include <r_userconf.h>
 #include <r_io.h>
 #include <r_lib.h>
-#ifdef _MSC_VER
-typedef unsigned int ssize_t;
-#endif
 
 typedef struct r_io_mmo_t {
 	char * filename;
@@ -187,7 +184,7 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	if (mmo->rawio) {
 		if (fd->obsz) {
 			char *a_buf;
-			ssize_t a_count;
+			int a_count;
 			// only do aligned reads in aligned offsets
 			const int aligned = fd->obsz; //512; // XXX obey fd->obsz? or it may be too slow? 128K..
 			//ut64 a_off = (io->off >> 9 ) << 9; //- (io->off & aligned);
@@ -237,7 +234,7 @@ static int r_io_def_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) 
 	if (mmo->rawio) {
 		if (fd->obsz) {
 			char *a_buf;
-			ssize_t a_count;
+			int a_count;
 			// only do aligned reads in aligned offsets
 			const int aligned = fd->obsz; //512; // XXX obey fd->obsz? or it may be too slow? 128K..
 			//ut64 a_off = (io->off >> 9 ) << 9; //- (io->off & aligned);

--- a/libr/io/p/io_r2pipe.c
+++ b/libr/io/p/io_r2pipe.c
@@ -79,7 +79,6 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		arr += 2;
 		for (num[0] = numi = bufi = 0; bufi < count && *arr; arr++) {
 			switch (*arr) {
-#ifdef _MSC_VER
 			case '0':
 			case '1':
 			case '2':
@@ -90,9 +89,6 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 			case '7':
 			case '8':
 			case '9':
-#else
-			case '0'...'9':
-#endif
 				num[numi++] = *arr;
 				num[numi] = 0;
 				break;

--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -19,6 +19,9 @@
 #include <mach/task_info.h>
 void macosx_debug_regions (RIO *io, task_t task, mach_vm_address_t address, int max);
 #endif
+#ifdef _MSC_VER
+#include <process.h>  // to compile getpid for msvc windows
+#endif
 
 #define PERM_READ 4
 #define PERM_WRITE 2

--- a/libr/io/p/io_w32.c
+++ b/libr/io/p/io_w32.c
@@ -51,7 +51,7 @@ static RIODesc *w32__open(RIO *io, const char *pathname, int rw, int mode) {
 	if (!strncmp (pathname, "w32://", 6)) {
 		RIOW32 *w32 = R_NEW0 (RIOW32);
 		const char *filename = pathname+6;
-		w32->hnd = CreateFile (filename,
+		w32->hnd = CreateFileA (filename,
 			GENERIC_READ | rw?GENERIC_WRITE:0,
 			FILE_SHARE_READ | rw? FILE_SHARE_WRITE:0,
 			NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/libr/magic/config.h
+++ b/libr/magic/config.h
@@ -20,10 +20,6 @@
 #define HAVE_UNISTD_H 1
 #define HAVE_WCHAR_H 1
 
-#ifdef _MSC_VER
-#undef HAVE_UNISTD_H
-#endif
-
 // TODO: add dependency for zlib?
 /* #define	HAVE_ZLIB_H	1	DO NOT ENABLE YET -- chl */
 /* #define	HAVE_LIBZ	1	DO NOT ENABLE YET -- ian */

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -2,6 +2,9 @@
 
 #include <r_reg.h>
 #include <r_util.h>
+#ifdef _MSC_VER
+#define strcasecmp stricmp
+#endif
 
 R_LIB_VERSION (r_reg);
 

--- a/libr/search/strings.c
+++ b/libr/search/strings.c
@@ -1,7 +1,9 @@
 /* radare - LGPL - Copyright 2006-2009 pancake<nopcode.org> */
 
 #include "r_search.h"
-
+#if _MSC_VER
+#define strncasecmp strnicmp
+#endif
 // TODO: this file needs some love
 enum {
 	ENCODING_ASCII = 0,

--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -50,12 +50,12 @@ R_API int r2p_close(R2Pipe *r2p) {
 #if __WINDOWS__ && !defined(__CYGWIN__)
 static int w32_createChildProcess(const char * szCmdline) {
 	PROCESS_INFORMATION piProcInfo;
-	STARTUPINFO siStartInfo;
+	STARTUPINFOA siStartInfo;
 	BOOL bSuccess = FALSE;
 	ZeroMemory (&piProcInfo, sizeof (PROCESS_INFORMATION));
 	ZeroMemory (&siStartInfo, sizeof (STARTUPINFO));
 	siStartInfo.cb = sizeof (STARTUPINFO);
-	bSuccess = CreateProcess (NULL, (LPSTR)szCmdline, NULL, NULL,
+	bSuccess = CreateProcessA (NULL, (LPSTR)szCmdline, NULL, NULL,
 		TRUE, 0, NULL, NULL, &siStartInfo, &piProcInfo);
 	if (!bSuccess)
 		return false;
@@ -66,7 +66,7 @@ static int w32_createChildProcess(const char * szCmdline) {
 
 static int w32_createPipe(R2Pipe *r2p, const char *cmd) {
 	CHAR buf[1024];
-	r2p->pipe = CreateNamedPipe ("\\\\.\\pipe\\R2PIPE_IN",
+	r2p->pipe = CreateNamedPipeA ("\\\\.\\pipe\\R2PIPE_IN",
 		PIPE_ACCESS_DUPLEX,PIPE_TYPE_MESSAGE | \
 		PIPE_READMODE_MESSAGE | \
 		PIPE_WAIT, PIPE_UNLIMITED_INSTANCES,
@@ -230,7 +230,7 @@ R_API int r2p_write(R2Pipe *r2p, const char *str) {
 /* TODO: add timeout here ? */
 R_API char *r2p_read(R2Pipe *r2p) {
 	int bufsz = 0;
-	char *newbuf, *buf = NULL;
+	char *buf = NULL;
 	if (!r2p) return NULL;
 	bufsz = 4096;
 	buf = calloc (1, bufsz);
@@ -248,6 +248,7 @@ R_API char *r2p_read(R2Pipe *r2p) {
 	}
 	buf[bufsz - 1] = 0;
 #else
+	char *newbuf;
 	int i, rv;
 	for (i = 0; i < bufsz; i++) {
 		rv = read (r2p->output[0], buf + i, 1);

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -48,6 +48,10 @@
 #include <util.h>
 #endif
 #endif
+#ifdef _MSC_VER
+#include <direct.h>   // to compile chdir in msvc windows
+#include <process.h>  // to compile execv in msvc windows
+#endif
 
 #define HAVE_PTY __UNIX__ && !__ANDROID__ && LIBC_HAVE_FORK && !defined(__sun)
 

--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -12,6 +12,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #ifdef _MSC_VER
 #pragma comment(lib, "ws2_32.lib")
 #endif
@@ -671,12 +672,7 @@ R_API int r_socket_write(RSocket *s, void *buf, int len) {
 		} else
 #endif
 		{
-#ifdef _MSC_VER
-			char* winbuf = (char*) buf + len;
-			ret = send (s->fd, winbuf, b, 0);
-#else
-			ret = send (s->fd, buf+delta, b, 0);
-#endif
+			ret = send (s->fd, (char *)buf+delta, b, 0);
 		}
 		//if (ret == 0) return -1;
 		if (ret<1) break;

--- a/libr/util/base85.c
+++ b/libr/util/base85.c
@@ -25,9 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
 #include <getopt.h>
-#endif
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -16,7 +16,7 @@ R_LIB_VERSION(r_lib);
   #define DLCLOSE(x) dlclose(x)
 #elif __WINDOWS__
 #include <windows.h>
-  #define DLOPEN(x)  LoadLibrary(x)
+  #define DLOPEN(x)  LoadLibraryA(x)
   #define DLSYM(x,y) GetProcAddress(x,y)
   #define DLCLOSE(x) 0//(x)
 //CloseLibrary(x)
@@ -167,7 +167,7 @@ R_API RLibHandler *r_lib_get_handler(RLib *lib, int type) {
 	return NULL;
 }
 
-R_API R_API int r_lib_close(RLib *lib, const char *file) {
+R_API int r_lib_close(RLib *lib, const char *file) {
 	RLibPlugin *p;
 	RListIter *iter, *iter_tmp;
 	r_list_foreach_safe (lib->plugins, iter, iter_tmp, p) {

--- a/libr/util/p_date.c
+++ b/libr/util/p_date.c
@@ -2,6 +2,10 @@
 
 #include "r_print.h"
 #include "r_util.h"
+#include <unistd.h>
+#include <sys/time.h>
+#include <time.h>
+#include <sys/stat.h>
 
 R_API int r_print_date_dos(RPrint *p, ut8 *buf, int len) {
 	ut8 _time[2] = { buf[0], buf[1] };

--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -4,7 +4,9 @@
 #include "r_util.h"
 #include "r_print.h"
 #include "r_reg.h"
-
+#ifdef _MSC_VER
+#include <time.h>
+#endif 
 #define NOPTR 0
 #define PTRSEEK 1
 #define PTRBACK 2

--- a/libr/util/prof.c
+++ b/libr/util/prof.c
@@ -1,7 +1,6 @@
 /* radare - LGPL - Copyright 2009-2012 - pancake */
 
 #include "r_util.h"
-
 typedef struct timeval tv;
 
 // Subtract the 'tv' values begin from end, storing result in RESULT

--- a/libr/util/sandbox.c
+++ b/libr/util/sandbox.c
@@ -2,6 +2,10 @@
 
 #include <r_util.h>
 #include <signal.h>
+#if _MSC_VER
+#include <process.h> // to compile execl under msvc windows
+#include <direct.h>  // to compile chdir under msvc windows
+#endif
 
 static bool enabled = false;
 static bool disabled = false;

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -29,11 +29,11 @@ R_API int r_sys_get_src_dir_w32(char *buf) {
 	int i = 0;
 	char fullpath[MAX_PATH + 1];
 
-	if (!GetModuleFileName(NULL, fullpath, MAX_PATH + 1)) {
+	if (!GetModuleFileNameA (NULL, fullpath, MAX_PATH + 1)) {
 		return false;
 	}
 
-	if (!GetShortPathName(fullpath, buf, MAX_PATH+1)) {
+	if (!GetShortPathNameA (fullpath, buf, MAX_PATH+1)) {
 		return false;
 	}
 
@@ -74,7 +74,7 @@ R_API char *r_sys_cmd_str_w32(const char *cmd) {
 
 	CreateChildProcess (cmd, out);
 
-	in = CreateFile (argv0,
+	in = CreateFileA (argv0,
 			GENERIC_READ,
 			FILE_SHARE_READ,
 			NULL,
@@ -101,7 +101,7 @@ R_API char *r_sys_cmd_str_w32(const char *cmd) {
 
 static int CreateChildProcess(const char *szCmdline, HANDLE out) {
 	PROCESS_INFORMATION piProcInfo;
-	STARTUPINFO siStartInfo;
+	STARTUPINFOA siStartInfo;
 	BOOL bSuccess = FALSE;
 
 	ZeroMemory (&piProcInfo, sizeof (PROCESS_INFORMATION) );
@@ -115,7 +115,7 @@ static int CreateChildProcess(const char *szCmdline, HANDLE out) {
 	siStartInfo.hStdInput = NULL;
 	siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
 
-	bSuccess = CreateProcess (NULL,
+	bSuccess = CreateProcessA (NULL,
 			(LPSTR)szCmdline,// command line
 			NULL,          // process security attributes
 			NULL,          // primary thread security attributes

--- a/libr/util/zip.c
+++ b/libr/util/zip.c
@@ -42,9 +42,6 @@ R_API ut8 *r_inflate(const ut8 *src, int srcLen, int *srcConsumed, int *dstLen) 
 	stream.opaque = Z_NULL;
 
 	// + 32 tells zlib not to care whether the stream is a zlib or gzip stream
-#ifdef _MSC_VER
-#pragma message ("TODO: Windows support here. Check dirent.h PR")
-#else
 	if (inflateInit2 (&stream, MAX_WBITS + 32) != Z_OK) {
 		return NULL;
 	}
@@ -80,6 +77,5 @@ R_API ut8 *r_inflate(const ut8 *src, int srcLen, int *srcConsumed, int *dstLen) 
 	err_exit:
 	inflateEnd (&stream);
 	free (dst);
-#endif
 	return NULL;
 }

--- a/shlr/sdb/src/disk.c
+++ b/shlr/sdb/src/disk.c
@@ -10,7 +10,7 @@
 #include "sdb.h"
 
 #if __SDB_WINDOWS__
-#define r_sys_mkdir(x) (CreateDirectory(x,NULL)!=0)
+#define r_sys_mkdir(x) (CreateDirectoryA(x,NULL)!=0)
 #ifndef ERROR_ALREADY_EXISTS
 #define ERROR_ALREADY_EXISTS 183
 #endif
@@ -106,7 +106,7 @@ SDB_API bool sdb_disk_finish (Sdb* s) {
 		reopen = true;
 	}
 #if __SDB_WINDOWS__
-	if (MoveFileEx (s->ndump, s->dir, MOVEFILE_REPLACE_EXISTING)) {
+	if (MoveFileExA (s->ndump, s->dir, MOVEFILE_REPLACE_EXISTING)) {
 		//eprintf ("Error 0x%02x\n", GetLastError ());
 	}
 #else

--- a/shlr/sdb/src/journal.c
+++ b/shlr/sdb/src/journal.c
@@ -1,11 +1,7 @@
 /* sdb - MIT - Copyright 2011-2016 - pancake */
 
 #include "sdb.h"
-#ifdef _MSC_VER
-#include <io.h>
-#else
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 
 static const char *sdb_journal_filename(Sdb *s) {

--- a/shlr/sdb/src/json.c
+++ b/shlr/sdb/src/json.c
@@ -246,7 +246,7 @@ SDB_API const char *sdb_json_format(SdbJsonString *s, const char *fmt, ...) {
 	char *arg_s, *x, tmp[128];
 	ut64 arg_l;
 	int i, arg_i;
-	float arg_f;
+	double arg_f;
 	va_list ap;
 #define JSONSTR_ALLOCATE(y)\
 	if (s->len + y > s->blen) {\

--- a/shlr/sdb/src/lock.c
+++ b/shlr/sdb/src/lock.c
@@ -2,13 +2,13 @@
 
 #include <stdio.h>
 #include <string.h>
-#ifdef _MSC_VER
-#include <windows.h>
-#else
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 #include "sdb.h"
+#ifdef _MSC_VER
+#include <process.h>
+#include <windows.h>
+#endif
 
 SDB_API const char *sdb_lock_file(const char *f) {
 	static char buf[128];

--- a/shlr/sdb/src/sdb.h
+++ b/shlr/sdb/src/sdb.h
@@ -29,15 +29,17 @@ extern "C" {
 #define SZT_ADD_OVFCHK(x, y) ((SIZE_MAX - (x)) <= (y))
 #endif
 
-#if __SDB_WINDOWS__ && !__CYGWIN__ && !_MSC_VER
+#if __SDB_WINDOWS__ && !__CYGWIN__
 #include <windows.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <io.h>
+#ifndef _MSC_VER
 extern __attribute__((dllimport)) void *__cdecl _aligned_malloc(size_t, size_t);
 extern char *strdup (const char *);
+#endif
 #undef r_offsetof
 #define r_offsetof(type, member) ((unsigned long) (ut64)&((type*)0)->member)
 //#define SDB_MODE 0

--- a/shlr/sdb/src/types.h
+++ b/shlr/sdb/src/types.h
@@ -31,7 +31,7 @@
 #define __MINGW__ 1
 #endif
 
-#if __WIN32__ || __MINGW__ || __WINDOWS__
+#if __WIN32__ || __MINGW__ || __WINDOWS__ || _MSC_VER
 #define __SDB_WINDOWS__ 1
 #include <windows.h>
 #define DIRSEP '\\'
@@ -40,8 +40,6 @@
 #define __SDB_WINDOWS__ 0
 #define DIRSEP '/'
 #endif
-
-#include <unistd.h>
 
 #include <inttypes.h>
 #define ULLFMT "ll"
@@ -55,7 +53,7 @@
 #define USE_MMAN HAVE_MMAN
 #endif
 
-
+#include <unistd.h>
 #ifndef UNUSED
 #  define UNUSED
 #  ifdef __GNUC__

--- a/shlr/sdb/src/util.c
+++ b/shlr/sdb/src/util.c
@@ -8,16 +8,16 @@
 #include <time.h>
 #else
 #ifdef _MSC_VER
-#pragma message ("TODO: Windows support is ugly here")
+#pragma message ("gettimeofday: Windows support is ugly here")
 #include <windows.h>
-int gettimeofday(struct timeval* p, void* tz) {
+int gettimeofday (struct timeval* p, void* tz) {
 	ULARGE_INTEGER ul; // As specified on MSDN.
 	FILETIME ft;
-	
+
 	// Returns a 64-bit value representing the number of
 	// 100-nanosecond intervals since January 1, 1601 (UTC).
-	GetSystemTimeAsFileTime(&ft);
-	
+	GetSystemTimeAsFileTime (&ft);
+
 	// Fill ULARGE_INTEGER low and high parts.
 	ul.LowPart = ft.dwLowDateTime;
 	ul.HighPart = ft.dwHighDateTime;
@@ -26,10 +26,10 @@ int gettimeofday(struct timeval* p, void* tz) {
 	// Remove Windows to UNIX Epoch delta.
 	ul.QuadPart -= 11644473600000000ULL;
 	// Modulo to retrieve the microseconds.
-	p->tv_usec = (long) (ul.QuadPart % 1000000LL);
+	p->tv_usec = (long)(ul.QuadPart % 1000000LL);
 	// Divide to retrieve the seconds.
-	p->tv_sec = (long) (ul.QuadPart / 1000000LL);
-	
+	p->tv_sec = (long)(ul.QuadPart / 1000000LL);
+
 	return 0;
 }
 

--- a/shlr/zip/zlib/gzguts.h
+++ b/shlr/zip/zlib/gzguts.h
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include "zlib.h"
 #include <string.h>
+#include <unistd.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <fcntl.h>


### PR DESCRIPTION
-Some stduint.h inclussion restored.
-Add R_API for MSVC to create .lib and .exp files
-Add R_PACKED macro for packed struct definition 
-r_util.h: Add gettimeofday prototype for msvc build
-Add some includes to correct import functions chdir,execv, .. under msvc build
-Change win api to always call multibyte functions.

Note: At this moment MSVC can compile withtout problems bin,bp,cons,crypto,flag,hash,io,magic,rahash2,rax2,reg,sdb,socket,syscall,util and zip libraries.

All this libraries are revised and compiled under VS2015 vias .vcproj files