### PR TITLE
Add octal esc handling to r_str_unescape

### DIFF
--- a/libr/include/r_util/r_str_util.h
+++ b/libr/include/r_util/r_str_util.h
@@ -10,6 +10,7 @@
 #define ISHEXCHAR(x) ((x>='0'&&x<='9') ||  (x>='a'&&x<='f') ||  (x>='A'&&x<='F'))
 #define IS_PRINTABLE(x) (x>=' '&&x<='~')
 #define IS_DIGIT(x) (x>='0'&&x<='9')
+#define IS_OCTAL(x) ((x) >= '0' && (x) <= '7')
 #define IS_WHITESPACE(x) (x==' '||x=='\t')
 #define IS_UPPER(c) ((c) >= 'A' && (c) <= 'Z')
 #define IS_LOWER(c) ((c) >= 'a' && (c) <= 'z')

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1180,6 +1180,19 @@ R_API int r_str_unescape(char *buf) {
 			}
 			buf[i] = (ch << 4) + ch2;
 			memmove (buf + i + 1, buf + i + 4, strlen (buf + i + 4) + 1);
+		} else if (IS_OCTAL (buf[i + 1])) {
+			int num_digits = 1;
+			buf[i] = buf[i + 1] - '0';
+			if (IS_OCTAL (buf[i + 2])) {
+				num_digits++;
+				buf[i] = (ut8)buf[i] * 8 + (buf[i + 2] - '0');
+				if (IS_OCTAL (buf[i + 3])) {
+					num_digits++;
+					buf[i] = (ut8)buf[i] * 8 + (buf[i + 3] - '0');
+				}
+			}
+			memmove (buf + i + 1, buf + i + 1 + num_digits,
+			         strlen (buf + i + 1 + num_digits) + 1);
 		} else {
 			eprintf ("'\\x' expected.\n");
 			return 0; // -1?


### PR DESCRIPTION
As per https://github.com/radare/radare2/pull/7827#issuecomment-312195198. Sorry forgot about this. Semantics as per [the C language](http://en.cppreference.com/w/c/language/escape).