### PR TITLE
Change references from osx to macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,11 +378,11 @@ tests:
 	fi
 	cd $(R2R) ; ${MAKE}
 
-osx-sign:
-	$(MAKE) -C binr/radare2 osx-sign
+macos-sign:
+	$(MAKE) -C binr/radare2 macos-sign
 
-osx-sign-libs:
-	$(MAKE) -C binr/radare2 osx-sign-libs
+macos-sign-libs:
+	$(MAKE) -C binr/radare2 macos-sign-libs
 
 osx-pkg:
 	sys/osx-pkg.sh $(VERSION)


### PR DESCRIPTION
Pending: Still the reference to build the package for macOS remains as OS X, as in "osx-pkg" and "osx-pkg.sh".