### PR TITLE
Add a calling to .ar* in the aeim command

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3524,8 +3524,10 @@ static void cmd_esil_mem(RCore *core, const char *input) {
 	// BP
 	sp = r_reg_get_name (core->dbg->reg, R_REG_NAME_BP);
 	r_debug_reg_set (core->dbg, sp, addr + (size / 2));
+	// PC
 	pc = r_reg_get_name (core->dbg->reg, R_REG_NAME_PC);
 	r_debug_reg_set (core->dbg, pc, curoff);
+	r_core_cmd0 (core, ".ar*");
 #if 0
 	if (!r_io_section_get_name (core->io, ESIL_STACK_NAME)) {
 		r_core_cmdf (core, "om %d 0x%"PFMT64x, cf->fd, addr);


### PR DESCRIPTION
The aeim command sets the PC register, however flags are not updated. This creates an desynchronization between what it is displayed in the disassembled code and the value in the PC register. The following exemple shows the issue.

```
> aeim

┌ (fcn) sym.f 40                                                                                                
│   sym.f ();                                                                                                   
│           ; var int local_4h @ rbp-0x4                                                                        
│              ; CALL XREF from 0x00000695 (sym.main)                                                           
│           0x00000660      55             pushq %rbp                                                           
│           0x00000661      4889e5         movq %rsp, %rbp                                                      
|           ;-- rip:                                                                                            
│           0x00000664      c745fc040000.  movl $4, local_4h                                                    
│           0x0000066b      8b55fc         movl local_4h, %edx                                                  
│           0x0000066e      89d0           movl %edx, %eax                                                      
│           0x00000670      01c0           addl %eax, %eax                                                      
│           0x00000672      01d0           addl %edx, %eax                                                      
│           0x00000674      8945fc         movl %eax, local_4h                                                  
│           0x00000677      8345fc02       addl $2, local_4h                                                    
│           0x0000067b      c165fc03       shll $3, local_4h                                                    
Press <enter> to return to Visual mode.    subl $5, local_4h                                                    
:> ar rip
0x00000672
```
where the rip is set to 0x00000672 however in the printed code a rip of 0x00000664 is  displayed.

I add a calling to '.ar*' in order to update flags from registers.