### PR TITLE
Fixed axtj/axfj extra null byte.

### DIFF
--- a/libr/anal/ref.c
+++ b/libr/anal/ref.c
@@ -35,7 +35,7 @@ R_API int r_anal_ref_add(RAnal *anal, ut64 addr, ut64 at, int type) {
 	return true;
 }
 
-R_API const char *r_anal_ref_to_string(RAnal *anal, int type) {
+R_API const char *r_anal_ref_to_string(int type) {
 	switch (type) {
 	case R_ANAL_REF_TYPE_NULL: return "null";
 	case R_ANAL_REF_TYPE_CODE: return "code";

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4937,7 +4937,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 					r_parse_filter (core->parser, core->flags,
 							asmop.buf_asm, str, sizeof (str), core->print->big_endian);
 
-					r_cons_printf ("{\"from\":%" PFMT64u ",\"type\":\"%c\",\"opcode\":\"%s\"", ref->addr, ref->type, str);
+					r_cons_printf ("{\"from\":%" PFMT64u ",\"type\":\"%s\",\"opcode\":\"%s\"", ref->addr, r_anal_ref_to_string (ref->type), str);
 					if (fcn) {
 						r_cons_printf (",\"fcn_addr\":%"PFMT64d",\"fcn_name\":\"%s\"", fcn->addr, fcn->name);
 					}
@@ -4993,7 +4993,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 						? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", strtok (comment, "\n"))
 						: r_str_newf ("%s", fcn ? fcn->name : "(nofunc)");
 					r_cons_printf ("%s 0x%" PFMT64x " [%s] %s\n",
-						buf_fcn, ref->addr, r_anal_ref_to_string (core->anal, ref->type), buf_asm);
+						buf_fcn, ref->addr, r_anal_ref_to_string (ref->type), buf_asm);
 					free (buf_asm);
 					free (buf_fcn);
 				}
@@ -5040,8 +5040,8 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 					r_core_read_at (core, ref->at, buf, 12);
 					r_asm_set_pc (core->assembler, ref->at);
 					r_asm_disassemble (core->assembler, &asmop, buf, 12);
-					r_cons_printf ("{\"from\":%" PFMT64d ",\"to\":%" PFMT64d ",\"type\":\"%c\",\"opcode\":\"%s\"}%s",
-						ref->at, ref->addr, ref->type, asmop.buf_asm, iter->n? ",": "");
+					r_cons_printf ("{\"from\":%" PFMT64d ",\"to\":%" PFMT64d ",\"type\":\"%s\",\"opcode\":\"%s\"}%s",
+						ref->at, ref->addr, r_anal_ref_to_string (ref->type), asmop.buf_asm, iter->n? ",": "");
 				}
 				r_cons_print ("]\n");
 			} else if (input[1] == '*') { // axf*

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1754,7 +1754,7 @@ static void do_ref_search(RCore *core, ut64 addr,ut64 from, ut64 to, struct sear
 				: r_str_newf ("%s", fcn ? fcn->name : "(nofunc)");
 			if (from <= ref->addr && to >= ref->addr) {
 				r_cons_printf ("%s 0x%" PFMT64x " [%s] %s\n",
-						buf_fcn, ref->addr, r_anal_ref_to_string (core->anal, ref->type), str);
+						buf_fcn, ref->addr, r_anal_ref_to_string (ref->type), str);
 				if (*param->cmd_hit) {
 					ut64 here = core->offset;
 					r_core_seek (core, ref->addr, true);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1412,7 +1412,7 @@ R_API RList* r_anal_get_fcns (RAnal *anal);
 R_API RAnalRef *r_anal_ref_new(void);
 R_API RList *r_anal_ref_list_new(void);
 R_API void r_anal_ref_free(void *ref);
-R_API const char *r_anal_ref_to_string(RAnal *anal, int type);
+R_API const char *r_anal_ref_to_string(int type);
 R_API int r_anal_ref_add(RAnal *anal, ut64 addr, ut64 at, int type);
 R_API int r_anal_ref_del(RAnal *anal, ut64 at, ut64 addr);
 R_API RList *r_anal_xref_get(RAnal *anal, ut64 addr);


### PR DESCRIPTION
I also modified the API function r_anal_ref_to_string prototype according to the r_anal_fcn_to_string one (RAnal * not needed).