### PR TITLE
Set prj.name before saving a project to save that value correctly

### DIFF
--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -57,12 +57,8 @@ static int cmd_project(void *data, const char *input) {
 		if (!file || !file[0]) { /* if no argument specified use current project */
 			file = str;
 		}
-		r_config_set (core->config, "prj.name", file);
 		if (r_core_project_save (core, file)) {
 			r_cons_println (file);
-		} else {
-			// reset prj.name on fail
-			r_config_set (core->config, "prj.name", str);
 		}
 		break;
 	case 'S':

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -57,9 +57,12 @@ static int cmd_project(void *data, const char *input) {
 		if (!file || !file[0]) { /* if no argument specified use current project */
 			file = str;
 		}
+		r_config_set (core->config, "prj.name", file);
 		if (r_core_project_save (core, file)) {
-			r_config_set (core->config, "prj.name", file);
 			r_cons_println (file);
+		} else {
+			// reset prj.name on fail
+			r_config_set (core->config, "prj.name", str);
 		}
 		break;
 	case 'S':


### PR DESCRIPTION
Goes along with https://github.com/radare/radare2-regressions/pull/843

prj.name should be set before saving the project, so it will be correct in the project file.
The resetting if the save fails is not beatiful, but I don't really know a better way in this case.