### PR TITLE
Support for dm commands in gdb

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -84,8 +84,108 @@ static int r_debug_gdb_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 
 static RList *r_debug_gdb_map_get(RDebug* dbg) { //TODO
 	check_connection (dbg);
-	//TODO
-	return NULL;
+	if (desc->pid <= 0) {
+		return NULL;
+	}
+	RList *retlist = NULL;
+
+	// Get file from GDB
+	char path[128];
+	ut8 *buf;
+	int ret, buflen;
+	// If /proc/%d/maps is not valid for gdbserver, we return NULL, as of now
+	snprintf (path, sizeof (path) - 1, "/proc/%d/maps", desc->pid);
+	if (gdbr_open_file (desc, path, O_RDONLY, S_IRUSR | S_IWUSR | S_IXUSR) < 0) {
+		eprintf ("Error opening file");
+		return NULL;
+	}
+	if (!(buf = malloc (4096))) {
+		return NULL;
+	}
+	if ((buflen = gdbr_read_file (desc, buf, 0, 4095)) < 0) {
+		gdbr_close_file (desc);
+		free (buf);
+		return NULL;
+	}
+	buf[buflen] = '\0';
+
+	// Get map list
+	int unk = 0, perm, i;
+	char *ptr, *pos_1;
+	size_t line_len;
+	char name[1024], region1[100], region2[100], perms[5];
+	RDebugMap *map = NULL;
+	region1[0] = region2[0] = '0';
+	region1[1] = region2[1] = 'x';
+	if (!(ptr = strtok ((char*) buf, "\n"))) {
+		gdbr_close_file (desc);
+		free (buf);
+		return NULL;
+	}
+	if (!(retlist = r_list_new ())) {
+		gdbr_close_file (desc);
+		free (buf);
+		return NULL;
+	}
+	while (ptr) {
+		ut64 map_start, map_end, offset;
+		bool map_is_shared = false;
+		line_len = strlen (ptr);
+		// maps files should not have empty lines
+		if (line_len == 0) {
+			break;
+		}
+		// We assume Linux target, for now, so -
+		// 7ffff7dda000-7ffff7dfd000 r-xp 00000000 08:05 265428 /usr/lib/ld-2.25.so
+		ret = sscanf (ptr, "%s %s %"PFMT64x" %*s %*s %[^\n]", &region1[2],
+			      perms, &offset, name);
+		if (ret == 3) {
+			name[0] = '\0';
+		} else if (ret != 4) {
+			eprintf ("%s: Unable to parse \"%s\"\n", __func__, path);
+			gdbr_close_file (desc);
+			free (buf);
+			r_list_free (retlist);
+			return NULL;
+		}
+		if (!(pos_1 = strchr (&region1[2], '-'))) {
+			ptr = strtok (NULL, "\n");
+			continue;
+		}
+		strncpy (&region2[2], pos_1 + 1, sizeof (region2) - 2 - 1);
+		if (!*name) {
+			snprintf (name, sizeof (name), "unk%d", unk++);
+		}
+		perm = 0;
+		for (i = 0; perms[i] && i < 5; i++) {
+			switch (perms[i]) {
+			case 'r': perm |= R_IO_READ; break;
+			case 'w': perm |= R_IO_WRITE; break;
+			case 'x': perm |= R_IO_EXEC; break;
+			case 'p': map_is_shared = false; break;
+			case 's': map_is_shared = true; break;
+			}
+		}
+		map_start = r_num_get (NULL, region1);
+		map_end = r_num_get (NULL, region2);
+		if (map_start == map_end || map_end == 0) {
+			eprintf ("%s: ignoring invalid map size: %s - %s\n",
+				 __func__, region1, region2);
+			ptr = strtok (NULL, "\n");
+			continue;
+		}
+		if (!(map = r_debug_map_new (name, map_start, map_end, perm, 0))) {
+			break;
+		}
+		map->offset = offset;
+		map->shared = map_is_shared;
+		map->file = strdup (name);
+		r_list_append (retlist, map);
+		ptr = strtok (NULL, "\n");
+	}
+	gdbr_close_file (desc);
+	free (buf);
+	return retlist;
 }
 
 static int r_debug_gdb_reg_write(RDebug *dbg, int type, const ut8 *buf, int size) {

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -113,8 +113,8 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 
 	if (gdbr_connect (&riog->desc, host, i_port) == 0) {
 		desc = &riog->desc;
-		desc->pid = i_pid;
 		if (pid) { // FIXME this is here for now because RDebug's pid and libgdbr's aren't properly synced.
+			desc->pid = i_pid;
 			int ret = gdbr_attach (desc, i_pid);
 			if (ret < 0) {
 				eprintf ("gdbr: Failed to attach to PID %i\n", i_pid);

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -82,5 +82,11 @@ int gdbr_set_hwbp(libgdbr_t *g, ut64 address, const char *conditions);
 int gdbr_remove_bp(libgdbr_t *g, ut64 address);
 int gdbr_remove_hwbp(libgdbr_t *g, ut64 address);
 
+/*!
+ * File read from remote target (only one file open at a time for now)
+ */
+int gdbr_open_file(libgdbr_t *g, const char *filename, int flags, int mode);
+int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 off, ut64 sz);
+int gdbr_close_file(libgdbr_t *g);
 
 #endif  // CLIENT_COMMANDS_H

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -86,7 +86,7 @@ int gdbr_remove_hwbp(libgdbr_t *g, ut64 address);
  * File read from remote target (only one file open at a time for now)
  */
 int gdbr_open_file(libgdbr_t *g, const char *filename, int flags, int mode);
-int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 off, ut64 sz);
+int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len);
 int gdbr_close_file(libgdbr_t *g);
 
 #endif  // CLIENT_COMMANDS_H

--- a/shlr/gdb/include/gdbclient/responses.h
+++ b/shlr/gdb/include/gdbclient/responses.h
@@ -23,14 +23,12 @@ int handle_cont(libgdbr_t* g);
 int handle_qStatus(libgdbr_t* g);
 int handle_qC(libgdbr_t* g);
 int handle_execFileRead(libgdbr_t* g);
-int handle_fOpen(libgdbr_t* g);
-int handle_fstat(libgdbr_t* g);
 int handle_qSupported(libgdbr_t* g);
 int handle_setbp(libgdbr_t* g);
 int handle_removebp(libgdbr_t* g);
 int handle_attach(libgdbr_t* g);
 int handle_vFile_open(libgdbr_t *g);
-int handle_vFile_pread(libgdbr_t *g, ut8 *buf, ut64 offset, int *len);
+int handle_vFile_pread(libgdbr_t *g, ut8 *buf);
 int handle_vFile_close(libgdbr_t *g);
 
 #endif  // RESPONSES_H

--- a/shlr/gdb/include/gdbclient/responses.h
+++ b/shlr/gdb/include/gdbclient/responses.h
@@ -29,5 +29,8 @@ int handle_qSupported(libgdbr_t* g);
 int handle_setbp(libgdbr_t* g);
 int handle_removebp(libgdbr_t* g);
 int handle_attach(libgdbr_t* g);
+int handle_vFile_open(libgdbr_t *g);
+int handle_vFile_pread(libgdbr_t *g, ut8 *buf, ut64 offset, int *len);
+int handle_vFile_close(libgdbr_t *g);
 
 #endif  // RESPONSES_H

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -131,9 +131,8 @@ typedef struct libgdbr_t {
 	int tid; // little endian
 	bool attached; // Remote server attached to process or created
 	libgdbr_stub_features_t stub_features;
-	char *exec_file_name;
-	int exec_fd;
-	uint64_t exec_file_sz;
+
+	int remote_file_fd; // For remote file I/O
 
 	bool no_ack;
 	bool is_server;

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -84,7 +84,7 @@ typedef struct libgdbr_stub_features_t {
 	// Cannot be determined with qSupported, found out on query
 	bool qC;
 
-	bool extended_mode;
+	int extended_mode;
 } libgdbr_stub_features_t;
 
 /*!

--- a/shlr/gdb/include/utils.h
+++ b/shlr/gdb/include/utils.h
@@ -9,8 +9,8 @@
 uint8_t cmd_checksum(const char* command);
 uint64_t unpack_uint64(char *buff, int len);
 uint64_t unpack_uint64_co(char* buff, int len);
-int unpack_hex(char* src, ut64 len, char* dst);
-int pack_hex(char* src, ut64 len, char* dst);
+int unpack_hex(const char* src, ut64 len, char* dst);
+int pack_hex(const char* src, ut64 len, char* dst);
 int hex2int(int ch);
 int int2hex(int i);
 void hexdump(void* ptr, ut64 len, ut64 offset);

--- a/shlr/gdb/src/gdbclient/responses.c
+++ b/shlr/gdb/src/gdbclient/responses.c
@@ -102,6 +102,7 @@ int handle_qC(libgdbr_t *g) {
 	return send_ack (g);
 }
 
+/*
 int handle_execFileRead(libgdbr_t *g) {
 	if (g->data[0] == 'E') {
 		send_ack (g);
@@ -146,7 +147,6 @@ int handle_fstat(libgdbr_t *g) {
 		send_ack (g);
 		return -1;
 	}
-/*
         libgdbr_fstat_t *fstat = (libgdbr_fstat_t*) (ptr + 1);
         g->exec_file_sz = 0;
         unsigned char *c = &fstat->size;
@@ -154,9 +154,9 @@ int handle_fstat(libgdbr_t *g) {
                 g->exec_file_sz <<= 4;
                 g->exec_file_sz |= *c;
         }
- */
 	return send_ack (g);
 }
+ */
 
 int handle_cont(libgdbr_t *g) {
 	// Possible answers here 'S,T,W,X,O,F'
@@ -173,6 +173,56 @@ int handle_removebp(libgdbr_t *g) {
 
 int handle_attach(libgdbr_t *g) {
 	if (g->data_len == 3 && g->data[0] == 'E') {
+		send_ack (g);
+		return -1;
+	}
+	return send_ack (g);
+}
+
+int handle_vFile_open(libgdbr_t *g) {
+	if (g->data_len < 2 || g->data[0] != 'F' || g->data[1] == '-'
+	    || !isxdigit (g->data[1])) {
+		send_ack (g);
+		return -1;
+	}
+	g->data[g->data_len] = '\0';
+	if (sscanf (g->data, "F%x", &g->remote_file_fd) != 1 || g->remote_file_fd <= 0) {
+		send_ack (g);
+		return -1;
+	}
+	return send_ack (g);
+}
+
+int handle_vFile_pread(libgdbr_t *g, ut8 *buf, ut64 offset, int *len) {
+	send_ack (g);
+	char *ptr;
+	if (g->data_len < 3 || g->data[0] != 'F' || !len) {
+		return -1;
+	}
+	// F-1 is an error, yes, but it probably should not be fatal, since it might
+	// mean we're reading beyond file end. So this is handled in gdbr_read_file
+	if (g->data[1] == '-') {
+		return 1;
+	}
+	if (!isxdigit (g->data[1])) {
+		return -1;
+	}
+	if (sscanf (g->data, "F%x;", len) != 1) {
+		return -1;
+	}
+	if (!(ptr = strchr (g->data, ';')) || ptr >= g->data + g->data_len) {
+		return -1;
+	}
+	ptr++;
+	if (*len > 0) {
+		memcpy (buf + offset, ptr, *len);
+	}
+	return 0;
+}
+
+int handle_vFile_close(libgdbr_t *g) {
+	if (g->data_len < 2 || g->data[0] != 'F' || g->data[1] == '-'
+	    || !isxdigit (g->data[1])) {
 		send_ack (g);
 		return -1;
 	}

--- a/shlr/gdb/src/gdbclient/responses.c
+++ b/shlr/gdb/src/gdbclient/responses.c
@@ -95,6 +95,7 @@ int handle_qC(libgdbr_t *g) {
 		} else {
 			t1++;
 			g->pid = (int) strtol (t1, NULL, 16);
+			eprintf ("g->pid: %x\n", g->pid);
 			t2++;
 		}
 	}

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -11,6 +11,7 @@ int gdbr_init(libgdbr_t *g, bool is_server) {
 	}
 	memset (g, 0, sizeof (libgdbr_t));
 	g->no_ack = false;
+	g->stub_features.extended_mode = -1;
 	g->remote_file_fd = -1;
 	g->is_server = is_server;
 	g->send_max = 2500;

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -11,6 +11,7 @@ int gdbr_init(libgdbr_t *g, bool is_server) {
 	}
 	memset (g, 0, sizeof (libgdbr_t));
 	g->no_ack = false;
+	g->remote_file_fd = -1;
 	g->is_server = is_server;
 	g->send_max = 2500;
 	g->send_buff = (char *) calloc (g->send_max, 1);
@@ -78,6 +79,5 @@ int gdbr_cleanup(libgdbr_t *g) {
 	free (g->send_buff);
 	g->send_len = 0;
 	free (g->read_buff);
-	free (g->exec_file_name);
 	return 0;
 }

--- a/shlr/gdb/src/packet.c
+++ b/shlr/gdb/src/packet.c
@@ -42,6 +42,7 @@ static bool append(libgdbr_t *g, const char ch) {
 static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
 	int i = 0;
 	int j = 0;
+	bool first = true;
 	g->read_buff[len] = '\0';
 	for (i = 0; i < len; i++) {
 		char cur = g->read_buff[i];
@@ -101,7 +102,7 @@ static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
 			ctx->flags |= ESC;
 			break;
 		case '*':
-			if (!ctx->last) {
+			if (first) {
 				eprintf ("%s: Invalid repeat\n", __func__);
 				return -1;
 			}
@@ -115,6 +116,7 @@ static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
 			}
 			/* Fall-through */
 		default:
+			first = false;
 			if (!append (g, cur)) {
 				return -1;
 			}

--- a/shlr/gdb/src/utils.c
+++ b/shlr/gdb/src/utils.c
@@ -90,7 +90,7 @@ char hex2char(char *hex) {
 	return (char) result;
 }
 
-int unpack_hex(char *src, ut64 len, char *dst) {
+int unpack_hex(const char *src, ut64 len, char *dst) {
 	int i = 0;
 	while (i < (len / 2)) {
 		int val = hex2int (src[(i * 2)]);
@@ -102,7 +102,7 @@ int unpack_hex(char *src, ut64 len, char *dst) {
 	return len;
 }
 
-int pack_hex(char *src, ut64 len, char *dst) {
+int pack_hex(const char *src, ut64 len, char *dst) {
 	int i = 0;
 	int x = 0;
 	while (i < (len * 2)) {


### PR DESCRIPTION
```
~$ r2 -d gdb://localhost:8000
= attach 6 6
[0x7ffff7ddad80]> dm
sys  32K 0x0000555555554000 - 0x000055555555c000 s -r-x /home/.../radare2/binr/radare2/radare2 /home/.../radare2/binr/radare2/radare2
sys   8K 0x000055555575b000 - 0x000055555575d000 s -rw- /home/.../radare2/binr/radare2/radare2 /home/.../radare2/binr/radare2/radare2
sys 388K 0x000055555575d000 - 0x00005555557be000 s -rw- [heap] [heap]
sys 140K 0x00007ffff7dda000 * 0x00007ffff7dfd000 s -r-x /usr/lib/ld-2.25.so /usr/lib/ld-2.25.so
sys   8K 0x00007ffff7ff8000 - 0x00007ffff7ffa000 s -r-- [vvar] [vvar]
sys   8K 0x00007ffff7ffa000 - 0x00007ffff7ffc000 s -r-x [vdso] [vdso]
sys   8K 0x00007ffff7ffc000 - 0x00007ffff7ffe000 s -rw- /usr/lib/ld-2.25.so /usr/lib/ld-2.25.so
sys   4K 0x00007ffff7ffe000 - 0x00007ffff7fff000 s -rw- unk0 unk0
sys 132K 0x00007ffffffde000 - 0x00007ffffffff000 s -rw- [stack] [stack]
sys   4K 0xffffffffff600000 - 0xffffffffff601000 s -r-x [vsyscall] [vsyscall]
[0x7ffff7ddad80]> oa 0x0000555555554000 /bin/radare2
[0x7ffff7ddad80]> db sym.main
[0x7ffff7ddad80]> dc
Selecting and continuing: 0
= attach 0 0
got signal...
= attach 0 1
= attach 6 1
[0x555555557816]> pd 5
debug_gdb_read_at: Error reading gdbserver memory (8 bytes at 0xfffffffffffff9dc)
debug_gdb_read_at: Error reading gdbserver memory (8 bytes at 0xfffffffffffff9d0)
            ;-- rip:
            0x555555557816      4889e5         mov rbp, rsp
            0x555555557819      53             push rbx
            0x55555555781a      4881ec380600.  sub rsp, 0x638
            0x555555557821      89bddcf9ffff   mov dword [rbp - 0x624], edi
            0x555555557827      4889b5d0f9ff.  mov qword [rbp - 0x630], rsi
[0x555555557816]> 
```
Once you have memory map, you can rebase symbols. Next will work on doing that automatically.