### PR TITLE
Fix osabi detection for FreeBSD and Solaris

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2067,6 +2067,11 @@ static inline int needle(ELFOBJ *bin, const char *s) {
 
 // TODO: must return const char * all those strings must be const char os[LINUX] or so
 char* Elf_(r_bin_elf_get_osabi_name)(ELFOBJ *bin) {
+	switch (bin->ehdr.e_ident[EI_OSABI]) {
+	case ELFOSABI_LINUX: return strdup("linux");
+	case ELFOSABI_SOLARIS: return strdup("solaris");
+	case ELFOSABI_FREEBSD: return strdup("freebsd");
+	}
 	/* Hack to identify OS */
 	if (needle (bin, "openbsd")) return strdup ("openbsd");
 	if (needle (bin, "netbsd")) return strdup ("netbsd");


### PR DESCRIPTION
The detection using needle seems to fail on a recent BSD
system, so using the elf header should be prefered.