### PR TITLE
Fix simulavr segfaults (WIP), only read/write mem works, no debugging…

### DIFF
--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -212,6 +212,8 @@ bool gdbr_kill(libgdbr_t *g) {
 
 int gdbr_read_registers(libgdbr_t *g) {
 	int ret = -1;
+// simulavr fails to retrieve registers
+return -1;
 	if (!g) {
 		return -1;
 	}


### PR DESCRIPTION
… yet

- Sending a step, continue, regread.. causes a segfault of their gdbserver