### PR TITLE
When a method has as an argument an object that belongs to a namespac…

### DIFF
--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -154,22 +154,23 @@ R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr) {
 	}
 	{
 		if (out) {
-			char *sign = (char *)strstr (out, "(");
+			char *sign = (char *)strchr (out, '(');
 			if (sign) {
 				char *str = out;
 				char *ptr = NULL;
 				char *nerd = str;
 				do {
 					ptr = strstr (str, "::");
-					if (!ptr || ptr > sign) break;
+					if (!ptr || ptr > sign) {
+						break;
+					}
 					nerd = ptr;
 					str = ptr + 1;
 				} while (1);
 
 				if (ptr && *ptr) {
 					*nerd = 0;
-					RBinSymbol *sym = 
-					r_bin_class_add_method (binfile, out, nerd + 2, 0);
+					RBinSymbol *sym = r_bin_class_add_method (binfile, out, nerd + 2, 0);
 					if (sym) {
 						sym->vaddr = vaddr;
 					}

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -153,15 +153,29 @@ R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr) {
 		r_str_replace_char (out, ' ', 0);
 	}
 	{
-		/* extract class/method information */
-		char *nerd = (char*)r_str_last (out, "::");
-		if (nerd && *nerd) {
-			*nerd = 0;
-			RBinSymbol *sym = r_bin_class_add_method (binfile, out, nerd + 2, 0);
-			if (sym) {
-				sym->vaddr = vaddr;
+		if (out) {
+			char *sign = (char *)strstr (out, "(");
+			if (sign) {
+				char *str = out;
+				char *ptr = NULL;
+				char *nerd = str;
+				do {
+					ptr = strstr (str, "::");
+					if (!ptr || ptr > sign) break;
+					nerd = ptr;
+					str = ptr + 1;
+				} while (1);
+
+				if (ptr && *ptr) {
+					*nerd = 0;
+					RBinSymbol *sym = 
+					r_bin_class_add_method (binfile, out, nerd + 2, 0);
+					if (sym) {
+						sym->vaddr = vaddr;
+					}
+					*nerd = ':';
+				}
 			}
-			*nerd = ':';
 		}
 	}
 	return out;

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -158,7 +158,7 @@ R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr) {
 			if (sign) {
 				char *str = out;
 				char *ptr = NULL;
-				char *nerd = str;
+				char *nerd = NULL;
 				do {
 					ptr = strstr (str, "::");
 					if (!ptr || ptr > sign) {
@@ -168,7 +168,7 @@ R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr) {
 					str = ptr + 1;
 				} while (1);
 
-				if (ptr && *ptr) {
+				if (nerd && *nerd) {
 					*nerd = 0;
 					RBinSymbol *sym = r_bin_class_add_method (binfile, out, nerd + 2, 0);
 					if (sym) {


### PR DESCRIPTION
…e, the last :: is not the correct delimeter. It should be the last :: before the first (

e.g: double_conversion::Bignum::AssignDecimalString(double_conversion::Vector<charconst>) should be classname: double_conversion::Bignum, method AssignDecimalString(double_conversion::Vector<charconst>)