### PR TITLE
Add pdJ for formatted JSON disassembly

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -180,6 +180,7 @@ static const char *help_msg_pd[] = {
 	"pdf", "", "disassemble function",
 	"pdi", "", "like 'pi', with offset and bytes",
 	"pdj", "", "disassemble to json",
+	"pdJ", "", "formatted disassembly like pd as json",
 	"pdk", "", "disassemble all methods of a class",
 	"pdl", "", "show instruction sizes",
 	"pdr", "", "recursive disassemble across the function graph",

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3896,6 +3896,10 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 			}
 		}
 	}
+
+	if (ds->use_json) {
+		r_cons_print ("[");
+	}
 toro:
 	// uhm... is this necesary? imho can be removed
 	r_asm_set_pc (core->assembler, p2v (ds, ds->addr + idx));
@@ -3916,10 +3920,6 @@ toro:
 		if (item) {
 			ds->dest = item->offset;
 		}
-	}
-
-	if (ds->use_json) {
-		r_cons_print ("[");
 	}
 
 	ds_print_esil_anal_init (ds);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4225,7 +4225,7 @@ toro:
 	}
 
 	if (ds->use_json) {
-		r_cons_print ("]");
+		r_cons_print ("]\n");
 	}
 
 	R_FREE (nbuf);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1130,11 +1130,13 @@ static void ds_show_xrefs(RDisasmState *ds) {
 					name = tmp;
 				}
 			}
+			ds_begin_json_line (ds);
 			ds_pre_xrefs (ds);
 			//those extra space to align
-			ds_comment (ds, false, "   %s; %s XREF from 0x%08"PFMT64x" (%s)%s\n",
+			ds_comment (ds, false, "   %s; %s XREF from 0x%08"PFMT64x" (%s)%s",
 				COLOR (ds, pal_comment), r_anal_xrefs_type_tostring (refi->type),
 				refi->addr, name, COLOR_RESET (ds));
+			ds_newline (ds);
 			R_FREE (name);
 		}
 	}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3903,7 +3903,7 @@ static void ds_print_as_string(RDisasmState *ds) {
 }
 
 // int l is for lines
-R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int l, int invbreak, int cbytes) {
+int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int l, int invbreak, int cbytes, bool json) {
 	int continueoninvbreak = (len == l) && invbreak;
 	RAnalFunction *of = NULL;
 	RAnalFunction *f = NULL;
@@ -3921,7 +3921,7 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 	ds->len = len;
 	ds->addr = addr;
 	ds->hint = NULL;
-	ds->use_json = true; // TODO: from parameter or config
+	ds->use_json = json;
 	ds->first_line = true;
 	//r_cons_printf ("len =%d l=%d ib=%d limit=%d\n", len, l, invbreak, p->limit);
 	// TODO: import values from debugger is possible

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3851,27 +3851,29 @@ static void ds_print_comments_right(RDisasmState *ds) {
 				if (strchr (comment, '\n')) {
 					char *align = r_str_newf ("%s  ;^ ", ds->pre);
 					comment = strdup (comment);
-					ds_newline (ds);
-					ds_begin_json_line (ds);
-					if (ds->use_json) {
-						int lines_count;
-						int *line_indexes = r_str_split_lines (comment, &lines_count);
-						if (line_indexes) {
-							int i;
-							for (i = 0; i < lines_count; i++) {
-								char *c = comment + line_indexes[i];
-								char *escstr = ds_esc_str (ds, c, (int)strlen (c), NULL);
-								if (escstr) {
-									r_cons_printf ("; %s", escstr);
-									ds_newline (ds);
-									ds_begin_json_line (ds);
-									free (escstr);
+					if (align && comment) {
+						ds_newline (ds);
+						ds_begin_json_line (ds);
+						if (ds->use_json) {
+							int lines_count;
+							int *line_indexes = r_str_split_lines (comment, &lines_count);
+							if (line_indexes) {
+								int i;
+								for (i = 0; i < lines_count; i++) {
+									char *c = comment + line_indexes[i];
+									char *escstr = ds_esc_str (ds, c, (int)strlen (c), NULL);
+									if (escstr) {
+										r_cons_printf ("; %s", escstr);
+										ds_newline (ds);
+										ds_begin_json_line (ds);
+										free (escstr);
+									}
 								}
 							}
+						} else {
+							char *c = r_str_prefix_all (comment, align);
+							r_cons_strcat (c);
 						}
-					} else {
-						char *c = r_str_prefix_all (comment, align);
-						r_cons_strcat (c);
 					}
 					free (comment);
 					free (align);
@@ -3885,9 +3887,7 @@ static void ds_print_comments_right(RDisasmState *ds) {
 						r_cons_printf ("; %s", comment);
 					}
 
-					if (escstr) {
-						free (escstr);
-					}
+					free (escstr);
 				}
 			}
 			//r_cons_strcat_justify (comment, strlen (ds->refline) + 5, ';');

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -239,12 +239,17 @@ typedef struct {
 	int cmtcount;
 	int shortcut_pos;
 	bool asm_anal;
+
+	bool use_json;
+	bool first_line;
 } RDisasmState;
 
 static void ds_setup_print_pre(RDisasmState *ds, bool tail, bool middle);
 static void ds_setup_pre(RDisasmState *ds, bool tail, bool middle);
 static void ds_print_pre(RDisasmState *ds);
 static void ds_beginline(RDisasmState *ds, RAnalFunction *f, bool nopre);
+static void ds_begin_json_line(RDisasmState *ds);
+static void ds_newline(RDisasmState *ds);
 static void ds_print_esil_anal(RDisasmState *ds);
 static void ds_reflines_init(RDisasmState *ds);
 static void ds_align_comment(RDisasmState *ds);
@@ -432,7 +437,7 @@ static void ds_comment_esil(RDisasmState *ds, bool up, bool end, const char *for
 
 	if (ds->show_comments && !ds->show_comment_right) {
 		if (end) {
-			r_cons_newline ();
+			ds_newline (ds);
 		}
 	}
 }
@@ -967,6 +972,25 @@ static void ds_beginline(RDisasmState *ds, RAnalFunction *f, bool nopre) {
 	ds->line = tmp;
 }
 
+static void ds_begin_json_line(RDisasmState *ds) {
+	if (!ds->use_json) {
+		return;
+	}
+	if (!ds->first_line) {
+		r_cons_print (",");
+	}
+	ds->first_line = false;
+	r_cons_printf ("{offset:%"PFMT64d",text:\"", ds->vat);
+}
+
+static void ds_newline(RDisasmState *ds) {
+	if (ds->use_json) {
+		r_cons_printf ("\"}");
+	} else {
+		r_cons_newline ();
+	}
+}
+
 static void ds_pre_xrefs(RDisasmState *ds) {
 	RCore *core = ds->core;
 	if (ds->show_fcnlines) {
@@ -1060,7 +1084,7 @@ static void ds_show_xrefs(RDisasmState *ds) {
 			if (count == cols) {
 				if (iter->n) {
 					ds_print_color_reset (ds);
-					r_cons_newline ();
+					ds_newline (ds);
 					ds_pre_xrefs (ds);
 					ds_comment (ds, false, "   %s; XREFS: ", ds->show_color? ds->pal_comment: "");
 				}
@@ -1070,7 +1094,7 @@ static void ds_show_xrefs(RDisasmState *ds) {
 			}
 		}
 		ds_print_color_reset (ds);
-		r_cons_newline ();
+		ds_newline (ds);
 		r_list_free (xrefs);
 		return;
 	}
@@ -1565,6 +1589,7 @@ static void ds_show_comments_right(RDisasmState *ds) {
 		}
 	}
 	if (!ds->show_comment_right) {
+		ds_begin_json_line (ds);
 		int mycols = ds->lcols;
 		if ((mycols + linelen + 10) > core->cons->columns) {
 			mycols = 0;
@@ -1595,16 +1620,18 @@ static void ds_show_comments_right(RDisasmState *ds) {
 			ds_print_color_reset (ds);
 		}
 		R_FREE (ds->comment);
-		r_cons_newline ();
+		ds_newline (ds);
 		/* flag one */
 		if (item && item->comment && ds->ocomment != item->comment) {
+			ds_begin_json_line (ds);
 			if (ds->show_color) {
 				r_cons_strcat (ds->pal_comment);
 			}
-			r_cons_newline ();
+			ds_newline (ds);
+			ds_begin_json_line (ds);
 			r_cons_strcat ("  ;  ");
 			r_cons_strcat_justify (item->comment, mycols, ';');
-			r_cons_newline ();
+			ds_newline (ds);
 			if (ds->show_color) {
 				ds_print_color_reset (ds);
 			}
@@ -1627,6 +1654,7 @@ static void ds_show_flags(RDisasmState *ds) {
 	f = fcnIn (ds, ds->at, R_ANAL_FCN_TYPE_NULL);
 	flaglist = r_flag_get_list (core->flags, ds->at);
 	r_list_foreach (flaglist, iter, flag) {
+		ds_begin_json_line (ds);
 		if (f && f->addr == flag->offset && !strcmp (flag->name, f->name)) {
 			// do not show flags that have the same name as the function
 			continue;
@@ -1673,7 +1701,7 @@ static void ds_show_flags(RDisasmState *ds) {
 		if (ds->show_color) {
 			r_cons_strcat (Color_RESET);
 		}
-		r_cons_newline ();
+		ds_newline (ds);
 	}
 }
 
@@ -3184,7 +3212,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 	}
 #if 0
 	if (!ds->show_comment_right && ds->cmtcount > 0) {
-		r_cons_newline ();
+		ds_newline (ds);
 	}
 #endif
 #if DEADCODE
@@ -3318,7 +3346,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 			if (msg && *msg) {
 				ds_comment_esil (ds, true, false, "; %s", msg);
 				if (ds->show_comments && !ds->show_comment_right) {
-					r_cons_newline ();
+					ds_newline (ds);
 				}
 			}
 		} else {
@@ -3328,7 +3356,7 @@ static int myregwrite(RAnalEsil *esil, const char *name, ut64 *val) {
 				ds_comment_esil (ds, true, false, "; %s=0x%"PFMT64x, name, *val);
 			}
 			if (ds->show_comments && !ds->show_comment_right) {
-				r_cons_newline ();
+				ds_newline (ds);
 			}
 		}
 	}
@@ -3783,7 +3811,7 @@ static void ds_print_comments_right(RDisasmState *ds) {
 					r_cons_strcat (ds->color_usrcmt);
 				}
 				if (strchr (comment, '\n')) {
-					r_cons_newline ();
+					ds_newline (ds);
 					char *align = r_str_newf ("%s  ;^ ", ds->pre);
 					char *c = r_str_prefix_all (strdup (comment), align);
 					r_cons_strcat (c);
@@ -3832,6 +3860,8 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 	ds->len = len;
 	ds->addr = addr;
 	ds->hint = NULL;
+	ds->use_json = true; // TODO: from parameter or config
+	ds->first_line = true;
 	//r_cons_printf ("len =%d l=%d ib=%d limit=%d\n", len, l, invbreak, p->limit);
 	// TODO: import values from debugger is possible
 	// TODO: allow to get those register snapshots from traces
@@ -3878,6 +3908,10 @@ toro:
 		if (item) {
 			ds->dest = item->offset;
 		}
+	}
+
+	if (ds->use_json) {
+		r_cons_print ("[");
 	}
 
 	ds_print_esil_anal_init (ds);
@@ -4024,6 +4058,9 @@ toro:
 				ds_print_esil_anal (ds);
 			}
 		}
+
+		ds_begin_json_line (ds); // TODO: correct position or rather before the if above?
+
 		ds_setup_print_pre (ds, false, false);
 		ds_print_lines_left (ds);
 		// f = r_anal_get_fcn_in (core->anal, ds->addr, 0);
@@ -4085,7 +4122,7 @@ toro:
 			ds->mi_found = false;
 		}
 
-		r_cons_newline ();
+		ds_newline (ds);
 		if (ds->show_bbline && !ds->bblined && !ds->fcn) {
 			switch (ds->analop.type) {
 			case R_ANAL_OP_TYPE_MJMP:
@@ -4123,6 +4160,11 @@ toro:
 		}
 		inc += ds->asmop.payload + (ds->asmop.payload % ds->core->assembler->dataalign);
 	}
+
+	if (ds->use_json) {
+		r_cons_print ("]");
+	}
+
 	R_FREE (nbuf);
 	r_cons_break_pop ();
 
@@ -4930,7 +4972,7 @@ R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int 
 			ds_show_refs (ds);
 			ds_print_esil_anal (ds);
 			if (!(ds->show_comments && ds->show_comment_right && ds->comment)) {
-				r_cons_newline ();
+				ds_newline (ds);
 			}
 			if (ds->line) {
 				R_FREE (ds->line);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -434,7 +434,7 @@ static void ds_comment(RDisasmState *ds, bool align, const char *format, ...) {
 	} else {
 		char buffer[4096];
 		vsnprintf (buffer, sizeof(buffer), format, ap);
-		char *escstr = ds_esc_str (ds, (const char *)buffer, (int)strlen(buffer), NULL);
+		char *escstr = ds_esc_str (ds, (const char *)buffer, (int)strlen (buffer), NULL);
 		if (escstr) {
 			r_cons_printf ("%s", escstr);
 			free (escstr);
@@ -1520,11 +1520,11 @@ static void ds_show_functions(RDisasmState *ds) {
 			if (comment) {
 				char *comment_esc = NULL;
 				if (ds->use_json) {
-					comment = comment_esc = ds_esc_str(ds, comment, (int)strlen(comment), NULL);
+					comment = comment_esc = ds_esc_str (ds, comment, (int)strlen (comment), NULL);
 				}
 
 				if (comment) {
-					r_cons_printf ("    %s; %s", COLOR(ds, color_comment), comment);
+					r_cons_printf ("    %s; %s", COLOR (ds, color_comment), comment);
 				}
 
 				if (comment_esc) {
@@ -3860,7 +3860,7 @@ static void ds_print_comments_right(RDisasmState *ds) {
 							int i;
 							for (i = 0; i < lines_count; i++) {
 								char *c = comment + line_indexes[i];
-								char *escstr = ds_esc_str (ds, c, (int)strlen(c), NULL);
+								char *escstr = ds_esc_str (ds, c, (int)strlen (c), NULL);
 								if (escstr) {
 									r_cons_printf ("; %s", escstr);
 									ds_newline (ds);
@@ -3911,7 +3911,7 @@ static void ds_print_as_string(RDisasmState *ds) {
 }
 
 // int l is for lines
-int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int l, int invbreak, int cbytes, bool json) {
+R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int l, int invbreak, int cbytes, bool json) {
 	int continueoninvbreak = (len == l) && invbreak;
 	RAnalFunction *of = NULL;
 	RAnalFunction *f = NULL;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -420,7 +420,7 @@ R_API RList *r_core_asm_bwdisassemble (RCore *core, ut64 addr, int n, int len);
 R_API RList *r_core_asm_back_disassemble_instr (RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API RList *r_core_asm_back_disassemble_byte (RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API ut32 r_core_asm_bwdis_len (RCore* core, int* len, ut64* start_addr, ut32 l);
-R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int lines, int invbreak, int nbytes);
+R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int lines, int invbreak, int nbytes, bool json);
 R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, int lines);
 R_API int r_core_print_disasm_instructions (RCore *core, int len, int l);
 R_API int r_core_print_disasm_all (RCore *core, ut64 addr, int l, int len, int mode);


### PR DESCRIPTION
What I described in https://github.com/radareorg/cutter/issues/177

I called it `pdJ` now, but of course we can still discuss the name.

Tests: https://github.com/radare/radare2-regressions/pull/1096