### PR TITLE
extend anal.in for few more command

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4552,12 +4552,12 @@ static void _anal_calls(RCore *core, ut64 addr, ut64 addr_end) {
 		if (!bufi) {
 			r_io_read_at (core->io, addr, buf, sizeof (buf));
 		}
-		if (!memcmp(buf, block, core->blocksize)) {
+		if (!memcmp(buf, block, 4096)) {
 			//eprintf ("Error: skipping uninitialized block \n");
 			break;
 		}
-		memset (block, 0, core->blocksize);
-		if (!memcmp(buf, block, core->blocksize)) {
+		memset (block, 0, 4096);
+		if (!memcmp(buf, block, 4096)) {
 			//eprintf ("Error: skipping uninitialized block \n");
 			break;
 		}	

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5681,6 +5681,8 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 				to = r_itv_end (map->itv);
 				if (!from && !to) {
 					eprintf ("Cannot determine xref search boundaries\n");
+				} else if (to - from > UT32_MAX) {
+					eprintf ("Skipping huge range\n");
 				} else {
 					r_core_anal_search_xrefs (core, from, to, rad);
 				}	


### PR DESCRIPTION
The updated list for command that honors anal.in are : 
1) aav
2) aar  (now this command becomes a lil slower by default , but still we could maintain some uniformity coz i am analyzing over complete search range instead of curseek)
3) aac 
4) aae
5) aat 
This almost covers all the command that are covered by aaa and aaaa command
I think with this implemented we can now avoid depending on curseek , and look to anal.in 