### PR TITLE
x86-16: Look in AH for syscall SN

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -2641,7 +2641,7 @@ static char *get_reg_profile(RAnal *anal) {
 		"=A3	dx\n"
 		"=A4	si\n"
 		"=A5	di\n"
-		"=SN	ax\n"
+		"=SN	ah\n"
 		"gpr	ip	.16	48	0\n"
 		"gpr	ax	.16	24	0\n"
 		"gpr	ah	.8	25	0\n"


### PR DESCRIPTION
=SN was set to AX for x86-16 mode but both BIOS and DOS only use AH
when multiple syscalls share a single software interrupt.  Using AX
caused SN to be shifted 8 bits which causes the SDB lookup to fail.