### PR TITLE
 Fix leave and ret doesn't translate to pseudocode

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -504,6 +504,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->varsub = r_config_get_i (core->config, "asm.varsub");
 	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
 	core->parser->localvar_only = r_config_get_i (core->config, "asm.varsub_only");
+	core->parser->retleave_asm = NULL;
 	ds->show_vars = r_config_get_i (core->config, "asm.vars");
 	ds->show_varsum = r_config_get_i (core->config, "asm.varsum");
 	ds->show_varxs = r_config_get_i (core->config, "asm.varxs");

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -26,6 +26,7 @@ typedef struct r_parse_t {
 	bool localvar_only; // if true use only the local variable name (e.g. [local_10h] instead of [ebp + local10h])
 	int relsub_addr;
 	int minval;
+	char *retleave_asm;
 	struct r_parse_plugin_t *cur;
 	RAnal *anal; // weak anal ref
 	RAnalHint *hint; // weak anal ref


### PR DESCRIPTION
It translates to pseudocode now. However, the problem has comprised more than leave and ret. It touched every op code that consists of a single word like leave, return or nop.  I am not sure if you like the pseudo code. 

