### PR TITLE
Do not crash on half formed json filter

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -97,10 +97,10 @@ static void parse_grep_expression(const char *str) {
 				char *jsonPathEnd = strchr (jsonPath, '}');
 				if (jsonPathEnd) {
 					*jsonPathEnd = 0;
+					free (cons->grep.json_path);
+					cons->grep.json_path = jsonPath;
+					cons->grep.json = 1;
 				}
-				free (cons->grep.json_path);
-				cons->grep.json_path = jsonPath;
-				cons->grep.json = 1;
 				return;
 			}
 			str++;


### PR DESCRIPTION
Fix #8640 

I am not 100% sure that's the right fix, but it fix the 2 crashes here, and ~{foo wouldn't be a valid input anyway.