### PR TITLE
remove unused variable + change type of typename (/libr/parse/code.c)

### DIFF
--- a/libr/parse/code.c
+++ b/libr/parse/code.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2013-2016 - pancake */
+/* radare - LGPL - Copyright 2013-2017 - pancake */
 
 #include "r_util.h"
 #include "r_types.h"
@@ -33,13 +33,12 @@ static int typeload(void *p, const char *k, const char *v) {
 	if (!strncmp (v, "struct", 6) && strncmp(k, "struct.", 7)) {
 		// structure
 		btype = VT_STRUCT;
-		char *typename = k;
+		const char *typename = k;
 		int typesize = 0;
 		// TODO: Add typesize here
 		char* query = sdb_fmt (-1, "struct.%s", k);
 		char *members = sdb_get (anal->sdb_types, query, 0);
 		char *next, *ptr = members;
-		int ret = 0;
 		if (members) {
 			do {
 				char *name = sdb_anext (ptr, &next);


### PR DESCRIPTION
remove unused variable (ret) + change type of typename to const char.
```
code.c:36:9: warning: initializing 'char *' with an expression of type 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
                char *typename = k;

```