### PR TITLE
Fix JSON graph output when opcode has quotes ('agj' command)

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4330,9 +4330,19 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		}
 		r_cons_printf (",\"size\":%d", ds->analop.size);
 		{
+			char *quoted_str, *qpos, *spos = NULL;
 			char *escaped_str = r_str_utf16_encode (str, -1);
-			r_cons_printf (",\"opcode\":\"%s\"", escaped_str);
+			qpos = quoted_str = malloc (strlen (escaped_str)*4 + 1);
+			for(spos = escaped_str; *spos != '\0'; spos++) {
+				if(*spos == '"') {
+					*qpos++ = '\\';
+				}
+				*qpos++ = *spos;
+			}
+			*qpos = '\0';
+			r_cons_printf (",\"opcode\":\"%s\"", quoted_str);
 			free (escaped_str);
+			free (quoted_str);
 		}
 		r_cons_printf (",\"bytes\":\"%s\"", asmop.buf_hex);
 		r_cons_printf (",\"family\":\"%s\"",


### PR DESCRIPTION
When the opcode entity has quotation marks in it, the old code wouldn't
escape them, causing unparseable JSON output. This fixes that, in a
manner similar to other JSON handling in the project.