### PR TITLE
Replace non-breaking spaces with 0x20

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3147,7 +3147,7 @@ static void do_debug_trace_calls(RCore *core, ut64 from, ut64 to, ut64 final_add
 				if (!called_in_range && addr_in_range && !shallow_trace) {
 					debug_to = addr + aop.size;
 				}
-				if (addr_in_range || shallow_trace) {
+				if (addr_in_range || shallow_trace) {
 					cur = add_trace_tree_child (tracenodes, tr, cur, addr);
 					if (debug_to != UT64_MAX) {
 						cur = cur->parent;
@@ -3162,7 +3162,7 @@ static void do_debug_trace_calls(RCore *core, ut64 from, ut64 to, ut64 final_add
 				if (!called_in_range && addr_in_range && !shallow_trace) {
 					debug_to = aop.addr + aop.size;
 				}
-				if (addr_in_range || shallow_trace) {
+				if (addr_in_range || shallow_trace) {
 					cur = add_trace_tree_child (tracenodes, tr, cur, addr);
 					if (debug_to != UT64_MAX) {
 						cur = cur->parent;


### PR DESCRIPTION
In 8748d5eb5eb1908a72bbaacc42327cbed83d1f34 non-breaking spaces were (accidentally) used instead of ASCII spaces, which results in compilation errors:

```
cmd_debug.c: In function ‘do_debug_trace_calls’:
cmd_debug.c:3150:5: error: stray ‘\302’ in program
     if (addr_in_range || shallow_trace) {
     ^
cmd_debug.c:3150:5: error: stray ‘\240’ in program
cmd_debug.c:3165:5: error: stray ‘\302’ in program
     if (addr_in_range || shallow_trace) {
     ^
cmd_debug.c:3165:5: error: stray ‘\240’ in program
```

This should fix the build.