### PR TITLE
bad checking in build.sh (capstone.h)

### DIFF
--- a/sys/build.sh
+++ b/sys/build.sh
@@ -68,7 +68,7 @@ echo
 if [ -z "${USE_R2_CAPSTONE}" ]; then
 	pkg-config --atleast-version=4.0 capstone 2>/dev/null
 	if [ $? = 0 ]; then
-		echo '#include <capstone.h>' > .a.c
+		echo '#include <capstone/capstone.h>' > .a.c
 		echo 'int main() {return 0;}' >> .a.c
 		gcc `pkg-config --cflags --libs capstone` -o .a.out .a.c
 		if [ $? = 0 ]; then


### PR DESCRIPTION
Fix: build.sh doesn't correctly check capstone header.