### PR TITLE
Add dcb (debug continue back) command

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3215,6 +3215,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 		"dc", " <pid>", "Continue execution of pid",
 		"dc", "[-pid]", "Stop execution of pid",
 		"dca", " [sym] [sym].", "Continue at every hit on any given symbol",
+		"dcb", "", "Continue back until breakpoint",
 		"dcc", "", "Continue until call (use step into)",
 		"dccu", "", "Continue until unknown call (call reg)",
 #if __WINDOWS__ && !__CYGWIN__
@@ -3282,6 +3283,13 @@ beach:
 	case 'a': // "dca"
 		eprintf ("TODO: dca\n");
 		break;
+	case 'b': // "dcb"
+		{
+			if (!r_debug_continue_back (core->dbg)) {
+				eprintf ("cannot continue back\n");
+			}
+			break;
+		}
 #if __WINDOWS__ && !__CYGWIN__
 	case 'e': // "dce"
 		r_reg_arena_swap (core->dbg->reg, true);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1224,10 +1224,13 @@ R_API bool r_debug_continue_back(RDebug *dbg) {
 	RBreakpointItem *prev = NULL;
 	int has_bp;
 	ut64 pc, end_addr;
-
-	if (r_debug_is_dead (dbg))
+	if (!dbg) {
 		return false;
+	}
 	if (!dbg->anal || !dbg->reg) {
+		return false;
+	}
+	if (r_debug_is_dead (dbg)) {
 		return false;
 	}
 	if (r_list_empty (dbg->sessions)) {
@@ -1246,16 +1249,19 @@ R_API bool r_debug_continue_back(RDebug *dbg) {
 	/* ### Get previous breakpoint ### */
 	// Firstly set the breakpoint at end address
 	has_bp = r_bp_get_in (dbg->bp, end_addr, R_BP_PROT_EXEC) != NULL;
-	if (!has_bp)
+	if (!has_bp) {
 		r_bp_add_sw (dbg->bp, end_addr, dbg->bpsize, R_BP_PROT_EXEC);
+	}
 
 	// Continue until end_addr
 	for (;;) {
-		if (r_debug_is_dead (dbg))
+		if (r_debug_is_dead (dbg)) {
 			break;
+		}
 		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
-		if (pc == end_addr)
+		if (pc == end_addr) {
 			break;
+		}
 		prev = r_bp_get_at (dbg->bp, pc);
 		r_debug_continue (dbg);
 	}
@@ -1273,8 +1279,9 @@ R_API bool r_debug_continue_back(RDebug *dbg) {
 	/* Rollback to previous state again */
 	r_debug_session_set (dbg, before);
 	for (;;) {
-		if (r_debug_is_dead (dbg))
+		if (r_debug_is_dead (dbg)) {
 			break;
+		}
 		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 		if (prev == r_bp_get_at (dbg->bp, pc)) {
 			break;

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -121,7 +121,7 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 		return;
 	}
 
-	eprintf ("Apply diff [0x%08"PFMT64x ", 0x%08"PFMT64x "]\n", snap->addr, snap->addr_end);
+	//eprintf ("Apply diff [0x%08"PFMT64x ", 0x%08"PFMT64x "]\n", snap->addr, snap->addr_end);
 
 	/* Roll back page datas that's been changed **after** specified SnapDiff 'diff' */
 	for (addr = snap->addr; addr < snap->addr_end; addr += SNAP_PAGE_SIZE) {
@@ -132,7 +132,7 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 			ut64 off = (ut64) last_page->page_off * SNAP_PAGE_SIZE;
 			/* Copy a page data of base snap to current addr. (i.e. roll back) */
 			dbg->iob.write_at (dbg->iob.io, addr, snap->data + off, SNAP_PAGE_SIZE);
-			eprintf ("Roll back 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
+			//eprintf ("Roll back 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
 		}
 	}
 
@@ -141,7 +141,7 @@ R_API void r_debug_diff_set(RDebug *dbg, RDebugSnapDiff *diff) {
 		page_off = (addr - snap->addr) / SNAP_PAGE_SIZE;
 		if ((prev_page = diff->last_changes[page_off])) {
 			r_page_data_set (dbg, prev_page);
-			eprintf ("Update 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
+			//eprintf ("Update 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
 		}
 	}
 	r_list_pop (snap->history);
@@ -162,7 +162,7 @@ R_API void r_debug_diff_set_base(RDebug *dbg, RDebugSnap *base) {
 		return;
 	}
 
-	eprintf ("Roll back to base [0x%08"PFMT64x ", 0x%08"PFMT64x "]\n", cur_map->addr, cur_map->addr_end);
+	//eprintf ("Roll back to base [0x%08"PFMT64x ", 0x%08"PFMT64x "]\n", cur_map->addr, cur_map->addr_end);
 
 	for (addr = base->addr; addr < base->addr_end; addr += SNAP_PAGE_SIZE) {
 		page_off = (addr - base->addr) / SNAP_PAGE_SIZE;
@@ -170,7 +170,7 @@ R_API void r_debug_diff_set_base(RDebug *dbg, RDebugSnap *base) {
 			ut64 off = (ut64) last_page->page_off * SNAP_PAGE_SIZE;
 			/* Copy a page data of base snap to current addr. (i.e. roll back) */
 			dbg->iob.write_at (dbg->iob.io, addr, base->data + off, SNAP_PAGE_SIZE);
-			eprintf ("Roll back 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
+			//eprintf ("Roll back 0x%08"PFMT64x "(page: %d)\n", addr, page_off);
 		}
 	}
 

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -584,6 +584,7 @@ R_API bool r_debug_session_set_idx(RDebug *dbg, int idx);
 R_API RDebugSession *r_debug_session_get(RDebug *dbg, RListIter *tail);
 R_API void r_debug_session_save(RDebug *dbg, const char *file);
 R_API int r_debug_step_back(RDebug *dbg);
+R_API bool r_debug_continue_back(RDebug *dbg);
 
 /* plugin pointers */
 extern RDebugPlugin r_debug_plugin_native;


### PR DESCRIPTION
Add new command 'dcb' that can continue backward until hit breakpoint.
When executing 'dcb', at first, get the previous breakpoint, and then, continue until this point.
