### PR TITLE
Use void in prototypes

### DIFF
--- a/libr/include/r2naked.h
+++ b/libr/include/r2naked.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void *r_core_new();
+void *r_core_new(void);
 char *r_core_cmd_str(void *p, const char *cmd);
 void r_core_free(void* core);
 void free(void*);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -210,7 +210,7 @@ typedef struct r_cons_palette_t {
 } RConsPalette;
 
 R_API const char *r_cons_rainbow_get(int idx, int last, bool bg);
-R_API void r_cons_rainbow_free();
+R_API void r_cons_rainbow_free(void);
 R_API void r_cons_rainbow_new(int sz);
 
 typedef void (*RConsEvent)(void *);
@@ -575,7 +575,7 @@ R_API int r_cons_eof(void);
 
 R_API int r_cons_palette_init(const unsigned char *pal);
 R_API int r_cons_pal_set(const char *key, const char *val);
-R_API void r_cons_pal_update_event();
+R_API void r_cons_pal_update_event(void);
 R_API void r_cons_pal_free(void);
 R_API void r_cons_pal_init(const char *foo);
 R_API char *r_cons_pal_parse(const char *str);

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -69,7 +69,7 @@ R_API void r_sign_list(RAnal *a, int format);
 
 R_API bool r_sign_foreach(RAnal *a, RSignForeachCallback cb, void *user);
 
-R_API RSignSearch *r_sign_search_new();
+R_API RSignSearch *r_sign_search_new(void);
 R_API void r_sign_search_free(RSignSearch *ss);
 R_API void r_sign_search_init(RAnal *a, RSignSearch *ss, int minsz, RSignSearchCallback cb, void *user);
 R_API int r_sign_search_update(RAnal *a, RSignSearch *ss, ut64 *at, const ut8 *buf, int len);
@@ -81,7 +81,7 @@ R_API bool r_sign_load(RAnal *a, const char *file);
 R_API char *r_sign_path(RAnal *a, const char *file);
 R_API bool r_sign_save(RAnal *a, const char *file);
 
-R_API RSignItem *r_sign_item_new();
+R_API RSignItem *r_sign_item_new(void);
 R_API RSignItem *r_sign_item_dup(RSignItem *it);
 R_API void r_sign_item_free(RSignItem *item);
 

--- a/libr/include/r_util/r_json.h
+++ b/libr/include/r_util/r_json.h
@@ -42,12 +42,12 @@ struct r_json_var {
 };
 
 R_API void r_json_var_free(RJSVar* var);
-R_API RJSVar* r_json_object_new();
+R_API RJSVar* r_json_object_new(void);
 R_API RJSVar* r_json_array_new(int len);
 R_API RJSVar* r_json_string_new(const char* name);
 R_API RJSVar* r_json_number_new(int value);
 R_API RJSVar* r_json_boolean_new(bool value);
-R_API RJSVar* r_json_null_new();
+R_API RJSVar* r_json_null_new(void);
 
 R_API void r_json_object_add(RJSVar* object, const char* name, RJSVar* value);
 R_API void r_json_array_add(RJSVar* array, RJSVar* value);

--- a/libr/include/sdb/sdbht.h
+++ b/libr/include/sdb/sdbht.h
@@ -19,7 +19,7 @@ extern SdbKv* sdb_kv_new(const char *k, const char *v);
 extern ut32 sdb_hash(const char *key);
 extern void sdb_kv_free(SdbKv *kv);
 
-SdbHash* sdb_ht_new();
+SdbHash* sdb_ht_new(void);
 // Destroy a hashtable and all of its entries.
 void sdb_ht_free(SdbHash* ht);
 void sdb_ht_free_deleted(SdbHash* ht);


### PR DESCRIPTION
This PR adds `void` in r2 includes. It aims at removing warning when compiling plugins with `-Wstrict-prototypes`.

There are ~50 others similar cases in r2 sources. I can fix them if you think that it is relevant.