### PR TITLE
Fix cmdline argument escape

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1873,15 +1873,12 @@ R_API char **r_str_argv(const char *cmdline, int *_argc) {
 				case '"':
 				case ' ':
 				case '\\':
-					args[args_current++] = '\\';
 					args[args_current++] = c;
 					break;
 				case '\0':
-					args[args_current++] = '\\';
 					end_of_current_arg = 1;
 					break;
 				default:
-					args[args_current++] = '\\';
 					args[args_current++] = c;
 				}
 				escaped = 0;


### PR DESCRIPTION
As explained in the comments, r_str_arg_escape() escapes a cmdline
argument so that it is parsed as a single argument by r_str_argv().
So r_str_argv() should undo escape before passing to execv().

But the code obviously still does escape logic, this is wrong,
we should just undo it.

This fixes a regression which prevents r2 -d working correctly
with `rarun2 ... input="blah\nblah"`.

Before this fix:
```
% r2 -d rarun2 program="/bin/cat" arg0="-" input="a\nb\n"  
Process with PID 18631 started...
= attach 18631 18631
bin.baddr 0xf5ea165000
Using 0xf5ea165000
asm.bits 64
 -- The door can see into your soul.
[0x7f06723ae1f0]> dc
[0x7fddcbbf81f0]> dc
[0x7fddcb90e4a9]> dc
child exited with status 0

==> Process finished

[0x7fddcbbf81f0]> dc
^D
Do you want to quit? (Y/n)
Do you want to kill the process? (Y/n)

```

After this fix:

```
% r2 -d rarun2 program="/bin/cat" arg0="-" input="a\nb\n"
Process with PID 2519 started...
= attach 2519 2519
bin.baddr 0xb26a3cc000
Using 0xb26a3cc000
asm.bits 64
 -- See you at the defcon CTF
[0x7fbbf0d7f1f0]> dc
[0x7fe4d4b431f0]> dc
a
b
^D
Do you want to quit? (Y/n)
Do you want to kill the process? (Y/n)
```