### PR TITLE
Move ich command to icc

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2463,7 +2463,7 @@ static int bin_classes(RCore *r, int mode) {
 				}
 				r_cons_printf ("}\n");
 				r_list_foreach (c->methods, iter3, sym) {
-					if (sym->rtype && sym->rtype[0] != "@") {
+					if (sym->rtype && sym->rtype[0] != '@') {
 						rp = get_rp (sym->rtype);
 						r_cons_printf ("%s (%s) %s\n", strncmp (sym->type,"METH",4) ? "+": "-", rp, sym->dname? sym->dname: sym->name);
 					}

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -19,7 +19,7 @@ static const char *help_msg_i[] = {
 	"ia", "", "Show all info (imports, exports, sections..)",
 	"ib", "", "Reload the current buffer for setting of the bin (use once only)",
 	"ic", "", "List classes, methods and fields",
-	"ich", "", "List classes, methods and fields in Header Format",
+	"icc", "", "List classes, methods and fields in Header Format",
 	"iC", "", "Show signature info (entitlements, ...)",
 	"id", "[?]", "Debug information (source lines)",
 	"iD", " lang sym", "demangle symbolname for given language",
@@ -624,8 +624,8 @@ static int cmd_info(void *data, const char *input) {
 			break;
 		case 'c': // for r2 `ic`
 			if (input[1] == '?') {
-				eprintf ("Usage: ic[ljq*] [class-index or name]\n");
-			} else if (input[1] == ' ' || input[1] == 'q' || input[1] == 'j' || input[1] == 'l' || input[1] == 'h') {
+				eprintf ("Usage: ic[ljqc*] [class-index or name]\n");
+			} else if (input[1] == ' ' || input[1] == 'q' || input[1] == 'j' || input[1] == 'l' || input[1] == 'c') {
 				RBinClass *cls;
 				RBinSymbol *sym;
 				RListIter *iter, *iter2;
@@ -709,9 +709,10 @@ static int cmd_info(void *data, const char *input) {
 									r_cons_newline ();
 								}
 							}
-						} else if (input[1] == 'h' && obj) { // "ich"
+						} else if (input[1] == 'c' && obj) { // "icc"
                 					mode = R_CORE_BIN_CLASSDUMP;
 							RBININFO ("classes", R_CORE_BIN_ACC_CLASSES, NULL, r_list_length (obj->classes));
+							input = " ";
 						} else {
 							RBININFO ("classes", R_CORE_BIN_ACC_CLASSES, NULL, r_list_length (obj->classes));
 						}

--- a/man/rabin2.1
+++ b/man/rabin2.1
@@ -38,6 +38,8 @@ Set bits (32, 64, ...)
 Override baddr
 .It Fl c
 List classes
+.It Fl cc
+List classes in header format
 .It Fl C Ar [fmt:C[:D]]
 Create [elf,mach0,pe] for arm and x86-32/64 tiny binaries where 'C' is an hexpair list of the code bytes and ':D' is an optional concatenation to describe the bytes for the data section.
 .It Fl d


### PR DESCRIPTION
The command ich has been changed to icc in order to be consistent with rabin2.

Rabin2 man page has been updated.