### PR TITLE
Bring onIterMap from siol

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -318,14 +318,16 @@ static void cmd_open_map (RCore *core, const char *input) {
 					*r = 0;
 					size = r_num_math (core->num, q+1);
 					delta = r_num_math (core->num, r+1);
-				} else size = r_num_math (core->num, q+1);
-			} else size = r_io_size (core->io);
-			if ((desc = r_io_desc_get (core->io, fd))) {
-				r_io_map_add (core->io, fd, desc->flags, delta, addr, size);	//rethink setting the flags
+				} else {
+					size = r_num_math (core->num, q+1);
+				}
 			} else {
-				eprintf ("Invalid fd\n");
+				size = r_io_size (core->io);
 			}
-		} else eprintf ("Invalid use of om . See om? for help.\n");
+			r_io_map_add (core->io, fd, 0, delta, addr, size);
+		} else {
+			eprintf ("Invalid use of om . See om? for help.");
+		}
 		free (s);
 		break;
 	case '-':

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -792,6 +792,8 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 	}
 	if (!strcmp (file, "-")) {
 		file = "malloc://512";
+	}
+	if (strstr (file, "malloc://")) {
 		flags = R_IO_READ | R_IO_WRITE;
 	}
 	//if not flags was passed open it with -r--

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -282,7 +282,7 @@ R_API RIODesc *r_io_open_as(RIO *io, const char *urihandler, const char *file, i
 R_API int r_io_reopen (RIO *io, RIODesc *desc, int flags, int mode);
 R_API int r_io_redirect(RIO *io, const char *file);
 //checks if io-access is reasonable at this offset
-R_API bool r_io_is_valid_offset (RIO *io, ut64 offset, int hasperm);
+R_API bool r_io_is_valid_offset (RIO *io, ut64 offset,int hasperm);
 
 R_API int r_io_get_fd(RIO *io);
 R_API bool r_io_use_fd(RIO *io, int fd);
@@ -353,6 +353,7 @@ R_API int r_io_map_write_update(RIO *io, int fd, ut64 addr, ut64 len);
 R_API int r_io_map_truncate_update(RIO *io, int fd, ut64 sz);
 R_API int r_io_map_count (RIO *io);
 R_API void r_io_map_list (RIO *io, int rad);
+R_API bool r_io_map_is_in_range(RIOMap* map, ut64 from, ut64 to);
 
 /* io/section.c */
 R_API void r_io_section_init(RIO *io);

--- a/libr/io/desc.c
+++ b/libr/io/desc.c
@@ -119,10 +119,10 @@ R_API ut64 r_io_desc_size(RIODesc* desc) {
 	if (r_io_desc_is_blockdevice (desc)) {
 		return UT64_MAX;
 	}
-	off = desc->plugin->lseek (desc->io, desc, 0LL, R_IO_SEEK_CUR);
-	ret = desc->plugin->lseek (desc->io, desc, 0LL, R_IO_SEEK_END);
+	off = r_io_desc_seek (desc, 0LL, R_IO_SEEK_CUR);
+	ret = r_io_desc_seek (desc, 0LL, R_IO_SEEK_END);
 	//what to do if that seek fails?
-	desc->plugin->lseek (desc->io, desc, off, R_IO_SEEK_SET);
+	r_io_desc_seek (desc, off, R_IO_SEEK_SET);
 	return ret;
 }
 

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -1075,8 +1075,7 @@ R_API bool r_io_is_valid_offset(RIO *io, ut64 offset, int hasperm) {
 	if (!io_va && r_io_map_exists_for_offset (io, offset)) {
 		return true;
 	}
-	return r_io_map_exists_for_offset (io, offset) ||
-		   r_io_section_exists_for_vaddr (io, offset, hasperm);
+	return r_io_section_exists_for_vaddr (io, offset, hasperm);
 }
 
 

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -19,6 +19,91 @@ R_LIB_VERSION (r_io);
 #define DO_THE_IO_DBG 0
 #define IO_IFDBG if (DO_THE_IO_DBG == 1)
 
+typedef int (*cbOnIterMap) (RIO *io, ut64 addr, ut8*buf, int len);
+static void onIterMap(SdbListIter* iter, RIO* io, ut64 vaddr, ut8* buf,
+		       int len, int match_flg, cbOnIterMap op) {
+	RIOMap* map;
+	RIODesc *desc;
+	ut64 vendaddr;
+	if (!io || !buf || len < 1) {
+		return;
+	}
+	if (!iter) {
+		// end of list
+		op (io, vaddr, buf, len);   
+		return;
+	}
+	// this block is not that much elegant
+	if (UT64_ADD_OVFCHK (len - 1, vaddr)) { 
+		// needed for edge-cases
+		int nlen;                   
+		// add a test for this block
+		vendaddr = UT64_MAX;        
+		nlen = (int) (UT64_MAX - vaddr + 1);
+		onIterMap (iter->p, io, 0LL, buf + nlen, len - nlen, match_flg, op);
+	} else {
+		vendaddr = vaddr + len - 1;
+	}
+	map = (RIOMap*) iter->data;
+	// search for next map or end of list
+	while (!r_io_map_is_in_range (map, vaddr, vendaddr)) {
+		iter = iter->p;
+		// end of list
+		if (!iter) {                      
+			// pread/pwrite
+			op (io, vaddr, buf, len); 
+			return;
+		}
+		map = (RIOMap*) iter->data;
+	}
+	if (map->from >= vaddr) {
+		onIterMap (iter->p, io, vaddr, buf, (int) (map->from - vaddr), match_flg, op);
+		buf = buf + (map->from - vaddr);
+		vaddr = map->from;
+		len = (int) (vendaddr - vaddr + 1);
+		if (vendaddr <= map->to) {
+			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
+				desc = io->desc;
+				r_io_use_fd (io, map->fd);
+				op (io, map->delta, buf, len);
+				io->desc = desc;
+			}
+		} else {
+			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
+				desc = io->desc;
+				r_io_use_fd (io, map->fd);
+				op (io, map->delta, buf, len - (int) (vendaddr - map->to));
+				io->desc = desc;
+			}
+			vaddr = map->to + 1;
+			buf = buf + (len - (int) (vendaddr - map->to));
+			len = (int) (vendaddr - map->to);
+			onIterMap (iter->p, io, vaddr, buf, len, match_flg, op);
+		}
+	} else {
+		if (vendaddr <= map->to) {
+			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
+				desc = io->desc;
+				r_io_use_fd (io, map->fd);
+				//warning: may overflow in rare usecases
+				op (io, map->delta + (vaddr - map->from), buf, len);            
+				io->desc = desc;
+			}
+		} else {
+			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
+				desc = io->desc;
+				r_io_use_fd (io, map->fd);
+				op (io, map->delta + (vaddr - map->from), buf, len - (int) (vendaddr - map->to));
+				io->desc = desc;
+			}
+			vaddr = map->to + 1;
+			buf = buf + (len - (int) (vendaddr - map->to));
+			len = (int) (vendaddr - map->to);
+			onIterMap (iter->p, io, vaddr, buf, len, match_flg, op);
+		}
+	}
+}
+
 R_API RIO *r_io_new() {
 	RIO *io = R_NEW0 (RIO);
 	if (!io) {
@@ -422,7 +507,6 @@ R_API int r_io_vread_at(RIO *io, ut64 vaddr, ut8 *buf, int len) {
 		if (io->ff) {
 			memset (buf, 0xff, len);
 		}
-		return len;
 	}
 	if (!io->maps) {
 		return r_io_pread_at (io, vaddr, buf, len);
@@ -431,12 +515,16 @@ R_API int r_io_vread_at(RIO *io, ut64 vaddr, ut8 *buf, int len) {
 		paddr = vaddr;
 	} else {
 		ut64 maddr = r_io_section_vaddr_to_maddr (io, vaddr);
+		onIterMap (io->maps->tail, io, maddr != UT64_MAX? maddr : vaddr, (ut8*)buf, len, 
+				R_IO_READ, (cbOnIterMap)r_io_pread_at);
+#if 0
 		paddr = r_io_map_select (io, maddr != UT64_MAX? maddr : vaddr);
 		if (paddr == UT64_MAX) {
 			paddr = vaddr;
 		}
+#endif
 	}
-	return r_io_pread_at (io, paddr, buf, len);
+	return len; 
 }
 
 //the API differs with SIOL in that returns a bool instead of amount read
@@ -686,12 +774,17 @@ R_API int r_io_vwrite_at(RIO *io, ut64 vaddr, const ut8 *buf, int len) {
 		paddr = vaddr;
 	} else {
 		ut64 maddr = r_io_section_vaddr_to_maddr (io, vaddr);
+
+		onIterMap (io->maps->tail, io, maddr != UT64_MAX? maddr : vaddr, (ut8*)buf, len, 
+				R_IO_WRITE, (cbOnIterMap)r_io_pwrite_at);
+#if 0
 		paddr = r_io_map_select (io, maddr != UT64_MAX? maddr : vaddr);
 		if (paddr == UT64_MAX) {
 			paddr = vaddr;
 		}
+#endif
 	}
-	return r_io_pwrite_at (io, paddr, buf, len);
+	return len;
 }
 
 R_API int r_io_write_at(RIO *io, ut64 addr, const ut8 *buf, int len) {

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -227,6 +227,9 @@ R_API RIOMap *r_io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut
 	RIOMap *map;
 	SdbListIter *iter;
 	ut64 end_addr = addr + size;
+	if (!flags) {
+		flags = R_IO_READ;
+	}
 	ls_foreach_prev (io->maps, iter, map) {
 		// XXX - This does not handle when file overflow 0xFFFFFFFF000 -> 0x00000000
 		// keeping (fd, to, from) tuples as separate maps
@@ -366,4 +369,21 @@ R_API void r_io_map_list(RIO *io, int mode) {
 			}
 		}
 	}
+}
+
+
+R_API bool r_io_map_is_in_range(RIOMap* map, ut64 from, ut64 to) { //rename pls
+	if (!map || (to < from)) {
+		return false;
+	}
+	if (R_BETWEEN (map->from, from, map->to)) {
+		return true;
+	}
+	if (R_BETWEEN (map->from, to, map->to)) {
+		return true;
+	}
+	if (map->from > from && to > map->to) {
+		return true;
+	}
+	return false;
 }

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -374,8 +374,9 @@ static bool __is_blockdevice (RIODesc *desc) {
 		return false;
 	}
 	mmo = desc->data;
-	if (fstat (mmo->fd, &buf) == -1)
+	if (fstat (mmo->fd, &buf) == -1) {
 		return false;
+	}
 	return ((buf.st_mode & S_IFBLK) == S_IFBLK);
 }
 #endif


### PR DESCRIPTION
This fix t.io/maps but it might introduce more regressions

Test from cmd_write is broken and is because `cp` is not copying at all but is independent from IO so kinda weird :S.