### PR TITLE
Additions to gdb xml parsing

### DIFF
--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -186,7 +186,9 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 }
 
 static int __close(RIODesc *fd) {
-	// TODO
+	gdbr_disconnect (desc);
+	gdbr_cleanup (desc);
+	free (desc);
 	return -1;
 }
 

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -222,6 +222,7 @@ int gdbr_disconnect(libgdbr_t *g) {
 	free (reg_cache.buf);
 	if (g->target.valid) {
 		free (g->target.regprofile);
+		free (g->registers);
 	}
 	g->connected = 0;
 	return 0;

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -273,7 +273,7 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 			}
 			strcpy (arch_regs[num_regs].name, regname);
 			arch_regs[num_regs].offset = reg_off;
-			arch_regs[num_regs].size = reg_sz;
+			arch_regs[num_regs].size = reg_sz / 8;
 			num_regs++;
 			arch_regs[num_regs].name[0] = '\0';
 			reg_off += reg_sz / 8;

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -130,14 +130,53 @@ static char *gdbr_read_feature(libgdbr_t *g, const char *file, ut64 *tot_len) {
 	return ret;
 }
 
+// NOTE:
+typedef struct {
+	char type[32];
+	struct {
+		char name[32];
+		ut32 bit_num;
+		ut32 sz; // size in bits
+	} fields[64];
+	ut32 num_bits;
+	ut32 num_fields;
+} gdbr_flags_reg_t;
+
+// sizeof (buf) needs to be atleast flags->num_bits + 1
+static void write_flag_bits (char *buf, const gdbr_flags_reg_t *flags) {
+	bool fc[26] = { false };
+	ut32 i, c;
+	memset (buf, '.', flags->num_bits);
+	buf[flags->num_bits] = '\0';
+	for (i = 0; i < flags->num_fields; i++) {
+		// How do we show multi-bit flags?
+		if (flags->fields[i].sz != 1) {
+			continue;
+		}
+		// To avoid duplicates. This skips flags if first char is same. i.e.
+		// for x86_64, it will skip VIF because VM already occured. This is
+		// same as default reg-profiles in r2
+		c = tolower (flags->fields[i].name[0]) - 'a';
+		if (fc[c]) {
+			continue;
+		}
+		fc[c] = true;
+		buf[flags->fields[i].bit_num] = 'a' + c;
+	}
+}
+
 static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 	char *arch, *feature, *reg, *reg_end, *regname, *reg_typ, *tmp1, *tmp2,
 	     tmpchar, pc_alias[64] = { 0 }, *profile = NULL;
 	ut64 reg_off = 0, reg_sz, reg_name_len, profile_line_len, profile_len = 0,
 	     profile_max_len = 0, blk_sz = 4096;
 	bool is_pc = false;
-	gdb_reg_t *arch_regs = NULL;
+	gdb_reg_t *arch_regs = NULL, *tmp_regs = NULL;
 	ut64 num_regs = 0, max_num_regs = 0, regs_blk_sz = 8;
+	gdbr_flags_reg_t *flags = NULL, *tmpflags = NULL;
+	ut64 num_flags = 0, num_fields = 0, name_sz = 0, cur_flag_num, i;
+	char *flagstr, *flagsend, *field_start, *field_end, flagtmpchar, fieldtmpchar;
+	char flag_bits[65];
 	// Find architecture
 	g->target.arch = R_SYS_ARCH_NONE;
 	if ((arch = strstr (xml_data, "<architecture"))) {
@@ -165,50 +204,132 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 	feature = xml_data;
 	while ((feature = strstr (feature, "<feature"))) {
 		reg = feature;
+		flagstr = reg;
 		if (!(feature = strstr (feature, "</feature>"))) {
-			free (profile);
-			free (arch_regs);
-			return -1;
+			goto exit_err;
 		}
+		*feature = '\0';
 		feature += strlen ("</feature>");
+		// Get flags
+		while ((flagstr = strstr (flagstr, "<flags"))) {
+			if (!(flagsend = strstr (flagstr, "</flags>"))) {
+				goto exit_err;
+			}
+			flagtmpchar = *flagsend;
+			*flagsend = '\0';
+			tmpflags = realloc (flags, (num_flags + 1) * sizeof (gdbr_flags_reg_t));
+			if (!tmpflags) {
+				goto exit_err;
+			}
+			flags = tmpflags;
+			memset (&flags[num_flags], 0, sizeof (gdbr_flags_reg_t));
+			// Get id
+			if (!(tmp1 = strstr (flagstr, "id="))) {
+				goto exit_err;
+			}
+			tmp1 += 4;
+			if (!(tmp2 = strchr (tmp1, '"'))) {
+				goto exit_err;
+			}
+			tmpchar = *tmp2;
+			*tmp2 = '\0';
+			name_sz = sizeof (flags[num_flags].type);
+			strncpy (flags[num_flags].type, tmp1, name_sz - 1);
+			flags[num_flags].type[name_sz - 1] = '\0';
+			*tmp2 = tmpchar;
+			// Get size of flags register
+			if (!(tmp1 = strstr (flagstr, "size="))) {
+				goto exit_err;
+			}
+			tmp1 += 6;
+			if (!(flags[num_flags].num_bits = (ut32) strtoul (tmp1, NULL, 10))) {
+				goto exit_err;
+			}
+			flags[num_flags].num_bits *= 8;
+			field_start = flagstr;
+			num_fields = 0;
+			while ((field_start = strstr (field_start, "<field"))) {
+				if (num_fields == 64) {
+					break;
+				}
+				if (!(field_end = strstr (field_start, "/>"))) {
+					goto exit_err;
+				}
+				fieldtmpchar = *field_end;
+				*field_end = '\0';
+				// Get name
+				if (!(tmp1 = strstr (field_start, "name="))) {
+					goto exit_err;
+				}
+				tmp1 += 6;
+				if (!(tmp2 = strchr (tmp1, '"'))) {
+					goto exit_err;
+				}
+				// If name length is 0, it is a 1 field. Don't include
+				if (tmp2 - tmp1 <= 1) {
+					*field_end = fieldtmpchar;
+					field_start = field_end + 1;
+					continue;
+				}
+				tmpchar = *tmp2;
+				*tmp2 = '\0';
+				name_sz = sizeof (flags[num_flags].fields[num_fields].name);
+				strncpy (flags[num_flags].fields[num_fields].name,
+					 tmp1, name_sz - 1);
+				flags[num_flags].fields[num_fields].name[name_sz - 1] = '\0';
+				*tmp2 = tmpchar;
+				// Get offset
+				if (!(tmp1 = strstr (field_start, "start="))) {
+					goto exit_err;
+				}
+				tmp1 += 7;
+				if (!isdigit (*tmp1)) {
+					goto exit_err;
+				}
+				flags[num_flags].fields[num_fields].bit_num = (ut32) strtoul (tmp1, NULL, 10);
+				// Get end
+				if (!(tmp1 = strstr (field_start, "end="))) {
+					goto exit_err;
+				}
+				tmp1 += 5;
+				if (!isdigit (*tmp1)) {
+					goto exit_err;
+				}
+				flags[num_flags].fields[num_fields].sz = (ut32) strtoul (tmp1, NULL, 10) + 1;
+				flags[num_flags].fields[num_fields].sz -= flags[num_flags].fields[num_fields].bit_num;
+				num_fields++;
+				*field_end = fieldtmpchar;
+				field_start = field_end + 1;
+			}
+			flags[num_flags].num_fields = num_fields;
+			num_flags++;
+			*flagsend = flagtmpchar;
+			flagstr = flagsend + 1;
+		}
 		// Get registers
 		while ((reg = strstr (reg, "<reg")) && reg < feature) {
 			// null out end of reg description
 			if (!(reg_end = strchr (reg, '/')) || reg_end >= feature) {
-				free (profile);
-				free (arch_regs);
-				return -1;
+				goto exit_err;
 			}
 			tmpchar = *reg_end;
 			*reg_end = '\0';
 			// name
 			if (!(regname = strstr (reg, "name="))) {
-				free (profile);
-				free (arch_regs);
-				*reg_end = tmpchar;
-				return -1;
+				goto exit_err;
 			}
 			regname += 6;
 			if (!(tmp1 = strchr (regname, '"'))) {
-				free (profile);
-				free (arch_regs);
-				*reg_end = tmpchar;
-				return -1;
+				goto exit_err;
 			}
 			reg_name_len = tmp1 - regname;
 			// size
 			if (!(tmp1 = strstr (reg, "bitsize="))) {
-				free (profile);
-				free (arch_regs);
-				*reg_end = tmpchar;
-				return -1;
+				goto exit_err;
 			}
 			tmp1 += 9;
 			if (!isdigit (*tmp1)) {
-				free (profile);
-				free (arch_regs);
-				*reg_end = tmpchar;
-				return -1;
+				goto exit_err;
 			}
 			reg_sz = strtoul (tmp1, NULL, 10);
 			// type
@@ -235,15 +356,24 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 						pc_alias[reg_name_len + 5] = '\0';
 					}
 				}
+				// Check all flags
+				for (cur_flag_num = 0; cur_flag_num < num_flags; cur_flag_num++) {
+					if (r_str_startswith (tmp1, flags[cur_flag_num].type)) {
+						// Max 64-bit :/
+						if (flags[cur_flag_num].num_bits > 64) {
+							cur_flag_num = num_flags;
+							break;
+						}
+						break;
+					}
+				}
 				// We need type information in r2 register profiles
 			}
 			*reg_end = tmpchar;
 			profile_line_len = strlen (reg_typ) + reg_name_len + 64;
 			if (profile_max_len - profile_len <= profile_line_len) {
 				if (!(tmp2 = realloc (profile, profile_max_len + blk_sz))) {
-					free (profile);
-					free (arch_regs);
-					return -1;
+					goto exit_err;
 				}
 				profile = tmp2;
 				profile_max_len += blk_sz;
@@ -257,16 +387,36 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 			}
 			tmpchar = regname[reg_name_len];
 			regname[reg_name_len] = '\0';
+			flag_bits[0] = '\0';
+			if (cur_flag_num < num_flags) {
+				write_flag_bits (flag_bits, &flags[cur_flag_num]);
+			}
 			snprintf (profile + profile_len, profile_line_len, "%s\t%s\t"
-				".%"PFMT64d "\t%"PFMT64d "\t0\n", reg_typ, regname,
-				reg_sz, reg_off);
+				  ".%"PFMT64d "\t%"PFMT64d "\t0\t%s\n", reg_typ, regname,
+				  reg_sz, reg_off, flag_bits);
+			profile_len += strlen (profile + profile_len);
+			if (cur_flag_num < num_flags) {
+				for (i = 0; i < flags[cur_flag_num].num_fields; i++) {
+					profile_line_len = strlen (flags[cur_flag_num].fields[i].name) + 64;
+					if (profile_max_len - profile_len <= profile_line_len) {
+						if (!(tmp2 = realloc (profile, profile_max_len + blk_sz))) {
+							goto exit_err;
+						}
+						profile = tmp2;
+						profile_max_len += blk_sz;
+					}
+					snprintf (profile + profile_len, profile_line_len,
+						  "gpr\t%s\t.%d\t.%"PFMT64d"\t0\n",
+						  flags[cur_flag_num].fields[i].name,
+						  flags[cur_flag_num].fields[i].sz,
+						  flags[cur_flag_num].fields[i].bit_num + (reg_off * 8));
+					profile_len += strlen (profile + profile_len);
+				}
+			}
 			if (num_regs + 1 >= max_num_regs) {
-				gdb_reg_t *tmp_regs;
 				tmp_regs = realloc (arch_regs, (max_num_regs + regs_blk_sz) * sizeof (gdb_reg_t));
 				if (!tmp_regs) {
-					free (profile);
-					free (arch_regs);
-					return -1;
+					goto exit_err;
 				}
 				arch_regs = tmp_regs;
 				max_num_regs += regs_blk_sz;
@@ -278,7 +428,6 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 			arch_regs[num_regs].name[0] = '\0';
 			reg_off += reg_sz / 8;
 			regname[reg_name_len] = tmpchar;
-			profile_len += strlen (profile + profile_len);
 			reg = reg_end;
 		}
 	}
@@ -286,17 +435,22 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 		profile_line_len = strlen (pc_alias);
 		if (profile_max_len - profile_len <= profile_line_len) {
 			if (!(tmp2 = realloc (profile, profile_max_len + profile_line_len + 1 - profile_len))) {
-				free (profile);
-				free (arch_regs);
-				return -1;
+				goto exit_err;
 			}
 			profile = tmp2;
 		}
 		strcpy (profile + profile_len, pc_alias);
 	}
 	free (g->target.regprofile);
+	free (flags);
 	g->target.regprofile = profile;
 	g->target.valid = true;
 	g->registers = arch_regs;
 	return 0;
+
+exit_err:
+	free (profile);
+	free (arch_regs);
+	free (flags);
+	return -1;
 }

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -118,7 +118,7 @@ static char *gdbr_read_feature(libgdbr_t *g, const char *file, ut64 *tot_len) {
 				retmax += subret_len + 1;
 			}
 			memmove (tmp + subret_len, tmp + subret_space,
-				 retlen - (tmp + subret_space - ret));
+				retlen - (tmp + subret_space - ret));
 			memcpy (tmp, subret, subret_len);
 			retlen += subret_len - subret_space;
 			ret[retlen] = '\0';
@@ -143,7 +143,7 @@ typedef struct {
 } gdbr_flags_reg_t;
 
 // sizeof (buf) needs to be atleast flags->num_bits + 1
-static void write_flag_bits (char *buf, const gdbr_flags_reg_t *flags) {
+static void write_flag_bits(char *buf, const gdbr_flags_reg_t *flags) {
 	bool fc[26] = { false };
 	ut32 i, c;
 	memset (buf, '.', flags->num_bits);
@@ -275,7 +275,7 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 				*tmp2 = '\0';
 				name_sz = sizeof (flags[num_flags].fields[num_fields].name);
 				strncpy (flags[num_flags].fields[num_fields].name,
-					 tmp1, name_sz - 1);
+					tmp1, name_sz - 1);
 				flags[num_flags].fields[num_fields].name[name_sz - 1] = '\0';
 				*tmp2 = tmpchar;
 				// Get offset
@@ -392,8 +392,8 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 				write_flag_bits (flag_bits, &flags[cur_flag_num]);
 			}
 			snprintf (profile + profile_len, profile_line_len, "%s\t%s\t"
-				  ".%"PFMT64d "\t%"PFMT64d "\t0\t%s\n", reg_typ, regname,
-				  reg_sz, reg_off, flag_bits);
+				".%"PFMT64d "\t%"PFMT64d "\t0\t%s\n", reg_typ, regname,
+				reg_sz, reg_off, flag_bits);
 			profile_len += strlen (profile + profile_len);
 			if (cur_flag_num < num_flags) {
 				for (i = 0; i < flags[cur_flag_num].num_fields; i++) {
@@ -406,10 +406,10 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 						profile_max_len += blk_sz;
 					}
 					snprintf (profile + profile_len, profile_line_len,
-						  "gpr\t%s\t.%d\t.%"PFMT64d"\t0\n",
-						  flags[cur_flag_num].fields[i].name,
-						  flags[cur_flag_num].fields[i].sz,
-						  flags[cur_flag_num].fields[i].bit_num + (reg_off * 8));
+						"gpr\t%s\t.%d\t.%"PFMT64d "\t0\n",
+						flags[cur_flag_num].fields[i].name,
+						flags[cur_flag_num].fields[i].sz,
+						flags[cur_flag_num].fields[i].bit_num + (reg_off * 8));
 					profile_len += strlen (profile + profile_len);
 				}
 			}

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -46,6 +46,9 @@ int gdbr_set_architecture(libgdbr_t *g, const char *arch, int bits) {
 	if (!g) {
 		return -1;
 	}
+	if (g->target.valid && g->registers) {
+		return 0;
+	}
 	if (!strcmp (arch, "mips")) {
 		g->registers = gdb_regs_mips;
 	} else if (!strcmp (arch, "lm32")) {


### PR DESCRIPTION
- Load gdbr's register array from xml
- Load flags
There is a problem with eflags/rflags on x86_64. gdb deals with the 32-bit eflags even on x86_64. But r2 doesn't display 32-bit registers for x86_64 in normal register listing (there is a check with asm.bits in commands like `dr`). So eflags is not listed for eg. in visual mode.