### PR TITLE
Fix Escaped Quotes in r_print_json_indent()

### DIFF
--- a/libr/util/json_indent.c
+++ b/libr/util/json_indent.c
@@ -200,7 +200,7 @@ R_API char* r_print_json_indent(const char* s, bool color, const char* tab, cons
 			if (s[0] == '"') {
 				instr = 0;
 			} else if (s[0] == '\\' && s[1] == '"') {
-				*o++ = *s;
+				*o++ = *s++;
 			}
 			if (instr) {
 				if (isValue) {


### PR DESCRIPTION
Tiny fix for `~{}` for cases like this:
```
{
  "test": "ping\"as"
}
```
