### PR TITLE
Fix the use after free which causes a segv

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1722,7 +1722,6 @@ R_API bool r_core_init(RCore *core) {
 	}
 	core->print->cons = core->cons;
 	r_cons_bind (&core->print->consbind);
-	core->cons->num = core->num;
 	core->lang = r_lang_new ();
 	core->lang->cmd_str = (char *(*)(void *, const char *))r_core_cmd_str;
 	core->lang->cmdf = (int (*)(void *, const char *, ...))r_core_cmdf;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1722,11 +1722,11 @@ R_API bool r_core_init(RCore *core) {
 	}
 	core->print->cons = core->cons;
 	r_cons_bind (&core->print->consbind);
-        
-        // We save the old num, in order to restore it after free
-        core->old_num = core->cons->num;
+
+	// We save the old num, in order to restore it after free
+	core->old_num = core->cons->num;
 	core->cons->num = core->num;
-        core->lang = r_lang_new ();
+	core->lang = r_lang_new ();
 	core->lang->cmd_str = (char *(*)(void *, const char *))r_core_cmd_str;
 	core->lang->cmdf = (int (*)(void *, const char *, ...))r_core_cmdf;
 	core->cons->editor = (RConsEditorCallback)r_core_editor;
@@ -1839,13 +1839,13 @@ R_API RCore *r_core_fini(RCore *c) {
 	free (c->lastcmd);
 	free (c->block);
 	r_io_free (c->io);
-        
-        // Check if the old num is saved. If yes, we restore it.
-        if (c->cons != NULL && c->old_num != NULL) { 
-                c->cons->num = c->old_num;
+
+	// Check if the old num is saved. If yes, we restore it.
+	if (c->cons != NULL && c->old_num != NULL) { 
+		c->cons->num = c->old_num;
 		c->old_num   = NULL;
-        }
-        r_num_free (c->num);
+	}
+	r_num_free (c->num);
 	// TODO: sync or not? sdb_sync (c->sdb);
 	// TODO: sync all dbs?
 	//r_core_file_free (c->file);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1722,7 +1722,11 @@ R_API bool r_core_init(RCore *core) {
 	}
 	core->print->cons = core->cons;
 	r_cons_bind (&core->print->consbind);
-	core->lang = r_lang_new ();
+        
+        // We save the old num, in order to restore it after free
+        core->old_num = core->cons->num;
+	core->cons->num = core->num;
+        core->lang = r_lang_new ();
 	core->lang->cmd_str = (char *(*)(void *, const char *))r_core_cmd_str;
 	core->lang->cmdf = (int (*)(void *, const char *, ...))r_core_cmdf;
 	core->cons->editor = (RConsEditorCallback)r_core_editor;
@@ -1835,7 +1839,13 @@ R_API RCore *r_core_fini(RCore *c) {
 	free (c->lastcmd);
 	free (c->block);
 	r_io_free (c->io);
-	r_num_free (c->num);
+        
+        // Check if the old num is saved. If yes, we restore it.
+        if (c->cons != NULL && c->old_num != NULL) { 
+                c->cons->num = c->old_num;
+		c->old_num   = NULL;
+        }
+        r_num_free (c->num);
 	// TODO: sync or not? sdb_sync (c->sdb);
 	// TODO: sync all dbs?
 	//r_core_file_free (c->file);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -133,7 +133,7 @@ typedef struct r_core_t {
 	RList *files;
 	RNum *num;
 	RNum *old_num;
-        RLib *lib;
+	RLib *lib;
 	RCmd *rcmd;
 	RCmdDescriptor root_cmd_descriptor;
 	RList/*<RCmdDescriptor>*/ *cmd_descriptors;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -132,7 +132,8 @@ typedef struct r_core_t {
 	RCoreFile *file;
 	RList *files;
 	RNum *num;
-	RLib *lib;
+	RNum *old_num;
+        RLib *lib;
 	RCmd *rcmd;
 	RCmdDescriptor root_cmd_descriptor;
 	RList/*<RCmdDescriptor>*/ *cmd_descriptors;


### PR DESCRIPTION
See [the related bug](https://github.com/radare/radare2/issues/8656)

When user calls _dmh_ , `cmd_dbg_map_heap_glibc_64` is called. This function looks for the main arena by calling `r_resolve_main_arena_64`, which instanciates a new `r_core_t` struct in order to resolve symbols (`get_vaddr_symbol` function is very important).

```c
typedef struct r_core_t {
	...
	/* files */
	RCons *cons;
	RIO *io;
	RCoreFile *file;
	RList *files;
	RNum *num;
	...
} RCore;
```
When it instanciates a new `r_core_t`, `r_core_init` is called, and vars in the struct are initialized.
```c
R_API bool r_core_init(RCore *core) {
        ...
        core->num = r_num_new (&num_callback, &str_callback, core); // <-- malloc of new num struct
        ...
	/* initialize libraries */
	core->cons = r_cons_new ();  // <--- create a new cons  ....
	if (core->cons->refcnt == 1) {
		core->cons = r_cons_singleton ();  // <--- but no, it takes the global singleton
		if (core->cons->line) {
		...
	}
	core->print->cons = core->cons;
	r_cons_bind (&core->print->consbind);
        core->cons->num = core->num;   // <-- cons->num becomes the new core->num which was mallocated just before
	...
	return 0;
}
```
But, at the end of `get_vaddr_symbol` function, we have this : 
```c
r_core_free (core);
	return vaddr;
}
```
If you look inside `r_core_free` and `r_core_fini` function, we see that it's going to free `core->num` : 
```c
R_API RCore *r_core_fini(RCore *c) {
...
    r_num_free (c->num);
...
}
```
But, c->num is the mallocated pointer, **but** the static global singleton is also the same struct. So the `r_cons_instance.num` is freed.

I read the rest of this part of code, and this assignment: 
```
core->cons->num = core->num;
```
is not needed (but core->num yes, but here there is no problem with it).
**Edit**: My bad, it is. Fixed