### PR TITLE
add logic to manage registers in num operation

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2949,7 +2949,6 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 
 	esil_init (core);
 	esil = core->anal->esil;
-	
 #	define hasNext(x) (x&1) ? (addr<addr_end) : (ops<ops_end)
 
 	mymemxsr = r_list_new ();

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2919,7 +2919,6 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	RAnalOp aop = R_EMPTY;
 	ut8 *buf;
 	RList* regnow;
-	RCore fakecore;
 	if (!core)
 		return false;
 	maxopsize = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE);
@@ -2947,10 +2946,9 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	}
 	(void)r_io_read_at (core->io, addr, (ut8 *)buf, buf_sz);
 	aea_stats_init (&stats);
+	esil_init (core);
+	esil = core->anal->esil;
 	
-	
-	esil_init (&fakecore);
-	esil = &fakecore.anal->esil;
 #	define hasNext(x) (x&1) ? (addr<addr_end) : (ops<ops_end)
 
 	mymemxsr = r_list_new ();
@@ -2975,7 +2973,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	esil->nowrite = false;
 	esil->cb.hook_reg_write = NULL;
 	esil->cb.hook_reg_read = NULL;
-	//esil_fini (core);
+	esil_fini (core);
 
 	regnow = r_list_newf (free);
 	{

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2919,6 +2919,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	RAnalOp aop = R_EMPTY;
 	ut8 *buf;
 	RList* regnow;
+	RCore fakecore;
 	if (!core)
 		return false;
 	maxopsize = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE);
@@ -2946,9 +2947,10 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	}
 	(void)r_io_read_at (core->io, addr, (ut8 *)buf, buf_sz);
 	aea_stats_init (&stats);
-
-	esil_init (core);
-	esil = core->anal->esil;
+	
+	
+	esil_init (&fakecore);
+	esil = &fakecore.anal->esil;
 #	define hasNext(x) (x&1) ? (addr<addr_end) : (ops<ops_end)
 
 	mymemxsr = r_list_new ();
@@ -2973,7 +2975,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	esil->nowrite = false;
 	esil->cb.hook_reg_write = NULL;
 	esil->cb.hook_reg_read = NULL;
-	esil_fini (core);
+	//esil_fini (core);
 
 	regnow = r_list_newf (free);
 	{

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2946,6 +2946,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	}
 	(void)r_io_read_at (core->io, addr, (ut8 *)buf, buf_sz);
 	aea_stats_init (&stats);
+
 	esil_init (core);
 	esil = core->anal->esil;
 	

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -573,7 +573,7 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 				if (ok) *ok = true;
 			}
 			// check for reg alias
-			struct r_reg_item_t *r = r_reg_get (core->dbg->reg, str, -1);
+			/*struct r_reg_item_t *r = r_reg_get (core->dbg->reg, str, -1);
 			if (!r) {
 				int type = r_reg_get_name_idx (str);
 				if (type != -1) {
@@ -587,7 +587,7 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 			} else {
 				ret = r_reg_get_value (core->dbg->reg, r);
 				if (ok) *ok = true;
-			}
+			}*/
 		}
 		break;
 	}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -572,6 +572,22 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 				ret = flag->offset;
 				if (ok) *ok = true;
 			}
+			// check for reg alias
+			struct r_reg_item_t *r = r_reg_get (core->dbg->reg, str, -1);
+			if (!r) {
+				int type = r_reg_get_name_idx (str);
+				if (type != -1) {
+					const char *alias = r_reg_get_name (core->dbg->reg, type);
+					r = r_reg_get (core->dbg->reg, alias, -1);
+					if (r) {
+						ret = r_reg_get_value (core->dbg->reg, r);
+						if (ok) *ok = true;
+					}
+				}
+			} else {
+				ret = r_reg_get_value (core->dbg->reg, r);
+				if (ok) *ok = true;
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
With this fix u can work with registers not flaged and alias register in aritmetic operations:
  aer PC=PC+1
  aer eip=PC+1
Before this fix u can work with this stuff if registers are flagged, but dont support register aliases.

