### PR TITLE
Fix a little bug with log output

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5438,7 +5438,8 @@ static int cmd_anal_all(RCore *core, const char *input) {
 					r_core_cmd0 (core, "aat");
 					rowlog_done (core);
 				} else {
-					rowlog (core, "[*] Use -AA or aaaa to perform additional experimental analysis.\n");
+					rowlog (core, "Use -AA or aaaa to perform additional experimental analysis.");
+					rowlog_done (core);
 				}
 				r_config_set_i (core->config, "anal.calls", c);
 				rowlog (core, "Constructing a function name for fcn.* and sym.func.* functions (aan)");


### PR DESCRIPTION
Just a little bug fix which turn this:
![image](https://user-images.githubusercontent.com/20182642/28611980-57339552-71f6-11e7-9a61-6df6f0d7602f.png)

Into this:
![image](https://user-images.githubusercontent.com/20182642/28611920-17996f52-71f6-11e7-9881-1c23b917775d.png)

~cheers

