### PR TITLE
Fix out of bounds access in 'p-'.

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3580,7 +3580,7 @@ static int cmd_print(void *data, const char *input) {
 
 		bool use_color = r_config_get_i (core->config, "scr.color");
 		len = 0;
-		for (i = 0; i < w; i++) {
+		for (i = 0; i < ((to-from)/piece); i++) {
 			at = from + (piece * i);
 			ate = at + piece;
 			p = (at - from) / piece;


### PR DESCRIPTION
Related test: https://github.com/radare/radare2-regressions/pull/1095

Fails on previous commit with:
```
 |   offset    | flags funcs cmts syms str  |
 |-------------)----------------------------|
 | 0x100001010 |    2    0    1    0    0   |
+| 0x100001018 |    1    0    0    0    0   |
+| 0x100001019 |    0    0 1610612736 1610612736 1514668189   |
+| 0x10000101a | 1094995319 1112033655 1365924471 1112821864 1094995252   |
+| 0x10000101b | 1865638759 1315857511 1736068409 1297371190 1246251316   |
+| 0x10000101c | 1094935924 1447384678 963398775 893605465 1379096678   |
+| 0x10000101d | 1256767872 1256770336 32736 32736    0   |
+| 0x10000101f |    0 1514668127 1610612736 1112821864 1096043828   |
+| 0x100001020 | 1112033655 1094995252 1112821864 1162104183 1096043895   |
+| 0x100001021 | 1865638706 1731421305 1111707449 827548217 813261945   |
+| 0x100001022 | 1162171970 961960307 959535221 827811194 2016567913   |
+| 0x100001023 |    0    0    0 1610612736    0   |
+| 0x100001025 | 825044017 1816618090 1446142764 1097425526 1514686770   |
+| 0x100001026 | 1094995319 1112033655 1094995320 1112821864 1094995252   |
+| 0x100001027 | 1865638759 1315857511 1498697017 1163153462 1246251314   |
+| 0x100001028 | 1095978035 1178948198 963398706 894652757 892491878   |
+| 0x100001029 | 960914038   61 1229481079    0    0   |
+| 0x10000102a | 1610612736    0   76    0    0   |
+| 0x10000102b |    0    0    0 1610612736    0   |
+| 0x10000102c |    0 327680    0    0    0   |
+| 0x10000102d |    0    0    0 458752 1256770800   |
+| 0x10000102e | 32736    0    0    0    0   |
+| 0x10000102f |    0    0    0 1610612736 78548099   |
+| 0x100001030 |    0 131072    0 4402276    0   |
+| 0x100001031 |    0 1256770976    0 32736    0   |
+| 0x100001032 |    0 -2147481602 78548188    0 1610612736   |
+| 0x100001034 | 1610612736 1610612736    0    3    0   |
+| 0x100001035 |   67    0    0 1376256    0   |
+| 0x100001036 | 32736    0    0    0    0   |
+| 0x100001037 |    0    6 1610612736    0    0   |
+| 0x100001038 |    0    0    0    0 1610612736   |
+| 0x100001039 |    3    0    0 131072   67   |
+| 0x10000103a | 1900544    0    0 1256771344 32736   |
 |-------------)----------------------------|
-|    total    |    2    0    1    0    0   |
+|    total    | 1338074750 -600959630 1212721100 2027924521 -1912905076   |
```