### PR TITLE
PDB Autoloading when debugging

### DIFF
--- a/libr/bin/pdb/pdb_downloader.c
+++ b/libr/bin/pdb/pdb_downloader.c
@@ -7,19 +7,16 @@
 static int checkPrograms () {
 #if __WINDOWS__ && !__CYGWIN__
 	char nul[] = "nul";
-	if (r_sys_cmd ("expand >nul") != 0) {
-		eprintf ("Missing expand\n");
+	if (r_sys_cmd ("expand -? >nul") != 0) {
 		return 0;
 	}
 #else
 	char nul[] = "/dev/null";
-	if (r_sys_cmd ("cabextract -v > /dev/null") != 0) {
-		eprintf ("Missing cabextract\n");
+	if (r_sys_cmd ("cabextract -v >/dev/null") != 0) {
 		return 0;
 	}
 #endif
 	if (r_sys_cmdf ("curl --version >%s", nul) != 0) {
-		eprintf ("Missing curl\n");
 		return 0;
 	}
 	return 1;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1949,6 +1949,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("pdb.useragent", "Microsoft-Symbol-Server/6.11.0001.402", "User agent for Microsoft symbol server");
 	SETPREF ("pdb.server", "https://msdl.microsoft.com/download/symbols", "Base URL for Microsoft symbol server");
 	SETI ("pdb.extract", 1, "Avoid extract of the pdb file, just download");
+	SETI ("pdb.autoload", false, "Automatically load the required pdb files for loaded DLLs");
 
 	/* anal */
 	SETPREF ("anal.fcnprefix", "fcn",  "Prefix new function names with this");

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -221,7 +221,9 @@ R_API int r_core_bind(RCore *core, RCoreBind *bnd) {
 	bnd->core = core;
 	bnd->bphit = (RCoreDebugBpHit)r_core_debug_breakpoint_hit;
 	bnd->cmd = (RCoreCmd)r_core_cmd0;
+	bnd->cmdf = (RCoreCmdF)r_core_cmdf;
 	bnd->cmdstr = (RCoreCmdStr)r_core_cmd_str;
+	bnd->cmdstrf = (RCoreCmdF)r_core_cmd_strf;
 	bnd->puts = (RCorePuts)r_cons_strcat;
 	bnd->setab = (RCoreSetArchBits)setab;
 	bnd->getName = (RCoreGetName)getName;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -3,6 +3,7 @@
 #include <r_userconf.h>
 #include <r_debug.h>
 #include <r_asm.h>
+#include <r_core.h>
 #include <r_reg.h>
 #include <r_lib.h>
 #include <r_anal.h>
@@ -301,7 +302,7 @@ static bool tracelib(RDebug *dbg, const char *mode, PLIB_ITEM item) {
 #endif
 
 /*
- * wait for an event and start trying to figure out what to do with it.
+ * Wait for an event and start trying to figure out what to do with it.
  *
  * Returns R_DEBUG_REASON_*
  */
@@ -318,11 +319,35 @@ static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 				reason = R_DEBUG_REASON_TRAP;
 			}
 			r_debug_info_free (r);
+
+			/* Check if autoload PDB is set, and load PDB information if yes */
+			bool autoload_pdb = false;
+			RCore* core = dbg->corebind.core;
+			if (core) {
+				autoload_pdb = r_config_get_i (core->config, "pdb.autoload");
+			}
+			if (autoload_pdb) {
+				char* o_res = dbg->corebind.cmdstrf (core, "o %s", ((PLIB_ITEM)(r->lib))->Path);
+				// File exists since we loaded it, however the "o" command fails sometimes hence the while loop
+				while (*o_res == 0) {
+					o_res = dbg->corebind.cmdstrf (core, "o %s", ((PLIB_ITEM)(r->lib))->Path);
+				}
+				int fd = atoi (o_res);
+				dbg->corebind.cmdf (core, "o %d", fd);
+				char* pdb_path = dbg->corebind.cmdstr (core, "i~pdb");
+				if (*pdb_path == 0) {
+					eprintf ("Failure...\n");
+					dbg->corebind.cmd (core, "i", 1);
+				} else {
+					pdb_path = strchr (pdb_path, ' ') + 1;
+					dbg->corebind.cmdf (core, ".idp* %s", pdb_path);
+				}
+				dbg->corebind.cmdf (core, "o-%d", fd);
+			}
 		} else {
 			eprintf ("Loading unknown library.\n");
 		}
-	}
-	else if (reason == R_DEBUG_REASON_EXIT_LIB) {
+	} else if (reason == R_DEBUG_REASON_EXIT_LIB) {
 		RDebugInfo *r = r_debug_native_info (dbg, "");
 		if (r && r->lib) {
 			if (tracelib (dbg, "unload", r->lib)) {

--- a/libr/include/r_bind.h
+++ b/libr/include/r_bind.h
@@ -6,8 +6,10 @@
 // TODO: move rprint here too
 
 typedef int (*RCoreCmd)(void *core, const char *cmd);
+typedef int (*RCoreCmdF)(void *user, const char *fmt, ...);
 typedef int (*RCoreDebugBpHit)(void *core, void *bp);
 typedef char* (*RCoreCmdStr)(void *core, const char *cmd);
+typedef char* (*RCoreCmdStrF)(void *core, const char *cmd, ...);
 typedef void (*RCorePuts)(const char *cmd);
 typedef void (*RCoreSetArchBits)(void *core, const char *arch, int bits);
 typedef char *(*RCoreGetName)(void *core, ut64 off);
@@ -16,7 +18,9 @@ typedef void (*RCoreSeekArchBits)(void *core, ut64 addr);
 typedef struct r_core_bind_t {
 	void *core;
 	RCoreCmd cmd;
+	RCoreCmdF cmdf;
 	RCoreCmdStr cmdstr;
+	RCoreCmdStrF cmdstrf;
 	RCorePuts puts;
 	RCoreDebugBpHit bphit;
 	RCoreSetArchBits setab;


### PR DESCRIPTION
Supposed to fix this https://github.com/radare/radare2/issues/3128 but it does not work because o does not map the opened DLL at the same offset, so the flags are misplaced.