### PR TITLE
Add error printing on execvp failure. Fixes #8471

### DIFF
--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -459,7 +459,6 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 					eprintf("Could not execvp: %s\n",strerror(errno));
 					exit (MAGIC_EXIT);
 				}
-
 			} else {
 				eprintf ("Invalid execvp\n");
 			}

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -4,6 +4,7 @@
 #include <r_lib.h>
 #include <r_util.h>
 #include <r_debug.h> /* only used for BSD PTRACE redefinitions */
+#include <string.h>
 
 #define USE_RARUN 0
 
@@ -453,7 +454,10 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 				for (i = 3; i < 1024; i++) {
 					(void)close (i);
 				}
-				execvp (argv[0], argv);
+				if (execvp (argv[0], argv) == -1) {
+					eprintf("Could not execvp: %s\n",strerror(errno));
+				}
+
 			} else {
 				eprintf ("Invalid execvp\n");
 			}

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -1,5 +1,6 @@
 /* radare - LGPL - Copyright 2007-2017 - pancake */
 
+#include <errno.h>
 #include <r_io.h>
 #include <r_lib.h>
 #include <r_util.h>

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -457,6 +457,7 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 				}
 				if (execvp (argv[0], argv) == -1) {
 					eprintf("Could not execvp: %s\n",strerror(errno));
+					exit (MAGIC_EXIT);
 				}
 
 			} else {


### PR DESCRIPTION
It is possible to get confusing messages without this check.