### PR TITLE
Fix #2479 impl bin -> hex (bignum)

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -11,6 +11,7 @@
 	}
 
 static RNum *num;
+static RPrint *rp;
 static int help();
 static ut64 flags = 0;
 static int use_stdin();
@@ -431,24 +432,7 @@ dotherax:
 
 		return true;
 	} else if (flags & (1 << 19)) { // -L
-		int i, j, index;
-		ut64 n, *buf = malloc (len / 8);
-		for (i = len - 1, index = 0; i >= 0; i -= 64, index++) {
-			n = 0;
-			for (j = 0; j < 64 && i - j >= 0; j++) {
-				n += (ut64) (str[i - j] - '0') << j;
-			}
-			buf[index] = n;
-		}
-		index--;
-		printf ("0x");
-		while (buf[index] == 0 && index > 0) index--;
-		printf ("%" PFMT64x, buf[index]);
-		index--;
-		for (i = index; i >= 0; i--) {
-			printf ("%016" PFMT64x, buf[i]);
-		}
-		printf ("\n");
+		print_hex_from_bin (rp, str);
 		return true;
 	}
 
@@ -536,6 +520,7 @@ static int use_stdin() {
 int main(int argc, char **argv) {
 	int i;
 	num = r_num_new (NULL, NULL, NULL);
+	rp = r_print_new ();
 	if (argc == 1) {
 		use_stdin ();
 	} else {

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -432,7 +432,7 @@ dotherax:
 
 		return true;
 	} else if (flags & (1 << 19)) { // -L
-		print_hex_from_bin (rp, str);
+		r_print_hex_from_bin (rp, str);
 		return true;
 	}
 

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -440,14 +440,13 @@ dotherax:
 			}
 			buf[index] = n;
 		}
+		index--;
 		printf ("0x");
-		while (buf[index] == 0 && index >= 0) index--;
-		if (index < 0) {
-			printf ("0\n");
-			return true;
-		}
+		while (buf[index] == 0 && index > 0) index--;
+		printf ("%" PFMT64x, buf[index]);
+		index--;
 		for (i = index; i >= 0; i--) {
-			printf ("%" PFMT64x, buf[i]);
+			printf ("%016" PFMT64x, buf[i]);
 		}
 		printf ("\n");
 		return true;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1868,7 +1868,7 @@ R_API int r_print_jsondump(RPrint *p, const ut8 *buf, int len, int wordsize) {
 	return words;
 }
 
-R_API void print_hex_from_bin (RPrint *p, char *bin_str) {
+R_API void r_print_hex_from_bin (RPrint *p, char *bin_str) {
 	int i, j, index;
 	const int len = strlen (bin_str);
 	ut64 n, *buf = malloc (len / 8);

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1867,3 +1867,31 @@ R_API int r_print_jsondump(RPrint *p, const ut8 *buf, int len, int wordsize) {
 	p->cb_printf ("]\n");
 	return words;
 }
+
+R_API void print_hex_from_bin (RPrint *p, char *bin_str) {
+	int i, j, index;
+	const int len = strlen (bin_str);
+	ut64 n, *buf = malloc (len / 8);
+	if (buf == NULL) {
+		eprintf ("allocation failed\n");
+		return;
+	}
+	for (i = len - 1, index = 0; i >= 0; i -= 64, index++) {
+		n = 0;
+		for (j = 0; j < 64 && i - j >= 0; j++) {
+			n += (ut64) (bin_str[i - j] - '0') << j;
+		}
+		buf[index] = n;
+	}
+	index--;
+	p->cb_printf ("0x");
+	while (buf[index] == 0 && index > 0) {
+		index--;
+	}
+	p->cb_printf ("%" PFMT64x, buf[index]);
+	index--;
+	for (i = index; i >= 0; i--) {
+		p->cb_printf ("%016" PFMT64x, buf[i]);
+	}
+	p->cb_printf ("\n");
+}

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1894,4 +1894,5 @@ R_API void r_print_hex_from_bin (RPrint *p, char *bin_str) {
 		p->cb_printf ("%016" PFMT64x, buf[i]);
 	}
 	p->cb_printf ("\n");
+	free (buf);
 }


### PR DESCRIPTION
Added -L option which prints hex value from binary format ( [01]+ ).

We can use like follows,
```
$ rax2 -L 100100011010001010110011110001001000010101011110011011111
0x1234567890abcdf
```