### PR TITLE
Add canary detection on OpenBSD

### DIFF
--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -872,7 +872,7 @@ static bool has_canary(RBinFile *arch) {
 	RBinImport *import;
 	if (imports_list) {
 		r_list_foreach (imports_list, iter, import) {
-			if (!strcmp (import->name, "__stack_chk_fail") ) {
+			if (!strcmp (import->name, "__stack_chk_fail") || !strcmp (import->name, "__stack_smash_handler")) {
 				ret = true;
 				break;
 			}


### PR DESCRIPTION
For some reason, OpenBSD use a different mechanism for
canary and stack protection, using a different functions
than others Unix based systems.