### PR TITLE
Tweak fs io (WIP)

### DIFF
--- a/libr/fs/p/fs_io.c
+++ b/libr/fs/p/fs_io.c
@@ -4,7 +4,7 @@
 #include <r_lib.h>
 #include <sys/stat.h>
 
-static RFSFile* fs_io_open(RFSRoot *root, const char *path) {
+static RFSFile *fs_io_open(RFSRoot *root, const char *path) {
 	char *cmd = r_str_newf ("m %s", path);
 	char *res = root->iob.system (root->iob.io, cmd);
 	free (cmd);
@@ -42,7 +42,7 @@ static bool fs_io_read(RFSFile *file, ut64 addr, int len) {
 			free (res);
 			return NULL:
 		}
-		file->data = (ut8*)calloc (1, len);
+		file->data = (ut8 *) calloc (1, len);
 		int ret = r_hex_str2bin (res, file->data);
 		if (ret != len) {
 			eprintf ("Inconsistent read\n");
@@ -55,7 +55,7 @@ static bool fs_io_read(RFSFile *file, ut64 addr, int len) {
 }
 
 static void fs_io_close(RFSFile *file) {
-	//fclose (file->ptr);
+	// fclose (file->ptr);
 }
 
 static void append_file(RList *list, const char *name, int type, int time, ut64 size) {
@@ -81,7 +81,7 @@ static RList *fs_io_dir(RFSRoot *root, const char *path, int view /*ignored*/) {
 		int *lines = r_str_split_lines (res, &count);
 		if (lines) {
 			for (i = 0; i < count; i++) {
-				const char * line = res + lines[i];
+				const char *line = res + lines[i];
 				if (!*line) {
 					continue;
 				}
@@ -122,8 +122,8 @@ RFSPlugin r_fs_plugin_io = {
 
 #ifndef CORELIB
 RLibStruct radare_plugin = {
-        .type = R_LIB_TYPE_FS,
-        .data = &r_fs_plugin_io,
-        .version = R2_VERSION
+	.type = R_LIB_TYPE_FS,
+	.data = &r_fs_plugin_io,
+	.version = R2_VERSION
 };
 #endif

--- a/libr/fs/p/fs_io.c
+++ b/libr/fs/p/fs_io.c
@@ -7,13 +7,13 @@
 static RFSFile *fs_io_open(RFSRoot *root, const char *path) {
 	char *cmd = r_str_newf ("m %s", path);
 	char *res = root->iob.system (root->iob.io, cmd);
-	free (cmd);
+	R_FREE (cmd);
 	if (res) {
 		ut32 size = 0;
 		if (sscanf (res, "%u", &size) != 1) {
 			size = 0;
 		}
-		free (res);
+		R_FREE (res);
 		if (size == 0) {
 			return NULL;
 		}
@@ -34,22 +34,26 @@ static bool fs_io_read(RFSFile *file, ut64 addr, int len) {
 	// char *cmd = r_str_newf ("mg %s %"PFMT64x" %d", file->path, addr, len);
 	char *cmd = r_str_newf ("mg %s", file->name);
 	char *res = root->iob.system (root->iob.io, cmd);
-	free (cmd);
+	R_FREE (cmd);
 	if (res) {
 		int encoded_size = strlen (res);
 		if (encoded_size != len * 2) {
 			eprintf ("Wrong size\n");
-			free (res);
-			return NULL:
+			R_FREE (res);
+			return NULL;
 		}
 		file->data = (ut8 *) calloc (1, len);
+		if (!file->data) {
+			R_FREE (res);
+			return NULL;
+		}
 		int ret = r_hex_str2bin (res, file->data);
 		if (ret != len) {
 			eprintf ("Inconsistent read\n");
-			free (file->data);
+			R_FREE (file->data);
 			file->data = NULL;
 		}
-		free (res);
+		R_FREE (res);
 	}
 	return NULL;
 }
@@ -92,11 +96,11 @@ static RList *fs_io_dir(RFSRoot *root, const char *path, int view /*ignored*/) {
 				}
 				append_file (list, line, type, 0, 0);
 			}
-			free (res);
-			free (lines);
+			R_FREE (res);
+			R_FREE (lines);
 		}
 	}
-	free (cmd);
+	R_FREE (cmd);
 	return list;
 }
 


### PR DESCRIPTION
- fs_io_open: expects the io plugin to return the file size as an usigned int string
- fs_io_read: use name instead of path (because fs_io_open sets the name as absolute path) and require the io plugin to provide file contents as hex encoded string
- fs_io_dir: honor the type provided by the io plugin as a single char followed by a space in each line of the output

Not sure exactly what this is going to break, i.e. what io plugins out there already support fs_io? if any i should port them and maybe write tests too.