### PR TITLE
Fix a simple bug in r2pm; make r_bin_get_size() behavior more intuitive

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -1,9 +1,6 @@
 #!/bin/sh
 # r2pm
 
-# Bail out on errors
-set -e
-
 # Honor user environment
 [ -z "${SUDO}" ] && SUDO=sudo
 [ -z "${WGET}" ] && WGET=wget

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -2636,7 +2636,7 @@ R_API ut64 r_bin_a2b(RBin *bin, ut64 addr) {
 
 R_API ut64 r_bin_get_size(RBin *bin) {
 	RBinObject *o = r_bin_cur_object (bin);
-	return o? o->size: UT64_MAX;
+	return o ? o->size : 0;
 }
 
 R_API int r_bin_file_delete_all(RBin *bin) {


### PR DESCRIPTION
This is my first pull request ever, so nothing special here, the changes should be quite self-explanatory. Feel free to whine about the stuff I broke and how I broke it, as I'm still learning my way around the code.