### PR TITLE
add changes to compile more plugins into msvc

### DIFF
--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -11,7 +11,7 @@
 #define CM ","
 #define XTENSA_MAX_LENGTH 8
 
-xtensa_isa xtensa_default_isa;
+extern xtensa_isa xtensa_default_isa;
 
 static int xtensa_length(const ut8 *insn) {
 	static int length_table[16] = { 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 8, 8 };

--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -11,7 +11,7 @@
 #define CM ","
 #define XTENSA_MAX_LENGTH 8
 
-extern xtensa_isa xtensa_default_isa;
+xtensa_isa xtensa_default_isa;
 
 static int xtensa_length(const ut8 *insn) {
 	static int length_table[16] = { 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 8, 8 };

--- a/libr/asm/arch/8051/8051_disas.h
+++ b/libr/asm/arch/8051/8051_disas.h
@@ -19,8 +19,8 @@ enum {
 	ARG,    // register
 };
 
-r_8051_op r_8051_decode(const ut8 *buf, int len);
-char *r_8051_disasm(r_8051_op op, ut32 addr, char *str, int len);
+R_API r_8051_op r_8051_decode(const ut8 *buf, int len);
+R_API char *r_8051_disasm(r_8051_op op, ut32 addr, char *str, int len);
 
 #endif /* 8051_DISASM_H */
 

--- a/libr/asm/arch/arm/winedbg/be_arm.h
+++ b/libr/asm/arch/arm/winedbg/be_arm.h
@@ -10,13 +10,13 @@ struct winedbg_arm_insn {
 	ut64 jmp, fail;
 };
 
-int arm_disasm_one_insn(struct winedbg_arm_insn *arminsn);
-void arm_set_pc(struct winedbg_arm_insn *arminsn, ut64 pc);
-void arm_set_input_buffer(struct winedbg_arm_insn *arminsn, const ut8 *buf);
-void arm_set_thumb(struct winedbg_arm_insn *arminsn, int thumb);
-char* winedbg_arm_insn_asm(struct winedbg_arm_insn *arminsn);
-char* winedbg_arm_insn_hex(struct winedbg_arm_insn *arminsn);
-void* arm_free(struct winedbg_arm_insn *arminsn);
-struct winedbg_arm_insn* arm_new();
+R_API int arm_disasm_one_insn(struct winedbg_arm_insn *arminsn);
+R_API void arm_set_pc(struct winedbg_arm_insn *arminsn, ut64 pc);
+R_API void arm_set_input_buffer(struct winedbg_arm_insn *arminsn, const ut8 *buf);
+R_API void arm_set_thumb(struct winedbg_arm_insn *arminsn, int thumb);
+R_API char* winedbg_arm_insn_asm(struct winedbg_arm_insn *arminsn);
+R_API char* winedbg_arm_insn_hex(struct winedbg_arm_insn *arminsn);
+R_API void* arm_free(struct winedbg_arm_insn *arminsn);
+R_API struct winedbg_arm_insn* arm_new();
 
 #endif

--- a/libr/asm/arch/cr16/cr16_disas.h
+++ b/libr/asm/arch/cr16/cr16_disas.h
@@ -46,7 +46,7 @@ struct cr16_cmd {
 	char	operands[CR16_INSTR_MAXLEN];
 };
 
-int cr16_decode_command(const ut8 *instr, struct cr16_cmd *cmd);
+R_API int cr16_decode_command(const ut8 *instr, struct cr16_cmd *cmd);
 
 enum cr16_opcodes {
 	CR16_ADD	= 0x0,

--- a/libr/asm/arch/ebc/ebc_disas.h
+++ b/libr/asm/arch/ebc/ebc_disas.h
@@ -91,6 +91,6 @@ typedef struct ebc_command {
 	char operands[EBC_OPERANDS_MAXLEN];
 } ebc_command_t;
 
-int ebc_decode_command(const uint8_t *instr, ebc_command_t *cmd);
+R_API int ebc_decode_command(const uint8_t *instr, ebc_command_t *cmd);
 
 #endif /* EBC_DISAS_H */

--- a/libr/asm/arch/h8300/h8300_disas.h
+++ b/libr/asm/arch/h8300/h8300_disas.h
@@ -125,6 +125,6 @@ struct h8300_cmd {
 	char	operands[H8300_INSTR_MAXLEN];
 };
 
-int h8300_decode_command(const ut8 *instr, struct h8300_cmd *cmd);
+R_API int h8300_decode_command(const ut8 *instr, struct h8300_cmd *cmd);
 
 #endif /* H8300_DISAS_H */

--- a/libr/asm/arch/include/xtensa-isa.h
+++ b/libr/asm/arch/include/xtensa-isa.h
@@ -21,6 +21,8 @@
 #ifndef XTENSA_LIBISA_H
 #define XTENSA_LIBISA_H
 
+#include "r_types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -176,19 +178,19 @@ typedef xtensa_insnbuf_word *xtensa_insnbuf;
 
 /* Get the size in "insnbuf_words" of the xtensa_insnbuf array.  */
 
-extern int
+R_API extern int
 xtensa_insnbuf_size (xtensa_isa isa); 
 
 
 /* Allocate an xtensa_insnbuf of the right size.  */
 
-extern xtensa_insnbuf
+R_API extern xtensa_insnbuf
 xtensa_insnbuf_alloc (xtensa_isa isa);
 
 
 /* Release an xtensa_insnbuf.  */
 
-extern void
+R_API extern void
 xtensa_insnbuf_free (xtensa_isa isa, xtensa_insnbuf buf);
 
 
@@ -206,11 +208,11 @@ xtensa_insnbuf_free (xtensa_isa isa, xtensa_insnbuf buf);
    can be read or written.  Otherwise, if "num_chars" is zero, the
    functions may read or write past the end of the code.  */
 
-extern int
+R_API extern int
 xtensa_insnbuf_to_chars (xtensa_isa isa, const xtensa_insnbuf insn,
 			 unsigned char *cp, int num_chars);
 
-extern void
+R_API extern void
 xtensa_insnbuf_from_chars (xtensa_isa isa, xtensa_insnbuf insn,
 			   const unsigned char *cp, int num_chars);
 
@@ -220,19 +222,19 @@ xtensa_insnbuf_from_chars (xtensa_isa isa, xtensa_insnbuf insn,
 
 /* Initialize the ISA information.  */
 
-extern xtensa_isa
+R_API extern xtensa_isa
 xtensa_isa_init (xtensa_isa_status *errno_p, char **error_msg_p);
 
 
 /* Deallocate an xtensa_isa structure.  */
 
-extern void
+R_API extern void
 xtensa_isa_free (xtensa_isa isa);
 
 
 /* Get the maximum instruction size in bytes.  */
 
-extern int
+R_API extern int
 xtensa_isa_maxlength (xtensa_isa isa); 
 
 
@@ -241,7 +243,7 @@ xtensa_isa_maxlength (xtensa_isa isa);
    required to decode the instruction length.  Returns
    XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_isa_length_from_chars (xtensa_isa isa, const unsigned char *cp);
 
 
@@ -252,31 +254,31 @@ xtensa_isa_length_from_chars (xtensa_isa isa, const unsigned char *cp);
    actual processor hardware, e.g., the hardware may have additional
    stages before stage 0.  Returns XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_isa_num_pipe_stages (xtensa_isa isa); 
 
 
 /* Get the number of various entities that are defined for this processor.  */
 
-extern int
+R_API extern int
 xtensa_isa_num_formats (xtensa_isa isa);
 
-extern int
+R_API extern int
 xtensa_isa_num_opcodes (xtensa_isa isa);
 
-extern int
+R_API extern int
 xtensa_isa_num_regfiles (xtensa_isa isa);
 
-extern int
+R_API extern int
 xtensa_isa_num_states (xtensa_isa isa);
 
-extern int
+R_API extern int
 xtensa_isa_num_sysregs (xtensa_isa isa);
 
-extern int
+R_API extern int
 xtensa_isa_num_interfaces (xtensa_isa isa);
 
-extern int
+R_API extern int
 xtensa_isa_num_funcUnits (xtensa_isa isa);
 
 
@@ -285,49 +287,49 @@ xtensa_isa_num_funcUnits (xtensa_isa isa);
 
 /* Get the name of a format.  Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_format_name (xtensa_isa isa, xtensa_format fmt);
 
 
 /* Given a format name, return the format number.  Returns
    XTENSA_UNDEFINED if the name is not a valid format.  */
 
-extern xtensa_format
+R_API extern xtensa_format
 xtensa_format_lookup (xtensa_isa isa, const char *fmtname);
 
 
 /* Decode the instruction format from a binary instruction buffer.
    Returns XTENSA_UNDEFINED if the format is not recognized.  */
 
-extern xtensa_format
+R_API extern xtensa_format
 xtensa_format_decode (xtensa_isa isa, const xtensa_insnbuf insn);
 
 
 /* Set the instruction format field(s) in a binary instruction buffer.
    All the other fields are set to zero.  Returns non-zero on error.  */
 
-extern int
+R_API extern int
 xtensa_format_encode (xtensa_isa isa, xtensa_format fmt, xtensa_insnbuf insn);
 
 
 /* Find the length (in bytes) of an instruction.  Returns
    XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_format_length (xtensa_isa isa, xtensa_format fmt);
 
 
 /* Get the number of slots in an instruction.  Returns XTENSA_UNDEFINED
    on error.  */
 
-extern int
+R_API extern int
 xtensa_format_num_slots (xtensa_isa isa, xtensa_format fmt);
 
 
 /* Get the opcode for a no-op in a particular slot.
    Returns XTENSA_UNDEFINED on error.  */
 
-extern xtensa_opcode
+R_API extern xtensa_opcode
 xtensa_format_slot_nop_opcode (xtensa_isa isa, xtensa_format fmt, int slot);
 
 
@@ -335,11 +337,11 @@ xtensa_format_slot_nop_opcode (xtensa_isa isa, xtensa_format fmt, int slot);
    instruction as a whole and put them into an insnbuf for that one
    slot, and do the opposite to set a slot.  Return non-zero on error.  */
 
-extern int
+R_API extern int
 xtensa_format_get_slot (xtensa_isa isa, xtensa_format fmt, int slot,
 			const xtensa_insnbuf insn, xtensa_insnbuf slotbuf);
 
-extern int
+R_API extern int
 xtensa_format_set_slot (xtensa_isa isa, xtensa_format fmt, int slot,
 			xtensa_insnbuf insn, const xtensa_insnbuf slotbuf);
 
@@ -350,7 +352,7 @@ xtensa_format_set_slot (xtensa_isa isa, xtensa_format fmt, int slot,
 /* Translate a mnemonic name to an opcode.  Returns XTENSA_UNDEFINED if
    the name is not a valid opcode mnemonic.  */
 
-extern xtensa_opcode
+R_API extern xtensa_opcode
 xtensa_opcode_lookup (xtensa_isa isa, const char *opname);
 
 
@@ -358,7 +360,7 @@ xtensa_opcode_lookup (xtensa_isa isa, const char *opname);
    buffer.  Returns the opcode or XTENSA_UNDEFINED if the opcode is
    illegal.  */
 
-extern xtensa_opcode
+R_API extern xtensa_opcode
 xtensa_opcode_decode (xtensa_isa isa, xtensa_format fmt, int slot,
 		      const xtensa_insnbuf slotbuf);
 
@@ -367,14 +369,14 @@ xtensa_opcode_decode (xtensa_isa isa, xtensa_format fmt, int slot,
    in the slot are set to zero.  Returns non-zero if the opcode cannot
    be encoded.  */
 
-extern int
+R_API extern int
 xtensa_opcode_encode (xtensa_isa isa, xtensa_format fmt, int slot,
 		      xtensa_insnbuf slotbuf, xtensa_opcode opc);
 
 
 /* Get the mnemonic name for an opcode.  Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_opcode_name (xtensa_isa isa, xtensa_opcode opc);
 
 
@@ -394,16 +396,16 @@ xtensa_opcode_name (xtensa_isa isa, xtensa_opcode opc);
    checking if the instruction has a PC-relative immediate
    operand.  */
 
-extern int
+R_API extern int
 xtensa_opcode_is_branch (xtensa_isa isa, xtensa_opcode opc);
 
-extern int
+R_API extern int
 xtensa_opcode_is_jump (xtensa_isa isa, xtensa_opcode opc);
 
-extern int
+R_API extern int
 xtensa_opcode_is_loop (xtensa_isa isa, xtensa_opcode opc);
 
-extern int
+R_API extern int
 xtensa_opcode_is_call (xtensa_isa isa, xtensa_opcode opc);
 
 
@@ -411,13 +413,13 @@ xtensa_opcode_is_call (xtensa_isa isa, xtensa_opcode opc);
    operands for an instruction.  These return XTENSA_UNDEFINED on
    error.  */
 
-extern int
+R_API extern int
 xtensa_opcode_num_operands (xtensa_isa isa, xtensa_opcode opc);
 
-extern int
+R_API extern int
 xtensa_opcode_num_stateOperands (xtensa_isa isa, xtensa_opcode opc);
 
-extern int
+R_API extern int
 xtensa_opcode_num_interfaceOperands (xtensa_isa isa, xtensa_opcode opc);
 
 
@@ -433,10 +435,10 @@ typedef struct xtensa_funcUnit_use_struct
   int stage;
 } xtensa_funcUnit_use;
 
-extern int
+R_API extern int
 xtensa_opcode_num_funcUnit_uses (xtensa_isa isa, xtensa_opcode opc);
 
-extern xtensa_funcUnit_use *
+R_API extern xtensa_funcUnit_use *
 xtensa_opcode_funcUnit_use (xtensa_isa isa, xtensa_opcode opc, int u);
 
 
@@ -445,7 +447,7 @@ xtensa_opcode_funcUnit_use (xtensa_isa isa, xtensa_opcode opc, int u);
 
 /* Get the name of an operand.  Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_operand_name (xtensa_isa isa, xtensa_opcode opc, int opnd);
 
 
@@ -462,7 +464,7 @@ xtensa_operand_name (xtensa_isa isa, xtensa_opcode opc, int opnd);
    "implicit", i.e., whether it is encoded in a field in the
    instruction.  */
 
-extern int
+R_API extern int
 xtensa_operand_is_visible (xtensa_isa isa, xtensa_opcode opc, int opnd);
 
 
@@ -473,7 +475,7 @@ xtensa_operand_is_visible (xtensa_isa isa, xtensa_opcode opc, int opnd);
    properly handle register allocation for conditional assignments.
    Returns 0 on error.  */
 
-extern char
+R_API extern char
 xtensa_operand_inout (xtensa_isa isa, xtensa_opcode opc, int opnd);
 
 
@@ -483,12 +485,12 @@ xtensa_operand_inout (xtensa_isa isa, xtensa_opcode opc, int opnd);
    functions return non-zero on error, e.g., if the field is not defined
    for the specified slot.  */
 
-extern int
+R_API extern int
 xtensa_operand_get_field (xtensa_isa isa, xtensa_opcode opc, int opnd,
 			  xtensa_format fmt, int slot,
 			  const xtensa_insnbuf slotbuf, uint32 *valp);
 
-extern int 
+R_API extern int
 xtensa_operand_set_field (xtensa_isa isa, xtensa_opcode opc, int opnd,
 			  xtensa_format fmt, int slot,
 			  xtensa_insnbuf slotbuf, uint32 val);
@@ -499,11 +501,11 @@ xtensa_operand_set_field (xtensa_isa isa, xtensa_opcode opc, int opnd,
    the details of that encoding.  The result values are returned through
    the argument pointer.  The return value is non-zero on error.  */
 
-extern int
+R_API extern int
 xtensa_operand_encode (xtensa_isa isa, xtensa_opcode opc, int opnd,
 		       uint32 *valp);
 
-extern int
+R_API extern int
 xtensa_operand_decode (xtensa_isa isa, xtensa_opcode opc, int opnd,
 		       uint32 *valp);
 
@@ -514,10 +516,10 @@ xtensa_operand_decode (xtensa_isa isa, xtensa_opcode opc, int opnd,
    XTENSA_UNDEFINED on error.  The "regfile" function returns the
    regfile for a register operand, or XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_operand_is_register (xtensa_isa isa, xtensa_opcode opc, int opnd);
 
-extern xtensa_regfile
+R_API extern xtensa_regfile
 xtensa_operand_regfile (xtensa_isa isa, xtensa_opcode opc, int opnd);
 
 
@@ -528,7 +530,7 @@ xtensa_operand_regfile (xtensa_isa isa, xtensa_opcode opc, int opnd);
    non-register operands, the return value is undefined.  Returns
    XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_operand_num_regs (xtensa_isa isa, xtensa_opcode opc, int opnd);
 				 
 
@@ -540,7 +542,7 @@ xtensa_operand_num_regs (xtensa_isa isa, xtensa_opcode opc, int opnd);
    register value is unknown, 1 if known, and XTENSA_UNDEFINED on
    error.  */
 
-extern int
+R_API extern int
 xtensa_operand_is_known_reg (xtensa_isa isa, xtensa_opcode opc, int opnd);
 
 
@@ -548,7 +550,7 @@ xtensa_operand_is_known_reg (xtensa_isa isa, xtensa_opcode opc, int opnd);
    operands and non-PC-relative immediates, 1 for PC-relative
    immediates, and XTENSA_UNDEFINED on error.  */
  
-extern int
+R_API extern int
 xtensa_operand_is_PCrelative (xtensa_isa isa, xtensa_opcode opc, int opnd);
 
 
@@ -566,11 +568,11 @@ xtensa_operand_is_PCrelative (xtensa_isa isa, xtensa_opcode opc, int opnd);
    operands must be encoded/decoded separately and the encode functions
    are responsible for detecting invalid operand values.  */
 
-extern int
+R_API extern int
 xtensa_operand_do_reloc (xtensa_isa isa, xtensa_opcode opc, int opnd,
 			 uint32 *valp, uint32 pc);
 
-extern int
+R_API extern int
 xtensa_operand_undo_reloc (xtensa_isa isa, xtensa_opcode opc, int opnd,
 			   uint32 *valp, uint32 pc);
 
@@ -581,14 +583,14 @@ xtensa_operand_undo_reloc (xtensa_isa isa, xtensa_opcode opc, int opnd,
 /* Get the state accessed by a state operand.  Returns XTENSA_UNDEFINED
    on error.  */
 
-extern xtensa_state
+R_API extern xtensa_state
 xtensa_stateOperand_state (xtensa_isa isa, xtensa_opcode opc, int stOp);
 
 
 /* Check if a state operand is an input ('i'), output ('o'), or inout
    ('m') operand.  Returns 0 on error.  */
 
-extern char
+R_API extern char
 xtensa_stateOperand_inout (xtensa_isa isa, xtensa_opcode opc, int stOp);
 
 
@@ -598,7 +600,7 @@ xtensa_stateOperand_inout (xtensa_isa isa, xtensa_opcode opc, int stOp);
 /* Get the external interface accessed by an interface operand.
    Returns XTENSA_UNDEFINED on error.  */
 
-extern xtensa_interface
+R_API extern xtensa_interface
 xtensa_interfaceOperand_interface (xtensa_isa isa, xtensa_opcode opc,
 				   int ifOp);
 
@@ -618,20 +620,20 @@ xtensa_interfaceOperand_interface (xtensa_isa isa, xtensa_opcode opc,
    ignores "view" regfiles since they always have the same shortname as
    their parents.  */
 
-extern xtensa_regfile
+R_API extern xtensa_regfile
 xtensa_regfile_lookup (xtensa_isa isa, const char *name);
 
-extern xtensa_regfile
+R_API extern xtensa_regfile
 xtensa_regfile_lookup_shortname (xtensa_isa isa, const char *shortname);
 
 
 /* Get the name or abbreviated "short name" of a regfile.
    Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_regfile_name (xtensa_isa isa, xtensa_regfile rf);
 
-extern const char *
+R_API extern const char *
 xtensa_regfile_shortname (xtensa_isa isa, xtensa_regfile rf);
 
 
@@ -639,21 +641,21 @@ xtensa_regfile_shortname (xtensa_isa isa, xtensa_regfile rf);
    view, the result is the same as the input parameter.  Returns
    XTENSA_UNDEFINED on error.  */
 
-extern xtensa_regfile
+R_API extern xtensa_regfile
 xtensa_regfile_view_parent (xtensa_isa isa, xtensa_regfile rf);
 
 
 /* Get the bit width of a regfile or regfile view.
    Returns XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_regfile_num_bits (xtensa_isa isa, xtensa_regfile rf);
 
 
 /* Get the number of regfile entries.  Returns XTENSA_UNDEFINED on
    error.  */
 
-extern int
+R_API extern int
 xtensa_regfile_num_entries (xtensa_isa isa, xtensa_regfile rf);
 
 
@@ -662,20 +664,20 @@ xtensa_regfile_num_entries (xtensa_isa isa, xtensa_regfile rf);
 
 /* Look up a state by name.  Returns XTENSA_UNDEFINED on error.  */
 
-extern xtensa_state
+R_API extern xtensa_state
 xtensa_state_lookup (xtensa_isa isa, const char *name);
 
 
 /* Get the name for a processor state.  Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_state_name (xtensa_isa isa, xtensa_state st);
 
 
 /* Get the bit width for a processor state.
    Returns XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_state_num_bits (xtensa_isa isa, xtensa_state st);
 
 
@@ -683,14 +685,14 @@ xtensa_state_num_bits (xtensa_isa isa, xtensa_state st);
    the condition is false, 1 if the condition is true, and
    XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_state_is_exported (xtensa_isa isa, xtensa_state st);
 
 
 /* Check for a "shared_or" state.  Returns 0 if the condition is false,
    1 if the condition is true, and XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_state_is_shared_or (xtensa_isa isa, xtensa_state st);
 
 
@@ -701,26 +703,26 @@ xtensa_state_is_shared_or (xtensa_isa isa, xtensa_state st);
    or a "special register".  Returns XTENSA_UNDEFINED if the sysreg does
    not exist.  */
 
-extern xtensa_sysreg
+R_API extern xtensa_sysreg
 xtensa_sysreg_lookup (xtensa_isa isa, int num, int is_user);
 
 
 /* Check if there exists a sysreg with a given name.
    If not, this function returns XTENSA_UNDEFINED.  */
 
-extern xtensa_sysreg
+R_API extern xtensa_sysreg
 xtensa_sysreg_lookup_name (xtensa_isa isa, const char *name);
 
 
 /* Get the name of a sysreg.  Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_sysreg_name (xtensa_isa isa, xtensa_sysreg sysreg);
 
 
 /* Get the register number.  Returns XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_sysreg_number (xtensa_isa isa, xtensa_sysreg sysreg);
 
 
@@ -728,7 +730,7 @@ xtensa_sysreg_number (xtensa_isa isa, xtensa_sysreg sysreg);
    Returns 0 for special registers, 1 for user registers and
    XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_sysreg_is_user (xtensa_isa isa, xtensa_sysreg sysreg);
 
 
@@ -738,27 +740,27 @@ xtensa_sysreg_is_user (xtensa_isa isa, xtensa_sysreg sysreg);
 /* Find an interface by name.  The return value is XTENSA_UNDEFINED if
    the specified interface is not found.  */
 
-extern xtensa_interface
+R_API extern xtensa_interface
 xtensa_interface_lookup (xtensa_isa isa, const char *ifname);
 
 
 /* Get the name of an interface.  Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_interface_name (xtensa_isa isa, xtensa_interface intf);
 
 
 /* Get the bit width for an interface.
    Returns XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_interface_num_bits (xtensa_isa isa, xtensa_interface intf);
 
 
 /* Check if an interface is an input ('i') or output ('o') with respect
    to the Xtensa processor core.  Returns 0 on error.  */
 
-extern char
+R_API extern char
 xtensa_interface_inout (xtensa_isa isa, xtensa_interface intf);
 
 
@@ -767,7 +769,7 @@ xtensa_interface_inout (xtensa_isa isa, xtensa_interface intf);
    interfaces do not.  Returns 1 if there are side effects, 0 if not,
    and XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_interface_has_side_effect (xtensa_isa isa, xtensa_interface intf);
 
 
@@ -780,7 +782,7 @@ xtensa_interface_has_side_effect (xtensa_isa isa, xtensa_interface intf);
    interfaces are related; the specific values of the identifiers have
    no particular meaning otherwise.  */
 
-extern int
+R_API extern int
 xtensa_interface_class_id (xtensa_isa isa, xtensa_interface intf);
 
 
@@ -790,20 +792,20 @@ xtensa_interface_class_id (xtensa_isa isa, xtensa_interface intf);
 /* Find a functional unit by name.  The return value is XTENSA_UNDEFINED if
    the specified unit is not found.  */
 
-extern xtensa_funcUnit
+R_API extern xtensa_funcUnit
 xtensa_funcUnit_lookup (xtensa_isa isa, const char *fname);
 
 
 /* Get the name of a functional unit.  Returns null on error.  */
 
-extern const char *
+R_API extern const char *
 xtensa_funcUnit_name (xtensa_isa isa, xtensa_funcUnit fun);
 
 
 /* Functional units may be replicated.  See how many instances of a
    particular function unit exist.  Returns XTENSA_UNDEFINED on error.  */
 
-extern int
+R_API extern int
 xtensa_funcUnit_num_copies (xtensa_isa isa, xtensa_funcUnit fun);
 
 

--- a/libr/asm/arch/msp430/msp430_disas.h
+++ b/libr/asm/arch/msp430/msp430_disas.h
@@ -84,5 +84,5 @@ struct msp430_cmd {
 	char	operands[MSP430_INSTR_MAXLEN];
 };
 
-int msp430_decode_command(const ut8 *instr, struct msp430_cmd *cmd);
+R_API int msp430_decode_command(const ut8 *instr, struct msp430_cmd *cmd);
 #endif /* MSP430_DISAS_H */

--- a/libr/asm/arch/tms320/c55x_plus/ins.h
+++ b/libr/asm/arch/tms320/c55x_plus/ins.h
@@ -5,7 +5,7 @@
 #include "utils.h"
 
 // instruction length
-ut32 get_ins_len(ut8 opcode);
+R_API ut32 get_ins_len(ut8 opcode);
 
 // gets instruction bytes from a position
 ut32 get_ins_part(ut32 pos, ut32 len);

--- a/libr/asm/arch/tms320/tms320_dasm.h
+++ b/libr/asm/arch/tms320/tms320_dasm.h
@@ -237,9 +237,9 @@ typedef struct {
 #define INSN_FLAG(af, av)		{ .f = af, .v = TMS320_FLAG_##av }
 #define INSN_SYNTAX(...)		(char *)#__VA_ARGS__
 
-extern int tms320_dasm(tms320_dasm_t *, const ut8 *, int);
+R_API extern int tms320_dasm(tms320_dasm_t *, const ut8 *, int);
 
-extern int tms320_dasm_init(tms320_dasm_t *);
-extern int tms320_dasm_fini(tms320_dasm_t *);
+R_API extern int tms320_dasm_init(tms320_dasm_t *);
+R_API extern int tms320_dasm_fini(tms320_dasm_t *);
 
 #endif /* __TMS320_DASM_H__ */

--- a/libr/asm/arch/v810/v810_disas.h
+++ b/libr/asm/arch/v810/v810_disas.h
@@ -141,6 +141,6 @@ struct v810_cmd {
 	char operands[V810_INSTR_MAXLEN];
 };
 
-int v810_decode_command(const ut8 *instr, int len, struct v810_cmd *cmd);
+R_API int v810_decode_command(const ut8 *instr, int len, struct v810_cmd *cmd);
 
 #endif /* R2_V810_DISASM_H */

--- a/libr/asm/arch/v850/v850_disas.h
+++ b/libr/asm/arch/v850/v850_disas.h
@@ -108,5 +108,5 @@ struct v850_cmd {
 	char	operands[V850_INSTR_MAXLEN];
 };
 
-int v850_decode_command (const ut8 *instr, struct v850_cmd *cmd);
+R_API int v850_decode_command (const ut8 *instr, struct v850_cmd *cmd);
 #endif /* R2_V850_DISASM_H */

--- a/shlr/bochs/include/libbochs.h
+++ b/shlr/bochs/include/libbochs.h
@@ -19,7 +19,7 @@ typedef struct libbochs_t {
 	HANDLE hWritePipeOut;
 	HANDLE ghWriteEvent;
 	PROCESS_INFORMATION processInfo;
-	STARTUPINFO info;
+	STARTUPINFOA info;
 #else
 	int hReadPipeIn;
 	int hReadPipeOut;

--- a/shlr/bochs/src/libbochs.c
+++ b/shlr/bochs/src/libbochs.c
@@ -205,9 +205,9 @@ bool bochs_open(libbochs_t* b, const char * pathBochs, const char * pathConfig) 
 	if (CreatePipe (&b->hReadPipeIn, &b->hReadPipeOut, &PipeAttributes, SIZE_BUF) &&
 	    CreatePipe (&b->hWritePipeIn, &b->hWritePipeOut, &PipeAttributes, SIZE_BUF)
 	   ) {
-		memset (&b->info, 0, sizeof (STARTUPINFO));
+		memset (&b->info, 0, sizeof (STARTUPINFOA));
 		memset (&b->processInfo, 0, sizeof (PROCESS_INFORMATION));
-		b->info.cb = sizeof (STARTUPINFO);
+		b->info.cb = sizeof (STARTUPINFOA);
 		b->info.hStdError = b->hReadPipeOut;
 		b->info.hStdOutput = b->hReadPipeOut;
 		b->info.hStdInput = b->hWritePipeIn;

--- a/shlr/wind/iob_pipe.c
+++ b/shlr/wind/iob_pipe.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "r_types.h"
 
 #if __WINDOWS__ || __CYGWIN__ || MINGW32
 #include <windows.h>
@@ -10,7 +11,7 @@
 
 static void *iob_pipe_open (const char *path) {
 	HANDLE hPipe;
-	hPipe = CreateFile (path, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+	hPipe = CreateFileA (path, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
 	eprintf ("iob_pipe_open: invocado %s\n", path);
 	if (hPipe != INVALID_HANDLE_VALUE) {
 		return (void *)(HANDLE)hPipe;


### PR DESCRIPTION
- Exposed some functions as R_API to can link ANAL vs ASM/p
- Fixed libbochs to always use multibyte structs.
- Fixed wind to alway use multybyte apis and include r_types.h to avoid set preprocessor directive __WINDOWS_