### PR TITLE
Add r_str_scpy and demonstrate its usage by fixing one vulnerable strncpy

### DIFF
--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -143,6 +143,7 @@ R_API bool r_str_endswith(const char *str, const char *needle);
 R_API bool r_str_isnumber (const char *str);
 R_API const char *r_str_last (const char *in, const char *ch);
 R_API char* r_str_highlight(char *str, const char *word, const char *color);
+R_API int r_str_scpy (char *dst, const char *src, int count);
 R_API char *r_qrcode_gen(const ut8* text, int len, bool utf8);
 
 #endif //  R_STR_H

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -131,7 +131,7 @@ R_API RLib *r_lib_new(const char *symname) {
 		}
 		lib->handlers = r_list_newf (free);
 		lib->plugins = r_list_newf (free);
-		strncpy (lib->symname, symname, sizeof (lib->symname)-1);
+		r_str_scpy (lib->symname, symname, sizeof (lib->symname));
 	}
 	return lib;
 }

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -4,6 +4,7 @@
 #include "r_util.h"
 #include "r_cons.h"
 #include "r_bin.h"
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
@@ -2927,4 +2928,18 @@ R_API char* r_str_highlight(char *str, const char *word, const char *color) {
 		}
 	}
 	return strdup (o);
+}
+
+R_API int r_str_scpy (char *dst, const char *src, int count) {
+	if (count <= 0) {
+		return -E2BIG;
+	}
+	int i = 0;
+	for (; i < count; i++) {
+		if (!(dst[i] = src[i])) {
+			return i;
+		}
+	}
+	dst[i - 1] = '\0';
+	return -E2BIG;
 }


### PR DESCRIPTION
http://elixir.free-electrons.com/linux/latest/source/lib/string.c#L177


```
#ifndef __HAVE_ARCH_STRSCPY
/**
 * strscpy - Copy a C-string into a sized buffer
 * @dest: Where to copy the string to
 * @src: Where to copy the string from
 * @count: Size of destination buffer
 *
 * Copy the string, or as much of it as fits, into the dest buffer.
 * The routine returns the number of characters copied (not including
 * the trailing NUL) or -E2BIG if the destination buffer wasn't big enough.
 * The behavior is undefined if the string buffers overlap.
 * The destination buffer is always NUL terminated, unless it's zero-sized.
 *
 * Preferred to strlcpy() since the API doesn't require reading memory
 * from the src string beyond the specified "count" bytes, and since
 * the return value is easier to error-check than strlcpy()'s.
 * In addition, the implementation is robust to the string changing out
 * from underneath it, unlike the current strlcpy() implementation.
 *
 * Preferred to strncpy() since it always returns a valid string, and
 * doesn't unnecessarily force the tail of the destination buffer to be
 * zeroed.  If the zeroing is desired, it's likely cleaner to use strscpy()
 * with an overflow test, then just memset() the tail of the dest buffer.
 */
```


#8025

If you are cautious, use `if (r_strscpy(dst, src, sizeof dst) < 0)` to check error, otherwise just ignore the return value and it will not overflow the buffer.