### PR TITLE
Set ptr and val to correct values in 8051 analyzer

### DIFF
--- a/libr/asm/arch/8051/8051_disas.c
+++ b/libr/asm/arch/8051/8051_disas.c
@@ -7,28 +7,6 @@
 #include "8051_ops.h"
 #include "8051_disas.h"
 
-static inline ut16 arg_offset (ut16 pc, ut8 offset) {
-	if (offset < 0x80) {
-		return pc + offset;
-	}
-	offset = 0 - offset;
-	return pc - offset;
-}
-
-static inline ut16 arg_addr11 (ut16 pc, const ut8 *buf) {
-	// ADDR11 is replacing lower 11 bit of (pre-incremented) PC
-	return (pc & 0xf800) + ((buf[0] & 0xe0) << 3) + buf[1];
-}
-
-static inline ut8 arg_bit (ut8 bit_addr) {
-	if (bit_addr < 0x80) {
-		// bit addresses 0x00-0x7f are mapped to bits at 0x20-0x2f
-		return (bit_addr >> 3) + 0x20;
-	}
-	// bit addresses > 0x80-0xff are mapped to bits at 0x80, 0x88, 0x98, ...
-	return bit_addr & 0xf8;
-}
-
 int _8051_disas (ut64 pc, RAsmOp *op, const ut8 *buf, ut64 len) {
 	int i = 0;
 	while (_8051_ops[i].string && _8051_ops[i].op != (buf[0] & ~_8051_ops[i].mask)) {

--- a/libr/asm/arch/8051/8051_ops.h
+++ b/libr/asm/arch/8051/8051_ops.h
@@ -5,6 +5,28 @@
 
 #include <r_types.h>
 
+static inline ut16 arg_offset (ut16 pc, ut8 offset) {
+	if (offset < 0x80) {
+		return pc + offset;
+	}
+	offset = 0 - offset;
+	return pc - offset;
+}
+
+static inline ut16 arg_addr11 (ut16 pc, const ut8 *buf) {
+	// ADDR11 is replacing lower 11 bits of (pre-incremented) PC
+	return (pc & 0xf800) + ((buf[0] & 0xe0) << 3) + buf[1];
+}
+
+static inline ut8 arg_bit (ut8 bit_addr) {
+	if (bit_addr < 0x80) {
+		// bit addresses 0x00-0x7f are mapped to bytes at 0x20-0x2f
+		return (bit_addr >> 3) + 0x20;
+	}
+	// bit addresses 0x80-0xff are mapped to bytes at 0x80, 0x88, 0x98, ...
+	return bit_addr & 0xf8;
+}
+
 enum {
 	OP_INVALID = 0,
 	OP_ADD,


### PR DESCRIPTION
Added logic in 8051 analyzer to set ptr and val in R_AnalOp structure.
Moved inline functions shared between 8051 anal and disas into include file

One behavior I can't figure out: when ptr itself is a valid ASCII character, pd outputs the character even though op->val is set to -1. Is there a way to suppress that output?

0x0000a2a1      f555           mov 0x55, a                 ; [0x55:1]=0 ; 'U'

[0x0000a2a1]> ao 1
address: 0xa2a1
opcode: mov 0x55, a
mnemonic: mov
prefix: 0
id: 0
bytes: f555
ptr: 0x00000055
refptr: 1
size: 2
type: mov
esil: A,0x10000,85,+,=[1],
stack: null
family: cpu
