### PR TITLE
update equivalent flags for -g

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -43,7 +43,7 @@ static int rabin_show_help(int v) {
 		" -E              globally exportable symbols\n"
 		" -f [str]        select sub-bin named str\n"
 		" -F [binfmt]     force to use that bin plugin (ignore header check)\n"
-		" -g              same as -SMResiz (show all info)\n"
+		" -g              same as -SMZIHVResizcld (show all info)\n"
 		" -G [addr]       load address . offset to header\n"
 		" -h              this help message\n"
 		" -H              header fields\n"


### PR DESCRIPTION
The list of flags to use to achieve the same result as using -g was out of date.