### PR TITLE
Added backtrace (dbt) to gdb

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -382,7 +382,7 @@ static const char *r_debug_gdb_reg_profile(RDebug *dbg) {
 				"=A0	eax\n"
 				"=A1	ebx\n"
 				"=A2	ecx\n"
-				"=A3	edi\n"
+				"=A3	edx\n"
 				"=SN	oeax\n"
 				"gpr	eax	.32	0	0\n"
 				"gpr	ecx	.32	4	0\n"
@@ -870,7 +870,7 @@ static const char *r_debug_gdb_reg_profile(RDebug *dbg) {
 	return NULL;
 }
 
-static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set) {
+static int r_debug_gdb_breakpoint (void *bp, RBreakpointItem *b, bool set) {
 	int ret;
 	if (!b) {
 		return false;
@@ -940,6 +940,12 @@ static RDebugInfo* r_debug_gdb_info(RDebug *dbg, const char *arg) {
 	return rdi;
 }
 
+#include "native/bt.c"
+
+static RList* r_debug_gdb_frames(RDebug *dbg, ut64 at) {
+	return r_debug_native_frames (dbg, at);
+}
+
 RDebugPlugin r_debug_plugin_gdb = {
 	.name = "gdb",
 	/* TODO: Add support for more architectures here */
@@ -961,6 +967,7 @@ RDebugPlugin r_debug_plugin_gdb = {
 	.kill = &r_debug_gdb_kill,
 	.info = &r_debug_gdb_info,
 	.select = &r_debug_gdb_select,
+	.frames = &r_debug_gdb_frames,
 	//.bp_write = &r_debug_gdb_bp_write,
 	//.bp_read = &r_debug_gdb_bp_read,
 };

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -164,21 +164,24 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	switch (whence) {
 	case R_IO_SEEK_SET:
-		return offset;
+		io->off = offset;
+		break;
 	case R_IO_SEEK_CUR:
-		return io->off + offset;
+		io->off += offset;
+		break;
 	case R_IO_SEEK_END:
-		return UT64_MAX;
-	default:
-		return offset;
+		io->off = UT64_MAX;
 	}
+	return io->off;
 }
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	memset (buf, 0xff, count);
 	ut64 addr = io->off;
-	if (!desc || !desc->data) return -1;
-	return debug_gdb_read_at(buf, count, addr);
+	if (!desc || !desc->data) {
+		return -1;
+	}
+	return debug_gdb_read_at (buf, count, addr);
 }
 
 static int __close(RIODesc *fd) {

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -352,7 +352,7 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 				if (r_str_startswith (tmp1, "code_ptr")) {
 					if (!is_pc) {
 						is_pc = true;
-						strcpy (pc_alias, "=PC ");
+						strcpy (pc_alias, "=PC\t");
 						strncpy (pc_alias + 4, regname, reg_name_len);
 						pc_alias[reg_name_len + 4] = '\n';
 						pc_alias[reg_name_len + 5] = '\0';
@@ -447,6 +447,27 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 			profile = tmp2;
 		}
 		strcpy (profile + profile_len, pc_alias);
+	}
+	// Difficult to parse these out from xml. So manually added from gdb's xml files
+	switch (g->target.arch) {
+	case R_SYS_ARCH_X86:
+		switch (g->target.bits) {
+		case 32:
+			if (!(profile = r_str_append(profile,
+						     "=SP\tesp\n"
+						     "=BP\tebp\n"))) {
+				goto exit_err;
+			}
+			break;
+		case 64:
+			if (!(profile = r_str_append(profile,
+						     "=SP\trsp\n"
+						     "=BP\trbp\n"))) {
+				goto exit_err;
+			}
+		}
+		break;
+		// TODO others
 	}
 	free (g->target.regprofile);
 	free (flags);


### PR DESCRIPTION
Code in `native/bt.c` is independent of the rest of `native`, so I used it here. I wanted to do something like `debug/p/common/` and move stuff there from native, but maybe it's an unnecessarily big change.

Also a hack to add `SP` and `BP` to the profile, because even the XML doesn't clearly specify which is which.

@jpenalbae maybe this works for you