### PR TITLE
gdb reg caching

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -818,7 +818,9 @@ static const char *r_debug_gdb_reg_profile(RDebug *dbg) {
 
 static int r_debug_gdb_breakpoint (RBreakpointItem *bp, int set, void *user) {
 	int ret;
-	if (!bp) return false;
+	if (!bp) {
+		return false;
+	}
 	// TODO handle rwx and conditions
 	if (set)
 		ret = bp->hw?

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -195,8 +195,9 @@ static int __system(RIO *io, RIODesc *fd, const char *cmd) {
         /* XXX ugly hack for testing purposes */
         if (!cmd[0] || cmd[0] == '?' || !strcmp (cmd, "help")) {
                 eprintf ("Usage: =!cmd args\n"
-                        " =!pid      - show targeted pid\n"
-                        " =!pkt s    - send packet 's'\n");
+                         " =!pid      - show targeted pid\n"
+                         " =!pkt s    - send packet 's'\n"
+                         " =!inv.reg  - invalidate reg cache\n");
 	} else if (!strncmp (cmd, "pkt ", 4)) {
 		if (send_msg (desc, cmd + 4) == -1) {
 			return false;
@@ -204,11 +205,13 @@ static int __system(RIO *io, RIODesc *fd, const char *cmd) {
 		int r = read_packet (desc);
 		eprintf ("r = %d\n", r);
 	} else if (!strncmp (cmd, "pid", 3)) {
-		int pid = 1234;
+		int pid = desc ? desc->pid : -1;
 		if (!cmd[3]) {
 			io->cb_printf ("%d\n", pid);
 		}
 		return pid;
+	} else if (!strncmp (cmd, "inv.reg", 7)) {
+		gdbr_invalidate_reg_cache ();
 	} else {
 		eprintf ("Try: '=!?'\n");
 	}

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -143,10 +143,10 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 				eprintf ("gdbr: Failed to attach to PID %i\n", i_pid);
 				return NULL;
 			}
-		} else if ((pid = desc->pid) <= 0) {
-			pid = -1;
+		} else if ((i_pid = desc->pid) <= 0) {
+			i_pid = -1;
 		}
-		riogdb = r_io_desc_new (&r_io_plugin_gdb, pid, file, rw, mode, riog);
+		riogdb = r_io_desc_new (&r_io_plugin_gdb, i_pid, file, rw, mode, riog);
 		return riogdb;
 	}
 	eprintf ("gdb.io.open: Cannot connect to host.\n");

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -20,6 +20,11 @@ int gdbr_connect(libgdbr_t *g, const char *server, int port);
 int gdbr_disconnect(libgdbr_t *g);
 
 /*!
+ * \brief invalidates the reg cache
+ */
+void gdbr_invalidate_reg_cache();
+
+/*!
  * \brief checks for extended mode availability
  * \returns a failure code (currently -1) or 0 if call successfully
  */

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -894,3 +894,7 @@ int gdbr_close_file(libgdbr_t *g) {
 	g->remote_file_fd = -1;
 	return 0;
 }
+
+void gdbr_invalidate_reg_cache() {
+	reg_cache.valid = false;
+}


### PR DESCRIPTION
Small fix to [#7807](https://github.com/radare/radare2/pull/7807), and reg caching in gdb (invalidated upon step, continue, attach/detach and reg_write)