### PR TITLE
[siol fire] Fix off-by-1 in io.c

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -355,7 +355,6 @@ R_API int r_io_map_write_update(RIO *io, int fd, ut64 addr, ut64 len);
 R_API int r_io_map_truncate_update(RIO *io, int fd, ut64 sz);
 R_API int r_io_map_count (RIO *io);
 R_API void r_io_map_list (RIO *io, int rad);
-R_API bool r_io_map_is_in_range(RIOMap* map, ut64 from, ut64 to);
 
 /* io/section.c */
 R_API void r_io_section_init(RIO *io);

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -370,20 +370,3 @@ R_API void r_io_map_list(RIO *io, int mode) {
 		}
 	}
 }
-
-
-R_API bool r_io_map_is_in_range(RIOMap* map, ut64 from, ut64 to) { //rename pls
-	if (!map || (to < from)) {
-		return false;
-	}
-	if (R_BETWEEN (map->from, from, map->to)) {
-		return true;
-	}
-	if (R_BETWEEN (map->from, to, map->to)) {
-		return true;
-	}
-	if (map->from > from && to > map->to) {
-		return true;
-	}
-	return false;
-}


### PR DESCRIPTION
Is there an operating system where 64-bit largest address 2^64-1 is supported and can be used in a memory mapping? `UT64_MAX` is used to indicate invalid address, thus I think it might not be realistic to support address wraparound. `static void onIterMap(SdbListIter* iter, RIO* io, ut64 vaddr, ut8* buf,`

On Linux x86_64 `ffffffffffe00000 - ffffffffffffffff (=2 MB) unused hole` this space can not be allocated. `-errno` is reserved for errno. If 2^64-1 was supported on some operating system, the overflow checking and the closed interval representation would be very cumbersome. Such high-end address space is also unlikely to be used for sections (likely to be stacks where we might not desire to map. 

If i read carefully, https://github.com/condret/siol/tree/master/lib/io used closed intervals [map->from, map->to] to refer to memory mappings while here [map->from, map->to) are used. A few off-by-1 errors are introduced because of this nuance.
