### PR TITLE
Fix pcdelta for arm thumb

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1333,9 +1333,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	const char *postfix = NULL;
 	char str[32][32];
 	int msr_flags;
-	//this should be the theory
-	//int pcdelta = (thumb ? 4 : 8);
-	int pcdelta = (op->size == 4)? 8: 4;
+	int pcdelta = (thumb ? 4 : 8);
 
 	opex (&op->opex, *handle, insn);
 


### PR DESCRIPTION
- make the delta depend on the value of `thumb` parameter instead of the op size, because otherwise when 4-bytes-long instructions are present in thumb mode (e.g. `ldr.w`) that delta is computed wrong

The point is: the disassembler output it's still wrong (not only in capstone) but in this way at least the analysis (and ESIL) is correct and can find references

updated tests here: https://github.com/radare/radare2-regressions/pull/913
related to: https://github.com/radare/radare2/issues/7883