### PR TITLE
Change references from osx to macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,11 +378,11 @@ tests:
 	fi
 	cd $(R2R) ; ${MAKE}
 
-osx-sign:
-	$(MAKE) -C binr/radare2 osx-sign
+macos-sign:
+	$(MAKE) -C binr/radare2 macos-sign
 
-osx-sign-libs:
-	$(MAKE) -C binr/radare2 osx-sign-libs
+macos-sign-libs:
+	$(MAKE) -C binr/radare2 macos-sign-libs
 
 osx-pkg:
 	sys/osx-pkg.sh $(VERSION)

--- a/binr/radare2/Makefile
+++ b/binr/radare2/Makefile
@@ -45,7 +45,7 @@ ios-sign iossign sign:
 ios_sdk_sign:
 	-codesign -s- --entitlements radare2.xml radare2
 
-osx-sign osxsign:
+macos-sign macossign:
 	rm -f radare2
 	${CC} radare2.c ${CFLAGS} ${LDFLAGS} -o radare2 \
 		-sectcreate __TEXT __info_plist Info.plist \
@@ -57,7 +57,7 @@ osx-sign osxsign:
 	#sudo chmod g+s radare2
 #	sudo chmod 4755 radare2
 
-osx-sign-libs:
+macos-sign-libs:
 	for LIB in ${SIGN_LIBS} ; do \
 		echo Signing $$LIB ; \
 		codesign -f -s ${CERTID} $$LIB ; \

--- a/doc/macos.md
+++ b/doc/macos.md
@@ -51,16 +51,16 @@ After Mac OS X 10.6, binaries that need permissions to debug require to be signe
 
 As said before, the signing process can also be done manually following the next process. First, you will need to sign the radare2 binary:
 
-	$ make -C binr/radare2 osxsign
+	$ make -C binr/radare2 macossign
 
 But this is not enough. As long as r2 code is splitted into several libraries, you should sign every single dependency (libr*).
 
-	$ make -C binr/radare2 osx-sign-libs
+	$ make -C binr/radare2 macos-sign-libs
 
 Another alternative is to build a static version of r2 and just sign it.
 
 	$ sys/static.sh
-	$ make -C binr/radare2 osxsign
+	$ make -C binr/radare2 macossign
 
 You can verify that the binary is properly signed and verified by using the code signing utility:
 

--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -586,8 +586,8 @@ task_t pid_to_task (int pid) {
 							(char *)MACH_ERROR_STRING (err));
 				}
 				eprintf ("You probably need to run as root or sign "
-					"the binary.\n Read doc/ios.md || doc/osx.md\n"
-					" make -C binr/radare2 ios-sign || osx-sign\n");
+					"the binary.\n Read doc/ios.md || doc/macos.md\n"
+					" make -C binr/radare2 ios-sign || macos-sign\n");
 				return 0;
 			}
 		}

--- a/sys/build.sh
+++ b/sys/build.sh
@@ -95,8 +95,8 @@ unset DEPS
 ./configure ${CFGARG} --prefix=${PREFIX} || exit 1
 ${MAKE} -s -j${MAKE_JOBS} MAKE_JOBS=${MAKE_JOBS} || exit 1
 if [ "`uname`" = Darwin ]; then
-	${MAKE} osx-sign osx-sign-libs CERTID="${CERTID}" || (
+	${MAKE} macos-sign macos-sign-libs CERTID="${CERTID}" || (
 		echo "CERTID not defined. If you want the bins signed to debug without root"
-		echo "follow the instructions described in doc/osx and run make osx-sign."
+		echo "follow the instructions described in doc/macos.md and run make macos-sign."
 	)
 fi


### PR DESCRIPTION
Change references from osx to macos based on the currently renamed document file: it is now called "doc/macos.md" rather than "doc/osx".