### PR TITLE
This fixes detection of overlay in PE files

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -877,9 +877,13 @@ int PE_(bin_pe_get_overlay)(struct PE_(r_bin_pe_obj_t)* bin, ut64* size) {
 
 	if (bin->optional_header) {
 		for (i = 0; i < PE_IMAGE_DIRECTORY_ENTRIES; i++) {
+			if (i == PE_IMAGE_DIRECTORY_ENTRY_SECURITY) {
+				continue;
+			}
+
 			computeOverlayOffset (
-				bin_pe_rva_to_paddr (bin, bin->optional_header->DataDirectory[i].VirtualAddress),
-				bin->optional_header->DataDirectory[i].Size,
+				bin_pe_rva_to_paddr (bin, bin->data_directory[i].VirtualAddress),
+				bin->data_directory[i].Size,
 				bin->size,
 				&largest_offset,
 				&largest_size);


### PR DESCRIPTION
Hi, I had troubles to detect overlay in some files, like the ransomware BadRabbit (sample here https://www.hybrid-analysis.com/sample/630325cac09ac3fab908f903e3b00d0dadd5fdaa0875ed8496fcbb97a558d0da?environmentId=100)

Then I compared the code implemented with the pefile's source, based in pefile library, we must avoid IMAGE_DIRECTORY_ENTRY_SECURITY.