### PR TITLE
fix a wrong definition to call GetLongPathName and fix for #8044

### DIFF
--- a/libr/asm/arch/ppc/libvle/vle.h
+++ b/libr/asm/arch/ppc/libvle/vle.h
@@ -33,10 +33,10 @@ typedef struct {
 	int cond;
 } vle_t;
 
-int vle_init(vle_handle* handle, const ut8* buffer, const ut32 size);
-vle_t* vle_next(vle_handle* handle);
-int vle_option(vle_handle* handle, ut32 option);
-void vle_free(vle_t* instr);
-void vle_snprint(char* str, int size, ut64 addr, vle_t* instr);
+R_API int vle_init(vle_handle* handle, const ut8* buffer, const ut32 size);
+R_API vle_t* vle_next(vle_handle* handle);
+R_API int vle_option(vle_handle* handle, ut32 option);
+R_API void vle_free(vle_t* instr);
+R_API void vle_snprint(char* str, int size, ut64 addr, vle_t* instr);
 
 #endif

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2567,7 +2567,9 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 			return NULL;
 		}
 		exports_sz = (bin->export_directory->NumberOfFunctions + 1) * sizeof (struct r_bin_pe_export_t);
-		if (exports_sz < 0 || exports_sz > bin->size) {
+		// we cant exit with export_sz > bin->size, us r_bin_pe_export_t is 256+256+8+8+8+4 bytes is easy get over file size
+		// to avoid fuzzing we can abort on export_directory->NumberOfFunctions>0xffff
+		if (exports_sz < 0 || bin->export_directory->NumberOfFunctions + 1 > 0xffff) {
 			return NULL;
 		}
 		if (!(exports = malloc (exports_sz))) {

--- a/libr/bin/pdb/pdb_downloader.h
+++ b/libr/bin/pdb/pdb_downloader.h
@@ -42,7 +42,7 @@ void deinit_pdb_downloader(SPDBDownloader *pdb_downloader);
 
 ///
 /// \brief download PDB file
-int r_bin_pdb_download (RCore* core, int isradjson, int* actions_done, SPDBOptions* options);
+R_API int r_bin_pdb_download (RCore* core, int isradjson, int* actions_done, SPDBOptions* options);
 
 #ifdef __cplusplus
 }

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -873,7 +873,7 @@ R_API int r_file_mkstemp(const char *prefix, char **oname) {
 
 R_API char *r_file_tmpdir() {
 #if __WINDOWS__
-	TCHAR tmpdir[MAX_PATH];
+	CHAR tmpdir[MAX_PATH];
 	char *path = NULL;
 
 	if (GetTempPath (sizeof (tmpdir), tmpdir) == 0) {
@@ -882,7 +882,7 @@ R_API char *r_file_tmpdir() {
 			path = strdup ("C:\\WINDOWS\\Temp\\");
 		}
 	} else {
-		void (*glpn)(TCHAR *, TCHAR *, size_t) = (void*)r_lib_dl_sym (GetModuleHandle (TEXT ("kernel32.dll")), "GetLongPathNameW");
+		DWORD (WINAPI *glpn)(LPCSTR, LPCSTR, DWORD) = r_lib_dl_sym (GetModuleHandle (TEXT ("kernel32.dll")), "GetLongPathNameA");
 		if (glpn) {
 			// Windows XP sometimes returns short path name
 			glpn (tmpdir, tmpdir, sizeof (tmpdir));


### PR DESCRIPTION
-Some bugs fixeds in this little function:

1) If no WINAPI is specified the call is made as cdecl this make a crash...
2) the api used the unicode version and then try to do a strdup from unicode string ... also no unicode string was defined the tmpdir is defined as TCHAR = char ....

-Fixed compilation error under windows for ppc arch, some functions from anal need be R_API.
-Fixed export issue #8044