### PR TITLE
Add diff-style memory snapshot

### DIFF
--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -118,7 +118,7 @@ R_API RDebugSession *r_debug_session_get(RDebug *dbg, ut64 addr) {
 	r_list_foreach_prev (dbg->sessions, iter, session) {
 		if (session->key.addr != addr) {
 			/* Sessions are saved along program flow. So key must be compared by "!=" not "<". *
-				 ex. Some operations like, jmp, can go back to former address in normal program flow. */
+			         ex. Some operations like, jmp, can go back to former address in normal program flow. */
 			return session;
 		}
 	}

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -23,8 +23,8 @@ R_API void r_debug_session_list(RDebug *dbg) {
 			if (snap->comment && *snap->comment) {
 				comment = snap->comment;
 			}
-			dbg->cb_printf ("%d 0x%08"PFMT64x " - 0x%08"PFMT64x " size: %d crc: %x  --  %s\n",
-				count, snap->addr, snap->addr_end, snap->size, snap->crc, comment);
+			dbg->cb_printf ("%d 0x%08"PFMT64x " - 0x%08"PFMT64x " size: %d  --  %s\n",
+				count, snap->addr, snap->addr_end, snap->size, comment);
 			count++;
 		}
 	}
@@ -117,6 +117,8 @@ R_API RDebugSession *r_debug_session_get(RDebug *dbg, ut64 addr) {
 	RListIter *iter;
 	r_list_foreach_prev (dbg->sessions, iter, session) {
 		if (session->key.addr != addr) {
+			/* Sessions are saved along program flow. So key must be compared by "!=" not "<". *
+				 ex. Some operations like, jmp, can go back to former address in normal program flow. */
 			return session;
 		}
 	}

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -2,7 +2,7 @@
 
 #include <r_debug.h>
 
-R_API RDebugSnap* r_debug_snap_new() {
+R_API RDebugSnap *r_debug_snap_new() {
 	RDebugSnap *snap = R_NEW0 (RDebugSnap);
 	ut64 algobit = r_hash_name_to_bits ("sha256");
 	if (!snap) {
@@ -13,8 +13,8 @@ R_API RDebugSnap* r_debug_snap_new() {
 	return snap;
 }
 
-R_API void r_debug_snap_free (void *p) {
-	RDebugSnap *snap = (RDebugSnap*)p;
+R_API void r_debug_snap_free(void *p) {
+	RDebugSnap *snap = (RDebugSnap *) p;
 	ut32 i = 0;
 	r_list_free (snap->history);
 	free (snap->data);
@@ -54,37 +54,40 @@ R_API void r_debug_snap_list(RDebug *dbg, int idx, int mode) {
 	ut32 count = 0;
 	RListIter *iter;
 	RDebugSnap *snap;
-	if (mode == 'j')
+	if (mode == 'j') {
 		dbg->cb_printf ("[");
+	}
 	r_list_foreach (dbg->snaps, iter, snap) {
 		comment = "";
-		comma = (iter->n)? ",":"";
+		comma = (iter->n)? ",": "";
 		if (idx != -1) {
 			if (idx != count) {
 				continue;
 			}
 		}
-		if (snap->comment && *snap->comment)
+		if (snap->comment && *snap->comment) {
 			comment = snap->comment;
+		}
 		switch (mode) {
 		case 'j':
-			dbg->cb_printf ("{\"count\":%d,\"addr\":%"PFMT64d",\"size\":%d,\"history\":%d,\"comment\":\"%s\"}%s",
+			dbg->cb_printf ("{\"count\":%d,\"addr\":%"PFMT64d ",\"size\":%d,\"history\":%d,\"comment\":\"%s\"}%s",
 				count, snap->addr, snap->size, r_list_length (snap->history), comment, comma);
 			break;
 		case '*':
-			dbg->cb_printf ("dms 0x%08"PFMT64x"\n", snap->addr);
+			dbg->cb_printf ("dms 0x%08"PFMT64x "\n", snap->addr);
 			break;
 		default:
-			dbg->cb_printf ("%d 0x%08"PFMT64x" - 0x%08"PFMT64x" history: %d size: %d  --  %s\n",
+			dbg->cb_printf ("%d 0x%08"PFMT64x " - 0x%08"PFMT64x " history: %d size: %d  --  %s\n",
 				count, snap->addr, snap->addr_end, r_list_length (snap->history), snap->size, comment);
 		}
 		count++;
 	}
-	if (mode == 'j')
+	if (mode == 'j') {
 		dbg->cb_printf ("]\n");
+	}
 }
 
-R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr) {
+R_API RDebugSnap *r_debug_snap_get(RDebug *dbg, ut64 addr) {
 	RListIter *iter;
 	RDebugSnap *snap;
 	r_list_foreach (dbg->snaps, iter, snap) {
@@ -95,10 +98,10 @@ R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr) {
 	return NULL;
 }
 
-R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap) {
+R_API int r_debug_snap_set(RDebug *dbg, RDebugSnap *snap) {
 	RListIter *iter;
 	RDebugSnapDiff *diff;
-	eprintf ("Writing %d bytes to 0x%08"PFMT64x"...\n", snap->size, snap->addr);
+	eprintf ("Writing %d bytes to 0x%08"PFMT64x "...\n", snap->size, snap->addr);
 	/* XXX: Set all history from oldest one. It's bit ugly. */
 	r_list_foreach (snap->history, iter, diff) {
 		ut64 addr = snap->addr + diff->page_off * SNAP_PAGE_SIZE;
@@ -107,12 +110,13 @@ R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap) {
 	return 1;
 }
 
-R_API int r_debug_snap_set_idx (RDebug *dbg, int idx) {
+R_API int r_debug_snap_set_idx(RDebug *dbg, int idx) {
 	RDebugSnap *snap;
 	RListIter *iter;
 	ut32 count = 0;
-	if (!dbg || idx < 0)
+	if (!dbg || idx < 0) {
 		return 0;
+	}
 	r_list_foreach (dbg->snaps, iter, snap) {
 		if (count == idx) {
 			r_debug_snap_set (dbg, snap);
@@ -124,15 +128,15 @@ R_API int r_debug_snap_set_idx (RDebug *dbg, int idx) {
 }
 
 /* XXX: Just for debugging. Duplicate soon */
-static void print_hash (ut8 *hash, int digest_size) {
+static void print_hash(ut8 *hash, int digest_size) {
 	int i = 0;
 	for (i = 0; i < digest_size; i++) {
-		eprintf ("%02"PFMT64x,hash[i]);
+		eprintf ("%02"PFMT64x, hash[i]);
 	}
 	eprintf ("\n");
 }
 
-static int r_debug_snap_map (RDebug *dbg, RDebugMap *map) {
+static int r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 	if (!dbg || !map || map->size < 1) {
 		eprintf ("Invalid map size\n");
 		return 0;
@@ -159,10 +163,10 @@ static int r_debug_snap_map (RDebug *dbg, RDebugMap *map) {
 			free (snap);
 			return 0;
 		}
-		snap->hashes = malloc (sizeof (ut8*) * page_num);
-		snap->last_changes = calloc (page_num, sizeof (RDebugSnapDiff*));
+		snap->hashes = malloc (sizeof (ut8 *) * page_num);
+		snap->last_changes = calloc (page_num, sizeof (RDebugSnapDiff *));
 
-		eprintf ("Reading %d bytes from 0x%08"PFMT64x"...\n", snap->size, snap->addr);
+		eprintf ("Reading %d bytes from 0x%08"PFMT64x "...\n", snap->size, snap->addr);
 		dbg->iob.read_at (dbg->iob.io, snap->addr, snap->data, snap->size);
 
 		ut32 clust_page = R_MIN (SNAP_PAGE_SIZE, snap->size);
@@ -174,14 +178,14 @@ static int r_debug_snap_map (RDebug *dbg, RDebugMap *map) {
 			hash = malloc (digest_size);
 			memcpy (hash, snap->hash_ctx->digest, digest_size);
 			snap->hashes[page_off] = hash;
-			//eprintf ("0x%08"PFMT64x"(page: %d)...\n",addr, page_off);
-			//print_hash (hash, digest_size);
+			// eprintf ("0x%08"PFMT64x"(page: %d)...\n",addr, page_off);
+			// print_hash (hash, digest_size);
 		}
 
 		r_list_append (dbg->snaps, snap);
 	} else {
 		/* A base snapshot have already been saved. *
-			So we only need to save different parts. */
+		        So we only need to save different parts. */
 		r_debug_diff_add (dbg, snap);
 	}
 	return 1;
@@ -202,18 +206,19 @@ R_API int r_debug_snap_all(RDebug *dbg, int perms) {
 R_API int r_debug_snap(RDebug *dbg, ut64 addr) {
 	RDebugMap *map = r_debug_map_get (dbg, addr);
 	if (!map) {
-		eprintf ("Cannot find map at 0x%08"PFMT64x"\n", addr);
+		eprintf ("Cannot find map at 0x%08"PFMT64x "\n", addr);
 		return 0;
 	}
 	return r_debug_snap_map (dbg, map);
 }
 
-R_API int r_debug_snap_comment (RDebug *dbg, int idx, const char *msg) {
+R_API int r_debug_snap_comment(RDebug *dbg, int idx, const char *msg) {
 	RDebugSnap *snap;
 	RListIter *iter;
 	ut32 count = 0;
-	if (!dbg || idx<0 || !msg || !*msg)
+	if (!dbg || idx < 0 || !msg || !*msg) {
 		return 0;
+	}
 	r_list_foreach (dbg->snaps, iter, snap) {
 		if (count == idx) {
 			free (snap->comment);
@@ -225,13 +230,13 @@ R_API int r_debug_snap_comment (RDebug *dbg, int idx, const char *msg) {
 	return 1;
 }
 
-R_API void r_debug_diff_free (void *p) {
+R_API void r_debug_diff_free(void *p) {
 	RDebugSnapDiff *diff = (RDebugSnapDiff *) p;
 	free (diff->data);
 	free (diff);
 }
 
-R_API void r_debug_diff_add (RDebug *dbg, RDebugSnap *base) {
+R_API void r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 	RDebugSnapDiff *last, *new;
 	ut64 addr;
 	int digest_size;
@@ -252,18 +257,18 @@ R_API void r_debug_diff_add (RDebug *dbg, RDebugSnap *base) {
 		/* Check If there is any last change for this page. */
 		if ((last = base->last_changes[page_off])) {
 			/* Use hash of last SnapDiff */
-			//eprintf ("found diff\n");
+			// eprintf ("found diff\n");
 			prev_hash = last->hash;
 		} else {
 			/* Use hash of base snapshot */
-			//eprintf ("use base\n");
+			// eprintf ("use base\n");
 			prev_hash = base->hashes[page_off];
 		}
 		/* Memory has been changed. So add new diff entry for this addr */
 		if (memcmp (cur_hash, prev_hash, digest_size) != 0) {
-			//eprintf ("different: 0x%08"PFMT64x"(page %d)...\n", addr, page_off);
-			//print_hash (cur_hash, digest_size);
-			//print_hash (prev_hash, digest_size);
+			// eprintf ("different: 0x%08"PFMT64x"(page %d)...\n", addr, page_off);
+			// print_hash (cur_hash, digest_size);
+			// print_hash (prev_hash, digest_size);
 			/* Create new diff entry, save one page and calculate hash. */
 			new = (RDebugSnapDiff *) malloc (sizeof (RDebugSnapDiff));
 			new->page_off = page_off;
@@ -271,7 +276,7 @@ R_API void r_debug_diff_add (RDebug *dbg, RDebugSnap *base) {
 			memcpy (new->hash, cur_hash, digest_size);
 
 			r_list_append (base->history, new);
-			base->last_changes [page_off] = new;
+			base->last_changes[page_off] = new;
 		}
 	}
 }

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -44,6 +44,7 @@ R_LIB_VERSION_HEADER(r_debug);
 #define PTRACE_SYSCALL PT_STEP
 #endif
 
+#define SNAP_PAGE_SIZE 512
 
 /*
  * states that a process can be in

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -4,6 +4,7 @@
 #include <r_types.h>
 #include <r_anal.h>
 #include <r_cons.h>
+#include <r_hash.h>
 #include <r_util.h>
 #include <r_reg.h>
 #include <r_bp.h>
@@ -154,10 +155,9 @@ typedef struct r_debug_desc_t {
 } RDebugDesc;
 
 typedef struct r_debug_snap_diff_t {
-	ut64 addr;
-	ut64 addr_end;
+	int page_off;
 	ut8 *data;
-	ut32 crc;
+	ut8 hash[128];
 } RDebugSnapDiff;
 
 typedef struct r_debug_snap_t {
@@ -165,8 +165,11 @@ typedef struct r_debug_snap_t {
 	ut64 addr_end;
 	ut8 *data;
 	ut32 size;
+	ut32 page_num;
 	ut64 timestamp;
-	RList *crcs; // <u32>
+	RHash *hash_ctx;
+	ut8 **hashes; // Hash of each pages
+	RDebugSnapDiff **last_changes; // Last diff entries of each pages
 	RList *history; // <RDebugSnapDiff*>
 	char *comment;
 } RDebugSnap;
@@ -524,6 +527,7 @@ R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
 
 /* snap diff */
 R_API void r_debug_diff_free (void *p) ;
+R_API void r_debug_diff_add (RDebug *dbg, RDebugSnap *base);
 
 /* debug session */
 R_API void r_debug_session_free (void *p) ;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -153,13 +153,21 @@ typedef struct r_debug_desc_t {
 	ut64 off;
 } RDebugDesc;
 
+typedef struct r_debug_snap_diff_t {
+	ut64 addr;
+	ut64 addr_end;
+	ut8 *data;
+	ut32 crc;
+} RDebugSnapDiff;
+
 typedef struct r_debug_snap_t {
 	ut64 addr;
 	ut64 addr_end;
 	ut8 *data;
 	ut32 size;
 	ut64 timestamp;
-	ut32 crc;
+	RList *crcs; // <u32>
+	RList *history; // <RDebugSnapDiff*>
 	char *comment;
 } RDebugSnap;
 
@@ -503,16 +511,19 @@ R_API int r_debug_esil_watch_empty(RDebug *dbg);
 R_API void r_debug_esil_prestep (RDebug *d, int p);
 
 /* snap */
+R_API RDebugSnap* r_debug_snap_new(void);
 R_API void r_debug_snap_free(void *snap);
 R_API int r_debug_snap_delete(RDebug *dbg, int idx);
 R_API void r_debug_snap_list(RDebug *dbg, int idx, int mode);
-R_API int r_debug_snap_diff(RDebug *dbg, int idx);
 R_API int r_debug_snap(RDebug *dbg, ut64 addr);
 R_API int r_debug_snap_comment (RDebug *dbg, int idx, const char *msg);
 R_API int r_debug_snap_all(RDebug *dbg, int perms);
 R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr);
 R_API int r_debug_snap_set_idx (RDebug *dbg, int idx);
 R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
+
+/* snap diff */
+R_API void r_debug_diff_free (void *p) ;
 
 /* debug session */
 R_API void r_debug_session_free (void *p) ;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -44,7 +44,7 @@ R_LIB_VERSION_HEADER(r_debug);
 #define PTRACE_SYSCALL PT_STEP
 #endif
 
-#define SNAP_PAGE_SIZE 512
+#define SNAP_PAGE_SIZE 4096
 
 /*
  * states that a process can be in


### PR DESCRIPTION
This patch add new diff-style format of memory snapshot.
User can save current memory snapshot by 'dms' command as before.
But internally, **only different memory page** from previous snapshot is saved, instead of entire memory area. It makes all snapshots memory-efficient.

Implementation:
This diff-style format consists of two components, 'RDebugSnap' and 'RDebugSnapDiff'.
Snap diffs are differences from base snapshot 'RDebugSnap' that has entire memory dump.
When user saves memory snapshot, firstly check If base snapshot have been already existed.
If no, take entire memory dump and create base snapshot.
Otherwise, take only different pages from **previous snapshot** (It can be base snapshot or diff snapshot), and create new 'RDebugSnapDiff' and then,
chained to 'RDebugSnap->history'. 
Binary diff is done by using calculated **SHA256 hash**. 