### PR TITLE
Fix regression with capstone 3

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -595,7 +595,9 @@ static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 		} else if (!strcmp (anal->cpu, "v3")) {
 			mode |= CS_MODE_MIPS3;
 		} else if (!strcmp (anal->cpu, "v2")) {
+#if CS_API_MAJOR > 3
 			mode |= CS_MODE_MIPS2;
+#endif
 		}
 	}
 	mode |= (anal->bits==64)? CS_MODE_MIPS64: CS_MODE_MIPS32;

--- a/libr/asm/p/asm_mips_cs.c
+++ b/libr/asm/p/asm_mips_cs.c
@@ -24,7 +24,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		} else if (!strcmp (a->cpu, "v3")) {
 			mode |= CS_MODE_MIPS3;
 		} else if (!strcmp (a->cpu, "v2")) {
+#if CS_API_MAJOR > 3
 			mode |= CS_MODE_MIPS2;
+#endif
 		}
 	}
 	mode |= (a->bits == 64)? CS_MODE_MIPS64 : CS_MODE_MIPS32;


### PR DESCRIPTION
Hello,
the constant `CS_MODE_MIPS2` from the patch against capstone-next in 1c6ee8dd3a will probably not be available in capstone 3. This results in compilation errors:
```
$ ./configure --prefix=/usr --with-syscapstone --with-syszip --with-openssl
...
$ make
...
/home/user/git/radare2/libr/..//libr/anal/p/anal_mips_cs.c:598:12: error: ‘CS_MODE_MIPS2’ undeclared (first use in this function); did you mean ‘CS_MODE_MIPS32’?
    mode |= CS_MODE_MIPS2;
            ^~~~~~~~~~~~~
            CS_MODE_MIPS32
```
I added some guards for this case. This will not help if capstone-next is installed at system level and `--with-syscapstone` is used until the patch is merged upstream.