### PR TITLE
Fix onIterMap & (I dropped "switch back to half-closed interval again" in this PR b/c resisitance)

### DIFF
--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -6,17 +6,15 @@
 
 R_LIB_VERSION (r_io);
 
-static void fd_read_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
-	bool *ret = (bool *)user;
-	*ret &= (r_io_fd_read_at (io, fd, addr, buf, len) == len);
+static int fd_read_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
+	return r_io_fd_read_at (io, fd, addr, buf, len);
 }
 
-static void fd_write_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
-	bool *ret = (bool *)user;
-	*ret &= (r_io_fd_write_at (io, fd, addr, buf, len) == len);
+static int fd_write_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
+	return r_io_fd_write_at (io, fd, addr, buf, len);
 }
 
-static void al_fd_read_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
+static int al_fd_read_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
 	RIOAccessLog *log = (RIOAccessLog *)user;
 	RIOAccessLogElement *ale = R_NEW0(RIOAccessLogElement);
 	int rlen = r_io_fd_read_at (io, fd, addr, buf, len);
@@ -33,9 +31,10 @@ static void al_fd_read_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, R
 	} else {
 		log->allocation_failed = true;
 	}
+	return rlen;
 }
 
-static void al_fd_write_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
+static int al_fd_write_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
 	RIOAccessLog *log = (RIOAccessLog *)user;
 	RIOAccessLogElement *ale = R_NEW0(RIOAccessLogElement);
 	int rlen = r_io_fd_write_at (io, fd, addr, buf, len);
@@ -52,70 +51,75 @@ static void al_fd_write_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, 
 	} else {
 		log->allocation_failed = true;
 	}
+	return rlen;
 }
 
-typedef void (*cbOnIterMap) (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user);
+typedef int (*cbOnIterMap)(RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user);
 
-static void onIterMap(SdbListIter* iter, RIO* io, ut64 vaddr, ut8* buf,
-		       int len, int match_flg, cbOnIterMap op, void *user) {
-	ut64 vendaddr = UT64_MAX;
-	if (!io || !iter || !buf || len < 1) {
-		return;
+// len > 0
+static int onIterMap(SdbListIter *iter, RIO *io, ut64 vaddr, ut8 *buf,
+		int len, int match_flg, cbOnIterMap op, void *user) {
+	// vendaddr may be 0 to denote 2**64
+	ut64 vendaddr = vaddr + len;
+	int t, ret = 0;
+	for (; iter; iter = iter->p) {
+		RIOMap *map = (RIOMap *)iter->data;
+		// [vaddr, vendaddr) [map->from, map->to]
+		if (vaddr <= map->to && map->from <= vendaddr - 1) {
+			if ((map->flags & match_flg) == match_flg || io->p_cache) {
+				t = vaddr < map->from
+					? op (io, map->fd, map->delta, buf + map->from - vaddr,
+								R_MIN (vendaddr - map->from, map->to - map->from + 1), map, user)
+					: op (io, map->fd, map->delta + vaddr - map->from, buf,
+								R_MIN (map->to - vaddr + 1, len), map, user);
+				if (t < 0) {
+					return t;
+				}
+				ret += t;
+			}
+			if (vaddr < map->from) {
+				t = onIterMap (iter->p, io, vaddr, buf, map->from - vaddr, match_flg, op, user);
+				if (t < 0) {
+					return t;
+				}
+				ret += t;
+			}
+			if (map->to < vendaddr - 1) {
+				t = onIterMap (iter->p, io, map->to, buf + map->to - vaddr + 1, vendaddr - map->to - 1, match_flg, op, user);
+				if (t < 0) {
+					return t;
+				}
+				ret += t;
+			}
+			break;
+		}
 	}
-	// this block is not that much elegant
-	if (UT64_ADD_OVFCHK (len - 1, vaddr)) {
-		int nlen = (int) (UT64_MAX - vaddr + 1);
-		onIterMap (iter->p, io, 0LL, buf + nlen, len - nlen, match_flg, op, user);
+	return ret;
+}
+
+// len >= 0
+static int onIterMap_wrap(SdbListIter *iter, RIO *io, ut64 vaddr, ut8 *buf,
+		int len, int match_flg, cbOnIterMap op, void *user) {
+	if (!len) {
+		return 0;
+	}
+	int len1, t, ret;
+	// vaddr + len > 2**64
+	if (vaddr > UT64_MAX - len + 1) {
+		len1 = UT64_MAX - vaddr + 1;
+		ret = onIterMap (iter, io, vaddr, buf, len1, match_flg, op, user);
+		if (ret >= 0) {
+			t = onIterMap (iter, io, 0, buf + len1, len - len1, match_flg, op, user);
+			if (t < 0) {
+				ret = t;
+			} else {
+				ret += t;
+			}
+		}
 	} else {
-		vendaddr = vaddr + len - 1;
+		ret = onIterMap (iter, io, vaddr, buf, len, match_flg, op, user);
 	}
-	RIOMap *map = (RIOMap*) iter->data;
-	// search for next map or end of list
-	while (!r_io_map_is_in_range (map, vaddr, vendaddr)) {
-		iter = iter->p;
-		// end of list
-		if (!iter && io->desc) {
-			// pread/pwrite
-			return;
-		}
-		map = (RIOMap*) iter->data;
-	}
-	if (map->from >= vaddr) {
-		onIterMap (iter->p, io, vaddr, buf, (int) (map->from - vaddr), match_flg, op, user);
-		buf = buf + (map->from - vaddr);
-		vaddr = map->from;
-		len = (int) (vendaddr - vaddr + 1);
-		if (vendaddr <= map->to) {
-			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
-				op (io, map->fd, map->delta, buf, len, map, user);
-			}
-		} else {
-			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
-				int nlen = len - (int) (vendaddr - map->to);
-				op (io, map->fd, map->delta, buf, nlen, map, user);
-			}
-			vaddr = map->to + 1;
-			buf = buf + (len - (int) (vendaddr - map->to));
-			len = (int) (vendaddr - map->to);
-			onIterMap (iter->p, io, vaddr, buf, len, match_flg, op, user);
-		}
-	} else {
-		if (vendaddr <= map->to) {
-			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
-				//can it overflow
-				op (io, map->fd, map->delta + (vaddr - map->from), buf, len, map, user);
-			}
-		} else {
-			if (((map->flags & match_flg) == match_flg) || io->p_cache) {
-				int nlen = len - (int) (vendaddr - map->to);
-				op (io, map->fd, map->delta + (vaddr - map->from), buf, nlen, map, user);
-			}
-			vaddr = map->to + 1;
-			buf = buf + (len - (int) (vendaddr - map->to));
-			len = (int) (vendaddr - map->to);
-			onIterMap (iter->p, io, vaddr, buf, len, match_flg, op, user);
-		}
-	}
+	return ret;
 }
 
 R_API RIO* r_io_new() {
@@ -303,7 +307,6 @@ R_API int r_io_pwrite_at(RIO* io, ut64 paddr, const ut8* buf, int len) {
 }
 
 R_API bool r_io_vread_at(RIO* io, ut64 vaddr, ut8* buf, int len) {
-	bool ret = true;
 	if (!io || !buf || (len < 1)) {
 		return false;
 	}
@@ -314,12 +317,10 @@ R_API bool r_io_vread_at(RIO* io, ut64 vaddr, ut8* buf, int len) {
 	if (!io->maps) {
 		return false;
 	}
-	onIterMap (io->maps->tail, io, vaddr, buf, len, R_IO_READ, fd_read_at_wrap, &ret);
-	return ret;
+	return onIterMap_wrap (io->maps->tail, io, vaddr, buf, len, R_IO_READ, fd_read_at_wrap, NULL) == len;
 }
 
 R_API bool r_io_vwrite_at(RIO* io, ut64 vaddr, const ut8* buf, int len) {
-	bool ret = true;
 	if (!io || !buf || (len < 1)) {
 		return false;
 	}
@@ -327,8 +328,7 @@ R_API bool r_io_vwrite_at(RIO* io, ut64 vaddr, const ut8* buf, int len) {
 	if (!io->maps) {
 		return false;
 	}
-	onIterMap (io->maps->tail, io, vaddr, (ut8*)buf, len, R_IO_WRITE, fd_write_at_wrap, &ret);
-	return ret;
+	return onIterMap_wrap (io->maps->tail, io, vaddr, (ut8*)buf, len, R_IO_WRITE, fd_write_at_wrap, NULL) == len;
 }
 
 R_API RIOAccessLog *r_io_al_vread_at(RIO* io, ut64 vaddr, ut8* buf, int len) {
@@ -344,7 +344,7 @@ R_API RIOAccessLog *r_io_al_vread_at(RIO* io, ut64 vaddr, ut8* buf, int len) {
 		memset (buf, 0xff, len);
 	}
 	log->buf = buf;
-	onIterMap (io->maps->tail, io, vaddr, buf, len, R_IO_READ, al_fd_read_at_wrap, log);
+	(void)onIterMap_wrap (io->maps->tail, io, vaddr, buf, len, R_IO_READ, al_fd_read_at_wrap, log);
 	return log;
 }
 
@@ -358,7 +358,7 @@ R_API RIOAccessLog *r_io_al_vwrite_at(RIO* io, ut64 vaddr, const ut8* buf, int l
 		return NULL;
 	}
 	log->buf = (ut8*)buf;
-	onIterMap (io->maps->tail, io, vaddr, (ut8*)buf, len, R_IO_WRITE, al_fd_write_at_wrap, log);
+	(void)onIterMap_wrap (io->maps->tail, io, vaddr, (ut8*)buf, len, R_IO_WRITE, al_fd_write_at_wrap, log);
 	return log;
 }
 
@@ -383,7 +383,7 @@ R_API bool r_io_read_at(RIO* io, ut64 addr, ut8* buf, int len) {
 
 R_API bool r_io_write_at(RIO* io, ut64 addr, const ut8* buf, int len) {
 	int i;
-	bool ret = false;
+	bool ret;
 	ut8 *mybuf = (ut8*)buf;
 	if (!io || !buf || len < 1) {
 		return false;
@@ -396,7 +396,7 @@ R_API bool r_io_write_at(RIO* io, ut64 addr, const ut8* buf, int len) {
 		}
 	}
 	if (io->cached) {
-		r_io_cache_write (io, addr, mybuf, len);	//can be ignored for the return
+		ret = r_io_cache_write (io, addr, mybuf, len);
 	} else if (io->va) {
 		ret = r_io_vwrite_at (io, addr, mybuf, len);
 	} else {


### PR DESCRIPTION
He confessed currently there are off-by-1 issues.

"condret | atm master does not read the last byte of a map, i want back to that state, bc it has worked, will watch yur patch after sleep"

A half-closed interval is what other 50+ call sites expect.
"pls don't break it anymore"

Drop unrealistic address wraparound because the current status is far from being able to support it.
You can always add `mapsplit` back with `from <= addr && (addr < to || !to)`. Please use half-closed intervals.

Please stop abusing `if (r_io_read_at (core->io, value, buf, sizeof (buf)))` with `bool r_io_read_at` nonsense. It's fine if the length is 4 or 8 or other small integer that full read is desired. Near the end of a map, mandating a full read is unrealistic.

I was insulted by your https://github.com/radare/radare2/commit/0161fa0ec2d1f20f38873d6a48ae13e08e2cc138 nonsense. I need an explanation.

Also see discussions at https://github.com/radare/radare2/issues/8264 .
I don't know why such misconception is so deeply ingrained in your minds. @condret @alvarofe