### PR TITLE
Fix 32-bit big-endian relsub_addr reads

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -766,7 +766,7 @@ static void ds_build_op_str(RDisasmState *ds) {
 				if (core->parser->relsub_addr == 0) {
 					ut64 killme = UT64_MAX;
 					const int be = core->assembler->big_endian;
-					r_io_read_i (core->io, ds->analop.ptr, &killme, sizeof (killme), be);
+					r_io_read_i (core->io, ds->analop.ptr, &killme, ds->analop.refptr, be);
 					core->parser->relsub_addr = (int)killme;
 				}
 			}


### PR DESCRIPTION
This reads 8 bytes instead of 4 and then truncates the result to 4
bytes. On 32-bit big-endian architectures this is truncating the wrong 4
bytes. Since ds->analop.refptr already contains the number of bytes to
read let's just read that much.