### PR TITLE
jemalloc: Add missing definition of LG_QUANTUM for m68k

### DIFF
--- a/shlr/heap/include/r_jemalloc/internal/jemalloc_internal.h
+++ b/shlr/heap/include/r_jemalloc/internal/jemalloc_internal.h
@@ -256,6 +256,9 @@ typedef unsigned szind_t;
 #  ifdef __hppa__
 #    define LG_QUANTUM		4
 #  endif
+#  ifdef __m68k__
+#    define LG_QUANTUM          3
+#  endif
 #  ifdef __mips__
 #    define LG_QUANTUM		3
 #  endif


### PR DESCRIPTION
radare2 currently fails to build from source on Debian/m68k because ```LG_QUANTUM``` is not defined for this architecture [1]:

```
gcc -c -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -MD  -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -g -Wall -D__UNIX__=1 -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -MD  -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -g -Wall -D__UNIX__=1 -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -MD  -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -g -Wall -D__UNIX__=1 -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/radare2-2.0.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -MD  -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -g -Wall -D__UNIX__=1 -I../../shlr/heap/include -DCORELIB -I../../shlr -I/<<BUILDDIR>>/radare2-2.0.0+dfsg/libr -I/<<BUILDDIR>>/radare2-2.0.0+dfsg/libr/include -o cmd.o cmd.c
In file included from /<<BUILDDIR>>/radare2-2.0.0+dfsg/libr/include/r_heap_jemalloc.h:4:0,
                 from cmd_debug.c:15,
                 from cmd.c:76:
../../shlr/heap/include/r_jemalloc/internal/jemalloc_internal.h:284:6: error: #error "Unknown minimum alignment for architecture; specify via "
 #    error "Unknown minimum alignment for architecture; specify via "
      ^~~~~
../../shlr/heap/include/r_jemalloc/internal/jemalloc_internal.h:285:3: error: expected identifier or '(' before string constant
   "--with-lg-quantum"
   ^~~~~~~~~~~~~~~~~~~
In file included from ../../shlr/heap/include/r_jemalloc/internal/jemalloc_internal.h:374:0,
                 from /<<BUILDDIR>>/radare2-2.0.0+dfsg/libr/include/r_heap_jemalloc.h:4,
                 from cmd_debug.c:15,
                 from cmd.c:76:
../../shlr/heap/include/r_jemalloc/internal/size_classes.h:1399:4: error: #error "No size class definitions match configuration"
 #  error "No size class definitions match configuration"
    ^~~~~
```

This PR fixes the issue by defining ```LG_QUANTUM``` to the correct value for m68k which is ```3```. After applying the patch, radare2 builds fine on Debian/m68k.

> [1] https://buildd.debian.org/status/fetch.php?pkg=radare2&arch=m68k&ver=2.0.0%2Bdfsg-1&stamp=1508236187&raw=0