### PR TITLE
`r_list_foreach` macros should not stop at an element whose data is NULL

### DIFF
--- a/libr/include/r_list.h
+++ b/libr/include/r_list.h
@@ -46,14 +46,14 @@ typedef struct r_oflist_t {
 //#define R_LIST_NEW(x,y) x=r_list_new();x->free=(RListFree)y
 #define r_list_foreach(list, it, pos)\
 	if (list)\
-		for (it = list->head; it && (pos = it->data); it = it->n)
+		for (it = list->head; it && (pos = it->data, 1); it = it->n)
 /* Safe when calling r_list_delete() while iterating over the list. */
 #define r_list_foreach_safe(list, it, tmp, pos)\
 	if (list)\
-		for (it = list->head; it && (pos = it->data) && ((tmp = it->n) || 1); it = tmp)
+		for (it = list->head; it && (pos = it->data, tmp = it->n, 1); it = tmp)
 #define r_list_foreach_prev(list, it, pos)\
 	if (list)\
-		for (it = list->tail; it && (pos = it->data); it = it->p)
+		for (it = list->tail; it && (pos = it->data, 1); it = it->p)
 #ifndef _R_LIST_C_
 #define r_list_push(x, y) r_list_append (x, y)
 #define r_list_iterator(x) (x)? (x)->head: NULL


### PR DESCRIPTION
Note, `r_list_append` does not append NULL `data`.
```c
R_API RListIter *r_list_append(RList *list, void *data) {
	RListIter *item = NULL;
	if (list && data) {
		item = R_NEW (RListIter);
```

which is inconsistent with `r_list_prepend`.

This change should be safe, if not, the issue definitely comes from the call site.