### PR TITLE
pf: missing structname fix and bumped the nesting limit to 5

### DIFF
--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -1164,7 +1164,7 @@ static void r_print_format_num (const RPrint *p, int endian, int mode, const cha
 					updateAddr (buf + i, size - i, endian, &addr, NULL);
 				}
 				if (elem == -1 || elem == 0) {
-				    r_print_format_num_specifier (p, addr, bytes, sign);
+					r_print_format_num_specifier (p, addr, bytes, sign);
 					if (elem == 0) {
 						elem = -2;
 					}
@@ -1193,7 +1193,7 @@ static void r_print_format_num (const RPrint *p, int endian, int mode, const cha
 					updateAddr (buf + i, size, endian, &addr, NULL);
 				}
 				if (elem == -1 || elem == 0) {
-				    r_print_format_num_specifier (p, addr, bytes, sign);
+					r_print_format_num_specifier (p, addr, bytes, sign);
 					if (elem == 0) {
 						elem = -2;
 					}
@@ -1797,7 +1797,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 				continue;
 			case 'p': // pointer reference
 				if (*(arg+1) == '2') {
-				    tmp = 'w';
+					tmp = 'w';
 					arg++;
 				} else if (*(arg+1) == '4') {
 					tmp = 'x';
@@ -2031,11 +2031,11 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 					slide += NESTEDSTRUCT;
 					if (size == -1) {
 						s = r_print_format_struct (p, seeki,
-									   buf+i, len-i, fmtname, slide,
-									   mode, setval, nxtfield, anon);
+									buf+i, len-i, fmtname, slide,
+									mode, setval, nxtfield, anon);
 						i += (isptr) ? (p->bits / 8) : s;
 						if (MUSTSEEJSON) {
-							 if (!isptr && (!arg[1] || arg[1] == ' ')) {
+							if (!isptr && (!arg[1] || arg[1] == ' ')) {
 								p->cb_printf ("]}");
 							}
 						}
@@ -2135,8 +2135,9 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 			last = tmp;
 
 			// XXX: Due to the already noted issues with the above, we need to strip
-			// args from fmt:args the same way we strip fmt
-			if (arg[0] == 'E' || arg[0] == '?') {
+			// args from fmt:args the same way we strip fmt BUT only for enums as
+			// nested structs seem to be handled correctly above!
+			if (arg[0] == 'E') {
 				char *end_fmt = strchr (arg, ' ');
 				char *next_args = strchr (end_fmt+1, ' ');
 				if (next_args) {

--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -6,7 +6,7 @@
 #include "r_reg.h"
 #ifdef _MSC_VER
 #include <time.h>
-#endif 
+#endif
 #define NOPTR 0
 #define PTRSEEK 1
 #define PTRBACK 2
@@ -1219,7 +1219,7 @@ int r_print_format_struct_size(const char *f, RPrint *p, int mode, int n) {
 	if (!f) {
 		return -1;
 	}
-	if (n >= 3) {
+	if (n >= 5) {  // This is the nesting level, is this not a bit arbitrary?!
 		return 0;
 	}
 	char *o = strdup (f);
@@ -1653,7 +1653,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 					// Max byte number where updateAddr will look into
 				if (len - i < 7) {
 					updateAddr (buf + i, THRESHOLD - (len - i), endian, &addr, &addr64);
-				} else { 
+				} else {
 					updateAddr (buf + i, len - i, endian, &addr, &addr64);
 				}
 			} else {
@@ -2133,6 +2133,19 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 				p->cb_printf ("\n");
 			}
 			last = tmp;
+
+			// XXX: Due to the already noted issues with the above, we need to strip
+			// args from fmt:args the same way we strip fmt
+			if (arg[0] == 'E' || arg[0] == '?') {
+				char *end_fmt = strchr (arg, ' ');
+				char *next_args = strchr (end_fmt+1, ' ');
+				if (next_args) {
+					while (*next_args != '\0') {
+						*end_fmt++ = *next_args++;
+					}
+				}
+				*end_fmt = '\0';
+			}
 		}
 		if (otimes > 1) {
 			if (MUSTSEEJSON) {


### PR DESCRIPTION
This bumps the arbitrary nesting limit to 5, needed for some of the MDMP structures.

It also fixes the issue where structnames cannot be found due to incorrect strings being sent during parsing and nesting. The approach is not pretty but as noted in the top of the file - this file is gross!