### PR TITLE
Cleaning up eprintf before release

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -100,7 +100,6 @@ static RList *r_debug_gdb_map_get(RDebug* dbg) { //TODO
 	// If /proc/%d/maps is not valid for gdbserver, we return NULL, as of now
 	snprintf (path, sizeof (path) - 1, "/proc/%d/maps", desc->pid);
 	if (gdbr_open_file (desc, path, O_RDONLY, S_IRUSR | S_IWUSR | S_IXUSR) < 0) {
-		eprintf ("%s: Error opening file: %s\n", __func__, path);
 		return NULL;
 	}
 	if (!(buf = malloc (buflen))) {

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -33,8 +33,6 @@ static int debug_gdb_read_at(ut8 *buf, int sz, ut64 addr) {
 	last = sz % size_max;
 	for (x = 0; x < packets; x++) {
 		if (gdbr_read_memory (desc, addr + (x * size_max), size_max) < 0) {
-			eprintf ("%s: Error reading gdbserver memory (%d bytes at 0x%"PFMT64x")\n",
-				 __func__, size_max, addr + (x * size_max));
 			return ret;
 		}
 		memcpy ((buf + (x * size_max)), desc->data + (x * size_max), R_MIN (sz, size_max));
@@ -42,8 +40,6 @@ static int debug_gdb_read_at(ut8 *buf, int sz, ut64 addr) {
 	}
 	if (last) {
 		if (gdbr_read_memory (desc, addr + x * size_max, last) < 0) {
-			eprintf ("%s: Error reading gdbserver memory (%d bytes at 0x%"PFMT64x")\n",
-				 __func__, last, addr + (x * size_max));
 			return ret;
 		}
 		memcpy ((buf + x * size_max), desc->data + (x * size_max), last);


### PR DESCRIPTION
These eprintfs were causing a lot of debug messages, for instance when r2 reads at an invalid address during `pd` to check for refs. We probably shouldn't have so many debug messages for release.

The one for file is because `/proc/pid/maps` will only work for linux, so we shouldn't have that warning on others.