### PR TITLE
Fixed a linker error on OpenSUSE

### DIFF
--- a/binr/rules.mk
+++ b/binr/rules.mk
@@ -32,13 +32,6 @@ LDFLAGS+=../../shlr/capstone/libcapstone.a
 LDFLAGS+=../../shlr/java/libr_java.a
 LDFLAGS+=../../libr/socket/libr_socket.a
 LDFLAGS+=../../libr/util/libr_util.a
-ifneq (${ANDROID},1)
-ifneq (${OSTYPE},linux)
-ifneq ($(CC),cccl)
-LDFLAGS+=-lpthread
-endif
-endif
-endif
 ifneq (${OSTYPE},haiku)
 ifneq ($(CC),cccl)
 LDFLAGS+=-lm
@@ -47,6 +40,13 @@ endif
 endif
 LDFLAGS+=${DL_LIBS}
 LDFLAGS+=${LINK}
+ifneq (${ANDROID},1)
+ifneq (${OSTYPE},linux)
+ifneq ($(CC),cccl)
+LDFLAGS+=-lpthread
+endif
+endif
+endif
 
 REAL_LDFLAGS=$(subst -shared,,$(LDFLAGS))
 


### PR DESCRIPTION
This fixed:

```
LD rax2
/usr/x86_64-suse-linux/lib64/libpthread.so.0: undefined reference to `h_errno@GLIBC_PRIVATE'
collect2: error: ld returned 1 exit status
```

by moving -lpthread later.