### PR TITLE
Add non-priv user to the Developer Tools group in macOS

### DIFF
--- a/doc/macos.md
+++ b/doc/macos.md
@@ -66,6 +66,10 @@ You can verify that the binary is properly signed and verified by using the code
 
 	$ codesign -dv binr/radare2/radare2
 
+Additionally, you can run the following command to add the non-priviledge user (username) to the Developer Tools group in macOS, avoiding the related Xcode prompts:
+
+	$ sudo dscl . append /Groups/_developer GroupMembership <username>
+
 After doing it you should be able to debug on macOS without root permissions!
 
 	$ r2 -d mybin


### PR DESCRIPTION
Added to the r2 debugging code signing doc for macOS.