### PR TITLE
Assemble REX.W prefix for 64-bit immediate mov to memory

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1368,6 +1368,10 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 				} else if (!(op->operands[0].type & OT_BYTE) &&
 				           !(op->operands[0].type & OT_QWORD)) {
 					data[l++] = 0x67;
+				} else if (op->operands[0].type & OT_QWORD) {
+					// The operand is a QWORD PTR memory access, so we want a
+					// REX prefix with a set W bit.
+					data[l++] = 0x48;
 				}
 			}
 			if (op->operands[0].type & (OT_DWORD | OT_QWORD)) {


### PR DESCRIPTION
Closes #8939.

When assembling a `mov` of an immediate value into a memory location with `bits = 64`, the result would be missing a REX prefix with set W bit (which indicates 64-bit operands).

CI will fail until the associated `radare2-regressions` PR is merged (https://github.com/radare/radare2-regressions/pull/1088).