### PR TITLE
Fix incorrect empty array compersion in armass64.c

### DIFF
--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -526,7 +526,7 @@ static bool parseOperands(char* str, ArmOp *op) {
 			break;
 		}
 		//printf ("operand %d type is %d - reg_type %d\n", operand, op->operands[operand].type, op->operands[operand].reg_type);
-		if (x == '\0') {
+		if (x[0] == '\0') {
 			free (t);
 			return true;
 		}


### PR DESCRIPTION
x is an array and seems [0] is missed,if so must be x[0]=='\0' for checking empty array.