### PR TITLE
Move {RAsm,RAnal}::addrbytes to RIO::addrbytes, delete asm.addrbytes and make cLEMENCy work again

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -353,7 +353,8 @@ static ut64 search_reg_val(RAnal *anal, ut8 *buf, ut64 len, ut64 addr, char *reg
 		0
 	};
 	ut64 ret = UT64_MAX;
-	for (offs = 0; offs < len; offs += anal->addrbytes * oplen) {
+	const int addrbytes = anal->iob.io ? anal->iob.io->addrbytes : 1;
+	for (offs = 0; offs < len; offs += addrbytes * oplen) {
 		r_anal_op_fini (&op);
 		if ((oplen = r_anal_op (anal, &op, addr + offs, buf + offs, len - offs)) < 1) {
 			break;
@@ -548,9 +549,9 @@ static int walk_switch(RAnal *anal, RAnalFunction *fcn, ut64 from, ut64 at) {
 }
 
 static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 len, int depth) {
-	int continue_after_jump = anal->opt.afterjmp;
-	int noncode = anal->opt.noncode;
-	int addrbytes = anal->addrbytes;
+	const int continue_after_jump = anal->opt.afterjmp;
+	const int noncode = anal->opt.noncode;
+	const int addrbytes = anal->iob.io ? anal->iob.io->addrbytes : 1;
 	RAnalBlock *bb = NULL;
 	RAnalBlock *bbg = NULL;
 	int ret = R_ANAL_RET_END, skip_ret = 0;

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2009-2017 - pancake, nibble */
 
 #include <stdio.h>
+#include <r_core.h>
 #include <r_types.h>
 #include <r_util.h>
 #include <r_asm.h>
@@ -438,7 +439,8 @@ R_API int r_asm_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	}
 	//XXX check against R_ASM_BUFSIZE other oob write
 	memcpy (op->buf, buf, R_MIN (R_ASM_BUFSIZE - 1, oplen));
-	r_hex_bin2str (buf, R_MIN (a->addrbytes * oplen,
+	const int addrbytes = a->user ? ((RCore *)a->user)->io->addrbytes : 1;
+	r_hex_bin2str (buf, R_MIN (addrbytes * oplen,
 		(sizeof (op->buf_hex) - 1) / 2), op->buf_hex);
 	return ret;
 }
@@ -565,10 +567,11 @@ R_API int r_asm_assemble(RAsm *a, RAsmOp *op, const char *buf) {
 R_API RAsmCode* r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len) {
 	RStrBuf *buf_asm;
 	RAsmCode *acode;
-	int ret, slen;
 	ut64 pc = a->pc;
 	RAsmOp op;
 	ut64 idx;
+	int ret, slen;
+	const int addrbytes = a->user ? ((RCore *)a->user)->io->addrbytes : 1;
 
 	if (!(acode = r_asm_code_new ())) {
 		return NULL;
@@ -584,7 +587,7 @@ R_API RAsmCode* r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len) {
 	if (!(buf_asm = r_strbuf_new (NULL))) {
 		return r_asm_code_free (acode);
 	}
-	for (idx = ret = slen = 0; idx + a->addrbytes <= len; idx += a->addrbytes * ret) {
+	for (idx = ret = slen = 0; idx + addrbytes <= len; idx += addrbytes * ret) {
 		r_asm_set_pc (a, pc + idx);
 		ret = r_asm_disassemble (a, &op, buf + idx, len - idx);
 		if (ret < 1) {

--- a/libr/core/asm.c
+++ b/libr/core/asm.c
@@ -67,7 +67,8 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 	char *tok, *tokens[1024], *code = NULL, *ptr;
 	int idx, tidx = 0, len;
 	int tokcount, matchcount, count = 0;
-	int matches = 0, addrbytes = core->assembler->addrbytes;
+	int matches = 0;
+	const int addrbytes = core->io->addrbytes;
 
 	if (!*input) {
 		return NULL;
@@ -388,7 +389,7 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 	ut64 at;
 	ut32 idx = 0, hit_count;
 	int numinstr, asmlen, ii;
-	int addrbytes = core->assembler->addrbytes;
+	const int addrbytes = core->io->addrbytes;
 	RAsmCode *c;
 	RList *hits = r_core_asm_hit_list_new();
 	if (!hits) return NULL;
@@ -401,16 +402,13 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 
 	buf = (ut8 *)malloc (len);
 	if (!buf) {
-		if (hits) {
-			r_list_free (hits);
-		}
+		r_list_free (hits);
 		return NULL;
 	} else if (!hits) {
 		free (buf);
 		return NULL;
 	}
-	len = len > addr ? addr : len;
-	if (!r_io_read_at (core->io, addr - len, buf, len)) {
+	if (!r_io_read_at (core->io, addr - len / addrbytes, buf, len)) {
 		r_list_free (hits);
 		free (buf);
 		return NULL;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -667,17 +667,6 @@ static int cb_asm_armimm(void *user, void *data) {
 	return true;
 }
 
-static int cb_asm_addrbytes(void *user, void *data) {
-	RCore *core = (RCore *) user;
-	RConfigNode *node = (RConfigNode *) data;
-	if (node->i_value < 1) {
-		eprintf ("asm.arch: asm.addrbytes should >= 1\n");
-		return false;
-	}
-	core->anal->addrbytes = core->assembler->addrbytes = node->i_value;
-	return true;
-}
-
 static int cb_asm_invhex(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -2132,7 +2121,6 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* asm */
 	//asm.os needs to be first, since other asm.* depend on it
-	SETICB ("asm.addrbytes", 1,  &cb_asm_addrbytes, "Number of bytes one vaddr unit uses");
 	SETICB ("asm.armimm", false,  &cb_asm_armimm, "Display # for immediates in ARM");
 	n = NODECB ("asm.os", R_SYS_OS, &cb_asmos);
 	SETDESC (n, "Select operating system (kernel)");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4276,7 +4276,7 @@ static void _anal_calls(RCore *core, ut64 addr, ut64 addr_end) {
 	RAnalOp op;
 	int bufi, minop = 1; // 4
 	int depth = r_config_get_i (core->config, "anal.depth");
-	int addrbytes = core->anal->addrbytes;
+	const int addrbytes = core->io->addrbytes;
 	ut8 buf[4096];
 	bufi = 0;
 	if (addr_end - addr > 0xffffff) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3297,7 +3297,7 @@ static int cmd_print(void *data, const char *input) {
 	ut32 tbs = core->blocksize;
 	ut64 n, off, from, to, at, ate, piece;
 	ut64 tmpseek = UT64_MAX;
-	int addrbytes = core->assembler->addrbytes;
+	const int addrbytes = core->io->addrbytes;
 	mode = w = p = i = l = len = ret = 0;
 	n = off = from = to = at = ate = piece = 0;
 

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -84,7 +84,7 @@ static bool addFcnBytes(RCore *core, RAnalFunction *fcn, const char *name) {
 	}
 	int maxsz = r_config_get_i (core->config, "zign.maxsz");
 	int fcnlen = r_anal_fcn_realsize (fcn);
-	int len = R_MIN (core->assembler->addrbytes * fcnlen, maxsz);
+	int len = R_MIN (core->io->addrbytes * fcnlen, maxsz);
 
 	ut8 *buf = malloc (len);
 	if (!buf) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2144,7 +2144,7 @@ static void ds_instruction_mov_lea(RDisasmState *ds, int idx) {
 	RCore *core = ds->core;
 	RAnalValue *src;
 	char *nl = ds->show_comment_right ? "" : "\n";
-	int addrbytes = core->assembler->addrbytes;
+	const int addrbytes = core->io->addrbytes;
 
 	switch (ds->analop.type) {
 	case R_ANAL_OP_TYPE_LENGTH:
@@ -3567,7 +3567,7 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 	int dorepeat = 1;
 	ut8 *nbuf = NULL;
 	RDisasmState *ds;
-	int addrbytes = core->assembler->addrbytes;
+	const int addrbytes = core->io->addrbytes;
 
 	// TODO: All those ds must be print flags
 	ds = ds_init (core);
@@ -3917,7 +3917,7 @@ R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opc
 	const ut64 old_offset = core->offset;
 	bool hasanal = false;
 	int nbytes = 0;
-	int addrbytes = core->assembler->addrbytes;
+	const int addrbytes = core->io->addrbytes;
 
 	r_reg_arena_push (core->anal->reg);
 	if (!nb_bytes) {
@@ -4680,11 +4680,11 @@ R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt) 
 	int esil = r_config_get_i (core->config, "asm.esil");
 	int flags = r_config_get_i (core->config, "asm.flags");
 	int i = 0, j, ret, err = 0;
-	int addrbytes = core->assembler->addrbytes;
 	ut64 old_offset = core->offset;
 	RAsmOp asmop;
 	const char *color_reg = R_CONS_COLOR_DEF (reg, Color_YELLOW);
 	const char *color_num = R_CONS_COLOR_DEF (num, Color_CYAN);
+	const int addrbytes = core->io->addrbytes;
 
 	if (fmt == 'e') {
 		show_bytes = 0;
@@ -4715,8 +4715,8 @@ R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt) 
 				// anal ignorance.
 				r_core_asm_bwdis_len (core, &nb_bytes, &core->offset,
 					nb_opcodes);
-				nb_bytes *= core->assembler->addrbytes;
 			}
+			nb_bytes *= core->io->addrbytes;
 			if (nb_bytes > core->blocksize) {
 				r_core_block_size (core, nb_bytes);
 			}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -591,7 +591,6 @@ typedef struct r_anal_t {
 	char *cpu;
 	char *os;
 	int bits;
-	int addrbytes;
 	int lineswidth; // wtf
 	int big_endian;
 	int split; // used only from core

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -96,7 +96,6 @@ typedef struct {
 typedef struct r_asm_t {
 	char *cpu;
 	int bits;
-	int addrbytes;
 	int big_endian;
 	int syntax;
 	ut64 pc;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -57,6 +57,7 @@ typedef struct r_io_t {
 	int va;		//all of this config stuff must be in 1 int
 	int ff;
 	int Oxff;
+	int addrbytes;
 	int aslr;
 	int autofd;
 	bool cached;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -130,6 +130,7 @@ R_API RIO* r_io_init(RIO* io) {
 	if (!io) {
 		return NULL;
 	}
+	io->addrbytes = 1;
 	r_io_desc_init (io);
 	r_io_map_init (io);
 	r_io_section_init (io);


### PR DESCRIPTION
`RAsm::user` in rasm2.c does not point to `RCore`, thus I cannot access `core->io->addrbytes` in rasm2.c 
radare2.c should be good.