### PR TITLE
Renewed dsb command for new session format

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -912,7 +912,7 @@ R_API int r_debug_step_back(RDebug *dbg) {
 	ut64 pc, end;
 	ut8 buf[32];
 	RAnalOp op;
-	RDebugSession *before, *latest;
+	RDebugSession *before;
 	if (r_debug_is_dead (dbg)) {
 		return 0;
 	}
@@ -927,7 +927,7 @@ R_API int r_debug_step_back(RDebug *dbg) {
 	}
 	eprintf ("before session (%d) 0x%08"PFMT64x"\n", before->key.id, before->key.addr);
 	/* Save current session. It is marked as a finish point of reverse execution */
-	latest = r_debug_session_add (dbg);
+	r_debug_session_add (dbg);
 
 	if (!r_list_length (before->memlist)) {
 		/* Diff list is empty. (i.e. Before session is base snapshot) *

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -39,7 +39,7 @@ R_API void r_debug_session_list(RDebug *dbg) {
 	}
 }
 
-R_API bool r_debug_session_add(RDebug *dbg) {
+R_API RDebugSession *r_debug_session_add(RDebug *dbg) {
 	RDebugSession *session;
 	RDebugSnapDiff *diff;
 	RListIter *iter;
@@ -48,7 +48,7 @@ R_API bool r_debug_session_add(RDebug *dbg) {
 	int i, perms = R_IO_RW;
 	session = R_NEW0 (RDebugSession);
 	if (!session) {
-		return false;
+		return NULL;
 	}
 
 	addr = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
@@ -78,13 +78,12 @@ R_API bool r_debug_session_add(RDebug *dbg) {
 	}
 
 	r_list_append (dbg->sessions, session);
-	return true;
+	return session;
 }
 
-R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session) {
-	RDebugSnapDiff *diff;
+static void r_debug_session_set_registers (RDebug *dbg, RDebugSession *session) {
 	RRegArena *arena;
-	RListIter *iter, *iterr;
+	RListIter *iterr;
 	int i;
 	/* Restore all regsiter values from the stack area pointed by session */
 	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 0);
@@ -95,10 +94,26 @@ R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session) {
 			memcpy (dbg->reg->regset[i].arena->bytes, arena->bytes, arena->size);
 		}
 	}
-	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
+	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);	
+}
+
+R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session) {
+	RListIter *iter;
+	RDebugSnapDiff *diff;
+	r_debug_session_set_registers (dbg, session);
 	/* Restore all memory values from memory (diff) snapshots */
 	r_list_foreach (session->memlist, iter, diff) {
 		r_debug_diff_set (dbg, diff);
+	}
+}
+
+R_API void r_debug_session_set_base(RDebug *dbg, RDebugSession *before) {
+	RListIter *iter;
+	RDebugSnap *snap;
+	r_debug_session_set_registers (dbg, before);
+	/* Restore all memory values from base memory snapshots */
+	r_list_foreach (dbg->snaps, iter, snap) {
+		r_debug_diff_set_base (dbg, snap);
 	}
 }
 

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -81,7 +81,7 @@ R_API RDebugSession *r_debug_session_add(RDebug *dbg) {
 	return session;
 }
 
-static void r_debug_session_set_registers (RDebug *dbg, RDebugSession *session) {
+static void r_debug_session_set_registers(RDebug *dbg, RDebugSession *session) {
 	RRegArena *arena;
 	RListIter *iterr;
 	int i;

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -10,7 +10,6 @@ static int r_debug_session_lastid(RDebug *dbg) {
 }
 
 R_API void r_debug_session_list(RDebug *dbg) {
-	const char *comment;
 	ut32 count = 0;
 	RListIter *iterse, *itersn, *iterpg;
 	RDebugSnap *snap;
@@ -23,10 +22,6 @@ R_API void r_debug_session_list(RDebug *dbg) {
 		dbg->cb_printf ("session:%2d\tat:0x%08"PFMT64x "\n", session->key.id, session->key.addr);
 		r_list_foreach (session->memlist, itersn, diff) {
 			snap = diff->base;
-			comment = "";
-			if (snap->comment && *snap->comment) {
-				comment = snap->comment;
-			}
 			dbg->cb_printf ("\t- %d 0x%08"PFMT64x " - 0x%08"PFMT64x " size: %d ",
 				count, snap->addr, snap->addr_end, snap->size);
 			dbg->cb_printf ("(pages: ");

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -94,7 +94,7 @@ static void r_debug_session_set_registers (RDebug *dbg, RDebugSession *session) 
 			memcpy (dbg->reg->regset[i].arena->bytes, arena->bytes, arena->size);
 		}
 	}
-	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);	
+	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
 }
 
 R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session) {
@@ -139,9 +139,8 @@ R_API RDebugSession *r_debug_session_get(RDebug *dbg, ut64 addr) {
 	RDebugSession *session;
 	RListIter *iter;
 	r_list_foreach_prev (dbg->sessions, iter, session) {
-		if (session->key.addr != addr) {
-			/* Sessions are saved along program flow. So key must be compared by "!=" not "<". *
-			         ex. Some operations like, jmp, can go back to former address in normal program flow. */
+		if (session->key.addr < addr) {
+			/* FIXME: Sessions must be saved along program flow. */
 			return session;
 		}
 	}

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -123,7 +123,7 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 			ut64 off = last_page->page_off * SNAP_PAGE_SIZE;
 			/* Copy a page data of base snap to current addr. (i.e. role back) */
 			dbg->iob.write_at (dbg->iob.io, addr, snap->data + off, SNAP_PAGE_SIZE);
-			eprintf ("Role back 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+			eprintf ("Role back 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
 		}
 	}
 
@@ -132,7 +132,7 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 		page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
 		if ((prev_page = diff->last_changes[page_off])) {
 			r_page_data_set (dbg, prev_page);
-			eprintf ("Update 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+			eprintf ("Update 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
 		}
 	}
 }
@@ -147,14 +147,14 @@ R_API void r_debug_diff_set_base(RDebug *dbg, RDebugSnap *base) {
 	if (!r_list_length (base->history)) {
 		return;
 	}
- 	latest = (RDebugSnapDiff *) r_list_tail (base->history)->data;
+	latest = (RDebugSnapDiff *) r_list_tail (base->history)->data;
 	for (addr = base->addr; addr < base->addr_end; addr += SNAP_PAGE_SIZE) {
 		page_off = (addr - base->addr) / SNAP_PAGE_SIZE;
 		if ((last_page = latest->last_changes[page_off])) {
 			ut64 off = last_page->page_off * SNAP_PAGE_SIZE;
 			/* Copy a page data of base snap to current addr. (i.e. role back) */
 			dbg->iob.write_at (dbg->iob.io, addr, base->data + off, SNAP_PAGE_SIZE);
-			eprintf ("Role back 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+			eprintf ("Role back 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
 		}
 	}
 }
@@ -183,11 +183,11 @@ R_API int r_debug_snap_set_idx(RDebug *dbg, int idx) {
 
 /* XXX: Just for debugging. Duplicate soon */
 /* static void print_hash(ut8 *hash, int digest_size) {
-	int i = 0;
-	for (i = 0; i < digest_size; i++) {
-		eprintf ("%02"PFMT32x, hash[i]);
-	}
-	eprintf ("\n");
+        int i = 0;
+        for (i = 0; i < digest_size; i++) {
+                eprintf ("%02"PFMT32x, hash[i]);
+        }
+        eprintf ("\n");
 } */
 
 R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -118,13 +118,12 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 	for (addr = snap->addr; addr < snap->addr_end; addr += SNAP_PAGE_SIZE) {
 		page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
 		prev_page = diff->last_changes[page_off];
-		/* Apply only latest pages, that's been changed after prev_pages */
+		/* Role back only latest page, that's been changed after prev_page */
 		if ((last_page = latest->last_changes[page_off]) && !prev_page) {
 			ut64 off = last_page->page_off * SNAP_PAGE_SIZE;
-			ut64 addr = snap->addr + off;
 			/* Copy a page data of base snap to current addr. (i.e. role back) */
 			dbg->iob.write_at (dbg->iob.io, addr, snap->data + off, SNAP_PAGE_SIZE);
-			// eprintf ("Role back 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+			eprintf ("Role back 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
 		}
 	}
 
@@ -133,7 +132,29 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 		page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
 		if ((prev_page = diff->last_changes[page_off])) {
 			r_page_data_set (dbg, prev_page);
-			// eprintf ("Update 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+			eprintf ("Update 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
+		}
+	}
+}
+
+/* Role back to base snapshot */
+R_API void r_debug_diff_set_base(RDebug *dbg, RDebugSnap *base) {
+	RPageData *last_page;
+	RDebugSnapDiff *latest;
+	eprintf ("Role back to base [0x%08"PFMT64x ", 0x%08"PFMT64x "]\n", base->addr, base->addr_end);
+	ut64 addr;
+	ut32 page_off;
+	if (!r_list_length (base->history)) {
+		return;
+	}
+ 	latest = (RDebugSnapDiff *) r_list_tail (base->history)->data;
+	for (addr = base->addr; addr < base->addr_end; addr += SNAP_PAGE_SIZE) {
+		page_off = (addr - base->addr) / SNAP_PAGE_SIZE;
+		if ((last_page = latest->last_changes[page_off])) {
+			ut64 off = last_page->page_off * SNAP_PAGE_SIZE;
+			/* Copy a page data of base snap to current addr. (i.e. role back) */
+			dbg->iob.write_at (dbg->iob.io, addr, base->data + off, SNAP_PAGE_SIZE);
+			eprintf ("Role back 0x%08"PFMT64x"(page: %d)\n", addr, page_off);
 		}
 	}
 }

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -192,6 +192,8 @@ typedef struct r_debug_session_t {
 	RDebugKey key;
 	RListIter *reg[R_REG_TYPE_LAST];
 	RList *memlist; // <RDebugSnapDiff*>
+	/* XXX: DebugSession should have base snapshot of memlist. */
+	//RDebugSnap *base;
 } RDebugSession;
 
 typedef struct r_debug_trace_t {
@@ -528,29 +530,30 @@ R_API void r_debug_snap_free(void *snap);
 R_API int r_debug_snap_delete(RDebug *dbg, int idx);
 R_API void r_debug_snap_list(RDebug *dbg, int idx, int mode);
 R_API int r_debug_snap(RDebug *dbg, ut64 addr);
-R_API int r_debug_snap_comment (RDebug *dbg, int idx, const char *msg);
+R_API int r_debug_snap_comment(RDebug *dbg, int idx, const char *msg);
 R_API RDebugSnapDiff* r_debug_snap_map(RDebug *dbg, RDebugMap *map);
 R_API int r_debug_snap_all(RDebug *dbg, int perms);
-R_API RDebugSnap* r_debug_snap_get (RDebug *dbg, ut64 addr);
-R_API int r_debug_snap_set_idx (RDebug *dbg, int idx);
-R_API int r_debug_snap_set (RDebug *dbg, RDebugSnap *snap);
+R_API RDebugSnap* r_debug_snap_get(RDebug *dbg, ut64 addr);
+R_API int r_debug_snap_set_idx(RDebug *dbg, int idx);
+R_API int r_debug_snap_set(RDebug *dbg, RDebugSnap *snap);
 
 /* snap diff */
-R_API void r_debug_diff_free (void *p);
+R_API void r_debug_diff_free(void *p);
 R_API RDebugSnapDiff* r_debug_diff_add(RDebug *dbg, RDebugSnap *base);
 R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff);
+R_API void r_debug_diff_set_base(RDebug *dbg, RDebugSnap *base);
 
 /* page data */
 R_API void r_page_data_free(void *p);
 
 /* debug session */
-R_API void r_debug_session_free (void *p) ;
-R_API void r_debug_session_list (RDebug *dbg);
-R_API bool r_debug_session_add (RDebug *dbg);
-R_API void r_debug_session_set (RDebug *dbg, RDebugSession *session);
-R_API bool r_debug_session_set_idx (RDebug *dbg, int idx);
-R_API RDebugSession* r_debug_session_get (RDebug *dbg, ut64 addr);
-R_API int r_debug_step_back (RDebug *dbg);
+R_API void r_debug_session_free(void *p) ;
+R_API void r_debug_session_list(RDebug *dbg);
+R_API RDebugSession *r_debug_session_add(RDebug *dbg);
+R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session);
+R_API bool r_debug_session_set_idx(RDebug *dbg, int idx);
+R_API RDebugSession* r_debug_session_get(RDebug *dbg, ut64 addr);
+R_API int r_debug_step_back(RDebug *dbg);
 
 /* plugin pointers */
 extern RDebugPlugin r_debug_plugin_native;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -551,6 +551,7 @@ R_API void r_debug_session_free(void *p) ;
 R_API void r_debug_session_list(RDebug *dbg);
 R_API RDebugSession *r_debug_session_add(RDebug *dbg);
 R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session);
+R_API void r_debug_session_set_base(RDebug *dbg, RDebugSession *before);
 R_API bool r_debug_session_set_idx(RDebug *dbg, int idx);
 R_API RDebugSession* r_debug_session_get(RDebug *dbg, ut64 addr);
 R_API int r_debug_step_back(RDebug *dbg);


### PR DESCRIPTION
Renewed dsb command logic for new trace session format. (#7579) 
User must save at least a one trace session by 'dts+' command before execution of 'dsb'.
When user tried to step one back using 'dsb', r2 internally saves latest trace session at that point, and then, 
find previous one, calculate difference between the previous one and latest one, and recover previous program state.
