### PR TITLE
Initial breakpoints, step, and continue for gdbserver. Plus *started* talking to GDB

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -941,8 +941,7 @@ static int r_core_rtr_gdb_cb(void *core_ptr, const char *cmd, char *out_buf, siz
 				case 'r': // dptr -> return current tid as int
 					return core->dbg->tid;
 				default:
-					r_core_cmd (core, cmd, 0);
-					return 0;
+					return r_core_cmd (core, cmd, 0);
 				}
 			}
 			break;
@@ -1005,6 +1004,8 @@ static int r_core_rtr_gdb_cb(void *core_ptr, const char *cmd, char *out_buf, siz
 				}
 			}
 			return ret;
+		default:
+			return r_core_cmd (core, cmd, 0);
 		}
 		break;
 	case 'm':


### PR DESCRIPTION
Server -
```
~$ r2 -
[0x00000000]> =g 8000 /bin/ls
= attach 6 6
Process with PID 23131 started...
File dbg:///usr/bin/ls  reopened in read-write mode
= attach 23131 23131
gdbserver started on port: 8000, file: /bin/ls
Breakpoint already set at this address.
Cannot set breakpoint at '0x7f4325bb8d88'
Selecting and continuing: 23131
hit breakpoint at: 7f4325bb8d88
```

Client
```
~$ r2 -e dbg.bpinmaps=false -d gdb://localhost:8000
= attach 6 6
[0x7f4325bb8d80]> pd 3
            ;-- rip:
            0x7f4325bb8d80      4889e7         mov rdi, rsp
            0x7f4325bb8d83      e8e83d0000     call 0x7f4325bbcb70
            0x7f4325bb8d88      4989c4         mov r12, rax
[0x7f4325bb8d80]> db 0x7f4325bb8d88
[0x7f4325bb8d80]> ds
got signal...
[0x7f4325bb8d80]> pd 3
            0x7f4325bb8d80      4889e7         mov rdi, rsp
            ;-- rip:
            0x7f4325bb8d83      e8e83d0000     call 0x7f4325bbcb70
            0x7f4325bb8d88 b    4989c4         mov r12, rax
[0x7f4325bb8d80]> dc
Selecting and continuing: 0
= attach 0 0
got signal...
= attach 0 1
= attach 6 1
[0x7f4325bb8d80]> pd 3
            0x7f4325bb8d80      4889e7         mov rdi, rsp
            0x7f4325bb8d83      e8e83d0000     call 0x7f4325bbcb70
            ;-- rip:
            0x7f4325bb8d88 b    4989c4         mov r12, rax
[0x7f4325bb8d80]> 
```
Setting breakpoints in r2 gdb client for now requires `e dbg.bpinmaps = false`

Also, GDB works with our gdbserver, and we can do non-source-level debugging stuff (breakpoints, single-step (`si`), continue, quit)