### PR TITLE
Fix hexdump offset in zoom mode

### DIFF
--- a/binr/rafind2/rafind2.c
+++ b/binr/rafind2/rafind2.c
@@ -67,7 +67,7 @@ static int hit(RSearchKeyword *kw, void *user, ut64 addr) {
 		} else {
 			printf ("0x%"PFMT64x"\n", addr);
 			if (pr) {
-				r_print_hexdump (pr, addr, (ut8*)buf + delta, 78, 16, true);
+				r_print_hexdump (pr, addr, (ut8*)buf + delta, 78, 16, 1, 1);
 				r_cons_flush ();
 			}
 		}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2148,7 +2148,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 		}
 		ut8 *buf = r_reg_get_bytes (core->dbg->reg, type, &len);
 		//r_print_hexdump (core->print, 0LL, buf, len, 16, 16);
-		r_print_hexdump (core->print, 0LL, buf, len, 32, 4);
+		r_print_hexdump (core->print, 0LL, buf, len, 32, 4, 1);
 		free (buf);
 		} break;
 	case 'c':

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1669,22 +1669,22 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 			} else {
 				switch (str[1]) {
 				case '1':
-					r_print_hexdump (core->print, 0LL, buf, len, 8, 1);
+					r_print_hexdump (core->print, 0LL, buf, len, 8, 1, 1);
 					break;
 				case '2':
-					r_print_hexdump (core->print, 0LL, buf, len, 16, 2);
+					r_print_hexdump (core->print, 0LL, buf, len, 16, 2, 1);
 					break;
 				case '4':
-					r_print_hexdump (core->print, 0LL, buf, len, 32, 4);
+					r_print_hexdump (core->print, 0LL, buf, len, 32, 4, 1);
 					break;
 				case '8':
-					r_print_hexdump (core->print, 0LL, buf, len, 64, 8);
+					r_print_hexdump (core->print, 0LL, buf, len, 64, 8, 1);
 					break;
 				default:
 					if (core->assembler->bits == 64) {
-						r_print_hexdump (core->print, 0LL, buf, len, 64, 8);
+						r_print_hexdump (core->print, 0LL, buf, len, 64, 8, 1);
 					} else {
-						r_print_hexdump (core->print, 0LL, buf, len, 32, 4);
+						r_print_hexdump (core->print, 0LL, buf, len, 32, 4, 1);
 					}
 					break;
 				}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3853,7 +3853,7 @@ static int cmd_print(void *data, const char *input) {
 								break;
 							}
 							cont_size = tmp_get_contsize (tmp_func);
-							loc_buf = calloc (cont_size, 1);;
+							loc_buf = calloc (cont_size, 1);
 							r_io_read_at (core->io, tmp_func->addr, loc_buf, cont_size);
 							if (!first) {
 								r_cons_print (",");
@@ -3872,7 +3872,7 @@ static int cmd_print(void *data, const char *input) {
 						free (func_buf);
 						for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
 							cont_size = tmp_get_contsize (tmp_func);
-							loc_buf = calloc (cont_size, 1);;
+							loc_buf = calloc (cont_size, 1);
 							r_io_read_at (core->io, tmp_func->addr, loc_buf, cont_size);
 							if (!first) {
 								r_cons_print (",");
@@ -4172,7 +4172,7 @@ static int cmd_print(void *data, const char *input) {
 			if (l > 0) {
 				int quiet = input[2] == 'q'; // "psbq"
 				char *s = malloc (core->blocksize + 1);
-				int i, j, hasnl = 0;;
+				int i, j, hasnl = 0;
 				if (s) {
 					memset (s, 0, core->blocksize);
 					if (!quiet) {
@@ -4546,7 +4546,7 @@ static int cmd_print(void *data, const char *input) {
 			if (l != 0) {
 				core->print->flags |= R_PRINT_FLAGS_NONHEX;
 				r_print_hexdump (core->print, core->offset,
-					core->block, len, 8, 1);
+					core->block, len, 8, 1, 1);
 				core->print->flags &= ~R_PRINT_FLAGS_NONHEX;
 			}
 			break;
@@ -4556,7 +4556,7 @@ static int cmd_print(void *data, const char *input) {
 				if (buf) {
 					r_io_read_at (core->io, core->offset, buf, len * 4);
 					core->print->flags |= R_PRINT_FLAGS_NONHEX;
-					r_print_hexdump (core->print, core->offset, buf, len * 4, 8, 1);
+					r_print_hexdump (core->print, core->offset, buf, len * 4, 8, 1, 1);
 					core->print->flags &= ~R_PRINT_FLAGS_NONHEX;
 					free (buf);
 				}
@@ -4625,7 +4625,7 @@ static int cmd_print(void *data, const char *input) {
 						len = core->blocksize;
 					}
 					r_print_hexdump (core->print, core->offset,
-						core->block, len, 16, 1);
+						core->block, len, 16, 1, 1);
 				} else {
 					r_core_print_cmp (core, from, to);
 				}
@@ -4641,7 +4641,7 @@ static int cmd_print(void *data, const char *input) {
 		case 'o': // "pxo"
 			if (l != 0) {
 				r_print_hexdump (core->print, core->offset,
-					core->block, len, 8, 1);
+					core->block, len, 8, 1, 1);
 			}
 			break;
 		case 't': // "pxt"
@@ -4662,22 +4662,22 @@ static int cmd_print(void *data, const char *input) {
 				case '1':
 					// 1 byte signed words (byte)
 					r_print_hexdump (core->print, core->offset,
-						core->block, len, -1, 4);
+						core->block, len, -1, 4, 1);
 					break;
 				case '2':
 					// 2 byte signed words (short)
 					r_print_hexdump (core->print, core->offset,
-						core->block, len, -10, 2);
+						core->block, len, -10, 2, 1);
 					break;
 				case '8':
 					r_print_hexdump (core->print, core->offset,
-						core->block, len, -8, 4);
+						core->block, len, -8, 4, 1);
 					break;
 				case '4':
 				default:
 					// 4 byte signed words
 					r_print_hexdump (core->print, core->offset,
-						core->block, len, 10, 4);
+						core->block, len, 10, 4, 1);
 				}
 			}
 			break;
@@ -4686,7 +4686,7 @@ static int cmd_print(void *data, const char *input) {
 				if (input[2] == 'j') {
 					r_print_jsondump (core->print, core->block, len, 32);
 				} else {
-					r_print_hexdump (core->print, core->offset, core->block, len, 32, 4);
+					r_print_hexdump (core->print, core->offset, core->block, len, 32, 4, 1);
 				}
 			}
 			break;
@@ -4775,7 +4775,7 @@ static int cmd_print(void *data, const char *input) {
 					r_cons_break_push (NULL, NULL);
 					r_print_hexdump (core->print, core->offset,
 						core->block, len,
-						bitsize, bitsize / 8);
+						bitsize, bitsize / 8, 1);
 					r_cons_break_pop ();
 					core->print->flags &= ~R_PRINT_FLAGS_REFS;
 					core->print->cols = ocols;
@@ -4788,7 +4788,7 @@ static int cmd_print(void *data, const char *input) {
 					r_print_jsondump (core->print, core->block, len, 16);
 				} else {
 					r_print_hexdump (core->print, core->offset,
-						core->block, len, 32, 2);
+						core->block, len, 32, 2, 1);
 				}
 			}
 			break;
@@ -4834,7 +4834,7 @@ static int cmd_print(void *data, const char *input) {
 				if (input[2] == 'j') {
 					r_print_jsondump (core->print, core->block, len, 64);
 				} else {
-					r_print_hexdump (core->print, core->offset, core->block, len, 64, 8);
+					r_print_hexdump (core->print, core->offset, core->block, len, 64, 8, 1);
 				}
 			}
 			break;
@@ -4879,7 +4879,7 @@ static int cmd_print(void *data, const char *input) {
 		case 's': // "pxs"
 			if (l) {
 				core->print->flags |= R_PRINT_FLAGS_SPARSE;
-				r_print_hexdump (core->print, core->offset, core->block, len, 16, 1);
+				r_print_hexdump (core->print, core->offset, core->block, len, 16, 1, 1);
 				core->print->flags &= (((ut32) - 1) & (~R_PRINT_FLAGS_SPARSE));
 			}
 			break;
@@ -4987,7 +4987,7 @@ static int cmd_print(void *data, const char *input) {
 						len = core->blocksize;
 					}
 					r_print_hexdump (core->print, core->offset,
-						core->block, len, 16, 1);
+						core->block, len, 16, 1, 1);
 				} else {
 					r_core_print_cmp (core, from, to);
 				}
@@ -5210,36 +5210,32 @@ static int cmd_print(void *data, const char *input) {
 			};
 			r_core_cmd_help (core, help_msg);
 		} else {
-			char *oldzoom = NULL;
+			ut64 from = r_config_get_i (core->config, "zoom.from");
+			ut64 to = r_config_get_i (core->config, "zoom.to");
 			ut64 maxsize = r_config_get_i (core->config, "zoom.maxsz");
-			ut64 from, to;
 			int oldva = core->io->va;
-			int do_zoom = 1;
+			char *oldmode = NULL;
+			bool do_zoom = true;
 
 			core->io->va = 0;
-			from = 0;
-			to = r_io_size (core->io);
-			from = r_config_get_i (core->config, "zoom.from");
-			to = r_config_get_i (core->config, "zoom.to");
+
 			if (input[1] && input[1] != ' ') {
-				oldzoom = strdup (r_config_get (core->config, "zoom.byte"));
+				oldmode = strdup (r_config_get (core->config, "zoom.byte"));
 				if (!r_config_set (core->config, "zoom.byte", input + 1)) {
 					eprintf ("Invalid zoom.byte mode (%s)\n", input + 1);
-					R_FREE (oldzoom);
-					do_zoom = 0;
+					do_zoom = false;
 				}
 			}
 			if (do_zoom && l > 0) {
 				r_print_zoom (core->print, core, printzoomcallback,
-					from, to, core->blocksize, (int) maxsize);
+					from, to, l, (int) maxsize);
 			}
-			if (oldzoom) {
-				r_config_set (core->config, "zoom.byte", oldzoom);
-				R_FREE (oldzoom);
+
+			if (oldmode) {
+				r_config_set (core->config, "zoom.byte", oldmode);
 			}
-			if (oldva) {
-				core->io->va = oldva;
-			}
+			core->io->va = oldva;
+			R_FREE (oldmode);
 		}
 		break;
 	default: {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2063,7 +2063,7 @@ static int ds_print_meta_infos(RDisasmState *ds, ut8* buf, int len, int idx) {
 					core->print->flags &= ~R_PRINT_FLAGS_HEADER;
 					if (!ds_print_data_type (ds, buf + idx, ds->hint? ds->hint->immbase: 0, mi->size)) {
 						r_cons_printf ("hex length=%" PFMT64d " delta=%d\n", mi->size , delta);
-						r_print_hexdump (core->print, ds->at, buf+idx, hexlen-delta, 16, 1);
+						r_print_hexdump (core->print, ds->at, buf+idx, hexlen-delta, 16, 1, 1);
 					}
 					core->inc = 16; // ds->oplen; //
 					core->print->flags |= R_PRINT_FLAGS_HEADER;

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -383,7 +383,7 @@ void GH(print_heap_chunk)(RCore *core) {
 	if (data) {
 		r_core_read_at (core, chunk + SZ * 2, (ut8 *)data, size);
 		PRINT_GA ("chunk data = \n");
-		r_print_hexdump (core->print, chunk + SZ * 2, (ut8 *)data, size, SZ * 8, SZ);
+		r_print_hexdump (core->print, chunk + SZ * 2, (ut8 *)data, size, SZ * 8, SZ, 1);
 		free (data);
 	}
 	free (cnk);

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -257,7 +257,7 @@ R_API int r_core_yank_hexdump(RCore *core, ut64 pos) {
 		if (pos < ybl) {
 			r_print_hexdump (core->print, pos,
 				core->yank_buf->buf + pos,
-				ybl - pos, 16, 1);
+				ybl - pos, 16, 1, 1);
 			res = true;
 		} else {
 			eprintf ("Position exceeds buffer length.\n");

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -114,7 +114,7 @@ R_API void r_print_unset_flags(RPrint *p, int flags);
 R_API void r_print_addr(RPrint *p, ut64 addr);
 R_API void r_print_columns (RPrint *p, const ut8 *buf, int len, int height);
 R_API void r_print_hexii(RPrint *p, ut64 addr, const ut8 *buf, int len, int step);
-R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int base, int step);
+R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int base, int step, int zoomsz);
 R_API int r_print_jsondump(RPrint *p, const ut8 *buf, int len, int wordsize);
 R_API void r_print_hexpairs(RPrint *p, ut64 addr, const ut8 *buf, int len);
 R_API void r_print_hexdiff(RPrint *p, ut64 aa, const ut8* a, ut64 ba, const ut8 *b, int len, int scndcol);

--- a/libr/io/p/io_r2k_linux.c
+++ b/libr/io/p/io_r2k_linux.c
@@ -486,7 +486,7 @@ int run_ioctl_command(RIO *io, RIODesc *iodesc, const char *buf) {
 			if (databuf) {
 				ret = ReadMemory (io, iodesc, ioctl_n, pid, addr, databuf, len);
 				if (ret > 0) {
-					r_print_hexdump (print, addr, (const ut8 *) databuf, ret, 16, 1);
+					r_print_hexdump (print, addr, (const ut8 *) databuf, ret, 16, 1, 1);
 				}
 			} else {
 				io->cb_printf ("Failed to allocate buffer\n");

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -706,6 +706,9 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 	if (inc < 1) {
 		inc = 1;
 	}
+	if (zoomsz < 1) {
+		zoomsz = 1;
+	}
 	switch (base) {
 	case -10:
 		fmt = "0x%08x ";

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -664,8 +664,7 @@ R_API void r_print_set_screenbounds(RPrint *p, ut64 addr) {
 	}
 }
 
-// XXX: step is broken
-R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int base, int step) {
+R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int base, int step, int zoomsz) {
 	PrintfCallback printfmt = (PrintfCallback) printf;
 	int i, j, k, inc = 16;
 	int sparse_char = 0;
@@ -847,7 +846,7 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 			}
 		}
 		if (use_offset) {
-			r_print_addr (p, addr + j);
+			r_print_addr (p, addr + j * zoomsz);
 		}
 		if (use_hexa) {
 			if (!compact) {
@@ -1250,12 +1249,11 @@ R_API void r_print_rangebar(RPrint *p, ut64 startA, ut64 endA, ut64 min, ut64 ma
 
 R_API void r_print_zoom(RPrint *p, void *user, RPrintZoomCallback cb, ut64 from, ut64 to, int len, int maxlen) {
 	static int mode = -1;
-	ut8 *bufz, *bufz2;
+	ut8 *bufz = NULL, *bufz2 = NULL;
 	int i, j = 0;
 	ut64 size = (to - from);
 	size = len? size / len: 0;
 
-	bufz = bufz2 = NULL;
 	if (maxlen < 2) {
 		maxlen = 1024 * 1024;
 	}
@@ -1301,7 +1299,7 @@ R_API void r_print_zoom(RPrint *p, void *user, RPrintZoomCallback cb, ut64 from,
 		p->zoom->size = size;
 	}
 	p->flags &= ~R_PRINT_FLAGS_HEADER;
-	r_print_hexdump (p, from, bufz, len, 16, size);
+	r_print_hexdump (p, from, bufz, len, 16, 1, size);
 	p->flags |= R_PRINT_FLAGS_HEADER;
 }
 


### PR DESCRIPTION
Add argument zoomsz to r_print_hexdump(). It allows to specify the real
size of each byte in the hexdump.