### PR TITLE
fix memory leak in disassemble()

### DIFF
--- a/libr/asm/p/asm_arm_cs.c
+++ b/libr/asm/p/asm_arm_cs.c
@@ -95,7 +95,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	}
 	cs_free (insn, n);
 	beach:
-	//cs_close (&cd);
+	cs_close (&cd);
 	if (op) {
 		if (!op->buf_asm[0]) {
 			strcpy (op->buf_asm, "invalid");


### PR DESCRIPTION
fix cs_open()-without-cs_close() memory leak in disassemble() by uncommenting //cs_close()