### PR TITLE
asm.strenc (asciidot)

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2118,7 +2118,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.payloads", "false", "Show payload bytes in disasm");
 	n = NODECB ("asm.strenc", "guess", &cb_asmstrenc);
 	SETDESC (n, "Assumed string encoding for disasm");
-	SETOPTIONS (n, "latin1", "utf8", "guess", NULL);
+	SETOPTIONS (n, "asciidot", "latin1", "utf8", "guess", NULL);
 	SETCB ("bin.strpurge", "false", &cb_strpurge, "Try to purge false positive strings");
 	SETPREF ("bin.libs", "false", "Try to load libraries after loading main binary");
 	n = NODECB ("bin.strfilter", "", &cb_strfilter);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2644,7 +2644,14 @@ static void ds_print_asmop_payload(RDisasmState *ds, const ut8 *buf) {
 
 static void ds_print_str(RDisasmState *ds, const char *str, int len) {
 	const char *nl = ds->show_comment_right ? "" : "\n";
-	if (!strcmp (ds->strenc, "latin1")) {
+	if (!strcmp (ds->strenc, "asciidot")) {
+		char *escstr = r_str_escape_asciidot (str);
+		if (escstr) {
+			ALIGN;
+			ds_comment (ds, true, "; \"%s\"%s", escstr, nl);
+			free (escstr);
+		}
+	} else if (!strcmp (ds->strenc, "latin1")) {
 		char *escstr = r_str_escape_latin1 (str);
 		if (escstr) {
 			ALIGN;

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -101,6 +101,7 @@ R_API int r_str_re_replace(const char *str, const char *reg, const char *sub);
 R_API int r_str_unescape(char *buf);
 R_API char *r_str_escape(const char *buf);
 R_API char *r_str_escape_dot(const char *buf);
+R_API char *r_str_escape_asciidot(const char *buf);
 R_API char *r_str_escape_latin1(const char *buf);
 R_API char *r_str_escape_utf8(const char *buf);
 R_API void r_str_uri_decode(char *buf);


### PR DESCRIPTION
Bringing back dots for unprintable characters. Useful if one deals with only ASCII strings, or to reduce clutter. A bit surprised this wasn't requested tbh.

WIll deal with the repeated `ds_print_str` code later.