### PR TITLE
paged reading for gdb (otherwise it doesn't work on qemu)

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1010,6 +1010,19 @@ static int cb_dbg_forks(void *user, void *data) {
 	return true;
 }
 
+static int cb_dbg_gdb_page_size(void *user, void *data) {
+	RCore *core = (RCore*) user;
+	RConfigNode *node = (RConfigNode*) data;
+	if (core->io && core->io->desc && core->io->desc->plugin
+	    && core->io->desc->plugin->name
+	    && !strcmp (core->io->desc->plugin->name, "gdb")) {
+		char cmd[64];
+		snprintf (cmd, sizeof (cmd), "page_size %"PFMT64d, node->i_value);
+		r_io_system (core->io, cmd);
+	}
+	return true;
+}
+
 static int cb_dbg_execs(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
@@ -2395,6 +2408,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("dbg.trace.libs", "true", "Trace library code too");
 	SETPREF ("dbg.exitkills", "true", "Kill process on exit");
 	SETPREF ("dbg.exe.path", NULL, "Path to binary being debugged");
+	SETICB ("dbg.gdb.page_size", 4096, &cb_dbg_gdb_page_size, "Page size on gdb target (useful for QEMU)");
 	SETCB ("dbg.consbreak", "false", &cb_consbreak, "SIGINT handle for attached processes");
 
 	r_config_set_getter (cfg, "dbg.swstep", (RConfigCallback)__dbg_swstep_getter);

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -206,20 +206,34 @@ int send_msg(libgdbr_t* g, const char* command);
 int read_packet(libgdbr_t* instance);
 
 static int __system(RIO *io, RIODesc *fd, const char *cmd) {
-        //printf("ptrace io command (%s)\n", cmd);
-        /* XXX ugly hack for testing purposes */
-        if (!cmd[0] || cmd[0] == '?' || !strcmp (cmd, "help")) {
-                eprintf ("Usage: =!cmd args\n"
-                         " =!pid             - show targeted pid\n"
-                         " =!pkt s           - send packet 's'\n"
-                         " =!monitor cmd     - hex-encode monitor command and pass"
-                                             " to target interpreter\n"
-                         " =!detach [pid]    - detach from remote/detach specific pid\n"
-                         " =!inv.reg         - invalidate reg cache\n"
-                         " =!pktsz           - get max packet size used\n"
-                         " =!pktsz bytes     - set max. packet size as 'bytes' bytes\n"
-                         " =!exec_file [pid] - get file which was executed for"
-                                             " current/specified pid\n");
+	if (!desc) {
+		return true;
+	}
+	if (!cmd[0] || cmd[0] == '?' || !strcmp (cmd, "help")) {
+		eprintf ("Usage: =!cmd args\n"
+			 " =!pid             - show targeted pid\n"
+			 " =!pkt s           - send packet 's'\n"
+			 " =!monitor cmd     - hex-encode monitor command and pass"
+			                     " to target interpreter\n"
+			 " =!detach [pid]    - detach from remote/detach specific pid\n"
+			 " =!inv.reg         - invalidate reg cache\n"
+			 " =!pktsz           - get max packet size used\n"
+			 " =!pktsz bytes     - set max. packet size as 'bytes' bytes\n"
+			 " =!page_size       - get current setting for page size\n"
+			 " =!page_size bytes - set page size for memory reads (useful for qemu)\n"
+			 " =!exec_file [pid] - get file which was executed for"
+			                     " current/specified pid\n");
+		return true;
+	}
+	if (!strncmp (cmd, "page_size", 9)) {
+		int page_size;
+		if (isspace (cmd[9]) && isdigit (cmd[10])) {
+			if ((page_size = atoi (cmd + 10)) >= 64) { // 64 is hardcoded min packet size
+				desc->page_size = page_size;
+			}
+			return true;
+		}
+		io->cb_printf ("page size: %d bytes\n", desc->page_size);
 		return true;
 	}
 	if (!strncmp (cmd, "pktsz", 5)) {

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -171,6 +171,7 @@ typedef struct libgdbr_t {
 	int last_code;
 	int pid; // little endian
 	int tid; // little endian
+	int page_size; // page size for target (useful for qemu)
 	bool attached; // Remote server attached to process or created
 	libgdbr_stub_features_t stub_features;
 

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -17,6 +17,7 @@ int gdbr_init(libgdbr_t *g, bool is_server) {
 	g->is_server = is_server;
 	g->send_max = 2500;
 	g->send_buff = (char *) calloc (g->send_max, 1);
+	g->page_size = 4096;
 	if (!g->send_buff) {
 		return -1;
 	}


### PR DESCRIPTION
gdb protocol specifies that a target can return partial mem-reads. But for qemu, if a mem-read request even partially overlaps an unmapped page, qemu returns an error. That's why the sudden `0xff` that @jpenalbae reported. Hopefully this fixes it T_T