### PR TITLE
Add dtst and dtsf commands for save and restore sessions.

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3595,8 +3595,8 @@ static int cmd_debug(void *data, const char *input) {
 				r_debug_session_add (core->dbg, NULL);
 				break;
 			case 't':
-				if (input[1] == ' ') {
-					r_debug_session_save (core->dbg, input + 2);
+				if (input[3] == ' ') {
+					r_debug_session_save (core->dbg, input + 4);
 				} else {
 					r_cons_println ("Usage: dtst [file] - save trace sessions to disk");
 				}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3601,6 +3601,13 @@ static int cmd_debug(void *data, const char *input) {
 					r_cons_println ("Usage: dtst [file] - save trace sessions to disk");
 				}
 				break;
+			case 'f':
+				if (input[3] == ' ') {
+					r_debug_session_restore (core->dbg, input + 4);
+				} else {
+					r_cons_println ("Usage: dtsf [file] - read trace sessions from disk");
+				}
+				break;
 			case 'A': // for debugging command (private command for developer)
 				r_debug_session_set_idx (core->dbg, atoi (input + 4));
 				break;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3594,6 +3594,13 @@ static int cmd_debug(void *data, const char *input) {
 			case '+':
 				r_debug_session_add (core->dbg, NULL);
 				break;
+			case 't':
+				if (input[1] == ' ') {
+					r_debug_session_save (core->dbg, input + 2);
+				} else {
+					r_cons_println ("Usage: dtst [file] - save trace sessions to disk");
+				}
+				break;
 			case 'A': // for debugging command (private command for developer)
 				r_debug_session_set_idx (core->dbg, atoi (input + 4));
 				break;
@@ -3603,6 +3610,8 @@ static int cmd_debug(void *data, const char *input) {
 					"Usage:", "dts[*]", "",
 					"dts", "", "List all trace sessions",
 					"dts+", "", "Add trace session",
+					"dtsf", " [file] ", "read trace sessions from disk",
+					"dtst", " [file] ", "save trace sessions to disk",
 					NULL };
 				r_core_cmd_help (core, help_msg);
 				}

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -165,7 +165,7 @@ R_API RDebugSession *r_debug_session_get(RDebug *dbg, RListIter *tail) {
 }
 
 /* XXX: bit ugly... :( )*/
-static ut32 r_snap_to_idx (RDebug *dbg, RDebugSnap *snap) {
+static ut32 r_snap_to_idx(RDebug *dbg, RDebugSnap *snap) {
 	RListIter *iter;
 	RDebugSnap *s;
 	ut32 base_idx = 0;
@@ -178,7 +178,7 @@ static ut32 r_snap_to_idx (RDebug *dbg, RDebugSnap *snap) {
 	return base_idx;
 }
 
-static RDebugSnap* r_idx_to_snap (RDebug *dbg, ut32 idx) {
+static RDebugSnap *r_idx_to_snap(RDebug *dbg, ut32 idx) {
 	RListIter *iter;
 	RDebugSnap *s;
 	ut32 base_idx = 0;
@@ -235,13 +235,13 @@ R_API void r_debug_session_save(RDebug *dbg, const char *file) {
 			RRegArena *arena = session->reg[i]->data;
 			r_file_dump (diff_file, &arena->size, sizeof (int), 1);
 			r_file_dump (diff_file, arena->bytes, arena->size, 1);
-			//eprintf ("arena[%d] size=%d\n", i, arena->size);
+			// eprintf ("arena[%d] size=%d\n", i, arena->size);
 		}
 		if (!header.difflist_len) {
 			continue;
 		}
-		//eprintf ("#### Sesssion ####\n");
-		//eprintf ("Saved all registers off=0x%"PFMT64x"\n", curp);
+		// eprintf ("#### Sesssion ####\n");
+		// eprintf ("Saved all registers off=0x%"PFMT64x"\n", curp);
 
 		/* Dump all diff entries */
 		r_list_foreach (session->memlist, iter2, snapdiff) {
@@ -327,8 +327,8 @@ R_API void r_debug_session_restore(RDebug *dbg, const char *file) {
 	for (i = 0; i < R_REG_TYPE_LAST; i++) {
 		r_list_purge (reg->regset[i].pool);
 	}
-	
-	while (true){
+
+	while (true) {
 		/* Restore session header */
 		if (!fread (&header, sizeof (RSessionHeader), 1, fd)) {
 			break;
@@ -338,7 +338,7 @@ R_API void r_debug_session_restore(RDebug *dbg, const char *file) {
 		session->key.id = header.id;
 		session->key.addr = header.addr;
 		r_list_append (dbg->sessions, session);
-		eprintf ("session: %d, 0x%"PFMT64x" diffs: %d\n", header.id, header.addr, header.difflist_len);
+		eprintf ("session: %d, 0x%"PFMT64x " diffs: %d\n", header.id, header.addr, header.difflist_len);
 		/* Restore registers */
 		for (i = 0; i < R_REG_TYPE_LAST; i++) {
 			/* Resotre RReagArena from raw dump*/
@@ -360,7 +360,7 @@ R_API void r_debug_session_restore(RDebug *dbg, const char *file) {
 		/* Restore diff entries */
 		for (i = 0; i < header.difflist_len; i++) {
 			fread (&diffentry, sizeof (RDiffEntry), 1, fd);
-			//eprintf ("diffentry base=%d pages=%d\n", diffentry.base_idx, diffentry.pages_len);
+			// eprintf ("diffentry base=%d pages=%d\n", diffentry.base_idx, diffentry.pages_len);
 			snapdiff = R_NEW0 (RDebugSnapDiff);
 
 			/* Restore diff->base */
@@ -394,5 +394,5 @@ R_API void r_debug_session_restore(RDebug *dbg, const char *file) {
 	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
 
 	fclose (fd);
-	//#endif
+	// #endif
 }

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -2,9 +2,7 @@
 #include <r_debug.h>
 
 R_API void r_debug_session_free(void *p) {
-	RDebugSession *session = (RDebugSession *) p;
-	r_list_free (session->memlist);
-	free (session);
+	free (p);
 }
 
 static int r_debug_session_lastid(RDebug *dbg) {
@@ -166,6 +164,33 @@ R_API RDebugSession *r_debug_session_get(RDebug *dbg, RListIter *tail) {
 	return session;
 }
 
+/* XXX: bit ugly... :( )*/
+static ut32 r_snap_to_idx (RDebug *dbg, RDebugSnap *snap) {
+	RListIter *iter;
+	RDebugSnap *s;
+	ut32 base_idx = 0;
+	r_list_foreach (dbg->snaps, iter, s) {
+		if (snap == s) {
+			break;
+		}
+		base_idx++;
+	}
+	return base_idx;
+}
+
+static RDebugSnap* r_idx_to_snap (RDebug *dbg, ut32 idx) {
+	RListIter *iter;
+	RDebugSnap *s;
+	ut32 base_idx = 0;
+	r_list_foreach (dbg->snaps, iter, s) {
+		if (base_idx == idx) {
+			return s;
+		}
+		base_idx++;
+	}
+	return NULL;
+}
+
 R_API void r_debug_session_save(RDebug *dbg, const char *file) {
 	RListIter *iter, *iter2, *iter3;
 	RDebugSession *session;
@@ -177,7 +202,7 @@ R_API void r_debug_session_save(RDebug *dbg, const char *file) {
 	RDiffEntry diffentry;
 	RSnapEntry snapentry;
 
-	ut32 i, base_idx = 0;
+	ut32 i;
 
 	char *base_file = r_str_newf ("%s.dump", file);
 	char *diff_file = r_str_newf ("%s.session", file);
@@ -202,9 +227,6 @@ R_API void r_debug_session_save(RDebug *dbg, const char *file) {
 		header.id = session->key.id;
 		header.addr = session->key.addr;
 		header.difflist_len = r_list_length (session->memlist);
-		if (!header.difflist_len) {
-			continue;
-		}
 		r_file_dump (diff_file, &header, sizeof (RSessionHeader), 1);
 
 		/* dump registers */
@@ -215,6 +237,9 @@ R_API void r_debug_session_save(RDebug *dbg, const char *file) {
 			r_file_dump (diff_file, arena->bytes, arena->size, 1);
 			//eprintf ("arena[%d] size=%d\n", i, arena->size);
 		}
+		if (!header.difflist_len) {
+			continue;
+		}
 		//eprintf ("#### Sesssion ####\n");
 		//eprintf ("Saved all registers off=0x%"PFMT64x"\n", curp);
 
@@ -222,14 +247,7 @@ R_API void r_debug_session_save(RDebug *dbg, const char *file) {
 		r_list_foreach (session->memlist, iter2, snapdiff) {
 			/* Dump diff header */
 			diffentry.pages_len = r_list_length (snapdiff->pages);
-			base_idx = 0;
-			r_list_foreach (dbg->snaps, iter3, base) {
-				if (base == snapdiff->base) {
-					break;
-				}
-				base_idx++;
-			}
-			diffentry.base_idx = base_idx;
+			diffentry.base_idx = r_snap_to_idx (dbg, snapdiff->base);
 			r_file_dump (diff_file, &diffentry, sizeof (RDiffEntry), 1);
 
 			/* Dump page entries */
@@ -258,24 +276,26 @@ R_API void r_debug_session_restore(RDebug *dbg, const char *file) {
 	RDiffEntry diffentry;
 	RSnapEntry snapentry;
 
-	ut32 i, base_idx;
+	ut32 i;
 	FILE *fd;
-
-	/* Clear current sessions to be replaced */
-	r_list_purge (dbg->snaps);
-	r_list_purge (dbg->sessions);
-	for (i = 0; i < R_REG_TYPE_LAST; i++) {
-		r_list_purge (reg->regset[i].pool);
-	}
 
 	char *base_file = r_str_newf ("%s.dump", file);
 	char *diff_file = r_str_newf ("%s.session", file);
 
-	/* Restore base snapshots */
 	fd = r_sandbox_fopen (base_file, "rb");
-	while (feof (fd)) {
+	if (!fd) {
+		return;
+	}
+
+	/* Clear current sessions to be replaced */
+	r_list_purge (dbg->snaps);
+
+	/* Restore base snapshots */
+	while (true) {
 		base = r_debug_snap_new ();
-		fread (&snapentry, sizeof (RSnapEntry), 1, fd);
+		if (!fread (&snapentry, sizeof (RSnapEntry), 1, fd)) {
+			break;
+		}
 		base->addr = snapentry.addr;
 		base->size = snapentry.size;
 		base->addr_end = base->addr + base->size;
@@ -298,14 +318,27 @@ R_API void r_debug_session_restore(RDebug *dbg, const char *file) {
 
 	/* Restore trace sessions */
 	fd = r_sandbox_fopen (diff_file, "rb");
-	while (feof (fd)) {
+	if (!fd) {
+		return;
+	}
+
+	/* Clear current sessions to be replaced */
+	r_list_purge (dbg->sessions);
+	for (i = 0; i < R_REG_TYPE_LAST; i++) {
+		r_list_purge (reg->regset[i].pool);
+	}
+	
+	while (true){
 		/* Restore session header */
+		if (!fread (&header, sizeof (RSessionHeader), 1, fd)) {
+			break;
+		}
 		session = R_NEW0 (RDebugSession);
 		session->memlist = r_list_newf (r_debug_diff_free);
-		fread (&header, sizeof (RSessionHeader), 1, fd);
 		session->key.id = header.id;
 		session->key.addr = header.addr;
-
+		r_list_append (dbg->sessions, session);
+		eprintf ("session: %d, 0x%"PFMT64x" diffs: %d\n", header.id, header.addr, header.difflist_len);
 		/* Restore registers */
 		for (i = 0; i < R_REG_TYPE_LAST; i++) {
 			/* Resotre RReagArena from raw dump*/
@@ -321,39 +354,45 @@ R_API void r_debug_session_restore(RDebug *dbg, const char *file) {
 			reg->regset[i].arena = arena;
 			reg->regset[i].cur = reg->regset[i].pool->tail;
 		}
-
+		if (!header.difflist_len) {
+			continue;
+		}
 		/* Restore diff entries */
-		fread (&diffentry, sizeof (RDiffEntry), 1, fd);
-		snapdiff = R_NEW0 (RDebugSnapDiff);
-		/* Restore diff->base */
-		base_idx = 0;
-		r_list_foreach (dbg->snaps, iter, base) {
-			if (base_idx == diffentry.base_idx) {
-					break;
-				}
-				base_idx++;
-		}
-		snapdiff->base = base;
-		snapdiff->last_changes = R_NEWS0 (RPageData *, base->page_num);
-		if (r_list_length (base->history)) {
-			/* Inherit last changes from previous SnapDiff */
-			RDebugSnapDiff *prev_diff = (RDebugSnapDiff *) r_list_tail (base->history)->data;
-			memcpy (snapdiff->last_changes, prev_diff->last_changes, sizeof (RPageData *) * base->page_num);
-		}
-		/* Restore pages */
-		for (i = 0; i < diffentry.pages_len; i++) {
-			page = R_NEW0 (RPageData);
-			fread (&page->page_off, sizeof (ut32), 1, fd);
-			fread (page->data, sizeof (ut32), 1, fd);
-			fread (page->hash, 128, 1, fd);
-			snapdiff->last_changes[page->page_off] = page;
-			r_list_append (snapdiff->pages, page);
-		}
-		r_list_append (base->history, snapdiff);
-	}
+		for (i = 0; i < header.difflist_len; i++) {
+			fread (&diffentry, sizeof (RDiffEntry), 1, fd);
+			//eprintf ("diffentry base=%d pages=%d\n", diffentry.base_idx, diffentry.pages_len);
+			snapdiff = R_NEW0 (RDebugSnapDiff);
 
+			/* Restore diff->base */
+			base = r_idx_to_snap (dbg, diffentry.base_idx);
+			snapdiff->base = base;
+			snapdiff->pages = r_list_newf (r_page_data_free);
+			snapdiff->last_changes = R_NEWS0 (RPageData *, base->page_num);
+
+			if (r_list_length (base->history)) {
+				/* Inherit last changes from previous SnapDiff */
+				RDebugSnapDiff *prev_diff = (RDebugSnapDiff *) r_list_tail (base->history)->data;
+				memcpy (snapdiff->last_changes, prev_diff->last_changes, sizeof (RPageData *) * base->page_num);
+			}
+			/* Restore pages */
+			ut32 p;
+			ut32 clust_page = R_MIN (SNAP_PAGE_SIZE, base->size);
+			for (p = 0; p < diffentry.pages_len; p++) {
+				page = R_NEW0 (RPageData);
+				page->data = malloc (clust_page);
+				fread (&page->page_off, sizeof (ut32), 1, fd);
+				fread (page->data, SNAP_PAGE_SIZE, 1, fd);
+				fread (page->hash, 128, 1, fd);
+				snapdiff->last_changes[page->page_off] = page;
+				r_list_append (snapdiff->pages, page);
+			}
+			r_list_append (base->history, snapdiff);
+			r_list_append (session->memlist, snapdiff);
+		}
+	}
 	/* After restoring all sessions, now sync register */
 	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, 1);
 
 	fclose (fd);
+	//#endif
 }

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -204,11 +204,11 @@ R_API int r_debug_snap_set_idx(RDebug *dbg, int idx) {
 /* XXX: Just for debugging. Duplicate soon */
 #if 0
 static void print_hash(ut8 *hash, int digest_size) {
-        int i = 0;
-        for (i = 0; i < digest_size; i++) {
-                eprintf ("%02"PFMT32x, hash[i]);
-        }
-        eprintf ("\n");
+	int i = 0;
+	for (i = 0; i < digest_size; i++) {
+		eprintf ("%02"PFMT32x, hash[i]);
+	}
+	eprintf ("\n");
 }
 #endif
 
@@ -253,7 +253,7 @@ R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 		for (addr = snap->addr; addr < snap->addr_end; addr += SNAP_PAGE_SIZE) {
 			ut32 page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
 			digest_size = r_hash_calculate (snap->hash_ctx, algobit, &snap->data[addr - snap->addr], clust_page);
-			hash = calloc (128, 1); // Fix hash size to 128 byte
+			hash = calloc (128, 1);	// Fix hash size to 128 byte
 			memcpy (hash, snap->hash_ctx->digest, digest_size);
 			snap->hashes[page_off] = hash;
 			// eprintf ("0x%08"PFMT64x"(page: %d)...\n",addr, page_off);
@@ -385,15 +385,15 @@ R_API RDebugSnapDiff *r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 		}
 	}
 	if (r_list_length (new_diff->pages)) {
-		#if 0
+#if 0
 		RPageData *page;
 		RListIter *iter;
 		eprintf ("saved: 0x%08"PFMT64x "(page: ", base->addr);
 		r_list_foreach (new_diff->pages, iter, page) {
-		        eprintf ("%d ", page->page_off);
+			eprintf ("%d ", page->page_off);
 		}
 		eprintf (")\n");
-		#endif
+#endif
 		r_list_append (base->history, new_diff);
 		return new_diff;
 	} else {

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2015 - pancake */
+/* radare - LGPL - Copyright 2015-2017 - pancake, rkx1209 */
 
 #include <r_debug.h>
 
@@ -205,13 +205,15 @@ R_API int r_debug_snap_set_idx(RDebug *dbg, int idx) {
 }
 
 /* XXX: Just for debugging. Duplicate soon */
-/* static void print_hash(ut8 *hash, int digest_size) {
+#if 0
+static void print_hash(ut8 *hash, int digest_size) {
         int i = 0;
         for (i = 0; i < digest_size; i++) {
                 eprintf ("%02"PFMT32x, hash[i]);
         }
         eprintf ("\n");
-}*/
+}
+#endif
 
 R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 	if (!dbg || !map || map->size < 1) {

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -19,9 +19,6 @@ R_API void r_debug_snap_free(void *p) {
 	r_list_free (snap->history);
 	free (snap->data);
 	free (snap->comment);
-	for (i = 0; i < snap->page_num; i++) {
-		free (snap->hashes[i]);
-	}
 	free (snap->hashes);
 	free (snap);
 }
@@ -224,7 +221,7 @@ R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 	ut64 addr;
 	ut64 algobit = r_hash_name_to_bits ("sha256");
 	ut32 page_num = map->size / SNAP_PAGE_SIZE;
-	int digest_size;
+	ut32 digest_size;
 	/* Get an existing snapshot entry */
 	RDebugSnap *snap = r_debug_snap_get_map (dbg, map);
 	if (!snap) {
@@ -256,7 +253,7 @@ R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 		for (addr = snap->addr; addr < snap->addr_end; addr += SNAP_PAGE_SIZE) {
 			ut32 page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
 			digest_size = r_hash_calculate (snap->hash_ctx, algobit, &snap->data[addr - snap->addr], clust_page);
-			hash = malloc (digest_size);
+			hash = calloc (128, 1); // Fix hash size to 128 byte
 			memcpy (hash, snap->hash_ctx->digest, digest_size);
 			snap->hashes[page_off] = hash;
 			// eprintf ("0x%08"PFMT64x"(page: %d)...\n",addr, page_off);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -203,19 +203,19 @@ typedef struct r_session_header {
 	ut64 addr;
 	ut32 id;
 	ut32 difflist_len;
-} __attribute__((__packed__)) RSessionHeader;
+} RSessionHeader;
 
 typedef struct r_diff_entry {
 	ut32 base_idx;
 	ut32 pages_len;
-} __attribute__((__packed__)) RDiffEntry;
+} RDiffEntry;
 
 typedef struct r_snap_entry {
 	ut64 addr;
 	ut32 size;
 	ut64 timestamp;
 	int perm;
-} __attribute__((__packed__)) RSnapEntry;
+} RSnapEntry;
 
 typedef struct r_debug_trace_t {
 	RList *traces;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -206,21 +206,10 @@ typedef struct r_session_header {
 	ut32 difflist_len;
 } __attribute__((__packed__)) RSessionHeader;
 
-typedef struct r_diff_table {
-	ut64 diff_off;
-	ut32 diff_size;
-	ut32 base_idx;
-} __attribute__((__packed__)) RDiffTable;
-
 typedef struct r_diff_entry {
+	ut32 base_idx;
 	ut32 pages_len;
 } __attribute__((__packed__)) RDiffEntry;
-
-typedef struct r_page_entry {
-	ut32 page_num;
-	ut8 data[SNAP_PAGE_SIZE];
-	ut8 hash[128];
-} __attribute__((__packed__)) RPageEntry;
 
 typedef struct r_snap_entry {
 	ut64 addr;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -120,7 +120,6 @@ typedef struct r_debug_frame_t {
 	ut64 bp;
 } RDebugFrame;
 
-
 typedef struct r_debug_reason_t {
 	int /*RDebugReasonType*/ type;
 	int tid;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -160,7 +160,7 @@ typedef struct r_debug_desc_t {
 struct r_debug_snap_diff_t;
 typedef struct r_page_data_t {
 	struct r_debug_snap_diff_t *diff; // Pointing SnapDiff that has this pagedata.
-	int page_off;
+	ut32 page_off;
 	ut8 *data;
 	ut8 hash[128];
 } RPageData;
@@ -188,7 +188,7 @@ typedef struct r_debug_snap_t {
 
 typedef struct r_debug_key {
 	ut64 addr;
-	int id;
+	ut32 id;
 } RDebugKey;
 
 typedef struct r_debug_session_t {
@@ -198,6 +198,35 @@ typedef struct r_debug_session_t {
 	/* XXX: DebugSession should have base snapshot of memlist. */
 	//RDebugSnap *base;
 } RDebugSession;
+
+/* Session file format */
+typedef struct r_session_header {
+	ut64 addr;
+	ut32 id;
+	ut32 difflist_len;
+} __attribute__((__packed__)) RSessionHeader;
+
+typedef struct r_diff_table {
+	ut32 diff_off;
+	ut32 diff_size;
+	ut32 base_idx;
+} __attribute__((__packed__)) RDiffTable;
+
+typedef struct r_diff_entry {
+	ut32 pages_len;
+} __attribute__((__packed__)) RDiffEntry;
+
+typedef struct r_page_entry {
+	ut32 page_num;
+	ut8 data[SNAP_PAGE_SIZE];
+	ut8 hash[128];
+} __attribute__((__packed__)) RPageEntry;
+
+typedef struct r_snap_entry {
+	ut64 addr;
+	ut32 size;
+	ut64 timestamp;
+} __attribute__((__packed__)) RSnapEntry;
 
 typedef struct r_debug_trace_t {
 	RList *traces;
@@ -560,6 +589,7 @@ R_API RDebugSession *r_debug_session_add(RDebug *dbg, RListIter **tail);
 R_API void r_debug_session_set(RDebug *dbg, RDebugSession *session);
 R_API bool r_debug_session_set_idx(RDebug *dbg, int idx);
 R_API RDebugSession *r_debug_session_get(RDebug *dbg, RListIter *tail);
+R_API void r_debug_session_save(RDebug *dbg, const char *file);
 R_API int r_debug_step_back(RDebug *dbg);
 
 /* plugin pointers */

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -207,7 +207,7 @@ typedef struct r_session_header {
 } __attribute__((__packed__)) RSessionHeader;
 
 typedef struct r_diff_table {
-	ut32 diff_off;
+	ut64 diff_off;
 	ut32 diff_size;
 	ut32 base_idx;
 } __attribute__((__packed__)) RDiffTable;
@@ -226,6 +226,7 @@ typedef struct r_snap_entry {
 	ut64 addr;
 	ut32 size;
 	ut64 timestamp;
+	int perm;
 } __attribute__((__packed__)) RSnapEntry;
 
 typedef struct r_debug_trace_t {


### PR DESCRIPTION
dtst saves all trace sessions to binary file. The format of binary file is simple serialized sessions.
dtsf restores all trace sessions from binary file.
