### PR TITLE
Added ae subcommand to emulate N instructions starting at X offset

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3792,7 +3792,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 static void cmd_aexn(RCore *core, ut64 addr, int off) {
 	RAnalEsil *esil = core->anal->esil;
 	int i, j = 0;
-        ut64 curpc = addr;
+	ut64 curpc = addr;
 	int instr_size = 0;
 	ut8 *buf;
 	RAnalOp aop = {0};


### PR DESCRIPTION
This is regarding this [issue](https://github.com/radare/radare2/issues/4363)
Now u can emulate instructions with just one command ```aexn [offset] [N] ``` 