### PR TITLE
fixed json format issue for iA command on arm fat mach-O files (xtr f…

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -2283,7 +2283,7 @@ static void list_xtr_archs(RBin *bin, int mode) {
 				bin->cb_printf (
 					"%s{\"arch\":\"%s\",\"bits\":%d,"
 					"\"offset\":%" PFMT64d
-					",\"size\":\"%" PFMT64d
+					",\"size\":%" PFMT64d
 					",\"machine\":\"%s\"}",
 					i++ ? "," : "", arch, bits,
 					xtr_data->offset, xtr_data->size,


### PR DESCRIPTION
fixed the format issues for json output of iA command for fat ARM mach-O binaries. However, the workflow should never be triggered for this file type.

The below if condition should never be taken for this file type in libr/bin/bin.c.

2315   if (binfile && binfile->curxtr) {
2316     list_xtr_archs (bin, mode);
2317     return;
2318   }

A new bug will be raised for that.
