### PR TITLE
Check which vcont commands and use them if they are

### DIFF
--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -31,6 +31,11 @@ void gdbr_invalidate_reg_cache();
 int gdbr_check_extended_mode(libgdbr_t *g);
 
 /*!
+ * \brief checks which subcommands of the vCont packet are supported
+ */
+int gdbr_check_vcont(libgdbr_t *g);
+
+/*!
  * \brief attaches to a process
  * \param pid of the process to attach to
  * \returns a failure code (currently -1) or 0 if call successfully

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -85,6 +85,9 @@ typedef struct libgdbr_stub_features_t {
 	bool qC;
 
 	int extended_mode;
+	struct {
+		bool c, C, s, S, t, r;
+	} vcont;
 } libgdbr_stub_features_t;
 
 /*!


### PR DESCRIPTION
Reporting support for multiprocess and not using vCont causes problems on latest gdbserver, atleast on Arch. This fixes it.