### PR TITLE
add dmm to gdb

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -222,6 +222,52 @@ static RList *r_debug_gdb_map_get(RDebug* dbg) { //TODO
 	return retlist;
 }
 
+static RList* r_debug_gdb_modules_get(RDebug *dbg) {
+	char *lastname = NULL;
+	RDebugMap *map;
+	RListIter *iter, *iter2;
+	RList *list, *last;
+	int must_delete;
+	list = r_debug_gdb_map_get (dbg);
+	if (!list) {
+		return NULL;
+	}
+	last = r_list_newf ((RListFree)r_debug_map_free);
+	if (!last) {
+		r_list_free (list);
+		return NULL;
+	}
+	r_list_foreach_safe (list, iter, iter2, map) {
+		const char *file = map->file;
+		if (!map->file) {
+			file = map->file = strdup (map->name);
+		}
+		must_delete = 1;
+		if (file && *file) {
+			if (file[0] == '/') {
+				if (lastname) {
+					if (strcmp (lastname, file)) {
+						must_delete = 0;
+					}
+				} else {
+					must_delete = 0;
+				}
+			}
+		}
+		if (must_delete) {
+			r_list_delete (list, iter);
+		} else {
+			r_list_append (last, map);
+			free (lastname);
+			lastname = strdup (file);
+		}
+	}
+	list->free = NULL;
+	free (lastname);
+	r_list_free (list);
+	return last;
+}
+
 static int r_debug_gdb_reg_write(RDebug *dbg, int type, const ut8 *buf, int size) {
 	check_connection (dbg);
 	if (!reg_buf) {
@@ -971,6 +1017,7 @@ RDebugPlugin r_debug_plugin_gdb = {
 	.canstep = 1,
 	.wait = &r_debug_gdb_wait,
 	.map_get = r_debug_gdb_map_get,
+	.modules_get = r_debug_gdb_modules_get,
 	.breakpoint = &r_debug_gdb_breakpoint,
 	.reg_read = &r_debug_gdb_reg_read,
 	.reg_write = &r_debug_gdb_reg_write,

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -227,13 +227,11 @@ static RList* r_debug_gdb_modules_get(RDebug *dbg) {
 	RDebugMap *map;
 	RListIter *iter, *iter2;
 	RList *list, *last;
-	int must_delete;
-	list = r_debug_gdb_map_get (dbg);
-	if (!list) {
+	bool must_delete;
+	if (!(list = r_debug_gdb_map_get (dbg))) {
 		return NULL;
 	}
-	last = r_list_newf ((RListFree)r_debug_map_free);
-	if (!last) {
+	if (!(last = r_list_newf ((RListFree)r_debug_map_free))) {
 		r_list_free (list);
 		return NULL;
 	}
@@ -242,16 +240,10 @@ static RList* r_debug_gdb_modules_get(RDebug *dbg) {
 		if (!map->file) {
 			file = map->file = strdup (map->name);
 		}
-		must_delete = 1;
-		if (file && *file) {
-			if (file[0] == '/') {
-				if (lastname) {
-					if (strcmp (lastname, file)) {
-						must_delete = 0;
-					}
-				} else {
-					must_delete = 0;
-				}
+		must_delete = true;
+		if (file && *file == '/') {
+			if (!lastname || strcmp (lastname, file)) {
+				must_delete = false;
 			}
 		}
 		if (must_delete) {

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1281,7 +1281,7 @@ static RList *r_debug_native_modules_get (RDebug *dbg) {
 	RDebugMap *map;
 	RListIter *iter, *iter2;
 	RList *list, *last;
-	int must_delete;
+	bool must_delete;
 #if __APPLE__
 	list = xnu_dbg_maps (dbg, 1);
 	if (list && !r_list_empty (list)) {
@@ -1294,12 +1294,10 @@ static RList *r_debug_native_modules_get (RDebug *dbg) {
 		return list;
 	}
 #endif
-	list = r_debug_native_map_get (dbg);
-	if (!list) {
+	if (!(list = r_debug_native_map_get (dbg))) {
 		return NULL;
 	}
-	last = r_list_newf ((RListFree)r_debug_map_free);
-	if (!last) {
+	if (!(last = r_list_newf ((RListFree)r_debug_map_free))) {
 		r_list_free (list);
 		return NULL;
 	}
@@ -1308,16 +1306,10 @@ static RList *r_debug_native_modules_get (RDebug *dbg) {
 		if (!map->file) {
 			file = map->file = strdup (map->name);
 		}
-		must_delete = 1;
-		if (file && *file) {
-			if (file[0] == '/') {
-				if (lastname) {
-					if (strcmp (lastname, file)) {
-						must_delete = 0;
-					}
-				} else {
-					must_delete = 0;
-				}
+		must_delete = true;
+		if (file && *file == '/') {
+			if (!lastname || strcmp (lastname, file)) {
+				must_delete = false;
 			}
 		}
 		if (must_delete) {


### PR DESCRIPTION
Fix #8916 
Identical to the code in r_debug_native.
dmm depends on the logic for dm so it will only work on platforms for which dm has been implemented (currently only Linux).