### PR TITLE
[siol] Add io->map_skyline as an RVector of uncovered map parts

### DIFF
--- a/libr/include/r_binheap.h
+++ b/libr/include/r_binheap.h
@@ -1,0 +1,26 @@
+#ifndef R2_BINHEAP_H
+#define R2_BINHEAP_H
+
+#include "r_vector.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct r_binheap_t {
+	RVector a;
+	RVectorComparator cmp;
+} RBinHeap;
+
+R_API void r_binheap_clear(RBinHeap *h, void (*elem_free)(void *));
+#define r_binheap_empty(h) (!(h)->a.len)
+R_API void r_binheap_init(RBinHeap *h, RVectorComparator cmp);
+R_API RBinHeap *r_binheap_new(RVectorComparator cmp);
+R_API bool r_binheap_push(RBinHeap *h, void *x);
+R_API void *r_binheap_pop(RBinHeap *h);
+#define r_binheap_top(h) ((h)->a.a[0])
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -7,6 +7,7 @@
 #include <r_list.h>
 #include <r_socket.h>
 #include <r_util.h>
+#include <r_vector.h>
 
 #define R_IO_READ	4
 #define R_IO_WRITE	2
@@ -70,6 +71,7 @@ typedef struct r_io_t {
 	RIDPool *sec_ids;
 	RIDPool *map_ids;
 	SdbList *maps; //from tail backwards maps with higher priority are found
+	RVector map_skyline; // map parts that are not covered by others
 	SdbList *sections;
 	RIDStorage *files;
 	RCache *buffer;
@@ -155,6 +157,12 @@ typedef struct r_io_map_t {
 	ut64 delta; //this delta means paddr when talking about section
 	char *name;
 } RIOMap;
+
+typedef struct r_io_map_skyline_t {
+	RIOMap *map;
+	ut64 from;
+	ut64 to;
+} RIOMapSkyline;
 
 typedef struct r_io_section_t {
 	char *name;

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -74,12 +74,12 @@ R_API void r_vector_sort(RVector *vec, RVectorComparator cmp);
 #define r_vector_foreach(vec, it) \
 	for (it = (vec)->a; it != (vec)->a + (vec)->len; it++)
 
-#define r_vector_lower_bound(vec, x, i, cmp_less) \
+#define r_vector_lower_bound(vec, x, i, cmp) \
 	do { \
 		int h = (vec)->len, m; \
 		for (i = 0; i < h; ) { \
 			m = i + ((h - i) >> 1); \
-			if (cmp_less ((vec)->a[m], x)) { \
+			if (cmp ((vec)->a[m], x) < 0) { \
 				i = m + 1; \
 			} else { \
 				h = m; \
@@ -87,12 +87,12 @@ R_API void r_vector_sort(RVector *vec, RVectorComparator cmp);
 		} \
 	} while (0) \
 
-#define r_vector_upper_bound(vec, x, i, cmp_less) \
+#define r_vector_upper_bound(vec, x, i, cmp) \
 	do { \
 		int h = (vec)->len, m; \
 		for (i = 0; i < h; ) { \
 			m = i + ((h - i) >> 1); \
-			if (!(cmp_less (x, (vec)->a[m]))) { \
+			if (!(cmp (x, (vec)->a[m]) < 0)) { \
 				i = m + 1; \
 			} else { \
 				h = m; \

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -1,11 +1,131 @@
-/* radare2 - LGPL - Copyright 2017 - condret */
+/* radare2 - LGPL - Copyright 2017 - condret, MaskRay */
 
-#include <r_io.h>
-#include <r_util.h>
-#include <sdb.h>
 #include <stdlib.h>
+#include <sdb.h>
+#include "r_binheap.h"
+#include "r_io.h"
+#include "r_util.h"
+#include "r_vector.h"
 
 #define END_OF_MAP_IDS  0xffffffff
+
+#define MAP_USE_HALF_CLOSED 0
+
+struct map_event_t {
+	RIOMap *map;
+	ut64 addr;
+	int id; // distinct priority in [0, len(maps))
+	bool is_to;
+};
+
+// Sort by address, (addr, !is_to) precedes (addr, is_to)
+static int _cmp_map_event(const void *a_, const void *b_) {
+	struct map_event_t *a = (void *)a_, *b = (void *)b_;
+	if (a->addr != b->addr) {
+		return a->addr < b->addr ? -1 : 1;
+	}
+	return a->is_to - b->is_to; // TODO swap if half-closed
+}
+
+static int _cmp_map_event_by_id(const void *a_, const void *b_) {
+	struct map_event_t *a = (void *)a_, *b = (void *)b_;
+	return a->id - b->id;
+}
+
+static bool _map_skyline_push(RVector *map_skyline, ut64 from, ut64 to, RIOMap *map) {
+	RIOMapSkyline *part = R_NEW (RIOMapSkyline);
+	if (!part) {
+		return false;
+	}
+	part->map = map;
+	part->from = from;
+	part->to = to - 1; // TODO half-closed
+	return r_vector_push (map_skyline, part);
+}
+
+// Store map parts that are not covered by others into io->map_skyline
+static void _calculate_skyline(RIO *io) {
+#if MAP_USE_HALF_CLOSED
+# error Please migrate to half-closed
+#endif
+#define PUSH
+	SdbListIter *iter;
+	RIOMap *map;
+	RVector events = {0};
+	RBinHeap heap;
+	struct map_event_t *ev;
+	bool *deleted = NULL;
+	r_vector_clear (&io->map_skyline, free);
+	if (!r_vector_reserve (&events, ls_length (io->maps) * 2) ||
+			!(deleted = calloc (ls_length (io->maps), 1))) {
+		goto out;
+	}
+
+	int i = 0;
+	ls_foreach (io->maps, iter, map) {
+		if (!(ev = R_NEW (struct map_event_t))) {
+			goto out;
+		}
+		ev->map = map;
+		ev->addr = map->from;
+		ev->is_to = false;
+		ev->id = i;
+		r_vector_push (&events, ev);
+		if (!(ev = R_NEW (struct map_event_t))) {
+			goto out;
+		}
+		ev->map = map;
+		ev->addr = map->to;
+		ev->is_to = true;
+		ev->id = i;
+		r_vector_push (&events, ev);
+		i++;
+	}
+	r_vector_sort (&events, _cmp_map_event);
+
+	r_binheap_init (&heap, _cmp_map_event_by_id);
+	ut64 last;
+	RIOMap *last_map = NULL;
+	for (i = 0; i < events.len; i++) {
+		ev = events.a[i];
+		if (ev->is_to) {
+			deleted[ev->id] = true;
+		} else {
+			r_binheap_push (&heap, ev);
+		}
+		while (!r_binheap_empty (&heap) && deleted[((struct map_event_t *)r_binheap_top (&heap))->id]) {
+			r_binheap_pop (&heap);
+		}
+		ut64 to = ev->addr + ev->is_to; // TODO half-closed
+		map = r_binheap_empty (&heap) ? NULL : ((struct map_event_t *)r_binheap_top (&heap))->map;
+		if (!i) {
+			last = to;
+			last_map = map;
+		} else if (last != to || (!to && ev->is_to)) {
+			if (last_map != map) {
+				if (last_map && !_map_skyline_push (&io->map_skyline, last, to, last_map)) {
+					break;
+				}
+				last = to;
+				last_map = map;
+			}
+			if (!to && ev->is_to) {
+				if (map) {
+					(void)_map_skyline_push (&io->map_skyline, last, to, map);
+				}
+				// This is a to == 2**64 event. There are no more skyline parts.
+				break;
+			}
+		} else if (map && (!last_map || map->id > last_map->id)) {
+			last_map = map;
+		}
+	}
+
+out:
+	r_binheap_clear (&heap, NULL);
+	r_vector_clear (&events, free);
+	free (deleted);
+}
 
 R_API RIOMap* r_io_map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size) {
 	if (!size || !io || !io->maps || !io->map_ids) {
@@ -29,6 +149,8 @@ R_API RIOMap* r_io_map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut
 	map->delta = delta;
 	// new map lives on the top, being top the list's tail
 	ls_append (io->maps, map);
+	// TODO When maps are added in batch (sections), do not recalculate each time
+	_calculate_skyline (io);
 	return map;
 }
 
@@ -47,6 +169,7 @@ R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr) {
 		return true;
 	}
 	map->to = addr + size - 1;
+	_calculate_skyline (io);
 	return true;
 }
 
@@ -145,6 +268,7 @@ R_API bool r_io_map_del(RIO* io, ut32 id) {
 		if (map->id == id) {
 			ls_delete (io->maps, iter);
 			r_id_pool_kick_id (io->map_ids, id);
+			_calculate_skyline (io);
 			return true;
 		}
 	}
@@ -169,6 +293,9 @@ R_API bool r_io_map_del_for_fd(RIO* io, int fd) {
 			ret = true;
 		}
 	}
+	if (ret) {
+		_calculate_skyline (io);
+	}
 	return ret;
 }
 
@@ -185,6 +312,7 @@ R_API bool r_io_map_priorize(RIO* io, ut32 id) {
 		if (map->id == id) {
 			ls_split_iter (io->maps, iter);
 			ls_append (io->maps, map);
+			_calculate_skyline (io);
 			return true;
 		}
 	}
@@ -214,6 +342,7 @@ R_API bool r_io_map_priorize_for_fd(RIO* io, int fd) {
 	ls_join (io->maps, list);
 	ls_free (list);
 	io->maps->free = _map_free;
+	_calculate_skyline (io);
 	return true;
 }
 
@@ -231,15 +360,21 @@ R_API void r_io_map_cleanup(RIO* io) {
 		r_io_map_init (io);
 		return;
 	}
+	bool del = false;
 	ls_foreach_safe (io->maps, iter, ator, map) {
 		//remove iter if the map is a null-ptr, this may fix some segfaults
 		if (!map) {
 			ls_delete (io->maps, iter);
+			del = true;
 		} else if (!r_io_desc_get (io, map->fd)) {
 			//delete map and iter if no desc exists for map->fd in io->files
 			r_id_pool_kick_id (io->map_ids, map->id);
 			ls_delete (io->maps, iter);
+			del = true;
 		}
+	}
+	if (del) {
+		_calculate_skyline (io);
 	}
 }
 
@@ -251,6 +386,7 @@ R_API void r_io_map_fini(RIO* io) {
 	io->maps = NULL;
 	r_id_pool_free (io->map_ids);
 	io->map_ids = NULL;
+	r_vector_clear (&io->map_skyline, free);
 }
 
 R_API void r_io_map_set_name(RIOMap* map, const char* name) {

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -4,7 +4,7 @@ NAME=r_util
 CFLAGS+=-DCORELIB -I$(TOP)/shlr
 DEPS=
 
-OBJS=mem.o pool.o unum.o str.o hex.o file.o range.o tinyrange.o
+OBJS=binheap.o mem.o pool.o unum.o str.o hex.o file.o range.o tinyrange.o
 OBJS+=prof.o cache.o sys.o buf.o w32-sys.o ubase64.o base85.o base91.o
 OBJS+=list.o flist.o mixed.o btree.o chmod.o graph.o
 OBJS+=regex/regcomp.o regex/regerror.o regex/regexec.o uleb128.o

--- a/libr/util/binheap.c
+++ b/libr/util/binheap.c
@@ -1,0 +1,55 @@
+#include "r_binheap.h"
+
+static inline void _heap_down(RBinHeap *h, int i, void *x) {
+	int j;
+	for (; j = i * 2 + 1, j < h->a.len; i = j) {
+		if (j + 1 < h->a.len && h->cmp (h->a.a[j+1], h->a.a[j])) {
+			j++;
+		}
+		if (!(h->cmp (h->a.a[j], x))) {
+			break;
+		}
+		h->a.a[i] = h->a.a[j];
+	}
+	h->a.a[i] = x;
+}
+
+static inline void _heap_up(RBinHeap *h, int i, void *x) {
+	int j;
+	for (; i && (j = (i-1) >> 1, h->cmp (x, h->a.a[j])); i = j) {
+		h->a.a[i] = h->a.a[j];
+	}
+	h->a.a[i] = x;
+}
+
+R_API void r_binheap_clear(RBinHeap *h, void (*elem_free)(void *)) {
+  r_vector_clear (&h->a, elem_free);
+}
+
+R_API void r_binheap_init(RBinHeap *h, RVectorComparator cmp) {
+	r_vector_init (&h->a);
+	h->cmp = cmp;
+}
+
+R_API RBinHeap *r_binheap_new(RVectorComparator cmp) {
+	RBinHeap *h = R_NEW (RBinHeap);
+	if (h) {
+		h->cmp = cmp;
+	}
+	return h;
+}
+
+R_API void *r_binheap_pop(RBinHeap *h) {
+	void *ret = h->a.a[0];
+	h->a.len--;
+	_heap_down (h, 0, h->a.a[h->a.len]);
+	return ret;
+}
+
+R_API bool r_binheap_push(RBinHeap *h, void *x) {
+	if (!r_vector_push (&h->a, NULL)) {
+		return false;
+	}
+	_heap_up (h, h->a.len - 1, x);
+	return true;
+}

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -164,13 +164,13 @@ R_API void **r_vector_shrink(RVector *vec) {
 }
 
 // CLRS Quicksort. It is slow, but simple.
-static void quick_sort(void **a, int n, RVectorComparator cmp_less) {
+static void quick_sort(void **a, int n, RVectorComparator cmp) {
 	if (n <= 1) return;
 	int i = rand() % n, j = 0;
 	void *t, *pivot = a[i];
 	a[i] = a[n - 1];
 	for (i = 0; i < n - 1; i++)
-		if (cmp_less (a[i], pivot)) {
+		if (cmp (a[i], pivot) < 0) {
 			t = a[i];
 			a[i] = a[j];
 			a[j] = t;
@@ -178,12 +178,12 @@ static void quick_sort(void **a, int n, RVectorComparator cmp_less) {
 		}
 	a[n - 1] = a[j];
 	a[j] = pivot;
-	quick_sort (a, j, cmp_less);
-	quick_sort (a + j + 1, n - j - 1, cmp_less);
+	quick_sort (a, j, cmp);
+	quick_sort (a + j + 1, n - j - 1, cmp);
 }
 
-R_API void r_vector_sort(RVector *vec, RVectorComparator cmp_less) {
-	quick_sort (vec->a, vec->len, cmp_less);
+R_API void r_vector_sort(RVector *vec, RVectorComparator cmp) {
+	quick_sort (vec->a, vec->len, cmp);
 }
 
 #if TEST
@@ -246,23 +246,23 @@ int main () {
 		r_vector_insert_range (&s, 0, a + 2, a + 5);
 		r_vector_insert_range (&s, 0, a, a + 2);
 
-#define CMP_LESS(x, y) x < y
-		r_vector_lower_bound (&s, (void *)4, l, CMP_LESS);
+#define CMP(x, y) x < y
+		r_vector_lower_bound (&s, (void *)4, l, CMP);
 		assert (s.a[l] == (void *)4);
-		r_vector_lower_bound (&s, (void *)5, l, CMP_LESS);
+		r_vector_lower_bound (&s, (void *)5, l, CMP);
 		assert (s.a[l] == (void *)6);
-		r_vector_lower_bound (&s, (void *)6, l, CMP_LESS);
+		r_vector_lower_bound (&s, (void *)6, l, CMP);
 		assert (s.a[l] == (void *)6);
-		r_vector_lower_bound (&s, (void *)9, l, CMP_LESS);
+		r_vector_lower_bound (&s, (void *)9, l, CMP);
 		assert (l == s.len);
 
-		r_vector_upper_bound (&s, (void *)4, l, CMP_LESS);
+		r_vector_upper_bound (&s, (void *)4, l, CMP);
 		assert (s.a[l] == (void *)6);
-		r_vector_upper_bound (&s, (void *)5, l, CMP_LESS);
+		r_vector_upper_bound (&s, (void *)5, l, CMP);
 		assert (s.a[l] == (void *)6);
-		r_vector_upper_bound (&s, (void *)6, l, CMP_LESS);
+		r_vector_upper_bound (&s, (void *)6, l, CMP);
 		assert (s.a[l] == (void *)8);
-#undef CMP_LESS
+#undef CMP
 
 		r_vector_clear (&s, NULL);
 
@@ -273,8 +273,7 @@ int main () {
 		r_vector_push (&s, strdup ("Caterpie"));
 		r_vector_sort (&s, my_cmp);
 
-#define CMP_LESS(x, y) strcmp (x, y) < 0
-		r_vector_lower_bound (&s, "Meow", l, CMP_LESS);
+		r_vector_lower_bound (&s, "Meow", l, strcmp);
 		assert (!strcmp (s.a[l], "Meowth"));
 
 		r_vector_clear (&s, free);


### PR DESCRIPTION
See comment at https://github.com/radare/radare2/pull/8279#issuecomment-325170198

`_calculate_skyline` is a scan line algorithm that finds all uncovered map parts (I refer it as "skyline") of maps. An interval is covered if there is another map of higher priority. By precomputing all uncovered parts of maps (they are also non-overlapping so binary search can be employed to locate an intersecting interval quickly), we can speed up `r_io_vread_at` when there are (say > 50) maps.

The algorithm creates two event point (`from` (+1) and `to` (-1)) for each map and sorts these event points. Next it sweeps from left to right, whenever a `from` endpoint is encountered, increases 1 to a counter, decreases 1 to the counter when a `to` endpoint is encountered.

The counter is sometimes positive and sometimes zero. The positive parts indicate a region of the union of these maps. When the counter is positive, all effective maps are stored in a binary heap (`libr/util/binheap.c`). The one of the highest priority is stored at the root of the binary heap.

The map of the highest priority is stored in `last_map` and `map`. Whenever the value changes, we should add a part to the whole skyline. I've also tested this algorithm at https://gist.github.com/MaskRay/83e666324071ea398272544f8543d4a9 and it seems to work for to == 2**64 maps.


Note, whenever the maps change, the map skyline should be recalculated. I left a TODO at

```c
R_API RIOMap* r_io_map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut
        map->delta = delta;
        // new map lives on the top, being top the list's tail
        ls_append (io->maps, map);
+       // TODO When maps are added in batch (sections), do not recalculate each time
+       _calculate_skyline (io);
        return map;
 }
```

because `r_io_map_new` may be used in batch and we should only do the calculation when all maps are added by RBin (or others, but I am not clear how it works and cannot do it in this PR) 



This one currently uses the closed-interval representation of `RIOMap`. There are a few changes if half-closed interval is the future.