### PR TITLE
Hide fcn name if fcn type shown

### DIFF
--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -298,14 +298,11 @@ R_API char *r_anal_type_func_args_name(RAnal *anal, const char *func_name, int i
 
 #define MIN_MATCH_LEN 4
 
-// TODO: Future optimizations
-// - symbol names are long and noisy, reduce searchspace for match here
-//   by preprocessing to delete noise, as much as we can.
-// - We ignore all func.*, but thats maybe most of sdb entries
-//   could maybe eliminate this work (strcmp).
 R_API char *r_anal_type_func_guess(RAnal *anal, char *func_name) {
-	int j = 0, offset = 0, n;
+	int offset = 0;
 	char *str = func_name;
+	const char *last_dot;
+	char *last_underline;
 
 	if (!func_name) {
 		return NULL;
@@ -322,24 +319,51 @@ R_API char *r_anal_type_func_guess(RAnal *anal, char *func_name) {
 			return NULL;
 		}
 	}
-	// strip r2 prefixes (sym, sym.imp, etc')
-	while(slen > 4 && (offset + 3 < slen ) && str[offset + 3] == '.') {
-		offset+=4;
+
+	// strip r2 prefixes (sym, sym.imp etc)
+	last_dot = r_str_lchr (str, '.');
+	if (last_dot) {
+		offset += last_dot - str + 1;
 	}
+
+	// sub. and sym.: strip dll_ prefix
+	if ((!strncmp (str, "sub.", 4) || !strncmp (str, "sym.", 4))
+	    && !strncmp (&str[offset], "dll_", 4)) {
+		offset += 4;
+	}
+
+	// sym.: strip underscore prefix
+	if (!strncmp (str, "sym._", 5)) {
+		offset += 1;
+	}
+
 	slen -= offset;
 	str = strdup (&func_name[offset]);
-	for (n = slen; n >= MIN_MATCH_LEN; --n) {
-		for (j = 0; j < slen - (n - 1); ++j) {
-			char saved = str[j + n];
-			str[j + n] = 0;
-			if (sdb_exists (anal->sdb_types, &str[j])) {
-				const char *res = sdb_const_get (anal->sdb_types, &str[j], 0);
-				bool is_func = res && !strcmp ("func", res);
-				if (is_func) {
-					return strdup (&str[j]);
-				}
+	if (!str) {
+		return NULL;
+	}
+
+	// strip index suffix
+	last_underline = (char *) r_str_lchr (str, '_');
+	if (last_underline) {
+		bool has_index_suffix = true;
+		const char *suffix_char = last_underline + 1;
+		for(; *suffix_char; suffix_char++) {
+			if (!IS_DIGIT (*suffix_char)) {
+				has_index_suffix = false;
+				break;
 			}
-			str[j + n] = saved;
+		}
+		if (has_index_suffix) {
+			*last_underline = 0;
+			slen = strlen (str);
+		}
+	}
+
+	if (slen >= MIN_MATCH_LEN && sdb_exists (anal->sdb_types, str)) {
+		const char *res = sdb_const_get (anal->sdb_types, str, 0);
+		if (res) {
+			return str;
 		}
 	}
 	return NULL;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -133,7 +133,7 @@ typedef struct r_disam_options_t {
 	bool show_varsum;
 	int midflags;
 	bool midcursor;
-	bool show_noisy_comments;
+	bool show_noisy;
 	const char *pal_comment;
 	const char *color_comment;
 	const char *color_fname;
@@ -494,7 +494,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->show_flag_in_bytes = r_config_get_i (core->config, "asm.flagsinbytes");
 	ds->show_hints = r_config_get_i (core->config, "asm.hints");
 	ds->show_marks = r_config_get_i (core->config, "asm.marks");
-	ds->show_noisy_comments = r_config_get_i (core->config, "asm.noisy");
+	ds->show_noisy = r_config_get_i (core->config, "asm.noisy");
 	ds->pre = strdup ("  ");
 	ds->ocomment = NULL;
 	ds->linesopts = 0;
@@ -2609,7 +2609,7 @@ static void ds_print_asmop_payload(RDisasmState *ds, const ut8 *buf) {
 }
 
 static inline bool is_filtered_flag(RDisasmState *ds, const char *name) {
-	if (ds->show_noisy_comments || strncmp (name, "str.", 4)) {
+	if (ds->show_noisy || strncmp (name, "str.", 4)) {
 		return false;
 	}
 	ut64 refaddr = ds->analop.ptr;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2419,7 +2419,9 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 						ds_comment (ds, true, "; %s+0x%x%s", f->name, delta, nl);
 					} else if (delta < 0) {
 						ds_comment (ds, true, "; %s-0x%x%s", f->name, -delta, nl);
-					} else {
+					} else if (ds->show_noisy || !ds->show_calls
+						   || (!r_anal_type_func_exist (core->anal, f->name)
+						       && !r_anal_type_func_guess (core->anal, f->name))) {
 						ds_comment (ds, true, "; %s%s", f->name, nl);
 					}
 				}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2414,6 +2414,7 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 			} else {
 				RAnalFunction *f2 = r_anal_get_fcn_in (core->anal, ds->at, 0);
 				if (f != f2) {
+					char *guess = NULL;
 					ALIGN;
 					if (delta > 0) {
 						ds_comment (ds, true, "; %s+0x%x%s", f->name, delta, nl);
@@ -2421,8 +2422,11 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 						ds_comment (ds, true, "; %s-0x%x%s", f->name, -delta, nl);
 					} else if (ds->show_noisy || !ds->show_calls
 						   || (!r_anal_type_func_exist (core->anal, f->name)
-						       && !r_anal_type_func_guess (core->anal, f->name))) {
+						       && !(guess = r_anal_type_func_guess (core->anal, f->name)))) {
 						ds_comment (ds, true, "; %s%s", f->name, nl);
+					}
+					if (guess) {
+						free (guess);
 					}
 				}
 			}


### PR DESCRIPTION
Also, `r_anal_type_func_guess` was generating false positives so I reduced its aggressiveness.