### PR TITLE
Remove error output from r_core_anal_graph()

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2381,7 +2381,6 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 		addr = core->offset;
 	}
 	if (r_list_empty (core->anal->fcns)) {
-		eprintf ("No functions to diff\n");
 		return false;
 	}
 	hc = r_config_hold_new (core->config);


### PR DESCRIPTION
This error is always printed to stderr when `ag` or `agj` is called and there are no functions yet, which is kind of annoying for Cutter since it randomly shows up in its output.

I think it can be removed, because it is not really an error. The message "No functions to diff" doesn't make any sense here anyway, does it?