### PR TITLE
Refactor search and support /d (delta) /bd (backward + delta) crossing blocksize boundaries

### DIFF
--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -47,11 +47,10 @@ typedef struct r_search_hit_t {
 	ut64 addr;
 } RSearchHit;
 
-typedef int (*RSearchUpdate)(void *s, ut64 from, const ut8 *buf, int len);
 typedef int (*RSearchCallback)(RSearchKeyword *kw, void *user, ut64 where);
 
 typedef struct r_search_t {
-	int n_kws;
+	int n_kws; // hit${n_kws}_${count}
 	int mode;
 	ut32 pattern_size;
 	ut32 string_min; // max length of strings for R_SEARCH_STRING
@@ -60,15 +59,15 @@ typedef struct r_search_t {
 	void *user; // user data passed to callback
 	RSearchCallback callback;
 	ut64 nhits;
-	ut64 maxhits;
+	ut64 maxhits; // search.maxhits
 	RList *hits;
 	RMemoryPool *pool;
 	int distance;
 	int inverse;
-	bool overlap;
+	bool overlap; // whether two matches can overlap
 	int contiguous;
 	int align;
-	RSearchUpdate update;
+	int (*update)(struct r_search_t *s, ut64 from, const ut8 *buf, int len);
 	RList *kws; // TODO: Use r_search_kw_new ()
 	RIOBind iob;
 	char bckwrds;
@@ -109,14 +108,15 @@ R_API int r_search_set_blocksize(RSearch *s, ut32 bsize);
 R_API int r_search_bmh(const RSearchKeyword *kw, const ut64 from, const ut8 *buf, const int len, ut64 *out);
 
 // TODO: is this an internal API?
-R_API int r_search_mybinparse_update(void *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_aes_update(void *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_rsa_update(void *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_magic_update(void *_s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_deltakey_update(void *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_strings_update(void *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_regexp_update(void *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_xrefs_update(void *s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_mybinparse_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_rsa_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_magic_update(RSearch *_s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_API int r_search_xrefs_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+// Returns 2 if search.maxhits is reached, 0 on error, otherwise 1
 R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr);
 R_API void r_search_set_distance(RSearch *s, int dist);
 R_API int r_search_strings(RSearch *s, ut32 min, ut32 max);

--- a/libr/search/aes-find.c
+++ b/libr/search/aes-find.c
@@ -37,7 +37,7 @@ static int aes_key_test(const unsigned char *buf) {
 	    &&  buf[31]==(table_sbox[buf[14]]^1))?1:0;
 }
 
-R_API int r_search_aes_update(void *s, ut64 from, const ut8 *buf, int len) {
+R_API int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i, last = len-31;
 	if (last>0)
 	for (i=0; i<last; i++) {

--- a/libr/search/regexp.c
+++ b/libr/search/regexp.c
@@ -3,13 +3,13 @@
 #include "r_search.h"
 #include <r_regex.h>
 
-R_API int r_search_regexp_update(void *_s, ut64 from, const ut8 *buf, int len) {
-	RSearch *s = (RSearch*)_s;
+R_API int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RSearchKeyword *kw;
 	RListIter *iter;
 	RRegexMatch match;
 	RRegex compiled;
-	int count = 0;
+	const int old_nhits = s->nhits;
+	int ret = 0;
 
 	r_list_foreach (s->kws, iter, kw) {
 		int reflags = R_REGEX_EXTENDED;
@@ -26,14 +26,24 @@ R_API int r_search_regexp_update(void *_s, ut64 from, const ut8 *buf, int len) {
 		match.rm_eo = len;
 
 		while (!r_regex_exec (&compiled, (char *)buf, 1, &match, R_REGEX_STARTEND)) {
-			r_search_hit_new (s, kw, from+match.rm_so);
-			kw->count++;
+			int t = r_search_hit_new (s, kw, from + match.rm_so);
+			if (!t) {
+				ret = -1;
+				goto beach;
+			}
+			if (t > 1) {
+				goto beach;
+			}
 			/* Setup the boundaries for R_REGEX_STARTEND */
 			match.rm_so = match.rm_eo;
 			match.rm_eo = len;
-			count++;
-		} 
+		}
 	}
 
-	return count;
+beach:
+	r_regex_fini (&compiled);
+	if (!ret) {
+		ret = s->nhits - old_nhits;
+	}
+	return ret;
 }

--- a/libr/search/rsa-find.c
+++ b/libr/search/rsa-find.c
@@ -45,7 +45,7 @@ static int check_rsa_fields(const ut8* start) {
 }
 
 // Finds and return index of private RSA key
-R_API int r_search_rsa_update(void* s, ut64 from, const ut8 *buf, int len) {
+R_API int r_search_rsa_update(RSearch* s, ut64 from, const ut8 *buf, int len) {
 	unsigned int i, k, index;
 	const ut8 versionmarker[] = {0x02, 0x01, 0x00, 0x02};
 

--- a/libr/search/strings.c
+++ b/libr/search/strings.c
@@ -60,8 +60,7 @@ static bool is_encoded(int encoding, unsigned char c) {
 	return false;
 }
 
-R_API int r_search_strings_update(void *_s, ut64 from, const ut8 *buf, int len) {
-	RSearch *s = (RSearch *)_s;
+R_API int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i = 0;
 	int widechar = 0;
 	int matches = 0;
@@ -79,7 +78,7 @@ R_API int r_search_strings_update(void *_s, ut64 from, const ut8 *buf, int len) 
 				matches++;
 		} else {
 			/* wide char check \x??\x00\x??\x00 */
-			if (matches && buf[i+2]=='\0' && buf[i]=='\0' && buf[i+1]!='\0') {
+			if (matches && i + 2 < len && buf[i+2]=='\0' && buf[i]=='\0' && buf[i+1]!='\0') {
 				widechar = 1;
 				return 1; // widechar
 			}
@@ -88,7 +87,6 @@ R_API int r_search_strings_update(void *_s, ut64 from, const ut8 *buf, int len) 
 				str[matches] = '\0';
 				int len = strlen(str);
 				if (len>2) {
-					kw->count++;
 					if (widechar) {
 						ut64 off = (ut64)from+i-(len*2)+1;
 						r_search_hit_new (s, kw, off);

--- a/libr/search/xrefs.c
+++ b/libr/search/xrefs.c
@@ -3,7 +3,7 @@
 #include "r_search.h"
 //#include <regex.h>
 
-R_API int r_search_xrefs_update(void *s, ut64 from, const ut8 *buf, int len) {
+R_API int r_search_xrefs_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 //	ut8 code[1024];
 //	ut8 mask[1024];
 	int count = 0;


### PR DESCRIPTION
    * fix out-of-bounds read in r_search_strings_update
    * Remove static variables searchhits maplist maxhits first_hit in cmd_search.c
    * Change semantics of r_search_hit_new (update kw->count s->nhits in it), return 2 if search.maxhits is reached and stop searching immediately
    * honor search.maxhits in r_search_regexp_update
    * Refactor _cb_hit, remove bckwrds/do_bckwrd_srch and static cmdhit
    * Fix mem leak in regexp.c
    * Add support for /d (delta) /bd (backward + delta) when crossing blocksize boundaries