### PR TITLE
fix for #7907

### DIFF
--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -130,6 +130,7 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 			newpid = core->io->winpid;
 			newtid = core->io->wintid;
 			r_debug_select (core->dbg, newpid, newtid);
+			core->dbg->reason.type = R_DEBUG_REASON_NONE;
 #endif
 		}
 		//reopen and attach

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1358,8 +1358,8 @@ R_API int r_debug_child_clone(RDebug *dbg) {
 	return 0;
 }
 
-R_API bool r_debug_is_dead(RDebug *dbg) {
-	bool is_dead = (dbg->pid == -1 && strncmp (dbg->h->name, "gdb", 3));
+R_API bool r_debug_is_dead (RDebug *dbg) {
+	bool is_dead = (dbg->pid == -1 && strncmp (dbg->h->name, "gdb", 3)) || (dbg->reason.type == R_DEBUG_REASON_DEAD);
 	if (!is_dead && dbg->h && dbg->h->kill) {
 		is_dead = !dbg->h->kill (dbg, dbg->pid, false, 0);
 	}


### PR DESCRIPTION
- Modified r_debug_is_dead, to return true if dbg->reason.tpye is dead.
- Modified r_core_file_reopen, to set dbg->reason.type to NONE when reload a debug program.