### PR TITLE
Bring back old read-4-byte hack in analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -521,9 +521,11 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 				goto error;
 			}
 		}
-		if (!r_io_read_at (core->io, at + delta, buf, buflen)) {
+		// TODO bring back old hack, should be fixed
+		if (!r_io_read_at (core->io, at + delta, buf, 4)) {
 			goto error;
 		}
+		(void)r_io_read_at (core->io, at + delta, buf, buflen);
 		if (r_cons_is_breaked ()) {
 			break;
 		}
@@ -3360,7 +3362,7 @@ static int esilbreak_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len) {
 		ut8 buf[8];
 		ut64 refptr;
 		if (len == 8) {
-			if (!r_io_read_at (mycore->io, addr, (ut8*)buf, sizeof (buf))) {
+			if (!r_io_read_at (mycore->io, addr, (ut8*)buf, len)) {
 				/* invalid read */
 				refptr = UT64_MAX;
 			} else {
@@ -3368,7 +3370,7 @@ static int esilbreak_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len) {
 				esilbreak_last_data = refptr;
 			}
 		} else {
-			if (!r_io_read_at (mycore->io, addr, (ut8*)buf, sizeof (buf))) {
+			if (!r_io_read_at (mycore->io, addr, (ut8*)buf, len)) {
 				/* invalid read */
 				refptr = UT64_MAX;
 			} else {


### PR DESCRIPTION
The tests failed because `r_io_read_at` tried to read 1024 bytes (sizeof buf) from malloc://512 and returned false (partial read should be accepted)

It reduces broken tests from 44 to 6.

I am for `int/st64 r_io_read_at`