### PR TITLE
Add 'u' prefix to wide UTF-16 strings

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2625,7 +2625,7 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len, bool string
 		// could be a wide string
 		int i = 0;
 		ALIGN;
-		ds_comment (ds, true, "; \"");
+		ds_comment (ds, true, "; u\"");
 		for (i = 0; i < len; i+=2) {
 			if (!str[i]) {
 				break;


### PR DESCRIPTION
This is based on [C++11 string literals](http://en.cppreference.com/w/cpp/language/string_literal).