### PR TITLE
Add `RVector` (array of void* objects) to r_util

### DIFF
--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -68,6 +68,32 @@ R_API void **r_vector_shrink(RVector *vec);
 #define r_vector_foreach(vec, it) \
 	for (it = (vec)->a; it != (vec)->a + (vec)->len; it++)
 
+#define r_vector_lower_bound(vec, x, i, cmp_less) \
+  do { \
+    int h = (vec)->len, m; \
+    for (i = 0; i < h; ) { \
+      m = i + ((h - i) >> 1); \
+      if (cmp_less ((vec)->a[m], x)) { \
+        i = m + 1; \
+      } else { \
+        h = m; \
+      } \
+    } \
+  } while (0) \
+
+#define r_vector_upper_bound(vec, x, i, cmp_less) \
+  do { \
+    int h = (vec)->len, m; \
+    for (i = 0; i < h; ) { \
+      m = i + ((h - i) >> 1); \
+      if (!(cmp_less (x, (vec)->a[m]))) { \
+        i = m + 1; \
+      } else { \
+        h = m; \
+      } \
+    } \
+  } while (0) \
+
 #ifdef __cplusplus
 }
 #endif

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -1,0 +1,75 @@
+#ifndef R2_VECTOR_H
+#define R2_VECTOR_H
+
+#include <r_types.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+  Insert functions returns NULL if reallocation happens and fails,
+  returns the address of newly inserted element if succeeded.
+
+  Delete functions returns the deleted element.
+  Callers should destruct it if necessary.
+
+  Usage:
+  int i;
+  void **it;
+
+  // heap allocated RVector
+  RVector *v = r_vector_new ();
+  if (!v) goto err_new;
+  if (!r_vector_append (v, a)) goto err_append;
+  if (!r_vector_insert (v, 0, b)) goto err_insert;
+  for (i = 0; i < v->len; i++) {
+    (void)v->a[i]; // Public members a and len are encouraged to access
+  }
+  r_vector_foreach (v, it) {
+    (void)*it;
+  }
+  // pass function pointer `elem_free`
+  r_vector_free (v, NULL);
+
+  // stack allocated RVector
+  RVector v = {0};
+  // r_vector_init (&v); // v.a = NULL; v.len = v.capacity = 0;
+  r_vector_append (&v, (void *)1);
+  assert (v.len == 1 && v.capacity == 10);
+  // for stack allocated RVector, use r_vector_clear instead of r_vector_free
+  r_vector_clear (&v, NULL);
+ */
+
+typedef struct r_vector_t {
+  void **a;
+  int len;
+  int capacity;
+} RVector;
+
+R_API void **r_vector_append(RVector *vec, void *x);
+R_API void r_vector_clear(RVector *vec, void (*elem_free)(void *));
+R_API RVector *r_vector_clone(RVector *vec);
+R_API void **r_vector_contains(RVector *vec, void *x);
+R_API void *r_vector_del_n(RVector *vec, int n);
+R_API bool r_vector_empty(RVector *vec);
+R_API void r_vector_fini(RVector *vec);
+R_API void r_vector_free(RVector *vec, void (*elem_free)(void *));
+R_API void r_vector_init(RVector *vec);
+R_API void **r_vector_insert(RVector *vec, int n, void *x);
+R_API RVector *r_vector_new(void);
+R_API RVector *r_vector_new_replicate(int len, void *x);
+R_API void *r_vector_pop(RVector *vec);
+R_API void *r_vector_pop_first(RVector *vec);
+R_API void **r_vector_prepend(RVector *vec, void *x);
+R_API void **r_vector_reserve(RVector *vec, int capacity);
+/* shrink capacity to len, NB. delete operations do not shrink space */
+R_API void **r_vector_shrink(RVector *vec);
+
+#define r_vector_foreach(vec, it) \
+	for (it = (vec)->a; it != (vec)->a + (vec)->len; it++)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -46,6 +46,8 @@ typedef struct r_vector_t {
   int capacity;
 } RVector;
 
+typedef int (*RVectorComparator)(const void *a, const void *b);
+
 R_API void **r_vector_append(RVector *vec, void *x);
 R_API void r_vector_clear(RVector *vec, void (*elem_free)(void *));
 R_API RVector *r_vector_clone(RVector *vec);
@@ -62,6 +64,7 @@ R_API void *r_vector_pop(RVector *vec);
 R_API void *r_vector_pop_first(RVector *vec);
 R_API void **r_vector_prepend(RVector *vec, void *x);
 R_API void **r_vector_reserve(RVector *vec, int capacity);
+R_API void r_vector_sort(RVector *vec, RVectorComparator cmp);
 /* shrink capacity to len, NB. delete operations do not shrink space */
 R_API void **r_vector_shrink(RVector *vec);
 

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -20,7 +20,7 @@ extern "C" {
   // heap allocated RVector
   RVector *v = r_vector_new ();
   if (!v) goto err_new;
-  if (!r_vector_append (v, a)) goto err_append;
+  if (!r_vector_push (v, a)) goto err_push;
   if (!r_vector_insert (v, 0, b)) goto err_insert;
   for (i = 0; i < v->len; i++) {
     (void)v->a[i]; // Public members a and len are encouraged to access
@@ -34,68 +34,71 @@ extern "C" {
   // stack allocated RVector
   RVector v = {0};
   // r_vector_init (&v); // v.a = NULL; v.len = v.capacity = 0;
-  r_vector_append (&v, (void *)1);
+  r_vector_push (&v, (void *)1);
   assert (v.len == 1 && v.capacity == 10);
   // for stack allocated RVector, use r_vector_clear instead of r_vector_free
   r_vector_clear (&v, NULL);
  */
 
 typedef struct r_vector_t {
-  void **a;
-  int len;
-  int capacity;
+	void **a;
+	int len;
+	int capacity;
 } RVector;
 
 typedef int (*RVectorComparator)(const void *a, const void *b);
 
-R_API void **r_vector_append(RVector *vec, void *x);
 R_API void r_vector_clear(RVector *vec, void (*elem_free)(void *));
 R_API RVector *r_vector_clone(RVector *vec);
 R_API void **r_vector_contains(RVector *vec, void *x);
-R_API void *r_vector_del_n(RVector *vec, int n);
+R_API void *r_vector_delete_at(RVector *vec, int n);
 R_API bool r_vector_empty(RVector *vec);
 R_API void r_vector_fini(RVector *vec);
 R_API void r_vector_free(RVector *vec, void (*elem_free)(void *));
 R_API void r_vector_init(RVector *vec);
 R_API void **r_vector_insert(RVector *vec, int n, void *x);
+R_API void **r_vector_insert_range(RVector *vec, int n, void **first, void **last);
 R_API RVector *r_vector_new(void);
-R_API RVector *r_vector_new_replicate(int len, void *x);
 R_API void *r_vector_pop(RVector *vec);
-R_API void *r_vector_pop_first(RVector *vec);
-R_API void **r_vector_prepend(RVector *vec, void *x);
+R_API void *r_vector_pop_front(RVector *vec);
+R_API void **r_vector_push(RVector *vec, void *x);
+R_API void **r_vector_push_front(RVector *vec, void *x);
 R_API void **r_vector_reserve(RVector *vec, int capacity);
-R_API void r_vector_sort(RVector *vec, RVectorComparator cmp);
 /* shrink capacity to len, NB. delete operations do not shrink space */
 R_API void **r_vector_shrink(RVector *vec);
+R_API void r_vector_sort(RVector *vec, RVectorComparator cmp);
+
+#define r_vector_find(vec, it, cmp_eq) \
+	for (it = (vec)->a; it != (vec)->a + (vec)->len && !(cmp_eq (*it, x)); it++);
 
 #define r_vector_foreach(vec, it) \
 	for (it = (vec)->a; it != (vec)->a + (vec)->len; it++)
 
 #define r_vector_lower_bound(vec, x, i, cmp_less) \
-  do { \
-    int h = (vec)->len, m; \
-    for (i = 0; i < h; ) { \
-      m = i + ((h - i) >> 1); \
-      if (cmp_less ((vec)->a[m], x)) { \
-        i = m + 1; \
-      } else { \
-        h = m; \
-      } \
-    } \
-  } while (0) \
+	do { \
+		int h = (vec)->len, m; \
+		for (i = 0; i < h; ) { \
+			m = i + ((h - i) >> 1); \
+			if (cmp_less ((vec)->a[m], x)) { \
+				i = m + 1; \
+			} else { \
+				h = m; \
+			} \
+		} \
+	} while (0) \
 
 #define r_vector_upper_bound(vec, x, i, cmp_less) \
-  do { \
-    int h = (vec)->len, m; \
-    for (i = 0; i < h; ) { \
-      m = i + ((h - i) >> 1); \
-      if (!(cmp_less (x, (vec)->a[m]))) { \
-        i = m + 1; \
-      } else { \
-        h = m; \
-      } \
-    } \
-  } while (0) \
+	do { \
+		int h = (vec)->len, m; \
+		for (i = 0; i < h; ) { \
+			m = i + ((h - i) >> 1); \
+			if (!(cmp_less (x, (vec)->a[m]))) { \
+				i = m + 1; \
+			} else { \
+				h = m; \
+			} \
+		} \
+	} while (0) \
 
 #ifdef __cplusplus
 }

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -14,7 +14,7 @@ OBJS+=p_seven.o slist.o randomart.o log.o zip.o debruijn.o
 OBJS+=utf8.o utf16.o utf32.o strbuf.o lib.o name.o spaces.o signal.o syscmd.o
 OBJS+=diff.o bdiff.o stack.o queue.o tree.o des.o idpool.o
 OBJS+=punycode.o r_pkcs7.o r_x509.o r_asn1.o json_indent.o skiplist.o
-OBJS+=r_json.o qrcode.o
+OBJS+=r_json.o qrcode.o vector.o
 
 # DO NOT BUILD r_big api (not yet used and its buggy)
 ifeq (1,0)

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -69,6 +69,7 @@ files=[
 'utf8.c',
 'utf16.c',
 'utf32.c',
+'vector.c',
 'w32-sys.c',
 'zip.c',
 'regex/regcomp.c',

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -162,6 +162,7 @@ int main () {
 	}
 	assert (r_vector_pop_first (v) == (void *)1337);
 	assert (r_vector_contains (v, (void *)9));
+
 	assert (r_vector_del_n (v, 9) == (void *)9);
 	assert (!r_vector_contains (v, (void *)9));
 
@@ -193,6 +194,47 @@ int main () {
 	}
 	r_vector_reserve (&s, 10);
 	r_vector_clear (&s, NULL);
+
+	{
+		RVector s = {0};
+		int l;
+		for (i = 0; i < 10; i += 2) {
+			r_vector_append (&s, (void *)i);
+		}
+
+#define CMP_LESS(x, y) x < y
+		r_vector_lower_bound (&s, (void *)4, l, CMP_LESS);
+		assert (s.a[l] == (void *)4);
+		r_vector_lower_bound (&s, (void *)5, l, CMP_LESS);
+		assert (s.a[l] == (void *)6);
+		r_vector_lower_bound (&s, (void *)6, l, CMP_LESS);
+		assert (s.a[l] == (void *)6);
+		r_vector_lower_bound (&s, (void *)9, l, CMP_LESS);
+		assert (l == s.len);
+
+		r_vector_upper_bound (&s, (void *)4, l, CMP_LESS);
+		assert (s.a[l] == (void *)6);
+		r_vector_upper_bound (&s, (void *)5, l, CMP_LESS);
+		assert (s.a[l] == (void *)6);
+		r_vector_upper_bound (&s, (void *)6, l, CMP_LESS);
+		assert (s.a[l] == (void *)8);
+#undef CMP_LESS
+
+		r_vector_clear (&s, NULL);
+
+#define CMP_LESS(x, y) strcmp (x, y) < 0
+		r_vector_append (&s, strdup ("Bulbasaur"));
+		r_vector_append (&s, strdup ("Caterpie"));
+		r_vector_append (&s, strdup ("Charmander"));
+		r_vector_append (&s, strdup ("Meowth"));
+		r_vector_append (&s, strdup ("Squirtle"));
+
+		r_vector_lower_bound (&s, "Meow", l, CMP_LESS);
+		assert (!strcmp (s.a[l], "Meowth"));
+
+		r_vector_clear (&s, free);
+	}
+
 	return 0;
 }
 #endif

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -1,0 +1,198 @@
+#include "r_vector.h"
+
+// Optimize memory usage on glibc
+#if __WORDSIZE == 32
+// Chunk size 24, minus 4 (chunk header), minus 8 for capacity and len, 12 bytes remaining for 3 void *
+#define INITIAL_VECTOR_LEN 3
+#else
+// For __WORDSIZE == 64
+// Chunk size 48, minus 8 (chunk header), minus 8 for capacity and len, 32 bytes remaining for 4 void *
+#define INITIAL_VECTOR_LEN 4
+#endif
+
+#define NEXT_VECTOR_CAPACITY (vec->capacity < INITIAL_VECTOR_LEN \
+	? INITIAL_VECTOR_LEN \
+	: vec->capacity <= 12 ? vec->capacity * 2 \
+	: vec->capacity + (vec->capacity >> 1))
+
+#define RESIZE_OR_RETURN_NULL(next_capacity) do { \
+		int new_capacity = next_capacity; \
+		void **new_a = realloc (vec->a, sizeof(void *) * new_capacity); \
+		if (!new_a) { \
+			return NULL; \
+		} \
+		vec->a = new_a; \
+		vec->capacity = new_capacity; \
+	} while (0)
+
+R_API void **r_vector_append(RVector *vec, void *x) {
+	if (vec->len >= vec->capacity) {
+		RESIZE_OR_RETURN_NULL (NEXT_VECTOR_CAPACITY);
+	}
+	vec->a[vec->len] = x;
+	return &vec->a[vec->len++];
+}
+
+R_API void r_vector_clear(RVector *vec, void (*elem_free)(void *)) {
+	if (elem_free) {
+		while (vec->len > 0) {
+			elem_free (vec->a[--vec->len]);
+		}
+	} else {
+		vec->len = 0;
+	}
+	R_FREE (vec->a);
+	vec->capacity = 0;
+}
+
+R_API RVector *r_vector_clone(RVector *vec) {
+	RVector *ret = R_NEW (RVector);
+	if (ret) {
+		ret->capacity = vec->capacity;
+		ret->len = vec->len;
+		if (!vec->len) {
+			ret->a = NULL;
+		} else {
+			ret->a = malloc (sizeof(void *) * vec->len);
+			if (!ret->a) {
+				R_FREE (ret);
+			} else {
+				memcpy (ret->a, vec->a, sizeof(void *) * vec->len);
+			}
+		}
+	}
+	return ret;
+}
+
+R_API void **r_vector_contains(RVector *vec, void *x) {
+	int i;
+	for (i = 0; i < vec->len; i++) {
+		if (vec->a[i] == x) {
+			return &vec->a[i];
+		}
+	}
+	return NULL;
+}
+
+R_API void *r_vector_del_n(RVector *vec, int n) {
+	void *ret = vec->a[n];
+	vec->len--;
+	for (; n < vec->len; n++) {
+		vec->a[n] = vec->a[n+1];
+	}
+	return ret;
+}
+
+R_API bool r_vector_empty(RVector *vec) {
+	return vec->len == 0;
+}
+
+R_API void r_vector_free(RVector *vec, void (*elem_free)(void *)) {
+	if (elem_free) {
+		while (vec->len > 0) {
+			elem_free (vec->a[--vec->len]);
+		}
+	} else {
+		vec->len = 0;
+	}
+	free (vec->a);
+	free (vec);
+}
+
+R_API void r_vector_init(RVector *vec) {
+	vec->a = NULL;
+	vec->capacity = vec->len = 0;
+}
+
+R_API void **r_vector_insert(RVector *vec, int n, void *x) {
+	if (vec->len >= vec->capacity) {
+		RESIZE_OR_RETURN_NULL (NEXT_VECTOR_CAPACITY);
+	}
+	int i;
+	for (i = vec->len++; i > n; i--) {
+		vec->a[i] = vec->a[i-1];
+	}
+	vec->a[n] = x;
+	return &vec->a[n];
+}
+
+R_API RVector *r_vector_new(void) {
+	return R_NEW0 (RVector);
+}
+
+R_API void *r_vector_pop(RVector *vec) {
+	return vec->a[--vec->len];
+}
+
+R_API void *r_vector_pop_first(RVector *vec) {
+	return r_vector_del_n (vec, 0);
+}
+
+R_API void **r_vector_prepend(RVector *vec, void *x) {
+	return r_vector_insert (vec, 0, x);
+}
+
+R_API void **r_vector_reserve(RVector *vec, int capacity) {
+	if (vec->capacity < capacity) {
+		RESIZE_OR_RETURN_NULL (capacity);
+	}
+	return vec->a;
+}
+
+R_API void **r_vector_shrink(RVector *vec) {
+	if (vec->len < vec->capacity) {
+		RESIZE_OR_RETURN_NULL (vec->len);
+	}
+	return vec->a;
+}
+
+#if TEST
+#include <assert.h>
+#include <stddef.h>
+
+// TODO: move into t/vector.c
+int main () {
+	ptrdiff_t i;
+	void **it;
+	RVector *v = r_vector_new ();
+	assert (*r_vector_append (v, (void *)1337) == (void *)1337);
+	for (i = 0; i < 10; i++) {
+		r_vector_append (v, (void *)i);
+		assert (v->len == i + 2);
+	}
+	assert (r_vector_pop_first (v) == (void *)1337);
+	assert (r_vector_contains (v, (void *)9));
+	assert (r_vector_del_n (v, 9) == (void *)9);
+	assert (!r_vector_contains (v, (void *)9));
+
+	i = 0;
+	r_vector_foreach (v, it) {
+		assert (*it == (void *)i++);
+	}
+
+	r_vector_shrink (v);
+	assert (v->len == 9);
+	RVector *v1 = r_vector_clone (v);
+	r_vector_clear (v, NULL);
+	assert (v->capacity == 0 && v->len == 0);
+	assert (v1->len == 9);
+
+	r_vector_free (v, NULL);
+	r_vector_free (v1, NULL);
+
+	RVector s;
+	r_vector_init (&s);
+	r_vector_reserve (&s, 10);
+	r_vector_clear (&s, NULL);
+
+	r_vector_reserve (&s, 10);
+	r_vector_append (&s, (void *)-1);
+	assert (s.len == 1 && s.capacity == 10);
+	for (i = 0; i < 20; i++) {
+		r_vector_append (&s, (void *)i);
+	}
+	r_vector_reserve (&s, 10);
+	r_vector_clear (&s, NULL);
+	return 0;
+}
+#endif


### PR DESCRIPTION
Usually, modification to a data structure concentrates mainly on the creation stage, then they are relatively stable and used mostly for read-only purposes. An array is a much better replacement for `RList` for this kind of use cases.

* Random access
* Smaller memory footprint
* Cache friendly
* When dynamic append/pop are used, no need to maintain two separate variables `len` and `capacity`. Maintaining them is error prone.
* Debugging friendly


Examples:
```c
int my_cmp(const void *a, const void *b) {
	return strcmp (a, b) < 0;
}

// TODO: move into t/vector.c
int main () {
	ptrdiff_t i;
	void **it;
	RVector *v = r_vector_new ();
	assert (*r_vector_push (v, (void *)1337) == (void *)1337);
	for (i = 0; i < 10; i++) {
		r_vector_push (v, (void *)i);
		assert (v->len == i + 2);
	}
	assert (r_vector_pop_front (v) == (void *)1337);
	assert (r_vector_contains (v, (void *)9));

	assert (r_vector_delete_at (v, 9) == (void *)9);
	assert (!r_vector_contains (v, (void *)9));

	i = 0;
	r_vector_foreach (v, it) {
		assert (*it == (void *)i++);
	}

	r_vector_shrink (v);
	assert (v->len == 9);
	RVector *v1 = r_vector_clone (v);
	r_vector_clear (v, NULL);
	assert (v->capacity == 0 && v->len == 0);
	assert (v1->len == 9);

	r_vector_free (v, NULL);
	r_vector_free (v1, NULL);

	RVector s;
	r_vector_init (&s);
	r_vector_reserve (&s, 10);
	r_vector_clear (&s, NULL);

	r_vector_reserve (&s, 10);
	r_vector_push (&s, (void *)-1);
	assert (s.len == 1 && s.capacity == 10);
	for (i = 0; i < 20; i++) {
		r_vector_push (&s, (void *)i);
	}
	r_vector_reserve (&s, 10);
	r_vector_clear (&s, NULL);

	{
		void *a[] = {(void*)0, (void*)2, (void*)4, (void*)6, (void*)8};
		RVector s = {0};
		int l;
		r_vector_insert_range (&s, 0, a + 2, a + 5);
		r_vector_insert_range (&s, 0, a, a + 2);

#define CMP_LESS(x, y) x < y
		r_vector_lower_bound (&s, (void *)4, l, CMP_LESS);
		assert (s.a[l] == (void *)4);
		r_vector_lower_bound (&s, (void *)5, l, CMP_LESS);
		assert (s.a[l] == (void *)6);
		r_vector_lower_bound (&s, (void *)6, l, CMP_LESS);
		assert (s.a[l] == (void *)6);
		r_vector_lower_bound (&s, (void *)9, l, CMP_LESS);
		assert (l == s.len);

		r_vector_upper_bound (&s, (void *)4, l, CMP_LESS);
		assert (s.a[l] == (void *)6);
		r_vector_upper_bound (&s, (void *)5, l, CMP_LESS);
		assert (s.a[l] == (void *)6);
		r_vector_upper_bound (&s, (void *)6, l, CMP_LESS);
		assert (s.a[l] == (void *)8);
#undef CMP_LESS

		r_vector_clear (&s, NULL);

		r_vector_push (&s, strdup ("Charmander"));
		r_vector_push (&s, strdup ("Squirtle"));
		r_vector_push (&s, strdup ("Bulbasaur"));
		r_vector_push (&s, strdup ("Meowth"));
		r_vector_push (&s, strdup ("Caterpie"));
		r_vector_sort (&s, my_cmp);

#define CMP_LESS(x, y) strcmp (x, y) < 0
		r_vector_lower_bound (&s, "Meow", l, CMP_LESS);
		assert (!strcmp (s.a[l], "Meowth"));

		r_vector_clear (&s, free);
	}

	return 0;
}
```

All functions which may allocate (thus possible being exposed under `ENOMEM`) return a pointer to indicate whether the operation is successful. The example above omits the checks for brevity.