### PR TITLE
Add on the double-quote in the r_str_utf16_encode() to be able to parse json

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2325,7 +2325,7 @@ R_API char *r_str_utf16_encode(const char *s, int len) {
 		if (*s == '\\') {
 			*d++ = '\\';
 			*d++ = '\\';
-		} else if ((*s >= 0x20) && (*s <= 126)) {
+		} else if ((*s >= 0x20) && (*s <= 126) && (*s != '"')) {
 			*d++ = *s;
 		} else {
 			*d++ = '\\';


### PR DESCRIPTION
Let the following C code :
```
const char FOO[] = "...\"...";
int main()
{
        return 0;
}
```

The psj command produces the following json on the FOO variable :
```
> psj 5 @ obj.FOO
{"string":"...".","offset":1784,"section":".rodata","length":5,"type":"ascii"}
```

The '"' is not escaped on the json data !
Thus following script will produce an error : 
```
import r2pipe
r2 = r2pipe.open('main')
r2.cmd('aaaa')
s = r2.cmdj('psj @ obj.FOO')

$ python script.py 
r2pipe.cmdj.Error: Expecting , delimiter: line 1 column 16 (char 15)
```

To solve the bug, I add an escape on the '"' in the r_str_utf16_encode() 