### PR TITLE
Fix segfault found by rafuzz2

### DIFF
--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -350,6 +350,7 @@ static int cmd_info(void *data, const char *input) {
 			// plugin that will be used to load the bin (e.g. malloc://)
 			// TODO: Might be nice to reload a bin at a specified offset?
 			r_core_bin_reload (core, NULL, baddr);
+			o = r_bin_cur_object (core->bin);
 			r_core_block_read (core);
 			newline = false;
 		}


### PR DESCRIPTION
Typing 'ibk' trigger the problem, which is caused by r_core_bin_reload
and o being a old pointer on the bin_cur_object.

Fix #8601