### PR TITLE
Cs 0: suppress printing of strings in disasm (initial implementation)

### DIFF
--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -675,6 +675,10 @@ static int cmd_meta_hsdmf(RCore *core, const char *input) {
 			strncpy (name, t, sizeof (name) - 1);
 			if (type != 'C') {
 				n = r_num_math (core->num, t);
+				if (n == 0 && type == 's' && t[0] == '0' && (!t[1] || t[1] == ' ')) { // "Cs 0"
+					r_meta_add_with_subtype (core->anal, type, '-', addr, addr, "");
+					break;
+				}
 				if (type == 'f') { // "Cf"
 					p = strchr (t, ' ');
 					if (p) {


### PR DESCRIPTION
- Using special subtype since meta framework is somewhat hostile towards 0-length metadata.
- Initial implementation since not fully integrated into r2 (e.g. the `Cs` report shows nothing). Will add help message for `Cs 0` when it's reasonably complete.