### PR TITLE
Support numeric conversion like rax2

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -470,11 +470,11 @@ static int cmd_help(void *data, const char *input) {
 				/* binary and floating point */
 				r_str_bits64 (out, n);
 				f = d = core->num->fvalue;
-				r_cons_printf ("%s %.01lf %ff %lf ", out, core->num->fvalue, f, d);
+				r_cons_printf ("0b%s %.01lf %ff %lf ", out, core->num->fvalue, f, d);
 
 				/* ternary */
 				r_num_to_trits (out, n);
-				r_cons_printf ("%s ", out);
+				r_cons_printf ("0t%s ", out);
 
 				r_cons_printf ("\n");
 			}

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -463,7 +463,13 @@ static int cmd_help(void *data, const char *input) {
 			/* binary and floating point */
 			r_str_bits64 (out, n);
 			f = d = core->num->fvalue;
-			r_cons_printf ("%s %.01lf %ff %lf\n", out, core->num->fvalue, f, d);
+			r_cons_printf ("%s %.01lf %ff %lf ", out, core->num->fvalue, f, d);
+
+			/* ternary */
+			r_num_to_trits (out, n);
+			r_cons_printf ("%s ", out);
+
+			r_cons_printf ("\n");
 		}
 		break;
 	case 'v': // "?v"

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -439,37 +439,46 @@ static int cmd_help(void *data, const char *input) {
 			ut32 s, a;
 			double d;
 			float f;
-			n = r_num_math (core->num, input + 1);
-			if (core->num->dbz) {
-				eprintf ("RNum ERROR: Division by Zero\n");
-			}
-			asnum  = r_num_as_string (NULL, n, false);
-			/* decimal, hexa, octal */
-			s = n >> 16 << 12;
-			a = n & 0x0fff;
-			r_num_units (unit, n);
-			r_cons_printf ("%"PFMT64d" 0x%"PFMT64x" 0%"PFMT64o
-				" %s %04x:%04x ",
-				n, n, n, unit, s, a);
-			if (n >> 32) {
-				r_cons_printf ("%"PFMT64d" ", (st64)n);
-			} else {
-				r_cons_printf ("%d ", (st32)n);
-			}
-			if (asnum) {
-				r_cons_printf ("\"%s\" ", asnum);
-				free (asnum);
-			}
-			/* binary and floating point */
-			r_str_bits64 (out, n);
-			f = d = core->num->fvalue;
-			r_cons_printf ("%s %.01lf %ff %lf ", out, core->num->fvalue, f, d);
+			char * const inputs = strdup (input + 1);
+			int inputs_len = r_str_split (inputs, ' ');
+			const char *iter = inputs;
+			for (i = 0; i < inputs_len; i++, iter += strlen (iter) + 1) {
+				if (*iter == '\0') {
+					continue;
+				}
+				n = r_num_math (core->num, iter);
+				if (core->num->dbz) {
+					eprintf ("RNum ERROR: Division by Zero\n");
+				}
+				asnum  = r_num_as_string (NULL, n, false);
+				/* decimal, hexa, octal */
+				s = n >> 16 << 12;
+				a = n & 0x0fff;
+				r_num_units (unit, n);
+				r_cons_printf ("%"PFMT64d" 0x%"PFMT64x" 0%"PFMT64o
+					" %s %04x:%04x ",
+					n, n, n, unit, s, a);
+				if (n >> 32) {
+					r_cons_printf ("%"PFMT64d" ", (st64)n);
+				} else {
+					r_cons_printf ("%d ", (st32)n);
+				}
+				if (asnum) {
+					r_cons_printf ("\"%s\" ", asnum);
+					free (asnum);
+				}
+				/* binary and floating point */
+				r_str_bits64 (out, n);
+				f = d = core->num->fvalue;
+				r_cons_printf ("%s %.01lf %ff %lf ", out, core->num->fvalue, f, d);
 
-			/* ternary */
-			r_num_to_trits (out, n);
-			r_cons_printf ("%s ", out);
+				/* ternary */
+				r_num_to_trits (out, n);
+				r_cons_printf ("%s ", out);
 
-			r_cons_printf ("\n");
+				r_cons_printf ("\n");
+			}
+			free (inputs);
 		}
 		break;
 	case 'v': // "?v"

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3088,7 +3088,7 @@ R_API char *r_str_from_ut64(ut64 val) {
 	return str;
 }
 
-R_API int r_snprintf (char *string, int len, const char *fmt, ...) {
+R_API int r_snprintf(char *string, int len, const char *fmt, ...) {
 	va_list ap;
 	va_start (ap, fmt);
 	int ret = vsnprintf (string, len, fmt, ap);

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -418,7 +418,12 @@ R_API int r_num_to_trits (char *out, ut64 num) {
 	for (i = 0; num; i++, num /= 3) {
 		out[i] = (char) ('0' + num % 3);
 	}
+	if (i == 0) {
+		out[0] = '0';
+		i++;
+	}
 	out[i] = '\0';
+
 	r_str_reverse (out);
 	return true;
 }


### PR DESCRIPTION
Related to the issue #4101,
There are three changes.
1. Support conversion for multiple values.
2. Add ternary value.
3. Add prefix for binary and ternary values

Output is following,
```
[0x00000000]> ? 1 2
1 0x1 01 1 0000:0001 1 "\x01" 0b00000001 1.0 1.000000f 1.000000 0t1
2 0x2 02 2 0000:0002 2 "\x02" 0b00000010 2.0 2.000000f 2.000000 0t2
```
