### PR TITLE
Remove unnecessary comparison

### DIFF
--- a/libr/asm/arch/arm/aarch64/aarch64-dis.c
+++ b/libr/asm/arch/arm/aarch64/aarch64-dis.c
@@ -728,7 +728,7 @@ aarch64_ext_limm (const aarch64_operand *self ATTRIBUTE_UNUSED,
     }
   else
     {
-      if (S >= 0x00 && S <= 0x1f) { simd_size = 32; }
+      if (S <= 0x1f) { simd_size = 32; }
       else if (S >= 0x20 && S <= 0x2f) { simd_size = 16; S &= 0xf; }
       else if (S >= 0x30 && S <= 0x37) { simd_size = 8; S &= 0x7; }
       else if (S >= 0x38 && S <= 0x3b) { simd_size = 4; S &= 0x3; }


### PR DESCRIPTION
S initialized as unsigned int,
<img width="213" alt="screen shot 2017-05-27 at 15 18 04" src="https://cloud.githubusercontent.com/assets/20374762/26520855/1a227f14-42f0-11e7-87c9-fa5217c78b03.png">
 it can not be less than 0x00 but just occurs warning in llvm .
<img width="938" alt="screen shot 2017-05-27 at 15 20 02" src="https://cloud.githubusercontent.com/assets/20374762/26520857/2fa2e2d4-42f0-11e7-95c2-a01020a55d00.png">
