### PR TITLE
Nix forced echo on breakpoint commands (#7724)

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -87,16 +87,13 @@ static int on_fcn_rename(void *_anal, void* _user, RAnalFunction *fcn, const cha
 }
 
 static void r_core_debug_breakpoint_hit(RCore *core, RBreakpointItem *bpi) {
-	bool oecho = core->cons->echo;
 	const char *cmdbp = r_config_get (core->config, "cmd.bp");
-	core->cons->echo = true;
 	if (cmdbp && *cmdbp) {
 		r_core_cmd0 (core, cmdbp);
 	}
 	if (bpi->data && bpi->data[0]) {
 		r_core_cmd0 (core, bpi->data);
 	}
-	core->cons->echo = oecho;
 }
 
 /* returns the address of a jmp/call given a shortcut by the user or UT64_MAX

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -88,11 +88,21 @@ static int on_fcn_rename(void *_anal, void* _user, RAnalFunction *fcn, const cha
 
 static void r_core_debug_breakpoint_hit(RCore *core, RBreakpointItem *bpi) {
 	const char *cmdbp = r_config_get (core->config, "cmd.bp");
-	if (cmdbp && *cmdbp) {
+	const bool cmdbp_exists = (cmdbp && *cmdbp);
+	const bool bpcmd_exists = (bpi->data && bpi->data[0]);
+	const bool may_output = (cmdbp_exists || bpcmd_exists);
+	if (may_output) {
+		r_cons_push ();
+	}
+	if (cmdbp_exists) {
 		r_core_cmd0 (core, cmdbp);
 	}
-	if (bpi->data && bpi->data[0]) {
+	if (bpcmd_exists) {
 		r_core_cmd0 (core, bpi->data);
+	}
+	if (may_output) {
+		r_cons_flush ();
+		r_cons_pop ();
 	}
 }
 


### PR DESCRIPTION
This isn't a complete excision of `scr.echo`; it just removes the bit responsible for #7724.

I gather regression tests are desirable?