### PR TITLE
Add size parsing for 'x/' command

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1353,7 +1353,24 @@ R_API void r_core_print_examine(RCore *core, const char *str) {
 		r_core_cmd0 (core, cmd);
 		break;
 	case 'x':
-		r_core_cmdf (core, "px %d @ 0x%"PFMT64x, count, addr);
+		switch (size) {
+		default:
+		case 1:
+			r_core_cmdf (core, "px %d @ 0x%"PFMT64x, count, addr);
+			break;
+		case 2:
+			r_core_cmdf (core, "px%c %d @ 0x%"PFMT64x,
+				'h', count * 2, addr);
+			break;
+		case 4:
+			r_core_cmdf (core, "px%c %d @ 0x%"PFMT64x,
+				'w', count * 4, addr);
+			break;
+		case 8:
+			r_core_cmdf (core, "px%c %d @ 0x%"PFMT64x,
+				'q', count * 8, addr);
+			break;
+		}
 		break;
 	case 'a':
 	case 'd':


### PR DESCRIPTION
Issue #4903 is due by a transposition of the format and size characters, which is possible in gdb.

This PR extends the functionality of the `x/` command to check the format character and bring it closer to the functionality of the gdb `x/` command.

The behaviour of the count is different than other commands. In this `x/`, the count is a multiple for the size. In other commands (`pxh`, `pxw`, `pxq`, etc), the count is treated as the number of bytes to show. Trailing bytes that do not fit exactly to a multiple of the size are truncated:
`floor(<count> / <size>)`

`pxw 11` shows 2, 4 byte values and truncates the last 3.

**Before change:**
```
[0x00000000]> x/10x str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x004005d4  4142 4344 4546 4748 494a                 ABCDEFGHIJ
[0x00000000]> x/3xh str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x004005d4  4142 43                                  ABC
[0x00000000]> x/3xw str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x004005d4  4142 43                                  ABC
[0x00000000]> x/3xg str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x004005d4  4142 43                                  ABC
```


**After Change:**
```
[0x00000000]> x/10x str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x004005d4  4142 4344 4546 4748 494a                 ABCDEFGHIJ
[0x00000000]> x/3xh str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
0x004005d4  0x4241 0x4443 0x4645                           ABCDEF
[0x00000000]> x/3xw str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
0x004005d4  0x44434241 0x48474645 0x4c4b4a49            ABCDEFGHIJKL
[0x00000000]> x/3xg str.ABCDEFGHIJKLMNOPQRSTUVWXYZ
0x004005d4  0x4847464544434241  0x504f4e4d4c4b4a49   ABCDEFGHIJKLMNOP
0x004005e4  0x5857565554535251                       QRSTUVWX
```