### PR TITLE
Delete `// TODO: implement r_list_foreach_prev` obsolete comment in r_list.h file

### DIFF
--- a/libr/include/r_list.h
+++ b/libr/include/r_list.h
@@ -8,8 +8,6 @@
 extern "C" {
 #endif
 
-// TODO: implement r_list_foreach_prev
-
 #ifndef _INCLUDE_R_LIST_HEAD_H_
 #define _INCLUDE_R_LIST_HEAD_H_
 typedef void (*RListFree)(void *ptr);


### PR DESCRIPTION
Commit cfb03d37 implements this macro. That comment is outdated.