### PR TITLE
call r_cons_break_pop after r_cons_break_push in a loop, avoiding loop

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -277,6 +277,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 				break;
 			}
 		}
+		r_cons_break_pop();
 	}
 	r_cons_break_pop ();
 	r_anal_emul_restore (core, hc);


### PR DESCRIPTION
Fix for the [issue #8709](https://github.com/radare/radare2/issues/8709#).