### PR TITLE
Fix #7989 impl noreturn_recurse

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -581,8 +581,12 @@ bool noreturn_recurse(RAnal *anal, ut64 addr) {
 	RAnalOp op = {0};
 	ut8 bbuf[0x10];
 	ut64 recurse_addr = UT64_MAX;
-	anal->iob.read_at (anal->iob.io, addr, bbuf, 0x10);
-	r_anal_op (anal, &op, addr, bbuf, 0x10);
+	memset(bbuf, '\0', sizeof (bbuf));
+	if (!anal->iob.read_at (anal->iob.io, addr, bbuf, sizeof (bbuf))) {
+		eprintf ("Couldn't read buffer\n");
+		return false;
+	}
+	r_anal_op (anal, &op, addr, bbuf, sizeof (bbuf));
 	switch (op.type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_JMP:
 		if (op.jump == UT64_MAX) {

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -579,9 +579,8 @@ R_API bool r_anal_noreturn_at_addr(RAnal *anal, ut64 addr) {
 
 bool noreturn_recurse(RAnal *anal, ut64 addr) {
 	RAnalOp op = {0};
-	ut8 bbuf[0x10];
+	ut8 bbuf[0x10] = {0};
 	ut64 recurse_addr = UT64_MAX;
-	memset(bbuf, '\0', sizeof (bbuf));
 	if (!anal->iob.read_at (anal->iob.io, addr, bbuf, sizeof (bbuf))) {
 		eprintf ("Couldn't read buffer\n");
 		return false;

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -2208,6 +2208,7 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 			if (INSOP(1).type == X86_OP_IMM) {
 				ut64 seg = INSOP(0).imm;
 				ut64 off = INSOP(1).imm;
+				op->ptr = INSOP (0).mem.disp;
 				op->jump = (seg << 4) + off;
 			} else {
 				op->jump = INSOP(0).imm;


### PR DESCRIPTION
Related to the issue #7989,
Enable to detect noreturn by looking at the first instruction of callee function.

before
![radare2-96emp-before](https://user-images.githubusercontent.com/13299299/34319794-b26cc08c-e7ea-11e7-9512-a9f7afa41cee.png)

after
![radare2-96ump](https://user-images.githubusercontent.com/13299299/34319769-62348f6e-e7ea-11e7-918d-fc35c6b6a491.png)
