### PR TITLE
Add `free` to RLibStruct & RLibPlugin.

### DIFF
--- a/libr/include/r_lib.h
+++ b/libr/include/r_lib.h
@@ -35,6 +35,7 @@ typedef struct r_lib_plugin_t {
 	void *dl_handler; // DL HANDLER
 	char *author;
 	char *version;
+	void (*free)(void *data);
 } RLibPlugin;
 
 /* store list of initialized plugin handlers */
@@ -52,6 +53,7 @@ typedef struct r_lib_struct_t {
 	int type;
 	void *data; /* pointer to data handled by plugin handler */
 	const char *version; /* r2 version */
+	void (*free)(void *data);
 } RLibStruct;
 
 // order matters because of libr/util/lib.c

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -177,9 +177,11 @@ R_API int r_lib_close(RLib *lib, const char *file) {
 	r_list_foreach_safe (lib->plugins, iter, iter_tmp, p) {
 		if ((file==NULL || (!strcmp (file, p->file)))) {
 			int ret = 0;
-			if (p->handler && p->handler->constructor) {
-				ret = p->handler->destructor (p,
-					p->handler->user, p->data);
+			if (p->handler && p->handler->destructor) {
+				ret = p->handler->destructor (p, p->handler->user, p->data);
+			}
+			if (p->free) {
+				p->free (p->data);
 			}
 			free (p->file);
 			r_list_delete (lib->plugins, iter);
@@ -195,7 +197,7 @@ R_API int r_lib_close(RLib *lib, const char *file) {
 	r_list_foreach (lib->plugins, iter, p) {
 		if (strstr (p->file, file)) {
 			int ret = 0;
-			if (p->handler && p->handler->constructor) {
+			if (p->handler && p->handler->destructor) {
 				ret = p->handler->destructor (p,
 					p->handler->user, p->data);
 			}
@@ -300,6 +302,7 @@ R_API int r_lib_open_ptr (RLib *lib, const char *file, void *handler, RLibStruct
 	p->file = strdup (file);
 	p->dl_handler = handler;
 	p->handler = r_lib_get_handler (lib, p->type);
+	p->free = stru->free;
 
 	ret = r_lib_run_handler (lib, p, stru);
 	if (ret == R_FAIL) {
@@ -338,7 +341,7 @@ R_API int r_lib_opendir(RLib *lib, const char *path) {
 	if (!wcpath) {
 		return false;	
 	}
-	swprintf (directory, sizeof (directory), L"%ls\\*.*", wcpath);	
+	swprintf (directory, sizeof (directory), L"%ls\\*.*", wcpath);
 	fh = FindFirstFileW (directory, &dir);
 	if (fh == INVALID_HANDLE_VALUE) {
 		IFDBG eprintf ("Cannot open directory %ls\n", wcpath);


### PR DESCRIPTION
This is useful for dynamically created plugins (e.g. ` r2lang.plugin("asm", r2m2_ad_plugin)`)

`radare2-bindings/libr/lang/p/python/anal.c:Radare_plugin_asm` `strdup` fields for
RAnalPlugin and they are not freed upon `r_lib_close`.
This commit adds `free` to RLibStruct & RLibPlugin with which
plugins can set their custom destructors (to free those `strdup`
fields).