### PR TITLE
Send SIGTSTP to the process group of r2 when SUSP key is pressed.

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -13,7 +13,7 @@ R_API char **r_sys_get_environ(void);
 R_API void r_sys_set_environ(char **e);
 R_API ut64 r_sys_now(void);
 R_API int r_sys_fork(void);
-R_API int r_sys_stop(void);
+R_API bool r_sys_stop(void);
 R_API char *r_sys_pid_to_path(int pid);
 R_API int r_sys_run(const ut8 *buf, int len);
 R_API int r_sys_getpid(void);

--- a/libr/util/sandbox.c
+++ b/libr/util/sandbox.c
@@ -275,10 +275,7 @@ R_API int r_sandbox_kill(int pid, int sig) {
 	// XXX: fine-tune. maybe we want to enable kill for child?
 	if (enabled) return -1;
 #if __UNIX__
-	if (pid > 0) {
-		return kill (pid, sig);
-	}
-	// eprintf ("r_sandbox_kill: Better not to kill pids <= 0.\n");
+	return kill (pid, sig);
 #endif
 	return -1;
 }
@@ -313,14 +310,13 @@ R_API DIR* r_sandbox_opendir (const char *path) {
 	return opendir (path);
 }
 #endif
-R_API int r_sys_stop () {
-	int pid;
+R_API bool r_sys_stop () {
 	if (enabled) {
 		return false;
 	}
-	pid = r_sys_getpid ();
-#ifndef SIGSTOP
-#define SIGSTOP 19
+#if __UNIX__
+	return !r_sandbox_kill (0, SIGTSTP);
+#else
+	return false;
 #endif
-	return (!r_sandbox_kill (pid, SIGSTOP));
 }


### PR DESCRIPTION
When binr/radare2/radare2 was running under a shell (e.g. `env.sh`), they were in the
same process group, pressing ^Z (SUSP) once just suspended radare2 itself, not
including the shell. The commit sends the signal to the whole process
group.