### PR TITLE
Fixes issue where grep is eaten by first command that executes

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -381,16 +381,14 @@ R_API void r_cons_grep_parsecmd(char *cmd, const char *quotestr) {
 R_API char * r_cons_grep_strip(char *cmd, const char *quotestr) {
 	char *ptr = NULL;
 
-	if (!cmd) {
-		return NULL;
+	if (cmd) {
+		ptr = preprocess_filter_expr (cmd, quotestr);
+		r_str_chop (cmd);
 	}
-
-	ptr = preprocess_filter_expr(cmd, quotestr);
-	r_str_chop (cmd);
 	return ptr;
 }
 
-R_API char * r_cons_grep_process(char * grep) {
+R_API void r_cons_grep_process(char * grep) {
 	if (grep) {
 		parse_grep_expression (grep);
 		free (grep);

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -378,6 +378,25 @@ R_API void r_cons_grep_parsecmd(char *cmd, const char *quotestr) {
 	}
 }
 
+R_API char * r_cons_grep_strip(char *cmd, const char *quotestr) {
+	char *ptr = NULL;
+
+	if (!cmd) {
+		return NULL;
+	}
+
+	ptr = preprocess_filter_expr(cmd, quotestr);
+	r_str_chop (cmd);
+	return ptr;
+}
+
+R_API char * r_cons_grep_process(char * grep) {
+	if (grep) {
+		parse_grep_expression (grep);
+		free (grep);
+	}
+}
+
 static int cmp(const void *a, const void *b) {
 	char *da = NULL;
 	char *db = NULL;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1679,6 +1679,7 @@ static int r_core_cmd_subst_i(RCore *core, char *cmd, char *colon) {
 	const char *tick = NULL;
 	char *ptr, *ptr2, *str;
 	char *arroba = NULL;
+	char *grep = NULL;
 	int i, ret = 0, pipefd;
 	bool usemyblock = false;
 	int scr_html = -1;
@@ -2147,7 +2148,7 @@ next2:
 		return true;
 	}
 	if (*cmd != '.') {
-		r_cons_grep_parsecmd (cmd, quotestr);
+		grep = r_cons_grep_strip (cmd, quotestr);
 	}
 
 	/* temporary seek commands */
@@ -2469,6 +2470,10 @@ next_arroba:
 
 	rc = cmd? r_cmd_call (core->rcmd, r_str_trim_head (cmd)): false;
 beach:
+
+	if (grep) {
+		r_cons_grep_process (grep);
+	}
 	if (scr_html != -1) {
 		r_cons_flush ();
 		r_config_set_i (core->config, "scr.html", scr_html);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2470,10 +2470,7 @@ next_arroba:
 
 	rc = cmd? r_cmd_call (core->rcmd, r_str_trim_head (cmd)): false;
 beach:
-
-	if (grep) {
-		r_cons_grep_process (grep);
-	}
+	r_cons_grep_process (grep);
 	if (scr_html != -1) {
 		r_cons_flush ();
 		r_config_set_i (core->config, "scr.html", scr_html);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -624,6 +624,8 @@ R_API char *r_cons_hud_file(const char *f);
 R_API const char *r_cons_get_buffer(void);
 R_API void r_cons_grep_help(void);
 R_API void r_cons_grep_parsecmd(char *cmd, const char *quotestr);
+R_API char * r_cons_grep_strip(char *cmd, const char *quotestr);
+R_API char * r_cons_grep_process(char * grep);
 R_API int r_cons_grep_line(char *buf, int len); // must be static
 R_API int r_cons_grepbuf(char *buf, int len);
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -625,7 +625,7 @@ R_API const char *r_cons_get_buffer(void);
 R_API void r_cons_grep_help(void);
 R_API void r_cons_grep_parsecmd(char *cmd, const char *quotestr);
 R_API char * r_cons_grep_strip(char *cmd, const char *quotestr);
-R_API char * r_cons_grep_process(char * grep);
+R_API void r_cons_grep_process(char * grep);
 R_API int r_cons_grep_line(char *buf, int len); // must be static
 R_API int r_cons_grepbuf(char *buf, int len);
 


### PR DESCRIPTION
Grep commands in radare2 are eaten by the first command to run after they are processed. This causes an issue when a user attempts to grep a command that runs its own r2 commands (such as in a Python plugin). This PR fixes this by separating the stripping and processing of a grep command so that nested commands will process their own grep before their parent processes its own. This allows plugins to safely use greps in their calls to r2lang.cmd() and in conjunction with a PR in radare2-bindings, it allows the user to safely grep the output of a Python plugin.