### PR TITLE
impl command R_BETWEEN

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -309,7 +309,7 @@ static int cmd_help(void *data, const char *input) {
 			free (buf);
 		} else if (input[1] == 't' && input[2] == 'w') { // "?btw"
 			if (r_num_between (core->num, input + 3) == -1) {
-				eprintf("Usage: ?btw num|(expr) num|(expr) num|(expr)\n");
+				eprintf ("Usage: ?btw num|(expr) num|(expr) num|(expr)\n");
 			}
 		} else {
 			n = r_num_get (core->num, input+1);

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -63,6 +63,7 @@ static const char *help_msg_question[] = {
 	"?_", " hudfile", "load hud menu with given file",
 	"?b", " [num]", "show binary value of number",
 	"?b64[-]", " [str]", "encode/decode in base64",
+	"?btw", " num|(expr) num|(expr) num|(expr)", "returns boolean value of a < b < c",
 	"?B", " [elem]", "show range boundaries like 'e?search.in",
 	"?d[.]", " opcode", "describe opcode for asm.arch",
 	"?e[nbgc]", " string", "echo string (nonl, gotoxy, column, bars)",
@@ -306,6 +307,10 @@ static int cmd_help(void *data, const char *input) {
 			}
 			r_cons_println (buf);
 			free (buf);
+		} else if (input[1] == 't' && input[2] == 'w') { // "?btw"
+			if (r_num_between (core->num, input + 3) == -1) {
+				eprintf("Usage: ?btw num|(expr) num|(expr) num|(expr)\n");
+			}
 		} else {
 			n = r_num_get (core->num, input+1);
 			r_num_to_bits (out, n);

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -72,6 +72,7 @@ R_API void r_num_irand(void);
 R_API ut16 r_num_ntohs(ut16 foo);
 R_API ut64 r_get_input_num_value(RNum *num, const char *input_value);
 R_API int r_is_valid_input_num_value(RNum *num, const char *input_value);
+R_API int r_num_between (RNum *num, const char *input_value);
 
 #ifdef __cplusplus
 }

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -582,9 +582,10 @@ R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex) {
 }
 
 R_API int r_num_between (RNum *num, const char *input_value) {
+	int i;
 	ut64 ns[3];
 	ns[0] = r_num_math (num, input_value);
-	for (int i = 1; i < 3; i++) {
+	for (i = 1; i < 3; i++) {
 		while (*input_value == ' ') {
 			input_value++;
 		}

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -580,3 +580,28 @@ R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex) {
 	mask = UT64_MAX << i;
 	return (addr & mask) | n;
 }
+
+R_API int r_num_between (RNum *num, const char *input_value) {
+	ut64 ns[3];
+	ns[0] = r_num_math (num, input_value);
+	for (int i = 1; i < 3; i++) {
+		while (*input_value == ' ') {
+			input_value++;
+		}
+		int num_parens = 0;
+		for (; num_parens != 0 || *input_value != ' '; input_value++) {
+			if (!*input_value) {
+				return -1;
+			}
+			if (*input_value == '(') {
+				num_parens++;
+			} else if (*input_value == ')') {
+				num_parens--;
+			}
+		}
+		ns[i] = r_num_math (num, input_value);
+	}
+	return num->value = ns[0] < ns[1] && ns[1] < ns[2]
+				? 1
+				: 0;
+}

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -602,7 +602,5 @@ R_API int r_num_between (RNum *num, const char *input_value) {
 		}
 		ns[i] = r_num_math (num, input_value);
 	}
-	return num->value = ns[0] < ns[1] && ns[1] < ns[2]
-				? 1
-				: 0;
+	return num->value = R_BETWEEN(ns[0], ns[1], ns[2]);
 }


### PR DESCRIPTION
Related to issue #7892 
This command `?btw` takes 3 arguments a, b, c and returns 1 if a < b && b < c else returns 0.
If the command is failed, it prints its usage, and returns undefined value.
Each argument is required to be either number or "(" expr ")".
```
[0x00000000]> ?btw 1 2
Usage: ?btw num|(expr) num|(expr) num|(expr)
[0x00000000]> ?btw 1 2 3
[0x00000000]> ??
1
[0x00000000]> ?btw 1 2 (1 + 2)
[0x00000000]> ??
1
[0x00000000]> ?btw 3 2 1
[0x00000000]> ??
0
```