### PR TITLE
[bin_mach0] added NULL check to fix a segmentation fault

### DIFF
--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -26,6 +26,9 @@ static char *entitlements(RBinFile *arch, bool json) {
 		return NULL;
 	}
 	bin = arch->o->bin_obj;
+	if (!bin->signature) {
+		return NULL;
+	}
 	return strdup ((char*) bin->signature);
 }
 


### PR DESCRIPTION
This fixes a NULL deference happening with the `iC` command.
(Reproduced with an iOS kernelcache.)