### PR TITLE
Windows fixes

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -955,6 +955,11 @@ R_API int r_cons_get_size(int *rows) {
 	GetConsoleScreenBufferInfo (GetStdHandle (STD_OUTPUT_HANDLE), &csbi);
 	I.columns = (csbi.srWindow.Right - csbi.srWindow.Left) - 1;
 	I.rows = csbi.srWindow.Bottom - csbi.srWindow.Top; // last row empty
+ 	if (I.columns == -1 && I.rows == 0) {
+		// Stdout is probably redirected so we set default values
+		I.columns = 80;
+		I.rows = 23;
+	}
 #elif EMSCRIPTEN
 	I.columns = 80;
 	I.rows = 23;

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -112,7 +112,7 @@ R_API ut64 r_sys_now(void) {
 R_API int r_sys_truncate(const char *file, int sz) {
 #if __WINDOWS__ && !__CYGWIN__
 	int fd = r_sandbox_open (file, O_RDWR, 0644);
-	if (fd != -1) {
+	if (fd == -1) {
 		return false;
 	}
 #ifdef _MSC_VER

--- a/shlr/sdb/src/sdb.c
+++ b/shlr/sdb/src/sdb.c
@@ -551,7 +551,8 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, int owned, ut32
 		return 0;
 	}
 	if (!val) {
-		val = "";
+		val = (char*) malloc (1);
+		*val = '\0';
 	}
 	// XXX strlen computed twice.. because of check_*()
 	klen = strlen (key);


### PR DESCRIPTION
I don't know if it is "correct" to call malloc(1) but definitely `var = ""` is wrong, since sdb is calling free on it later.