### PR TITLE
gdb get exec file name, and threads list

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -32,6 +32,14 @@ static int r_debug_gdb_step(RDebug *dbg) {
 	return true;
 }
 
+static RList* r_debug_gdb_threads(RDebug *dbg, int pid) {
+	RList *list;
+	if ((list = gdbr_threads_list (desc, pid))) {
+		list->free = (RListFree) &r_debug_pid_free;
+	}
+	return list;
+}
+
 static int r_debug_gdb_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 	int copy_size;
 	int buflen = 0;
@@ -861,6 +869,7 @@ RDebugPlugin r_debug_plugin_gdb = {
 	.cont = r_debug_gdb_continue,
 	.attach = &r_debug_gdb_attach,
 	.detach = &r_debug_gdb_detach,
+	.threads = &r_debug_gdb_threads,
 	.canstep = 1,
 	.wait = &r_debug_gdb_wait,
 	.map_get = r_debug_gdb_map_get,

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -3,6 +3,7 @@
 
 #include "../libgdbr.h"
 #include "r_types_base.h"
+#include <r_util.h>
 
 
 /*!
@@ -109,5 +110,15 @@ int gdbr_remove_hwbp(libgdbr_t *g, ut64 address);
 int gdbr_open_file(libgdbr_t *g, const char *filename, int flags, int mode);
 int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len);
 int gdbr_close_file(libgdbr_t *g);
+
+/*!
+ * \brief get list of threads for given pid
+ */
+RList* gdbr_threads_list(libgdbr_t *g, int pid);
+
+/*!
+ * Get absolute name of file executed to create a process
+ */
+char* gdbr_exec_file_read(libgdbr_t *g, int pid);
 
 #endif  // CLIENT_COMMANDS_H

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -1041,3 +1041,113 @@ int gdbr_send_qRcmd(libgdbr_t *g, const char *cmd) {
 	free (buf);
 	return -1;
 }
+
+char* gdbr_exec_file_read(libgdbr_t *g, int pid) {
+	if (!g) {
+		return NULL;
+	}
+	char msg[128], pidstr[16];
+	char *path = NULL;
+	ut64 len = g->stub_features.pkt_sz, off = 0;
+	memset (pidstr, 0, sizeof (pidstr));
+	if (pid > 0) {
+		snprintf (pidstr, sizeof (pidstr), "%x", pid);
+	}
+	while (1) {
+		if (snprintf (msg, sizeof (msg) - 1,
+			      "qXfer:exec-file:read:%s:%"PFMT64x",%"PFMT64x,
+			      pidstr, off, len) < 0) {
+			free (path);
+			return NULL;
+		}
+		if (send_msg (g, msg) < 0 || read_packet (g) < 0
+		    || send_ack (g) < 0 || g->data_len == 0) {
+			free (path);
+			return NULL;
+		}
+		g->data[g->data_len] = '\0';
+		if (g->data[0] == 'l') {
+			if (g->data_len == 1) {
+				return path;
+			}
+			return r_str_append (path, g->data + 1);
+		}
+		if (g->data[0] != 'm') {
+			free (path);
+			return NULL;
+		}
+		off += strlen (g->data + 1);
+		if (!(path = r_str_append (path, g->data + 1))) {
+			return NULL;
+		}
+	}
+}
+
+#include <r_debug.h>
+
+RList* gdbr_threads_list(libgdbr_t *g, int pid) {
+	if (!g) {
+		return NULL;
+	}
+	RList *list;
+	int tpid = -1, ttid = -1;
+	char *ptr, *ptr2, *exec_file;
+	RDebugPid *dpid;
+	if (!g->stub_features.qXfer_exec_file_read
+	    || !(exec_file = gdbr_exec_file_read (g, pid))) {
+		exec_file = "";
+	}
+	if (g->stub_features.qXfer_threads_read) {
+		// XML thread description is supported
+		// TODO: Handle this case
+	}
+	if (send_msg (g, "qfThreadInfo") < 0 || read_packet (g) < 0 || send_ack (g) < 0
+	    || g->data_len == 0 || g->data[0] != 'm') {
+		return NULL;
+	}
+	if (!(list = r_list_new())) {
+		return NULL;
+	}
+	while (1) {
+		g->data[g->data_len] = '\0';
+		ptr = g->data + 1;
+		while (ptr) {
+			if ((ptr2 = strchr (ptr, ','))) {
+				*ptr2 = '\0';
+				ptr2++;
+			}
+			if (read_thread_id (ptr, &tpid, &ttid,
+					    g->stub_features.multiprocess) < 0) {
+				ptr = ptr2;
+				continue;
+			}
+			if (g->stub_features.multiprocess && tpid != pid) {
+				ptr = ptr2;
+				continue;
+			}
+			if (!(dpid = R_NEW0 (RDebugPid))
+			    || !(dpid->path = strdup (exec_file))) {
+				r_list_free (list);
+				return NULL;
+			}
+			dpid->pid = ttid;
+			dpid->runnable = true;
+			// This is what linux native does as fallback, but
+			// probably not correct.
+			// TODO: Implement getting correct thread status from GDB
+			dpid->status = R_DBG_PROC_STOP;
+			r_list_append (list, dpid);
+			ptr = ptr2;
+		}
+		if (send_msg (g, "qsThreadInfo") < 0 || read_packet (g) < 0
+		    || send_ack (g) < 0 || g->data_len == 0
+		    || (g->data[0] != 'm' && g->data[0] != 'l')) {
+			r_list_free (list);
+			return NULL;
+		}
+		if (g->data[0] == 'l') {
+			break;
+		}
+	}
+	return list;
+}


### PR DESCRIPTION
Haven't yet found how to extract information about a thread from gdb other than dead/not dead. (There is `qThreadExtraInfo` but it is OS specific and reply is not defined in the protocol)

Also in `gdbr_threads_list` I've done `r_list_foreach` at the end to check if thread is dead, instead of within the main loop. The gdb protocol says -
`-> qfThreadInfo` `<- list of threads`
then, repeated `-> qsThreadInfo` `<- next threads`
So thread info is stateful. But there is no explicit guarantee that the state will be preserved if there is another packet between `qsThreadInfo`.