### PR TITLE
r2pipe-python binding name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The easiest way to install the python bindings is to run:
 
 	$ r2pm install lang-python2 #lang-python3 for python3 bindings
 	$ r2pm install r2api-python
-	$ r2pm install r2pipe-python
+	$ r2pm install r2pipe-py
 
 In addition there are `r2pipe` bindings, which are an API
 interface to interact with the prompt, passing commands


### PR DESCRIPTION
The r2pipe-python binding seems to be called now r2pipe-py.