### PR TITLE
Fix typo regarding byte size

### DIFF
--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -518,7 +518,7 @@ int main(int argc, char **argv) {
 			return 1;
 		} else if (compareBin_len != r_hash_size (algobit))   {
 			eprintf (
-				"rahash2: Given -c hash has %d bytes but the selected algorithm returns %d bytes.\n",
+				"rahash2: Given -c hash has %d byte(s) but the selected algorithm returns %d byte(s).\n",
 				compareBin_len,
 				r_hash_size (algobit));
 			free (compareBin);

--- a/libr/anal/data.c
+++ b/libr/anal/data.c
@@ -98,7 +98,7 @@ R_API char *r_anal_data_to_string(RAnalData *d, RConsPalette *pal) {
 
 	line = malloc (mallocsz);
 	if (!line) {
-		eprintf ("Cannot allocate %d bytes\n", mallocsz);
+		eprintf ("Cannot allocate %d byte(s)\n", mallocsz);
 		return NULL;
 	}
 	if (pal) {
@@ -224,7 +224,7 @@ R_API RAnalData *r_anal_data_new_string(ut64 addr, const char *p, int len, int t
 		ad->buf = malloc (len + 1);
 		if (!ad->buf) {
 			r_anal_data_free (ad);
-			eprintf ("Cannot allocate %d bytes\n", len + 1);
+			eprintf ("Cannot allocate %d byte(s)\n", len + 1);
 			return NULL;
 		}
 		memcpy (ad->buf, ad->str, len + 1);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1822,7 +1822,7 @@ R_API int r_anal_str_to_fcn(RAnal *a, RAnalFunction *f, const char *sig) {
 	/* Add 'function' keyword */
 	char *str = calloc (1, length);
 	if (!str) {
-		eprintf ("Cannot allocate %d bytes\n", length);
+		eprintf ("Cannot allocate %d byte(s)\n", length);
 		return false;
 	}
 	strcpy (str, "function ");

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -722,7 +722,7 @@ static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 	memset (op, '\0', sizeof (RAnalOp));
 
 	IFDBG {
-		//eprintf ("Extracting op from buffer (%d bytes) @ 0x%04x\n", len, addr);
+		//eprintf ("Extracting op from buffer (%d byte(s)) @ 0x%04x\n", len, addr);
 		//eprintf ("Parsing op: (0x%02x) %s.\n", op_byte, JAVA_OPS[op_byte].name);
 	}
 	op->addr = addr;

--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -126,7 +126,7 @@ R_API void r_bin_filter_classes(RList *list) {
 				if (sym->name)
 					r_bin_filter_sym (db, sym->vaddr, sym);
 			}
-		} else eprintf ("Cannot alloc %d bytes\n", namepad_len);
+		} else eprintf ("Cannot alloc %d byte(s)\n", namepad_len);
 	}
 	sdb_free (db);
 }

--- a/libr/bin/format/elf/elf_write.c
+++ b/libr/bin/format/elf/elf_write.c
@@ -163,7 +163,7 @@ ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const cha
 	r_buf_read_at (bin->b, rsz_offset + rsz_osize, (ut8*)buf, rest_size);
 	printf ("COPY TO 0x%08"PFMT64x"\n", (ut64)(rsz_offset+rsz_size));
 	r_buf_write_at (bin->b, rsz_offset + rsz_size, (ut8*)buf, rest_size);
-	printf ("Shifted %d bytes\n", (int)delta);
+	printf ("Shifted %d byte(s)\n", (int)delta);
 	free (buf);
 	bin->size = bin->b->length;
 

--- a/libr/cons/editor.c
+++ b/libr/cons/editor.c
@@ -62,7 +62,7 @@ static void filesave() {
 		}
 	}
 	if (r_file_dump (path, (const ut8 *)lines, bytes, 0)) {
-		eprintf ("File '%s' saved (%d bytes)\n", path, bytes);
+		eprintf ("File '%s' saved (%d byte(s))\n", path, bytes);
 	} else {
 		eprintf ("Cannot save file\n");
 	}
@@ -81,7 +81,7 @@ R_API char *r_cons_editor(const char *file, const char *str) {
 		bytes = 0;
 		lines = r_file_slurp (file, &bytes);
 		nlines = r_str_split (lines, '\n');
-		eprintf ("Loaded %d lines on %d bytes\n",
+		eprintf ("Loaded %d lines on %d byte(s)\n",
 			(nlines? (nlines - 1): 0), bytes);
 	} else {
 		path = NULL;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1054,7 +1054,7 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 				r_core_print_disasm_json (core, bbi->addr, buf, bbi->size, 0);
 				free (buf);
 			} else {
-				eprintf ("cannot allocate %d bytes\n", bbi->size);
+				eprintf ("cannot allocate %d byte(s)\n", bbi->size);
 			}
 			r_cons_printf ("]}");
 			continue;

--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -80,7 +80,7 @@ R_API bool r_core_dump(RCore *core, const char *file, ut64 addr, ut64 size, int 
 		bs = 4096;
 	buf = malloc (bs);
 	if (!buf) {
-		eprintf ("Cannot alloc %d bytes\n", bs);
+		eprintf ("Cannot alloc %d byte(s)\n", bs);
 		fclose (fd);
 		return false;
 	}
@@ -378,7 +378,7 @@ R_API int r_core_shift_block(RCore *core, ut64 addr, ut64 b_size, st64 dist) {
 	}
 	shift_buf = calloc (b_size, 1);
 	if (!shift_buf) {
-		eprintf ("Cannot allocated %d bytes\n", (int)b_size);
+		eprintf ("Cannot allocated %d byte(s)\n", (int)b_size);
 		return false;
 	}
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3899,7 +3899,7 @@ static void cmd_aespc(RCore *core, ut64 addr, int off) {
 	}
 	buf = malloc (bsize);
 	if (!buf) {
-		eprintf ("Cannot allocate %d bytes\n", bsize);
+		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		free (buf);
 		return;
 	}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1224,7 +1224,7 @@ static int dump_maps(RCore *core, int perm, const char *filename) {
 				eprintf ("Cannot write '%s'\n", file);
 				ret = 0;
 			} else {
-				eprintf ("Dumped %d bytes into %s\n", (int)map->size, file);
+				eprintf ("Dumped %d byte(s) into %s\n", (int)map->size, file);
 			}
 			free (file);
 			free (buf);
@@ -1558,14 +1558,14 @@ static int cmd_debug_map(RCore *core, const char *input) {
 				char *buf = r_file_slurp (input + 2, &sz);
 				//TODO: use mmap here. we need a portable implementation
 				if (!buf) {
-					eprintf ("Cannot allocate 0x%08"PFMT64x" bytes\n", map->size);
+					eprintf ("Cannot allocate 0x%08"PFMT64x" byte(s)\n", map->size);
 					return false;
 				}
 				r_io_write_at (core->io, map->addr, (const ut8*)buf, sz);
 				if (sz != map->size)
 					eprintf	("File size differs from region size (%d vs %"PFMT64d")\n",
 							sz, map->size);
-				eprintf ("Loaded %d bytes into the map region at 0x%08"PFMT64x"\n",
+				eprintf ("Loaded %d byte(s) into the map region at 0x%08"PFMT64x"\n",
 						sz, map->addr);
 				free (buf);
 				return true;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -754,7 +754,7 @@ static void cmd_pDj(RCore *core, const char *arg) {
 			r_core_print_disasm_json (core, core->offset, buf, bsize, 0);
 			free (buf);
 		} else {
-			eprintf ("cannot allocate %d bytes\n", bsize);
+			eprintf ("cannot allocate %d byte(s)\n", bsize);
 		}
 	}
 	r_cons_print ("]");
@@ -976,7 +976,7 @@ static void cmd_print_format(RCore *core, const char *_input, int len) {
 			_input++;
 			val = sdb_get (core->print->formats, _input, NULL);
 			if (val != NULL) {
-				r_cons_printf ("%d bytes\n", r_print_format_struct_size (val, core->print, mode, 0));
+				r_cons_printf ("%d byte(s)\n", r_print_format_struct_size (val, core->print, mode, 0));
 			} else {
 				eprintf ("Struct %s not defined\nUsage: pfs.struct_name | pfs format\n", _input);
 			}
@@ -985,7 +985,7 @@ static void cmd_print_format(RCore *core, const char *_input, int len) {
 				_input++;
 			}
 			if (*_input) {
-				r_cons_printf ("%d bytes\n", r_print_format_struct_size (_input, core->print, mode, 0));
+				r_cons_printf ("%d byte(s)\n", r_print_format_struct_size (_input, core->print, mode, 0));
 			} else {
 				eprintf ("Struct %s not defined\nUsage: pfs.struct_name | pfs format\n", _input);
 			}
@@ -3104,7 +3104,7 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 					r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
 					free (buf);
 				} else {
-					eprintf ("cannot allocate %d bytes\n", b->size);
+					eprintf ("cannot allocate %d byte(s)\n", b->size);
 				}
 			}
 		}
@@ -3132,7 +3132,7 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 				r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
 				free (buf);
 			} else {
-				eprintf ("cannot allocate %d bytes\n", b->size);
+				eprintf ("cannot allocate %d byte(s)\n", b->size);
 			}
 		}
 		for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
@@ -3162,7 +3162,7 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 					r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
 					free (buf);
 				} else {
-					eprintf ("cannot allocate %d bytes\n", b->size);
+					eprintf ("cannot allocate %d byte(s)\n", b->size);
 				}
 			}
 		}
@@ -3858,7 +3858,7 @@ static int cmd_print(void *data, const char *input) {
 				r_cons_println (buf + from);
 				free (buf);
 			} else {
-				eprintf ("ERROR: Cannot malloc %d bytes\n", size);
+				eprintf ("ERROR: Cannot malloc %d byte(s)\n", size);
 			}
 		}
 	}
@@ -3879,7 +3879,7 @@ static int cmd_print(void *data, const char *input) {
 				r_cons_println (buf);
 				free (buf);
 			} else {
-				eprintf ("ERROR: Cannot malloc %d bytes\n", size);
+				eprintf ("ERROR: Cannot malloc %d byte(s)\n", size);
 			}
 		}
 	}
@@ -4219,7 +4219,7 @@ static int cmd_print(void *data, const char *input) {
 							}
 						}
 					} else {
-						eprintf ("cannot allocate %d bytes\n", fcn_size);
+						eprintf ("cannot allocate %d byte(s)\n", fcn_size);
 					}
 					r_cons_printf ("]}\n");
 					pd_result = 0;
@@ -4372,7 +4372,7 @@ static int cmd_print(void *data, const char *input) {
 						core->num->value = r_core_print_disasm (core->print,
 							core, addr, block, addrbytes * l, l, 0, 1, formatted_json);
 					} else {
-						eprintf ("Cannot allocate %d bytes\n", addrbytes * l);
+						eprintf ("Cannot allocate %d byte(s)\n", addrbytes * l);
 					}
 				} else {
 					int bs1 = l * 16;

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1613,7 +1613,7 @@ static int emulateSyscallPrelude(RCore *core, ut64 at, ut64 curpc) {
 	
 	arr = malloc (bsize);
 	if (!arr) {
-		eprintf ("Cannot allocate %d bytes\n", bsize);
+		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		free (arr);
 		return -1;
 	}
@@ -1675,7 +1675,7 @@ static void do_syscall_search(RCore *core, struct search_parameters *param) {
 	}
 	buf = malloc (bsize);
 	if (!buf) {
-		eprintf ("Cannot allocate %d bytes\n", bsize);
+		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		r_anal_esil_free (esil);
 		free (buf);
 		return;
@@ -1846,7 +1846,7 @@ static void do_anal_search(RCore *core, struct search_parameters *param, const c
 	input = r_str_chop_ro (input);
 	buf = malloc (bsize);
 	if (!buf) {
-		eprintf ("Cannot allocate %d bytes\n", bsize);
+		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		return;
 	}
 	r_cons_break_push (NULL, NULL);
@@ -2357,7 +2357,7 @@ static ut8 *v_writebuf(RCore *core, RList *nums, int len, char ch, int bsize) {
 	int i = 0;
 	ut8 *buf = malloc (bsize);
 	if (!buf) {
-		eprintf ("Cannot allocate %d bytes\n", bsize);
+		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		free (buf);
 		return NULL;
 	}	
@@ -2946,7 +2946,7 @@ reread:
 		len = r_str_unescape (inp);
 #if 0
 		if (!json) {
-			eprintf ("Searching %d bytes from 0x%08"PFMT64x " to 0x%08"PFMT64x ": ",
+			eprintf ("Searching %d byte(s) from 0x%08"PFMT64x " to 0x%08"PFMT64x ": ",
 					len, search_itv.addr, r_itv_end (search_itv));
 			for (i = 0; i < len; i++) {
 				eprintf ("%02x ", (ut8) inp[i]);
@@ -3091,7 +3091,7 @@ reread:
 			kw = r_search_keyword_new (buf + offset, len, NULL, 0, NULL);
 			if (kw) {
 				r_search_kw_add (core->search, kw);
-				// eprintf ("Searching %d bytes...\n", kw->keyword_length);
+				// eprintf ("Searching %d byte(s)...\n", kw->keyword_length);
 				r_search_begin (core->search);
 				dosearch = true;
 			} else {
@@ -3121,7 +3121,7 @@ reread:
 			}
 			if (kw) {
 				r_search_kw_add (core->search, kw);
-				// eprintf ("Searching %d bytes...\n", kw->keyword_length);
+				// eprintf ("Searching %d byte(s)...\n", kw->keyword_length);
 				r_search_begin (core->search);
 				dosearch = true;
 			} else {

--- a/libr/core/cmd_section.c
+++ b/libr/core/cmd_section.c
@@ -198,7 +198,7 @@ static bool dumpSectionsToDisk(RCore *core) {
 			free (buf);
 			return false;
 		}
-		eprintf ("Dumped %d bytes into %s\n", (int)s->size, file);
+		eprintf ("Dumped %d byte(s) into %s\n", (int)s->size, file);
 		free (buf);
 	}
 	return true;
@@ -239,7 +239,7 @@ static bool dumpSectionToDisk(RCore *core, char *file) {
 				free (heapfile);
 				return false;
 			}
-			eprintf ("Dumped %d bytes into %s\n", (int)s->size, file);
+			eprintf ("Dumped %d byte(s) into %s\n", (int)s->size, file);
 			free (buf);
 			free (heapfile);
 			return true;
@@ -472,7 +472,7 @@ static int cmd_section(void *data, const char *input) {
 					return false;
 				}
 				r_io_write_at (core->io, s->vaddr, (const ut8*)buf, sz);
-				eprintf ("Loaded %d bytes into the map region "
+				eprintf ("Loaded %d byte(s) into the map region "
 					" at 0x%08"PFMT64x"\n", sz, s->vaddr);
 				free (buf);
 				return true;

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -208,7 +208,7 @@ static bool encrypt_or_decrypt_block(RCore *core, const char *algo, const char *
 	RCrypto *cry = r_crypto_new ();
 	if (r_crypto_use (cry, algo)) {
 		if (!binkey) {
-			eprintf ("Cannot allocate %d bytes\n", keylen);
+			eprintf ("Cannot allocate %d byte(s)\n", keylen);
 			r_crypto_free (cry);
 			return false;
 		}
@@ -232,7 +232,7 @@ static bool encrypt_or_decrypt_block(RCore *core, const char *algo, const char *
 			ut8 *result = r_crypto_get_output (cry, &result_size);
 			if (result) {
 				r_io_write_at (core->io, core->offset, result, result_size);
-				eprintf ("Written %d bytes\n", result_size);
+				eprintf ("Written %d byte(s)\n", result_size);
 				free (result);
 			}
 		} else {
@@ -628,7 +628,7 @@ static int cmd_write(void *data, const char *input) {
 					r_io_write_at (core->io, core->offset, buf, len);
 					r_core_block_read (core);
 					free (buf);
-				} else eprintf ("Cannot allocate %d bytes\n", (int)len);
+				} else eprintf ("Cannot allocate %d byte(s)\n", (int)len);
 			}
 		}
 		break;
@@ -928,7 +928,7 @@ static int cmd_write(void *data, const char *input) {
 				r_core_write_at (core, core->offset, buf, len);
 				WSEEK (core, len);
 				free (buf);
-			} else eprintf ("Cannot allocate %d bytes\n", len);
+			} else eprintf ("Cannot allocate %d byte(s)\n", len);
 		}
 		break;
 	case 'A':
@@ -1291,7 +1291,7 @@ static int cmd_write(void *data, const char *input) {
 					cmd_write_hexpair(core, acode->buf_hex);
 				} else {
 					if (r_config_get_i (core->config, "scr.prompt"))
-						eprintf ("Written %d bytes (%s) = wx %s\n", acode->len, input+2, acode->buf_hex);
+						eprintf ("Written %d byte(s) (%s) = wx %s\n", acode->len, input+2, acode->buf_hex);
 					r_core_write_at (core, core->offset, acode->buf, acode->len);
 					WSEEK (core, acode->len);
 					r_core_block_read (core);
@@ -1310,7 +1310,7 @@ static int cmd_write(void *data, const char *input) {
 						cmd_write_hexpair(core, acode->buf_hex);
 					} else {
 						if (r_config_get_i (core->config, "scr.prompt"))
-						eprintf ("Written %d bytes (%s)=wx %s\n", acode->len, input+1, acode->buf_hex);
+						eprintf ("Written %d byte(s) (%s)=wx %s\n", acode->len, input+1, acode->buf_hex);
 						r_core_write_at (core, core->offset, acode->buf, acode->len);
 						WSEEK (core, acode->len);
 						r_core_block_read (core);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -283,7 +283,7 @@ static void core_post_write_callback(void *user, ut64 maddr, ut8 *bytes, int cnt
 		return;
 	}
 
-	char *comment = r_str_newf ("patch: %d bytes (%s)", cnt, hex_pairs);
+	char *comment = r_str_newf ("patch: %d byte(s) (%s)", cnt, hex_pairs);
 	free (hex_pairs);
 	if (!comment) {
 		eprintf ("core_post_write_callback: Cannot create comment\n");
@@ -1662,7 +1662,7 @@ R_API bool r_core_init(RCore *core) {
 	core->blocksize = R_CORE_BLOCKSIZE;
 	core->block = (ut8*)calloc (R_CORE_BLOCKSIZE + 1, 1);
 	if (!core->block) {
-		eprintf ("Cannot allocate %d bytes\n", R_CORE_BLOCKSIZE);
+		eprintf ("Cannot allocate %d byte(s)\n", R_CORE_BLOCKSIZE);
 		/* XXX memory leak */
 		return false;
 	}
@@ -2276,7 +2276,7 @@ reaccept:
 					free (ptr);
 					ptr = NULL;
 				} else {
-					eprintf ("Cannot read %d bytes\n", i);
+					eprintf ("Cannot read %d byte(s)\n", i);
 					r_socket_free (c);
 					// TODO: reply error here
 					goto out_of_function;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2926,7 +2926,7 @@ static void ds_print_asmop_payload(RDisasmState *ds, const ut8 *buf) {
 		}
 	}
 	if (ds->asmop.payload != 0) {
-		r_cons_printf ("\n; .. payload of %d bytes", ds->asmop.payload);
+		r_cons_printf ("\n; .. payload of %d byte(s)", ds->asmop.payload);
 		if (ds->showpayloads) {
 			int mod = ds->asmop.payload % ds->core->assembler->dataalign;
 			int x;

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -797,7 +797,7 @@ static int r_core_rtr_http_run(RCore *core, int launch, const char *path) {
 						r_file_dump (filename, ret, retlen, 0);
 						free (filename);
 						snprintf (buf, sizeof (buf),
-							"<html><body><h2>uploaded %d bytes. Thanks</h2>\n", retlen);
+							"<html><body><h2>uploaded %d byte(s). Thanks</h2>\n", retlen);
 							r_socket_http_response (rs, 200, buf, 0, headers);
 					}
 					free (ret);
@@ -959,7 +959,7 @@ static int write_big_reg(char *buf, ut64 sz, const utX *val, int regsize, bool b
 				 r_swap_ut64 (val->v128.Low),
 				 r_swap_ut64 (val->v128.High));
 	default:
-		eprintf ("%s: big registers (%d bytes) not yet supported\n",
+		eprintf ("%s: big registers (%d byte(s)) not yet supported\n",
 			 __func__, regsize);
 		return -1;
 	}
@@ -1006,7 +1006,7 @@ static int swap_big_regs (char *dest, ut64 sz, const char *src, int regsz) {
 		return snprintf (dest, sz, "0x%016"PFMT64x"%016"PFMT64x,
 				 val.v128.High, val.v128.Low);
 	default:
-		eprintf ("%s: big registers (%d bytes) not yet supported\n",
+		eprintf ("%s: big registers (%d byte(s)) not yet supported\n",
 			 __func__, regsz);
 		return -1;
 	}

--- a/libr/core/task.c
+++ b/libr/core/task.c
@@ -76,7 +76,7 @@ R_API void r_core_task_run(RCore *core, RCoreTask *_task) {
 		}
 		task->state = 'r'; // running
 		str = r_core_cmd_str (core, task->msg->text);
-		eprintf ("Task %d finished width %d bytes: %s\n%s\n",
+		eprintf ("Task %d finished width %d byte(s): %s\n%s\n",
 				task->id, (int)strlen (str), task->msg->text, str);
 		task->state = 'd'; // done
 		task->msg->done = 1; // done DUP!!
@@ -97,7 +97,7 @@ R_API void r_core_task_run_bg(RCore *core, RCoreTask *_task) {
 		}
 		task->state = 'r'; // running
 		str = r_core_cmd_str (core, task->msg->text);
-		eprintf ("Task %d finished width %d bytes: %s\n%s\n",
+		eprintf ("Task %d finished width %d byte(s): %s\n%s\n",
 				task->id, (int)strlen (str), task->msg->text, str);
 		task->state = 'd'; // done
 		task->msg->done = 1; // done DUP!!

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -243,7 +243,7 @@ R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 			free (snap->data);
 			goto error;
 		}
-		eprintf ("Reading %d bytes from 0x%08"PFMT64x "...\n", snap->size, snap->addr);
+		eprintf ("Reading %d byte(s) from 0x%08"PFMT64x "...\n", snap->size, snap->addr);
 		dbg->iob.read_at (dbg->iob.io, snap->addr, snap->data, snap->size);
 
 		ut32 clust_page = R_MIN (SNAP_PAGE_SIZE, snap->size);

--- a/libr/io/p/io_bfdbg.c
+++ b/libr/io/p/io_bfdbg.c
@@ -171,7 +171,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			return r_io_desc_new (io, &r_io_plugin_bfdbg,
 				pathname, rw, mode, mal);
 		}
-		eprintf ("Cannot allocate (%s) %d bytes\n",
+		eprintf ("Cannot allocate (%s) %d byte(s)\n",
 			pathname+9, mal->size);
 		free (mal);
 		free (out);

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -318,7 +318,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 			}
 			return NULL;
 		}
-		io->cb_printf ("num_retries: %d bytes\n", desc->page_size);
+		io->cb_printf ("num_retries: %d byte(s)\n", desc->page_size);
 		return NULL;
 	}
 	if (r_str_startswith (cmd, "page_size")) {
@@ -329,7 +329,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 			}
 			return NULL;
 		}
-		io->cb_printf ("page size: %d bytes\n", desc->page_size);
+		io->cb_printf ("page size: %d byte(s)\n", desc->page_size);
 		return NULL;
 	}
 	// Sets a flag that next call to get memmap will be for getting baddr

--- a/libr/io/p/io_gzip.c
+++ b/libr/io/p/io_gzip.c
@@ -171,7 +171,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			return r_io_desc_new (io, &r_io_plugin_gzip, pathname, rw, mode, mal);
 		}
 		free (data);
-		eprintf ("Cannot allocate (%s) %d bytes\n", pathname+9, mal->size);
+		eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname+9, mal->size);
 		free (mal);
 	}
 	return NULL;

--- a/libr/io/p/io_http.c
+++ b/libr/io/p/io_http.c
@@ -94,7 +94,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 				return r_io_desc_new (io, &r_io_plugin_http,
 					pathname, rw, mode, mal);
 			}
-			eprintf ("Cannot allocate (%s) %d bytes\n", pathname+9, mal->size);
+			eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname+9, mal->size);
 			free (mal);
 		}
 		free (out);

--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -329,7 +329,7 @@ static int mach_write_at(RIO *io, RIODesc *desc, const void *buf, int len, ut64 
 	}
 	operms = tsk_getperm (io, task, pageaddr);
 	if (!tsk_setperm (io, task, pageaddr, total_size, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY)) {
-		eprintf ("io.mach: Cannot set page perms for %d bytes at 0x%08"
+		eprintf ("io.mach: Cannot set page perms for %d byte(s) at 0x%08"
 			PFMT64x"\n", (int)pagesize, (ut64)pageaddr);
 		return -1;
 	}

--- a/libr/io/p/io_malloc.c
+++ b/libr/io/p/io_malloc.c
@@ -184,7 +184,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 		if (mal->buf) {
 			return r_io_desc_new (io, &r_io_plugin_malloc, pathname, R_IO_RW | rw, mode, mal);
 		}
-		eprintf ("Cannot allocate (%s) %d bytes\n", pathname + 9, mal->size);
+		eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname + 9, mal->size);
 		free (mal);
 	}
 	return NULL;

--- a/libr/io/p/io_sparse.c
+++ b/libr/io/p/io_sparse.c
@@ -78,7 +78,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 		if (size > 0) {
 			ut8 *data = malloc (size);
 			if (!data) {
-				eprintf ("Cannot allocate (%s) %d bytes\n",
+				eprintf ("Cannot allocate (%s) %d byte(s)\n",
 					pathname+9, size);
 				mal->offset = 0;
 			} else {

--- a/libr/io/p/io_tcp.c
+++ b/libr/io/p/io_tcp.c
@@ -152,7 +152,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 				return r_io_desc_new (io, &r_io_plugin_tcp,
 					pathname, rw, mode, mal);
 			}
-			eprintf ("Cannot allocate (%s) %d bytes\n", pathname + 9, mal->size);
+			eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname + 9, mal->size);
 			free (mal);
 		}
 		free (out);

--- a/libr/magic/d/default/archive
+++ b/libr/magic/d/default/archive
@@ -81,7 +81,7 @@
 >9	string	\0		
 >>0	string	KWAJ		
 >>>7	string	\321\003	MS Compress archive data
->>>>14	ulong	>0		\b, original size: %d bytes
+>>>>14	ulong	>0		\b, original size: %d byte(s)
 >>>>18		ubyte	>0x65  	
 >>>>>18		string	x    	\b, was %.8s
 >>>>>(10.b-4)	string	x    	\b.%.3s
@@ -233,7 +233,7 @@
 0	string	RZIP		rzip compressed data
 >4	byte	x		- version %d
 >5	byte	x		\b.%d
->6	belong	x		(%d bytes)
+>6	belong	x		(%d byte(s))
 
 # From: Dirk Jagdmann <doj@cubic.org>
 # xar archive format: http://code.google.com/p/xar/

--- a/libr/magic/d/default/compressed
+++ b/libr/magic/d/default/compressed
@@ -50,7 +50,7 @@
 >8	byte		>4		\b, invalid extra flags
 >3      byte            &0x02           \b, has header CRC
 >3      byte&0x04       0x04
->>10	leshort		x		\b, has %d bytes of extra data
+>>10	leshort		x		\b, has %d byte(s) of extra data
 >3      byte&0xC        =0x08		\b, has original file name
 >>10	string		x		\b{file-name:%s}
 >>10    string          x               \b: "%s"

--- a/libr/magic/d/default/filesystems
+++ b/libr/magic/d/default/filesystems
@@ -834,7 +834,7 @@
 
 # romfs filesystems - Juan Cespedes <cespedes@debian.org>
 0	string		-rom1fs-\0	romfs filesystem, version 1
->8	belong	x			%d bytes,
+>8	belong	x			%d byte(s),
 >16	string	x			named %s.
 
 # netboot image - Juan Cespedes <cespedes@debian.org>
@@ -1206,30 +1206,30 @@
 >28	beshort	x	version %d.
 >30	beshort x	\b%d,
 >28	beshort <3
->>8	belong	x	%d bytes,
+>>8	belong	x	%d byte(s),
 >28	beshort >2
 >>63	bequad x	%lld bytes,
-#>>67	belong	x	%d bytes,
+#>>67	belong	x	%d byte(s),
 >4	belong	x	%d inodes,
 >28	beshort <2
->>32	beshort	x	blocksize: %d bytes,
+>>32	beshort	x	blocksize: %d byte(s),
 >28	beshort >1
->>51	belong	x	blocksize: %d bytes,
+>>51	belong	x	blocksize: %d byte(s),
 >39	bedate	x	created: %s
 
 0	string	hsqs	Squashfs filesystem, little endian,
 >28	leshort	x	version %d.
 >30	leshort	x	\b%d,
 >28	leshort <3
->>8	lelong	x	%d bytes,
+>>8	lelong	x	%d byte(s),
 >28	leshort >2
 >>63	lequad x	%lld bytes,
-#>>63	lelong	x	%d bytes,
+#>>63	lelong	x	%d byte(s),
 >4	lelong	x	%d inodes,
 >28	leshort <2
->>32	leshort	x	blocksize: %d bytes,
+>>32	leshort	x	blocksize: %d byte(s),
 >28	leshort >1
->>51	lelong	x	blocksize: %d bytes,
+>>51	lelong	x	blocksize: %d byte(s),
 >39	ledate	x	created: %s
 
 # Squashfs
@@ -1237,44 +1237,44 @@
 >28	leshort	x	version %d.
 >30	leshort	x	\b%d,
 >28	leshort <3
->>8	lelong	x	%d bytes,
+>>8	lelong	x	%d byte(s),
 >28	leshort >2
 >>63	lequad x	%lld bytes,
-#>>63	lelong	x	%d bytes,
+#>>63	lelong	x	%d byte(s),
 >4	lelong	x	%d inodes,
 >28	leshort <2
->>32	leshort	x	blocksize: %d bytes,
+>>32	leshort	x	blocksize: %d byte(s),
 >28	leshort >1
->>51	lelong	x	blocksize: %d bytes,
+>>51	lelong	x	blocksize: %d byte(s),
 >39	ledate	x	created: %s
 0	string	hsqt	Squashfs filesystem, little endian,
 >28	beshort	x	version %d.
 >30	beshort x	\b%d,
 >28	beshort <3
->>8	belong	x	%d bytes,
+>>8	belong	x	%d byte(s),
 >28	beshort >2
 >>63	bequad x	%lld bytes,
-#>>67	belong	x	%d bytes,
+#>>67	belong	x	%d byte(s),
 >4	belong	x	%d inodes,
 >28	beshort <2
->>32	beshort	x	blocksize: %d bytes,
+>>32	beshort	x	blocksize: %d byte(s),
 >28	beshort >1
->>51	belong	x	blocksize: %d bytes,
+>>51	belong	x	blocksize: %d byte(s),
 >39	bedate	x	created: %s
 
 #  0	string	hsqs	Squashfs filesystem, little endian,
 #  >28	leshort	x	version %d.
 #  >30	leshort	x	\b%d,
 #  >28	leshort <3
-#  >>8	lelong	x	%d bytes,
+#  >>8	lelong	x	%d byte(s),
 #  >28	leshort >2
 #  >>63	lequad x	%lld bytes,
-#  #>>63	lelong	x	%d bytes,
+#  #>>63	lelong	x	%d byte(s),
 #  >4	lelong	x	%d inodes,
 #  >28	leshort <2
-#  >>32	leshort	x	blocksize: %d bytes,
+#  >>32	leshort	x	blocksize: %d byte(s),
 #  >28	leshort >1
-#  >>51	lelong	x	blocksize: %d bytes,
+#  >>51	lelong	x	blocksize: %d byte(s),
 #  >39	ledate	x	created: %s
 
 #0	string		td\000		floppy image data (TeleDisk)

--- a/libr/magic/d/default/freebsd
+++ b/libr/magic/d/default/freebsd
@@ -139,6 +139,6 @@
 #
 0	string	SCRSHOT_	scrshot(1) screenshot,
 >8	byte	x		version %d,
->9	byte	2		%d bytes in header,
+>9	byte	2		%d byte(s) in header,
 >>10	byte	x		%d chars wide by
 >>11	byte	x		%d chars high

--- a/libr/parse/p/parse_mreplace/mmemory.c
+++ b/libr/parse/p/parse_mreplace/mmemory.c
@@ -58,7 +58,7 @@ memChunk *memReserve(long size) {
 		perror ("memReserve");
 		exit (0);
   	}
-	//printf("- reservando %d bytes\n",size);
+	//printf("- reservando %d byte(s)\n",size);
 	buffer->size = size;
 	memset (buffer->address, 0, buffer->size);
 	mInfo->allocated += buffer->size;
@@ -84,7 +84,7 @@ void memCopy(memChunk *dest,memChunk *source) {
 	if ((!source->address) || (!dest->address)) return;
 	nbytes=dest->size > source->size ? source->size : dest->size;
 	#if DEBUG3
-	eprintf ("Copying %d bytes to dest (size %d)\n", nbytes, dest->address, dest->size);
+	eprintf ("Copying %d byte(s) to dest (size %d)\n", nbytes, dest->address, dest->size);
 	#endif
 	memcpy (dest->address, source->address, nbytes);
 }

--- a/libr/parse/p/parse_mreplace/mreplace.c
+++ b/libr/parse/p/parse_mreplace/mreplace.c
@@ -239,7 +239,7 @@ void doChecks(){
 	}
 
 	for(n=1;n<=CHECKS_CHUNCK_COUNT;n+=1+CHECKS_CHUNCK_COUNT/10){
-		fprintf(stdout,"\r[ + ] Checking stability for different input sizes consistence %d bytes, memory allocated: %d bytes",n*CHECKS_CHUNCK_COUNT*CHECKS_CHUNCK_SIZE,memAllocated());
+		fprintf(stdout,"\r[ + ] Checking stability for different input sizes consistence %d byte(s), memory allocated: %d byte(s)",n*CHECKS_CHUNCK_COUNT*CHECKS_CHUNCK_SIZE,memAllocated());
 		fflush(stdout);
 		memset(checkBuffer,'.',n*CHECKS_CHUNCK_SIZE-1);
 		checkBuffer[n*CHECKS_CHUNCK_SIZE]=0;
@@ -247,7 +247,7 @@ void doChecks(){
 		treplace(checkBuffer,"_",".");
 	}
 	fprintf(stdout,"\n");
-	fprintf(stdout,"[ m ] Memory allocated final: %d bytes\n",memAllocated());
+	fprintf(stdout,"[ m ] Memory allocated final: %d byte(s)\n",memAllocated());
 }
 
 /*

--- a/libr/util/bdiff.c
+++ b/libr/util/bdiff.c
@@ -322,7 +322,7 @@ R_API int r_diff_buffers_delta(RDiff *d, const ut8 *sa, int la, const ut8 *sb, i
 			}
 #if 0	
 			if (rlen > 0) {
-				//printf ("Remove %d bytes at %d\n", rlen, offa);
+				//printf ("Remove %d byte(s) at %d\n", rlen, offa);
 				printf ("r-%d @ 0x%"PFMT64x"\n", rlen, (ut64)offa);
 			}
 			printf ("e file.write=true\n"); // XXX

--- a/libr/util/diff.c
+++ b/libr/util/diff.c
@@ -40,7 +40,7 @@ R_API int r_diff_buffers_static(RDiff *d, const ut8 *a, int la, const ut8 *b, in
 	lb = R_ABS (lb);
 	if (la != lb) {
 	 	len = R_MIN(la, lb);
-		eprintf ("Buffer truncated to %d bytes (%d not compared)\n", len, R_ABS(lb-la));
+		eprintf ("Buffer truncated to %d byte(s) (%d not compared)\n", len, R_ABS(lb-la));
 	} else {
 		len = la;
 	}

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -873,7 +873,7 @@ R_API char *r_str_word_get_first(const char *text) {
 	len = strlen (text);
 	ret = (char *)malloc (len + 1);
 	if (!ret) {
-		eprintf ("Cannot allocate %d bytes.\n", len+1);
+		eprintf ("Cannot allocate %d byte(s).\n", len+1);
 		return NULL;
 	}
 	strncpy (ret, text, len);

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -3821,7 +3821,7 @@ R_API RBinJavaAttrInfo *r_bin_java_source_debug_attr_new(ut8 *buffer, ut64 sz, u
 		attr->info.debug_extensions.debug_extension = NULL;
 		return attr;
 	} else if ((attr->length + offset) > sz) {
-		eprintf ("r_bin_java_source_debug_attr_new: Expected %d bytes got %"
+		eprintf ("r_bin_java_source_debug_attr_new: Expected %d byte(s) got %"
 			PFMT64d " bytes for debug_extension.\n", attr->length, (offset + sz));
 	}
 	attr->info.debug_extensions.debug_extension = (ut8 *) malloc (attr->length);
@@ -4335,11 +4335,11 @@ R_API RBinJavaStackMapFrame *r_bin_java_stack_map_frame_new(ut8 *buffer, ut64 sz
 		IFDBG eprintf("r_bin_java_stack_map_frame_new: Parsing R_BIN_JAVA_STACK_FRAME_FULL_FRAME.\n");
 		stack_frame->offset_delta = R_BIN_JAVA_USHORT (buffer, offset);
 		offset += 2;
-		// IFDBG eprintf ("r_bin_java_stack_map_frame_new: Code Size > 65535, read(%d bytes), offset = 0x%08x.\n", var_sz, stack_frame->offset_delta);
+		// IFDBG eprintf ("r_bin_java_stack_map_frame_new: Code Size > 65535, read(%d byte(s)), offset = 0x%08x.\n", var_sz, stack_frame->offset_delta);
 		// Read the number of variables based on the max # local variable
 		stack_frame->number_of_locals = R_BIN_JAVA_USHORT (buffer, offset);
 		offset += 2;
-		// IFDBG eprintf ("r_bin_java_stack_map_frame_new: Max ulocalvar > 65535, read(%d bytes), number_of_locals = 0x%08x.\n", var_sz, stack_frame->number_of_locals);
+		// IFDBG eprintf ("r_bin_java_stack_map_frame_new: Max ulocalvar > 65535, read(%d byte(s)), number_of_locals = 0x%08x.\n", var_sz, stack_frame->number_of_locals);
 		IFDBG r_bin_java_print_stack_map_frame_summary(stack_frame);
 		// read the number of locals off the stack
 		for (i = 0; i < stack_frame->number_of_locals; i++) {
@@ -4357,7 +4357,7 @@ R_API RBinJavaStackMapFrame *r_bin_java_stack_map_frame_new(ut8 *buffer, ut64 sz
 		// Read the number of stack items based on the max size of stack
 		stack_frame->number_of_stack_items = R_BIN_JAVA_USHORT (buffer, offset);
 		offset += 2;
-		// IFDBG eprintf ("r_bin_java_stack_map_frame_new: Max ustack items > 65535, read(%d bytes), number_of_locals = 0x%08x.\n", var_sz, stack_frame->number_of_stack_items);
+		// IFDBG eprintf ("r_bin_java_stack_map_frame_new: Max ustack items > 65535, read(%d byte(s)), number_of_locals = 0x%08x.\n", var_sz, stack_frame->number_of_stack_items);
 		// read the stack items
 		for (i = 0; i < stack_frame->number_of_stack_items; i++) {
 			se = r_bin_java_read_from_buffer_verification_info_new (buffer + offset, sz - offset, buf_offset + offset);
@@ -8765,16 +8765,16 @@ R_API int U(r_bin_java_utf8_cp_set)(RBinJavaObj * bin, ut16 idx, const ut8 * buf
 	if (!cp_obj) {
 		return false;
 	}
-	eprintf ("Writing %d bytes (%s)\n", len, buffer);
+	eprintf ("Writing %d byte(s) (%s)\n", len, buffer);
 	// r_bin_java_check_reset_cp_obj(cp_obj, R_BIN_JAVA_CP_INTEGER);
 	if (cp_obj->tag != R_BIN_JAVA_CP_UTF8) {
 		eprintf ("Not supporting the overwrite of CP Objects with one of a different size.\n");
 		return false;
 	}
 	if (cp_obj->info.cp_utf8.length != len) {
-		eprintf ("Not supporting the resize, rewriting utf8 string up to %d bytes.\n", cp_obj->info.cp_utf8.length);
+		eprintf ("Not supporting the resize, rewriting utf8 string up to %d byte(s).\n", cp_obj->info.cp_utf8.length);
 		if (cp_obj->info.cp_utf8.length > len) {
-			eprintf ("Remaining %d bytes will be filled with \\x00.\n", cp_obj->info.cp_utf8.length - len);
+			eprintf ("Remaining %d byte(s) will be filled with \\x00.\n", cp_obj->info.cp_utf8.length - len);
 		}
 	}
 	memcpy (cp_obj->info.cp_utf8.bytes, buffer, cp_obj->info.cp_utf8.length);

--- a/shlr/java/code.c
+++ b/shlr/java/code.c
@@ -118,7 +118,7 @@ R_API int java_print_opcode(RBinJavaObj *obj, ut64 addr, int idx, const ut8 *byt
 	}
 
 #if 0
-	IFDBG eprintf ("Handling the following opcode %s expects: %d bytes, BYTES_CONSUMED: 0x%04"PFMT64x"\n",
+	IFDBG eprintf ("Handling the following opcode %s expects: %d byte(s), BYTES_CONSUMED: 0x%04"PFMT64x"\n",
 			JAVA_OPS[idx].name, JAVA_OPS[idx].size, BYTES_CONSUMED);
 #endif
 	switch (op_byte) {

--- a/shlr/qnx/src/utils.c
+++ b/shlr/qnx/src/utils.c
@@ -140,7 +140,7 @@ extract_signed_integer (const ut8 *addr, int len, int be) {
 
 	if (len > (int)sizeof(LONGEST))
 		eprintf (
-			"This operation is not available on integers of more than %d bytes\n",
+			"This operation is not available on integers of more than %d byte(s)\n",
 			(int)sizeof(LONGEST));
 
 	/* Start at the most significant end of the integer, and work towards
@@ -170,7 +170,7 @@ extract_unsigned_integer (const ut8 *addr, int len, int be) {
 
 	if (len > (int)sizeof(LONGEST))
 		eprintf (
-			"This operation is not available on integers of more than %d bytes\n",
+			"This operation is not available on integers of more than %d byte(s)\n",
 			(int)sizeof(LONGEST));
 
 	/* Start at the most significant end of the integer, and work towards

--- a/shlr/sdb/src/json/path.c
+++ b/shlr/sdb/src/json/path.c
@@ -126,7 +126,7 @@ SDB_IPI Rangstr json_find (const char *s, Rangstr *rs) {
 	if (len > RESFIXSZ) {
 		res = calloc (len + 1, sizeof (RangstrType));
 		if (!res) {
-			eprintf ("Cannot allocate %d bytes\n", len + 1);
+			eprintf ("Cannot allocate %d byte(s)\n", len + 1);
 			return rangstr_null ();
 		}
 	}

--- a/shlr/tcc/libtcc.c
+++ b/shlr/tcc/libtcc.c
@@ -132,7 +132,7 @@ PUB_FUNC void *tcc_mallocz(unsigned long size)
 PUB_FUNC void tcc_memstats(void)
 {
 #ifdef MEM_DEBUG
-	printf ("memory: %d bytes, max = %d bytes\n", mem_cur_size, mem_max_size);
+	printf ("memory: %d byte(s), max = %d byte(s)\n", mem_cur_size, mem_max_size);
 #endif
 }
 


### PR DESCRIPTION
`byte(s)` will handle all cases: both `1 byte` and `0 or >1 bytes`. 

Fixes #9005 