### PR TITLE
Add rax -l option for preventing print '\n' char from end of line

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -90,7 +90,6 @@ static int help() {
 		"  hex   ->  ternary       ;  rax2 Tx23\n"
 		"  raw   ->  hex           ;  rax2 -S < /binfile\n"
 		"  hex   ->  raw           ;  rax2 -s 414141\n"
-		"  -l    print without nl  ;  rax2 -l -E salam\n"
 		"  -b    bin -> str        ;  rax2 -b 01000101 01110110\n"
 		"  -B    str -> bin        ;  rax2 -B hello\n"
 		"  -d    force integer     ;  rax2 -d 3 -> 3 instead of 0x3\n"
@@ -102,6 +101,7 @@ static int help() {
 		"  -h    help              ;  rax2 -h\n"
 		"  -k    keep base         ;  rax2 -k 33+3 -> 36\n"
 		"  -K    randomart         ;  rax2 -K 0x34 1020304050\n"
+		"  -l    print without nl  ;  rax2 -l -E salam\n"
 		"  -n    binary number     ;  rax2 -n 0x1234 # 34120000\n"
 		"  -N    binary number     ;  rax2 -N 0x1234 # \\x34\\x12\\x00\\x00\n"
 		"  -r    r2 style output   ;  rax2 -r 0x1234\n"
@@ -191,9 +191,6 @@ static int rax(char *str, int len, int last) {
 		}
 	}
 dotherax:
-	if (flags & (1 << 19)) { // -l
-		newline[0] = '\0';
-	}
 	if (flags & 1) { // -s
 		int n = ((strlen (str)) >> 1) + 1;
 		buf = malloc (n);
@@ -203,9 +200,10 @@ dotherax:
 			if (n > 0) {
 				fwrite (buf, n, 1, stdout);
 			}
-#if __EMSCRIPTEN__
-			puts ("");
-#endif
+			printf("%s", newline);
+//#if __EMSCRIPTEN__
+//			puts ("");
+//#endif
 			fflush (stdout);
 			free (buf);
 		}
@@ -425,7 +423,10 @@ dotherax:
 
 		return true;
 	}
-
+	if (flags & (1 << 19)) { // -l
+		newline[0] = '\0';
+		return true;
+	}
 	if (str[0] == '0' && str[1] == 'x') {
 		out_mode = (flags & 32)? '0': 'I';
 	} else if (str[0] == 'b') {

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -17,7 +17,7 @@ static int use_stdin();
 static int force_mode = 0;
 static int rax(char *str, int len, int last);
 
-static int format_output(char mode, const char *s, char newline) {
+static int format_output(char mode, const char *s, char * newline) {
 	ut64 n = r_num_math (num, s);
 	char strbits[65];
 	if (force_mode) {
@@ -29,7 +29,7 @@ static int format_output(char mode, const char *s, char newline) {
 	}
 	switch (mode) {
 	case 'I':
-		printf ("%" PFMT64d "%c", n, newline);
+		printf ("%" PFMT64d "%s", n, newline);
 		break;
 	case '0': {
 		int len = strlen (s);
@@ -37,31 +37,31 @@ static int format_output(char mode, const char *s, char newline) {
 			R_STATIC_ASSERT (sizeof (float) == 4)
 			float f = (float) num->fvalue;
 			ut8 *p = (ut8 *) &f;
-			printf ("Fx%02x%02x%02x%02x%c", p[3], p[2], p[1], p[0], newline);
+			printf ("Fx%02x%02x%02x%02x%s", p[3], p[2], p[1], p[0], newline);
 		} else {
-			printf ("0x%" PFMT64x "%c", n, newline);
+			printf ("0x%" PFMT64x "%s", n, newline);
 		}
 	} break;
 	case 'F': {
 		float *f = (float *) &n;
-		printf ("%ff%c", *f, newline);
+		printf ("%ff%s", *f, newline);
 	} break;
-	case 'f': printf ("%.01lf%c", num->fvalue, newline); break;
-	case 'O': printf ("0%" PFMT64o "%c", n, newline); break;
+	case 'f': printf ("%.01lf%s", num->fvalue, newline); break;
+	case 'O': printf ("0%" PFMT64o "%s", n, newline); break;
 	case 'B':
 		if (n) {
 			r_num_to_bits (strbits, n);
-			printf ("%sb%c", strbits, newline);
+			printf ("%sb%s", strbits, newline);
 		} else {
-			printf ("0b%c", newline);
+			printf ("0b%s", newline);
 		}
 		break;
 	case 'T':
 		if (n) {
 			r_num_to_trits (strbits, n);
-			printf ("%st%c", strbits, newline);
+			printf ("%st%s", strbits, newline);
 		} else {
-			printf ("0t%c", newline);
+			printf ("0t%s", newline);
 		}
 		break;
 	default:
@@ -118,7 +118,8 @@ static int help() {
 static int rax(char *str, int len, int last) {
 	float f;
 	ut8 *buf;
-	char *p, newline = '\n', out_mode = (flags & 128)? 'I': '0';
+	char *p, out_mode = (flags & 128)? 'I': '0';
+	char newline[2] = "\n\0";
 	int i;
 	if (!(flags & 4) || !len) {
 		len = strlen (str);
@@ -191,7 +192,7 @@ static int rax(char *str, int len, int last) {
 	}
 dotherax:
 	if (flags & (1 << 19)) { // -l
-		newline = '\0';
+		newline[0] = '\0';
 	}
 	if (flags & 1) { // -s
 		int n = ((strlen (str)) >> 1) + 1;
@@ -214,7 +215,7 @@ dotherax:
 		for (i = 0; i < len; i++) {
 			printf ("%02x", (ut8) str[i]);
 		}
-		printf ("%c", newline);
+		printf ("%s", newline);
 		return true;
 	} else if (flags & (1 << 3)) { // -b
 		int i, len;
@@ -226,7 +227,7 @@ dotherax:
 		return true;
 	} else if (flags & (1 << 4)) { // -x
 		int h = r_str_hash (str);
-		printf ("0x%x%c", h, newline);
+		printf ("0x%x%s", h, newline);
 		return true;
 	} else if (flags & (1 << 5)) { // -k
 		out_mode = 'I';
@@ -246,11 +247,11 @@ dotherax:
 		if (n < 1 || !memcmp (str, "0x", 2)) {
 			ut64 q = r_num_math (num, str);
 			s = r_print_randomart ((ut8 *) &q, sizeof (q), q);
-			printf ("%s%c", s, newline);
+			printf ("%s%s", s, newline);
 			free (s);
 		} else {
 			s = r_print_randomart ((ut8 *) buf, n, *m);
-			printf ("%s%c", s, newline);
+			printf ("%s%s", s, newline);
 			free (s);
 		}
 		free (m);
@@ -264,7 +265,7 @@ dotherax:
 				fwrite (&n, sizeof (n), 1, stdout);
 			} else {
 				printf ("%02x%02x%02x%02x"
-					"%02x%02x%02x%02x%c",
+					"%02x%02x%02x%02x%s",
 					np[0], np[1], np[2], np[3],
 					np[4], np[5], np[6], np[7], newline);
 			}
@@ -275,7 +276,7 @@ dotherax:
 			if (flags & 1) {
 				fwrite (&n32, sizeof (n32), 1, stdout);
 			} else {
-				printf ("%02x%02x%02x%02x%c",
+				printf ("%02x%02x%02x%02x%s",
 					np[0], np[1], np[2], np[3], newline);
 			}
 		}
@@ -308,7 +309,7 @@ dotherax:
 		} else if (n >> 7) {
 			n = (st64) (st8) n;
 		}
-		printf ("%" PFMT64d "%c", n, newline);
+		printf ("%" PFMT64d "%s", n, newline);
 		fflush (stdout);
 		return true;
 	} else if (flags & (1 << 15)) { // -N
@@ -320,7 +321,7 @@ dotherax:
 				fwrite (&n, sizeof (n), 1, stdout);
 			} else {
 				printf ("\\x%02x\\x%02x\\x%02x\\x%02x"
-					"\\x%02x\\x%02x\\x%02x\\x%02x%c",
+					"\\x%02x\\x%02x\\x%02x\\x%02x%s",
 					np[0], np[1], np[2], np[3],
 					np[4], np[5], np[6], np[7], newline);
 			}
@@ -331,7 +332,7 @@ dotherax:
 			if (flags & 1) {
 				fwrite (&n32, sizeof (n32), 1, stdout);
 			} else {
-				printf ("\\x%02x\\x%02x\\x%02x\\x%02x%c",
+				printf ("\\x%02x\\x%02x\\x%02x\\x%02x%s",
 					np[0], np[1], np[2], np[3], newline);
 			}
 		}
@@ -340,7 +341,7 @@ dotherax:
 	} else if (flags & (1 << 10)) { // -u
 		char buf[80];
 		r_num_units (buf, r_num_math (NULL, str));
-		printf ("%s%c", buf, newline);
+		printf ("%s%s", buf, newline);
 		return true;
 	} else if (flags & (1 << 11)) { // -t
 		ut32 n = r_num_math (num, str);
@@ -353,7 +354,7 @@ dotherax:
 		char *out = calloc (sizeof (char), ((len + 1) * 4) / 3);
 		if (out) {
 			r_base64_encode (out, (const ut8 *) str, len);
-			printf ("%s%c", out, newline);
+			printf ("%s%s", out, newline);
 			fflush (stdout);
 			free (out);
 		}
@@ -364,7 +365,7 @@ dotherax:
 		ut8 *out = calloc (sizeof (ut8), ((len + 2) / 3) * 4);
 		if (out) {
 			r_base64_decode (out, str, len);
-			printf ("%s%c", out, newline);
+			printf ("%s%s", out, newline);
 			fflush (stdout);
 			free (out);
 		}
@@ -374,7 +375,7 @@ dotherax:
 		if (str) {
 			char *res = r_hex_from_c (str);
 			if (res) {
-				printf ("%s%c", res, newline);
+				printf ("%s%s", res, newline);
 				fflush (stdout);
 				free (res);
 			} else {
@@ -419,7 +420,7 @@ dotherax:
 		}
 		/* binary and floating point */
 		r_str_bits (out, (const ut8 *) &n, sizeof (n), NULL);
-		eprintf ("%s %.01lf %ff %lf%c",
+		eprintf ("%s %.01lf %ff %lf%s",
 			out, num->fvalue, f, d, newline);
 
 		return true;
@@ -452,7 +453,7 @@ dotherax:
 	} else if (str[strlen (str) - 1] == 'f') {
 		ut8 *p = (ut8 *) &f;
 		sscanf (str, "%f", &f);
-		printf ("Fx%02x%02x%02x%02x%c", p[3], p[2], p[1], p[0], newline);
+		printf ("Fx%02x%02x%02x%02x%s", p[3], p[2], p[1], p[0], newline);
 		return true;
 	}
 	while ((p = strchr (str, ' '))) {


### PR DESCRIPTION
rax2 has not any option for preventing print '\n' char from end of line.
I think it is a good feature because, if someone wants to use rax2 with redirecting output, gives wrong result.
For example, i want to do twice base64 encode with rax2 : base64(base64(salam))
```
$./rax2 -E salam | ./rax2 -E 
YzJGc1lXMD0K => it's wrong because result is base64(base64('salam'+'\n'))
```
but in my case
```
$./rax2 -! -E salam | ./rax2 -E 
YzJGc1lXMD0= => it's fixed
```