### PR TITLE
Add doc/zsh/{_rabin2,_ragg2,_ragg2-cc}, drop GNU sed dependency from zsh completion files

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -727,6 +727,7 @@ int main(int argc, char **argv) {
 		case 'v': return blob_version ("rabin2");
 		case 'L':
 			set_action (R_BIN_REQ_LISTPLUGINS);
+			break;
 		case 'G':
 			laddr = r_num_math (NULL, optarg);
 			if (laddr == UT64_MAX) {

--- a/doc/zsh/_r2
+++ b/doc/zsh/_r2
@@ -8,58 +8,65 @@ r2_qc() {
 
 _r2() {
   local -a options=(
-  # '-=[perform !=! command to run all commands remotely'
+  '-\=[perform !=! command to run all commands remotely]'
   '-0[print \x00 after init and every command]'
   '-a+[set asm.arch]: :->arch'
   "-A[run 'aaa' command to analyze all referenced code]"
-  '-b+[set asm.bits]:bits'
+  '-b+[set asm.bits]:bits:(8 16 32 64)'
   '-B+[set base address for PIE binaries]:baddr'
   '-c+[execute radare command]:cmd'
   '-C[file is host:port (alias for -c+=http://%s/cmd/)]'
   "-d[debug the executable 'file' or running process 'pid']"
-  '-D+[enable debug mode (e cfg.debug=true)]'
+  '-D+[enable debug mode (e cfg.debug=true)]: :->dbg.backend'
   '-e+[evaluate config var]: :->config'
   '-f[block size = file size]'
-  '-F=[force to use that rbin plugin]:binplug'
-  '(-h, -hh)'{-h,-hh}'[show help message, -hh for long]'
+  '-F+[force to use that rbin plugin]:binplug'
+  '(-h -hh)-h[show help message]'
+  '(-h -hh)-hh[show long help message]'
   '-H[display variable]'
-  '-i+[run script file]: :_files'
-  '-I+[run script file before the file is opened]: :_files'
-  '-k+[set asm.os (linux, macos, w32, netbsd, ...)]: :->os'
-  '-l+[load plugin file]:lib'
+  '-i+[run script file]:script:_files'
+  '-I+[run script file before the file is opened]:script:_files'
+  '-k+[set asm.os (linux, macos, w32, netbsd, ...)]: :->asm.os'
+  '-l+[load plugin file]:lib:_files'
   '-L[list supported IO plugins]'
   '-m+[map file at given address (loadaddr)]:addr'
   '-M[do not demangle symbol names]'
-  '(-n -nn)'{-n,-nn}'[do not load RBin info (-nn only load bin structures)]'
+  '(-n -nn)-n[do not load RBin info]'
+  '(-n -nn)-nn[only load bin structures]'
   '-N[do not load user settings and scripts]'
-  '(-q -Q)'-q'[quiet mode (no prompt) and quit after -i]'
-  '(-q -Q)'-Q'[quiet mode (no prompt) and quit faster (quietLeak=true)]'
+  '(-q -Q)-q[quiet mode (no prompt) and quit after -i]'
+  '(-q -Q)-Q[quiet mode (no prompt) and quit faster (quietLeak=true)]'
   '-p+[use project, list if no arg, load if no file]: :->project'
-  '-P+[apply rapatch file and quit]: :_files'
-  '-R+[specify rarun2 profile to load (same as -e dbg.profile=X)]:rarun2'
+  '-P+[apply rapatch file and quit]:rapatch:_files'
+  '-R+[specify rarun2 profile to load (same as -e dbg.profile=X)]:dbg.profile'
   '-s+[initial seek]:addr'
   '-S[start r2 in sandbox mode]'
   '-t[load rabin2 info in thread]'
   '-u[set bin.filter=false to get raw sym/sec/cls names]'
-  '(-v -V)'{-v,-V}'[show radare2 version (-V show lib versions)]'
+  '(-v -V)-v[show radare2 version]'
+  '(-v -V)-V[show radare2 and lib versions)]'
   '-w[open file in write mode]'
   '-X+[specify custom rarun2 directive]:rr2rule'
-  '(-z -zz)'{-z,-zz}'[do not load strings or load them even in raw]'
+  '(-z -zz)-z[do not load strings]'
+  '(-z -zz)-zz[load strings from raw binary (even if unknown)]'
   )
 
   _arguments -S -s : $options '1:file:_files' && ret=0
 
   case $state in
     arch)
-      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -r 's/ (.*)/[\1]/')"})
+      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -E 's/ (.*)/[\1]/')"})
       _values 'arch' $sub && ret=0
+      ;;
+    asm.os)
+      _values 'asm.os' $(r2_qc 'e asm.os=?') && ret=0
       ;;
     config)
       local -a sub=(${(f)"$(r2_qc 'e??' | sed -E -e 's/\[/\\[/g' -e 's/]/\\]/g' -e 's/\s*([^:]+): (.*)/\1[\2]:value:/')"})
       _values 'config var' $sub && ret=0
       ;;
-    os)
-      _values 'arch' $(r2_qc 'e asm.os=?') && ret=0
+    dbg.backend)
+      _values 'dbg.backend' $(r2 '-D?') && ret=0
       ;;
     project)
       _values 'project' $(r2 -p) && ret=0

--- a/doc/zsh/_rabin2
+++ b/doc/zsh/_rabin2
@@ -1,0 +1,90 @@
+#compdef rabin2
+local context state state_descr line
+local -i ret=1
+
+r2_qc() {
+  r2 -qc $1 --
+}
+
+_rabin2() {
+  local -a options=(
+  '-@+[show section, symbol or import at addr]:addr'
+  '-A[list sub-binaries and their arch-bits pairs]'
+  '-a+[set arch (x86, arm, .. or <arch>_<bits>)]: :->arch'
+  '-b+[set bits (32, 64 ...)]:bits:(8 16 32 64)'
+  '-B+[override base address (pie bins)]:addr'
+  '-c[list classes]'
+  '-C[create \[elf,mach0,pe\] with Code and Data hexpairs (see -a)]:fmt\:C\:D'
+  '-d[show debug/dwarf information]'
+  '-D+[demangle symbol name (-D all for bin.demangle=true)]:language'
+  '-e[entrypoint]'
+  '-E[globally exportable symbols]'
+  '-f+[select sub-bin named str]:str'
+  '-F+[force to use that bin plugin (ignore header check)]:binfmt'
+  '-g[same as -SMZIHVResizcld (show all info)]'
+  '-G+[load address . offset to header]:addr'
+  '-h[this help message]'
+  '-H[header fields]'
+  '-i[imports (symbols imported from libraries)]'
+  '-I[binary info]'
+  '(-j -q -qq -r)-j[output in json]'
+  "-k+[run sdb query. for example: '*']:sdb-query"
+  '-K+[calculate checksums (md5, sha1, ..)]: :->checksum'
+  '-l[linked libraries]'
+  '-L[list supported bin plugins or plugin details]: :->plugin'
+  '-m+[show source line at addr]:addr'
+  '-M[main (show address of main symbol)]'
+  '-n+[show section, symbol or import named str]:str'
+  '-N[force min:max number of chars per string (see -z and -zz)]:min\:max'
+  '-o+[output file/folder for write operations (out by default)]:_files'
+  '-O+[write/extract operations (-O help)]:str'
+  '-p[show physical addresses]'
+  '(-P -PP)-P[show debug/pdb information]'
+  '(-P -PP)-PP[download pdb file for binary]'
+  '(-j -q -qq -r)-q[be quiet, just show fewer data]'
+  '(-j -q -qq -r)-qq[show less info (no offset/size for -z for ex.)]'
+  '-Q[show load address used by dlopen (non-aslr libs)]'
+  '-r[radare output]'
+  '-R[relocations]'
+  '-s[symbols]'
+  '-S[sections]'
+  '-u[unfiltered (no rename duplicated symbols/sections)]'
+  '-U[resoUrces]'
+  '-v[display version and quit]'
+  '-V[Show binary version information]'
+  '-x[extract bins contained in file]'
+  '-X+[\[f\] .. package in fat or zip the given files and bins contained in file]:fmt'
+  '(-z -zz -zzz)-z[strings (from data section)]'
+  '(-z -zz -zzz)-zz[strings (from raw bins \[e bin.rawstr=1\])]'
+  '(-z -zz -zzz)-zzz[dump raw strings to stdout (for huge files)]'
+  '-Z[guess size of binary program]'
+  )
+
+  _arguments -S -s : $options '*:file:_files' && ret=0
+
+  case $state in
+    arch)
+      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -E 's/ (.*)/[\1]/')"})
+      _values 'arch' $sub && ret=0
+      ;;
+    checksum)
+      _values 'checksum' all $(r2_qc 'ph?') && ret=0
+      ;;
+    plugin)
+      local -a sub=(${(f)"$(rabin2 -L | grep '^bin ' | sed -E 's/bin +([^ ]+) +(.*)/\1[\2]/')"})
+      _values 'plugin' $sub && ret=0
+      ;;
+  esac
+  return ret
+}
+
+_rabin2 "$@"
+
+# Local Variables:
+# mode: shell-script
+# coding: utf-8-unix
+# indent-tabs-mode: nil
+# sh-indentation: 2
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 sts=2 et

--- a/doc/zsh/_radiff2
+++ b/doc/zsh/_radiff2
@@ -9,8 +9,9 @@ r2_qc() {
 _radiff2() {
   local -a options=(
   '-a[specify architecture plugin to use (x86, arm, ..)]: :->arch'
-  '(-A -AA)'{-A,-AA}'[run aaa or aaaa after loading each binary (see -C)]'
-  '-b[specify register size for arch (16 (thumb), 32, 64, ..)]:bits'
+  '(-A -AA)-A[run aaa after loading each binary (see -C)]'
+  '(-A -AA)-AA[run aaaa after loading each binary (see -C)]'
+  '-b+[specify register size for arch (16 (thumb), 32, 64, ..)]:bits:(8 16 32 64)'
   '-c[count of changes]'
   '(-C -g -i)-C[graphdiff code (columns: off-A, match-ratio, off-B) (see -A)]'
   '-d[use delta diffing]'
@@ -31,7 +32,7 @@ _radiff2() {
   '-t+[set threshold for code diff (default is 70%)]:0-100'
   '-x[show two column hexdump diffing]'
   '(-j -r -u -U)-u[unified output (---+++)]'
-  '(-j -r -u -U)-U[unified output using system 'diff']'
+  "(-j -r -u -U)-U[unified output using system 'diff']"
   '-v[show version information]'
   '-V[be verbose (current only for -s)]'
   '-z[diff on extracted strings]'
@@ -41,7 +42,7 @@ _radiff2() {
 
   case $state in
     arch)
-      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -r 's/ (.*)/[\1]/')"})
+      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -E 's/ (.*)/[\1]/')"})
       _values 'arch' $sub && ret=0
       ;;
   esac

--- a/doc/zsh/_rafind2
+++ b/doc/zsh/_rafind2
@@ -4,17 +4,17 @@ local context state state_descr line
 _rafind2() {
   local -a options=(
   '-a+[only accept aligned hits]:align'
-  '-b[set block size]:size'
+  '-b+[set block size]:size'
   '*-e+[search for regular expression string matches]:regex'
-  "-f[start searching from address 'from']:from"
+  "-f+[start searching from address 'from']:from"
   '-h[show this help]'
   '-m[magic search, file-type carver]'
-  '-M[set a binary mask to be applied on keywords]:str'
+  '-M+[set a binary mask to be applied on keywords]:str'
   '-n[do not stop on read errors]'
   '-r[print using radare commands]'
   '*-s+[search for a specific string (can be used multiple times)]:str'
   '*-S+[search for a specific wide string (can be used multiple times)]:str'
-  "-t[stop search at address 'to']:to"
+  "-t+[stop search at address 'to']:to"
   '-v[print version and exit]'
   '*-x+[search for hexpair string (909090) (can be used multiple times)]:hex'
   '-X[show hexdump of search results]'

--- a/doc/zsh/_ragg2
+++ b/doc/zsh/_ragg2
@@ -1,0 +1,64 @@
+#compdef ragg2
+local context state state_descr line
+local -i ret=1
+
+r2_qc() {
+  r2 -qc $1 --
+}
+
+_ragg2() {
+  local -a options=(
+  '-a+[select architecture (x86, mips, arm)]: :->arch'
+  '-b+[register size (32, 64, ..)]:bits:(32 64)'
+  '-B+[append some hexpair bytes]:hexpairs'
+  '-c+[set configuration options]:k=v'
+  '-C+[append contents of file]:file'
+  '-d+[patch dword (4 bytes) at given offset]:off\:dword'
+  '-D+[patch qword (8 bytes) at given offset]:off\:qword'
+  '-e+[use specific encoder. see -L]:encoder'
+  '-f+[output format (raw, pe, elf, mach0)]:format'
+  '-F[output native format (osx=mach0, linux=elf, ..)]'
+  '-h[show this help]'
+  '-i+[include shellcode plugin, uses options. see -L]:shellcode'
+  '-I+[add include path]: :_directories'
+  "-k+[operating system's kernel (linux,bsd,osx,w32)]: :->asm.os"
+  '-L[list all plugins (shellcodes and encoders)]'
+  '-n+[append 32bit number (4 bytes)]:dword'
+  '-N+[append 64bit number (8 bytes)]:dword'
+  '-o+[output file]: :_files'
+  '-O[use default output file (filename without extension or a.out)]'
+  '-p+[add padding after compilation (padding=n10s32)]:padding'
+  '-P+[prepend debruijn pattern]:size'
+  '-q+[debruijn pattern offset]:fragment'
+  '-r[show raw bytes instead of hexpairs]'
+  '-s[show assembler]'
+  '-v[show version]'
+  '-w+[patch hexpairs at given offset]:off\:hex'
+  '-x[execute]'
+  '-z[output in C string syntax]'
+  )
+
+  _arguments -S -s : $options '1:file:_files' && ret=0
+
+  case $state in
+    arch)
+      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -E 's/ (.*)/[\1]/')"})
+      _values 'arch' $sub && ret=0
+      ;;
+    asm.os)
+      _values 'asm.os' $(r2_qc 'e asm.os=?') && ret=0
+      ;;
+  esac
+  return ret
+}
+
+_ragg2 "$@"
+
+# Local Variables:
+# mode: shell-script
+# coding: utf-8-unix
+# indent-tabs-mode: nil
+# sh-indentation: 2
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 sts=2 et

--- a/doc/zsh/_ragg2-cc
+++ b/doc/zsh/_ragg2-cc
@@ -1,0 +1,45 @@
+#compdef ragg2-cc
+local context state state_descr line
+local -i ret=1
+
+r2_qc() {
+  r2 -qc $1 --
+}
+
+_ragg2-cc() {
+  local -a options=(
+  '-a+[select architecture (x86, mips, arm)]: :->arch'
+  '-b+[register size (32, 64, ..)]:bits:(32 64)'
+  '-c[generate compiled shellcode]'
+  '-d[enable debug mode]'
+  "-k+[set kernel]: :->asm.os"
+  '-o+[set output file]: :_files'
+  '-s[generate assembly]'
+  '-v[show version]'
+  '-x[show hexpair bytes]'
+  )
+
+  _arguments -S -s : $options '1:file:_files' && ret=0
+
+  case $state in
+    arch)
+      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -E 's/ (.*)/[\1]/')"})
+      _values 'arch' $sub && ret=0
+      ;;
+    asm.os)
+      _values 'asm.os' $(r2_qc 'e asm.os=?') && ret=0
+      ;;
+  esac
+  return ret
+}
+
+_ragg2-cc "$@"
+
+# Local Variables:
+# mode: shell-script
+# coding: utf-8-unix
+# indent-tabs-mode: nil
+# sh-indentation: 2
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 sts=2 et

--- a/doc/zsh/_rahash2
+++ b/doc/zsh/_rahash2
@@ -2,6 +2,10 @@
 local context state state_descr line
 local -i ret=1
 
+r2_qc() {
+  r2 -qc $1 --
+}
+
 _rahash2() {
   local -a options=(
   "-a+[comma separated list of algorithms (default is 'sha256')]: :->algo"
@@ -9,8 +13,8 @@ _rahash2() {
   '-B[show per-block hash]'
   '-c+[compare with this hash]:hash'
   '-e[swap endian (use little endian)]'
-  '-E[encrypt. Use -S to set key and -I to set IV]: :->algo_coder'
-  '-D[decrypt. Use -S to set key and -I to set IV]: :->algo_coder'
+  '-E[encrypt. Use -S to set key and -I to set IV]: :->coder'
+  '-D[decrypt. Use -S to set key and -I to set IV]: :->coder'
   '-f+[start hashing at given address]:from'
   '-i+[repeat hash N iterations]:num'
   '-I[use give initialization vector (IV) (hexa or s:string)]:iv'
@@ -27,18 +31,16 @@ _rahash2() {
 
   _arguments -S -s : $options '*:file:_files' && ret=0
 
-  if [[ -n $state ]]; then
-    local -a algo=(rc2 rc4 rc6 aes-ecb aes-cbc ror rol rot blowfish cps2 des-ecb xor)
-    local -a coder=(base64 base91 punycode)
-    case $state in
-      algo)
-        _values 'algo' $algo && ret=0
-        ;;
-      algo_coder)
-        _values 'arch' $algo $coder && ret=0
-        ;;
-    esac
-  fi
+  case $state in
+    algo)
+      _values 'algo' all $(r2_qc 'ph?') && ret=0
+      ;;
+    coder)
+      local -a crypto=(rc2 rc4 rc6 aes-ecb aes-cbc ror rol rot blowfish cps2 des-ecb xor)
+      local -a coder=(base64 base91 punycode)
+      _values 'encoder/decoder' $crypto $coder && ret=0
+      ;;
+  esac
   return ret
 }
 

--- a/doc/zsh/_rasm2
+++ b/doc/zsh/_rasm2
@@ -10,7 +10,7 @@ _rasm2() {
   local -a options=(
   '-a+[Set architecture to assemble/disassemble (see -L)]: :->arch'
   '-A[Show Analysis information from given hexpairs]'
-  '-b+[Set cpu register size (8, 16, 32, 64) (RASM2_BITS)]:bits'
+  '-b+[Set cpu register size (8, 16, 32, 64) (RASM2_BITS)]:bits:(8 16 32 64)'
   '-c+[Select specific CPU (depends on arch)]:cpu'
   '-C[Output in C format]'
   '(-d -D)'{-d,-D}'[Disassemble from hexpair bytes (-D show hexpairs)]'
@@ -20,7 +20,7 @@ _rasm2() {
   '-F+[Specify input and/or output filters (att2intel, x86.pseudo, ...)]:in\:out'
   '(-h, -hh)'{-h,-hh}'[show help message, -hh for long]'
   '-i+[ignore/skip N bytes of the input buffer]:bytes'
-  '-k+[Select operating system (linux, windows, darwin, ..)]:kernel'
+  '-k+[Select operating system (linux, windows, darwin, ..)]: :->asm.os'
   '-l+[Input/Output length]:len'
   '-L[List Asm plugins: (a=asm, d=disasm, A=analyze, e=ESIL)]'
   '-o+[Set start address for code (default 0)]:offset'
@@ -37,8 +37,11 @@ _rasm2() {
 
   case $state in
     arch)
-      local -a sub=(${(f)"$(r2_qc 'e asm.arch=?~[2,4-99]' | sed -r 's/ (.*)/[\1]/')"})
+      local -a sub=(${(f)"$(rasm2 -L | cut -c 18-28 | tr -d ' ')"})
       _values 'arch' $sub && ret=0
+      ;;
+    asm.os)
+      _values 'asm.os' $(r2_qc 'e asm.os=?') && ret=0
       ;;
     syntax)
       _values 'syntax' $(rasm2 '-s?') && ret=0


### PR DESCRIPTION
Fix a benign missing fallthrough in rabin2.c

`sed -r` and regex escape sequence `\S` should be avoided as they are non-portable GNU extensions.