### PR TITLE
Fixed -r option to load rarun2 profile 

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -481,7 +481,7 @@ int main(int argc, char **argv, char **envp) {
 		return 0;
 	}
 
-	while ((c = getopt (argc, argv, "=02AMCwxfF:H:hm:e:nk:NdqQs:p:b:B:a:Lui:I:l:P:R:c:D:vVSzuX"
+	while ((c = getopt (argc, argv, "=02AMCwxfF:H:hm:e:nk:NdqQs:p:b:B:a:Lui:I:l:P:R:r:c:D:vVSzuX"
 #if USE_THREADS
 "t"
 #endif


### PR DESCRIPTION
I guess there was a shift from `-R` to `-r` but somebody forgot to add it to `getopt`'s optstring.

`r2 -r myprof.r2 /bin/ls` was throwing error, `invalid option -- 'r'`