### PR TITLE
Egg Issues

### DIFF
--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -252,41 +252,53 @@ R_API void r_egg_printf(REgg *egg, const char *fmt, ...) {
 	va_end (ap);
 }
 
-R_API int r_egg_assemble(REgg *egg) {
+R_API int r_egg_assemble_asm(REgg *egg, char **asm_list) {
 	RAsmCode *asmcode = NULL;
 	char *code = NULL;
 	int ret = false;
-	if (egg->remit == &emit_x86 || egg->remit == &emit_x64) {
-		r_asm_use (egg->rasm, "x86.nz");
+	char *asm_name = NULL;
+
+	if (asm_list) {
+		char **asm_;
+
+		for (asm_ = asm_list; *asm_; asm_+= 2) {
+			if (!strcmp (egg->remit->arch, asm_[0])) {
+				asm_name = asm_[1];
+				break;
+			}
+		}
+	}
+	if (!asm_name) {
+		if (egg->remit == &emit_x86 || egg->remit == &emit_x64) {
+			asm_name = "x86.nz";
+		} else if (egg->remit == &emit_arm) {
+			asm_name = "arm";
+		}
+	}
+	if (asm_name) {
+		r_asm_use (egg->rasm, asm_name);
 		r_asm_set_bits (egg->rasm, egg->bits);
 		r_asm_set_big_endian (egg->rasm, egg->endian);
 		r_asm_set_syntax (egg->rasm, R_ASM_SYNTAX_INTEL);
-
 		code = r_buf_to_string (egg->buf);
 		asmcode = r_asm_massemble (egg->rasm, code);
 		if (asmcode) {
-			if (asmcode->len > 0)
+			if (asmcode->len > 0) {
 				r_buf_append_bytes (egg->bin, asmcode->buf, asmcode->len);
+			}
 			// LEAK r_asm_code_free (asmcode);
-		} else eprintf ("fail assembling\n");
-	} else
-	if (egg->remit == &emit_arm) {
-		r_asm_use (egg->rasm, "arm");
-		r_asm_set_bits (egg->rasm, egg->bits);
-		r_asm_set_big_endian (egg->rasm, egg->endian);
-		r_asm_set_syntax (egg->rasm, R_ASM_SYNTAX_INTEL);
-
-		code = r_buf_to_string (egg->buf);
-		asmcode = r_asm_massemble (egg->rasm, code);
-		if (asmcode) {
-			r_buf_append_bytes (egg->bin, asmcode->buf, asmcode->len);
-			// LEAK r_asm_code_free (asmcode);
+		} else {
+			eprintf ("fail assembling\n");
 		}
 	}
 	free (code);
 	ret = (asmcode != NULL);
 	r_asm_code_free (asmcode);
 	return ret;
+}
+
+R_API int r_egg_assemble(REgg *egg) {
+	return r_egg_assemble_asm (egg, NULL);
 }
 
 R_API int r_egg_compile(REgg *egg) {

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -581,20 +581,28 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 	}
 	if (str[0] == '.') {
 		REggEmit *e = egg->remit;
-		idx = atoi (str + 4) + delta + e->size;
 		if (!strncmp (str + 1, "ret", 3)) {
+			idx = atoi (str + 4) + delta + e->size;
 			strcpy (out, e->retvar);
 		} else if (!strncmp (str + 1, "fix", 3)) {
+			idx = atoi (str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx - stackfixed);
 			// sprintf(out, "%d(%%"R_BP")", -(atoi(str+4)+delta+R_SZ-stackfixed));
 		} else if (!strncmp (str + 1, "var", 3)) {
+			idx = atoi (str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx);
 			// sprintf(out, "%d(%%"R_BP")", -(atoi(str+4)+delta+R_SZ));
+		} else if (!strncmp (str + 1, "rarg", 4)) {
+			if (e->get_ar) {
+				idx = atoi (str + 5);
+				e->get_ar (egg, out, idx);
+			}
 		} else if (!strncmp (str + 1, "arg", 3)) {
 			if (str[4]) {
 				if (stackframe == 0) {
 					e->get_var (egg, 1, out, 4);	// idx-4);
 				} else {
+					idx = atoi (str + 4) + delta + e->size;
 					e->get_var (egg, 2, out, idx + 4);
 				}
 			} else {
@@ -708,10 +716,12 @@ static void rcc_fun(REgg *egg, const char *str) {
 				dstval = malloc (4096);
 			} else if (strstr (ptr, "naked")) {
 				mode = NAKED;
+				/*
 				free (dstvar);
 				dstvar = strdup (skipspaces (str));
 				dstval = malloc (4096);
 				ndstval = 0;
+				*/
 				r_egg_printf (egg, "%s:\n", str);
 			} else if (strstr (ptr, "inline")) {
 				mode = INLINE;
@@ -1150,16 +1160,16 @@ static void rcc_next(REgg *egg) {
 
 		/* store result of call */
 		if (dstvar) {
-			if (mode != NAKED) {
-				*buf = 0;
-				free (str);
-				str = r_egg_mkvar (egg, buf, dstvar, 0);
-				if (*buf == 0) {
-					eprintf ("Cannot resolve variable '%s'\n", dstvar);
-				} else {
-					e->get_result (egg, buf);
-				}
+			//if (mode != NAKED) {
+			*buf = 0;
+			free (str);
+			str = r_egg_mkvar (egg, buf, dstvar, 0);
+			if (*buf == 0) {
+				eprintf ("Cannot resolve variable '%s'\n", dstvar);
+			} else {
+				e->get_result (egg, buf);
 			}
+			//}
 			R_FREE (dstvar);
 		}
 		rcc_reset_callname ();

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -556,7 +556,7 @@ static void rcc_pushstr(REgg *egg, char *str, int filter) {
 }
 
 R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
-	int i, idx, len, qi;
+	int i, len, qi;
 	char *oldstr = NULL, *str = NULL, foo[32], *q, *ret = NULL;
 
 	delta += stackfixed;	// XXX can be problematic
@@ -582,19 +582,18 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 	if (str[0] == '.') {
 		REggEmit *e = egg->remit;
 		if (!strncmp (str + 1, "ret", 3)) {
-			idx = atoi (str + 4) + delta + e->size;
 			strcpy (out, e->retvar);
 		} else if (!strncmp (str + 1, "fix", 3)) {
-			idx = atoi (str + 4) + delta + e->size;
+			int idx = (int)r_num_math (NULL, str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx - stackfixed);
 			// sprintf(out, "%d(%%"R_BP")", -(atoi(str+4)+delta+R_SZ-stackfixed));
 		} else if (!strncmp (str + 1, "var", 3)) {
-			idx = atoi (str + 4) + delta + e->size;
+			int idx = (int)r_num_math (NULL, str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx);
 			// sprintf(out, "%d(%%"R_BP")", -(atoi(str+4)+delta+R_SZ));
 		} else if (!strncmp (str + 1, "rarg", 4)) {
 			if (e->get_ar) {
-				idx = atoi (str + 5);
+				int idx = (int)r_num_math (NULL, str + 5);
 				e->get_ar (egg, out, idx);
 			}
 		} else if (!strncmp (str + 1, "arg", 3)) {
@@ -602,7 +601,7 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 				if (stackframe == 0) {
 					e->get_var (egg, 1, out, 4);	// idx-4);
 				} else {
-					idx = atoi (str + 4) + delta + e->size;
+					int idx = (int)r_num_math (NULL, str + 4) + delta + e->size;
 					e->get_var (egg, 2, out, idx + 4);
 				}
 			} else {

--- a/libr/include/r_egg.h
+++ b/libr/include/r_egg.h
@@ -106,6 +106,7 @@ typedef struct r_egg_emit_t {
 	void (*restore_stack)(REgg *egg, int size);
 	void (*syscall_args)(REgg *egg, int nargs);
 	void (*get_var)(REgg *egg, int type, char *out, int idx);
+	void (*get_ar)(REgg *egg, char *out, int idx);
 	void (*while_end)(REgg *egg, const char *label);
 	void (*load)(REgg *egg, const char *str, int sz);
 	void (*load_ptr)(REgg *egg, const char *str);
@@ -143,6 +144,7 @@ R_API void r_egg_printf(REgg *egg, const char *fmt, ...);
 R_API int r_egg_compile(REgg *egg);
 R_API int r_egg_padding (REgg *egg, const char *pad);
 R_API int r_egg_assemble(REgg *egg);
+R_API int r_egg_assemble_asm(REgg *egg, char **asm_list);
 R_API void r_egg_pattern(REgg *egg, int size);
 R_API RBuffer *r_egg_get_bin(REgg *egg);
 //R_API int r_egg_dump (REgg *egg, const char *file) { }


### PR DESCRIPTION

Fix pushing inmmediate args using the x64 arch
Added .rargX (a0, a1,...etc) directive.
Added r_egg_assemble_asm() function . 

Using the directive rargX, we can set a returned value from the called function to an aX register (a0, a1...etc). (the r_debug_execute function return value from the a0 register). 

For example:
  

```
sc@syscall(1);
  @syscall() {
    : mov eax, `.arg`
    : int 0x80
  }
  main@naked() {
    .rarg0 = sc (0x0102030405060708);
  }
----------------
main:
  mov rax, 0x0102030405060708
  push rax
# set syscall args
  mov rdi, [rsp]
# syscall
 mov eax, 1
 int 0x80
  add rsp, 8
  mov rdi, rax
```

With r_egg_assemble_asm()  you can force use an specific assembler.
 For example:

> 

      char *asm_list[] = {
                        "x86", "x86.as",
                        "x64", "x86.as",
                        NULL};
       r_egg_assemble_asm (dbg->egg,  asm_list);
 