### PR TITLE
`P` commands: move `help_msg_*[]` arrays to top

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3160,6 +3160,7 @@ R_API void r_core_cmd_init(RCore *core) {
 	r_cmd_add (core->rcmd, "write",    "write bytes", &cmd_write);
 	r_cmd_add (core->rcmd, "Code",     "code metadata", &cmd_meta);
 	r_cmd_add (core->rcmd, "Project",  "project", &cmd_project);
+	cmd_project_init ();
 	r_cmd_add (core->rcmd, "open",     "open or map file", &cmd_open);
 	r_cmd_add (core->rcmd, "yank",     "yank bytes", &cmd_yank);
 	r_cmd_add (core->rcmd, "resize",   "change file size", &cmd_resize);

--- a/libr/core/cmd_project.c
+++ b/libr/core/cmd_project.c
@@ -4,6 +4,42 @@
 #include "r_core.h"
 #include "r_print.h"
 
+static const char *help_msg_P[] = {
+	"Usage:", "P[?osi] [file]", "Project management",
+	"Pc", " [file]", "show project script to console",
+	"Pd", " [file]", "delete project",
+	"Pi", " [file]", "show project information",
+	"Pl", "", "list all projects",
+	"Pn", "[j]", "show project notes (Pnj for json)",
+	"Pn", " [base64]", "set notes text",
+	"Pn", " -", "edit notes with cfg.editor",
+	"Po", " [file]", "open project",
+	"Ps", " [file]", "save project",
+	"PS", " [file]", "save script file",
+	"P-", " [file]", "delete project (alias for Pd)",
+	"NOTE:", "", "See 'e??prj.'",
+	"NOTE:", "", "project are stored in ~/.config/radare2/projects",
+	NULL
+};
+
+static const char *help_msg_Pn[] = {
+	"Usage:", "Pn[j-?] [...]", "Project Notes",
+	"Pn", "", "show project notes",
+	"Pn", " -", "edit notes with cfg.editor",
+	"Pn-", "", "delete notes",
+	"Pn-", "str", "delete lines matching /str/ in notes",
+	"Pn+", "str", "append one line to the notes",
+	"Pnj", "", "show notes in base64",
+	"Pnj", " [base64]", "set notes in base64",
+	"Pnx", "", "run project note commands",
+	NULL
+};
+
+static void cmd_project_init(void) {
+	DEFINE_CMD_DESCRIPTOR (P);
+	DEFINE_CMD_DESCRIPTOR (Pn);
+}
+
 static int cmd_project(void *data, const char *input) {
 	RCore *core = (RCore *) data;
 	const char *file, *arg = (input && *input)? input + 1: NULL;
@@ -70,19 +106,7 @@ static int cmd_project(void *data, const char *input) {
 		break;
 	case 'n': // "Pn"
 		if (input[1] == '?') {
-			const char *help_msg[] = {
-				"Usage:", "Pn[j-?] [...]", "Project Notes",
-				"Pn", "", "show project notes",
-				"Pn", " -", "edit notes with cfg.editor",
-				"Pn-", "", "delete notes",
-				"Pn-", "str", "delete lines matching /str/ in notes",
-				"Pn+", "str", "append one line to the notes",
-				"Pnx", "", "run project note commands",
-				"Pnj", "", "show notes in base64",
-				"Pnj", " [base64]", "set notes in base64",
-				NULL
-			};
-			r_core_cmd_help (core, help_msg);
+			r_core_cmd_help (core, help_msg_Pn);
 		} else if (!fileproject || !*fileproject) {
 			eprintf ("No project\n");
 		} else {
@@ -210,26 +234,8 @@ static int cmd_project(void *data, const char *input) {
 			free (prjName);
 		}
 		break;
-	default: {
-		const char *help_msg[] = {
-			"Usage:", "P[?osi] [file]", "Project management",
-			"Pc", " [file]", "show project script to console",
-			"Pd", " [file]", "delete project",
-			"Pi", " [file]", "show project information",
-			"Pl", "", "list all projects",
-			"Pn", "[j]", "show project notes (Pnj for json)",
-			"Pn", " [base64]", "set notes text",
-			"Pn", " -", "edit notes with cfg.editor",
-			"Po", " [file]", "open project",
-			"Ps", " [file]", "save project",
-			"PS", " [file]", "save script file",
-			"P-", " [file]", "delete project (alias for Pd)",
-			"NOTE:", "", "See 'e??prj.'",
-			"NOTE:", "", "project are stored in ~/.config/radare2/projects",
-			NULL
-		};
-		r_core_cmd_help (core, help_msg);
-	}
+	default:
+		r_core_cmd_help (core, help_msg_P);
 		break;
 	}
 	free (str);


### PR DESCRIPTION
Press `P Tab`

```
% r2 -e cmd.comphint=1 --
|Usage: P[?osi] [file]Project management
| Pc [file]    show project script to console
| Pd [file]    delete project
| Pi [file]    show project information
| Pl           list all projects
| Pn[j]        show project notes (Pnj for json)
| Pn [base64]  set notes text
| Pn -         edit notes with cfg.editor
| Po [file]    open project
| Ps [file]    save project
| PS [file]    save script file
| P- [file]    delete project (alias for Pd)
| NOTE:        See 'e??prj.'
| NOTE:        project are stored in ~/.config/radare2/projects
[0x00000000]> P
```