### PR TITLE
Fix Cs* output for Csa strings

### DIFF
--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -517,7 +517,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 }
 
 static int cmd_meta_hsdmf(RCore *core, const char *input) {
-	int n, type = input[0];
+	int n, type = input[0], subtype;
 	char *t = 0, *p, name[256], *str;
 	int repeat = 1;
 	ut64 addr_end = 0LL, addr = core->offset;
@@ -716,7 +716,12 @@ static int cmd_meta_hsdmf(RCore *core, const char *input) {
 				n++;
 			}
 			addr_end = addr + n;
-			r_meta_add (core->anal, type, addr, addr_end, name);
+			if (type == 's') {
+				subtype = input[1] == 'a' ? R_STRING_ENC_LATIN1 : R_STRING_ENC_GUESS;
+				r_meta_add_with_subtype (core->anal, type, subtype, addr, addr_end, name);
+			} else {
+				r_meta_add (core->anal, type, addr, addr_end, name);
+			}
 			free (t);
 			repcnt ++;
 			addr = addr_end;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2078,7 +2078,7 @@ static int ds_print_meta_infos(RDisasmState *ds, ut8* buf, int len, int idx) {
 	if (infos) {
 		for (;*infos; infos++) {
 			/* XXX wtf, must use anal.meta.deserialize() */
-			char *p, *q;
+			char *p, *q, *r;
 			if (*infos == ',') {
 				continue;
 			}
@@ -2086,6 +2086,7 @@ static int ds_print_meta_infos(RDisasmState *ds, ut8* buf, int len, int idx) {
 			metas = sdb_const_get (s, key, 0);
 			MI.size = sdb_array_get_num (s, key, 0, 0);
 			MI.type = *infos;
+			MI.subtype = 0;
 			MI.from = ds->at;
 			MI.to = ds->at + MI.size;
 			if (metas) {
@@ -2097,6 +2098,13 @@ static int ds_print_meta_infos(RDisasmState *ds, ut8* buf, int len, int idx) {
 				q = strchr (p + 1, ',');
 				if (!q) {
 					continue;
+				}
+				if (MI.type == R_META_TYPE_STRING) {
+					r = strchr (q + 1, ',');
+					if (r) {
+						MI.subtype = *(q + 1);
+						q = r;
+					}
 				}
 				MI.str = (char*)sdb_decode (q + 1, 0);
 			} else {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -45,6 +45,7 @@ typedef struct r_anal_meta_item_t {
 	ut64 to;
 	ut64 size;
 	int type;
+	int subtype;
 	char *str;
 	int space;
 } RAnalMetaItem;
@@ -1516,6 +1517,7 @@ R_API int r_meta_set_var_comment (RAnal *a, int type, ut64 idx, ut64 addr, const
 R_API int r_meta_del(RAnal *m, int type, ut64 from, ut64 size, const char *str);
 R_API int r_meta_var_comment_del(RAnal *a, int type, ut64 idx, ut64 addr);
 R_API int r_meta_add(RAnal *m, int type, ut64 from, ut64 size, const char *str);
+R_API int r_meta_add_with_subtype(RAnal *m, int type, int subtype, ut64 from, ut64 size, const char *str);
 R_API RAnalMetaItem *r_meta_find(RAnal *m, ut64 off, int type, int where);
 R_API int r_meta_cleanup(RAnal *m, ut64 from, ut64 to);
 R_API const char *r_meta_type_to_string(int type);

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -8,11 +8,11 @@ extern "C" {
 #endif
 
 typedef enum {
-	R_STRING_ENC_LATIN1,
-	R_STRING_ENC_UTF8,
-	R_STRING_ENC_UTF16LE,
-	R_STRING_ENC_UTF32LE,
-	R_STRING_ENC_GUESS,
+	R_STRING_ENC_LATIN1 = 'a',
+	R_STRING_ENC_UTF8 = '8',
+	R_STRING_ENC_UTF16LE = 'u',
+	R_STRING_ENC_UTF32LE = 'U',
+	R_STRING_ENC_GUESS = 'g',
 } RStrEnc;
 
 typedef int (*RStrRangeCallback) (void *, int);


### PR DESCRIPTION
Will consolidate `RAnalMetaItem` serialization/deserialization into `serialize()`/`deserialize()` later.