### PR TITLE
Use standard r_bp_size in order to get breakpoint size

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -200,29 +200,9 @@ static int r_debug_recoil(RDebug *dbg, RDebugRecoilMode rc_mode) {
 	return r_debug_bps_enable (dbg);
 }
 
-static int get_bpsz_arch(RDebug *dbg) {
-#define CMP_ARCH(x) strncmp (dbg->arch, (x), R_MIN (len_arch, strlen ((x))))
-	int bpsz , len_arch = strlen (dbg->arch);
-	if (!CMP_ARCH ("arm")) {
-		//TODO add better handle arm/thumb
-		bpsz = 4;
-	} else if (!CMP_ARCH ("mips")) {
-		bpsz = 4;
-	} else if (!CMP_ARCH ("ppc")) {
-		bpsz = 4;
-	} else if (!CMP_ARCH ("sparc")) {
-		bpsz = 4;
-	} else if (!CMP_ARCH ("sh")) {
-		bpsz = 2;
-	} else {
-		bpsz = 1;
-	}
-	return bpsz;
-}
-
 /* add a breakpoint with some typical values */
 R_API RBreakpointItem *r_debug_bp_add(RDebug *dbg, ut64 addr, int hw, bool watch, int rw, char *module, st64 m_delta) {
-	int bpsz = get_bpsz_arch (dbg);
+	int bpsz = r_bp_size(dbg->bp);
 	RBreakpointItem *bpi;
 	const char *module_name = module;
 	RListIter *iter;


### PR DESCRIPTION
this PR tries to make r_debug_bp_add a little bit more arch agnostic.
