### PR TITLE
scr.breaklines: Break lines in Visual mode instead of truncating them

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -330,6 +330,7 @@ R_API RCons *r_cons_new() {
 	I.fdin = stdin;
 	I.fdout = 1;
 	I.breaked = false;
+	I.break_lines = false;
 	//I.lines = 0;
 	I.buffer = NULL;
 	I.buffer_sz = 0;
@@ -720,6 +721,7 @@ R_API void r_cons_visual_write (char *buffer) {
 	char white[1024];
 	int cols = I.columns;
 	int alen, plen, lines = I.rows;
+	bool break_lines = I.break_lines;
 	const char *endptr;
 	char *nl, *ptr = buffer, *pptr;
 
@@ -736,9 +738,9 @@ R_API void r_cons_visual_write (char *buffer) {
 		pptr = ptr > buffer ? ptr - 1 : ptr;
 		plen = ptr > buffer ? len : len - 1;
 
-		if (alen > cols) {
+		if (!break_lines && alen > cols) {
 			int olen = len;
-			endptr = r_str_ansi_chrn (ptr, cols);
+			endptr = r_str_ansi_chrn (ptr, cols + 1);
 			endptr++;
 			len = endptr - ptr;
 			plen = ptr > buffer ? len : len - 1;
@@ -750,7 +752,7 @@ R_API void r_cons_visual_write (char *buffer) {
 			}
 		} else {
 			if (lines > 0) {
-				int w = cols - alen;
+				int w = cols - (alen % cols == 0 ? cols : alen % cols);
 				r_cons_write (pptr, plen);
 				if (I.blankline && w > 0) {
 					if (w > sizeof (white) - 1) {
@@ -765,7 +767,11 @@ R_API void r_cons_visual_write (char *buffer) {
 				r_cons_write (pptr, plen);
 			}
 		}
-		lines--; // do not use last line
+		if (break_lines) {
+			lines -= alen / cols + (alen % cols == 0 ? 0 : 1);
+		} else {
+			lines--; // do not use last line
+		}
 		ptr = nl + 1;
 	}
 	/* fill the rest of screen */

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -731,6 +731,7 @@ R_API void r_cons_visual_write (char *buffer) {
 	memset (&white, ' ', sizeof (white));
 	while ((nl = strchr (ptr, '\n'))) {
 		int len = ((int)(size_t)(nl-ptr))+1;
+		int lines_needed;
 
 		*nl = 0;
 		alen = real_strlen (ptr, len);
@@ -738,9 +739,13 @@ R_API void r_cons_visual_write (char *buffer) {
 		pptr = ptr > buffer ? ptr - 1 : ptr;
 		plen = ptr > buffer ? len : len - 1;
 
-		if (!break_lines && alen > cols) {
+		if (break_lines) {
+			lines_needed = alen / cols + (alen % cols == 0 ? 0 : 1);
+		}
+		if ((break_lines && lines < lines_needed && lines > 0)
+		    || (!break_lines && alen > cols)) {
 			int olen = len;
-			endptr = r_str_ansi_chrn (ptr, cols + 1);
+			endptr = r_str_ansi_chrn (ptr, (break_lines ? cols * lines : cols) + 1);
 			endptr++;
 			len = endptr - ptr;
 			plen = ptr > buffer ? len : len - 1;
@@ -768,7 +773,7 @@ R_API void r_cons_visual_write (char *buffer) {
 			}
 		}
 		if (break_lines) {
-			lines -= alen / cols + (alen % cols == 0 ? 0 : 1);
+			lines -= lines_needed;
 		} else {
 			lines--; // do not use last line
 		}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1385,6 +1385,12 @@ static int cb_pager(void *user, void *data) {
 	return true;
 }
 
+static int cb_breaklines(void *user, void *data) {
+	RConfigNode *node = (RConfigNode *) data;
+	r_cons_singleton ()->break_lines = node->i_value;
+	return true;
+}
+
 static int cb_fps(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *) data;
 	r_cons_singleton ()->fps = node->i_value;
@@ -2435,6 +2441,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI ("scr.wheelspeed", 4, "Mouse wheel speed");
 	// DEPRECATED: USES hex.cols now SETI ("scr.colpos", 80, "Column position of cmd.cprompt in visual");
 	SETCB ("scr.breakword", "", &cb_scrbreakword, "Emulate console break (^C) when a word is printed (useful for pD)");
+	SETCB ("scr.breaklines", "false", &cb_breaklines, "Break lines in Visual instead of truncating them");
 	SETICB ("scr.columns", 0, &cb_scrcolumns, "Force console column count (width)");
 	SETCB ("scr.rows", "0", &cb_scrrows, "Force console row count (height) ");
 	SETICB ("scr.rows", 0, &cb_rows, "Force console row count (height) (duplicate?)");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -299,6 +299,7 @@ typedef struct r_cons_t {
 	int fix_rows;
 	int fix_columns;
 	bool breaked;
+	bool break_lines;
 	int noflush;
 	FILE *fdin; // FILE? and then int ??
 	int fdout; // only used in pipe.c :?? remove?


### PR DESCRIPTION
`scr.breaklines=false`:
![scr breaklines false](https://user-images.githubusercontent.com/12002672/27992830-79e810a2-64cf-11e7-8d06-9d59cf6eaf86.png)

`scr.breaklines=true`:
![scr breaklines true](https://user-images.githubusercontent.com/12002672/27992832-83e92726-64cf-11e7-9427-06b21d9c5c7a.png)

No test since there doesn't seem to be a way to test for this.