### PR TITLE
Fix regression with capstone 3

### DIFF
--- a/libr/asm/p/asm_x86_cs.c
+++ b/libr/asm/p/asm_x86_cs.c
@@ -58,7 +58,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	}
 	// always unsigned immediates (kernel addresses)
 	// maybe r2 should have an option for this too?
+#if CS_API_MAJOR >= 4
 	cs_option (cd, CS_OPT_UNSIGNED, CS_OPT_ON);
+#endif
 	if (a->syntax == R_ASM_SYNTAX_MASM) {
 #if CS_API_MAJOR >= 4
 		cs_option (cd, CS_OPT_SYNTAX, CS_OPT_SYNTAX_MASM);


### PR DESCRIPTION
Hello,
the compilation with system capstone (v3) fails since 0b4eb17:
```
$ ./configure --prefix=/usr --with-syscapstone --with-syszip --with-openssl
...
$ make
...
p/asm_x86_cs.c:61:17: error: ‘CS_OPT_UNSIGNED’ undeclared (first use in this function); did you mean ‘CS_OP_INVALID’?
  cs_option (cd, CS_OPT_UNSIGNED, CS_OPT_ON);
                 ^~~~~~~~~~~~~~~
...
```
The option `CS_OPT_UNSIGNED` is part of capstone-next and not available in capstone 3. I have added an `#ifdef` for this case.