### PR TITLE
fix gcc 7.1 compile error: variable-sized object may not be initialized

### DIFF
--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -793,8 +793,8 @@ static uid_t uidFromPid(pid_t pid) {
 	size_t procBufferSize = sizeof (process);
 
 	// Compose search path for sysctl. Here you can specify PID directly.
-	const u_int pathLenth = 4;
-	int path[pathLenth] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+	int path[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+	const u_int pathLenth = (sizeof(path) / sizeof(int));
 	int sysctlResult = sysctl (path, pathLenth, &process, &procBufferSize, NULL, 0);
 	// If sysctl did not fail and process with PID available - take UID.
 	if ((sysctlResult == 0) && (procBufferSize != 0)) {


### PR DESCRIPTION
Hello,
When tried to compile radare2 with gcc 7.1 in macOS, i got a compile error.
```
gcc-7 -c -g3 -MD -fno-common   -fPIC -g -Wall -D__UNIX__=1 -DCORELIB -Ip/libbfwbf/include -I/Users/sajjad/radare2/libr/../shlr/bochs/include/ -I/Users/sajjad/radare2/libr/../shlr/gdb/include/ -I/Users/sajjad/radare2/libr/../shlr/qnx/include/ -Ip/librapwrap/include -I/Users/sajjad/radare2/libr/../shlr/wind/ -DXNU_USE_PTRACE=0 -I/Users/sajjad/radare2/libr -I/Users/sajjad/radare2/libr/include -o p/debug_qnx.o p/debug_qnx.c
gcc-7 -c -g3 -MD -fno-common   -fPIC -g -Wall -D__UNIX__=1 -DCORELIB -Ip/libbfwbf/include -I/Users/sajjad/radare2/libr/../shlr/bochs/include/ -I/Users/sajjad/radare2/libr/../shlr/gdb/include/ -I/Users/sajjad/radare2/libr/../shlr/qnx/include/ -Ip/librapwrap/include -I/Users/sajjad/radare2/libr/../shlr/wind/ -DXNU_USE_PTRACE=0 -I/Users/sajjad/radare2/libr -I/Users/sajjad/radare2/libr/include -o p/debug_rap.o p/debug_rap.c
gcc-7 -c -g3 -MD -fno-common   -fPIC -g -Wall -D__UNIX__=1 -DCORELIB -Ip/libbfwbf/include -I/Users/sajjad/radare2/libr/../shlr/bochs/include/ -I/Users/sajjad/radare2/libr/../shlr/gdb/include/ -I/Users/sajjad/radare2/libr/../shlr/qnx/include/ -Ip/librapwrap/include -I/Users/sajjad/radare2/libr/../shlr/wind/ -DXNU_USE_PTRACE=0 -I/Users/sajjad/radare2/libr -I/Users/sajjad/radare2/libr/include -o p/debug_wind.o p/debug_wind.c
gcc-7 -c -g3 -MD -fno-common   -fPIC -g -Wall -D__UNIX__=1 -DCORELIB -Ip/libbfwbf/include -I/Users/sajjad/radare2/libr/../shlr/bochs/include/ -I/Users/sajjad/radare2/libr/../shlr/gdb/include/ -I/Users/sajjad/radare2/libr/../shlr/qnx/include/ -Ip/librapwrap/include -I/Users/sajjad/radare2/libr/../shlr/wind/ -DXNU_USE_PTRACE=0 -I/Users/sajjad/radare2/libr -I/Users/sajjad/radare2/libr/include -o p/native/xnu/xnu_debug.o p/native/xnu/xnu_debug.c
p/native/xnu/xnu_debug.c: In function ‘xnu_continue’:
p/native/xnu/xnu_debug.c:213:16: warning: variable ‘kr’ set but not used [-Wunused-but-set-variable]
  kern_return_t kr;
                ^~
p/native/xnu/xnu_debug.c: In function ‘uidFromPid’:
p/native/xnu/xnu_debug.c:800:2: error: variable-sized object may not be initialized
  int path[pathLenth] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
  ^~~
p/native/xnu/xnu_debug.c:800:25: warning: excess elements in array initializer
  int path[pathLenth] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
                         ^~~~~~~~
p/native/xnu/xnu_debug.c:800:25: note: (near initialization for ‘path’)
p/native/xnu/xnu_debug.c:800:35: warning: excess elements in array initializer
  int path[pathLenth] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
                                   ^~~~~~~~~
p/native/xnu/xnu_debug.c:800:35: note: (near initialization for ‘path’)
p/native/xnu/xnu_debug.c:800:46: warning: excess elements in array initializer
  int path[pathLenth] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
                                              ^~~~~~~~~~~~~
p/native/xnu/xnu_debug.c:800:46: note: (near initialization for ‘path’)
p/native/xnu/xnu_debug.c:800:61: warning: excess elements in array initializer
  int path[pathLenth] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
                                                             ^~~
p/native/xnu/xnu_debug.c:800:61: note: (near initialization for ‘path’)
make[4]: *** [p/native/xnu/xnu_debug.o] Error 1
make[3]: *** [foo] Error 2
make[2]: *** [debug] Error 2
make[1]: *** [all] Error 2
make: *** [all] Error 2
```