### PR TITLE
Fix memory leaks in libr/anal

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -197,6 +197,8 @@ R_API void r_anal_esil_free(RAnalEsil *esil) {
 	esil->interrupts = NULL;
 	sdb_free (esil->stats);
 	esil->stats = NULL;
+	sdb_free (esil->db_trace);
+	esil->db_trace = NULL;
 	r_anal_esil_stack_free (esil);
 	free (esil->stack);
 	if (esil->anal && esil->anal->cur && esil->anal->cur->esil_fini) {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1625,6 +1625,7 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		.bits = a->bits
 	};
 	int regsz = 4;
+	static RRegItem regs[2];
 	switch (a->bits) {
 	case 64: regsz = 8; break;
 	case 16: regsz = 2; break;
@@ -1845,14 +1846,16 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		op->ptr = UT64_MAX;
 
 		op->src[0] = r_anal_value_new ();
-		op->src[0]->reg = R_NEW0 (RRegItem);
+		ZERO_FILL (regs[1]);
+		op->src[0]->reg = &regs[1];
 		op->dst = r_anal_value_new ();
 
 		parse_reg_name_mov (op->src[0]->reg, &gop.handle, insn, 1);
 
 		switch (INSOP(0).type) {
 		case X86_OP_MEM:
-			op->dst->reg = R_NEW0 (RRegItem);
+			ZERO_FILL (regs[1]);
+			op->dst->reg = &regs[0];
 			parse_reg_name_mov (op->dst->reg, &gop.handle, insn, 0);
 
 			op->cycles = CYCLE_MEM;
@@ -1999,9 +2002,11 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 	case X86_INS_LEA:
 		op->type = R_ANAL_OP_TYPE_LEA;
 		op->src[0] = r_anal_value_new ();
-		op->src[0]->reg = R_NEW0 (RRegItem);
+		ZERO_FILL (regs[1]);
+		op->src[0]->reg = &regs[1];
 		op->dst = r_anal_value_new ();
-		op->dst->reg = R_NEW0 (RRegItem);
+		ZERO_FILL (regs[0]);
+		op->dst->reg = &regs[0];
 
 		parse_reg_name_lea (op->src[0]->reg, &gop.handle, insn, 1);
 		parse_reg_name_mov (op->dst->reg, &gop.handle, insn, 0);

--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -337,11 +337,14 @@ R_API char *r_anal_type_func_guess(RAnal *anal, char *func_name) {
 				const char *res = sdb_const_get (anal->sdb_types, &str[j], 0);
 				bool is_func = res && !strcmp ("func", res);
 				if (is_func) {
-					return strdup (&str[j]);
+					char *ret = strdup (&str[j]);
+					free (str);
+					return ret;
 				}
 			}
 			str[j + n] = saved;
 		}
 	}
+	free (str);
 	return NULL;
 }

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1050,7 +1050,7 @@ static int elf_init(ELFOBJ *bin) {
 	bin->strtab_section = NULL;
 	bin->dyn_buf = NULL;
 	bin->dynstr = NULL;
-	memset (bin->version_info, 0, DT_VERSIONTAGNUM);
+	ZERO_FILL (bin->version_info);
 
 	bin->g_sections = NULL;
 	bin->g_symbols = NULL;

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -246,6 +246,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 			RAnalOp *op = r_core_anal_op (core, addr);
 			int loop_count = sdb_num_get (core->anal->esil->db_trace, sdb_fmt (-1, "0x%"PFMT64x".count", addr), 0);
 			if (loop_count > LOOP_MAX || !op || op->type == R_ANAL_OP_TYPE_RET || addr >= bb->addr + bb->size || addr < bb->addr) {
+				r_anal_op_free (op);
 				break;
 			}
 			sdb_num_set (core->anal->esil->db_trace, sdb_fmt (-1, "0x%"PFMT64x".count", addr), loop_count + 1, 0);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2336,7 +2336,7 @@ R_API int r_core_esil_step(RCore *core, ut64 until_addr, const char *until_expr)
 	// Stepping
 	int ret;
 	ut8 code[256];
-	RAnalOp op;
+	RAnalOp op = {0};
 	RAnalEsil *esil = core->anal->esil;
 	const char *name = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 	if (!esil) {
@@ -2514,9 +2514,11 @@ repeat:
 		}
 	}
 out_return_one:
+	r_anal_op_fini (&op);
 	r_cons_break_pop ();
 	return 1;
 out_return_zero:
+	r_anal_op_fini (&op);
 	r_cons_break_pop ();
 	return 0;
 }

--- a/libr/debug/trace.c
+++ b/libr/debug/trace.c
@@ -47,7 +47,7 @@ R_API int r_debug_trace_tag (RDebug *dbg, int tag) {
  */
 R_API int r_debug_trace_pc (RDebug *dbg, ut64 pc) {
 	ut8 buf[32];
-	RAnalOp op;
+	RAnalOp op = {0};
 	static ut64 oldpc = UT64_MAX; // Must trace the previously traced instruction
 	if (dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf)) != sizeof (buf)) {
 		eprintf ("trace_pc: cannot read memory at 0x%"PFMT64x"\n", pc);
@@ -64,6 +64,7 @@ R_API int r_debug_trace_pc (RDebug *dbg, ut64 pc) {
 		r_debug_trace_add (dbg, oldpc, op.size); //XXX review what this line really do
 	}
 	oldpc = pc;
+	r_anal_op_fini (&op);
 	return true;
 }
 


### PR DESCRIPTION
Fix memory leaks in libr/anal/types.c and libr/anal/p/anal_x86_cs.c

`libr/anal/p/anal_x86_cs.c`: use static variable for `op->{dst,src[0]}->reg` because they are not freed in `r_anal_op_fini`.

Also fix a trivial memset bug in `libr/bin/format/elf/elf.c`
