### PR TITLE
Fixed windows network path (\\server\file.exe) and random err

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1050,6 +1050,9 @@ repeat:
 			reason == R_DEBUG_REASON_EXIT_TID ) {
 			goto repeat;
 		}
+		if (reason == R_DEBUG_REASON_EXIT_PID) {
+			dbg->pid = -1;
+		}
 #endif
 
 		/* if continuing killed the inferior, we won't be able to get

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -256,7 +256,7 @@ static void print_lasterr (const char *caller, char *cause) {
 				NULL)) {
 		eprintf ("Format message failed with 0x%d\n", (ut32)GetLastError ());
 	} else {
-		eprintf ("Error detected in %s/%s: %s\n", r_str_get (caller), r_str_get (cause), r_str_get (cbuffer));
+		eprintf ("Error detected in %s/%s: %s", r_str_get (caller), r_str_get (cause), r_str_get (cbuffer));
 	}
 }
 
@@ -1111,7 +1111,7 @@ static int w32_reg_read (RDebug *dbg, int type, ut8 *buf, int size) {
 			size = 0;
 		}
 	} else {
-		eprintf ("GetThreadContext: %x\n", (int)GetLastError ());
+		print_lasterr ((char*)__FUNCTION__, "GetThreadContext");
 		size = 0;
 	}
 	if (showfpu) {

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -174,6 +174,10 @@ R_API char *r_file_abspath(const char *file) {
 		if (cwd && *file != '/')
 			ret = r_str_newf ("%s"R_SYS_DIR"%s", cwd, file);
 #elif __WINDOWS__ && !__CYGWIN__
+		// Network path
+		if (!strncmp (file, "\\\\", 2)) {
+			return strdup (file);
+		}
 		if (cwd && !strchr (file, ':')) {
 			ret = r_str_newf ("%s\\%s", cwd, file);
 		}

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1789,6 +1789,7 @@ R_API char **r_str_argv(const char *cmdline, int *_argc) {
 				case '"':
 				case ' ':
 				case '\\':
+					args[args_current++] = '\\';
 					args[args_current++] = c;
 					break;
 				case '\0':


### PR DESCRIPTION
* Set pid to -1 when the reason is EXIT_PID
* Removed extra newline
* More verbose error message
* Added support to network files (debugger did not work when reopening a file which was remote)