### PR TITLE
Support of more jmptbl still WIP

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1052,6 +1052,8 @@ repeat:
 				}
 				if (op.ptr != UT64_MAX) {       // direct jump
 					ret = try_walkthrough_jmptbl (anal, fcn, depth, addr + idx, op.ptr, ret);
+					anal->cmdtail = r_str_appendf (anal->cmdtail, "pxt. 0x%08" PFMT64x
+						" @ 0x%08" PFMT64x "\n", op.addr, op.ptr);
 
 				} else {        // indirect jump: table pointer is unknown
 					if (op.src[0] && op.src[0]->reg) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2620,10 +2620,15 @@ static void _pointer_table(RCore *core, ut64 origin, ut64 offset, const ut8 *buf
 		delta = (st32 *) (buf + i);
 		addr = offset + *delta;
 		if (!r_io_is_valid_offset (core->io, addr, 0)) {
-			break;
+			//let check for jmptbl which are not relative addresses
+			//jmp dword [eax*4 + jmptbl.0x66204a6d]
+			if (!r_io_is_valid_offset (core->io, *delta, 0)) {
+				break;
+			}
+			addr = *delta;
 		}
 		if (mode == '*') {
-			r_cons_printf ("af case.%d.0x%"PFMT64x " 0x%08"PFMT64x "\n", i, offset, addr);
+			r_cons_printf ("af case.%d.0x%"PFMT64x " 0x%08"PFMT64x "\n", n, offset, addr);
 			r_cons_printf ("ax 0x%"PFMT64x " 0x%08"PFMT64x "\n", offset, addr);
 			r_cons_printf ("ax 0x%"PFMT64x " 0x%08"PFMT64x "\n", addr, offset); // wrong, but useful because forward xrefs dont work :?
 			r_cons_printf ("aho case 0x%"PFMT64x " 0x%08"PFMT64x " @ 0x%08"PFMT64x "\n", (ut64)i, addr, offset + i); // wrong, but useful because forward xrefs dont work :?
@@ -3109,6 +3114,10 @@ static int cmd_print(void *data, const char *input) {
 					if (l > tbs) {
 						if (input[0] == 'x' && input[1] == 'l') {
 							l *= core->print->cols;
+						}
+						//workaround to fix pxt. with huge va
+						if (input[0] == 'x' && input[1] == 't') {
+							l = core->blocksize;
 						}
 						if (!r_core_block_size (core, l)) {
 							eprintf ("This block size is too big. Did you mean 'p%c @ %s' instead?\n",


### PR DESCRIPTION
Still many stuff to get fixed but it recognizes this kind of jmptbl so better than before

Before

```
|           0x66204971      ff24856d4a20.  jmp dword [eax*4 + 0x66204a6d] ; "xI f.I f.I f.I f.I f.I f.I f.I f.I
|           0x66204978      68701b2066     push 0x66201b70             ; "CAPABILITY"
|              ; XREFS: JMP 0x662049f3  JMP 0x662049fa  JMP 0x66204a01  JMP 0x66204a0b  JMP 0x66204a15
|              ; XREFS: JMP 0x66204a1f  JMP 0x66204a29  JMP 0x66204a33  JMP 0x66204a3d  JMP 0x662049db
|              ; XREFS: JMP 0x6620499c  JMP 0x662049a3  JMP 0x662049aa  JMP 0x662049b1  JMP 0x662049b8
|              ; XREFS: JMP 0x662049bf  JMP 0x662049c6  JMP 0x662049cd  JMP 0x662049d4
| .......-> 0x6620497d      8b7510         mov esi, dword [arg_10h]    ; [0x10:4]=184
| |||||||   0x66204980      8b7d08         mov edi, dword [arg_8h]     ; [0x8:4]=4
| |||||||   0x66204983      68581b2066     push 0x66201b58             ; "%s"
| |||||||   0x66204988      56             push esi
| |||||||   0x66204989      57             push edi
| |||||||   0x6620498a      e8cdfbffff     call fcn.6620455c           ;[1]
| |||||||   0x6620498f      83c410         add esp, 0x10
...

             ; DATA XREF from 0x66204971 (fcn.6620494d)
        ,=< 0x66204a6d      7849           js 0x66204ab8               ;[1]
        |   0x66204a6f      206697         and byte [esi - 0x69], ah
        |   0x66204a72      49             dec ecx
        |   0x66204a73      20669e         and byte [esi - 0x62], ah
        |   0x66204a76      49             dec ecx
        |   0x66204a77      2066a5         and byte [esi - 0x5b], ah
        |   0x66204a7a      49             dec ecx
        |   0x66204a7b      2066ac         and byte [esi - 0x54], ah
```

After

```
│           0x66204971      jmp dword [eax*4 + jmptbl.0x66204a6d]      ; "xI f\x97I f\x9eI f\xa5I f\xacI f\xb3I
│              ; UNKNOWN XREF from 0x66204a6d (jmptbl.0x66204a6d + 0)
│           0x66204978      push 0x66201b70                            ; "CAPABILITY" ; case 0:
│              ; XREFS: JMP 0x662049f3  JMP 0x662049fa  JMP 0x66204a01  JMP 0x66204a0b  JMP 0x66204a15
│              ; XREFS: JMP 0x66204a1f  JMP 0x66204a29  JMP 0x66204a33  JMP 0x66204a3d  JMP 0x662049db
│              ; XREFS: JMP 0x6620499c  JMP 0x662049a3  JMP 0x662049aa  JMP 0x662049b1  JMP 0x662049b8
│              ; XREFS: JMP 0x662049bf  JMP 0x662049c6  JMP 0x662049cd  JMP 0x662049d4
│ ┌┌┌┌┌┌┌─> 0x6620497d      mov esi, dword [arg_10h]                   ; [0x10:4]=184
│ |||||||   0x66204980      mov edi, dword [arg_8h]                    ; [0x8:4]=4
│ |||||||   0x66204983      push 0x66201b58                            ; "%s"
│ |||||||   0x66204988      push esi
│ |||||||   0x66204989      push edi
│ |||||||   0x6620498a      call fcn.6620455c                          ;[1] ; fcn.6620455c
│ |||||||   0x6620498f      add esp, 0x10
│ ────────< 0x66204992      jmp 0x66204a5c                             ;[2]
│ ↑↑↑↑↑↑↑      ; UNKNOWN XREF from 0x66204a6d (jmptbl.0x66204a6d + 0)
│ |||||||   0x66204997      push 0x66201b7c                            ; "EVENT" ; case 1:
│ ────────< 0x6620499c      jmp 0x6620497d                             ;[3]
│ ↑↑↑↑↑↑↑      ; UNKNOWN XREF from 0x66204a6d (jmptbl.0x66204a6d + 0)
│ |||||||   0x6620499e      push 0x66201b84                            ; "IDENTITY" ; case 2:
...
        ┌─< 0x66204a6d      case 0 0x66204978                          ;[1] ; unlikely ; (case 0:) ; (case 1:) ;
        │   0x66204a71      case 1 0x66204997
        │   0x66204a75      case 2 0x6620499e
        │   0x66204a79      case 3 0x662049a5
        │   0x66204a7d      case 4 0x662049ac
        │   0x66204a81      case 5 0x662049b3                          ; 0x49 ; 'I'
        │   0x66204a85      case 6 0x662049ba                          ; 0xc1662049
        │   0x66204a89      case 7 0x662049c1
        │   0x66204a8d      case 8 0x662049c8                          ; 0x2049 ; "Disabled.." 0x00002049  ; "Di
        │   0x66204a91      case 9 0x662049cf
```