### PR TITLE
Fix color of cmd.gprompt

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2648,6 +2648,7 @@ static int agraph_print(RAGraph *g, int is_interactive, RCore *core, RAnalFuncti
 	}
 
 	r_cons_canvas_print_region (g->can);
+	r_cons_strcat (Color_RESET);
 
 	if (is_interactive) {
 		const char *cmdv;


### PR DESCRIPTION
The prompt triggered by `|` and `cmd.gprompt` output do not use the default foreground color, which is fixed by this commit.