### PR TITLE
fix an unimportant warning (gdbserver/core.c)

### DIFF
--- a/shlr/gdb/src/gdbserver/core.c
+++ b/shlr/gdb/src/gdbserver/core.c
@@ -160,7 +160,7 @@ static int _server_handle_vCont(libgdbr_t *g, int (*cmd_cb) (void*, const char*,
 	if (!(action = strtok (g->data, ";"))) {
 		return send_msg (g, "E01");
 	}
-	while (action = strtok (NULL, ";")) {
+	while ((action = strtok (NULL, ";")) != 0) {
 		eprintf ("action: %s\n", action);
 		switch (action[0]) {
 		case 's':

--- a/shlr/gdb/src/gdbserver/core.c
+++ b/shlr/gdb/src/gdbserver/core.c
@@ -160,7 +160,7 @@ static int _server_handle_vCont(libgdbr_t *g, int (*cmd_cb) (void*, const char*,
 	if (!(action = strtok (g->data, ";"))) {
 		return send_msg (g, "E01");
 	}
-	while ((action = strtok (NULL, ";")) != 0) {
+	while ((action = strtok (NULL, ";"))) {
 		eprintf ("action: %s\n", action);
 		switch (action[0]) {
 		case 's':


### PR DESCRIPTION
```
src/gdbserver/core.c:163:16: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
        while (action = strtok (NULL, ";")) {
               ~~~~~~~^~~~~~~~~~~~~~~~~~~~
src/gdbserver/core.c:163:16: note: place parentheses around the assignment to silence this warning
        while (action = strtok (NULL, ";")) {
                      ^
               (                          )
src/gdbserver/core.c:163:16: note: use '==' to turn this assignment into an equality comparison
        while (action = strtok (NULL, ";")) {
                      ^
                      ==
1 warning generated.
```