### PR TITLE
Fix #8278 , fix issue in afta

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -652,8 +652,7 @@ static void type_cmd(RCore *core, const char *input) {
 		seek = core->offset;
 		r_core_cmd0 (core, "aei");
 		r_core_cmd0 (core, "aeim");
-		r_config_set_i (core->config, "io.cache", true);
-			r_reg_arena_push (core->anal->reg);
+		r_reg_arena_push (core->anal->reg);	
 		r_list_foreach (core->anal->fcns, it, fcn) {
 			int ret = r_core_seek (core, fcn->addr, true);
 			if (!ret) {
@@ -668,8 +667,7 @@ static void type_cmd(RCore *core, const char *input) {
 		r_core_cmd0 (core, "aeim-");
 		r_core_cmd0 (core, "aei-");
 		r_core_seek (core, seek, true);
-		r_config_set_i (core->config, "io.cache", io_cache);
-			r_reg_arena_pop (core->anal->reg);
+		r_reg_arena_pop (core->anal->reg);
 		break;
 	case 'm': // "aftm"
 		r_config_set_i (core->config, "io.cache", true);


### PR DESCRIPTION
This PR is regarding this issue [reanalyzing is slower than initial analyzing](https://github.com/radare/radare2/issues/8278)
Enabling io.cache in command afta  is causing the analysis to slow every time we run aaaa in same r2 session , now u get const run time output !

Before my fix : 
```
[0x004048c5]> ?t aaaa
[x] Type matching analysis for all functions (afta)
2.585129
[0x004048c5]> ?t aaaa
[x] Type matching analysis for all functions (afta)
3.185129 (and so on increase linearly .... )
```
After my fix : 
```
[0x004048c5]> ?t aaaa
....
[x] Type matching analysis for all functions (afta)
2.085129
[0x004048c5]> ?t aaaa
[x] Type matching analysis for all functions (afta)
2.003612
```
We will be needing io.cache only when we store and restore memory region like stack   
