### PR TITLE
no use r_core_file_get_next_map and delegate to r_bin_load to map desc

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -961,6 +961,7 @@ int main(int argc, char **argv, char **envp) {
 								(void)r_core_bin_load (&r, filepath, baddr);
 							}
 						} else {
+							r_io_map_new (r.io, iod->fd, iod->flags, 0LL, 0LL, r_io_desc_size (iod));
 							if (run_anal < 0) {
 								// PoC -- must move -rk functionalitiy into rcore
 								// this may be used with caution (r2 -nn $FILE)

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -754,7 +754,6 @@ static int cmd_open(void *data, const char *input) {
 			r_core_file_list (core, 'n');
 			break;
 		}
-
 		/* fall through */
 	case ' ':
 		{
@@ -762,18 +761,17 @@ static int cmd_open(void *data, const char *input) {
 			ut64 ma = 0L;
 			char *fn = strdup (input + (isn? 2:1));
 			if (!fn || !*fn) {
-				eprintf ("Usage: on [file]\n");
+				if (isn) {
+					eprintf ("Usage: on [file]\n");
+				} else {
+					eprintf ("Usage: o [file] addr\n");
+				}
 				free (fn);
 				break;
 			}
 			ptr = strchr (fn, ' ');
 			if (ptr) {
 				*ptr++ = '\0';
-				char *ptr2 = strchr (ptr, ' ');
-				if (ptr2) {
-					*ptr2++ = 0;
-					ba = r_num_math (core->num, ptr2);
-				}
 				ma = r_num_math (core->num, ptr);
 			}
 			int num = atoi (input + 1);
@@ -785,6 +783,9 @@ static int cmd_open(void *data, const char *input) {
 						// MUST CLEAN BEFORE LOADING
 						if (!isn) {
 							r_core_bin_load (core, fn, ba);
+						} else {
+							RIODesc *d = r_io_desc_get (core->io, file->fd);
+							r_io_map_new (core->io, d->fd, d->flags, 0LL, ma, r_io_desc_size (d));
 						}
 					} else if (!nowarn) {
 						eprintf ("Cannot open file '%s'\n", fn);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2194,8 +2194,7 @@ reaccept:
 					file = r_core_file_open (core, (const char *)ptr, perm, 0);
 					if (file) {
 						r_core_bin_load (core, NULL, baddr);
-						file->map = r_io_map_add (core->io, file->fd,
-								perm, 0, 0, r_io_fd_size (core->io, file->fd));
+						r_io_map_add (core->io, file->fd, perm, 0, 0, r_io_fd_size (core->io, file->fd));
 						if (core->file) {
 							pipefd = core->file->fd;
 						} else {

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -58,11 +58,6 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 
 	// HACK: move last mapped address to higher place
 	// XXX - why does this hack work?
-	if (ofile->map) {
-		ofrom = ofile->map->from;
-		ofile->map->from = UT32_MAX;
-	}
-	// closing the file to make sure there are no collisions
 	// when the new memory maps are created.
 	path = strdup (ofilepath);
 	free (obinfilepath);
@@ -72,9 +67,6 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 	if (file) {
 		bool had_rbin_info = false;
 
-		if (ofile->map) {
-			ofile->map->from = ofrom;
-		}
 		if (ofile) {
 			if (r_bin_file_delete (core->bin, ofile->fd)) {
 				had_rbin_info = true;
@@ -82,9 +74,6 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 		}
 		r_core_file_close (core, ofile);
 		r_core_file_set_by_file (core, file);
-		if (file) {
-			r_core_file_set_by_fd (core, file->fd);
-		}
 		ofile = NULL;
 		odesc = NULL;
 		//	core->file = file;
@@ -111,9 +100,6 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 		// lower it down back
 		//ofile = r_core_file_open (core, path, R_IO_READ, addr);
 		r_core_file_set_by_file (core, ofile);
-		if (ofile->map) {
-			ofile->map->from = ofrom;
-		}
 	} else {
 		eprintf ("Cannot reopen\n");
 	}
@@ -637,6 +623,10 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 			libaddr += 0x2000000;
 		}
 	}
+	//workaround to map correctly malloc:// and raw binaries
+	if (!plugin || !strcmp (plugin->name, "any") || !desc->plugin || !desc->plugin->isdbg) {
+		r_io_map_new (r->io, desc->fd, desc->flags, 0LL, 0LL, r_io_desc_size (desc));
+	}
 	return true;
 }
 
@@ -667,7 +657,7 @@ R_API RIOMap *r_core_file_get_next_map(RCore *core, RCoreFile *fh, int mode, ut6
 			}
 		}
 	}
-//	r_io_sort_maps (core->io); //necessary ???	//condret says yes
+//	r_io_sort_maps (core->io); //necessary ???	//condret says no
 	return map;
 }
 
@@ -716,25 +706,10 @@ R_API RCoreFile *r_core_file_open_many(RCore *r, const char *file, int flags, ut
 		fh->fd = fd->fd;
 		r->file = fh;
 		// XXX - load addr should be at a set offset
-		fh->map = r_core_file_get_next_map (r, fh, flags, current_loadaddr);
-
-		if (!fh->map) {
-			r_core_file_free (fh);
-			if (!strcmp (suppress_warning, "false")) {
-				eprintf ("Unable to load file due to failed mapping.\n");
-			}
-			continue;
-		}
-
-		current_loadaddr = fh->map->to;
-		if (!top_file) {
-			top_file = fh;
-			// check load addr to make sure its still valid
-			loadaddr = top_file->map->from;
-		}
+		//r_core_file_get_next_map (r, fh, flags, current_loadaddr);
 		r_bin_bind (r->bin, &(fh->binb));
 		r_list_append (r->files, fh);
-		r_core_bin_load (r, fd->name, fh->map->from);
+		r_core_bin_load (r, fd->name, 0LL);
 	}
 	if (!top_file) {
 		free (loadmethod);
@@ -746,7 +721,6 @@ R_API RCoreFile *r_core_file_open_many(RCore *r, const char *file, int flags, ut
 	}
 
 	r_config_set (r->config, "file.path", r_file_abspath (r_io_desc_get (r->io, top_file->fd)->name));
-	r_config_set_i (r->config, "zoom.to", top_file->map->from + r_io_fd_size (r->io, top_file->fd));
 	if (loadmethod) {
 		r_config_set (r->config, "file.loadmethod", loadmethod);
 	}
@@ -819,15 +793,6 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 		r_config_set (r->config, "file.path", absfile);
 		free (absfile);
 	}
-	fh->map = r_core_file_get_next_map (r, fh, flags, loadaddr);
-	if (!fh->map) {
-		r_core_file_free (fh);
-		fh = NULL;
-		if (!strcmp (suppress_warning, "false")) {
-			eprintf ("Unable to load file due to failed mapping.\n");
-		}
-		goto beach;
-	}
 	// check load addr to make sure its still valid
 	r_bin_bind (r->bin, &(fh->binb));
 
@@ -835,10 +800,8 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 		r->files = r_list_newf ((RListFree)r_core_file_free);
 	}
 
-	r_list_append (r->files, fh);
 	r_core_file_set_by_file (r, fh);
-	r_config_set_i (r->config, "zoom.to", fh->map->from + r_io_desc_size (fd));
-
+	r_list_append (r->files, fh);
 	if (r_config_get_i (r->config, "cfg.debug")) {
 		bool swstep = true;
 		if (r->dbg->h && r->dbg->h->canstep) {
@@ -948,11 +911,7 @@ R_API int r_core_file_list(RCore *core, int mode) {
 	}
 	r_list_foreach (core->files, iter, f) {
 		desc = r_io_desc_get (core->io, f->fd);
-		if (f->map) {
-			from = f->map->from;
-		} else {
-			from = 0LL;
-		}
+		from = 0LL;
 		switch (mode) {
 		case 'j':
 			r_cons_printf ("{\"raised\":%s,\"fd\":%d,\"uri\":\"%s\",\"from\":%"
@@ -1056,11 +1015,10 @@ R_API int r_core_file_binlist(RCore *core) {
 		int fd = binfile->fd;
 		cf = r_core_file_get_by_fd (core, fd);
 		desc = r_io_desc_get (core->io, fd);
-		if (cf && cf->map) {
-			r_cons_printf ("%c %d %s @ 0x%"PFMT64x " ; %s\n",
+		if (cf) {
+			r_cons_printf ("%c %d %s ; %s\n",
 				core->io->desc == desc ? '*': '-',
-				fd, desc->uri, cf->map->from,
-				desc->flags & R_IO_WRITE? "rw": "r");
+				fd, desc->uri, desc->flags & R_IO_WRITE? "rw": "r");
 		}
 	}
 	r_core_file_set_by_file (core, cur_cf);
@@ -1169,8 +1127,12 @@ R_API RCoreFile *r_core_file_find_by_name(RCore *core, const char *name) {
 }
 
 R_API int r_core_file_set_by_fd(RCore *core, ut64 fd) {
-	RCoreFile *cf = r_core_file_find_by_fd (core, fd);
-	return r_core_file_set_by_file (core, cf);
+	if (core) {
+		r_io_use_fd (core->io, fd);
+		r_core_bin_set_by_fd (core, fd);
+		return true;
+	}
+	return false;
 }
 
 R_API int r_core_file_set_by_name(RCore *core, const char *name) {
@@ -1179,14 +1141,11 @@ R_API int r_core_file_set_by_name(RCore *core, const char *name) {
 }
 
 R_API int r_core_file_set_by_file(RCore *core, RCoreFile *cf) {
-	if (cf && core) {
-		RIODesc *desc = r_io_desc_get (core->io, cf->fd);
-		core->offset = cf && cf->map? cf->map->from: 0LL;
-		core->file = cf;
-		if (desc) {
-			r_io_use_fd (core->io, cf->fd);
-			r_core_bin_set_by_fd (core, cf->fd);
+	if (core && cf) {
+		if (!r_core_file_set_by_fd (core, cf->fd)) {
+			return false;
 		}
+		core->file = cf;
 		return true;
 	}
 	return false;

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -524,6 +524,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 	ut64 laddr = r_config_get_i (r->config, "bin.laddr");
 	RBinFile *binfile = NULL;
 	RBinPlugin *plugin = NULL;
+	RBinObject *obj = NULL;
 	int is_io_load;
 	if (!cf) {
 		return false;
@@ -592,7 +593,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 		r->bin->minstrlen = r_config_get_i (r->config, "bin.minstr");
 		r->bin->maxstrbuf = r_config_get_i (r->config, "bin.maxstrbuf");
 	} else if (binfile) {
-		RBinObject *obj = r_bin_get_object (r->bin);
+		obj = r_bin_get_object (r->bin);
 		RBinInfo *info = obj? obj->info: NULL;
 		if (plugin && plugin->name && info) {
 			if (strcmp (plugin->name, "any")) {
@@ -623,8 +624,9 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 			libaddr += 0x2000000;
 		}
 	}
+	obj = r_bin_cur_object (r->bin);
 	//workaround to map correctly malloc:// and raw binaries
-	if (!plugin || !strcmp (plugin->name, "any") || r_io_desc_is_dbg (desc)) {
+	if (!plugin || !strcmp (plugin->name, "any") || r_io_desc_is_dbg (desc) || !obj->sections) {
 		r_io_map_new (r->io, desc->fd, desc->flags, 0LL, laddr, r_io_desc_size (desc));
 	}
 	return true;

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -626,7 +626,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 	}
 	obj = r_bin_cur_object (r->bin);
 	//workaround to map correctly malloc:// and raw binaries
-	if (!plugin || !strcmp (plugin->name, "any") || r_io_desc_is_dbg (desc) || !obj->sections) {
+	if (!plugin || !strcmp (plugin->name, "any") || r_io_desc_is_dbg (desc) || !obj->sections) {
 		r_io_map_new (r->io, desc->fd, desc->flags, 0LL, laddr, r_io_desc_size (desc));
 	}
 	return true;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -90,7 +90,6 @@ typedef struct r_core_log_t {
 } RCoreLog;
 
 typedef struct r_core_file_t {
-	RIOMap *map;
 	int dbg;
 	int fd;
 	RBinBind binb;


### PR DESCRIPTION
r_bin_load if detects that there was not plugin to handle the file, it
will map the desc, honoring its flags. Therefore, for binaries at 0 when
io.va=0 there won't be nothing mapped

The function r_core_file_get_next_map is maintained but not used to discuss
about what it was its purpose