### PR TITLE
fixes ood

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -311,7 +311,10 @@ R_API void r_core_file_reopen_debug (RCore *core, const char *args) {
 		r_core_bin_rebase (core, new_baddr);
 		// r_core_bin_load (core, newfile, new_baddr);
 		// reload symbols with new baddr
-		r_core_cmd0 (core, ".isrzM*");
+		r_core_cmd0 (core, ".is*");
+		r_core_cmd0 (core, ".ir*");
+		r_core_cmd0 (core, ".iz*");
+		r_core_cmd0 (core, ".iM*");
 	}
 #endif
 	r_core_cmd0 (core, "sr PC");


### PR DESCRIPTION
fixes #7346 (ood, pie binary) and probably also related to #7461
`isrzM*` doesn't return radare commands correctly.