### PR TITLE
Handle arm thumb/thumb2 pc-relative in relsub

### DIFF
--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -254,7 +254,8 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 			rip += 4;
 			char *tstr_new, *ripend = strchr (rip, ']');
 			const char *neg = strchr (rip, '-');
-			ut64 repl_num = (2 * oplen) + addr;
+			ut64 off = (oplen == 2 || strstr(tstr, ".w")) ? 4 : 8;
+			ut64 repl_num = (addr + off) & ~0b11;
 			if (!ripend) {
 				ripend = "]";
 			}

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -254,8 +254,8 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 			rip += 4;
 			char *tstr_new, *ripend = strchr (rip, ']');
 			const char *neg = strchr (rip, '-');
-			ut64 off = (oplen == 2 || strstr(tstr, ".w")) ? 4 : 8;
-			ut64 repl_num = (addr + off) & ~0b11;
+			ut64 off = (oplen == 2 || strstr (tstr, ".w")) ? 4 : 8;
+			ut64 repl_num = (addr + off) & ~3;
 			if (!ripend) {
 				ripend = "]";
 			}


### PR DESCRIPTION
- in thumb mode, PC is always 4 bytes ahead (even in 32-bit thumb2 instructions)
- the resulting pc value must be aligned to 4 bytes, by ignoring last 2 bits

if merging this, there are tests fixes: https://github.com/radare/radare2-regressions/pull/1106 