### PR TITLE
Fix node and edge overlapping issue in graph mode

### DIFF
--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -262,3 +262,24 @@ R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int 
 	}
 	c->attr = Color_RESET;
 }
+
+R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int ybendpoint1, int xbendpoint, int ybendpoint2) {
+	int min_x1 = R_MIN (x, xbendpoint);
+	int min_x2 = R_MIN (x2, xbendpoint);
+	int diff_x1 = R_ABS (x - xbendpoint);
+	int diff_x2 = R_ABS (x2 - xbendpoint);
+	int diff_y = R_ABS ((y + ybendpoint1) - (y2 - ybendpoint2));
+	int w1 = diff_x1 == 0 ? 0 : diff_x1 + 1;
+	int w2 = diff_x2 == 0 ? 0 : diff_x2 + 1;
+	int min_y = R_MIN (ybendpoint1, ybendpoint2);
+	int sty1 = min_x1 == x ? APEX_DOT : DOT_APEX;
+	int sty2 = min_x2 == x2 ? APEX_DOT : DOT_APEX;
+
+	apply_line_style (c, x, y, x2, y2, style);
+
+	draw_vertical_line (c, x, y + 1, ybendpoint1 + 1);
+	draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX);
+	draw_vertical_line (c, xbendpoint, y2 - min_y, diff_y + 1);
+	draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, sty2);
+	draw_vertical_line (c, x2, y2 - ybendpoint2, 1 + ybendpoint2);
+}

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -50,6 +50,11 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 			W ("f");
 		}
 		break;
+	case LINE_NOSYM:
+		if (G (x, y)) {
+			W (useUtf8 ? RUNECODESTR_LINE_VERT : "|");
+		}
+		break;
 	case LINE_NONE:
 	default:
 		break;
@@ -221,6 +226,38 @@ R_API void r_cons_canvas_line_square (RConsCanvas *c, int x, int y, int x2, int 
 				draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX);
 			}
 			draw_vertical_line (c, x2, y2, diff_y);
+		}
+	}
+	c->attr = Color_RESET;
+}
+
+
+R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int bendpoint) {
+	int min_x = R_MIN (x, x2);
+	int diff_x = R_ABS (x - x2);
+	int diff_y = R_ABS (y - y2);
+
+	apply_line_style (c, x, y, x2, y2, style);
+
+	if (x2 == x) {
+		draw_vertical_line (c, x, y + 1, diff_y);
+	} else if (y2 - y > 1) {
+		int h1 = 1 + bendpoint;
+		int h2 = diff_y - h1;
+		int w = diff_x == 0 ? 0 : diff_x + 1;
+		int style = min_x == x ? APEX_DOT : DOT_APEX;
+		draw_vertical_line (c, x, y + 1, h1);
+		draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style);
+		draw_vertical_line (c, x2, y + h1 + 1 + 1, h2);
+	} else {
+		//TODO: currently copy-pasted
+		if (y2 == y) {
+			draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT);
+		} else {
+			if (x != x2) {
+				draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX);
+			}
+			draw_vertical_line (c, x2, y2, diff_y-2);
 		}
 	}
 	c->attr = Color_RESET;

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -10,11 +10,16 @@ enum {
 	APEX_DOT = 0,
 	DOT_APEX,
 	REV_APEX_APEX,
-	DOT_DOT
+	DOT_DOT,
+	NRM_DOT,
+	NRM_APEX,
+	DOT_NRM,
+	REV_APEX_NRM,
+	NRM_NRM
 };
 
 static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
-		RCanvasLineStyle *style){
+		RCanvasLineStyle *style, int isvert) {
 	RCons *cons = r_cons_singleton ();
 	switch (style->color) {
 	case LINE_UNCJMP:
@@ -37,7 +42,11 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 	switch (style->symbol) {
 	case LINE_UNCJMP:
 		if (G (x, y)) {
-			W ("v");
+			if (isvert) {
+				W ("v");
+			} else {
+				W (">");
+			}
 		}
 		break;
 	case LINE_TRUE:
@@ -50,9 +59,14 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 			W ("f");
 		}
 		break;
-	case LINE_NOSYM:
+	case LINE_NOSYM_VERT:
 		if (G (x, y)) {
 			W (useUtf8 ? RUNECODESTR_LINE_VERT : "|");
+		}
+		break;
+	case LINE_NOSYM_HORIZ:
+		if (G (x, y)) {
+			W (useUtf8 ? RUNECODESTR_LINE_HORIZ : "-");
 		}
 		break;
 	case LINE_NONE:
@@ -63,7 +77,7 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 
 R_API void r_cons_canvas_line_diagonal (RConsCanvas *c, int x, int y, int x2, int y2,
 		RCanvasLineStyle *style) {
-	apply_line_style(c,x,y,x2,y2,style);
+	apply_line_style(c,x,y,x2,y2,style, 1);
 	if(y2<y){
 		int tmp = y2;
 		y2=y;
@@ -153,12 +167,55 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		}
 		break;
 	case DOT_DOT:
-	default:
 		if (useUtf8) {
 			l_corner = RUNECODESTR_CORNER_TL;
 			r_corner = RUNECODESTR_CORNER_TR;
 		} else {
 			l_corner = r_corner = ".";
+		}
+		break;
+	case NRM_DOT:
+		if (useUtf8) {
+			l_corner = RUNECODESTR_LINE_HORIZ;
+			r_corner = RUNECODESTR_CORNER_TR;
+		} else {
+			l_corner = "-";
+			r_corner = ".";
+		}
+		break;
+	case NRM_APEX:
+		if (useUtf8) {
+			l_corner = RUNECODESTR_LINE_HORIZ;
+			r_corner = RUNECODESTR_CORNER_BR;
+		} else {
+			l_corner = "-";
+			r_corner = "'";
+		}
+		break;
+	case DOT_NRM:
+		if (useUtf8) {
+			l_corner = RUNECODESTR_CORNER_TL;
+			r_corner = RUNECODESTR_LINE_HORIZ;
+		} else {
+			l_corner = ".";
+			r_corner = "-";
+		}
+		break;
+	case REV_APEX_NRM:
+		if (useUtf8) {
+			l_corner = RUNECODESTR_CORNER_BL;
+			r_corner = RUNECODESTR_LINE_HORIZ;
+		} else {
+			l_corner = "`";
+			r_corner = "-";
+		}
+		break;
+	case NRM_NRM:
+	default:
+		if (useUtf8) {
+			l_corner = r_corner = RUNECODESTR_LINE_HORIZ;
+		} else {
+			l_corner = r_corner = "-";
 		}
 		break;
 	}
@@ -211,7 +268,7 @@ R_API void r_cons_canvas_line_square (RConsCanvas *c, int x, int y, int x2, int 
 	int diff_x = R_ABS (x - x2);
 	int diff_y = R_ABS (y - y2);
 
-	apply_line_style (c, x, y, x2, y2, style);
+	apply_line_style (c, x, y, x2, y2, style, 1);
 
 	// --
 	// TODO: find if there's any collision in this line
@@ -237,38 +294,56 @@ R_API void r_cons_canvas_line_square (RConsCanvas *c, int x, int y, int x2, int 
 }
 
 
-R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int bendpoint) {
+R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int bendpoint, int isvert) {
 	int min_x = R_MIN (x, x2);
 	int diff_x = R_ABS (x - x2);
 	int diff_y = R_ABS (y - y2);
+	int min_y = R_MIN (y, y2);
 
-	apply_line_style (c, x, y, x2, y2, style);
+	apply_line_style (c, x, y, x2, y2, style, isvert);
 
-	if (x2 == x) {
-		draw_vertical_line (c, x, y + 1, diff_y);
-	} else if (y2 - y > 1) {
-		int h1 = 1 + bendpoint;
-		int h2 = diff_y - h1;
-		int w = diff_x == 0 ? 0 : diff_x + 1;
-		int style = min_x == x ? APEX_DOT : DOT_APEX;
-		draw_vertical_line (c, x, y + 1, h1);
-		draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style);
-		draw_vertical_line (c, x2, y + h1 + 1 + 1, h2);
-	} else {
-		//TODO: currently copy-pasted
-		if (y2 == y) {
-			draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT);
+	if (isvert) {
+		if (x2 == x) {
+			draw_vertical_line (c, x, y + 1, diff_y);
+		} else if (y2 - y > 1) {
+			int h1 = 1 + bendpoint;
+			int h2 = diff_y - h1;
+			int w = diff_x == 0 ? 0 : diff_x + 1;
+			int style = min_x == x ? APEX_DOT : DOT_APEX;
+			draw_vertical_line (c, x, y + 1, h1);
+			draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style);
+			draw_vertical_line (c, x2, y + h1 + 1 + 1, h2);
 		} else {
-			if (x != x2) {
-				draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX);
+			//TODO: currently copy-pasted
+			if (y2 == y) {
+				draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT);
+			} else {
+				if (x != x2) {
+					draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX);
+				}
+				draw_vertical_line (c, x2, y2, diff_y-2);
 			}
-			draw_vertical_line (c, x2, y2, diff_y-2);
+		}
+	} else {
+		if (y2 == y) {
+			draw_horizontal_line (c, min_x + 1, y, diff_x, NRM_NRM);
+		} else if (x2 - x > 1) {
+			int w1 = 1 + bendpoint;
+			int w2 = diff_x - w1;
+			//int h = diff_x;// == 0 ? 0 : diff_x + 1;
+			//int style = min_x == x ? APEX_DOT : DOT_APEX;
+			//draw_vertical_line (c, x, y + 1, h1);
+			draw_horizontal_line (c, x + 1, y, w1 + 1, y2 > y ? NRM_DOT : NRM_APEX);
+			//draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style);
+			draw_vertical_line (c, x + 1 + w1, min_y + 1, diff_y - 1);
+			//draw_vertical_line (c, x2, y + h1 + 1 + 1, h2);
+			draw_horizontal_line (c, x + 1 + w1, y2, w2, y2 < y ? DOT_NRM : REV_APEX_NRM);
 		}
 	}
 	c->attr = Color_RESET;
 }
 
-R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int ybendpoint1, int xbendpoint, int ybendpoint2) {
+R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int ybendpoint1, int xbendpoint, int ybendpoint2, int isvert) {
 	int min_x1 = R_MIN (x, xbendpoint);
 	int min_x2 = R_MIN (x2, xbendpoint);
 
@@ -280,11 +355,24 @@ R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, i
 	int w1 = diff_x1 == 0 ? 0 : diff_x1 + 1;
 	int w2 = diff_x2 == 0 ? 0 : diff_x2 + 1;
 
-	apply_line_style (c, x, y, x2, y2, style);
+	apply_line_style (c, x, y, x2, y2, style, isvert);
 
-	draw_vertical_line (c, x, y + 1, ybendpoint1 + 1);
-	draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX);
-	draw_vertical_line (c, xbendpoint, y2 - ybendpoint2 + 1, diff_y - 1);
-	draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, DOT_DOT);
-	draw_vertical_line (c, x2, y2 - ybendpoint2 + 1, ybendpoint2);
+	if (isvert) {
+		draw_vertical_line (c, x, y + 1, ybendpoint1 + 1);
+		draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX);
+		draw_vertical_line (c, xbendpoint, y2 - ybendpoint2 + 1, diff_y - 1);
+		draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, DOT_DOT);
+		draw_vertical_line (c, x2, y2 - ybendpoint2 + 1, ybendpoint2);
+	} else {
+		int miny1 = R_MIN (y, xbendpoint);
+		int miny2 = R_MIN (y2, xbendpoint);
+		int diff_y1 = R_ABS (y - xbendpoint);
+		int diff_y2 = R_ABS (y2 - xbendpoint);
+
+		draw_horizontal_line (c, x + 1, y, 1 + ybendpoint1 + 1, xbendpoint > y ? NRM_DOT : NRM_APEX);
+		draw_vertical_line (c, x + 1 + ybendpoint1 + 1, miny1 + 1, diff_y1 - 1);
+		draw_horizontal_line (c, x2 - ybendpoint2, xbendpoint, (x + 1 + ybendpoint1 + 1) - (x2 - ybendpoint2) + 1, xbendpoint > y ? REV_APEX_APEX : DOT_DOT);
+		draw_vertical_line (c, x2 - ybendpoint2, miny2 + 1, diff_y2 - 1);
+		draw_horizontal_line (c, x2 - ybendpoint2, y2, ybendpoint2 + 1, xbendpoint > y ? DOT_NRM : REV_APEX_NRM);
+	}
 }

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -154,7 +154,12 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		break;
 	case DOT_DOT:
 	default:
-		l_corner = r_corner = ".";
+		if (useUtf8) {
+			l_corner = RUNECODESTR_CORNER_TL;
+			r_corner = RUNECODESTR_CORNER_TR;
+		} else {
+			l_corner = r_corner = ".";
+		}
 		break;
 	}
 
@@ -266,20 +271,20 @@ R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int 
 R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int ybendpoint1, int xbendpoint, int ybendpoint2) {
 	int min_x1 = R_MIN (x, xbendpoint);
 	int min_x2 = R_MIN (x2, xbendpoint);
+
 	int diff_x1 = R_ABS (x - xbendpoint);
 	int diff_x2 = R_ABS (x2 - xbendpoint);
-	int diff_y = R_ABS ((y + ybendpoint1) - (y2 - ybendpoint2));
+
+	int diff_y = R_ABS ((y + ybendpoint1 + 1) - (y2 - ybendpoint2- 1));
+
 	int w1 = diff_x1 == 0 ? 0 : diff_x1 + 1;
 	int w2 = diff_x2 == 0 ? 0 : diff_x2 + 1;
-	int min_y = R_MIN (ybendpoint1, ybendpoint2);
-	int sty1 = min_x1 == x ? APEX_DOT : DOT_APEX;
-	int sty2 = min_x2 == x2 ? APEX_DOT : DOT_APEX;
 
 	apply_line_style (c, x, y, x2, y2, style);
 
 	draw_vertical_line (c, x, y + 1, ybendpoint1 + 1);
 	draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX);
-	draw_vertical_line (c, xbendpoint, y2 - min_y, diff_y + 1);
-	draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, sty2);
-	draw_vertical_line (c, x2, y2 - ybendpoint2, 1 + ybendpoint2);
+	draw_vertical_line (c, xbendpoint, y2 - ybendpoint2 + 1, diff_y - 1);
+	draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, DOT_DOT);
+	draw_vertical_line (c, x2, y2 - ybendpoint2 + 1, ybendpoint2);
 }

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -501,6 +501,7 @@ R_API void r_cons_canvas_line_square(RConsCanvas *c, int x, int y, int x2, int y
 R_API int r_cons_canvas_resize(RConsCanvas *c, int w, int h);
 R_API void r_cons_canvas_fill(RConsCanvas *c, int x, int y, int w, int h, char ch, int replace);
 R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int bendpoint);
+R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int ybendpoint1, int xbendpoint, int ybendpoint2);
 
 R_API RCons *r_cons_new(void);
 R_API RCons *r_cons_singleton(void);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -448,7 +448,8 @@ enum {
 	LINE_TRUE,
 	LINE_FALSE,
 	LINE_UNCJMP,
-	LINE_NOSYM
+	LINE_NOSYM_VERT,
+	LINE_NOSYM_HORIZ
 };
 
 typedef struct r_cons_canvas_line_style_t {
@@ -500,8 +501,8 @@ R_API void r_cons_canvas_line_diagonal(RConsCanvas *c, int x, int y, int x2, int
 R_API void r_cons_canvas_line_square(RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style);
 R_API int r_cons_canvas_resize(RConsCanvas *c, int w, int h);
 R_API void r_cons_canvas_fill(RConsCanvas *c, int x, int y, int w, int h, char ch, int replace);
-R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int bendpoint);
-R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int ybendpoint1, int xbendpoint, int ybendpoint2);
+R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int bendpoint, int isvert);
+R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int ybendpoint1, int xbendpoint, int ybendpoint2, int isvert);
 
 R_API RCons *r_cons_new(void);
 R_API RCons *r_cons_singleton(void);
@@ -717,6 +718,7 @@ typedef struct r_ascii_node_t {
 
 	int layer;
 	int layer_height;
+	int layer_width;
 	int pos_in_layer;
 	int is_dummy;
 	int is_reversed;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -715,6 +715,7 @@ typedef struct r_ascii_node_t {
 	int h;
 
 	int layer;
+	int layer_height;
 	int pos_in_layer;
 	int is_dummy;
 	int is_reversed;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -448,6 +448,7 @@ enum {
 	LINE_TRUE,
 	LINE_FALSE,
 	LINE_UNCJMP,
+	LINE_NOSYM
 };
 
 typedef struct r_cons_canvas_line_style_t {
@@ -499,6 +500,7 @@ R_API void r_cons_canvas_line_diagonal(RConsCanvas *c, int x, int y, int x2, int
 R_API void r_cons_canvas_line_square(RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style);
 R_API int r_cons_canvas_resize(RConsCanvas *c, int w, int h);
 R_API void r_cons_canvas_fill(RConsCanvas *c, int x, int y, int w, int h, char ch, int replace);
+R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style, int bendpoint);
 
 R_API RCons *r_cons_new(void);
 R_API RCons *r_cons_singleton(void);


### PR DESCRIPTION
For a simple graph without any loop (backedges), it will not have any kind of node/edge overlapping to the best of my knowledge. Code is in its worst condition since I have not removed the part of the code that is not required anymore (need to review it before making it available for merge).

TODO:
- [x] fix overlapping issue for backedges in loop
- [x] code cleaning

If you test it out and find any issue, please let me know 😄 

EDIT:
- This will overlap/merge more than one branch of same type (true/false/unconditional edge) that have same destination node - but this will happen mainly just above the destination node and not anywhere in between.
- There might come a place where two different type of vertical edges overlap each other in a small part. Again this will only happen after/before edge crossing between two layers.