### PR TITLE
I fixed the whitespace issue, i.e. whenever you tried to tab complete a

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -11,6 +11,7 @@
 #define USE_UTF8 0
 #else
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <termios.h>
 #include <signal.h>
 #define USE_UTF8 1
@@ -461,6 +462,7 @@ R_API void r_line_autocomplete() {
 				end_word: I.buffer.data + I.buffer.index;
 		int largv0 = strlen (argv[0]? argv[0]: "");
 		size_t len_t = strlen (t);
+		p[largv0]='\0';
 
 		if ((p - I.buffer.data) + largv0 + 1 + len_t < plen) {
 			if (len_t > 0) {
@@ -471,7 +473,15 @@ R_API void r_line_autocomplete() {
 				memmove (p + tt, t, len_t);
 			}
 			memcpy (p, argv[0], largv0);
-			p[largv0] = ' ';
+			struct stat s;
+			stat(p, &s);
+			if(S_ISDIR(s.st_mode)){
+				p[largv0] = '/';
+			} else {
+				p[largv0] = ' ';
+			}
+
+
 			if (!len_t) {
 				p[largv0 + 1] = '\0';
 			}

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -479,8 +479,8 @@ R_API void r_line_autocomplete() {
 					p[largv0 + 1] = '\0';
 				}
 			}
-		I.buffer.length = strlen (I.buffer.data);
-		I.buffer.index = I.buffer.length;
+			I.buffer.length = strlen (I.buffer.data);
+			I.buffer.index = I.buffer.length;
 		}
 	} else if (argc > 0) {
 		if (*p) {

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -11,7 +11,6 @@
 #define USE_UTF8 0
 #else
 #include <sys/ioctl.h>
-#include <sys/stat.h>
 #include <termios.h>
 #include <signal.h>
 #define USE_UTF8 1
@@ -473,20 +472,15 @@ R_API void r_line_autocomplete() {
 				memmove (p + tt, t, len_t);
 			}
 			memcpy (p, argv[0], largv0);
-			struct stat s;
-			stat(p, &s);
-			if(S_ISDIR(s.st_mode)){
-				p[largv0] = '/';
-			} else {
+
+			if (p[largv0 - 1] != '/') {
 				p[largv0] = ' ';
+				if (!len_t) {
+					p[largv0 + 1] = '\0';
+				}
 			}
-
-
-			if (!len_t) {
-				p[largv0 + 1] = '\0';
-			}
-			I.buffer.length = strlen (I.buffer.data);
-			I.buffer.index = (p - I.buffer.data) + largv0 + 1;
+		I.buffer.length = strlen (I.buffer.data);
+		I.buffer.index = I.buffer.length;
 		}
 	} else if (argc > 0) {
 		if (*p) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -767,13 +767,24 @@ static int autocompleteProcessPath(RLine *line, const char *path, int argv_idx) 
 
 	list= r_sys_dir (dirname);
 	n = strlen (basename);
+	char *tmpstring;
+	int chgdir = (!strncmp (line->buffer.data, "cd ", 3) ? 1 : 0);
 	if (list) {
 		r_list_foreach (list, iter, filename) {
 			if (*filename == '.') {
 				continue;
 			}
-			if (!basename[0] || !strncmp (filename, basename, n)) {
-				tmp_argv[i++] = r_str_newf ("%s%s", dirname, filename);
+
+			if (!basename[0] || !strncmp (filename, basename, n))  {
+				tmpstring = r_str_newf ("%s%s", dirname, filename);
+				if (r_file_is_directory (tmpstring ) && chgdir) {
+					tmp_argv[i++] = r_str_newf ("%s/", tmpstring);
+				} else if (r_file_is_directory (tmpstring) && !chgdir) {
+					tmp_argv[i++] = r_str_newf ("%s/", tmpstring);
+				} else if (!chgdir) {
+					tmp_argv[i++] = tmpstring;
+				}
+
 				if (i == TMP_ARGV_SZ - 1) {
 					i--;
 					break;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -768,7 +768,7 @@ static int autocompleteProcessPath(RLine *line, const char *path, int argv_idx) 
 	list= r_sys_dir (dirname);
 	n = strlen (basename);
 	char *tmpstring;
-	int chgdir = (!strncmp (line->buffer.data, "cd ", 3) ? 1 : 0);
+	bool chgdir = !strncmp (line->buffer.data, "cd ", 3);
 	if (list) {
 		r_list_foreach (list, iter, filename) {
 			if (*filename == '.') {


### PR DESCRIPTION
I fix the whitespace issue when you use tab completion for
paths in r2 cmd line mode: r2 put a whitespace in so you had to
backspace to remove the whitespace before tab completing again.

Now it works just fine. Anyway, when someone tab completes his entire
path and then insers an whitespace and afterwards presses tab again,
r2 suggest once again the entire path. I have no idea what the best
logic default behaviour should be. Maybe bash style?