### PR TITLE
fixed meson compilation

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -9,14 +9,12 @@
 
 #if __linux__ && __GNU_LIBRARY__ && __GLIBC__ && __GLIBC_MINOR__
 #include "r_heap_glibc.h"
-#endif
-
 #define HAVE_JEMALLOC 1
 #if HAVE_JEMALLOC
 #include "r_heap_jemalloc.h"
 #include "linux_heap_jemalloc.c"
 #endif
-
+#endif
 static const char *help_msg_d[] = {
 	"Usage:", "d", " # Debug commands",
 	"db", "[?]", "Breakpoints commands",

--- a/libr/core/meson.build
+++ b/libr/core/meson.build
@@ -60,7 +60,8 @@ files=[
 ]
 r_core = library('r_core', files,
   include_directories: [platform_inc, include_directories([
-	'../../shlr'
+	'../../shlr',
+	'../../shlr/heap/include'
   ])],
   c_args: ['-DCORELIB=1', '-I' + meson.current_build_dir() + '/../..'],
   link_with: [r_util, r_reg, r_syscall, r_search, r_cons, r_anal, r_socket, r_io, r_fs, r_lang, r_hash, r_flag, r_parse, r_egg, r_debug, r_magic, r_crypto, r_config, r_bin, r_asm, r_bp],


### PR DESCRIPTION
The jemalloc pr break windows build, to avoid this only jemalloc is usable for non windows version of radare, i need check all the changes to can build under win