### PR TITLE
Fix search.in=io.section

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -606,7 +606,7 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int protection, const char 
 			append_bound (list, NULL, search_itv, part->itv.addr, part->itv.size);
 		}
 	} else if (!strcmp (mode, "io.section")) {
-		RIOSection *s = r_io_section_get (core->io, core->offset);
+		RIOSection *s = r_io_section_vget (core->io, core->offset);
 		if (s) {
 			append_bound (list, core->io, search_itv, s->vaddr, s->vsize);
 		}


### PR DESCRIPTION
Fix

```
[XX] t/va12
$ r2 -escr.utf8=0 -escr.color=0 -N -Q -i /tmp/tmp-2151517ME11duvBFX.tmp /home/travis/build/radare/radare2/radare2-regressions/bins/elf/analysis/x86-simple
e search.in=io.section
/x 5b
pi 1 @ hit0_0
0x08048065 hit0_0 5b
pop ebx
```