### PR TITLE
Tiny improvements

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2205,6 +2205,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.slow", "true", "Perform slow analysis operations in disasm");
 	SETPREF ("asm.decode", "false", "Use code analysis as a disassembler");
 	SETPREF ("asm.flgoff", "false", "Show offset in flags");
+	SETPREF ("asm.immstr", "true", "Show immediates values as strings");
 	SETPREF ("asm.offless", "false", "Remove all offsets and constants from disassembly");
 	SETPREF ("asm.indent", "false", "Indent disassembly based on reflines depth");
 	SETI ("asm.indentspace", 2, "How many spaces to indent the code");

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -158,6 +158,7 @@ R_API bool r_str_isnumber (const char *str);
 R_API const char *r_str_last (const char *in, const char *ch);
 R_API char* r_str_highlight(char *str, const char *word, const char *color);
 R_API char *r_qrcode_gen(const ut8 *text, int len, bool utf8, bool inverted);
+R_API char *r_str_from_ut64(ut64 val);
 #ifdef __cplusplus
 }
 #endif

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3073,3 +3073,16 @@ R_API wchar_t* r_str_mb_to_wc(const char *buf) {
 	}
 	return r_str_mb_to_wc_l (buf, strlen (buf));
 }
+
+R_API char *r_str_from_ut64(ut64 val) {
+	int i = 0;
+	char *v = (char *)&val;
+	char *str = (char *)calloc(1, 65);
+	if (!str) {
+		return NULL;
+	}
+	while (i < 64 && *v && *v >= '!' && *v <= '~') {
+		str[i++] = *v++;
+	}
+	return str;
+}


### PR DESCRIPTION
Now this works, before it wasn't at least there is a hidden functionality i am not aware of. I touched ds_print_ptr to handles this. I think we could close this https://github.com/radare/radare2/issues/5912
```
            0x00000478      mov dword [rbp - 0x78], 0x736f6c43         ; 'Clos'
            0x0000047f      mov dword [rbp - 0x74], 0x6e614865         ; 'eHan'
            0x00000486      mov dword [rbp - 0x70], 0x656c64           ; 'dle'
```

Moreover i changed alignments in ds

Before 
```
            0x00000464      call 0                                     ;[1] ; CALL: 0x0, 0x0, 0x0, 0x0
            0x00000469      mov rcx, qword [rsp + 0x60]                ; [0x60:8]=0x4d00004550398141 ; '`'
```

After (extra space more pleasant to the eyes)
```
            0x00000464      call 0                                     ; [1] ; CALL: 0x0, 0x0, 0x0, 0x0
            0x00000469      mov rcx, qword [rsp + 0x60]                ; [0x60:8]=0x4d00004550398141 ; '`'
```

Improvements in CoST.exe binary. Before there was neither export nor imports, now when finding an error, we return what we have done until that point.

```
vaddr=0x7efd0001 paddr=0x00000001 ord=002 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_2_EntryPoint
vaddr=0x7efd01e6 paddr=0x000001e6 ord=003 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_3_EntryPoint2
vaddr=0x7efd0220 paddr=0x00000220 ord=004 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_4_Main
vaddr=0x7efd19c8 paddr=0x000019c8 ord=005 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_antis
vaddr=0x7efd03a8 paddr=0x000003a8 ord=006 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_check_OS
vaddr=0x7efd0570 paddr=0x00000570 ord=007 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_classics
vaddr=0x7efd02fc paddr=0x000002fc ord=008 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_completed
vaddr=0x7efd2210 paddr=0x00002210 ord=009 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_disassembly
vaddr=0x7efd1440 paddr=0x00001440 ord=010 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_encodings
vaddr=0x7efd0178 paddr=0x00000178 ord=011 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_erased_call_operand
vaddr=0x7efd1b3e paddr=0x00001b3e ord=012 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_exceptions
vaddr=0x7efd1a50 paddr=0x00001a50 ord=013 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_getips
vaddr=0x7efd01fd paddr=0x000001fd ord=014 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_init
vaddr=0x7efd00d0 paddr=0x000000d0 ord=015 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_init_console
vaddr=0x7efd035d paddr=0x0000035d ord=016 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_init_null_buffer
vaddr=0x7efd0430 paddr=0x00000430 ord=017 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_jumps
vaddr=0x7efd1758 paddr=0x00001758 ord=018 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_nops
vaddr=0x7efd5040 paddr=0x00005040 ord=019 fwd= sz=0 bind=GLOBAL type=FUNC name=CoST.exe_print_easy
vaddr=0x7efd00f0 paddr=0x000000f0 ord=020 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_print_handler
vaddr=0x7efd0e00 paddr=0x00000e00 ord=021 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_rares
vaddr=0x7efd2290 paddr=0x00002290 ord=022 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_sixtyfour
vaddr=0x7efd1280 paddr=0x00001280 ord=023 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_specifics
vaddr=0x7efd0003 paddr=0x00000003 ord=024 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_the_dragon
vaddr=0x7efd11c0 paddr=0x000011c0 ord=025 fwd=NONE sz=0 bind=GLOBAL type=FUNC name=CoST.exe_undocumented
```

Before

```
            0x7efd01fd      c705bebafeca.  mov dword [0xcafebabe], 0x7efd2cbb ; [0x7efd2cbb:4]=0x6972745b ; "[tr
            0x7efd0207      e851010000     call 0x7efd035d             ;[1]
            0x7efd020c      c705bebafeca.  mov dword [0xcafebabe], 0x7efd2ce2 ; [0x7efd2ce2:4]=0x63656863 ; "che
            0x7efd0216      e88d010000     call 0x7efd03a8             ;[2]
```

After 
```
            ;-- CoST.exe_init:
            0x7efd01fd      mov dword [0xcafebabe], 0x7efd2cbb         ; [0x7efd2cbb:4]=0x6972745b ; "[trick] allocating buffer [0000-ffff]." 
            0x7efd0207      call sym.CoST.exe_init_null_buffer         ; sym.CoST.exe_init_null_buffer; CALL: 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
            0x7efd020c      mov dword [0xcafebabe], 0x7efd2ce2         ; [0x7efd2ce2:4]=0x63656863 ; "checking OS version." 
            0x7efd0216      call sym.CoST.exe_check_OS                 ; sym.CoST.exe_check_OS; CALL: 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff

```

Last but not least, when using asm.emu we fucked up hook_mem_write so aes was not working as expected.