### PR TITLE
Fix multiple arrobas

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2146,6 +2146,13 @@ next2:
 		ut8 *buf;
 
 		*ptr++ = '\0';
+		arroba = (ptr[0] && ptr[1] && ptr[2])?
+			strchr (ptr + 2, '@'): NULL;
+repeat_arroba:
+		if (arroba) {
+			*arroba = 0;
+		}
+
 		for (; *ptr == ' '; ptr++) {
 			//nothing to see here
 		}
@@ -2154,12 +2161,9 @@ next2:
 		} else {
 			ptr--;
 		}
-		arroba = (ptr[0] && ptr[1] && ptr[2])?
-			strchr (ptr + 2, '@'): NULL;
-repeat_arroba:
-		if (arroba) {
-			*arroba = 0;
-		}
+
+		ptr = r_str_trim_tail (ptr);
+
 		if (ptr[1] == '?') {
 			r_core_cmd_help (core, help_msg_at);
 		} else if (ptr[0] && ptr[1] == ':' && ptr[2]) {
@@ -2318,7 +2322,8 @@ ignore:
 		}
 next_arroba:
 		if (arroba) {
-			ptr = arroba;
+			ptr = arroba + 1;
+			*arroba = '@';
 			arroba = NULL;
 			goto repeat_arroba;
 		}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2146,9 +2146,9 @@ next2:
 		ut8 *buf;
 
 		*ptr++ = '\0';
-		arroba = (ptr[0] && ptr[1] && ptr[2])?
-			strchr (ptr + 2, '@'): NULL;
 repeat_arroba:
+		arroba = (ptr[0] && ptr[1] && ptr[2])?
+				 strchr (ptr + 2, '@'): NULL;
 		if (arroba) {
 			*arroba = 0;
 		}


### PR DESCRIPTION
Fixes #8857.
A maximum of two @s was supported before and even then it was mostly broken. This fixes it for any number.

Also, resetting temporary evals was done in the order they were specified before, which would break if a variable was specified more than once:
```
e a=0
something @e:a=1,a=1
```
would result in a=1 afterwards.

Tests: https://github.com/radare/radare2-regressions/pull/1075