### PR TITLE
fix segfault in vsnprintf on 32 bit systems examining a PPC ELF

### DIFF
--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -623,7 +623,11 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			break;
 		case PPC_INS_CLRLWI:
 			op->type = R_ANAL_OP_TYPE_AND;
-			esilprintf (op, "%s,0x%"PFMT64x",&,%s,=", ARG (1), cmask32 (ARG (2), "31"), ARG (0));
+			#if __WORDSIZE == 64
+                        esilprintf (op, "%s,0x%"PFMT64x",&,%s,=", ARG (1), cmask32 (ARG (2), "31"), ARG (0));
+			#else
+                        esilprintf (op, "%s,0x%"PFMT32x",&,%s,=", ARG (1), cmask32 (ARG (2), "31"), ARG (0));
+			#endif
 			break;
 		case PPC_INS_RLWINM:
 			op->type = R_ANAL_OP_TYPE_ROL;

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -623,7 +623,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			break;
 		case PPC_INS_CLRLWI:
 			op->type = R_ANAL_OP_TYPE_AND;
-                        esilprintf (op, "%s,0x%"PFMT64x",&,%s,=", ARG (1), (ut64) cmask32 (ARG (2), "31"), ARG (0));
+			esilprintf (op, "%s,0x%"PFMT64x",&,%s,=", ARG (1), (ut64) cmask32 (ARG (2), "31"), ARG (0));
 			break;
 		case PPC_INS_RLWINM:
 			op->type = R_ANAL_OP_TYPE_ROL;

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -623,11 +623,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			break;
 		case PPC_INS_CLRLWI:
 			op->type = R_ANAL_OP_TYPE_AND;
-			#if __WORDSIZE == 64
-                        esilprintf (op, "%s,0x%"PFMT64x",&,%s,=", ARG (1), cmask32 (ARG (2), "31"), ARG (0));
-			#else
-                        esilprintf (op, "%s,0x%"PFMT32x",&,%s,=", ARG (1), cmask32 (ARG (2), "31"), ARG (0));
-			#endif
+                        esilprintf (op, "%s,0x%"PFMT64x",&,%s,=", ARG (1), (ut64) cmask32 (ARG (2), "31"), ARG (0));
 			break;
 		case PPC_INS_RLWINM:
 			op->type = R_ANAL_OP_TYPE_ROL;


### PR DESCRIPTION
On a 32-bit x86 computer, examining a PowerPC ELF with the "aa" command caused a segfault in vsnprintf. 

The %llx  (PFMT64x) format attempts to get the next 64 bits from the stack. This will consume the cmask32 and ARG(0) values. The following "%s" will cause a segfault if the next 32 bits is not pointing to readable memory.

I doubt this is the best fix. Maybe libr/include/r_types.h should be changed? You guys know better.