### PR TITLE
Show 0x1b as either \e or \x1b based on asm.esc_e

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2098,6 +2098,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.cmtpatch", "false", "Show patch comments in disasm");
 	SETPREF ("asm.cmtoff", "nodup", "Show offset comment in disasm (true, false, nodup)");
 	SETPREF ("asm.payloads", "false", "Show payload bytes in disasm");
+	SETPREF ("asm.esc_e", "true", "Show 0x1b as \e instead of \x1b");
 	SETCB ("bin.strpurge", "false", &cb_strpurge, "Try to purge false positive strings");
 	SETPREF ("bin.libs", "false", "Try to load libraries after loading main binary");
 	n = NODECB ("bin.strfilter", "", &cb_strfilter);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -113,6 +113,7 @@ typedef struct r_disam_options_t {
 	bool show_fcncalls;
 	bool show_hints;
 	bool show_marks;
+	RStr1bMode mode_1b;
 	int cursor;
 	int show_comment_right_default;
 	int flagspace_ports;
@@ -487,6 +488,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->show_functions = r_config_get_i (core->config, "asm.functions");
 	ds->show_fcncalls = r_config_get_i (core->config, "asm.fcncalls");
 	ds->nbytes = r_config_get_i (core->config, "asm.nbytes");
+	ds->mode_1b = r_config_get_i (core->config, "asm.esc_e") ? R_STR_1B_ESC_E : R_STR_1B_ESC_X;
 	core->print->bytespace = r_config_get_i (core->config, "asm.bytespace");
 	ds->cursor = 0;
 	ds->nb = 0;
@@ -2656,7 +2658,7 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len, bool string
 				    && str[i] != '"' && str[i] != '\\') {
 					ds_comment (ds, false, "%c", str[i]);
 				} else {
-					char *escchar = r_str_escape_all (&str[i]);
+					char *escchar = r_str_escape_all (&str[i], ds->mode_1b);
 					if (escchar) {
 						ds_comment (ds, false, "%s", escchar);
 						free (escchar);
@@ -2669,7 +2671,7 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len, bool string
 		ds_comment (ds, false, "\"%s", nl);
 	} else {
 		if (!string_found) {
-			char *escstr = r_str_escape_all (str);
+			char *escstr = r_str_escape_all (str, ds->mode_1b);
 			if (escstr) {
 				ALIGN;
 				ds_comment (ds, true, "; \"%s\"%s", escstr, nl);

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -5,6 +5,12 @@
 
 typedef int (*RStrRangeCallback) (void *, int);
 
+typedef enum {
+	R_STR_1B_IGNORE,
+	R_STR_1B_ESC_X,
+	R_STR_1B_ESC_E
+} RStr1bMode;
+
 static inline void r_str_rmch(char *s, char ch) {
 	for (;*s; s++) {
 		if (*s==ch)
@@ -101,7 +107,7 @@ R_API int r_str_re_replace(const char *str, const char *reg, const char *sub);
 R_API int r_str_unescape(char *buf);
 R_API char *r_str_escape(const char *buf);
 R_API char *r_str_escape_dot(const char *buf);
-R_API char *r_str_escape_all(const char *buf);
+R_API char *r_str_escape_all(const char *buf, RStr1bMode mode_1b);
 R_API void r_str_uri_decode(char *buf);
 R_API char *r_str_uri_encode(const char *buf);
 R_API char *r_str_utf16_decode(const ut8 *s, int len);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1198,7 +1198,7 @@ R_API void r_str_sanitize(char *c) {
 
 /* Internal function. dot_nl specifies wheter to convert \n into the
  * graphiz-compatible newline \l */
-static char *r_str_escape_(const char *buf, const int dot_nl, const bool ign_esc_seq) {
+static char *r_str_escape_(const char *buf, int dot_nl, RStr1bMode mode_1b) {
 	char *new_buf, *q;
 	const char *p;
 
@@ -1247,7 +1247,7 @@ static char *r_str_escape_(const char *buf, const int dot_nl, const bool ign_esc
 			*q++ = 'b';
 			break;
 		case 0x1b: // ESC
-			if (ign_esc_seq) {
+			if (mode_1b == R_STR_1B_IGNORE) {
 				p++;
 				/* Parse the ANSI code (only the graphic mode
 				 * set ones are supported) */
@@ -1262,7 +1262,12 @@ static char *r_str_escape_(const char *buf, const int dot_nl, const bool ign_esc
 					}
 				}
 				break;
+			} else if (mode_1b == R_STR_1B_ESC_E) {
+				*q++ = '\\';
+				*q++ = 'e';
+				break;
 			}
+			/* fallthrough if mode_1b == R_STR_1B_ESC_X */
 		default:
 			/* Outside the ASCII printable range */
 			if (!IS_PRINTABLE (*p)) {
@@ -1282,15 +1287,15 @@ out:
 }
 
 R_API char *r_str_escape(const char *buf) {
-	return r_str_escape_ (buf, false, true);
+	return r_str_escape_ (buf, false, R_STR_1B_IGNORE);
 }
 
-R_API char *r_str_escape_all(const char *buf) {
-	return r_str_escape_ (buf, false, false);
+R_API char *r_str_escape_all(const char *buf, RStr1bMode mode_1b) {
+	return r_str_escape_ (buf, false, mode_1b);
 }
 
 R_API char *r_str_escape_dot(const char *buf) {
-	return r_str_escape_ (buf, true, true);
+	return r_str_escape_ (buf, true, R_STR_1B_IGNORE);
 }
 
 /* ansi helpers */


### PR DESCRIPTION
Controlled by `asm.esc_e` since `\e` is nonstandard.