### PR TITLE
Removed end point trace session

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -932,11 +932,8 @@ R_API int r_debug_step_back(RDebug *dbg) {
 
 	end = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 
-	/* Save current session. It is marked as a finish point of reverse execution */
-	r_debug_session_add (dbg, &tail);
-
 	/* Get previous state */
-	before = r_debug_session_get (dbg, tail);
+	before = r_debug_session_get (dbg, dbg->sessions->tail);
 	if (!before) {
 		return 0;
 	}
@@ -946,7 +943,7 @@ R_API int r_debug_step_back(RDebug *dbg) {
 	r_debug_session_set (dbg, before);
 
 	pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
-	eprintf ("execute from 0x%08"PFMT64x" to 0x%08"PFMT64x"\n", pc, end);
+	//eprintf ("execute from 0x%08"PFMT64x" to 0x%08"PFMT64x"\n", pc, end);
 
 	/* Get the previous operation address.
 	 * XXX: too slow... */

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -157,14 +157,9 @@ R_API bool r_debug_session_set_idx(RDebug *dbg, int idx) {
 /* Get most recent used session at the time */
 R_API RDebugSession *r_debug_session_get(RDebug *dbg, RListIter *tail) {
 	RDebugSession *session;
-	RListIter *prev;
 	if (!tail) {
 		return NULL;
 	}
-	prev = tail->p;
-	if (!prev) {
-		return NULL;
-	}
-	session = (RDebugSession *) prev->data;
+	session = (RDebugSession *) tail->data;
 	return session;
 }


### PR DESCRIPTION
Putting end point trace session cause many bugs and confusing.
So end point should be created only time when applying new memory snapshots.