### PR TITLE
Print an empty JSON list when there are no xrefs

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4136,6 +4136,10 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 				}
 			}
 			r_list_free (list);
+		} else {
+			if (input[1] == 'j') { // "axtj"
+				r_cons_print ("[]\n");
+			}
 		}
 	} break;
 	case 'f': { // "axf"
@@ -4214,6 +4218,10 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 				}
 			}
 			r_list_free (list_);
+		} else {
+			if (input[1] == 'j') { // axfj
+				r_cons_print ("[]\n");
+			}
 		}
 	} break;
 	case 'F':


### PR DESCRIPTION
Instead of staying silent (which can cause an error when using r2pipe and it is expecting JSON data) print an empty list when no cross references exist to/from an address.