### PR TITLE
Add new trace session format

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3492,7 +3492,7 @@ static int cmd_debug(void *data, const char *input) {
 			case '+':
 				r_debug_session_add (core->dbg);
 				break;
-			case 'A':
+			case 'A': // for debugging command (private command for developer)
 				r_debug_session_set_idx (core->dbg, atoi (input + 4));
 				break;
 			default:
@@ -3501,7 +3501,6 @@ static int cmd_debug(void *data, const char *input) {
 					"Usage:", "dts[*]", "",
 					"dts", "", "List all trace sessions",
 					"dts+", "", "Add trace session",
-					"dtsA", " id", "Apply trace session",
 					NULL };
 				r_core_cmd_help (core, help_msg);
 				}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1141,7 +1141,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 					ut64 closest_addr = UT64_MAX;
 					RList *symbols = r_bin_get_symbols (core->bin);
 					RBinSymbol *symbol, *closest_symbol = NULL;
-					
+
 					r_list_foreach (symbols, iter, symbol) {
 						if (symbol->vaddr > addr) {
 							if (symbol->vaddr - addr < closest_addr) {
@@ -1321,7 +1321,7 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg) {
 		value = r_reg_get_value (core->dbg->reg, r);
 		rrstr = r_core_anal_hasrefs (core, value, true);
 		if (bits == 64) {
-			if (r->flags) {	
+			if (r->flags) {
 				tmp = r_reg_get_bvalue (reg, r);
 				r_cons_printf ("%6s %018s", r->name, tmp);
 			} else {
@@ -2017,7 +2017,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				case 0:
 					r_cons_printf ("0x%08"PFMT64x"\n", off);
 					break;
-				case 1: 
+				case 1:
 					r_cons_printf ("Unknown register '%s'\n", str + 1);
 					break;
 				case 80:
@@ -2156,8 +2156,8 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 	case 't': // "dbt"
 		switch (input[2]) {
 			case 'e': // "dbte"
-				for (p = input + 3; *p == ' '; p++) { 
-					/* nothing to do here */ 
+				for (p = input + 3; *p == ' '; p++) {
+					/* nothing to do here */
 				}
 				if (*p == '*') {
 					r_bp_set_trace_all (core->dbg->bp,true);
@@ -3136,7 +3136,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 				}
 			}
 		}
-		
+
 		eprintf ("Selecting and continuing: %d\n", main_pid);
 		r_debug_select (core->dbg, main_pid, main_pid);
 		r_debug_continue (core->dbg);
@@ -3493,7 +3493,7 @@ static int cmd_debug(void *data, const char *input) {
 				r_debug_session_add (core->dbg);
 				break;
 			case 'A':
-				r_debug_session_set_idx (core->dbg, atoi (input + 2));
+				r_debug_session_set_idx (core->dbg, atoi (input + 4));
 				break;
 			default:
 				{

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -97,7 +97,6 @@ R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session) {
 		}
 	}
 	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
-
 	/* Restore all memory values from memory (diff) snapshots */
 	r_list_foreach (session->memlist, iter, diff) {
 		r_debug_diff_set (dbg, diff);
@@ -112,9 +111,8 @@ R_API bool r_debug_session_set_idx(RDebug *dbg, int idx) {
 	if (!dbg || idx < 0) {
 		return false;
 	}
-
 	r_list_foreach (dbg->sessions, iter, session) {
-		if (count == idx) {
+		if (session->key.id == idx) {
 			r_debug_session_set (dbg, session);
 			return true;
 		}

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -12,10 +12,12 @@ static int r_debug_session_lastid(RDebug *dbg) {
 R_API void r_debug_session_list(RDebug *dbg) {
 	const char *comment;
 	ut32 count = 0;
-	RListIter *iterse, *itersn;
+	RListIter *iterse, *itersn, *iterpg;
 	RDebugSnap *snap;
 	RDebugSnapDiff *diff;
 	RDebugSession *session;
+	RPageData *page;
+
 	r_list_foreach (dbg->sessions, iterse, session) {
 		count = 0;
 		dbg->cb_printf ("session:%2d\tat:0x%08"PFMT64x "\n", session->key.id, session->key.addr);
@@ -25,8 +27,13 @@ R_API void r_debug_session_list(RDebug *dbg) {
 			if (snap->comment && *snap->comment) {
 				comment = snap->comment;
 			}
-			dbg->cb_printf ("\t- %d 0x%08"PFMT64x " - 0x%08"PFMT64x " size: %d (page: %d)  --  %s\n",
-				count, snap->addr, snap->addr_end, snap->size, diff->page_off, comment);
+			dbg->cb_printf ("\t- %d 0x%08"PFMT64x " - 0x%08"PFMT64x " size: %d ",
+				count, snap->addr, snap->addr_end, snap->size);
+			dbg->cb_printf ("(pages: ");
+			r_list_foreach (diff->pages, itersn, page) {
+				dbg->cb_printf ("%d ", page->page_off);
+			}
+			dbg->cb_printf (")\n");
 			count++;
 		}
 	}

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -97,7 +97,7 @@ R_API RDebugSnap *r_debug_snap_get(RDebug *dbg, ut64 addr) {
 	return NULL;
 }
 
-static void r_page_data_set (RDebug *dbg, RPageData *page) {
+static void r_page_data_set(RDebug *dbg, RPageData *page) {
 	RDebugSnapDiff *diff = page->diff;
 	ut64 addr = diff->base->addr + page->page_off * SNAP_PAGE_SIZE;
 	dbg->iob.write_at (dbg->iob.io, addr, page->data, SNAP_PAGE_SIZE);
@@ -107,12 +107,12 @@ static void r_page_data_set (RDebug *dbg, RPageData *page) {
 R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 	RPageData *prev_page, *last_page;
 	RDebugSnap *snap = diff->base;
-	//assert (r_list_length (snap->history) > 0);
-	RDebugSnapDiff *latest = 	(RDebugSnapDiff *)r_list_tail (snap->history)->data;
+	// assert (r_list_length (snap->history) > 0);
+	RDebugSnapDiff *latest = (RDebugSnapDiff *) r_list_tail (snap->history)->data;
 	ut64 addr;
 	ut32 page_off;
 
-	eprintf ("Apply diff [0x%08"PFMT64x", 0x%08"PFMT64x"]\n", snap->addr, snap->addr_end);
+	eprintf ("Apply diff [0x%08"PFMT64x ", 0x%08"PFMT64x "]\n", snap->addr, snap->addr_end);
 
 	/* Role back page datas that's been changed **after** specified SnapDiff 'diff' */
 	for (addr = snap->addr; addr < snap->addr_end; addr += SNAP_PAGE_SIZE) {
@@ -124,7 +124,7 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 			ut64 addr = snap->addr + off;
 			/* Copy a page data of base snap to current addr. (i.e. role back) */
 			dbg->iob.write_at (dbg->iob.io, addr, snap->data + off, SNAP_PAGE_SIZE);
-			//eprintf ("Role back 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+			// eprintf ("Role back 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
 		}
 	}
 
@@ -133,7 +133,7 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 		page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
 		if ((prev_page = diff->last_changes[page_off])) {
 			r_page_data_set (dbg, prev_page);
-			//eprintf ("Update 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+			// eprintf ("Update 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
 		}
 	}
 }
@@ -169,7 +169,7 @@ static void print_hash(ut8 *hash, int digest_size) {
 	eprintf ("\n");
 }
 
-R_API RDebugSnapDiff* r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
+R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 	if (!dbg || !map || map->size < 1) {
 		eprintf ("Invalid map size\n");
 		return 0;
@@ -275,7 +275,7 @@ R_API void r_debug_diff_free(void *p) {
 	free (diff);
 }
 
-R_API RDebugSnapDiff* r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
+R_API RDebugSnapDiff *r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 	RDebugSnapDiff *prev_diff = NULL, *new_diff;
 	RPageData *new_page, *last_page;
 	ut64 addr;
@@ -325,14 +325,14 @@ R_API RDebugSnapDiff* r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 			new_page->page_off = page_off;
 			new_page->data = buf;
 			memcpy (new_page->hash, cur_hash, digest_size);
-			new_diff->last_changes [page_off] = new_page; //Update last change to new page
+			new_diff->last_changes[page_off] = new_page;	// Update last change to new page
 			r_list_append (new_diff->pages, new_page);
 		}
 	}
 	if (r_list_length (new_diff->pages)) {
 		RPageData *page;
 		RListIter *iter;
-		eprintf ("saved: 0x%08"PFMT64x"(page: ", addr);
+		eprintf ("saved: 0x%08"PFMT64x "(page: ", addr);
 		r_list_foreach (new_diff->pages, iter, page) {
 			eprintf ("%d ", page->page_off);
 		}

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -23,7 +23,6 @@ R_API void r_debug_snap_free(void *p) {
 		free (snap->hashes[i]);
 	}
 	free (snap->hashes);
-	free (snap->last_changes);
 	free (snap);
 }
 
@@ -98,19 +97,49 @@ R_API RDebugSnap *r_debug_snap_get(RDebug *dbg, ut64 addr) {
 	return NULL;
 }
 
+static void r_page_data_set (RDebug *dbg, RPageData *page) {
+	RDebugSnapDiff *diff = page->diff;
+	ut64 addr = diff->base->addr + page->page_off * SNAP_PAGE_SIZE;
+	dbg->iob.write_at (dbg->iob.io, addr, page->data, SNAP_PAGE_SIZE);
+}
+
+/* snap->history must have at least one entry */
 R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
-	ut64 addr = diff->base->addr + diff->page_off * SNAP_PAGE_SIZE;
-	dbg->iob.write_at (dbg->iob.io, addr, diff->data, SNAP_PAGE_SIZE);
+	RPageData *prev_page, *last_page;
+	RDebugSnap *snap = diff->base;
+	//assert (r_list_length (snap->history) > 0);
+	RDebugSnapDiff *latest = 	(RDebugSnapDiff *)r_list_tail (snap->history)->data;
+	ut64 addr;
+	ut32 page_off;
+
+	/* Role back page datas that's been changed **after** specified SnapDiff 'diff' */
+	for (addr = snap->addr; addr < snap->addr_end; snap += SNAP_PAGE_SIZE) {
+		page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
+		prev_page = diff->last_changes[page_off];
+		/* Apply only latest pages, that's been changed after prev_pages */
+		if ((last_page = latest->last_changes[page_off]) && last_page != prev_page) {
+			ut64 off = last_page->page_off * SNAP_PAGE_SIZE;
+			ut64 addr = snap->addr + off;
+			/* Copy a page data of base snap to current addr. (i.e. role back) */
+			dbg->iob.write_at (dbg->iob.io, addr, snap->data + off, SNAP_PAGE_SIZE);
+		}
+	}
+
+	/* Set all previous history (including specified SnapDiff 'diff')*/
+	for (addr = snap->addr; addr < snap->addr_end; snap += SNAP_PAGE_SIZE) {
+		page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
+		if ((prev_page = diff->last_changes[page_off])) {
+			r_page_data_set (dbg, prev_page);
+		}
+	}
 }
 
 R_API int r_debug_snap_set(RDebug *dbg, RDebugSnap *snap) {
 	RListIter *iter;
 	RDebugSnapDiff *diff;
+	ut64 addr;
 	eprintf ("Writing %d bytes to 0x%08"PFMT64x "...\n", snap->size, snap->addr);
-	/* XXX: Set all history from oldest one. It's bit ugly. */
-	r_list_foreach (snap->history, iter, diff) {
-		r_debug_diff_set (dbg, diff);
-	}
+	// XXX:
 	return 1;
 }
 
@@ -168,7 +197,6 @@ static int r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 			return 0;
 		}
 		snap->hashes = malloc (sizeof (ut8 *) * page_num);
-		snap->last_changes = calloc (page_num, sizeof (RDebugSnapDiff *));
 
 		eprintf ("Reading %d bytes from 0x%08"PFMT64x "...\n", snap->size, snap->addr);
 		dbg->iob.read_at (dbg->iob.io, snap->addr, snap->data, snap->size);
@@ -234,19 +262,38 @@ R_API int r_debug_snap_comment(RDebug *dbg, int idx, const char *msg) {
 	return 1;
 }
 
+R_API void r_page_data_free(void *p) {
+	RPageData *page = (RPageData *) p;
+	free (page->data);
+	free (page);
+}
+
 R_API void r_debug_diff_free(void *p) {
 	RDebugSnapDiff *diff = (RDebugSnapDiff *) p;
-	free (diff->data);
+	r_list_free (diff->pages);
+	free (diff->last_changes);
 	free (diff);
 }
 
 R_API void r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
-	RDebugSnapDiff *last, *new;
+	RDebugSnapDiff *prev_diff = NULL, *new_diff;
+	RPageData *new_page, *last_page;
 	ut64 addr;
 	int digest_size;
 	ut32 page_off;
 	ut64 algobit = r_hash_name_to_bits ("sha256");
 	ut32 clust_page = R_MIN (SNAP_PAGE_SIZE, base->size);
+
+	new_diff = (RDebugSnapDiff *) malloc (sizeof (RDebugSnapDiff));
+	new_diff->base = base;
+	new_diff->pages = r_list_newf (r_page_data_free);
+	new_diff->last_changes = calloc (base->page_num, sizeof (RPageData *));
+
+	if (r_list_length (base->history)) {
+		/* Inherit last changes from previous SnapDiff */
+		prev_diff = (RDebugSnapDiff *) r_list_tail (base->history)->data;
+		memcpy (new_diff->last_changes, prev_diff->last_changes, sizeof (RPageData) * base->page_num);
+	}
 
 	/* Compare hash of pages. */
 	for (addr = base->addr; addr < base->addr_end; addr += SNAP_PAGE_SIZE) {
@@ -259,10 +306,10 @@ R_API void r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 
 		page_off = (addr - base->addr) / SNAP_PAGE_SIZE;
 		/* Check If there is any last change for this page. */
-		if ((last = base->last_changes[page_off])) {
+		if (prev_diff && (last_page = prev_diff->last_changes[page_off])) {
 			/* Use hash of last SnapDiff */
 			// eprintf ("found diff\n");
-			prev_hash = last->hash;
+			prev_hash = last_page->hash;
 		} else {
 			/* Use hash of base snapshot */
 			// eprintf ("use base\n");
@@ -270,18 +317,28 @@ R_API void r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 		}
 		/* Memory has been changed. So add new diff entry for this addr */
 		if (memcmp (cur_hash, prev_hash, digest_size) != 0) {
-			// eprintf ("different: 0x%08"PFMT64x"(page %d)...\n", addr, page_off);
 			// print_hash (cur_hash, digest_size);
 			// print_hash (prev_hash, digest_size);
-			/* Create new diff entry, save one page and calculate hash. */
-			new = (RDebugSnapDiff *) malloc (sizeof (RDebugSnapDiff));
-			new->base = base;
-			new->page_off = page_off;
-			new->data = buf;
-			memcpy (new->hash, cur_hash, digest_size);
-
-			r_list_append (base->history, new);
-			base->last_changes[page_off] = new;
+			/* Create new page diff entry, save one page and calculate hash. */
+			new_page = (RPageData *) malloc (sizeof (RPageData));
+			new_page->diff = new_diff;
+			new_page->page_off = page_off;
+			new_page->data = buf;
+			memcpy (new_page->hash, cur_hash, digest_size);
+			new_diff->last_changes [page_off] = new_page; //Update last change to new page
+			r_list_append (new_diff->pages, new_page);
 		}
+	}
+	if (r_list_length (new_diff->pages)) {
+		RPageData *page;
+		RListIter *iter;
+		eprintf ("saved: 0x%08"PFMT64x"(page: ", addr);
+		r_list_foreach (new_diff->pages, iter, page) {
+			eprintf ("%d ", page->page_off);
+		}
+		eprintf (")\n");
+		r_list_append (base->history, new_diff);
+	} else {
+		r_debug_diff_free (new_diff);
 	}
 }

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -288,7 +288,7 @@ R_API RDebugSnapDiff* r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 	if (r_list_length (base->history)) {
 		/* Inherit last changes from previous SnapDiff */
 		prev_diff = (RDebugSnapDiff *) r_list_tail (base->history)->data;
-		memcpy (new_diff->last_changes, prev_diff->last_changes, sizeof (RPageData) * base->page_num);
+		memcpy (new_diff->last_changes, prev_diff->last_changes, sizeof (RPageData *) * base->page_num);
 	}
 
 	/* Compare hash of pages. */

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -134,12 +134,8 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 	}
 }
 
+// XXX: snap_set will be duplicated soon
 R_API int r_debug_snap_set(RDebug *dbg, RDebugSnap *snap) {
-	RListIter *iter;
-	RDebugSnapDiff *diff;
-	ut64 addr;
-	eprintf ("Writing %d bytes to 0x%08"PFMT64x "...\n", snap->size, snap->addr);
-	// XXX:
 	return 1;
 }
 
@@ -169,7 +165,7 @@ static void print_hash(ut8 *hash, int digest_size) {
 	eprintf ("\n");
 }
 
-static int r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
+R_API RDebugSnapDiff* r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 	if (!dbg || !map || map->size < 1) {
 		eprintf ("Invalid map size\n");
 		return 0;
@@ -218,9 +214,9 @@ static int r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 	} else {
 		/* A base snapshot have already been saved. *
 		        So we only need to save different parts. */
-		r_debug_diff_add (dbg, snap);
+		return r_debug_diff_add (dbg, snap);
 	}
-	return 1;
+	return NULL;
 }
 
 R_API int r_debug_snap_all(RDebug *dbg, int perms) {
@@ -275,7 +271,7 @@ R_API void r_debug_diff_free(void *p) {
 	free (diff);
 }
 
-R_API void r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
+R_API RDebugSnapDiff* r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 	RDebugSnapDiff *prev_diff = NULL, *new_diff;
 	RPageData *new_page, *last_page;
 	ut64 addr;
@@ -340,5 +336,7 @@ R_API void r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 		r_list_append (base->history, new_diff);
 	} else {
 		r_debug_diff_free (new_diff);
+		return NULL;
 	}
+	return new_diff;
 }

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -167,7 +167,7 @@ struct r_debug_snap_t;
 typedef struct r_debug_snap_diff_t {
 	struct r_debug_snap_t *base;
 	RList *pages; // <RPageData*>
-	RPageData **last_changes; // Last diff entries of each pages	
+	RPageData **last_changes; // Last diff entries of each pages
 } RDebugSnapDiff;
 
 typedef struct r_debug_snap_t {
@@ -529,6 +529,7 @@ R_API int r_debug_snap_delete(RDebug *dbg, int idx);
 R_API void r_debug_snap_list(RDebug *dbg, int idx, int mode);
 R_API int r_debug_snap(RDebug *dbg, ut64 addr);
 R_API int r_debug_snap_comment (RDebug *dbg, int idx, const char *msg);
+R_API RDebugSnapDiff* r_debug_snap_map(RDebug *dbg, RDebugMap *map);
 R_API int r_debug_snap_all(RDebug *dbg, int perms);
 R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr);
 R_API int r_debug_snap_set_idx (RDebug *dbg, int idx);
@@ -536,7 +537,7 @@ R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
 
 /* snap diff */
 R_API void r_debug_diff_free (void *p);
-R_API void r_debug_diff_add (RDebug *dbg, RDebugSnap *base);
+R_API RDebugSnapDiff* r_debug_diff_add(RDebug *dbg, RDebugSnap *base);
 R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff);
 
 /* page data */

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -155,12 +155,19 @@ typedef struct r_debug_desc_t {
 	ut64 off;
 } RDebugDesc;
 
-struct r_debug_snap_t;
-typedef struct r_debug_snap_diff_t {
-	struct r_debug_snap_t *base;
+struct r_debug_snap_diff_t;
+typedef struct r_page_data_t {
+	struct r_debug_snap_diff_t *diff; // Pointing SnapDiff that has this pagedata.
 	int page_off;
 	ut8 *data;
 	ut8 hash[128];
+} RPageData;
+
+struct r_debug_snap_t;
+typedef struct r_debug_snap_diff_t {
+	struct r_debug_snap_t *base;
+	RList *pages; // <RPageData*>
+	RPageData **last_changes; // Last diff entries of each pages	
 } RDebugSnapDiff;
 
 typedef struct r_debug_snap_t {
@@ -172,7 +179,6 @@ typedef struct r_debug_snap_t {
 	ut64 timestamp;
 	RHash *hash_ctx;
 	ut8 **hashes; // Hash of each pages
-	RDebugSnapDiff **last_changes; // Last diff entries of each pages
 	RList *history; // <RDebugSnapDiff*>
 	char *comment;
 } RDebugSnap;
@@ -529,9 +535,12 @@ R_API int r_debug_snap_set_idx (RDebug *dbg, int idx);
 R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
 
 /* snap diff */
-R_API void r_debug_diff_free (void *p) ;
+R_API void r_debug_diff_free (void *p);
 R_API void r_debug_diff_add (RDebug *dbg, RDebugSnap *base);
 R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff);
+
+/* page data */
+R_API void r_page_data_free(void *p);
 
 /* debug session */
 R_API void r_debug_session_free (void *p) ;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -155,7 +155,9 @@ typedef struct r_debug_desc_t {
 	ut64 off;
 } RDebugDesc;
 
+struct r_debug_snap_t;
 typedef struct r_debug_snap_diff_t {
+	struct r_debug_snap_t *base;
 	int page_off;
 	ut8 *data;
 	ut8 hash[128];
@@ -183,7 +185,7 @@ typedef struct r_debug_key {
 typedef struct r_debug_session_t {
 	RDebugKey key;
 	RListIter *reg[R_REG_TYPE_LAST];
-	RList *memlist; // <RDebugSnap*>
+	RList *memlist; // <RDebugSnapDiff*>
 } RDebugSession;
 
 typedef struct r_debug_trace_t {
@@ -529,6 +531,7 @@ R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
 /* snap diff */
 R_API void r_debug_diff_free (void *p) ;
 R_API void r_debug_diff_add (RDebug *dbg, RDebugSnap *base);
+R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff);
 
 /* debug session */
 R_API void r_debug_session_free (void *p) ;


### PR DESCRIPTION
**About:**
Add new trace session format, that saved by 'dts+' command.
Trace session is now using new diff style memory snapshots ( #7537 ) 

**Implementation:**
When user try to save trace session, a new memory snapshot, RDebugSnapDiff is created and 
session->memlist points it.

We can also apply trace session at any time. 'r_debug_session_set' function must be used.
This function calls 'r_debug_diff_set' for each memlist to apply diff page to actual memory page.

In 'r_debug_diff_set', at first, we need to role back current memory pages, that have been changed
**after specified diff log**. To do that, we compare 'last_changes' table of the diff file and **latest diff file**.

After that, we apply specified diff file and previous diff files from it.
That's how, we can recover the previous memory areas correctly by only using diff data.