### PR TITLE
Fix bugs in rcc_mathop of egg_lang.c

### DIFF
--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -321,23 +321,22 @@ static void rcc_internal_mathop(REgg *egg, char *ptr, char *ep, char op) {
 static void rcc_mathop(REgg *egg, char **pos, int level) {
 	REggEmit *e = egg->remit;
 	int op_ret = level;
-	char op, *next_pos, *p;
+	char op, *next_pos;
 
 	while (**pos && is_space (**pos)) (*pos)++;
 	next_pos = *pos + 1;
 
 	do {
 		op = (is_op (**pos) && !(is_var (*pos)))? **pos: '=';
-		p = (is_op (**pos) && !(is_var (*pos)))? *pos + 1: *pos;
+		*pos = (is_op (**pos) && !(is_var (*pos)))? *pos + 1: *pos;
 		op_ret = get_op (&next_pos);
 		if (op_ret > level) {
-			(*pos)++;
 			rcc_mathop (egg, pos, op_ret);
 			rcc_internal_mathop (egg, strdup (e->regs (egg, op_ret - 1))
 				, strdup (e->regs (egg, level - 1)), op);
 			next_pos = *pos + 1;
 		} else {
-			rcc_internal_mathop (egg, p, strdup (e->regs (egg, level - 1)), op);
+			rcc_internal_mathop (egg, *pos, strdup (e->regs (egg, level - 1)), op);
 			*pos = next_pos;
 			next_pos++;
 		}

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -1336,7 +1336,7 @@ R_API int r_egg_lang_parsechar(REgg *egg, char c) {
 					elem_n = 0;
 					R_FREE (ifelse_table[CTX][nestedi[CTX] - 1])
 					ifelse_table[CTX][nestedi[CTX] - 1] =
-						r_str_newf ("  __end_%d_%d_%d:",
+						r_str_newf ("  __end_%d_%d_%d",
 							nfunctions, CTX, nestedi[CTX]);
 				}
 				r_egg_printf (egg, "  __begin_%d_%d_%d:\n",


### PR DESCRIPTION
When the local variables assignment starts with bit operations, the ragg2 works wrong.

```
$ cat test.r
write@syscall(4);

main@global(128, 128) {
    .var0 = 6 & 15 + 1;                 #7
    write(1, "123456789abcdef", .var0); #1234567
}
```

```
$ ragg2 -b 32 -a x86 -F -o test test.r
$ ./test
1%
```

The right output should be __"1234567%"__

Fixed, and writing tests now.