### PR TITLE
Fix Try to fix attaching issues for Windows #8770

### DIFF
--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -814,7 +814,6 @@ static RDebugPid *build_debug_pid(PROCESSENTRY32 *pe) {
 	*image_name = '\0';
 	if (process) {
 		if (w32_QueryFullProcessImageName) {
-			eprintf ("HOLA");
 			w32_QueryFullProcessImageName (process, 0, image_name, &length);
 		}
 		CloseHandle(process);


### PR DESCRIPTION
If we call CreateProcess function with DEBUG_ONLY_THIS_PROCESS flag then
fail DebugActiveProcess when execute the following radare command:
r2 -d test.exe
Removed verbose ouput :/