### PR TITLE
Free the egg variable in the compile shellcode command

### DIFF
--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -54,9 +54,11 @@ static int compileShellcode(REgg *egg, const char *input){
 	RBuffer *b;
 	if (!r_egg_shellcode (egg, input)) {
 		eprintf ("Unknown shellcode '%s'\n", input);
+		return 1;
 	}
 	if (!r_egg_assemble (egg)) {
 		eprintf ("r_egg_assemble : invalid assembly\n");
+		r_egg_reset (egg);
 		return 1;
 	}
 	if (!egg->bin) {
@@ -64,6 +66,7 @@ static int compileShellcode(REgg *egg, const char *input){
 	}
 	if (!(b = r_egg_get_bin (egg))) {
 		eprintf ("r_egg_get_bin: invalid egg :(\n");
+		r_egg_reset (egg);
 		return 1;
 	}
 	r_egg_finalize (egg);
@@ -71,6 +74,7 @@ static int compileShellcode(REgg *egg, const char *input){
 		r_cons_printf ("%02x", b->buf[i]);
 	}
 	r_cons_newline ();
+	r_egg_reset (egg);
 	return 0;
 }
 


### PR DESCRIPTION
In the compile shellcode command `egg->bin` is not free between two command

Before
```
[0x00010314]> gi exec
022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368
[0x00010314]> gi exec
022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368
[0x00010314]> gi exec
022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368
```

After
```
[0x00010314]> gi exec
022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368
[0x00010314]> gi exec
022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368
[0x00010314]> gi exec
022042e01c308fe204308de508208de51302a0e10720c3e504308fe204108de20120c3e50b0b90ef2f62696e2f7368

```