### PR TITLE
Fix creation of invalid function refs when saving/loading a project.

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2043,13 +2043,13 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	r_list_foreach (fcn->refs, refiter, refi) {
 		switch (refi->type) {
 		case R_ANAL_REF_TYPE_CALL:
-			r_cons_printf ("afxC 0x%"PFMT64x" 0x%"PFMT64x"\n", fcn->addr, refi->addr);
+			r_cons_printf ("afxC 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->at, refi->addr);
 			break;
 		case R_ANAL_REF_TYPE_DATA:
-			r_cons_printf ("afxd 0x%"PFMT64x" 0x%"PFMT64x"\n", fcn->addr, refi->addr);
+			r_cons_printf ("afxd 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->at, refi->addr);
 			break;
 		case R_ANAL_REF_TYPE_CODE:
-			r_cons_printf ("afxc 0x%"PFMT64x" 0x%"PFMT64x"\n", fcn->addr, refi->addr);
+			r_cons_printf ("afxc 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->at, refi->addr);
 			break;
 		}
 	}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2169,7 +2169,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 				*p = 0;
 				a = r_num_math (core->num, mi + 3);
 				b = r_num_math (core->num, p + 1);
-				fcn = r_anal_get_fcn_in (core->anal, a, R_ANAL_FCN_TYPE_ROOT);
+				fcn = r_anal_get_fcn_in (core->anal, a, R_ANAL_FCN_TYPE_NULL);
 				if (fcn) {
 					r_anal_fcn_xref_add (core->anal, fcn, a, b, input[2]);
 				} else eprintf ("Cannot add reference to non-function\n");


### PR DESCRIPTION
This resolves radare/radare2#7774.

When saving a project, a dump of the output from the "afl*" command is
used to store all the function references in the project rc file. The
handler for "afl*" generates many afx[cCd] commands to add function
references. However, instead of using the actual reference from
address, the handler uses the function root address as the from
address for the afx[cCd] command. After loading a project, the
execution of the commands in the project rc file causes the invalid
function xrefs to be created, as described in radare/radare2#7774.

The fix does two things. First it changes the way the afx[cCd]
commands are generated by the "afl*" handler so it uses the actual
reference from address instead of the function root address for the
afx[cCd] from address. Second, it changes the afx[cCds] command
handler to add function references even when the reference from
address is not necessarily a function root. I'm not sure why the
original code required the from address to be a function root.

This fixes the output of commands axt and afx after loading a
project. They now match the command output prior to saving a project.