### PR TITLE
[huge] Replace RIOMap::{from,to} with RAddrInterval itv and fix #8388

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -315,7 +315,7 @@ static int cmd_help(void *data, const char *input) {
 		k = r_str_chop_ro (input + 1);
 		tmp = r_core_get_boundaries (core, k);
 		r_list_foreach (tmp, iter, map) {
-			r_cons_printf ("0x%"PFMT64x" 0x%"PFMT64x"\n", map->from, map->to);
+			r_cons_printf ("0x%"PFMT64x" 0x%"PFMT64x"\n", map->itv.addr, r_itv_end (map->itv));
 		}
 		r_list_free (tmp);
 		break;
@@ -733,7 +733,7 @@ static int cmd_help(void *data, const char *input) {
 				r_num_math (core->num, input+2): core->offset;
 			RIOMap *map = r_io_map_get_paddr (core->io, n);
 			if (map) {
-				o = n + map->from - map->delta;
+				o = n + map->itv.addr - map->delta;
 				r_cons_printf ("0x%08"PFMT64x"\n", o);
 			} else {
 				r_cons_printf ("no map at 0x%08"PFMT64x"\n", n);
@@ -749,7 +749,7 @@ static int cmd_help(void *data, const char *input) {
 				r_num_math (core->num, input + 2): core->offset;
 			RIOMap *map = r_io_map_get (core->io, n);
 			if (map) {
-				o = n - map->from + map->delta;
+				o = n - map->itv.addr + map->delta;
 				r_cons_printf ("0x%08"PFMT64x"\n", o);
 			} else {
 				r_cons_printf ("no map at 0x%08"PFMT64x"\n", n);

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -6,6 +6,7 @@
 #include "r_print.h"
 #include "r_bin.h"
 #include "r_debug.h"
+#include "r_util/r_addr_interval.h"
 
 static const char *help_msg_o[] = {
 	"Usage: o","[com- ] [file] ([offset])","",
@@ -160,7 +161,7 @@ static void cmd_open_init(RCore *core) {
 
 // very similiar to section list, must reuse more code
 static void list_maps_visual(RIO *io, ut64 seek, ut64 len, int width, int use_color) {
-	ut64 mul, min = -1, max = -1;
+	ut64 mul, min = -1, max = 0;
 	SdbListIter *iter;
 	RIOMap *s;
 	int j, i;
@@ -173,12 +174,8 @@ static void list_maps_visual(RIO *io, ut64 seek, ut64 len, int width, int use_co
 	// seek = (io->va || io->debug) ? r_io_section_vaddr_to_maddr_try (io, seek) : seek;
 
 	ls_foreach_prev (io->maps, iter, s) {			//this must be prev, maps the previous map allways has lower priority
-		if (min == -1 || s->from < min) {
-			min = s->from;
-		}
-		if (max == -1 || s->to > max) {
-			max = s->to;
-		}
+		min = R_MIN (min, s->itv.addr);
+		max = R_MAX (max, r_itv_end (s->itv) - 1);
 	}
 	mul = (max - min) / width;
 	if (min != -1 && mul != 0) {
@@ -201,24 +198,22 @@ static void list_maps_visual(RIO *io, ut64 seek, ut64 len, int width, int use_co
 			}
 			if (io->va) {
 				io->cb_printf ("%02d%c %s0x%08"PFMT64x"%s |", i,
-						(seek>=s->from&& seek<s->to)?'*':' ',
-						//(seek>=s->vaddr && seek<s->vaddr+s->size)?'*':' ',
-						color, s->from, color_end);
+						r_itv_contain (s->itv, seek) ? '*' : ' ',
+						color, s->itv.addr, color_end);
 			} else {
 				io->cb_printf ("%02d%c %s0x%08"PFMT64x"%s |", i,
-						(seek >= s->from && seek < s->to) ? '*':' ',
-						color, s->from, color_end);
+						r_itv_contain (s->itv, seek) ? '*' : ' ',
+						color, s->itv.addr, color_end);
 			}
-			for (j=0; j<width; j++) {
-				ut64 pos = min + (j*mul);
-				ut64 npos = min + ((j+1)*mul);
-				if (s->from<npos && (s->to)>pos)
-					io->cb_printf ("#");
-				else io->cb_printf ("-");
+			for (j = 0; j < width; j++) {
+				ut64 pos = min + j * mul;
+				ut64 npos = min + (j + 1) * mul;
+				// TODO trailing bytes
+				io->cb_printf (r_itv_overlap2 (s->itv, pos, npos - pos) ? "#" : "-");
 			}
 			io->cb_printf ("| %s0x%08"PFMT64x"%s %s %d %s\n",
-				color, s->to, color_end,
-				r_str_rwx_i (s->flags), s->fd, s->name);
+					color, r_itv_end (s->itv), color_end,
+					r_str_rwx_i (s->flags), s->fd, s->name);
 			i++;
 		}
 		/* current seek */
@@ -437,19 +432,19 @@ static void map_list(RIO *io, int mode, RPrint *print, int fd) {
 			first = false;
 			print->cb_printf ("{\"map\":%i,\"fd\":%d,\"delta\":%"PFMT64d",\"from\":%"PFMT64d
 					",\"to\":%"PFMT64d",\"flags\":\"%s\",\"name\":\"%s\"}", map->id, map->fd,
-					map->delta, map->from, map->to,
+					map->delta, map->itv.addr, r_itv_end (map->itv),
 					r_str_rwx_i (map->flags), (map->name ? map->name : ""));
 			break;
 		case 1:
 		case '*':
 		case 'r':
 			print->cb_printf ("om %d 0x%"PFMT64x" 0x%"PFMT64x" 0x%"PFMT64x"\n", map->fd,
-					map->from, map->to - map->from + 1, map->delta);
+					map->itv.addr, map->itv.size, map->delta);
 			break;
 		default:
 			print->cb_printf ("%2d fd: %i +0x%08"PFMT64x" 0x%08"PFMT64x
 					" - 0x%08"PFMT64x" %s %s\n", map->id, map->fd,
-					map->delta, map->from, map->to,
+					map->delta, map->itv.addr, r_itv_end (map->itv),
 					r_str_rwx_i (map->flags), (map->name ? map->name : ""));
 			break;
 		}
@@ -512,7 +507,7 @@ static void cmd_omf (RCore *core, const char *input) {
 		// change perms of current map
 		int flags = (arg && *arg)? r_str_rwx (arg): 7;
 		ls_foreach (core->io->maps, iter, map) {
-			if (R_BETWEEN (map->from, core->offset, map->to)) {
+			if (r_itv_contain (map->itv, core->offset)) {
 				map->flags = flags;
 			}
 		}
@@ -530,11 +525,11 @@ static void cmd_open_map(RCore *core, const char *input) {
 
 	switch (input[1]) {
 	case '.':
-		map = r_io_map_get (core->io, core->offset);	
+		map = r_io_map_get (core->io, core->offset);
 		if (map) {
 			core->print->cb_printf ("map: %i fd: %i +0x%"PFMT64x" 0x%"PFMT64x
-			  " - 0x%"PFMT64x" ; %s : %s\n", map->id, map->fd,
-			map->delta, map->from, map->to,
+				" - 0x%"PFMT64x" ; %s : %s\n", map->id, map->fd,
+				map->delta, map->itv.addr, r_itv_end (map->itv),
 			r_str_rwx_i (map->flags), map->name ? map->name : "");
 		}
 

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3419,8 +3419,8 @@ static int cmd_print(void *data, const char *input) {
 			RList *list = r_core_get_boundaries (core, "file");
 			RIOMap *map = r_list_first (list);
 			if (map) {
-				from = map->from;
-				to = map->to;
+				from = map->itv.addr;
+				to = r_itv_end (map->itv);
 			}
 			r_list_free (list);
 		}

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -680,8 +680,8 @@ static bool search(RCore *core, bool rad) {
 	if (useBytes) {
 		list = r_core_get_boundaries_prot (core, R_IO_EXEC | R_IO_WRITE | R_IO_READ, mode);
 		r_list_foreach (list, iter, map) {
-			eprintf ("[+] searching 0x%08"PFMT64x" - 0x%08"PFMT64x"\n", map->from, map->to);
-			retval &= searchRange (core, map->from, map->to, rad, &bytes_search_ctx);
+			eprintf ("[+] searching 0x%08"PFMT64x" - 0x%08"PFMT64x"\n", map->itv.addr, r_itv_end (map->itv));
+			retval &= searchRange (core, map->itv.addr, r_itv_end (map->itv), rad, &bytes_search_ctx);
 		}
 		r_list_free (list);
 	}

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -909,7 +909,7 @@ R_API int r_core_file_list(RCore *core, int mode) {
 					char *absfile = r_file_abspath (desc->uri);
 					r_list_foreach (maps, iter, current_map) {
 						if (current_map) {
-							r_cons_printf ("on %s 0x%"PFMT64x "\n", absfile, (ut64) current_map->from);
+							r_cons_printf ("on %s 0x%"PFMT64x "\n", absfile, current_map->itv.addr);
 						}
 					}
 					r_list_free (maps);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2202,7 +2202,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 						} else {
 							RIOMap *map = ls_pop (core->io->maps);
 							if (map) {
-								entry = map->from;
+								entry = map->itv.addr;
 							} else {
 								entry = r_config_get_i (core->config, "bin.baddr");
 							}

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -50,7 +50,7 @@ static int perform_mapped_file_yank(RCore *core, ut64 offset, ut64 len, const ch
 		if (yankdesc && load_align) {
 			yank_file_sz = r_io_size (core->io);
 			map = r_io_map_add_next_available (core->io, yankdesc->fd, R_IO_READ, 0, 0, yank_file_sz, load_align);
-			loadaddr = map? map->from: -1;
+			loadaddr = map? map->itv.addr: -1;
 			if (yankdesc && map && loadaddr != -1) {
 				// ***NOTE*** this is important, we need to
 				// address the file at its physical address!

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -3,10 +3,10 @@
 #ifndef R2_IO_H
 #define R2_IO_H
 
-#include <r_socket.h>
-#include <r_list.h>
-#include <r_util.h>
-#include <r_vector.h>
+#include "r_list.h"
+#include "r_socket.h"
+#include "r_util.h"
+#include "r_vector.h"
 
 #define R_IO_READ	4
 #define R_IO_WRITE	2
@@ -159,8 +159,7 @@ typedef struct r_io_map_t {
 	int fd;
 	int flags;
 	ut32 id;
-	ut64 from;
-	ut64 to;
+	RAddrInterval itv;
 	ut64 delta; //this delta means paddr when talking about section
 	char *name;
 } RIOMap;
@@ -307,7 +306,6 @@ R_API void r_io_map_fini (RIO *io);
 R_API bool r_io_map_is_in_range (RIOMap *map, ut64 from, ut64 to);
 R_API void r_io_map_set_name (RIOMap *map, const char *name);
 R_API void r_io_map_del_name (RIOMap *map);
-R_API bool r_io_map_is_in_range (RIOMap* map, ut64 from, ut64 to);
 R_API RIOMap *r_io_map_add_next_available(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, ut64 load_align);
 R_API void r_io_map_calculate_skyline(RIO *io);
 R_API RList* r_io_map_get_for_fd(RIO *io, int fd);

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -26,6 +26,7 @@
 int gettimeofday (struct timeval* p, void* tz);
 #endif
 #include <sys/time.h>
+#include "r_util/r_addr_interval.h"
 #include "r_util/r_rbtree.h"
 #include "r_util/r_big.h"
 #include "r_util/r_base64.h"

--- a/libr/include/r_util/r_addr_interval.h
+++ b/libr/include/r_util/r_addr_interval.h
@@ -11,6 +11,11 @@ typedef struct r_addr_interval_t {
 	ut64 size;
 } RAddrInterval;
 
+// Returns the right endpoint address (not included)
+static inline ut64 r_itv_end(RAddrInterval itv) {
+	return itv.addr + itv.size;
+}
+
 // Returns true if itv contained addr
 static inline bool r_itv_contain(RAddrInterval itv, ut64 addr) {
 	ut64 end = itv.addr + itv.size;

--- a/libr/io/p_cache.c
+++ b/libr/io/p_cache.c
@@ -229,7 +229,7 @@ static int __desc_cache_list_cb(void *user, const char *k, const char *v) {
 			}
 			cache->data = data;
 			cache->size = i;
-			cache->to = cache->from + i - 1;
+			cache->to = cache->from + i;
 			i = 0;
 			r_list_push (writes, cache);
 			cache = NULL;
@@ -237,7 +237,7 @@ static int __desc_cache_list_cb(void *user, const char *k, const char *v) {
 	}
 	if (cache) {
 		cache->size = i;
-		cache->to = blockaddr + R_IO_DESC_CACHE_SIZE - 1;
+		cache->to = blockaddr + R_IO_DESC_CACHE_SIZE;
 		r_list_push (writes, cache);
 	}
 	return true;

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -549,7 +549,7 @@ static bool _section_reapply_for_emul(RIO *io, RIOSection *sec) {
 			sec->filemap = sec->memmap = 0;
 			return _section_apply (io, sec, R_IO_SECTION_APPLY_FOR_EMULATOR);
 		}
-		size = (size_t) (map->to - map->from + 1);
+		size = map->itv.size;
 		buf = calloc (1, size + 1);
 		if (!buf) {
 			return false;
@@ -603,7 +603,7 @@ static bool _section_reapply_for_emul(RIO *io, RIOSection *sec) {
 	if (!map) {
 		return _section_apply (io, sec, R_IO_SECTION_APPLY_FOR_EMULATOR);
 	}
-	size = (size_t) (map->to - map->from + 1);
+	size = map->itv.size;
 	//save desc to restore later
 	desc = io->desc;
 	r_io_use_fd (io, map->fd);


### PR DESCRIPTION
There are far more half-closed intervals than closed intervals.

I know it's painstaking, but the sooner the better. Just found another off-by-1  https://github.com/radare/radare2-regressions/pull/991

Fix #8388 