### PR TITLE
Cs: show unfiltered strings

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -374,7 +374,11 @@ static void printmetaitem(RAnal *a, RAnalMetaItem *d, int rad) {
 			return;
 		}
 	}
-	str = r_str_escape (d->str);
+	if (d->type == 's') {
+		str = r_str_escape_latin1 (d->str, false, true);
+	} else {
+		str = r_str_escape (d->str);
+	}
 	if (str || d->type == 'd') {
 		if (d->type=='s' && !*str) {
 			free (str);
@@ -382,6 +386,8 @@ static void printmetaitem(RAnal *a, RAnalMetaItem *d, int rad) {
 		}
 		if (!str) {
 			pstr = "";
+		} else if (d->type == 's') {
+			pstr = str;
 		} else if (d->type != 'C') {
 			r_name_filter (str, 0);
 			pstr = str;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2668,7 +2668,7 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len) {
 	const char *prefix = "";
 	switch (ds->strenc) {
 	case R_STRING_ENC_LATIN1:
-		escstr = r_str_escape_latin1 (str, ds->show_asciidot);
+		escstr = r_str_escape_latin1 (str, ds->show_asciidot, false);
 		break;
 	case R_STRING_ENC_UTF8:
 		escstr = r_str_escape_utf8 (str, ds->show_asciidot);
@@ -2704,7 +2704,7 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len) {
 				escstr = r_str_escape_utf32le (str, len, ds->show_asciidot);
 				prefix = "U";
 			} else {
-				escstr = r_str_escape_latin1 (str, ds->show_asciidot);
+				escstr = r_str_escape_latin1 (str, ds->show_asciidot, false);
 			}
 		} else {
 			RStrEnc enc = R_STRING_ENC_LATIN1;
@@ -2717,7 +2717,7 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len) {
 			}
 			escstr = (enc == R_STRING_ENC_UTF8 ?
 			          r_str_escape_utf8 (str, ds->show_asciidot) :
-			          r_str_escape_latin1 (str, ds->show_asciidot));
+			          r_str_escape_latin1 (str, ds->show_asciidot, false));
 		}
 	}
 	if (escstr) {

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -116,7 +116,7 @@ R_API int r_str_re_replace(const char *str, const char *reg, const char *sub);
 R_API int r_str_unescape(char *buf);
 R_API char *r_str_escape(const char *buf);
 R_API char *r_str_escape_dot(const char *buf);
-R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot);
+R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot, bool ign_bslash);
 R_API char *r_str_escape_utf8(const char *buf, bool show_asciidot);
 R_API char *r_str_escape_utf16le(const char *buf, int buf_size, bool show_asciidot);
 R_API char *r_str_escape_utf32le(const char *buf, int buf_size, bool show_asciidot);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1227,7 +1227,7 @@ R_API void r_str_sanitize(char *c) {
 	}
 }
 
-static void r_str_byte_escape(const char *p, char **dst, int dot_nl, bool default_dot) {
+static void r_str_byte_escape(const char *p, char **dst, int dot_nl, bool default_dot, bool ign_bslash) {
 	char *q = *dst;
 	switch (*p) {
 	case '\n':
@@ -1240,7 +1240,9 @@ static void r_str_byte_escape(const char *p, char **dst, int dot_nl, bool defaul
 		break;
 	case '\\':
 		*q++ = '\\';
-		*q++ = '\\';
+		if (!ign_bslash) {
+			*q++ = '\\';
+		}
 		break;
 	case '\t':
 		*q++ = '\\';
@@ -1278,7 +1280,7 @@ static void r_str_byte_escape(const char *p, char **dst, int dot_nl, bool defaul
 
 /* Internal function. dot_nl specifies wheter to convert \n into the
  * graphiz-compatible newline \l */
-static char *r_str_escape_(const char *buf, int dot_nl, bool ign_esc_seq, bool show_asciidot) {
+static char *r_str_escape_(const char *buf, int dot_nl, bool ign_esc_seq, bool show_asciidot, bool ign_bslash) {
 	char *new_buf, *q;
 	const char *p;
 
@@ -1313,7 +1315,7 @@ static char *r_str_escape_(const char *buf, int dot_nl, bool ign_esc_seq, bool s
 				break;
 			}
 		default:
-			r_str_byte_escape (p, &q, dot_nl, show_asciidot);
+			r_str_byte_escape (p, &q, dot_nl, show_asciidot, ign_bslash);
 		}
 		p++;
 	}
@@ -1323,15 +1325,15 @@ out:
 }
 
 R_API char *r_str_escape(const char *buf) {
-	return r_str_escape_ (buf, false, true, false);
+	return r_str_escape_ (buf, false, true, false, false);
 }
 
 R_API char *r_str_escape_dot(const char *buf) {
-	return r_str_escape_ (buf, true, true, false);
+	return r_str_escape_ (buf, true, true, false, false);
 }
 
-R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot) {
-	return r_str_escape_ (buf, false, false, show_asciidot);
+R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot, bool ign_bslash) {
+	return r_str_escape_ (buf, false, false, show_asciidot, ign_bslash);
 }
 
 static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool show_asciidot) {
@@ -1398,7 +1400,7 @@ static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool s
 				*q++ = "0123456789abcdef"[ch >> 4 * i & 0xf];
 			}
 		} else {
-			r_str_byte_escape (p, &q, false, false);
+			r_str_byte_escape (p, &q, false, false, false);
 		}
 		switch (enc) {
 		case R_STRING_ENC_UTF16LE:


### PR DESCRIPTION
For UTF/wide strings, Cs shows the individual UTF8 bytes. That will be fixed later.