### PR TITLE
Move fortunes to libr/core/fortune.c

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -1201,7 +1201,7 @@ int main(int argc, char **argv, char **envp) {
 	}
 	if (r_config_get_i (r.config, "scr.prompt")) {
 		if (run_rc && r_config_get_i (r.config, "cfg.fortunes")) {
-			r_core_print_fortune (&r);
+			r_core_fortune_print_random (&r);
 			r_cons_flush ();
 		}
 	}

--- a/libr/core/Makefile
+++ b/libr/core/Makefile
@@ -7,7 +7,7 @@ DEPS+=r_debug r_hash r_bin r_lang r_io r_anal r_parse r_bp r_egg
 DEPS+=r_reg r_search r_syscall r_socket r_fs r_magic r_crypto
 
 OBJS=core.o cmd.o file.o cconfig.o visual.o cio.o yank.o libs.o graph.o
-OBJS+=hack.o vasm.o patch.o cbin.o log.o rtr.o cmd_api.o
+OBJS+=fortune.o hack.o vasm.o patch.o cbin.o log.o rtr.o cmd_api.o
 OBJS+=canal.o project.o gdiff.o asm.o vmenus.o disasm.o plugin.o
 OBJS+=help.o task.o panels.o pseudo.o vmarks.o anal_tp.o blaze.o
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -906,6 +906,26 @@ static int cb_cfgsanbox(void *user, void *data) {
 	return (!node->i_value && ret)? 0: 1;
 }
 
+static int cb_cfg_fortunes(void *user, void *data) {
+	RCore *core = (RCore *)user;
+	RConfigNode *node = (RConfigNode *)data;
+	// TODO CN_BOOL option does not receive the right hand side of assignment as an argument
+	if (node->value[0] == '?') {
+		r_core_fortune_list (core);
+		return false;
+	}
+	return true;
+}
+
+static int cb_cfg_fortunes_type(void *user, void *data) {
+	RConfigNode *node = (RConfigNode *)data;
+	if (node->value[0] == '?') {
+		r_core_fortune_list_types ();
+		return false;
+	}
+	return true;
+}
+
 static int cb_cmdlog(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -1823,7 +1843,6 @@ static int cb_binminstr(void *user, void *data) {
 }
 
 static int cb_searchin(void *user, void *data) {
-	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
 	if (node->value[0] == '?') {
 		if (strlen (node->value) > 1 && node->value[1] == '?') {
@@ -1849,7 +1868,7 @@ static int cb_searchin(void *user, void *data) {
 			print_node_options (node);
 		}
 		return false;
-	} 
+	}
 	return true;
 }
 
@@ -2304,8 +2323,8 @@ R_API int r_core_config_init(RCore *core) {
 	free (p);
 	r_config_desc (cfg, "cfg.editor", "Select default editor program");
 	SETPREF ("cfg.user", r_sys_whoami (buf), "Set current username/pid");
-	SETPREF ("cfg.fortunes", "true", "If enabled show tips at start");
-	SETPREF ("cfg.fortunes.type", "tips,fun", "Type of fortunes to show (tips, fun, nsfw, creepy)");
+	SETCB ("cfg.fortunes", "true", &cb_cfg_fortunes, "If enabled show tips at start");
+	SETCB ("cfg.fortunes.type", "tips,fun", &cb_cfg_fortunes_type, "Type of fortunes to show (tips, fun, nsfw, creepy)");
 	SETPREF ("cfg.fortunes.clippy", "false", "Use ?E instead of ?e");
 	SETPREF ("cfg.fortunes.tts", "false", "Speak out the fortune");
 	SETI ("cfg.hashlimit", SLURP_LIMIT, "If the file is bigger than hashlimit, do not compute hashes");

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -177,53 +177,6 @@ static void flagbars(RCore *core, const char *glob) {
 	}
 }
 
-R_API void r_core_print_fortune(RCore *core) {
-	// TODO: use file.fortunes // can be dangerous in sandbox mode
-	const char *fortunes_tips = R2_PREFIX "/share/doc/radare2/fortunes.tips";
-	const char *fortunes_fuun = R2_PREFIX "/share/doc/radare2/fortunes.fun";
-	const char *fortunes_nsfw = R2_PREFIX "/share/doc/radare2/fortunes.nsfw";
-	const char *fortunes_crep = R2_PREFIX "/share/doc/radare2/fortunes.creepy";
-	const char *types = (char *)r_config_get (core->config, "cfg.fortunes.type");
-	char *line = NULL, *templine = NULL;
-	int i = 0;
-	if (strstr (types, "tips")) {
-		templine = r_file_slurp_random_line_count (fortunes_tips, &i);
-		line = templine;
-	}
-	if (strstr (types, "fun")) {
-		templine = r_file_slurp_random_line_count (fortunes_fuun, &i);
-		if (templine) {
-			free (line);
-			line = templine;
-		}
-	}
-	if (strstr (types, "nsfw")) {
-		templine = r_file_slurp_random_line_count (fortunes_nsfw, &i);
-		if (templine) {
-			free (line);
-			line = templine;
-		}
-	}
-	if (strstr (types, "creepy")) {
-		templine = r_file_slurp_random_line_count (fortunes_crep, &i);
-		if (templine) {
-			free (line);
-			line = templine;
-		}
-	}
-	if (line) {
-		if (r_config_get_i (core->config, "cfg.fortunes.clippy")) {
-			r_core_clippy (line);
-		} else {
-			r_cons_printf (" -- %s\n", line);
-		}
-		if (r_config_get_i (core->config, "cfg.fortunes.tts")) {
-			r_sys_tts (line, true);
-		}
-		free (line);
-	}
-}
-
 static int cmd_flag(void *data, const char *input) {
 	static int flagenum = 0;
 	RCore *core = (RCore *)data;
@@ -706,7 +659,7 @@ rep:
 		} else eprintf ("Usage: fC [name] [comment]\n");
 		break;
 	case 'o': // "fo"
-		r_core_print_fortune (core);
+		r_core_fortune_print_random (core);
 		break;
 	case 'r':
 		if (input[1]==' ' && input[2]) {

--- a/libr/core/fortune.c
+++ b/libr/core/fortune.c
@@ -1,0 +1,66 @@
+#include "r_core.h"
+
+static const struct {
+	const char *type;
+	const char *filename;
+} fortunes[] = {
+	{"tips" , R2_PREFIX "/share/doc/radare2/fortunes.tips"},
+	{"fuun" , R2_PREFIX "/share/doc/radare2/fortunes.fun"},
+	{"nsfw" , R2_PREFIX "/share/doc/radare2/fortunes.nsfw"},
+	{"crep" , R2_PREFIX "/share/doc/radare2/fortunes.creepy"},
+};
+
+R_API void r_core_fortune_list_types(void) {
+	int i;
+	for (i = 0; i < R_ARRAY_SIZE (fortunes); i++) {
+		r_cons_printf ("%s\n", fortunes[i].type);
+	}
+}
+
+R_API void r_core_fortune_list(RCore *core) {
+	// TODO: use file.fortunes // can be dangerous in sandbox mode
+	const char *types = (char *)r_config_get (core->config, "cfg.fortunes.type");
+	char *str;
+	int i, j;
+	for (i = 0; i < R_ARRAY_SIZE (fortunes); i++) {
+		if (strstr (types, fortunes[i].type) && (str = r_file_slurp (fortunes[i].filename, NULL))) {
+			for (j = 0; str[j]; j++) {
+				if (str[j] == '\n') {
+					if (i < j) {
+						str[j] = '\0';
+						r_cons_printf ("%s\n", str + i);
+					}
+					i = j + 1;
+				}
+			}
+			free (str);
+		}
+	}
+}
+
+R_API void r_core_fortune_print_random(RCore *core) {
+	// TODO: use file.fortunes // can be dangerous in sandbox mode
+	const char *types = (char *)r_config_get (core->config, "cfg.fortunes.type");
+	char *line = NULL, *templine;
+	int i, lines = 0;
+	for (i = 0; i < R_ARRAY_SIZE (fortunes); i++) {
+		if (strstr (types, fortunes[i].type)) {
+			templine = r_file_slurp_random_line_count (fortunes[i].filename, &lines);
+			if (templine) {
+				free (line);
+				line = templine;
+			}
+		}
+	}
+	if (line) {
+		if (r_config_get_i (core->config, "cfg.fortunes.clippy")) {
+			r_core_clippy (line);
+		} else {
+			r_cons_printf (" -- %s\n", line);
+		}
+		if (r_config_get_i (core->config, "cfg.fortunes.tts")) {
+			r_sys_tts (line, true);
+		}
+		free (line);
+	}
+}

--- a/libr/core/meson.build
+++ b/libr/core/meson.build
@@ -38,6 +38,7 @@ files=[
 'core.c',
 'disasm.c',
 'file.c',
+'fortune.c',
 'gdiff.c',
 'graph.c',
 'hack.c',

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -313,6 +313,11 @@ R_API ut32 r_core_file_cur_fd (RCore *core);
 
 R_API void r_core_debug_rr (RCore *core, RReg *reg);
 
+/* fortune */
+R_API void r_core_fortune_list_types(void);
+R_API void r_core_fortune_list(RCore *core);
+R_API void r_core_fortune_print_random(RCore *core);
+
 /* project */
 R_API bool r_core_project_load(RCore *core, const char *prjfile, const char *rcfile);
 R_API RThread *r_core_project_load_bg(RCore *core, const char *prjfile, const char *rcfile);
@@ -413,7 +418,6 @@ R_API RList *r_core_asm_bwdisassemble (RCore *core, ut64 addr, int n, int len);
 R_API RList *r_core_asm_back_disassemble_instr (RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API RList *r_core_asm_back_disassemble_byte (RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API ut32 r_core_asm_bwdis_len (RCore* core, int* len, ut64* start_addr, ut32 l);
-R_API void r_core_print_fortune(RCore *core);
 R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int lines, int invbreak, int nbytes);
 R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, int lines);
 R_API int r_core_print_disasm_instructions (RCore *core, int len, int l);


### PR DESCRIPTION
You can enumerate all fortunes by calling `r_core_fortune_list(core)`, however, currently there is no way to complete `CN_BOOL` typed config var.

https://github.com/radare/radare2/issues/8414