### PR TITLE
The simulavr gdb fix 

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -279,7 +279,6 @@ static RDebugReasonType r_debug_gdb_wait(RDebug *dbg, int pid) {
 			return R_DEBUG_REASON_UNKNOWN;
 		}
 	}
-	desc->stop_reason.is_valid = false;
 	if (desc->stop_reason.thread.present) {
 		dbg->reason.tid = desc->stop_reason.thread.tid;
 		dbg->pid = desc->stop_reason.thread.pid;

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -177,6 +177,7 @@ typedef struct libgdbr_t {
 	libgdbr_stub_features_t stub_features;
 
 	int remote_file_fd; // For remote file I/O
+	int num_retries; // number of retries for packet reading
 
 	int remote_type;
 	bool no_ack;

--- a/shlr/gdb/include/packet.h
+++ b/shlr/gdb/include/packet.h
@@ -23,9 +23,10 @@ int send_packet(libgdbr_t *g);
 /*!
  * \brief Function reads data from the established connection
  * \param g the "instance" of the current libgdbr session
+ * \param vcont whether it's called to receive reply to a vcont packet
  * \returns a failure code (currently -1) or 0 if call successfully
  */
-int read_packet(libgdbr_t *g);
+int read_packet(libgdbr_t *g, bool vcont);
 
 int pack(libgdbr_t *g, const char *msg);
 

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -862,9 +862,7 @@ static bool _isbreaked = false;
 static HANDLE h;
 static BOOL __w32_signal(DWORD type) {
 	if (type == CTRL_C_EVENT) {
-		if (cur_desc) {
-			_isbreaked = true;
-		}
+		_isbreaked = true;
 		return true;
 	}
 	return false;

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -34,7 +34,7 @@ static char *gdbr_read_feature(libgdbr_t *g, const char *file, ut64 *tot_len) {
 		snprintf (msg, sizeof (msg), "qXfer:features:read:%s:%"PFMT64x
 			",%"PFMT64x, file, off, len);
 		if (send_msg (g, msg) < 0
-		    || read_packet (g) < 0 || send_ack (g) < 0) {
+		    || read_packet (g, false) < 0 || send_ack (g) < 0) {
 			free (ret);
 			*tot_len = 0;
 			return NULL;

--- a/shlr/gdb/src/gdbserver/core.c
+++ b/shlr/gdb/src/gdbserver/core.c
@@ -497,7 +497,7 @@ int gdbr_server_serve(libgdbr_t *g, gdbr_server_cmd_cb cmd_cb, void *core_ptr) {
 		return -1;
 	}
 	while (1) {
-		if (read_packet (g) < 0) {
+		if (read_packet (g, false) < 0) {
 			continue;
 		}
 		if (g->data_len == 0) {

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -18,6 +18,7 @@ int gdbr_init(libgdbr_t *g, bool is_server) {
 	g->send_max = 2500;
 	g->send_buff = (char *) calloc (g->send_max, 1);
 	g->page_size = 4096;
+	g->num_retries = 10; // safe number, should be ~2.5 seconds
 	if (!g->send_buff) {
 		return -1;
 	}

--- a/shlr/gdb/src/packet.c
+++ b/shlr/gdb/src/packet.c
@@ -139,7 +139,7 @@ static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
 	return 1;
 }
 
-int read_packet(libgdbr_t *g) {
+int read_packet(libgdbr_t *g, bool vcont) {
 	struct parse_ctx ctx = { 0 };
 	int ret;
 	if (!g) {
@@ -159,7 +159,14 @@ int read_packet(libgdbr_t *g) {
 		}
 	}
 	g->data_len = 0;
-	while (r_socket_ready (g->sock, 0, READ_TIMEOUT) > 0) {
+	while (1) {
+		ret = r_socket_ready (g->sock, 0, READ_TIMEOUT);
+		if (ret == 0 && !vcont) {
+			continue;
+		}
+		if (ret <= 0) {
+			return -1;
+		}
 		int sz = r_socket_read (g->sock, (void *)g->read_buff, g->read_max - 1);
 		if (sz <= 0) {
 			eprintf ("%s: read failed\n", __func__);

--- a/shlr/gdb/src/packet.c
+++ b/shlr/gdb/src/packet.c
@@ -141,7 +141,7 @@ static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
 
 int read_packet(libgdbr_t *g, bool vcont) {
 	struct parse_ctx ctx = { 0 };
-	int ret;
+	int ret, i;
 	if (!g) {
 		eprintf ("Initialize libgdbr_t first\n");
 		return -1;
@@ -159,7 +159,7 @@ int read_packet(libgdbr_t *g, bool vcont) {
 		}
 	}
 	g->data_len = 0;
-	while (1) {
+	for (i = 0; i < g->num_retries; vcont ? 0 : i++) {
 		ret = r_socket_ready (g->sock, 0, READ_TIMEOUT);
 		if (ret == 0 && !vcont) {
 			continue;


### PR DESCRIPTION
Reintroduced the infinite loop in `send_vcont`. Hopefully slightly better implemented so that you can break out of it.