### PR TITLE
Fix #8189 - refactor search.c

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1854,6 +1854,10 @@ static void do_string_search(RCore *core, struct search_parameters *param) {
 		r_cons_printf ("fs hits\n");
 	}
 	core->search->inverse = param->inverse;
+	// TODO Bad but is to be compatible with the legacy behavior
+	if (param->inverse) {
+		core->search->maxhits = 1;
+	}
 	searchcount = r_config_get_i (core->config, "search.count");
 	if (searchcount) {
 		searchcount++;
@@ -2265,7 +2269,7 @@ static int cmd_search(void *data, const char *input) {
                 //fin = ini + s->size;
         }
  */
-	maxhits = r_config_get_i (core->config, "search.maxhits");
+	core->search->maxhits = r_config_get_i (core->config, "search.maxhits");
 	searchprefix = r_config_get (core->config, "search.prefix");
 	core->search->overlap = r_config_get_i (core->config, "search.overlap");
 	// TODO: get ranges from current IO section
@@ -2670,7 +2674,7 @@ reread:
 		if (input[0] == 'j') {
 			json = true;
 		}
-	/* pass-thru */
+		// fallthrough
 	case ' ': // "/ " search string
 		inp = strdup (input + 1 + ignorecase + json);
 		len = r_str_unescape (inp);
@@ -2710,6 +2714,7 @@ reread:
 				break;
 			}
 			r_search_reset (core->search, R_SEARCH_REGEXP);
+			// TODO distance is unused
 			r_search_set_distance (core->search, (int)
 				r_config_get_i (core->config, "search.distance"));
 			r_search_kw_add (core->search, kw);
@@ -2788,7 +2793,7 @@ reread:
 					RSearchKeyword *kw;
 					r_search_reset (core->search, R_SEARCH_KEYWORD);
 					r_search_set_distance (core->search, (int)
-							r_config_get_i (core->config, "search.distance"));
+						r_config_get_i (core->config, "search.distance"));
 					kw = r_search_keyword_new (buf + offset, size - offset, NULL, 0, NULL);
 					if (kw) {
 						r_search_kw_add (core->search, kw);

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -34,8 +34,6 @@ typedef struct r_search_keyword_t {
 	ut8 *bin_binmask;
 	ut32 keyword_length;
 	ut32 binmask_length;
-	ut32 idx[R_SEARCH_DISTANCE_MAX]; // searching purposes
-	int distance;
 	void *data;
 	int count;
 	int kwidx;
@@ -56,12 +54,14 @@ typedef struct r_search_t {
 	int n_kws;
 	int mode;
 	ut32 pattern_size;
-	ut32 string_min; /* min number of matches */
-	ut32 string_max; /* max number of matches */
-	void *user; /* user data */
+	ut32 string_min; // max length of strings for R_SEARCH_STRING
+	ut32 string_max; // min length of strings for R_SEARCH_STRING
+	void *data; // data used by search algorithm
+	void *user; // user data passed to callback
 	RSearchCallback callback;
+	ut64 nhits;
+	ut64 maxhits;
 	RList *hits;
-	int nhits;
 	RMemoryPool *pool;
 	int distance;
 	int inverse;


### PR DESCRIPTION
* fix r_search_mybinparse_update when locating `a+a+b` in `a+a+a+b` where len(a) > 1, e.g. locating `ababc` in `abababc`
* swap the order of the nested loop from

  for (i = 0; i < len; i++)
    r_list_foreach (s->kws, iter, kw)

  to

  r_list_foreach (s->kws, iter, kw)
    for (i = 0; i < len; i++)

  rationale:
  + searching for more needles is rare. the branches used in inner loop harms performance
  + it's cumbersome to bookkeep for each kw in advanced searching algorithms



Fixed tests:

```
[FX]  42  cmd_search: /x with bin mask
[FX]  43  cmd_search: /x with bin mask
```