### PR TITLE
properly sign-extend parameters to SH bt/f instructions in analysis

### DIFF
--- a/libr/anal/p/anal_sh.c
+++ b/libr/anal/p/anal_sh.c
@@ -196,10 +196,13 @@ static ut64 disarm_12bit_offset (RAnalOp *op, unsigned int insoff) {
 
 /* for bt,bf sign-extended offsets : return PC+4+ (exts.b offset)<<1 */
 static ut64 disarm_8bit_offset (ut64 pc, ut32 offs) {
+        /* pc (really, op->addr) is 64 bits, so we need to sign-extend
+         * to 64 bits instead of the 32 the actual CPU does */
+        ut64 off = offs;
 	/* sign extend if higher bit is 1 (0x08) */
-	if ((offs & 0x80) == 0x80)
-		offs |= ~0xFF;
-	return (offs<<1) + pc + 4;
+	if ((off & 0x80) == 0x80)
+		off |= ~0xFF;
+	return (off<<1) + pc + 4;
 }
 
 static char *regs[]={"r0","r1","r2","r3","r4","r5","r6","r7","r8","r9","r10","r11","r12","r13","r14","r15","pc"};

--- a/libr/anal/p/anal_sh.c
+++ b/libr/anal/p/anal_sh.c
@@ -189,7 +189,9 @@ static ut64 disarm_12bit_offset (RAnalOp *op, unsigned int insoff) {
 	ut64 off = insoff;
 	/* sign extend if higher bit is 1 (0x0800) */
 	if ((off & 0x0800) == 0x0800)
+	{
 		off |= ~0xFFF;
+	}
 	return (op->addr) + (off<<1) + 4;
 }
 
@@ -201,7 +203,9 @@ static ut64 disarm_8bit_offset (ut64 pc, ut32 offs) {
         ut64 off = offs;
 	/* sign extend if higher bit is 1 (0x08) */
 	if ((off & 0x80) == 0x80)
+	{
 		off |= ~0xFF;
+	}
 	return (off<<1) + pc + 4;
 }
 


### PR DESCRIPTION
Code comment says it all - since we operate on `pc`, a 64-bit variable (as opposed to the real hardware's 32-bit register), of course we need to sign-extend the extra 32 bits as well :)