### PR TITLE
Make the "ag" command work with "loc" functions

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2373,7 +2373,8 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 		r_cons_printf ("[");
 	}
 	r_list_foreach (core->anal->fcns, iter, fcni) {
-		if (fcni->type & (R_ANAL_FCN_TYPE_SYM | R_ANAL_FCN_TYPE_FCN) &&
+		if (fcni->type & (R_ANAL_FCN_TYPE_SYM | R_ANAL_FCN_TYPE_FCN |
+		                  R_ANAL_FCN_TYPE_LOC) &&
 		    (!addr || r_anal_fcn_in (fcni, addr))) {
 			if (!addr && (from != UT64_MAX && to != UT64_MAX)) {
 				if (fcni->addr < from || fcni->addr > to) {


### PR DESCRIPTION
I'm not sure if this is intentional, but when when I try to generate a graph for a "loc" function radare currently returns an empty graph. This is despite commands like `v`, `pdf`, etc. working as expected.

In fact, is the function `type` check required at all? Can it just be removed? I'm not sure why there is this restriction for generating graphs for certain function types when other commands work fine. Please let me know your thoughts!