### PR TITLE
Fix #6714

### DIFF
--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -65,7 +65,7 @@ R_API int r_core_dump(RCore *core, const char *file, ut64 addr, ut64 size, int a
 	ut8 *buf;
 	int bs = core->blocksize,check_time=1;
 	FILE *fd;
-	time_t start,poll,elapse;
+	time_t start,elapse;
 
 	start = time (NULL);
 	if (append) {

--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -90,7 +90,7 @@ R_API int r_core_dump(RCore *core, const char *file, ut64 addr, ut64 size, int a
 	r_cons_break_push (NULL, NULL);
 	for (i = 0; i < size; i += bs) {
 		if (check_time) {
-		elapse = time(NULL) - start;
+		elapse = time (NULL) - start;
 		if (elapse > 3) {
 			eprintf("This is taking more than 3 seconds\n");
 			check_time = 0;

--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -63,8 +63,11 @@ R_API int r_core_seek_base (RCore *core, const char *hex) {
 R_API int r_core_dump(RCore *core, const char *file, ut64 addr, ut64 size, int append) {
 	ut64 i;
 	ut8 *buf;
-	int bs = core->blocksize;
+	int bs = core->blocksize,check_time=1;
 	FILE *fd;
+	time_t start,poll,elapse;
+
+	start = time (NULL);
 	if (append) {
 		fd = r_sandbox_fopen (file, "ab");
 	} else {
@@ -86,6 +89,13 @@ R_API int r_core_dump(RCore *core, const char *file, ut64 addr, ut64 size, int a
 	}
 	r_cons_break_push (NULL, NULL);
 	for (i = 0; i < size; i += bs) {
+		if (check_time) {
+		elapse = time(NULL) - start;
+		if (elapse > 3) {
+			eprintf("This is taking more than 3 seconds\n");
+			check_time = 0;
+			}
+		}
 		if (r_cons_is_breaked ()) {
 			break;
 		}


### PR DESCRIPTION
This fix notifies the user if the write to a file(using wtf!) is taking more than N seconds, right now I've hard-coded it to 3 seconds. This is my first pull request so let me know if there are any coding guidelines that I'm not adhering to or if the current implementation has some shortcomings.