### PR TITLE
fix esil

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -273,7 +273,14 @@ static int internal_esil_mem_read_no_null(RAnalEsil *esil, ut64 addr, ut8 *buf, 
 		esil->trap_code = addr;
 		return false;
 	}
-	return esil->anal->iob.read_at (esil->anal->iob.io, addr, buf, len);
+	esil->anal->iob.read_at (esil->anal->iob.io, addr, buf, len);
+	if (!r_io_is_valid_offset (esil->anal->iob.io, addr, false)) {
+		if (esil->iotrap) {
+			esil->trap = R_ANAL_TRAP_READ_ERR;
+			esil->trap_code = addr;
+		}
+	}
+	return len;
 }
 
 R_API int r_anal_esil_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len) {
@@ -349,13 +356,13 @@ static int internal_esil_mem_write_no_null(RAnalEsil *esil, ut64 addr, const ut8
 		return 0;
 	}
 	ret = esil->anal->iob.write_at (esil->anal->iob.io, addr, buf, len);
-	if (ret != len) {
+	if (!r_io_is_valid_offset (esil->anal->iob.io, addr, false)) {
 		if (esil->iotrap) {
 			esil->trap = R_ANAL_TRAP_WRITE_ERR;
 			esil->trap_code = addr;
 		}
 	}
-	return ret;
+	return len;
 }
 
 R_API int r_anal_esil_mem_write(RAnalEsil *esil, ut64 addr, const ut8 *buf, int len) {

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -233,7 +233,6 @@ static bool alignCheck(RAnalEsil *esil, ut64 addr) {
 }
 
 static int internal_esil_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len) {
-	int ret;
 	if (!esil || !esil->anal || !esil->anal->iob.io) {
 		return 0;
 	}
@@ -249,7 +248,7 @@ static int internal_esil_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len)
 			}
 		}
 	}
-	ret = esil->anal->iob.read_at (esil->anal->iob.io, addr, buf, len);
+	esil->anal->iob.read_at (esil->anal->iob.io, addr, buf, len);
 	// check if request addres is mapped , if dont fire trap and esil ioer callback
 	// now with siol, read_at return true/false cant be used to check error vs len
 	if (!esil->anal->iob.is_valid_offset (esil->anal->iob.io, addr, false)) {
@@ -316,7 +315,6 @@ R_API int r_anal_esil_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len) {
 }
 
 static int internal_esil_mem_write(RAnalEsil *esil, ut64 addr, const ut8 *buf, int len) {
-	int ret;
 	if (!esil || !esil->anal || !esil->anal->iob.io || esil->nowrite) {
 		return 0;
 	}
@@ -332,7 +330,7 @@ static int internal_esil_mem_write(RAnalEsil *esil, ut64 addr, const ut8 *buf, i
 			}
 		}
 	}
-	ret = esil->anal->iob.write_at (esil->anal->iob.io, addr, buf, len);
+	esil->anal->iob.write_at (esil->anal->iob.io, addr, buf, len);
 	// check if request addres is mapped , if dont fire trap and esil ioer callback
 	// now with siol, write_at return true/false cant be used to check error vs len
 	if (!esil->anal->iob.is_valid_offset (esil->anal->iob.io, addr, false)) {

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -346,14 +346,13 @@ static int internal_esil_mem_write(RAnalEsil *esil, ut64 addr, const ut8 *buf, i
 }
 
 static int internal_esil_mem_write_no_null(RAnalEsil *esil, ut64 addr, const ut8 *buf, int len) {
-	int ret;
 	if (!esil || !esil->anal || !esil->anal->iob.io || !addr) {
 		return 0;
 	}
 	if (esil->nowrite) {
 		return 0;
 	}
-	ret = esil->anal->iob.write_at (esil->anal->iob.io, addr, buf, len);
+	esil->anal->iob.write_at (esil->anal->iob.io, addr, buf, len);
 	if (!esil->anal->iob.is_valid_offset (esil->anal->iob.io, addr, false)) {
 		if (esil->iotrap) {
 			esil->trap = R_ANAL_TRAP_WRITE_ERR;

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -252,7 +252,7 @@ static int internal_esil_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len)
 	ret = esil->anal->iob.read_at (esil->anal->iob.io, addr, buf, len);
 	// check if request addres is mapped , if dont fire trap and esil ioer callback
 	// now with siol, read_at return true/false cant be used to check error vs len
-	if (!r_io_is_valid_offset (esil->anal->iob.io, addr, false)) {
+	if (!esil->anal->iob.is_valid_offset (esil->anal->iob.io, addr, false)) {
 		if (esil->iotrap) {
 			esil->trap = R_ANAL_TRAP_READ_ERR;
 			esil->trap_code = addr;
@@ -274,7 +274,7 @@ static int internal_esil_mem_read_no_null(RAnalEsil *esil, ut64 addr, ut8 *buf, 
 		return false;
 	}
 	esil->anal->iob.read_at (esil->anal->iob.io, addr, buf, len);
-	if (!r_io_is_valid_offset (esil->anal->iob.io, addr, false)) {
+	if (!esil->anal->iob.is_valid_offset (esil->anal->iob.io, addr, false)) {
 		if (esil->iotrap) {
 			esil->trap = R_ANAL_TRAP_READ_ERR;
 			esil->trap_code = addr;
@@ -335,7 +335,7 @@ static int internal_esil_mem_write(RAnalEsil *esil, ut64 addr, const ut8 *buf, i
 	ret = esil->anal->iob.write_at (esil->anal->iob.io, addr, buf, len);
 	// check if request addres is mapped , if dont fire trap and esil ioer callback
 	// now with siol, write_at return true/false cant be used to check error vs len
-	if (!r_io_is_valid_offset (esil->anal->iob.io, addr, false)) {
+	if (!esil->anal->iob.is_valid_offset (esil->anal->iob.io, addr, false)) {
 		if (esil->iotrap) {
 			esil->trap = R_ANAL_TRAP_WRITE_ERR;
 			esil->trap_code = addr;
@@ -356,7 +356,7 @@ static int internal_esil_mem_write_no_null(RAnalEsil *esil, ut64 addr, const ut8
 		return 0;
 	}
 	ret = esil->anal->iob.write_at (esil->anal->iob.io, addr, buf, len);
-	if (!r_io_is_valid_offset (esil->anal->iob.io, addr, false)) {
+	if (!esil->anal->iob.is_valid_offset (esil->anal->iob.io, addr, false)) {
 		if (esil->iotrap) {
 			esil->trap = R_ANAL_TRAP_WRITE_ERR;
 			esil->trap_code = addr;


### PR DESCRIPTION
- internal_esil_mem_read: Implemented error callbacks
- internal_esil_mem_write: Adapted to SIOL, now read_at return true/false and cant be used to check errors vs size comparation.