### PR TITLE
Fix leaks in canal.c

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -116,7 +116,7 @@ R_API int r_anal_xrefs_from (RAnal *anal, RList *list, const char *kind, const R
 }
 
 R_API RList *r_anal_xrefs_get (RAnal *anal, ut64 to) {
-	RList *list = r_list_new ();
+	RList *list = r_list_newf (r_anal_ref_free);
 	if (!list) {
 		return NULL;
 	}
@@ -133,7 +133,7 @@ R_API RList *r_anal_xrefs_get (RAnal *anal, ut64 to) {
 }
 
 R_API RList *r_anal_refs_get (RAnal *anal, ut64 from) {
-	RList *list = r_list_new ();
+	RList *list = r_list_newf (r_anal_ref_free);
 	if (!list) {
 		return NULL;
 	}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -731,6 +731,7 @@ static void ds_build_op_str(RDisasmState *ds) {
 					break;
 				}
 			}
+			r_list_free (list);
 		}
 	}
 	char *asm_str = colorize_asm_string (core, ds);
@@ -2770,6 +2771,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			}
 		}
 	}
+	r_list_free (list);
 	bool flag_printed = false;
 	bool refaddr_printed = false;
 	bool string_printed = false;
@@ -4873,6 +4875,7 @@ R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt) 
 					r_cons_printf ("%s%s"Color_RESET "\n",
 						r_print_color_op_type (core->print, aop.type),
 						asm_str);
+					r_anal_op_fini (&aop);
 				} else {
 					r_cons_println (asm_str);
 				}


### PR DESCRIPTION
This PR (freeing `op`) is on top of #8152 .

When doing `r2 =true -c aaaa`, there is at least one other leak: some of bb created in `appendBasicBlock` are not listed in `r_core_fini`.

```
Indirect leak of 6 byte(s) in 1 object(s) allocated from:                                                                                                                 
    #0 0x7fae8a8cda48 in __interceptor_calloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:70                                                       
    #1 0x7fae882f486c in r_anal_bb_new /home/ray/Dev/Bin/radare2/libr/anal/bb.c:24                                                                                        
    #2 0x7fae882e687f in appendBasicBlock /home/ray/Dev/Bin/radare2/libr/anal/fcn.c:247                                                                                   
    #3 0x7fae882e95d7 in fcn_recurse /home/ray/Dev/Bin/radare2/libr/anal/fcn.c:611  
```