### PR TITLE
Add workaround for .--

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1845,9 +1845,9 @@ R_API int r_core_rtr_cmds (RCore *core, const char *port) {
 					buf[i] = buf[i + 1]? ';': '\0';
 				}
 			}
-			if (!r_config_get_i (core->config, "scr.prompt") &&
-			    (!strcmp ((char *)buf, "q!") ||
-			    !strcmp ((char *)buf, ".--"))) {
+			if ((!r_config_get_i (core->config, "scr.prompt") &&
+			     !strcmp ((char *)buf, "q!")) ||
+			    !strcmp ((char *)buf, ".--")) {
 				r_socket_close (ch);
 				break;
 			}


### PR DESCRIPTION
  1. Rap server have still scr.prompt and scr.interactive enabled.
    That's why .-- will terminate a rap server loop and turn back
    to an interactive mode.