### PR TITLE
asm.strenc: tighten up guess for utf16le string

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -691,7 +691,7 @@ static int cb_asmstrenc (void *user, void *data) {
 	RConfigNode *node = (RConfigNode *)data;
 	if (node->value[0] == '?') {
 		print_node_options (node);
-		r_cons_printf ("  -- if string's 2nd byte is 0 then utf16le else "
+		r_cons_printf ("  -- if string's 2nd & 4th bytes are 0 then utf16le else "
 		               "if utf8 char detected then utf8 else latin1\n");
 		return false;
 	}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2677,13 +2677,10 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len) {
 		break;
 	default:
 		str_len = strlen (str);
-		if (str_len == 1) {
-			// could be a wide string
+		if (str_len == 1 && len > 3 && str[2] && !str[3]) {
+			// could be a utf16le string
 			escstr = r_str_escape_utf16le (str, len, ds->show_asciidot);
-			if (escstr) {
-				int escstr_len = strlen (escstr);
-				prefix = escstr_len == 1 || (escstr_len == 2 && escstr[0] == '\\') ? "" : "u";
-			}
+			prefix = "u";
 		} else {
 			RStrEnc enc = R_STRING_ENC_LATIN1;
 			const char *ptr = str, *end = str + str_len;


### PR DESCRIPTION
This appears equivalent to what is done in `string_scan_range` of `bin.c` except for the first-char utf8 check. Greatly reduces the false positive in #7755.