### PR TITLE
Fix div with byte divisor

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1369,11 +1369,17 @@ static void anop_esil (RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		{
 			int width = INSOP(0).size;
 			dst = getarg (&gop, 0, 0, NULL, DST_AR);
-			const char *r_ax = (width==2)?"ax": (width==4)?"eax":"rax";
-			const char *r_dx = (width==2)?"dx": (width==4)?"edx":"rdx";
+			const char *r_quot = (width==1)?"al": (width==2)?"ax": (width==4)?"eax":"rax";
+			const char *r_rema = (width==1)?"ah": (width==2)?"dx": (width==4)?"edx":"rdx";
+			const char *r_nume = (width==1)?"ax": r_quot;
 			// TODO update flags & handle signedness
-			esilprintf (op, "%s,%s,%%,%s,=,%s,%s,/,%s,=",
-				dst, r_ax, r_dx, dst, r_ax, r_ax);
+			if ( width == 1 ) {
+				esilprintf(op, "0xffffff00,eflags,&=,%s,%s,%%,eflags,|=,%s,%s,/,%s,=,0xff,eflags,&,%s,=,0xffffff00,eflags,&=,2,eflags,|=",
+					   dst, r_nume, dst, r_nume, r_quot, r_rema);
+			} else {
+				esilprintf (op, "%s,%s,%%,%s,=,%s,%s,/,%s,=",
+					    dst, r_nume, r_rema, dst, r_nume, r_quot);
+			}
 		}
 		break;
 	case X86_INS_IMUL:


### PR DESCRIPTION
The following code performs a division with a byte as divisor :
```
$ cat main.S
        .text
        .global main
msg:
        .string "0x%08x\n"
main:
        movl $0xCAFE0000, %eax
        mov $5, %ax
        mov $2, %cl
        div %cl
        
        push %eax
        push $msg
        call printf

        xor %eax, %eax
        call exit
$ gcc -o main main.S -m32
$ ./main
0xcafe0102
```

With r2 the 'div %cl' is translated as
```
       0x000005f5      f6f1           cl,rax,%,rdx,=,cl,rax,/,rax,=
```
and does not change the eax value. Indeed:
```
ar eax=0xcafe0005
ar cl=2
ae cl,rax,%,rdx,=,cl,rax,/,rax,=
ar eax
0xcafe0005
```

The associated code to the DIV in libr/anal/p/anal_x86_cs.c does not check the case where the width of operand is equal to 1. So I have added the following fix:
```
                        const char *r_quot = (width==1)?"al": (width==2)?"ax": (width==4)?"eax":"rax";
                        const char *r_rema = (width==1)?"ah": (width==2)?"dx": (width==4)?"edx":"rdx";
                        const char *r_nume = (width==1)?"ax": r_quot;

                        esilprintf (op, "%s,%s,%%,%s,=,%s,%s,/,%s,=",
                                dst, r_nume, r_rema, dst, r_nume, r_quot);
```
And I get:
```
ar eax=0xcafe0005
ar cl=2
ae cl,ax,%,ah,=,cl,ax,/,al,=
ar eax
0xcafe0182
```
This produces an invalid result, because a part of the input (ax) is modified (ah) before produced all output (ah : remainder, al : quotient) ! Indeed this is equivalent to the following code:
```
ar eax=0xcafe0005
ar cl=2
ae cl,ax,%,ah,=
ar eax
0xcafe0105

ae cl,ax,/,al,=
ar eax
0xcafe0182
```

So I seek a way to use temporary variable inside an ESIL expression, but I did not found it. However I notice inside the "Intel Software Developers Manual IIb" manual that :
```
Flags Affected
The CF, OF, SF, ZF, AF, and PF flags are undefined.
```
It means that a valid implementation of the x86 is allow to modify these flags ! Thus, in this case, why not to use the LSB of the eflags register as temporary variable ?

The layout of the LSB of eflags register after the div operation could be :
```
  offset 0 : CF  : can be reset to 0
  offset 1 : 1   : 1
  offset 2 : PF  : can be reset to 0
  offset 3 : 0   : 0
  offset 4 : AF  : can be reset to 0
  offset 5 : 0   : 0
  offset 6 : ZF  : can be reset to 0
  offset 7 : SF  : can be reset to 0
```

In pseudo-code we have :
```
AX = B * AL + AH

eflags &= 0xffffff00
eflags |= AX % B
AL = AX / B
AH = eflags & 0xff
eflags &= 0xffffff00
eflags |= 2
```
Which corresponds in ESIL expression to:
```
0xffffff00,eflags,&=,cl,ax,%,eflags,|=,cl,ax,/,al,=,0xff,eflags,&,ah,=,0xffffff00,eflags,&=,2,eflags,|=
```

The following code produce the waiting result:
```
ar eax=0xcafe0005
ar cl=2
"ae 0xffffff00,eflags,&=,cl,ax,%,eflags,|=,cl,ax,/,al,=,0xff,eflags,&,ah,=,0xffffff00,eflags,&=,2,eflags,|="
ar eax
```
This corresponds to the proposed fix associated to the commit :
```
                        const char *r_quot = (width==1)?"al": (width==2)?"ax": (width==4)?"eax":"rax";
                        const char *r_rema = (width==1)?"ah": (width==2)?"dx": (width==4)?"edx":"rdx";
                        const char *r_nume = (width==1)?"ax": r_quot;
                        // TODO update flags & handle signedness                                                                                                                                                                  
                        if ( width == 1 ) {
                                esilprintf(op, "0xffffff00,eflags,&=,%s,%s,%%,eflags,|=,%s,%s,/,%s,=,0xff,eflags,&,%s,=,0xffffff00,eflags,&=,2,eflags,|=",
                                           dst, r_nume, dst, r_nume, r_quot, r_rema);
                        } else {
                                esilprintf (op, "%s,%s,%%,%s,=,%s,%s,/,%s,=",
                                           dst, r_nume, r_rema, dst, r_nume, r_quot);
                        }
```


Perspective
=========
It is sure that using the LSB of the eflags register as temporary variable is a bad pratice, and tends to make the code unreadable. A better solution to my mind is to enhance the ESIL engine, by instance to make accessible one or some temporay variables that are reset to 0 at each ESIL expression. Actually I have no idea to implement it. 

