### PR TITLE
fix help message of ?btw

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -63,7 +63,7 @@ static const char *help_msg_question[] = {
 	"?_", " hudfile", "load hud menu with given file",
 	"?b", " [num]", "show binary value of number",
 	"?b64[-]", " [str]", "encode/decode in base64",
-	"?btw", " num|(expr) num|(expr) num|(expr)", "returns boolean value of a < b < c",
+	"?btw", " num|(expr) num|(expr) num|(expr)", "returns boolean value of a <= b <= c",
 	"?B", " [elem]", "show range boundaries like 'e?search.in",
 	"?d[.]", " opcode", "describe opcode for asm.arch",
 	"?e[nbgc]", " string", "echo string (nonl, gotoxy, column, bars)",

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -602,5 +602,5 @@ R_API int r_num_between (RNum *num, const char *input_value) {
 		}
 		ns[i] = r_num_math (num, input_value);
 	}
-	return num->value = R_BETWEEN(ns[0], ns[1], ns[2]);
+	return num->value = R_BETWEEN (ns[0], ns[1], ns[2]);
 }


### PR DESCRIPTION
R_BETWEEN returns the value of `x <= y && y <= z` so `?btw` should return same value.