### PR TITLE
r_io_cache_read: fix number of bytes returned (1, should be 0) when c->to == addr

### DIFF
--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -7,39 +7,25 @@
 // TODO: Optimize to use memcpy when buffers are not in range..
 // check buf boundaries and offsets and use memcpy or memmove
 
-// copied from riocacheread
+// copied from libr/io/cache.c:r_io_cache_read
 // ret # of bytes copied
 static int sparse_read(RList *list, ut64 addr, ut8 *buf, int len) {
-        int l, ret, da, db;
-        RListIter *iter;
-        RBufferSparse *c;
-
-        r_list_foreach (list, iter, c) {
-                if (r_range_overlap (addr, addr+len-1, c->from, c->to, &ret)) {
-                        if (ret > 0) {
-                                da = ret;
-                                db = 0;
-                                l = c->size;
-                        } else if (ret < 0) {
-                                da = 0;
-                                db = -ret;
-                                l = c->size-db;
-                        } else {
-                                da = 0;
-                                db = 0;
-                                l = c->size;
-                        }
-			// say hello to integer overflow, but this won't happen in
-			// realistic scenarios because malloc will fail befor
-                        if ((l + da) > len) {
-				l = len - da;
+	int l, covered = 0;
+	RListIter *iter;
+	RBufferSparse *c;
+	r_list_foreach (list, iter, c) {
+		if (addr < c->to && c->from < addr + len) {
+			if (addr < c->from) {
+				l = R_MIN (addr + len - c->from, c->size);
+				memcpy (buf + c->from - addr, c->data, l);
+			} else {
+				l = R_MIN (c->to - addr, len);
+				memcpy (buf, c->data + addr - c->from, l);
 			}
-			if (l > 0) {
-				memcpy (buf + da, c->data + db, l);
-			}
-                }
-        }
-        return len;
+			covered += l;
+		}
+	}
+	return covered;
 }
 
 static RBufferSparse *sparse_append(RList *l, ut64 addr, const ut8 *data, int len) {
@@ -471,9 +457,7 @@ static int r_buf_cpy(RBuffer *b, ut64 addr, ut8 *dst, const ut8 *src, int len, i
 		} else {
 			// read from sparse and write into dst
 			memset (dst, 0xff, len);
-			if (sparse_read (b->sparse, addr, dst, len) < 0) {
-				return -1;
-			}
+			(void)sparse_read (b->sparse, addr, dst, len);
 		}
 		return len;
 	}


### PR DESCRIPTION
The correct way to check whether two half-closed intervals [a,b) [c,d) overlap is a < d && c < b.
The code actually used a < d && c <= b, which might report false positive overlapping and return 1.

I consider this snippet as one example where a sorted array should be superior to a list.