### PR TITLE
lldb compatibility [#1] : read registers from lldb-server

### DIFF
--- a/shlr/gdb/include/gdbclient/responses.h
+++ b/shlr/gdb/include/gdbclient/responses.h
@@ -31,4 +31,7 @@ int handle_vFile_pread(libgdbr_t *g, ut8 *buf);
 int handle_vFile_close(libgdbr_t *g);
 int handle_stop_reason(libgdbr_t *g);
 
+// LLDB
+int handle_lldb_read_reg(libgdbr_t *g);
+
 #endif  // RESPONSES_H

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -15,6 +15,9 @@ typedef unsigned int ssize_t;
 #define MSG_NOT_SUPPORTED -1
 #define MSG_ERROR_1 -2
 
+#define GDB_REMOTE_TYPE_GDB 0
+#define GDB_REMOTE_TYPE_LLDB 1
+
 /*!
  * Structure that saves a gdb message
  */
@@ -81,9 +84,14 @@ typedef struct libgdbr_stub_features_t {
 	bool EnableDisableTracepoints;
 	bool tracenz;
 	bool BreakpointCommands;
+	// lldb-specific features
+	struct {
+		bool QThreadSuffixSupported;
+		bool QListThreadsInStopReply;
+		bool qEcho;
+	} lldb;
 	// Cannot be determined with qSupported, found out on query
 	bool qC;
-
 	int extended_mode;
 	struct {
 		bool c, C, s, S, t, r;
@@ -165,6 +173,7 @@ typedef struct libgdbr_t {
 
 	int remote_file_fd; // For remote file I/O
 
+	int remote_type;
 	bool no_ack;
 	bool is_server;
 	bool server_debug;

--- a/shlr/gdb/src/common.c
+++ b/shlr/gdb/src/common.c
@@ -93,9 +93,20 @@ int handle_qSupported(libgdbr_t *g) {
 				g->stub_features.QTBuffer_size = (tok[strlen ("QTBuffer:size")] == '+');
 			} else if (r_str_startswith (tok, "QThreadEvents")) {
 				g->stub_features.QThreadEvents = (tok[strlen ("QThreadEvents")] == '+');
+			} else if (r_str_startswith (tok, "QThreadSuffixSupported")) {
+				g->remote_type = GDB_REMOTE_TYPE_LLDB;
+				g->stub_features.lldb.QThreadSuffixSupported
+					= (tok[strlen ("QThreadSuffixSupported")] == '+');
+			} else if (r_str_startswith (tok, "QListThreadsInStopReply")) {
+				g->remote_type = GDB_REMOTE_TYPE_LLDB;
+				g->stub_features.lldb.QListThreadsInStopReply
+					= (tok[strlen ("QListThreadsInStopReply")] == '+');
 			}
 		} else if (r_str_startswith (tok, "multiprocess")) {
 			g->stub_features.multiprocess = (tok[strlen ("multiprocess")] == '+');
+		} else if (r_str_startswith (tok, "qEcho")) {
+			g->remote_type = GDB_REMOTE_TYPE_LLDB;
+			g->stub_features.lldb.qEcho = (tok[strlen ("qEcho")] == '+');
 		}
 		// TODO
 		tok = strtok (NULL, ";");

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -37,6 +37,7 @@ int gdbr_init(libgdbr_t *g, bool is_server) {
 		R_FREE (g->read_buff);
 		return -1;
 	}
+	g->remote_type = GDB_REMOTE_TYPE_GDB;
 	return 0;
 }
 


### PR DESCRIPTION
Even though lldb-server is supposed to extend gdbserver packets, it actually doesn't handle some basic ones. Like reading registers using `g`.