### PR TITLE
Fix svc esil code for aarch64

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1279,6 +1279,9 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		}
 		r_strbuf_appendf (&op->esil, ",0,-,%s,=", REG64 (0));
 		break;
+	case ARM64_INS_SVC:
+		r_strbuf_setf (&op->esil, "%u,$", IMM64 (0));
+		break;
 	}
 	return 0;
 }


### PR DESCRIPTION
analop64_esil lacked case ARM64_INS_SVC. This patch adds it and the
code to correctly print the esil representation for svc instruction.

This fixes issue #8370.