### PR TITLE
Changed finding logic of session key

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3621,7 +3621,7 @@ static int cmd_debug(void *data, const char *input) {
 				r_debug_session_list (core->dbg);
 				break;
 			case '+':
-				r_debug_session_add (core->dbg);
+				r_debug_session_add (core->dbg, NULL);
 				break;
 			case 'A': // for debugging command (private command for developer)
 				r_debug_session_set_idx (core->dbg, atoi (input + 4));

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -922,8 +922,12 @@ R_API int r_debug_step_back(RDebug *dbg) {
 	if (r_debug_is_dead (dbg)) {
 		return 0;
 	}
-	if (!dbg->anal || !dbg->reg)
+	if (!dbg->anal || !dbg->reg) {
 		return 0;
+	}
+	if (r_list_empty (dbg->sessions)) {
+		return 0;
+	}
 
 	end = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 
@@ -953,7 +957,7 @@ R_API int r_debug_step_back(RDebug *dbg) {
 		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 		r_io_read_at (dbg->iob.io, pc, buf, sizeof (buf));
 		r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf));
-		//eprintf ("executing [0x%08"PFMT64x",0x%08"PFMT64x"]\n", pc, pc + op.size);
+		eprintf ("executing [0x%08"PFMT64x",0x%08"PFMT64x"]\n", pc, pc + op.size);
 		if (pc + op.size == end)
 			return 1;
 		if (!r_debug_step (dbg, 1))

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -917,6 +917,8 @@ R_API int r_debug_step_back(RDebug *dbg) {
 	ut8 buf[32];
 	RAnalOp op;
 	RDebugSession *before;
+	RListIter *tail;
+
 	if (r_debug_is_dead (dbg)) {
 		return 0;
 	}
@@ -924,14 +926,16 @@ R_API int r_debug_step_back(RDebug *dbg) {
 		return 0;
 
 	end = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
+
+	/* Save current session. It is marked as a finish point of reverse execution */
+	r_debug_session_add (dbg, &tail);
+
 	/* rollback to previous state */
-	before = r_debug_session_get (dbg, end);
+	before = r_debug_session_get (dbg, tail);
 	if (!before) {
 		return 0;
 	}
 	eprintf ("before session (%d) 0x%08"PFMT64x"\n", before->key.id, before->key.addr);
-	/* Save current session. It is marked as a finish point of reverse execution */
-	r_debug_session_add (dbg);
 
 	if (!r_list_length (before->memlist)) {
 		/* Diff list is empty. (i.e. Before session is base snapshot) *

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -527,21 +527,21 @@ R_API int r_debug_esil_watch_empty(RDebug *dbg);
 R_API void r_debug_esil_prestep (RDebug *d, int p);
 
 /* snap */
-R_API RDebugSnap* r_debug_snap_new(void);
+R_API RDebugSnap *r_debug_snap_new(void);
 R_API void r_debug_snap_free(void *snap);
 R_API int r_debug_snap_delete(RDebug *dbg, int idx);
 R_API void r_debug_snap_list(RDebug *dbg, int idx, int mode);
 R_API int r_debug_snap(RDebug *dbg, ut64 addr);
 R_API int r_debug_snap_comment(RDebug *dbg, int idx, const char *msg);
-R_API RDebugSnapDiff* r_debug_snap_map(RDebug *dbg, RDebugMap *map);
+R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map);
 R_API int r_debug_snap_all(RDebug *dbg, int perms);
-R_API RDebugSnap* r_debug_snap_get(RDebug *dbg, ut64 addr);
+R_API RDebugSnap *r_debug_snap_get(RDebug *dbg, ut64 addr);
 R_API int r_debug_snap_set_idx(RDebug *dbg, int idx);
 R_API int r_debug_snap_set(RDebug *dbg, RDebugSnap *snap);
 
 /* snap diff */
 R_API void r_debug_diff_free(void *p);
-R_API RDebugSnapDiff* r_debug_diff_add(RDebug *dbg, RDebugSnap *base);
+R_API RDebugSnapDiff *r_debug_diff_add(RDebug *dbg, RDebugSnap *base);
 R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff);
 R_API void r_debug_diff_set_base(RDebug *dbg, RDebugSnap *base);
 
@@ -551,11 +551,11 @@ R_API void r_page_data_free(void *p);
 /* debug session */
 R_API void r_debug_session_free(void *p) ;
 R_API void r_debug_session_list(RDebug *dbg);
-R_API RDebugSession *r_debug_session_add(RDebug *dbg);
+R_API RDebugSession *r_debug_session_add(RDebug *dbg, RListIter **tail);
 R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session);
 R_API void r_debug_session_set_base(RDebug *dbg, RDebugSession *before);
 R_API bool r_debug_session_set_idx(RDebug *dbg, int idx);
-R_API RDebugSession* r_debug_session_get(RDebug *dbg, ut64 addr);
+R_API RDebugSession *r_debug_session_get(RDebug *dbg, RListIter *tail);
 R_API int r_debug_step_back(RDebug *dbg);
 
 /* plugin pointers */

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -181,6 +181,7 @@ typedef struct r_debug_snap_t {
 	RHash *hash_ctx;
 	ut8 **hashes; // Hash of each pages
 	RList *history; // <RDebugSnapDiff*>
+	int perm;
 	char *comment;
 } RDebugSnap;
 


### PR DESCRIPTION
Previous trace session key must be found along with recently recorded sessions.