### PR TITLE
Suppress warnings in cmd.c and remove unused functions in cmd_{anal,print}.c

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2169,6 +2169,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("time.fmt", "%Y-%m-%d %H:%M:%S %z", &cb_cfgdatefmt, "Date format (%Y-%m-%d %H:%M:%S %z)");
 	SETICB ("time.zone", 0, &cb_timezone, "Time zone, in hours relative to GMT: +2, -1,..");
 	SETCB ("cfg.log", "false", &cb_cfglog, "Log changes using the T api needed for realtime syncing");
+	SETPREF ("cfg.newtab", "false", "Show descriptions in command completion");
 	SETCB ("cfg.debug", "false", &cb_cfgdebug, "Debugger mode");
 	p = r_sys_getenv ("EDITOR");
 #if __WINDOWS__ && !__CYGWIN__
@@ -2320,7 +2321,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("cmd.fcn.new", "", "Run when new function is analyzed");
 	SETPREF ("cmd.fcn.delete", "", "Run when a function is deleted");
 	SETPREF ("cmd.fcn.rename", "", "Run when a function is renamed");
-	SETPREF ("cmd.comphint", "false", "Show descriptions in command completion");
 	SETPREF ("cmd.visual", "", "Replace current print mode");
 	SETPREF ("cmd.vprompt", "", "Visual prompt commands");
 

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3112,9 +3112,9 @@ static void cmd_descriptor_init(RCore *core) {
 	qsort (cmd_descriptors, cmd_descriptors_len, sizeof (RCmdDescriptor), compare_cmd_descriptor_name);
 	int i, n_cmd_descriptors = cmd_descriptors_len;
 	for (i = 0; i < n_cmd_descriptors; i++) {
-		const char *p;
+		const ut8 *p;
 		RCmdDescriptor *x = &core->cmd_descriptor;
-		for (p = cmd_descriptors[i].name; *p; p++) {
+		for (p = (const ut8*)cmd_descriptors[i].name; *p; p++) {
 			if (!x->sub[*p]) {
 				if (cmd_descriptors_len >= MAX_NUM_CMD_DESCRIPTORS) {
 					eprintf ("Please increase MAX_NUM_CMD_DESCRIPTORS in libr/core/cmd.c\n");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2353,10 +2353,6 @@ static void __anal_reg_list(RCore *core, int type, int size, char mode) {
 	core->dbg->reg = hack;
 }
 
-static void ar_show_help(RCore *core) {
-	r_core_cmd_help (core, help_msg_ar);
-}
-
 // XXX dup from drp :OOO
 void cmd_anal_reg(RCore *core, const char *str) {
 	int size = 0, i, type = R_REG_TYPE_GPR;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -930,14 +930,6 @@ static void helpCmdAt(RCore *core) {
 	r_core_cmd_help (core, help_msg_at);
 }
 
-static void print_format_help_help(RCore *core) {
-	r_core_cmd_help (core, help_detail_pf);
-}
-
-static void print_format_help_help_help(RCore *core) {
-	r_core_cmd_help (core, help_detail2_pf);
-}
-
 static void print_format_help_help_help_help(RCore *core) {
 	const char *help_msg[] = {
 		"    STAHP IT!!!", "", "",
@@ -1005,7 +997,7 @@ static void cmd_print_format(RCore *core, const char *_input, int len) {
 						r_core_cmd_help (core, help_detail2_pf);
 					}
 				} else {
-					print_format_help_help (core);
+					r_core_cmd_help (core, help_detail_pf);
 				}
 			} else {
 				SdbListIter *iter;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1211,8 +1211,8 @@ static int autocomplete(RLine *line) {
 			line->completion.argc = i;
 			line->completion.argv = tmp_argv;
 		} else {
-			int i, j, cmd_comphint = r_config_get_i (core->config, "cmd.comphint");
-			if (cmd_comphint) {
+			int i, j, cfg_newtab = r_config_get_i (core->config, "cfg.newtab");
+			if (cfg_newtab) {
 				RCmdDescriptor *desc = &core->cmd_descriptor;
 				for (i = 0; i < line->buffer.index && desc; i++) {
 					ut8 c = line->buffer.data[i];


### PR DESCRIPTION
Fix #8023 
Rename cmd.comphint to cfg.newtab