### PR TITLE
Updated r_name_validate_char by adding the space character to list of…

### DIFF
--- a/libr/util/name.c
+++ b/libr/util/name.c
@@ -9,6 +9,7 @@ R_API int r_name_validate_char(const char ch) {
 	case ':':
 	case '.':
 	case '_':
+	case ' ':
 		return true;
 	}
 	return false;


### PR DESCRIPTION
As described in issue #9063 there was an issue with the Ps command saving meta data (which was created via the Cf command) correctly.  After some debugging it appears the point of failure is within the function r_name_validate_char (called from r_meta_print).  Since the space character was not part of the valid character list, the spaces within a Cf command were being replaced with the underscore character.

The fix for this issue is to add the space character to the list of valid characters (as is done in this patch)