### PR TITLE
scr.html: do not print <br /> at the end

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -800,10 +800,11 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 		if (ptr[0] == '\n') {
 			tmp = (int) (size_t) (ptr - str);
 			r_strbuf_append_n (res, str, tmp);
-			r_strbuf_append (res, "<br />");
 			if (!ptr[1]) {
 				// write new line if it's the end of the output
 				r_strbuf_append (res, "\n");
+			} else {
+				r_strbuf_append (res, "<br />");
 			}
 			str = ptr + 1;
 			continue;


### PR DESCRIPTION
JSON commands usually output a trailing newline. In combination with scr.html, this results in json with a `<br />` at the end and thus invalid json.
This fix simply does not print that if it is the last newline.

Not the perfect solution in general, because by design `scr.html` is applied to the final json. Also, some commands like `pdj` output two newlines for some reason, so there will still be a `<br />` for these commands.

Also, I hope this does not break anything because the change applies to all commands, not only json ones.