### PR TITLE
mdmp|pe: squashed some memory leaks and fixed resolve error in mdmp

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -731,7 +731,7 @@ static Sdb *store_versioninfo_gnu_verdef(ELFOBJ *bin, Elf_(Shdr) *shdr, int sz) 
 	sdb_num_set (sdb, "link", shdr->sh_link, 0);
 	sdb_set (sdb, "link_section_name", link_section_name, 0);
 
-	for (cnt = 0, i = 0; i >= 0 && cnt < shdr->sh_info && (end - (char *)defs > i); ++cnt) {
+	for (cnt = 0, i = 0; i >= 0 && cnt < shdr->sh_info && ((char *)defs + i < end); ++cnt) {
 		Sdb *sdb_verdef = sdb_new0 ();
 		char *vstart = ((char*)defs) + i;
 		char key[32] = {0};
@@ -754,7 +754,7 @@ static Sdb *store_versioninfo_gnu_verdef(ELFOBJ *bin, Elf_(Shdr) *shdr, int sz) 
 			goto out_error;
 		}
 		vstart += vdaux;
-		if (vstart > end || end - vstart < sizeof (Elf_(Verdaux))) {
+		if (vstart > end || vstart + sizeof (Elf_(Verdaux)) > end) {
 			sdb_free (sdb_verdef);
 			goto out_error;
 		}
@@ -781,7 +781,7 @@ static Sdb *store_versioninfo_gnu_verdef(ELFOBJ *bin, Elf_(Shdr) *shdr, int sz) 
 			Sdb *sdb_parent = sdb_new0 ();
 			isum += aux.vda_next;
 			vstart += aux.vda_next;
-			if (vstart > end || end - vstart < sizeof (Elf_(Verdaux))) {
+			if (vstart > end || vstart + sizeof (Elf_(Verdaux)) > end) {
 				sdb_free (sdb_verdef);
 				sdb_free (sdb_parent);
 				goto out_error;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -749,7 +749,7 @@ static Sdb *store_versioninfo_gnu_verdef(ELFOBJ *bin, Elf_(Shdr) *shdr, int sz) 
 		verdef->vd_aux = READ32 (dfs, j)
 		verdef->vd_next = READ32 (dfs, j)
 		int vdaux = verdef->vd_aux;
-		if (vdaux < 1 || (char *)UINTPTR_MAX - vstart < vdaux) {
+		if (vdaux < 1 || vstart + vdaux < vstart) {
 			sdb_free (sdb_verdef);
 			goto out_error;
 		}

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -109,7 +109,7 @@ void r_bin_mdmp_free(struct r_bin_mdmp_obj *obj) {
 	r_list_free (obj->pe64_bins);
 
 	r_buf_free (obj->b);
-  obj->b = NULL;
+	obj->b = NULL;
 	free (obj);
 
 	return;

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -77,6 +77,7 @@ ut32 r_bin_mdmp_get_srwx(struct r_bin_mdmp_obj *obj, ut64 vaddr)
 static void r_bin_mdmp_free_pe32_bin(void *pe_bin_) {
 	struct Pe32_r_bin_mdmp_pe_bin *pe_bin = pe_bin_;
 	if (pe_bin) {
+		sdb_free (pe_bin->bin->kv);
 		Pe32_r_bin_pe_free (pe_bin->bin);
 		R_FREE (pe_bin);
 	}
@@ -85,6 +86,7 @@ static void r_bin_mdmp_free_pe32_bin(void *pe_bin_) {
 static void r_bin_mdmp_free_pe64_bin(void *pe_bin_) {
 	struct Pe64_r_bin_mdmp_pe_bin *pe_bin = pe_bin_;
 	if (pe_bin) {
+		sdb_free (pe_bin->bin->kv);
 		Pe64_r_bin_pe_free (pe_bin->bin);
 		R_FREE (pe_bin);
 	}
@@ -106,12 +108,9 @@ void r_bin_mdmp_free(struct r_bin_mdmp_obj *obj) {
 	r_list_free (obj->pe32_bins);
 	r_list_free (obj->pe64_bins);
 
-	// fails because sub-sdb of this instance doesnt handle refs properly
-	// better leak than crash
-	//sdb_free (obj->kv);
 	r_buf_free (obj->b);
-
-	R_FREE (obj);
+  obj->b = NULL;
+	free (obj);
 
 	return;
 }

--- a/libr/bin/format/mdmp/mdmp_pe.c
+++ b/libr/bin/format/mdmp/mdmp_pe.c
@@ -175,7 +175,7 @@ RList *PE_(r_bin_mdmp_pe_get_sections)(struct PE_(r_bin_mdmp_pe_bin) *pe_bin) {
 		}
 		ptr->paddr = sections[i].paddr + pe_bin->paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
-		ptr->add = true;
+		ptr->add = false;
 		ptr->srwx = R_BIN_SCN_MAP;
 		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].flags)) {
 			ptr->srwx |= R_BIN_SCN_EXECUTABLE;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -436,6 +436,9 @@ static int bin_pe_parse_imports(struct PE_(r_bin_pe_obj_t)* bin,
 					if (symname) {
 						snprintf (import_name, PE_NAME_LENGTH, "%s_%s", dll_name, symname);
 					}
+					free (symname);
+					sdb_free (db);
+					db = NULL;
 				} else {
 					bprintf ("Cannot find %s\n", filename);
 
@@ -1961,6 +1964,8 @@ static Sdb* Pe_r_bin_store_string(String* string) {
 	}
 	sdb_set (sdb, "key",   encodedKey, 0);
 	sdb_set (sdb, "value", encodedVal, 0);
+	free (encodedKey);
+	free (encodedVal);
 	return sdb;
 }
 
@@ -1982,6 +1987,7 @@ static Sdb* Pe_r_bin_store_string_table(StringTable* stringTable) {
 		return NULL;
 	}
 	sdb_set (sdb, "key", encodedKey, 0);
+	free (encodedKey);
 	for (; i < stringTable->numOfChildren; i++) {
 		snprintf (key, 20, "string%d", i);
 		sdb_ns_set (sdb, key, Pe_r_bin_store_string (stringTable->Children[i]));
@@ -3402,6 +3408,7 @@ void* PE_(r_bin_pe_free)(struct PE_(r_bin_pe_obj_t)* bin) {
 	free (bin->import_directory);
 	free (bin->resource_directory);
 	free (bin->delay_import_directory);
+  free (bin->tls_directory);
 	r_list_free (bin->resources);
 	r_pkcs7_free_cms (bin->cms);
 	r_buf_free (bin->b);

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -409,6 +409,9 @@ static int bin_pe_parse_imports(struct PE_(r_bin_pe_obj_t)* bin,
 
 				if (!sdb_module || strcmp (symdllname, sdb_module)) {
 					sdb_free (db);
+					if (db) {
+						sdb_free (db);
+					}
 					db = NULL;
 					free (sdb_module);
 					sdb_module = strdup (symdllname);
@@ -435,10 +438,8 @@ static int bin_pe_parse_imports(struct PE_(r_bin_pe_obj_t)* bin,
 					symname = resolveModuleOrdinal (db, symdllname, import_ordinal);
 					if (symname) {
 						snprintf (import_name, PE_NAME_LENGTH, "%s_%s", dll_name, symname);
+						R_FREE (symname);
 					}
-					free (symname);
-					sdb_free (db);
-					db = NULL;
 				} else {
 					bprintf ("Cannot find %s\n", filename);
 
@@ -482,11 +483,19 @@ static int bin_pe_parse_imports(struct PE_(r_bin_pe_obj_t)* bin,
 		}
 	} while (import_table);
 
+	if (db) {
+		sdb_free (db);
+		db = NULL;
+	}
 	free (symdllname);
 	free (sdb_module);
 	return i;
 
 error:
+	if (db) {
+		sdb_free (db);
+		db = NULL;
+	}
 	free (symdllname);
 	free (sdb_module);
 	return false;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -3408,7 +3408,7 @@ void* PE_(r_bin_pe_free)(struct PE_(r_bin_pe_obj_t)* bin) {
 	free (bin->import_directory);
 	free (bin->resource_directory);
 	free (bin->delay_import_directory);
-  free (bin->tls_directory);
+	free (bin->tls_directory);
 	r_list_free (bin->resources);
 	r_pkcs7_free_cms (bin->cms);
 	r_buf_free (bin->b);

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -78,8 +78,8 @@ static RBinInfo *info(RBinFile *bf) {
 	obj = (struct r_bin_mdmp_obj *)bf->o->bin_obj;
 
 	ret->big_endian = obj->endian;
-	ret->claimed_checksum = strdup (sdb_fmt (0, "0x%08x", obj->hdr->check_sum));
-	ret->file = bf->file ? strdup (bf->file) : NULL;
+	ret->claimed_checksum = strdup (sdb_fmt (0, "0x%08x", obj->hdr->check_sum));  // FIXME: Leaks
+	ret->file = arch->file ? strdup (bf->file) : NULL;
 	ret->has_va = true;
 	ret->rclass = strdup ("mdmp");
 	ret->rpath = strdup ("NONE");

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -280,6 +280,7 @@ static RList *sections(RBinFile *bf) {
 		index += memory64->data_size;
 	}
 
+	// XXX: Never add here as they are covered above
 	r_list_foreach (obj->streams.modules, it, module) {
 		if (!(ptr = R_NEW0 (RBinSection))) {
 			return ret;
@@ -291,7 +292,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = module->size_of_image;
 		ptr->paddr = r_bin_mdmp_get_paddr (obj, ptr->vaddr);
 		ptr->size = module->size_of_image;
-		ptr->add = true;
+		ptr->add = false;
 		ptr->has_strings = false;
 		/* As this is an encompassing section we will set the RWX to 0 */
 		ptr->srwx = R_BIN_SCN_MAP;

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -405,17 +405,30 @@ static int is_vb6(RBinFile *bf) {
 }
 
 static int has_canary(RBinFile *bf) {
-	// XXX: We only need imports here but this causes leaks, we need to wait for the below
-	struct PE_ (r_bin_pe_obj_t) *bin = bf->o->bin_obj;
-	const RList* relocs_list = bin->relocs;
-	RListIter *iter;
-	RBinReloc *rel;
+	// XXX: We only need imports here but this causes leaks, we need to wait for the below. This is a horrible solution!
 	// TODO: use O(1) when imports sdbized
-	if (relocs_list) {
-		r_list_foreach (relocs_list, iter, rel)
-			if (!strcmp (rel->import->name, "__security_init_cookie")) {
-				return 1;
+	RListIter *iter;
+	struct PE_ (r_bin_pe_obj_t) *bin = bf->o->bin_obj;
+	if (bin) {
+		const RList* relocs_list = bin->relocs;
+		RBinReloc *rel;
+		if (relocs_list) {
+			r_list_foreach (relocs_list, iter, rel) {
+				if (!strcmp (rel->import->name, "__security_init_cookie")) {
+					return 1;
+				}
 			}
+		}
+	} else {  // rabin2 needs this as it will not initialise bin
+		const RList* imports_list = imports (bf);
+		RBinImport *imp;
+		if (imports_list) {
+			r_list_foreach (imports_list, iter, imp) {
+				if (!strcmp (imp->name, "__security_init_cookie")) {
+					return 1;
+				}
+			}
+		}
 	}
 	return 0;
 }

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -228,40 +228,40 @@ static RList* symbols(RBinFile *bf) {
 	}
 	if ((symbols = PE_(r_bin_pe_get_exports)(bf->o->bin_obj))) {
 		for (i = 0; !symbols[i].last; i++) {
-		    if (!(ptr = R_NEW0 (RBinSymbol))) {
+			if (!(ptr = R_NEW0 (RBinSymbol))) {
 				break;
 			}
-		    ptr->name = strdup ((char *)symbols[i].name);
-		    ptr->forwarder = r_str_const ((char *)symbols[i].forwarder);
-		    //strncpy (ptr->bind, "NONE", R_BIN_SIZEOF_STRINGS);
-		    ptr->bind = r_str_const ("GLOBAL");
-		    ptr->type = r_str_const ("FUNC");
-		    ptr->size = 0;
-		    ptr->vaddr = symbols[i].vaddr;
-		    ptr->paddr = symbols[i].paddr;
-		    ptr->ordinal = symbols[i].ordinal;
-		    r_list_append (ret, ptr);
+			ptr->name = strdup ((char *)symbols[i].name);
+			ptr->forwarder = r_str_const ((char *)symbols[i].forwarder);
+			//strncpy (ptr->bind, "NONE", R_BIN_SIZEOF_STRINGS);
+			ptr->bind = r_str_const ("GLOBAL");
+			ptr->type = r_str_const ("FUNC");
+			ptr->size = 0;
+			ptr->vaddr = symbols[i].vaddr;
+			ptr->paddr = symbols[i].paddr;
+			ptr->ordinal = symbols[i].ordinal;
+			r_list_append (ret, ptr);
 		}
 		free (symbols);
 	}
 
 	if ((imports = PE_(r_bin_pe_get_imports)(bf->o->bin_obj))) {
-        for (i = 0; !imports[i].last; i++) {
-            if (!(ptr = R_NEW0 (RBinSymbol))) {
-                break;
+		for (i = 0; !imports[i].last; i++) {
+			if (!(ptr = R_NEW0 (RBinSymbol))) {
+				break;
 			}
-            //strncpy (ptr->name, (char*)symbols[i].name, R_BIN_SIZEOF_STRINGS);
+			//strncpy (ptr->name, (char*)symbols[i].name, R_BIN_SIZEOF_STRINGS);
 			ptr->name = r_str_newf ("imp.%s", imports[i].name);
-            //strncpy (ptr->forwarder, (char*)imports[i].forwarder, R_BIN_SIZEOF_STRINGS);
-            ptr->bind = r_str_const ("NONE");
-            ptr->type = r_str_const ("FUNC");
-            ptr->size = 0;
-            ptr->vaddr = imports[i].vaddr;
-            ptr->paddr = imports[i].paddr;
-            ptr->ordinal = imports[i].ordinal;
-            r_list_append (ret, ptr);
-        }
-        free (imports);
+			//strncpy (ptr->forwarder, (char*)imports[i].forwarder, R_BIN_SIZEOF_STRINGS);
+			ptr->bind = r_str_const ("NONE");
+			ptr->type = r_str_const ("FUNC");
+			ptr->size = 0;
+			ptr->vaddr = imports[i].vaddr;
+			ptr->paddr = imports[i].paddr;
+			ptr->ordinal = imports[i].ordinal;
+			r_list_append (ret, ptr);
+		}
+		free (imports);
 	}
 	find_pe_overlay(bf);
 	return ret;
@@ -405,7 +405,7 @@ static int is_vb6(RBinFile *bf) {
 }
 
 static int has_canary(RBinFile *bf) {
-  // XXX: We only need imports here but this causes leaks, we need to wait for the below
+	// XXX: We only need imports here but this causes leaks, we need to wait for the below
 	struct PE_ (r_bin_pe_obj_t) *bin = bf->o->bin_obj;
 	const RList* relocs_list = bin->relocs;
 	RListIter *iter;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1299,7 +1299,7 @@ static void set_bin_relocs(RCore *r, RBinReloc *reloc, ut64 addr, Sdb **db, char
 				}
 				if (*db) {
 					// ordinal-1 because we enumerate starting at 0
-					char *symname = resolveModuleOrdinal (*db, module, ordinal - 1);
+					char *symname = resolveModuleOrdinal (*db, module, ordinal - 1);  // uses sdb_get
 					if (symname) {
 						if (r->bin->prefix) {
 							reloc->import->name = r_str_newf
@@ -1308,6 +1308,7 @@ static void set_bin_relocs(RCore *r, RBinReloc *reloc, ut64 addr, Sdb **db, char
 							reloc->import->name = r_str_newf
 								("%s.%s", module, symname);
 						}
+						free (symname);
 					}
 				}
 			}
@@ -1466,6 +1467,11 @@ static int bin_relocs(RCore *r, int mode, int va) {
 	if (IS_MODE_NORMAL (mode)) {
 		r_cons_printf ("\n%i relocations\n", i);
 	}
+
+	R_FREE (sdb_module);
+	sdb_free (db);
+	db = NULL;
+
 	return relocs != NULL;
 }
 
@@ -2951,6 +2957,11 @@ static void bin_pe_resources(RCore *r, int mode) {
 			r_cons_printf ("\tlanguage: %s\n", lang);
 			free (humanSize);
 		}
+
+		R_FREE (timestr);
+		R_FREE (type);
+		R_FREE (lang)
+
 		index++;
 	}
 	if (IS_MODE_JSON (mode)) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1308,7 +1308,7 @@ static void set_bin_relocs(RCore *r, RBinReloc *reloc, ut64 addr, Sdb **db, char
 							reloc->import->name = r_str_newf
 								("%s.%s", module, symname);
 						}
-						free (symname);
+						R_FREE (symname);
 					}
 				}
 			}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1348,13 +1348,13 @@ static void r_w32_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
 	int fd_out = -1, cons_out = -1;
 	char *_shell_cmd;
 
-	sa.nLength = sizeof (SECURITY_ATTRIBUTES); 
-	sa.bInheritHandle = TRUE; 
-	sa.lpSecurityDescriptor = NULL; 
+	sa.nLength = sizeof (SECURITY_ATTRIBUTES);
+	sa.bInheritHandle = TRUE;
+	sa.lpSecurityDescriptor = NULL;
    	if (!CreatePipe (&pipe[0], &pipe[1], &sa, 0)) {
 		r_sys_perror ("r_w32_cmd_pipe/CreatePipe");
 		goto err_r_w32_cmd_pipe;
-	}	
+	}
 	if (!SetHandleInformation (pipe[1], HANDLE_FLAG_INHERIT, 0)) {
 		r_sys_perror ("r_w32_cmd_pipe/SetHandleInformation");
 		goto err_r_w32_cmd_pipe;

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -654,7 +654,7 @@ R_API int r_cmd_macro_call(RCmdMacro *mac, const char *name) {
 				if (!ptr2) {
 					eprintf ("Oops. invalid label name\n");
 					break;
-				} else if (ptr != ptr2) { 
+				} else if (ptr != ptr2) {
 					ptr = ptr2;
 					if (end) *end ='\n';
 					end = strchr (ptr, '\n');

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3323,7 +3323,7 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 		char *s = cmd_syscall_dostr (core, -1);
 		if (s) {
 			// XXX this should be shown in ds_comment_esil, for some reason it doesnt
-			r_cons_printf ("; "); 
+			r_cons_printf ("; ");
 			ds_comment_esil (ds, true, "; %s", s);
 			free (s);
 		}
@@ -4298,7 +4298,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			}
 		}
 
-		r_parse_filter (core->parser, core->flags, asmop.buf_asm, str, 
+		r_parse_filter (core->parser, core->flags, asmop.buf_asm, str,
 			sizeof (str), core->print->big_endian);
 
 		r_cons_printf (j > 0 ? ",{" : "{");


### PR DESCRIPTION
Squashed some memory leaks relating to pe and mdmp file types. While hopefully not introducing any bugs!

Found what I believe to be the cause of the resolve error. It seems that r2 does not handle sections with duplicate vaddr/paddr properly. Thus changed `add` to false for overlapped sections.