### PR TITLE
Add `asm.addrbytes` eval config var to make one vaddr unit use more than 1 bytes

### DIFF
--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -462,6 +462,8 @@ int main (int argc, char *argv[]) {
 		r_asm_set_bits (a, sysbits);
 		r_anal_set_bits (anal, sysbits);
 	}
+	// TODO set addrbytes
+	anal->addrbytes = a->addrbytes = 1;
 	char *r2arch = r_sys_getenv ("R2_ARCH");
 	if (r2arch) {
 		arch = r2arch;

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -413,9 +413,6 @@ R_API int r_asm_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	} else {
 		oplen = op->size;
 	}
-	if (oplen > len) {
-		oplen = len;
-	}
 	if (oplen < 1) {
 		oplen = 1;
 	}
@@ -438,11 +435,8 @@ R_API int r_asm_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	}
 	//XXX check against R_ASM_BUFSIZE other oob write
 	memcpy (op->buf, buf, R_MIN (R_ASM_BUFSIZE - 1, oplen));
-	*op->buf_hex = 0;
-	if ((oplen * 4) >= sizeof (op->buf_hex)) {
-		oplen = (sizeof (op->buf_hex) / 4) - 1;
-	}
-	r_hex_bin2str (buf, oplen, op->buf_hex);
+	r_hex_bin2str (buf, R_MIN (a->addrbytes * oplen,
+														 (sizeof (op->buf_hex) - 1) / 2), op->buf_hex);
 	return ret;
 }
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2032,6 +2032,7 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* asm */
 	//asm.os needs to be first, since other asm.* depend on it
+	SETI ("asm.addrbytes", 1,  "Number of bytes one vaddr unit uses");
 	n = NODECB ("asm.os", R_SYS_OS, &cb_asmos);
 	SETDESC (n, "Select operating system (kernel)");
 	SETOPTIONS (n, "ios", "dos", "darwin", "linux", "freebsd", "openbsd", "netbsd", "windows", NULL);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -639,6 +639,17 @@ static int cb_emuskip(void *user, void *data) {
 	return true;
 }
 
+static int cb_asm_addrbytes(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	if (node->i_value < 1) {
+		eprintf ("asm.arch: asm.addrbytes should >= 1\n");
+		return false;
+	}
+	core->anal->addrbytes = core->assembler->addrbytes = node->i_value;
+	return true;
+}
+
 static int cb_asm_invhex(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -2032,7 +2043,7 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* asm */
 	//asm.os needs to be first, since other asm.* depend on it
-	SETI ("asm.addrbytes", 1,  "Number of bytes one vaddr unit uses");
+	SETICB ("asm.addrbytes", 1,  &cb_asm_addrbytes, "Number of bytes one vaddr unit uses");
 	n = NODECB ("asm.os", R_SYS_OS, &cb_asmos);
 	SETDESC (n, "Select operating system (kernel)");
 	SETOPTIONS (n, "ios", "dos", "darwin", "linux", "freebsd", "openbsd", "netbsd", "windows", NULL);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3306,6 +3306,7 @@ static int cmd_print(void *data, const char *input) {
 	ut32 tbs = core->blocksize;
 	ut64 n, off, from, to, at, ate, piece;
 	ut64 tmpseek = UT64_MAX;
+	int addrbytes = core->assembler->addrbytes;
 	mode = w = p = i = l = len = ret = 0;
 	n = off = from = to = at = ate = piece = 0;
 
@@ -4210,17 +4211,17 @@ static int cmd_print(void *data, const char *input) {
 						eprintf ("Block size too big\n");
 						return 1;
 					}
-					block = malloc (l);
+					block = malloc (addrbytes * l);
 					if (block) {
-						if (l > core->blocksize) {
-							r_core_read_at (core, addr, block, l); // core->blocksize);
+						if (addrbytes * l > core->blocksize) {
+							r_core_read_at (core, addr, block, addrbytes * l); // core->blocksize);
 						} else {
-							memcpy (block, core->block, l);
+							memcpy (block, core->block, addrbytes * l);
 						}
 						core->num->value = r_core_print_disasm (core->print,
-							core, addr, block, l, l, 0, 1);
+							core, addr, block, addrbytes * l, l, 0, 1);
 					} else {
-						eprintf ("Cannot allocate %d bytes\n", l);
+						eprintf ("Cannot allocate %d bytes\n", addrbytes * l);
 					}
 				} else {
 					block = malloc (R_MAX (l * 10, bs));

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -56,7 +56,6 @@ typedef struct r_disam_options_t {
 	bool capitalize;
 	bool show_flgoff;
 	bool hasMidflag;
-	int addrbytes;
 	int atabs;
 	int atabsonce;
 	int atabsoff;
@@ -413,7 +412,6 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->color_gui_alt_background = P(gui_alt_background): Color_GRAY;
 	ds->color_gui_border = P(gui_border): Color_BGGRAY;
 
-	ds->addrbytes = r_config_get_i (core->config, "asm.addrbytes");
 	ds->use_esil = r_config_get_i (core->config, "asm.esil");
 	ds->show_flgoff = r_config_get_i (core->config, "asm.flgoff");
 	ds->show_nodup = r_config_get_i (core->config, "asm.nodup");
@@ -2143,6 +2141,7 @@ static void ds_instruction_mov_lea(RDisasmState *ds, int idx) {
 	RCore *core = ds->core;
 	RAnalValue *src;
 	char *nl = ds->show_comment_right ? "" : "\n";
+	int addrbytes = core->assembler->addrbytes;
 
 	switch (ds->analop.type) {
 	case R_ANAL_OP_TYPE_LENGTH:
@@ -2158,7 +2157,7 @@ static void ds_instruction_mov_lea(RDisasmState *ds, int idx) {
 					if (src->reg->name && pc && !strcmp (src->reg->name, pc)) {
 						RFlagItem *item;
 						ut8 b[8];
-						ut64 ptr = ds->addrbytes * idx + ds->addr + src->delta + ds->analop.size;
+						ut64 ptr = addrbytes * idx + ds->addr + src->delta + ds->analop.size;
 						ut64 off = 0LL;
 						r_core_read_at (core, ptr, b, src->memref);
 						off = r_mem_get_num (b, src->memref);
@@ -3548,6 +3547,7 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 	int dorepeat = 1;
 	ut8 *nbuf = NULL;
 	RDisasmState *ds;
+	int addrbytes = core->assembler->addrbytes;
 
 	// TODO: All those ds must be print flags
 	ds = ds_init (core);
@@ -3615,7 +3615,7 @@ toro:
 	ds->stackptr = core->anal->stackptr;
 	r_cons_break_push (NULL, NULL);
 	r_anal_build_range_on_hints (core->anal);
-	for (i = idx = ret = 0; ds->addrbytes * idx < len && ds->lines < ds->l; idx += inc, i++, ds->index += inc, ds->lines++) {
+	for (i = idx = ret = 0; addrbytes * idx < len && ds->lines < ds->l; idx += inc, i++, ds->index += inc, ds->lines++) {
 		ds->at = ds->addr + idx;
 		ds->vat = p2v (ds, ds->at);
 		if (r_cons_is_breaked ()) {
@@ -3681,7 +3681,7 @@ toro:
 			}
 		} else {
 			if (idx >= 0) {
-				ret = ds_disassemble (ds, buf + ds->addrbytes * idx, len - ds->addrbytes * idx);
+				ret = ds_disassemble (ds, buf + addrbytes * idx, len - addrbytes * idx);
 				if (ret == -31337) {
 					inc = ds->oplen;
 					continue;
@@ -3702,7 +3702,7 @@ toro:
 			r_anal_op_fini (&ds->analop);
 		}
 		if (!ds->lastfail) {
-			r_anal_op (core->anal, &ds->analop, ds->at, buf + ds->addrbytes * idx, (int)(len - ds->addrbytes * idx));
+			r_anal_op (core->anal, &ds->analop, ds->at, buf + addrbytes * idx, (int)(len - addrbytes * idx));
 		}
 		if (ret < 1) {
 			r_strbuf_init (&ds->analop.esil);
@@ -3776,12 +3776,12 @@ toro:
 			ds_print_dwarf (ds);
 			ret = ds_print_middle (ds, ret);
 
-			ds_print_asmop_payload (ds, buf + ds->addrbytes * idx);
+			ds_print_asmop_payload (ds, buf + addrbytes * idx);
 			if (core->assembler->syntax != R_ASM_SYNTAX_INTEL) {
 				RAsmOp ao; /* disassemble for the vm .. */
 				int os = core->assembler->syntax;
 				r_asm_set_syntax (core->assembler, R_ASM_SYNTAX_INTEL);
-				r_asm_disassemble (core->assembler, &ao, buf + ds->addrbytes * idx, len - ds->addrbytes * idx + 5);
+				r_asm_disassemble (core->assembler, &ao, buf + addrbytes * idx, len - addrbytes * idx + 5);
 				r_asm_set_syntax (core->assembler, os);
 			}
 			ds_print_core_vmode (ds);
@@ -3881,7 +3881,7 @@ toro:
 	R_FREE (nbuf);
 	/* used by asm.emu */
 	r_reg_arena_pop (core->anal->reg);
-	return ds->addrbytes * idx; //-ds->lastfail;
+	return addrbytes * idx; //-ds->lastfail;
 }
 
 /* Disassemble either `nb_opcodes` instructions, or

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -591,6 +591,7 @@ typedef struct r_anal_t {
 	char *cpu;
 	char *os;
 	int bits;
+	int addrbytes;
 	int lineswidth; // wtf
 	int big_endian;
 	int split; // used only from core

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -96,6 +96,7 @@ typedef struct {
 typedef struct r_asm_t {
 	char *cpu;
 	int bits;
+	int addrbytes;
 	int big_endian;
 	int syntax;
 	ut64 pc;


### PR DESCRIPTION
To support cLEMENCy, no 9-bit specific code should be kept to make the code base clean. This commit enables an alternative disassembly solution:

- An IO plugin making "seek to vaddr i" correspond to "seek to file offset 2*i"
- In `disasm.c`, vaddr advances at a different pace (1 in the case of 16-bit padding of cLEMENCy) of how the file offset (various `ut8 *buf` arguments or local variables. 2 in the case). This is achieved by setting `e asm.addrbytes=2`.

There may be other variables depending on `len` that are not changed to `ds->addrbytes * len`. But it should cause no trouble to normal architectures.

With this commit, I'm able to disassemble cLEMENCy instructions (`buf_hex[]` does not reflect the correct length in the picture)

![](https://ptpb.pw/SzCZ.jpg)