### PR TITLE
Workaround capstone bug for mips64 disassembly

### DIFF
--- a/libr/asm/p/asm_mips_cs.c
+++ b/libr/asm/p/asm_mips_cs.c
@@ -25,9 +25,11 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 			mode |= CS_MODE_MIPS3;
 //		} else if (!strcmp (a->cpu, "gp64")) {
 //			a->bits = 64;
+		} else if (!strcmp (a->cpu, "64v2")) {
+			mode |= CS_MODE_MIPS32;
 		}
 	}
-	mode |= (a->bits == 64)? (CS_MODE_MIPS64 | CS_MODE_MIPS32) : CS_MODE_MIPS32;
+	mode |= (a->bits == 64)? CS_MODE_MIPS64 : CS_MODE_MIPS32;
 	memset (op, 0, sizeof (RAsmOp));
 	op->size = 4;
 	if (cd != 0) {

--- a/libr/asm/p/asm_mips_cs.c
+++ b/libr/asm/p/asm_mips_cs.c
@@ -26,7 +26,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 //		} else if (!strcmp (a->cpu, "gp64")) {
 //			a->bits = 64;
 		} else if (!strcmp (a->cpu, "64v2")) {
-			mode |= CS_MODE_MIPS32;
+			mode |= CS_MODE_MIPS32 | CS_MODE_MIPS64;
 		}
 	}
 	mode |= (a->bits == 64)? CS_MODE_MIPS64 : CS_MODE_MIPS32;

--- a/libr/asm/p/asm_mips_cs.c
+++ b/libr/asm/p/asm_mips_cs.c
@@ -27,7 +27,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 //			a->bits = 64;
 		}
 	}
-	mode |= (a->bits == 64)? CS_MODE_64: CS_MODE_32;
+	mode |= (a->bits == 64)? (CS_MODE_MIPS64 | CS_MODE_MIPS32) : CS_MODE_MIPS32;
 	memset (op, 0, sizeof (RAsmOp));
 	op->size = 4;
 	if (cd != 0) {


### PR DESCRIPTION
This is an ugly hack, but it's needed for mips64 to work on modern capstone. 

see https://github.com/aquynh/capstone/issues/938

fixes https://github.com/radare/radare2/issues/7611