### PR TITLE
bug in varsub in att syntax

### DIFF
--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -335,13 +335,13 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 			}
 		}
 		char *ptr = strstr(tstr, oldstr);
-		if (ptr && (!att || *(ptr - 1) != '-')) {
+		if (ptr && (!att || *(ptr - 1) == ' ')) {
 			tstr = r_str_replace (tstr, oldstr, newstr, 1);
 			break;
 		} else {
 			r_str_case (oldstr, false);
 			ptr = strstr(tstr, oldstr);
-			if (ptr && (!att || *(ptr - 1) != '-')) {
+			if (ptr && (!att || *(ptr - 1) == ' ')) {
 				tstr = r_str_replace (tstr, oldstr, newstr, 1);
 				break;
 			}
@@ -372,13 +372,13 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 			}
 		}
 		char *ptr = strstr(tstr, oldstr);
-		if (ptr && (!att || *(ptr - 1) != '-')) {
+		if (ptr && (!att || *(ptr - 1) == ' ')) {
 			tstr = r_str_replace (tstr, oldstr, newstr, 1);
 			break;
 		} else {
 			r_str_case (oldstr, false);
 			ptr = strstr(tstr, oldstr);
-			if (ptr && (!att || *(ptr - 1) != '-')) {
+			if (ptr && (!att || *(ptr - 1) == ' ')) {
 				tstr = r_str_replace (tstr, oldstr, newstr, 1);
 				break;
 			}


### PR DESCRIPTION
Sorry I only considered the case where a minus sign is before `oldstr`, actually this should be the correct way to handle that so arguments like `8(%rbp)` and `28(%rbp)` will work too.
Will send PR to r2r to adjust the test later.

EDIT: related to #7538 