### PR TITLE
Fix a mem leak in graph.c

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3095,6 +3095,7 @@ static void agraph_init(RAGraph *g) {
 static void free_anode(RANode *n) {
 	free (n->title);
 	free (n->body);
+	free (n);
 }
 
 static int free_anode_cb(void *user UNUSED, const char *k UNUSED, const char *v) {


### PR DESCRIPTION
There are other issues

https://github.com/radare/radare2/issues/8522

```
Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7fd9a40f2ce1 in __interceptor_calloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:70
    #1 0x7fd9a398cc31 in r_agraph_add_node /home/ray/Dev/Bin/radare2/libr/core/graph.c:3156
    #2 0x7fd9a397321e in create_dummy_nodes /home/ray/Dev/Bin/radare2/libr/core/graph.c:614
    #3 0x7fd9a397e795 in set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:1781
    #4 0x7fd9a3984d1f in agraph_set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:2449
    #5 0x7fd9a398ac34 in check_changes /home/ray/Dev/Bin/radare2/libr/core/graph.c:2945
    #6 0x7fd9a398b438 in agraph_print /home/ray/Dev/Bin/radare2/libr/core/graph.c:2985
    #7 0x7fd9a398c180 in agraph_refresh /home/ray/Dev/Bin/radare2/libr/core/graph.c:3072
    #8 0x7fd9a3990321 in r_core_visual_graph /home/ray/Dev/Bin/radare2/libr/core/graph.c:3530
    #9 0x7fd9a395eabd in r_core_visual_cmd /home/ray/Dev/Bin/radare2/libr/core/visual.c:1803
    #10 0x7fd9a3967337 in r_core_visual /home/ray/Dev/Bin/radare2/libr/core/visual.c:2717
    #11 0x7fd9a39217c5 in cmd_visual /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1090
    #12 0x7fd9a39c0cba in r_cmd_call /home/ray/Dev/Bin/radare2/libr/core/cmd_api.c:226
    #13 0x7fd9a3929d01 in r_core_cmd_subst_i /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2358
    #14 0x7fd9a3923d28 in r_core_cmd_subst /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1539
    #15 0x7fd9a392e994 in r_core_cmd /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2987
    #16 0x7fd9a381623f in r_core_prompt_exec /home/ray/Dev/Bin/radare2/libr/core/core.c:2026
    #17 0x7fd9a4fd9818 in _dl_relocate_object (/usr/lib/ld-2.26.so+0xc818)
    #18 0x7fd99d4cef69 in __libc_start_main (/usr/lib/libc.so.6+0x20f69)

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7fd9a40f2ce1 in __interceptor_calloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:70
    #1 0x7fd9a3971e2d in view_dummy /home/ray/Dev/Bin/radare2/libr/core/graph.c:508
    #2 0x7fd99dd5c114 in dfs_node /home/ray/Dev/Bin/radare2/libr/util/graph.c:65
    #3 0x7fd99dd5d889 in r_graph_dfs /home/ray/Dev/Bin/radare2/libr/util/graph.c:261
    #4 0x7fd9a3972f40 in create_dummy_nodes /home/ray/Dev/Bin/radare2/libr/core/graph.c:603
    #5 0x7fd9a397e795 in set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:1781
    #6 0x7fd9a3984d1f in agraph_set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:2449
    #7 0x7fd9a398ac34 in check_changes /home/ray/Dev/Bin/radare2/libr/core/graph.c:2945
    #8 0x7fd9a398b438 in agraph_print /home/ray/Dev/Bin/radare2/libr/core/graph.c:2985
    #9 0x7fd9a398c180 in agraph_refresh /home/ray/Dev/Bin/radare2/libr/core/graph.c:3072
    #10 0x7fd9a3990321 in r_core_visual_graph /home/ray/Dev/Bin/radare2/libr/core/graph.c:3530
    #11 0x7fd9a395eabd in r_core_visual_cmd /home/ray/Dev/Bin/radare2/libr/core/visual.c:1803
    #12 0x7fd9a3967337 in r_core_visual /home/ray/Dev/Bin/radare2/libr/core/visual.c:2717
    #13 0x7fd9a39217c5 in cmd_visual /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1090
    #14 0x7fd9a39c0cba in r_cmd_call /home/ray/Dev/Bin/radare2/libr/core/cmd_api.c:226
    #15 0x7fd9a3929d01 in r_core_cmd_subst_i /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2358
    #16 0x7fd9a3923d28 in r_core_cmd_subst /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1539
    #17 0x7fd9a392e994 in r_core_cmd /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2987
    #18 0x7fd9a381623f in r_core_prompt_exec /home/ray/Dev/Bin/radare2/libr/core/core.c:2026
    #19 0x7fd9a4fd9818 in _dl_relocate_object (/usr/lib/ld-2.26.so+0xc818)
    #20 0x7fd99d4cef69 in __libc_start_main (/usr/lib/libc.so.6+0x20f69)

Indirect leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7fd9a40893b1 in __interceptor_strdup /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_interceptors.cc:560
    #1 0x7fd9a398ccbe in r_agraph_add_node /home/ray/Dev/Bin/radare2/libr/core/graph.c:3161
    #2 0x7fd9a397321e in create_dummy_nodes /home/ray/Dev/Bin/radare2/libr/core/graph.c:614
    #3 0x7fd9a397e795 in set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:1781
    #4 0x7fd9a3984d1f in agraph_set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:2449
    #5 0x7fd9a398ac34 in check_changes /home/ray/Dev/Bin/radare2/libr/core/graph.c:2945
    #6 0x7fd9a398b438 in agraph_print /home/ray/Dev/Bin/radare2/libr/core/graph.c:2985
    #7 0x7fd9a398c180 in agraph_refresh /home/ray/Dev/Bin/radare2/libr/core/graph.c:3072
    #8 0x7fd9a3990321 in r_core_visual_graph /home/ray/Dev/Bin/radare2/libr/core/graph.c:3530
    #9 0x7fd9a395eabd in r_core_visual_cmd /home/ray/Dev/Bin/radare2/libr/core/visual.c:1803
    #10 0x7fd9a3967337 in r_core_visual /home/ray/Dev/Bin/radare2/libr/core/visual.c:2717
    #11 0x7fd9a39217c5 in cmd_visual /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1090
    #12 0x7fd9a39c0cba in r_cmd_call /home/ray/Dev/Bin/radare2/libr/core/cmd_api.c:226
    #13 0x7fd9a3929d01 in r_core_cmd_subst_i /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2358
    #14 0x7fd9a3923d28 in r_core_cmd_subst /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1539
    #15 0x7fd9a392e994 in r_core_cmd /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2987
    #16 0x7fd9a381623f in r_core_prompt_exec /home/ray/Dev/Bin/radare2/libr/core/core.c:2026
    #17 0x7fd9a4fd9818 in _dl_relocate_object (/usr/lib/ld-2.26.so+0xc818)
    #18 0x7fd99d4cef69 in __libc_start_main (/usr/lib/libc.so.6+0x20f69)

Indirect leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7fd9a40893b1 in __interceptor_strdup /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_interceptors.cc:560
    #1 0x7fd9a398cc6a in r_agraph_add_node /home/ray/Dev/Bin/radare2/libr/core/graph.c:3160
    #2 0x7fd9a397321e in create_dummy_nodes /home/ray/Dev/Bin/radare2/libr/core/graph.c:614
    #3 0x7fd9a397e795 in set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:1781
    #4 0x7fd9a3984d1f in agraph_set_layout /home/ray/Dev/Bin/radare2/libr/core/graph.c:2449
    #5 0x7fd9a398ac34 in check_changes /home/ray/Dev/Bin/radare2/libr/core/graph.c:2945
    #6 0x7fd9a398b438 in agraph_print /home/ray/Dev/Bin/radare2/libr/core/graph.c:2985
    #7 0x7fd9a398c180 in agraph_refresh /home/ray/Dev/Bin/radare2/libr/core/graph.c:3072
    #8 0x7fd9a3990321 in r_core_visual_graph /home/ray/Dev/Bin/radare2/libr/core/graph.c:3530
    #9 0x7fd9a395eabd in r_core_visual_cmd /home/ray/Dev/Bin/radare2/libr/core/visual.c:1803
    #10 0x7fd9a3967337 in r_core_visual /home/ray/Dev/Bin/radare2/libr/core/visual.c:2717
    #11 0x7fd9a39217c5 in cmd_visual /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1090
    #12 0x7fd9a39c0cba in r_cmd_call /home/ray/Dev/Bin/radare2/libr/core/cmd_api.c:226
    #13 0x7fd9a3929d01 in r_core_cmd_subst_i /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2358
    #14 0x7fd9a3923d28 in r_core_cmd_subst /home/ray/Dev/Bin/radare2/libr/core/cmd.c:1539
    #15 0x7fd9a392e994 in r_core_cmd /home/ray/Dev/Bin/radare2/libr/core/cmd.c:2987
    #16 0x7fd9a381623f in r_core_prompt_exec /home/ray/Dev/Bin/radare2/libr/core/core.c:2026
    #17 0x7fd9a4fd9818 in _dl_relocate_object (/usr/lib/ld-2.26.so+0xc818)
    #18 0x7fd99d4cef69 in __libc_start_main (/usr/lib/libc.so.6+0x20f69)

SUMMARY: AddressSanitizer: 98 byte(s) leaked in 4 allocation(s).
```