### PR TITLE
Add a calling to .ar* for the aec / aecu / aecue commands

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4107,6 +4107,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 				until_addr = r_num_math (core->num, input + 2);
 			else until_expr = "0";
 			r_core_esil_step (core, until_addr, until_expr, NULL);
+			r_core_cmd0 (core, ".ar*");
 		}
 		break;
 	case 'i': // "aei"


### PR DESCRIPTION
This is a similar bug of [https://github.com/radare/radare2/pull/9046], where the flag rip is not updated after the execution of the command.