### PR TITLE
Patch to enable zsh completion

### DIFF
--- a/doc/bash_autocompletion.sh
+++ b/doc/bash_autocompletion.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ -z "$BASH" ]; then
+	autoload bashcompinit
+	bashcompinit
+fi
+
 _r2 () {
 	local cur
 	COMPREPLY=()


### PR DESCRIPTION
Adding the following compatibility commands to this file enables this completion file to be loaded by zsh as well as bash.