### PR TITLE
Refuse to assemble group 1 ops with dwords on 64bit

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -347,6 +347,12 @@ static int process_1byte_op(RAsm *a, ut8 *data, const Opcode *op, int op1) {
 		return l;
 	}
 
+	if (a->bits == 64) {
+		if (!(op->operands[0].type & op->operands[1].type)) {
+			return -1;
+		}
+	}
+
 	if (a->bits == 64 &&
 		((op->operands[0].type & OT_QWORD) |
 		 (op->operands[1].type & OT_QWORD))) {


### PR DESCRIPTION
Only if operands differ in size

FIX #268 