### PR TITLE
Add fcn_tree to RAnal (interval tree based on augmented red-black tree) and optimize r_anal_get_fcn_in (O(n) -> O(log n))

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -95,6 +95,7 @@ R_API RAnal *r_anal_new() {
 	anal->bits_ranges = r_list_newf (free);
 	anal->lineswidth = 0;
 	anal->fcns = r_anal_fcn_list_new ();
+	anal->fcn_tree = NULL;
 #if USE_NEW_FCN_STORE
 	anal->fcnstore = r_listrange_new ();
 #endif
@@ -400,6 +401,7 @@ R_API int r_anal_purge (RAnal *anal) {
 	sdb_reset (anal->sdb_zigns);
 	r_list_free (anal->fcns);
 	anal->fcns = r_anal_fcn_list_new ();
+	anal->fcn_tree = NULL;
 #if USE_NEW_FCN_STORE
 	r_listrange_free (anal->fcnstore);
 	anal->fcnstore = r_listrange_new ();

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -37,6 +37,16 @@
 
 #define VERBOSE_DELAY if (0)
 
+#define FCN_CONTAINER(x) container_of (x, RAnalFunction, rb)
+#define fcn_tree_foreach_intersect(root, it, data, from, to) \
+	for (it = _fcn_tree_iter_first (root, from, to); it.cur && (data = FCN_CONTAINER (it.cur), 1); _fcn_tree_iter_next (&(it), from, to))
+
+typedef struct fcn_tree_iter_t {
+	int len;
+	RBNode *cur;
+	RBNode *path[R_RBTREE_MAX_HEIGHT];
+} FcnTreeIter;
+
 #if USE_SDB_CACHE
 static Sdb *HB = NULL;
 #endif
@@ -59,6 +69,39 @@ static int cmpaddr(const void *_a, const void *_b) {
 	return (a->addr - b->addr);
 }
 
+static int _fcn_tree_cmp_addr(const void *a_, const RBNode *b_) {
+	const RAnalFunction *a = (const RAnalFunction *)a_,
+			*b = container_of (b_, const RAnalFunction, rb);
+	ut64 from0 = a->addr, to0 = a->addr + a->_size,
+			from1 = b->addr, to1 = b->addr + b->_size;
+	if (from0 != from1) {
+		return from0 < from1 ? -1 : 1;
+	}
+	if (to0 != to1) {
+		return to0 - 1 < to1 - 1 ? -1 : 1;
+	}
+	return 0;
+}
+
+static void _fcn_tree_calc_max_addr(RBNode *node) {
+	RAnalFunction *fcn = FCN_CONTAINER (node), *fcn1;
+	int i;
+	fcn->rb_max_addr = fcn->addr + fcn->_size - 1;
+	for (i = 0; i < 2; i++) {
+		if (node->child[i]) {
+			fcn1 = container_of (node->child[i], RAnalFunction, rb);
+			if (fcn1->rb_max_addr > fcn->rb_max_addr) {
+				fcn->rb_max_addr = fcn1->rb_max_addr;
+			}
+		}
+	}
+}
+
+static void _fcn_tree_free(RBNode *node) {
+	// TODO after ownership transfered from fcns to fcn_tree
+	// r_anal_fcn_free (FCN_CONTAINER (node));
+}
+
 static void update_tinyrange_bbs(RAnalFunction *fcn) {
 	RAnalBlock *bb;
 	RListIter *iter;
@@ -66,6 +109,90 @@ static void update_tinyrange_bbs(RAnalFunction *fcn) {
 	r_tinyrange_fini (&fcn->bbr);
 	r_list_foreach (fcn->bbs, iter, bb) {
 		r_tinyrange_add (&fcn->bbr, bb->addr, bb->addr + bb->size);
+	}
+}
+
+static RBNode *_fcn_tree_probe(FcnTreeIter *it, RBNode *x_, ut64 from, ut64 to) {
+	RAnalFunction *x = FCN_CONTAINER (x_), *y;
+	RBNode *y_;
+	for (;;) {
+		if ((y_ = x_->child[0]) && (y = FCN_CONTAINER (y_), from <= y->rb_max_addr)) {
+			it->path[it->len++] = x_;
+			x_ = y_;
+			x = y;
+			continue;
+		}
+		if (x->addr <= to - 1) {
+			if (from <= x->addr + x->_size - 1) {
+				return x_;
+			}
+			if ((y_ = x_->child[1])) {
+				x_ = y_;
+				x = FCN_CONTAINER (y_);
+				if (from <= x->rb_max_addr) {
+					continue;
+				}
+			}
+		}
+		return NULL;
+	}
+}
+
+R_API bool r_anal_fcn_tree_delete(RBNode **root, RAnalFunction *data) {
+	return r_rbtree_aug_delete (root, data, _fcn_tree_cmp_addr, _fcn_tree_free, _fcn_tree_calc_max_addr);
+}
+
+R_API void r_anal_fcn_tree_insert(RBNode **root, RAnalFunction *fcn) {
+	r_rbtree_aug_insert (root, fcn, &fcn->rb, _fcn_tree_cmp_addr, _fcn_tree_calc_max_addr);
+}
+
+static RAnalFunction *_fcn_tree_find_addr(RBNode *x_, ut64 from) {
+	while (x_) {
+		RAnalFunction *x = FCN_CONTAINER (x_);
+		if (from < x->addr) {
+			x_ = x_->child[0];
+		} else if (from > x->addr) {
+			x_ = x_->child[1];
+		} else {
+			return x;
+		}
+	}
+	return NULL;
+}
+
+static FcnTreeIter _fcn_tree_iter_first(RBNode *x_, ut64 from, ut64 to) {
+	FcnTreeIter it;
+	it.len = 0;
+	if (x_ && from <= FCN_CONTAINER (x_)->rb_max_addr) {
+		it.cur = _fcn_tree_probe (&it, x_, from, to);
+	} else {
+		it.cur = NULL;
+	}
+	return it;
+}
+
+static void _fcn_tree_iter_next(FcnTreeIter *it, ut64 from, ut64 to) {
+	RBNode *x_ = it->cur, *y_;
+	RAnalFunction *x = FCN_CONTAINER (x_), *y;
+	for (;;) {
+		if ((y_ = x_->child[1]) && (y = FCN_CONTAINER (y_), from <= y->rb_max_addr)) {
+			it->cur = _fcn_tree_probe (it, y_, from, to);
+			break;
+		}
+		if (!it->len) {
+			it->cur = NULL;
+			break;
+		}
+		x_ = it->path[--it->len];
+		x = FCN_CONTAINER (x_);
+		if (to - 1 < x->addr) {
+			it->cur = NULL;
+			break;
+		}
+		if (from <= x->addr + x->_size - 1) {
+			it->cur = x_;
+			break;
+		}
 	}
 }
 
@@ -1304,6 +1431,7 @@ R_API int r_anal_fcn_insert(RAnal *anal, RAnalFunction *fcn) {
 #endif
 	/* TODO: sdbization */
 	r_list_append (anal->fcns, fcn);
+	r_anal_fcn_tree_insert (&anal->fcn_tree, fcn);
 	if (anal->cb.on_fcn_new) {
 		anal->cb.on_fcn_new (anal, anal->user, fcn);
 	}
@@ -1366,6 +1494,7 @@ R_API int r_anal_fcn_del_locs(RAnal *anal, ut64 addr) {
 			continue;
 		}
 		if (fcn->addr >= f->addr && fcn->addr < (f->addr + r_anal_fcn_size (f))) {
+			r_anal_fcn_tree_delete (&anal->fcn_tree, fcn);
 			r_list_delete (anal->fcns, iter);
 		}
 	}
@@ -1380,6 +1509,7 @@ R_API int r_anal_fcn_del(RAnal *a, ut64 addr) {
 		a->fcnstore = r_listrange_new ();
 #else
 		r_list_free (a->fcns);
+		a->fcn_tree = NULL;
 		if (!(a->fcns = r_anal_fcn_list_new ())) {
 			return false;
 		}
@@ -1399,6 +1529,7 @@ R_API int r_anal_fcn_del(RAnal *a, ut64 addr) {
 				if (a->cb.on_fcn_delete) {
 					a->cb.on_fcn_delete (a, a->user, fcni);
 				}
+				r_anal_fcn_tree_delete (&a->fcn_tree, fcni);
 				r_list_delete (a->fcns, iter);
 			}
 		}
@@ -1413,9 +1544,11 @@ R_API RAnalFunction *r_anal_get_fcn_in(RAnal *anal, ut64 addr, int type) {
 	// if (root) return r_listrange_find_root (anal->fcnstore, addr);
 	return r_listrange_find_in_range (anal->fcnstore, addr);
 #else
-	RAnalFunction *fcn, *ret = NULL;
-	RListIter *iter;
-	if (type == R_ANAL_FCN_TYPE_ROOT) {
+	FcnTreeIter it;
+	RAnalFunction *fcn;
+# if 0
+		RListIter *iter;
+		if (type == R_ANAL_FCN_TYPE_ROOT) {
 		r_list_foreach (anal->fcns, iter, fcn) {
 			if (addr == fcn->addr) {
 				return fcn;
@@ -1426,12 +1559,20 @@ R_API RAnalFunction *r_anal_get_fcn_in(RAnal *anal, ut64 addr, int type) {
 	r_list_foreach (anal->fcns, iter, fcn) {
 		if (!type || (fcn && fcn->type & type)) {
 			if (fcn->addr == addr || (!ret && r_anal_fcn_is_in_offset (fcn, addr))) {
-				ret = fcn;
-				break;
+				return fcn;
 			}
 		}
 	}
-	return ret;
+# endif
+	if (type == R_ANAL_FCN_TYPE_ROOT) {
+		return _fcn_tree_find_addr (anal->fcn_tree, addr);
+	}
+	fcn_tree_foreach_intersect (anal->fcn_tree, it, fcn, addr, addr + 1) {
+		if ((!type || (fcn && fcn->type & type)) && r_anal_fcn_is_in_offset (fcn, addr)) {
+			return fcn;
+		}
+	}
+	return NULL;
 #endif
 }
 

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -604,6 +604,7 @@ static int java_analyze_fns_from_buffer( RAnal *anal, ut64 start, ut64 end, int 
 			break;
 		}
 		//r_listrange_add (anal->fcnstore, fcn);
+		r_anal_fcn_tree_insert (&anal->fcn_tree, fcn);
 		r_list_append (anal->fcns, fcn);
 		offset += r_anal_fcn_size (fcn);
 		if (!analyze_all) break;
@@ -655,6 +656,7 @@ static int java_analyze_fns( RAnal *anal, ut64 start, ut64 end, int reftype, int
 						// XXX - TO Stop or not to Stop ??
 					}
 					//r_listrange_add (anal->fcnstore, fcn);
+					r_anal_fcn_tree_insert (&anal->fcn_tree, fcn);
 					r_list_append (anal->fcns, fcn);
 				}
 			} // End of methods loop

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1454,11 +1454,13 @@ R_API int r_core_anal_fcn_clean(RCore *core, ut64 addr) {
 
 	if (!addr) {
 		r_list_purge (core->anal->fcns);
+		core->anal->fcn_tree = NULL;
 		if (!(core->anal->fcns = r_anal_fcn_list_new ()))
 			return false;
 	} else {
 		r_list_foreach_safe (core->anal->fcns, iter, iter_tmp, fcni) {
 			if (r_anal_fcn_in (fcni, addr)) {
+				r_anal_fcn_tree_delete (&core->anal->fcn_tree, fcni);
 				r_list_delete (core->anal->fcns, iter);
 			}
 		}
@@ -3321,6 +3323,7 @@ R_API void r_core_anal_fcn_merge (RCore *core, ut64 addr, ut64 addr2) {
 	r_anal_fcn_set_size (f1, max - min);
 	// resize
 	f2->bbs = NULL;
+	r_anal_fcn_tree_delete (&core->anal->fcn_tree, f2);
 	r_list_delete_data (core->anal->fcns, f2);
 }
 

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -35,6 +35,7 @@ R_API int r_core_gdiff(RCore *c, RCore *c2) {
 		/* remove strings */
 		r_list_foreach_safe (cores[i]->anal->fcns, iter, iter2, fcn) {
 			if (!strncmp (fcn->name, "str.", 4)) {
+				r_anal_fcn_tree_delete (&cores[i]->anal->fcn_tree, fcn);
 				r_list_delete (cores[i]->anal->fcns, iter);
 			}
 		}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -279,6 +279,7 @@ typedef struct r_anal_type_function_t {
 	const char *cc; // calling convention
 	char* attr; // __attribute__(()) list
 	ut64 addr;
+	ut64 rb_max_addr; // maximum of addr + _size - 1 in the subtree, for interval tree
 	int stack; //stack frame size
 	int maxstack;
 	int ninstr;
@@ -298,6 +299,7 @@ typedef struct r_anal_type_function_t {
 #endif
 	RAnalFcnMeta meta;
 	RRangeTiny bbr;
+	RBNode rb;
 } RAnalFunction;
 
 struct r_anal_type_t {
@@ -599,6 +601,7 @@ typedef struct r_anal_t {
 	void *user;
 	ut64 gp; // global pointer. used for mips. but can be used by other arches too in the future
 	RList *fcns;
+	RBNode *fcn_tree;
 	RListRange *fcnstore;
 	RList *refs;
 	RList *vartypes;
@@ -1320,6 +1323,8 @@ R_API int r_anal_fcn_add_bb(RAnal *anal, RAnalFunction *fcn,
 		ut64 addr, ut64 size,
 		ut64 jump, ut64 fail, int type, RAnalDiff *diff);
 R_API bool r_anal_check_fcn(RAnal *anal, ut8 *buf, ut16 bufsz, ut64 addr, ut64 low, ut64 high);
+R_API bool r_anal_fcn_tree_delete(RBNode **root, RAnalFunction *fcn);
+R_API void r_anal_fcn_tree_insert(RBNode **root, RAnalFunction *fcn);
 
 /* locals */
 #if 0


### PR DESCRIPTION
https://github.com/radare/radare2/pull/8381 upgrades the current red-black tree to an augmented red-black tree, by which an [interval tree](https://en.wikipedia.org/wiki/Interval_tree) can be built.

Interval trees are useful in `RAnal::fcns` (addr, addr + _size) and flags (addr, addr+size). The tree consists of `RAnalFunction`s that are ordered by `addr`. The intrusive node `RBNode rb` is used to store tree links and color. Given a `[from, to)`, all intersecting functions `[addr, addr+_size)` can be listed in O(log n + m) time where m is the number of functions produced by the query.

I optimized `r_anal_get_fcn_in` by replacing the current linear search with an intersection query on the interval tree.

Much time is spent on `R_API RAnalFunction *r_anal_get_fcn_at(RAnal *anal, ut64 addr, int type) {` called by `fcn_recurse` defined in `libr/anal/fcn.c`. Let's start the optimization journey with this PR!

The long term plan is to phase out RAnal::fcns and migrate to RAnal::fcn_tree.

You can also find descriptions of interval trees at https://www.kernel.org/doc/Documentation/rbtree.txt .
My version uses only one additional function pointer `sum` (monoid sum) as opposed three used in Linux kernel.

The following tree was suggested by @condret 
![](https://cdn.bulbagarden.net/upload/d/d2/796Xurkitree.png)