### PR TITLE
Csg: add string (guess encoding)

### DIFF
--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -68,6 +68,7 @@ static const char *help_msg_Cs[] = {
 	"Cs", "", "list all strings in human friendly form",
 	"Cs*", "", "list all strings in r2 commands",
 	"Cs", " [size] @addr", "add string (guess latin1/utf16le)",
+	" Csg", " [size] [@addr]", "as above but addr not needed",
 	" Cz", " [size] [@addr]", "ditto",
 	"Csa", " [size] [@addr]", "add ascii/latin1 string",
 	"Cs-", " [@addr]", "remove string",
@@ -576,6 +577,7 @@ static int cmd_meta_hsdmf(RCore *core, const char *input) {
 		break;
 	case ' ':
 	case '\0':
+	case 'g':
 	case 'a':
 		if (type != 'z' && !input[1] && !core->tmpseek) {
 			r_meta_list (core->anal, type, 0);

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -68,7 +68,7 @@ static const char *help_msg_Cs[] = {
 	"Cs", "", "list all strings in human friendly form",
 	"Cs*", "", "list all strings in r2 commands",
 	"Cs", " [size] @addr", "add string (guess latin1/utf16le)",
-	" Csg", " [size] [@addr]", "as above but addr not needed",
+	"Csg", " [size] [@addr]", "as above but addr not needed",
 	" Cz", " [size] [@addr]", "ditto",
 	"Csa", " [size] [@addr]", "add ascii/latin1 string",
 	"Cs-", " [@addr]", "remove string",


### PR DESCRIPTION
Due to https://github.com/radare/radare2/issues/7335#issuecomment-324007261 and https://github.com/radare/radare2/pull/8625#issuecomment-334028572 and also because `Csg` is clearer (as a command) than `Cz` as to what it does.