### PR TITLE
[FreeBSD] ino64 change on -head

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1648,6 +1648,7 @@ static RList *r_debug_desc_native_list (int pid) {
 		case KF_TYPE_VNODE: type = 'v'; break;
 		case KF_TYPE_SOCKET:
 			type = 's';
+#if __FreeBSD_version < 1200031
 			if (kve->kf_sock_domain == AF_LOCAL) {
 				struct sockaddr_un *sun =
 					(struct sockaddr_un *)&kve->kf_sa_local;
@@ -1661,6 +1662,21 @@ static RList *r_debug_desc_native_list (int pid) {
 				addr_to_string (&kve->kf_sa_peer, path + strlen (path),
 						sizeof (path));
 			}
+#else
+			if (kve->kf_sock_domain == AF_LOCAL) {
+				struct sockaddr_un *sun =
+					(struct sockaddr_un *)&kve->kf_un.kf_sock.kf_sa_local;;
+				if (sun->sun_path[0] != 0)
+					addr_to_string (&kve->kf_un.kf_sock.kf_sa_local, path, sizeof(path));
+				else
+					addr_to_string (&kve->kf_un.kf_sock.kf_sa_peer, path, sizeof(path));
+			} else {
+				addr_to_string (&kve->kf_un.kf_sock.kf_sa_local, path, sizeof(path));
+				strcat (path, " ");
+				addr_to_string (&kve->kf_un.kf_sock.kf_sa_peer, path + strlen (path),
+						sizeof (path));
+			}
+#endif
 			str = path;
 			break;
 		case KF_TYPE_PIPE: type = 'p'; break;


### PR DESCRIPTION
Hi,

FreeBSD 12.0 is coming soon, few changes breaks API. One of such change called ino64, here is link to news: https://www.phoronix.com/scan.php?page=news_item&px=FreeBSD-64-bit-Inodes-ino64

This patch allows to compile radare2 on pre-ino64 and post-ino64 freebsd platforms. 
Tested by several people, this patch is landed in freebsd ports: https://svnweb.freebsd.org/ports/head/devel/radare2/files/patch-libr_debug_p_debug__native.c?revision=454555&view=co

Thanks!