### PR TITLE
NULL pointer dereference in the file egg.c

### DIFF
--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -456,6 +456,7 @@ R_API int r_egg_encode(REgg *egg, const char *name) {
 	r_list_foreach (egg->plugins, iter, p) {
 		if (p->type == R_EGG_PLUGIN_ENCODER && !strcmp (name, p->name)) {
 			b = p->build (egg);
+			if (!b) return false;
 			r_buf_free (egg->bin);
 			egg->bin = b;
 			return true;


### PR DESCRIPTION
In the file _egg_xor.c_ there is this allocation for the _buf_ variable

https://github.com/radare/radare2/blob/4bb5c15faab0edc8db3f32e80e303a8ceeff447e/libr/egg/p/egg_xor.c#L44

In the file _egg.c_ the _b_ variable is the return value of the _p->build_ function

```
b = p->build (egg);
r_buf_free (egg->bin);
egg->bin = b;

```
There is no checks for the _b_ variable.
I found that is possible to reproduce the sigsegv typing 3 times the command:
`ge xor`

