### PR TITLE
fix #8969 , optimize aav

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2618,7 +2618,7 @@ R_API int r_core_search_value_in_range(RCore *core, RAddrInterval search_itv, ut
 					}
 				}
 			}
-			if (match) {
+			if (match && value) {
 				bool isValidMatch = true;
 				if (align && (value % align)) {
 					// ignored .. unless we are analyzing arm/thumb and lower bit is 1


### PR DESCRIPTION
Hey this PR is regarding this issue [Analysis hangs with a specific library (shared object)](https://github.com/radare/radare2/issues/8969)

I have tested with this file [libmedia.zip](https://github.com/radare/radare2/files/1534666/libmedia.zip)

Before my fix : 
       The analysis aav takes around 1- 1.5 hrs

After the fix : 
       The analysis aav now takes a 1-2 min 

The issue was aav was considering addr 0x000000 to be a hit and was creating reference in so many area , hopefully this dosen't break anything !!!

But still this only optimize aav when we are searching in empty space , i am still working on implementing anal.in for a  complete fix !!