### PR TITLE
Add RCmdDescriptor and cmd.newcomplete for new command completion.

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2319,6 +2319,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("cmd.fcn.new", "", "Run when new function is analyzed");
 	SETPREF ("cmd.fcn.delete", "", "Run when a function is deleted");
 	SETPREF ("cmd.fcn.rename", "", "Run when a function is renamed");
+	SETPREF ("cmd.comphint", "false", "Show descriptions in command completion");
 	SETPREF ("cmd.visual", "", "Replace current print mode");
 	SETPREF ("cmd.vprompt", "", "Visual prompt commands");
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -101,7 +101,7 @@ static const char *help_msg_ae[] = {
 	NULL
 };
 
-static const char *help_msg_ae_detail[] = {
+static const char *help_detail_ae[] = {
 	"Examples:", "ESIL", " examples and documentation",
 	"+", "=", "A+=B => B,A,+=",
 	"+", "", "A=A+B => B,A,+,A,=",
@@ -272,24 +272,17 @@ static const char *help_msg_aft[] = {
 	NULL
 };
 
-static const char *help_msg_afx[] = {
-	"Usage:", "afx[-cCd?] [src] [dst]", "# manage function references (see also ar?)",
-	"afxc", " sym.main+0x38 sym.printf", "add code ref",
-	"afxC", " sym.main sym.puts", "add call ref",
-	"afxd", " sym.main str.helloworld", "add data ref",
-	"afx-", " sym.main str.helloworld", "remove reference",
-	NULL
-};
-
-static const char *help_msg_afvs[] = {
-	"Usage:", "afvs", " [idx] [type] [name]",
-	"afvs", "", "list stack based arguments and locals",
-	"afvs*", "", "same as afvs but in r2 commands",
-	"afvs", " [idx] [name] [type]", "define stack based arguments,locals",
-	"afvsj", "", "return list of stack based arguments and locals in JSON format",
-	"afvs-", " [name]", "delete stack based argument or locals with the given name",
-	"afvsg", " [idx] [addr]", "define var get reference",
-	"afvss", " [idx] [addr]", "define var set reference",
+static const char *help_msg_afv[] = {
+	"Usage:", "afv","[rbs]",
+	"afvr", "[?]", "manipulate register based arguments",
+	"afvb", "[?]", "manipulate bp based arguments/locals",
+	"afvs", "[?]", "manipulate sp based arguments/locals",
+	"afvR", " [varname]", "list addresses where vars are accessed",
+	"afvW", " [varname]", "list addresses where vars are accessed",
+	"afva", "", "analyze function arguments/locals",
+	"afvd", " name", "output r2 command for displaying the value of args/locals in the debugger",
+	"afvn", " [old_name] [new_name]", "rename argument/local",
+	"afvt", " [name] [new_type]", "change type for given argument/local",
 	NULL
 };
 
@@ -317,17 +310,24 @@ static const char *help_msg_afvr[] = {
 	NULL
 };
 
-static const char *help_msg_afv[] = {
-	"Usage:", "afv","[rbs]",
-	"afvr", "[?]", "manipulate register based arguments",
-	"afvb", "[?]", "manipulate bp based arguments/locals",
-	"afvs", "[?]", "manipulate sp based arguments/locals",
-	"afvR", " [varname]", "list addresses where vars are accessed",
-	"afvW", " [varname]", "list addresses where vars are accessed",
-	"afva", "", "analyze function arguments/locals",
-	"afvd", " name", "output r2 command for displaying the value of args/locals in the debugger",
-	"afvn", " [old_name] [new_name]", "rename argument/local",
-	"afvt", " [name] [new_type]", "change type for given argument/local",
+static const char *help_msg_afvs[] = {
+	"Usage:", "afvs", " [idx] [type] [name]",
+	"afvs", "", "list stack based arguments and locals",
+	"afvs*", "", "same as afvs but in r2 commands",
+	"afvs", " [idx] [name] [type]", "define stack based arguments,locals",
+	"afvsj", "", "return list of stack based arguments and locals in JSON format",
+	"afvs-", " [name]", "delete stack based argument or locals with the given name",
+	"afvsg", " [idx] [addr]", "define var get reference",
+	"afvss", " [idx] [addr]", "define var set reference",
+	NULL
+};
+
+static const char *help_msg_afx[] = {
+	"Usage:", "afx[-cCd?] [src] [dst]", "# manage function references (see also ar?)",
+	"afxc", " sym.main+0x38 sym.printf", "add code ref",
+	"afxC", " sym.main sym.puts", "add call ref",
+	"afxd", " sym.main str.helloworld", "add data ref",
+	"afx-", " sym.main str.helloworld", "remove reference",
 	NULL
 };
 
@@ -492,6 +492,39 @@ static const char *help_msg_ax[] = {
 	"ax*", "", "output radare commands",
 	NULL
 };
+
+static void cmd_anal_init(void) {
+	DEFINE_CMD_DESCRIPTOR(a);
+	DEFINE_CMD_DESCRIPTOR(aa);
+	DEFINE_CMD_DESCRIPTOR(aar);
+	DEFINE_CMD_DESCRIPTOR(ad);
+	DEFINE_CMD_DESCRIPTOR(ae);
+	DEFINE_CMD_DESCRIPTOR(aea);
+	DEFINE_CMD_DESCRIPTOR(aec);
+	DEFINE_CMD_DESCRIPTOR(aep);
+	DEFINE_CMD_DESCRIPTOR(af);
+	DEFINE_CMD_DESCRIPTOR(afb);
+	DEFINE_CMD_DESCRIPTOR(afl);
+	DEFINE_CMD_DESCRIPTOR(afll);
+	DEFINE_CMD_DESCRIPTOR(afn);
+	DEFINE_CMD_DESCRIPTOR(aft);
+	DEFINE_CMD_DESCRIPTOR(afv);
+	DEFINE_CMD_DESCRIPTOR(afvb);
+	DEFINE_CMD_DESCRIPTOR(afvr);
+	DEFINE_CMD_DESCRIPTOR(afvs);
+	DEFINE_CMD_DESCRIPTOR(afx);
+	DEFINE_CMD_DESCRIPTOR(ag);
+	DEFINE_CMD_DESCRIPTOR(age);
+	DEFINE_CMD_DESCRIPTOR(agg);
+	DEFINE_CMD_DESCRIPTOR(agn);
+	DEFINE_CMD_DESCRIPTOR(ah);
+	DEFINE_CMD_DESCRIPTOR(ao);
+	DEFINE_CMD_DESCRIPTOR(ar);
+	DEFINE_CMD_DESCRIPTOR(ara);
+	DEFINE_CMD_DESCRIPTOR(arw);
+	DEFINE_CMD_DESCRIPTOR(as);
+	DEFINE_CMD_DESCRIPTOR(ax);
+}
 
 /* better aac for windows-x86-32 */
 #define JAYRO_03 0
@@ -3738,7 +3771,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		break;
 	case '?':
 		if (input[1] == '?') {
-			r_core_cmd_help (core, help_msg_ae_detail);
+			r_core_cmd_help (core, help_detail_ae);
 			break;
 		}
 		/* fallthrough */

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -76,6 +76,14 @@ typedef struct r_cmd_t {
 	RCmdAlias aliases;
 } RCmd;
 
+// TODO WIP
+typedef struct r_cmd_descriptor_t {
+	const char *name;
+	const char **help_msg;
+	const char **help_detail;
+	struct r_cmd_descriptor_t *sub[127];
+} RCmdDescriptor;
+
 typedef struct r_core_plugin_t {
 	const char *name;
 	const char *desc;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -135,6 +135,7 @@ typedef struct r_core_t {
 	RNum *num;
 	RLib *lib;
 	RCmd *rcmd;
+	RCmdDescriptor cmd_descriptor;
 	RAnal *anal;
 	RAsm *assembler;
 	/* ^^ */


### PR DESCRIPTION
It organizes commands as a tree by their names and uses
`r_core_cmd_help (core, desc->help_msg);` currently to show command
candidates.

Type the following command and press `Tab`:
```
% r2 -e cmd.newcomplete=1 --
 -- getdruid to get eclectic uid
|Usage: a[abdefFghoprxstc] [...]
| aa[?]            analyze all (fcns + bbs) (aa0 to avoid sub renaming)
| ab [hexpairs]    analyze bytes
| abb [len]        analyze N basic blocks in [len] (section.size by default)
| ac [cycles]      analyze which op could be executed in [cycles]
| ad[?]            analyze data trampoline (wip)
| ad [from] [to]   analyze data pointers to (from-to)
| ae[?] [expr]     analyze opcode eval expression (see ao)
| af[?]            analyze Functions
| aF               same as above, but using anal.depth=1
| ag[?] [options]  output Graphviz code
| ah[?]            analysis hints (force opcode size, ...)
| ai [addr]        address information (show perms, stack, heap, ...)
| ao[?] [len]      analyze Opcodes (or emulate it)
| aO               Analyze N instructions in M bytes
| ap               find prelude for current offset
| ar[?]            like 'dr' but for the esil vm. (registers)
| as[?] [num]      analyze syscall using dbg.reg
| av[?] [.]        show vtables
| ax[?]            manage refs/xrefs (see also afx?)
[0x00000000]> a
```

See https://github.com/radare/radare2/issues/7967