### PR TITLE
gdbserver rebasing symbols. gdb source-level debugging now works

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -3,7 +3,7 @@
 #define USE_THREADS 1
 #define UNCOLORIZE_NONTTY 0
 #ifdef _MSC_VER
-#ifndef WIN32_LEAN_AND_MEAN 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 #endif
@@ -77,59 +77,6 @@ static int verify_version(int show) {
 		}
 	}
 	return ret;
-}
-
-// we should probably move this functionality into the r_debug API
-// r_debug_get_baddr
-static ut64 getBaddrFromDebugger(RCore *r, const char *file) {
-	char *abspath;
-	RListIter *iter;
-	RDebugMap *map;
-	if (!r || !r->io || !r->io->desc) {
-		return 0LL;
-	}
-#if __WINDOWS__
-	typedef struct {
-		int pid;
-		int tid;
-		PROCESS_INFORMATION pi;
-	} RIOW32Dbg;
-	RIODesc *d = r->io->desc;
-	if (!strcmp ("w32dbg", d->plugin->name)) {
-		RIOW32Dbg *g = d->data;
-		r->io->desc->fd = g->pid;
-		r_debug_attach (r->dbg, g->pid);
-	}
-	return r->io->winbase;
-#else
-	int pid = r->io->desc->fd;
-	if (r_debug_attach (r->dbg, pid) == -1) {
-		return 0LL;
-	}
-	r_debug_select (r->dbg, pid, pid);
-#endif
-	r_debug_map_sync (r->dbg);
-	abspath = r_file_abspath (file);
-	if (!abspath) {
-		abspath = strdup (file);
-	}
-	if (abspath) {
-		r_list_foreach (r->dbg->maps, iter, map) {
-			if (!strcmp (abspath, map->name)) {
-				free (abspath);
-				return map->addr;
-			}
-		}
-		free (abspath);
-	}
-	// fallback resolution (osx/w32?)
-	// we asume maps to be loaded in order, so lower addresses come first
-	r_list_foreach (r->dbg->maps, iter, map) {
-		if (map->perm == 5) { // r-x
-			return map->addr;
-		}
-	}
-	return 0LL;
 }
 
 static int main_help(int line) {
@@ -983,7 +930,7 @@ int main(int argc, char **argv, char **envp) {
 			}
 			/* load symbols when doing r2 -d ls */
 			// NOTE: the baddr is redefined to support PIE/ASLR
-			baddr = getBaddrFromDebugger (&r, pfile);
+			baddr = r_debug_get_baddr (r.dbg, pfile);
 			if (baddr != UT64_MAX && baddr != 0) {
 				eprintf ("bin.baddr 0x%08" PFMT64x "\n", baddr);
 				va = 2;

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -5,6 +5,7 @@
 #include "r_core.h"
 #include "r_print.h"
 #include "r_bin.h"
+#include "r_debug.h"
 
 
 static inline ut32 find_binfile_id_by_fd (RBin *bin, ut32 fd) {
@@ -302,8 +303,7 @@ R_API void r_core_file_reopen_debug (RCore *core, const char *args) {
 	r_core_file_reopen (core, newfile, 0, 2);
 	newfile = newfile2;
 #if !__WINDOWS__
-	//XXX: need cmd_debug.h for r_debug_get_baddr
-	ut64 new_baddr = r_debug_get_baddr (core, newfile);
+	ut64 new_baddr = r_debug_get_baddr (core->dbg, newfile);
 	ut64 old_baddr = r_config_get_i (core->config, "bin.baddr");
 	if (old_baddr != new_baddr) {
 		r_bin_set_baddr (core->bin, new_baddr);

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -889,15 +889,14 @@ R_API int r_core_rtr_http(RCore *core, int launch, const char *path) {
 	return ret;
 }
 
-static int r_core_rtr_gdb_cb(void *core_ptr, const char *cmd, char *out_buf, size_t max_len) {
+static int r_core_rtr_gdb_cb(libgdbr_t *g, void *core_ptr, const char *cmd, char *out_buf, size_t max_len) {
 	int ret;
 	RList *list;
 	RListIter *iter;
-	RRegItem *reg_item;
-	int reg_size;
-	ut64 reg_value;
-	utX reg_value_big;
-	ut64 m_off;
+	gdb_reg_t *gdb_reg;
+	utX val_big;
+	ut64 m_off, reg_val;
+	bool be;
 	RDebugPid *dbgpid;
 	if (!core_ptr || ! cmd) {
 		return -1;
@@ -950,63 +949,80 @@ static int r_core_rtr_gdb_cb(void *core_ptr, const char *cmd, char *out_buf, siz
 			}
 			break;
 		case 'r': // dr
-			if (!(list = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR))) {
-				return -1;
-			}
+			be = r_config_get_i (core->config, "cfg.bigendian");
 			ret = 0;
-			if ((reg_size = r_config_get_i (core->config, "asm.bits")) == 0) {
+			if (!(gdb_reg = g->registers)) {
 				return -1;
 			}
-			r_list_foreach (list, iter, reg_item) {
-				// TODO thumb (ref. - dreg.c:140)
-				if (reg_item->size != reg_size) {
-					continue;
-				}
-				if (reg_size < 80) {
-					reg_value = r_reg_get_value (core->dbg->reg, reg_item);
-					if (!(r_config_get_i (core->config, "cfg.bigendian"))) {
-						reg_value = r_swap_ut64 (reg_value);
-					}
-					snprintf (out_buf + ret, max_len - ret - 1, "%016"PFMT64x, reg_value);
-				} else {
-					reg_value = r_reg_get_value_big (core->dbg->reg, reg_item, &reg_value_big);
-					switch (reg_size) {
-					case 80:
-						if (!(r_config_get_i (core->config, "cfg.bigendian"))) {
-							snprintf (out_buf + ret, max_len - ret - 1, "%016"PFMT64x"%04x",
-								  r_swap_ut64 (reg_value_big.v80.Low), r_swap_ut16 (reg_value_big.v80.High));
-							break;
-						}
-						snprintf (out_buf + ret, max_len - ret - 1, "%04x%016"PFMT64x,
-							  reg_value_big.v80.High, reg_value_big.v80.Low);
-						break;
-					case 96:
-						if (!(r_config_get_i (core->config, "cfg.bigendian"))) {
-							snprintf (out_buf + ret, max_len - ret - 1, "%016"PFMT64x"%08x",
-								  r_swap_ut64 (reg_value_big.v80.Low), r_swap_ut32 (reg_value_big.v80.High));
-							break;
-						}
-						snprintf (out_buf + ret, max_len - ret - 1, "%08x%016"PFMT64x,
-							  reg_value_big.v96.High, reg_value_big.v96.Low);
-						break;
-					case 128:
-						if (!(r_config_get_i (core->config, "cfg.bigendian"))) {
-							snprintf (out_buf + ret, max_len - ret - 1, "%016"PFMT64x"%016"PFMT64x,
-								  r_swap_ut64 (reg_value_big.v80.Low), r_swap_ut64 (reg_value_big.v80.High));
-							break;
-						}
-						snprintf (out_buf + ret, max_len - ret - 1, "%016"PFMT64x"%016"PFMT64x,
-							  reg_value_big.v128.High, reg_value_big.v128.Low);
-						break;
-					default:
-						return -1;
-					}
-				}
-				ret += reg_size / 4;
-				if (ret >= max_len) {
+			while (*gdb_reg->name) {
+				if (ret + gdb_reg->size * 2 >= max_len - 1) {
 					return -1;
 				}
+				if (gdb_reg->size <= 8) {
+					reg_val = r_reg_getv (core->dbg->reg, gdb_reg->name);
+					if (!be) {
+						switch (gdb_reg->size) {
+						case 2:
+							reg_val = r_swap_ut16 (reg_val) & 0xFFFF;
+							break;
+						case 4:
+							reg_val = r_swap_ut32 (reg_val) & 0xFFFFFFFF;
+							break;
+						case 8:
+							reg_val = r_swap_ut64 (reg_val);
+							break;
+						default:
+							eprintf ("%s: Unsupported reg size: %d\n", __func__,
+								 (int) gdb_reg->size);
+						}
+					}
+					snprintf (out_buf + ret, gdb_reg->size * 2 + 1,
+						  gdb_reg->size == 2 ? "%04"PFMT64x
+						  : gdb_reg->size == 4 ? "%08"PFMT64x
+						  : "%016"PFMT64x, reg_val);
+				} else {
+					r_reg_get_value_big (core->dbg->reg,
+							     r_reg_get (core->dbg->reg, gdb_reg->name, -1),
+							     &val_big);
+					switch (gdb_reg->size) {
+					case 10:
+						if (be) {
+							snprintf (out_buf + ret, gdb_reg->size * 2 + 1,
+								  "%04x%016"PFMT64x, val_big.v80.High,
+								  val_big.v80.Low);
+						} else {
+							snprintf (out_buf + ret, gdb_reg->size * 2 + 1,
+								  "%016"PFMT64x"%04x", r_swap_ut64 (val_big.v80.Low),
+								  r_swap_ut16 (val_big.v80.High));
+						}
+					case 12:
+						if (be) {
+							snprintf (out_buf + ret, gdb_reg->size * 2 + 1,
+								  "%08"PFMT32x"%016"PFMT64x, val_big.v96.High,
+								  val_big.v96.Low);
+						} else {
+							snprintf (out_buf + ret, gdb_reg->size * 2 + 1,
+								  "%016"PFMT64x"%08"PFMT32x, r_swap_ut64 (val_big.v96.Low),
+								  r_swap_ut32 (val_big.v96.High));
+						}
+					case 16:
+						if (be) {
+							snprintf (out_buf + ret, gdb_reg->size * 2 + 1,
+								  "%016"PFMT64x"%016"PFMT64x, val_big.v128.High,
+								  val_big.v128.Low);
+						} else {
+							snprintf (out_buf + ret, gdb_reg->size * 2 + 1,
+								  "%016"PFMT64x"%016"PFMT64x, r_swap_ut64 (val_big.v128.Low),
+								  r_swap_ut64 (val_big.v128.High));
+						}
+					default:
+						eprintf ("%s: big registers not yet supported\n", __func__);
+					}
+				}
+				ret += gdb_reg->size * 2;
+				gdb_reg++;
 			}
+			out_buf[ret] = '\0';
 			return ret;
 		default:
 			return r_core_cmd (core, cmd, 0);
@@ -1087,6 +1103,7 @@ static int r_core_rtr_gdb_run(RCore *core, int launch, const char *path) {
 		return -1;
 	}
 	gdbr_init (g, true);
+	gdbr_set_architecture (g, r_config_get (core->config, "asm.arch"), r_config_get_i (core->config, "asm.bits"));
 	core->gdbserver_up = 1;
 	eprintf ("gdbserver started on port: %s, file: %s\n", port, file);
 

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -153,13 +153,13 @@ static int r_debug_gdb_attach(RDebug *dbg, int pid) {
 			support_hw_bp = UNKNOWN;
 			int arch = r_sys_arch_id (dbg->arch);
 			int bits = dbg->anal->bits;
-			if (( desc = &g->desc ))
+			desc = &g->desc;
 			switch (arch) {
 			case R_SYS_ARCH_X86:
 				if (bits == 16 || bits == 32) {
-					gdbr_set_architecture (&g->desc, X86_32);
+					gdbr_set_architecture (desc, "x86", 32);
 				} else if (bits == 64) {
-					gdbr_set_architecture (&g->desc, X86_64);
+					gdbr_set_architecture (desc, "x86", 64);
 				} else {
 					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
 					return false;
@@ -170,9 +170,9 @@ static int r_debug_gdb_attach(RDebug *dbg, int pid) {
 				break;
 			case R_SYS_ARCH_ARM:
 				if (bits == 16 || bits == 32) {
-					gdbr_set_architecture (&g->desc, ARM_32);
+					gdbr_set_architecture (desc, "arm", 32);
 				} else if (bits == 64) {
-					gdbr_set_architecture (&g->desc, ARM_64);
+					gdbr_set_architecture (desc, "arm", 64);
 				} else {
 					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
 					return false;
@@ -180,7 +180,7 @@ static int r_debug_gdb_attach(RDebug *dbg, int pid) {
 				break;
 			case R_SYS_ARCH_LM32:
 				if (bits == 32) {
-					gdbr_set_architecture(&g->desc, LM32);
+					gdbr_set_architecture(desc, "lm32", 32);
 				} else {
 					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
 					return false;
@@ -188,20 +188,14 @@ static int r_debug_gdb_attach(RDebug *dbg, int pid) {
 				break;
 			case R_SYS_ARCH_MIPS:
 				if (bits == 32 || bits == 64) {
-					gdbr_set_architecture (&g->desc, MIPS);
+					gdbr_set_architecture (desc, "mips", bits);
 				} else {
 					eprintf ("Not supported register %s %d profile\n", dbg->arch, bits);
 					return false;
 				}
 				break;
 			case R_SYS_ARCH_AVR:
-				if (bits == 16) {
-					gdbr_set_architecture (&g->desc, AVR);
-				} else {
-					gdbr_set_architecture (&g->desc, AVR);
-					//eprintf ("Not supported register profile\n");
-					//return false;
-				}
+				gdbr_set_architecture (desc, "avr", 16);
 				break;
 			}
 		} else {

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -428,6 +428,8 @@ R_API bool r_debug_use(RDebug *dbg, const char *str);
 R_API RDebugInfo *r_debug_info(RDebug *dbg, const char *arg);
 R_API void r_debug_info_free (RDebugInfo *rdi);
 
+R_API ut64 r_debug_get_baddr(RDebug *dbg, const char *file);
+
 /* send signals */
 R_API void r_debug_signal_init(RDebug *dbg);
 R_API int r_debug_signal_send(RDebug *dbg, int num);

--- a/shlr/gdb/include/arch.h
+++ b/shlr/gdb/include/arch.h
@@ -4,34 +4,25 @@
 
 #include <stdint.h>
 
-#define ARCH_X86_64 0
-#define ARCH_X86_32 1
-#define ARCH_ARM_32 2
-#define ARCH_ARM_64 3
-#define ARCH_MIPS 4
-#define ARCH_AVR 5
-#define ARCH_LM32 6
-
 /*!
- * This struct defines a generic
- * register view
+ * This struct defines a generic register view
  */
-typedef struct registers_t {
+typedef struct gdb_reg {
 	char name[32]; /*! The Name of the current register */
 	uint64_t offset; /*! Offset in the data block */
 	uint64_t size;	/*! Size of the register */
-} registers_t;
+} gdb_reg_t;
 
 /*!
  * Existing register sets
  */
-extern registers_t gdb_regs_x86_64[];
-extern registers_t gdb_regs_x86_32[];
-extern registers_t gdb_regs_arm32[];
-extern registers_t gdb_regs_aarch64[];
-extern registers_t gdb_regs_lm32[];
-extern registers_t gdb_regs_mips[];
-extern registers_t gdb_regs_avr[];
+extern gdb_reg_t gdb_regs_x86_64[];
+extern gdb_reg_t gdb_regs_x86_32[];
+extern gdb_reg_t gdb_regs_arm32[];
+extern gdb_reg_t gdb_regs_aarch64[];
+extern gdb_reg_t gdb_regs_lm32[];
+extern gdb_reg_t gdb_regs_mips[];
+extern gdb_reg_t gdb_regs_avr[];
 
 
 #endif

--- a/shlr/gdb/include/gdbserver/core.h
+++ b/shlr/gdb/include/gdbserver/core.h
@@ -4,7 +4,9 @@
 #include <r_socket.h>
 #include "../libgdbr.h"
 
-int gdbr_server_serve(libgdbr_t *g, int (*cmd_cb) (void*, const char*, char*, size_t), void *core_ptr);
+typedef int (*gdbr_server_cmd_cb) (libgdbr_t*, void*, const char*, char*, size_t);
+
+int gdbr_server_serve(libgdbr_t *g, gdbr_server_cmd_cb cmd_cb, void *core_ptr);
 
 
 #endif  // GDB_SERVER_CORE_H

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -11,14 +11,6 @@ typedef unsigned int ssize_t;
 #include "r_types_base.h"
 #include "r_socket.h"
 
-#define X86_64 ARCH_X86_64
-#define X86_32 ARCH_X86_32
-#define ARM_32 ARCH_ARM_32
-#define ARM_64 ARCH_ARM_64
-#define MIPS ARCH_MIPS
-#define AVR ARCH_AVR
-#define LM32 ARCH_LM32
-
 #define MSG_OK 0
 #define MSG_NOT_SUPPORTED -1
 #define MSG_ERROR_1 -2
@@ -131,8 +123,7 @@ typedef struct libgdbr_t {
 	char *data;
 	ssize_t data_len;
 	ssize_t data_max;
-	uint8_t architecture;
-	registers_t *registers;
+	gdb_reg_t *registers;
 	int last_code;
 	int pid; // little endian
 	int tid; // little endian
@@ -156,7 +147,7 @@ int gdbr_init(libgdbr_t *g, bool is_server);
  * \param architecture defines the architecure used (registersize, and such)
  * \returns a failure code
  */
-int gdbr_set_architecture(libgdbr_t *g, uint8_t architecture);
+int gdbr_set_architecture(libgdbr_t *g, const char *arch, int bits);
 
 /*!
  * \brief frees all buffers and cleans the libgdbr instance stuff

--- a/shlr/gdb/src/arch.c
+++ b/shlr/gdb/src/arch.c
@@ -1,6 +1,8 @@
+// NOTE: Keep in sync with debug/p/debug_gdb.c (it isn't as of now)
+
 #include "arch.h"
 
-registers_t gdb_regs_x86_64[] = {
+gdb_reg_t gdb_regs_x86_64[] = {
 	{ "rax", 0, 8 },
 	{ "rbx", 8, 8 },
 	{ "rcx", 16, 8 },
@@ -25,6 +27,7 @@ registers_t gdb_regs_x86_64[] = {
 	{ "es", 152, 4 },
 	{ "fs", 156, 4 },
 	{ "gs", 160, 4 },
+/* Commented until the long registers are implemented
 	{ "st0", 164, 10 },
 	{ "st1", 174, 10 },
 	{ "st2", 184, 10 },
@@ -58,11 +61,12 @@ registers_t gdb_regs_x86_64[] = {
 	{ "xmm14", 500, 16 },
 	{ "xmm15", 516, 16 },
 	{ "mxcsr", 532, 4 },
+*/
 	{ "", 0, 0 }
 };
 
 
-registers_t gdb_regs_x86_32[] = {
+gdb_reg_t gdb_regs_x86_32[] = {
 	{ "eax", 0, 4 },
 	{ "ecx", 4, 4 },
 	{ "edx", 8, 4 },
@@ -79,6 +83,7 @@ registers_t gdb_regs_x86_32[] = {
 	{ "es", 52, 4 },
 	{ "fs", 56, 4 },
 	{ "gs", 60, 4 },
+/* Commented until the long registers are implemented
 	{ "st0", 64, 10 },
 	{ "st1", 74, 10 },
 	{ "st2", 84, 10 },
@@ -104,10 +109,11 @@ registers_t gdb_regs_x86_32[] = {
 	{ "xmm6", 272, 16 },
 	{ "xmm7", 288, 16 },
 	{ "mxcsr", 304, 4 },
+*/
 	{ "", 0, 0 }
 };
 
-registers_t gdb_regs_arm32[] = {
+gdb_reg_t gdb_regs_arm32[] = {
 	{ "r0", 0, 4 },
 	{ "r1", 4, 4 },
 	{ "r2", 8, 4 },
@@ -137,7 +143,7 @@ registers_t gdb_regs_arm32[] = {
 	{ "", 0, 0 }
 };
 
-registers_t gdb_regs_aarch64[] = {
+gdb_reg_t gdb_regs_aarch64[] = {
 	{ "x0", 0, 8 },
 	{ "x1", 8, 8 },
 	{ "x2", 16, 8 },
@@ -209,7 +215,7 @@ registers_t gdb_regs_aarch64[] = {
 	{ "", 0, 0 }
 };
 
-registers_t gdb_regs_lm32[] = {
+gdb_reg_t gdb_regs_lm32[] = {
 	{ "r0", 0, 4 },
 	{ "r1", 4, 4 },
 	{ "r2", 8, 4 },
@@ -252,7 +258,7 @@ registers_t gdb_regs_lm32[] = {
 	{ "", 0, 0 }
 };
 
-registers_t gdb_regs_mips[] = {
+gdb_reg_t gdb_regs_mips[] = {
 	{ "zero", 0, 0 },
 	{ "at", 4, 0 },
 	{ "v0", 8, 0 },
@@ -329,7 +335,7 @@ registers_t gdb_regs_mips[] = {
 	{ "", 0, 0 }
 };
 
-registers_t gdb_regs_avr[] = {
+gdb_reg_t gdb_regs_avr[] = {
 	{ "r0", 0, 1 },
 	{ "r1", 1, 1 },
 	{ "r2", 2, 1 },

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -37,35 +37,34 @@ int gdbr_init(libgdbr_t *g, bool is_server) {
 	return 0;
 }
 
-int gdbr_set_architecture(libgdbr_t *g, uint8_t architecture) {
+int gdbr_set_architecture(libgdbr_t *g, const char *arch, int bits) {
 	if (!g) {
 		return -1;
 	}
-	g->architecture = architecture;
-	switch (architecture) {
-	case ARCH_X86_32:
-		g->registers = gdb_regs_x86_32;
-		break;
-	case ARCH_X86_64:
-		g->registers = gdb_regs_x86_64;
-		break;
-	case ARCH_ARM_32:
-		g->registers = gdb_regs_arm32;
-		break;
-	case ARCH_ARM_64:
-		g->registers = gdb_regs_aarch64;
-		break;
-	case ARCH_MIPS:
+	if (!strcmp (arch, "mips")) {
 		g->registers = gdb_regs_mips;
-		break;
-	case ARCH_AVR:
-		g->registers = gdb_regs_avr;
-		break;
-	case ARCH_LM32:
+	} else if (!strcmp (arch, "lm32")) {
 		g->registers = gdb_regs_lm32;
-		break;
-	default:
-		eprintf ("Error unknown architecture set\n");
+	} else if (!strcmp (arch, "avr")) {
+		g->registers = gdb_regs_avr;
+	} else if (!strcmp (arch, "x86")) {
+		if (bits == 32) {
+			g->registers = gdb_regs_x86_32;
+		} else if (bits == 64) {
+			g->registers = gdb_regs_x86_64;
+		} else {
+			eprintf ("%s: unsupported x86 bits: %d\n", __func__, bits);
+			return -1;
+		}
+	} else if (!strcmp (arch, "arm")) {
+		if (bits == 32) {
+			g->registers = gdb_regs_arm32;
+		} else if (bits == 64) {
+			g->registers = gdb_regs_aarch64;
+		} else {
+			eprintf ("%s: unsupported arm bits: %d\n", __func__, bits);
+			return -1;
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
GDB -
```
~$ gdb
...
(gdb) symbol-file /bin/radare2 
Reading symbols from /bin/radare2...done.
(gdb) set arch i386:x86-64:intel 
The target architecture is assumed to be i386:x86-64:intel
(gdb) target remote localhost:8000
Remote debugging using localhost:8000
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x00007f8e637efd80 in ?? ()
(gdb) break main
Breakpoint 1 at 0x55dc32d47835: file radare2.c, line 375.
(gdb) c
Continuing.

Breakpoint 1, main (argc=2, argv=0x7ffe23d2eae8, envp=0x7ffe23d2eb00) at radare2.c:375
375		RThreadLock *lock = NULL;
(gdb) i r
rax            0x55dc32d47815	94404233951253
rbx            0x0	0
rcx            0x0	0
rdx            0x7ffe23d2eb00	140729499446016
rsi            0x7ffe23d2eae8	140729499445992
rdi            0x2	2
rbp            0x7ffe23d2ea00	0x7ffe23d2ea00
rsp            0x7ffe23d2e3c0	0x7ffe23d2e3c0
r8             0x55dc32d4a310	94404233962256
r9             0x7f8e637fe650	140249531410000
r10            0x4	4
r11            0x1	1
r12            0x55dc32d46d00	94404233948416
r13            0x7ffe23d2eae0	140729499445984
r14            0x0	0
r15            0x0	0
rip            0x55dc32d47835	0x55dc32d47835 <main+32>
eflags         0x206	[ PF IF ]
cs             0x33	51
ss             0x2b	43
ds             0x0	0
es             0x0	0
fs             0x0	0
gs             0x0	0
(gdb) s
376		RThread *rabin_th = NULL;
(gdb)
```

r2 gdbserver -
```
~$ r2 -
[0x00000000]> =g 8000 /bin/radare2 -
= attach 6 6
Process with PID 1965 started...
File dbg:///home/barua/Documents/radare2/radare2/binr/radare2/radare2 - reopened in read-write mode
= attach 1965 1965
gdbserver started on port: 8000, file: /bin/radare2
Selecting and continuing: 1965
hit breakpoint at: 55dc32d47835
```

Note: GDB first needs to load symbol-file and set architecture, otherwise this doesn't work yet.

Note-2:  rebasing symbols for r2 gdb client requires a bit more work