### PR TITLE
rax2 Fix hex from c

### DIFF
--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -66,10 +66,12 @@ R_API char *r_hex_from_c(const char *code) {
 				break;
 			} else if (*code == '"') {
 				parse_on = false;
+				char *s1 = strchr (code+1, ';');
+				char *s2 = strchr (code+1, '"');
+				if (s2 == NULL || (s1 < s2)) {
+					break;
+				}
 				continue;
-			} else if (*code == ';') {
-				// stop parsing after the string statement
-				break;
 			}
 		} else {
 			if (*code == '{') {
@@ -94,7 +96,7 @@ R_API char *r_hex_from_c(const char *code) {
 			if (comma) {
 				char *word = r_str_ndup (code, comma - code);
 				char * _word = word;
-				while (*word == ' ') {
+				while (IS_WHITESPACE (*word)) {
 					word++;
 				}
 				if (IS_DIGIT (*word)) {

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -93,6 +93,10 @@ R_API char *r_hex_from_c(const char *code) {
 			if (!comma) comma = strchr (code, '}');
 			if (comma) {
 				char *word = r_str_ndup (code, comma - code);
+				char * _word = word;
+				while (*word == ' ') {
+					word++;
+				}
 				if (IS_DIGIT (*word)) {
 					ut8 n = (ut8)r_num_math (NULL, word);
 					*out++ = abc[(n >> 4) & 0xf];
@@ -101,7 +105,7 @@ R_API char *r_hex_from_c(const char *code) {
 					parse_on = false;
 				}
 				code = comma;
-				free (word);
+				free (_word);
 			}
 		} else if (*code == '"') {
 			if (code[1] == '\\') {

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -60,8 +60,14 @@ R_API char *r_hex_from_c(const char *code) {
 			continue;
 		}
 		if (parse_on) {
-			if (*code == '}' || *code == '"') {
+			if (*code == '}') {
 				parse_on = false;
+				// stop parsing after the first string statement
+				break;
+			} else if (*code == '"') {
+				parse_on = false;
+				continue;
+			} else if (*code == ';') {
 				// stop parsing after the string statement
 				break;
 			}

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -27,107 +27,108 @@ R_API char *r_hex_from_c(const char *code) {
 	const char abc[] = "0123456789abcdefABCDEF";
 	bool parse_on = false;
 	int parse_mode = 0;
-	char *out, *ret;
+	char *out;
 	int is_hexa = 0;
 
-	if (code) {
-		ret = malloc (strlen (code) * 3);
-	} else {
-		ret = malloc (3);
+	char * const ret = code != NULL
+					 ? malloc (strlen (code) * 3)
+					 : malloc (3);
+	if (!ret) {
+		return NULL;
 	}
-	if (!ret) return NULL;
-	*ret = 0;
+	*ret = '\0';
 	out = ret;
-	if (code) {
-		for (;*code; code++) {
-			if (!strncmp (code, "/*", 2)) {
-				/* skip comments */
-				char *end = strstr (code, "*/");
-				if (end) {
-					code = end + 1;
-				} else {
-					eprintf ("Missing closing comment\n");
-				}
-				continue;
-			}
-			if (!strncmp (code, "//", 2)) {
-				char *end = strchr (code, '\n');
-				if (end) {
-					code = end;
-				}
-				continue;
-			}
-			if (parse_on) {
-				if (*code == '}' || *code == '"') {
-					parse_on = false;
-					// stop parsing after the first string statement
-					break;
-				}
+	if(!code) {
+		return ret;
+	}
+	for (;*code; code++) {
+		if (!strncmp (code, "/*", 2)) {
+			/* skip comments */
+			char *end = strstr (code, "*/");
+			if (end) {
+				code = end + 1;
 			} else {
-				if (*code == '{') {
-					parse_mode = *code;
-					for (code++;*code; code++) {
-						if (IS_WHITESPACE (*code))
-							continue;
-						if (IS_DIGIT (*code)) {
-							parse_on = true;
-							break;
-						} else {
-							parse_on = false;
-							parse_mode = 0;
-							break;
-						}
-					}
-				}
+				eprintf ("Missing closing comment\n");
 			}
-			if (parse_on && parse_mode == '{') {
-				char *comma = strchr (code, ',');
-				if (!comma) comma = strchr (code, '}');
-				if (comma) {
-					char *word = r_str_ndup (code, comma - code);
-					if (IS_DIGIT (*word)) {
-						ut8 n = (ut8)r_num_math (NULL, word);
-						*out++ = abc[(n >> 4) & 0xf];
-						*out++ = abc[n & 0xf];
+			continue;
+		}
+		if (!strncmp (code, "//", 2)) {
+			char *end = strchr (code, '\n');
+			if (end) {
+				code = end;
+			}
+			continue;
+		}
+		if (parse_on) {
+			if (*code == '}' || *code == '"') {
+				parse_on = false;
+				// stop parsing after the string statement
+				break;
+			}
+		} else {
+			if (*code == '{') {
+				parse_mode = *code;
+				for (code++; *code; code++) {
+					if (IS_WHITESPACE (*code))
+						continue;
+					if (IS_DIGIT (*code)) {
+						parse_on = true;
+						break;
 					} else {
 						parse_on = false;
-					}
-					code = comma;
-					free (word);
-				}
-			} else if (*code == '"') {
-				if (code[1] == '\\') {
-					parse_on = true;
-				} else {
-					parse_on = !parse_on;
-					parse_mode = *code;
-				}
-			} else if (parse_on) {
-				if (*code == '\\') {
-					code++;
-					switch (code[0]) {
-					case 'e': *out++='1';*out++='b';break;
-					case 'r': *out++='0';*out++='d';break;
-					case 'n': *out++='0';*out++='a';break;
-					case 'x': is_hexa ++; break;
-					default: goto error;
-					}
-				} else {
-					if (is_hexa) {
-						if (strchr (abc, *code)) {
-							*out++ = *code;
-							if (++is_hexa == 3)
-								is_hexa = 0;
-						} else goto error;
-					} else {
-						*out++ = abc[*code >>4];
-						*out++ = abc[*code & 0xf];
+						parse_mode = 0;
+						break;
 					}
 				}
 			}
 		}
+		if (parse_on && parse_mode == '{') {
+			char *comma = strchr (code, ',');
+			if (!comma) comma = strchr (code, '}');
+			if (comma) {
+				char *word = r_str_ndup (code, comma - code);
+				if (IS_DIGIT (*word)) {
+					ut8 n = (ut8)r_num_math (NULL, word);
+					*out++ = abc[(n >> 4) & 0xf];
+					*out++ = abc[n & 0xf];
+				} else {
+					parse_on = false;
+				}
+				code = comma;
+				free (word);
+			}
+		} else if (*code == '"') {
+			if (code[1] == '\\') {
+				parse_on = true;
+			} else {
+				parse_on = !parse_on;
+				parse_mode = *code;
+			}
+		} else if (parse_on) {
+			if (*code == '\\') {
+				code++;
+				switch (code[0]) {
+				case 'e': *out++='1';*out++='b';break;
+				case 'r': *out++='0';*out++='d';break;
+				case 'n': *out++='0';*out++='a';break;
+				case 'x': is_hexa ++; break;
+				default: goto error;
+				}
+			} else {
+				if (is_hexa) {
+					if (strchr (abc, *code)) {
+						*out++ = *code;
+						if (++is_hexa == 3)
+							is_hexa = 0;
+					} else goto error;
+				} else {
+					*out++ = abc[*code >>4];
+					*out++ = abc[*code & 0xf];
+				}
+			}
+		}
 	}
-	*out++ = 0;
+	*out++ = '\0';
 	return ret;
 error:
 	free (ret);

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -122,7 +122,7 @@ R_API char *r_hex_from_c(const char *code) {
 							is_hexa = 0;
 					} else goto error;
 				} else {
-					*out++ = abc[*code >>4];
+					*out++ = abc[*code >> 4];
 					*out++ = abc[*code & 0xf];
 				}
 			}


### PR DESCRIPTION
Related to the issue #2639 

It enables parse following code by `rax2 -F
```c
char *shellcode = "\x31\xc0\x50\x68\x2f\x2f\x73\x68\x68\x2f\x62\x69"
		  "\x6e\x89\xe3\x50\x53\x89\xe1\xb0\x0b\xcd\x80";
```

before this patch, the result is
```
31c050682f2f7368682f6269
```

after this patch,
```
31c050682f2f7368682f62696e89e3505389e1b00bcd80
```