### PR TITLE
Fixed flag register and aea

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -571,6 +571,27 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 			if ((flag = r_flag_get (core->flags, str))) {
 				ret = flag->offset;
 				if (ok) *ok = true;
+				return ret;
+			}
+
+			// check for reg alias
+			struct r_reg_item_t *r = r_reg_get (core->dbg->reg, str, -1);
+			if (!r) {
+				int type = r_reg_get_name_idx (str);
+				if (type != -1) {
+					const char *alias = r_reg_get_name (core->dbg->reg, type);
+					r = r_reg_get (core->dbg->reg, alias, -1);
+					if (r) {
+						if (ok) *ok = true;
+						ret = r_reg_get_value (core->dbg->reg, r);
+						return ret;
+					}
+				}
+			}
+			else {
+				if (ok) *ok = true;
+				ret = r_reg_get_value (core->dbg->reg, r);
+				return ret;
 			}
 		}
 		break;


### PR DESCRIPTION
With this fix u can work with registers not flaged and alias register in aritmetic operations:
aer PC=PC+1
aer eip=PC+1
Before this fix u can work with this stuff if registers are flagged, but dont support register aliases.
And now test will be pass.

Also cmd_aea is modified to avoid change context of esil core, now have a own esil instance and save reg arena.