### PR TITLE
take bits wildcard into account

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -353,7 +353,7 @@ R_API int r_bp_size(RBreakpoint *bp) {
 	int i, bpsize = 8;
 	for (i = 0; bp->cur->bps[i].bytes; i++) {
 		bpa = &bp->cur->bps[i];
-		if (bpa->bits != bp->bits) {
+		if (bpa->bits && bpa->bits != bp->bits) {
 			continue;
 		}
 		if (bpa->length < bpsize) {


### PR DESCRIPTION
Hello,
I found a regression with int r_bp_size. (which breaks dcu)
It wasn't taking into account that a 0 bits value seemed to mean "whatever bits"
leading to a bad core->dbg->bpsize value.

see file libr/bp/p/bp_x86.c for my supposition about the "whatever bits"
```
static struct r_bp_arch_t r_bp_plugin_x86_bps[] = {         
    { 0, 1, 0, (const ut8*)"\xcc" }, // valid for 16, 32, 64
    { 0, 2, 0, (const ut8*)"\xcd\x03" },                    
    { 0, 0, 0, NULL },                                      
};                                                          
```
it appears setting a bp with the "db" command still worked because of a dirty hack in libr/debug/debug.c

```
static int get_bpsz_arch(RDebug *dbg) {                                     
#define CMP_ARCH(x) strncmp (dbg->arch, (x), R_MIN (len_arch, strlen ((x))))
    int bpsz , len_arch = strlen (dbg->arch);                               
    if (!CMP_ARCH ("arm")) {                                                
        //TODO add better handle arm/thumb                                  
        bpsz = 4;                                                           
    } else if (!CMP_ARCH ("mips")) {                                        
        bpsz = 4;                                                           
    } else if (!CMP_ARCH ("ppc")) {                                         
        bpsz = 4;                                                           
    } else if (!CMP_ARCH ("sparc")) {                                       
        bpsz = 4;                                                           
    } else if (!CMP_ARCH ("sh")) {                                          
        bpsz = 2;                                                           
    } else {                                                                
        bpsz = 1;                                                           
    }                                                                       
    return bpsz;                                                            
}                                                                           
```
I guess the code in that file should be architecture independent. and should also be using r_bp_size.
But maybe this was there to workaround another problem ?
If you give me green light, I am willing to fix it as well.
Just let me know.