### PR TITLE
Removed unneeded message (profanity) from build system

### DIFF
--- a/libr/bin/p/vsf.mk
+++ b/libr/bin/p/vsf.mk
@@ -6,6 +6,5 @@ TARGET_VSF=bin_vsf.${EXT_SO}
 ALL_TARGETS+=${TARGET_VSF}
 
 ${TARGET_VSF}: ${OBJ_VSF}
-	echo "FUCKOFF"
 	${CC} $(call libname,bin_vsf) -shared ${CFLAGS} \
 		-o ${TARGET_VSF} ${OBJ_VSF} $(LINK) $(LDFLAGS)


### PR DESCRIPTION
There was an _unneeded message_ (literally, "FUCKOFF") in one of the makefiles. I don't think that it was intended for that line to be commited to the repo, so I've deleted it.