### PR TITLE
Fix #8328, allow @ 0-1 (temporarily setting core->offset to UT64_MAX)

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2305,18 +2305,14 @@ next_arroba:
 				tmpseek = true;
 			}
 			if (usemyblock) {
-				if (addr != UT64_MAX) {
-					core->offset = addr;
-				}
+				core->offset = addr;
 				ret = r_cmd_call (core->rcmd, r_str_trim_head (cmd));
 			} else {
-				if (addr != UT64_MAX) {
-					if (ptr[1]) {
-						r_core_seek (core, addr, 1);
-						r_core_block_read (core);
-					}
-					ret = r_cmd_call (core->rcmd, r_str_trim_head (cmd));
+				if (ptr[1]) {
+					r_core_seek (core, addr, 1);
+					r_core_block_read (core);
 				}
+				ret = r_cmd_call (core->rcmd, r_str_trim_head (cmd));
 			}
 			if (tmpseek) {
 				// restore ranges


### PR DESCRIPTION
Rationale:
`s 0-1` is already allowed, so should `@ 0-1`
r_num_math returns 0 on error, testing addr with UT64_MAX does not make sense
appease condret