### PR TITLE
Fix ragg2-cc compile error with Xcode 7

### DIFF
--- a/binr/ragg2/ragg2-cc
+++ b/binr/ragg2/ragg2-cc
@@ -223,13 +223,13 @@ esac
 USE_CLANG=0
 case "$K-$A-$B" in
 darwin-arm-64)
-	CC="xcrun --sdk iphoneos gcc -arch arm64"
+	CC="xcrun --sdk iphoneos gcc -arch arm64 -miphoneos-version-min=0.0"
 	USE_CLANG=1
 	TEXT=0.__TEXT.__text
 	;;
 darwin-arm-32)
 	USE_CLANG=1
-	CC="xcrun --sdk iphoneos gcc -arch armv7"
+	CC="xcrun --sdk iphoneos gcc -arch armv7 -miphoneos-version-min=0.0"
 	TEXT=0.__TEXT.__text
 	;;
 esac


### PR DESCRIPTION
This commit is just setting the `-miphoneos-version-min` compiler parameter to `0.0` dummy value in order to get it working.

Please note that I don't use Xcode, I only noticed this while trying to compile a Linux shellcode. So there may be incompatibilities with older toolchains, etc.. I can't test for anything other than Xcode7.