### PR TITLE
max_global_fast

### DIFF
--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -83,7 +83,7 @@ static void GH(print_main_arena)(RCore *core, GHT m_arena, GH(RHeap_MallocState)
 	PRINTF_BA ("0x%08x\n", (ut32)main_arena->flags);
 	PRINT_GA ("  fastbinsY = {\n");
 
-	for (i = 0, j = 1, k = SZ * 4; i < NFASTBINS; i++, j++, k += SZ * 2) {
+	for (i = 0, j = 1, k = SZ * 4; i < NFASTBINS - 2; i++, j++, k += SZ * 2) {
 		PRINTF_YA (" Fastbin %02d: ", j);
 		PRINT_GA (" chunksize:");
 		PRINTF_BA (" == %04d ", k);

--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -21,7 +21,7 @@ R_LIB_VERSION_HEADER(r_heap_glibc);
 
 #define NBINS 128
 #define NSMALLBINS 64
-#define NFASTBINS 8
+#define NFASTBINS 10
 #define BINMAPSHIFT 5
 #define SZ core->dbg->bits
 #define BITSPERMAP (1U << BINMAPSHIFT)


### PR DESCRIPTION
Limit to 0x80 size at fastbin in 64 bits and 0x40 in 32 bits according variable max_global_fast