### PR TITLE
Speedup nearest flag lookup by using skiplist.

### DIFF
--- a/libr/anal/Makefile
+++ b/libr/anal/Makefile
@@ -4,7 +4,7 @@ EXTRA_TARGETS+=do
 EXTRA_CLEAN=doclean
 
 NAME=r_anal
-DEPS=r_util r_reg r_syscall r_search r_cons
+DEPS=r_util r_reg r_syscall r_search r_cons r_flag
 CFLAGS+=-DCORELIB -Iarch -I$(TOP)/shlr
 CFLAGS+=-I$(LTOP)/asm/arch/include
 

--- a/libr/anal/meson.build
+++ b/libr/anal/meson.build
@@ -90,7 +90,7 @@ r_anal = library('r_anal', files,
 
   ])],
   c_args : ['-DCORELIB=1', '-I' + meson.current_build_dir() + '/../..'],
-  link_with: [r_util, r_reg, r_syscall, r_search, r_cons, libr2udis86],
+  link_with: [r_util, r_reg, r_syscall, r_search, r_cons, r_flag, libr2udis86],
   objects: [
 	libr2capstone.extract_all_objects(),
 	libr2sdb.extract_all_objects(),

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -12,7 +12,7 @@ const char *getRealRef(RCore *core, ut64 off) {
 	RFlagItem *item = NULL;
 	RListIter *iter = NULL;
 
-	RList *list = r_flag_get_list (core->flags, off);
+	const RList *list = r_flag_get_list (core->flags, off);
 	if (!list) {
 		return NULL;
 	}

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -12,7 +12,7 @@ const char *getRealRef(RCore *core, ut64 off) {
 	RFlagItem *item = NULL;
 	RListIter *iter = NULL;
 
-	RList *list = ht_find (core->flags->ht_off, sdb_fmt (2, "flg.%"PFMT64x, off), NULL);
+	RList *list = r_flag_get_list (core->flags, off);
 	if (!list) {
 		return NULL;
 	}

--- a/libr/include/r_flag.h
+++ b/libr/include/r_flag.h
@@ -4,6 +4,7 @@
 #include <r_types.h>
 #include <r_util.h>
 #include <r_list.h>
+#include <r_skiplist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,6 +32,11 @@ typedef struct r_flag_zone_item_t {
 
 /* flag.c */
 
+typedef struct r_flags_at_offset_t {
+	ut64 off;
+	RList *flags;   /* list of RFlagItem at offset */
+} RFlagsAtOffset;
+
 typedef struct r_flag_item_t {
 	char *name;     /* unique name, escaped to avoid issues with r2 shell */
 	char *realname; /* real name, without any escaping */
@@ -48,7 +54,7 @@ typedef struct r_flag_t {
 	bool space_strict; /* when true returned flag items must belong to the selected space */
 	char *spaces[R_FLAG_SPACES_MAX]; /* array of flag spaces */
 	RNum *num;
-	SdbHash *ht_off; /* hashmap key=item name, value=RList of items */
+	RSkipList *by_off; /* flags sorted by offset, value=RFlagsAtOffset */
 	SdbHash *ht_name; /* hashmap key=item name, value=RList of items */
 	RList *flags;   /* list of RFlagItem contained in the flag */
 	RList *spacestack;

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -32,9 +32,13 @@ R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data);
 R_API bool r_skiplist_delete(RSkipList* list, void* data);
 R_API bool r_skiplist_delete_node(RSkipList *list, RSkipListNode *node);
 R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data);
+R_API RSkipListNode* r_skiplist_find_geq(RSkipList* list, void* data);
+R_API RSkipListNode* r_skiplist_find_leq(RSkipList* list, void* data);
 R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2);
 R_API void *r_skiplist_get_first(RSkipList *list);
 R_API void *r_skiplist_get_n(RSkipList *list, int n);
+R_API void* r_skiplist_get_geq(RSkipList* list, void* data);
+R_API void* r_skiplist_get_leq(RSkipList* list, void* data);
 R_API bool r_skiplist_empty(RSkipList *list);
 R_API RList *r_skiplist_to_list(RSkipList *list);
 

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -46,6 +46,7 @@ files=[
 'range.c',
 'sandbox.c',
 'signal.c',
+'skiplist.c',
 'slist.c',
 'spaces.c',
 'stack.c',

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -9,7 +9,7 @@
 
 #include <r_skiplist.h>
 
-const int kSkipListDepth = 15; // max depth
+#define SKIPLIST_MAX_DEPTH 31
 
 static RSkipListNode *r_skiplist_node_new (void *data, int level) {
 	RSkipListNode *res = R_NEW0 (RSkipListNode);
@@ -37,7 +37,7 @@ static void r_skiplist_node_free (RSkipList *list, RSkipListNode *node) {
 
 static void init_head (RSkipListNode *head) {
 	int i;
-	for (i = 0; i <= kSkipListDepth; i++) {
+	for (i = 0; i <= SKIPLIST_MAX_DEPTH; i++) {
 		head->forward[i] = head;
 	}
 }
@@ -73,7 +73,7 @@ static RSkipListNode *find_insertpoint(RSkipList *list, void *data, RSkipListNod
 
 static bool delete_element(RSkipList* list, void* data, bool by_data) {
 	int i;
-	RSkipListNode *update[kSkipListDepth + 1], *x;
+	RSkipListNode *update[SKIPLIST_MAX_DEPTH + 1], *x;
 
 	// locate delete points in the lists of all levels
 	x = find_insertpoint (list, data, update, by_data);
@@ -109,7 +109,7 @@ R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn) {
 		return NULL;
 	}
 
-	list->head = r_skiplist_node_new (NULL, kSkipListDepth);
+	list->head = r_skiplist_node_new (NULL, SKIPLIST_MAX_DEPTH);
 	if (!list->head) {
 		free (list);
 		return NULL;
@@ -153,7 +153,7 @@ R_API void r_skiplist_free(RSkipList *list) {
 // Inserts an element to the skiplist, and returns a pointer to the element's
 // node.
 R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
-	RSkipListNode *update[kSkipListDepth + 1];
+	RSkipListNode *update[SKIPLIST_MAX_DEPTH + 1];
 	RSkipListNode *x;
 	int i, x_level, new_level;
 
@@ -165,7 +165,7 @@ R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
 	}
 
 	// randomly choose the number of levels the new node will be put in
-	for (x_level = 0; rand() < RAND_MAX/2 && x_level < kSkipListDepth; x_level++);
+	for (x_level = 0; rand() < RAND_MAX/2 && x_level < SKIPLIST_MAX_DEPTH; x_level++);
 
 	// update the `update` array with default values when the current node
 	// has a level greater than the current one

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -27,7 +27,7 @@ static RSkipListNode *r_skiplist_node_new (void *data, int level) {
 
 static void r_skiplist_node_free (RSkipList *list, RSkipListNode *node) {
 	if (node) {
-		if (list->freefn) {
+		if (list->freefn && node->data) {
 			list->freefn (node->data);
 		}
 		free (node->forward);
@@ -212,6 +212,24 @@ R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data) {
 	return NULL;
 }
 
+R_API RSkipListNode* r_skiplist_find_geq(RSkipList* list, void* data) {
+	RSkipListNode* x = find_insertpoint (list, data, NULL, true);
+	return x != list->head ? x : NULL;
+}
+
+R_API RSkipListNode* r_skiplist_find_leq(RSkipList* list, void* data) {
+	RSkipListNode *x = list->head;
+	int i;
+
+	for (i = list->list_level; i >= 0; i--) {
+		while (x->forward[i] != list->head 
+			&& list->compare (x->forward[i]->data, data) <= 0) {
+			x = x->forward[i];
+		}
+	}
+	return x != list->head ? x : NULL;
+}
+
 // Move all the elements of `l2` in `l1`.
 R_API void r_skiplist_join(RSkipList *l1, RSkipList *l2) {
 	RSkipListNode *it;
@@ -248,6 +266,17 @@ R_API void *r_skiplist_get_n(RSkipList *list, int n) {
 		++count;
 	}
 	return NULL;
+}
+
+
+R_API void* r_skiplist_get_geq(RSkipList* list, void* data) {
+	RSkipListNode *x = r_skiplist_find_geq (list, data);
+	return x ? x->data : NULL;
+}
+
+R_API void* r_skiplist_get_leq(RSkipList* list, void* data) {
+	RSkipListNode *x = r_skiplist_find_leq (list, data);
+	return x ? x->data : NULL;
 }
 
 // Return true if the list is empty


### PR DESCRIPTION
I measured the change in time for open + "aa" on the content of my /usr/bin/[a-f]* . Time for most of the executables taking more than 0.5s improved or didn't become worse.

[times.csv.txt](https://github.com/radare/radare2/files/1136856/times.csv.txt)
![plot](https://user-images.githubusercontent.com/7101031/28036911-71119d38-65c2-11e7-9525-48dd1e5f6619.png)

