### PR TITLE
Added checks and a fix for the gs command

### DIFF
--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -134,7 +134,9 @@ static int cmd_egg(void *data, const char *input) {
 				buf = r_core_syscall (core, oa, "");
 			}
 			free (oa);
-			showBuffer (buf);
+			if (buf) {
+				showBuffer (buf);
+			}
 			egg->lang.nsyscalls = 0;
 		} else {
 			eprintf ("Usage: gs [syscallname] [parameters]\n");

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -135,6 +135,7 @@ static int cmd_egg(void *data, const char *input) {
 			}
 			free (oa);
 			showBuffer (buf);
+			egg->lang.nsyscalls = 0;
 		} else {
 			eprintf ("Usage: gs [syscallname] [parameters]\n");
 		}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2516,10 +2516,33 @@ R_API RBuffer *r_core_syscall (RCore *core, const char *name, const char *args) 
 	char code[1024];
 	int num;
 
-	num = r_syscall_get_num (core->anal->syscall, name);
-	if (!num) {
-		num = atoi (name);
+	//arch check
+	if (strcmp (core->anal->cur->arch, "x86")) {
+		eprintf ("architecture not yet supported!\n");
+		return 0;
 	}
+
+	num = r_syscall_get_num (core->anal->syscall, name);
+
+	//bits check
+	switch (core->assembler->bits) {
+	case 32:
+		if (strcmp (name, "setup") && !num ) {
+			eprintf ("syscall not found!\n");
+			return 0;
+		}
+		break;
+	case 64:
+		if (strcmp (name, "read") && !num ) {
+			eprintf ("syscall not found!\n");
+			return 0;
+		}
+		break;
+	default:
+		eprintf ("syscall not found!\n");
+		return 0;
+	}
+
 	snprintf (code, sizeof (code),
 		"sc@syscall(%d);\n"
 		"main@global(0) { sc(%s);\n"

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -438,7 +438,7 @@ R_API int r_egg_shellcode(REgg *egg, const char *name) {
 		if (p->type == R_EGG_PLUGIN_SHELLCODE && !strcmp (name, p->name)) {
 			b = p->build (egg);
 			if (!b) {
-				eprintf ("%s Encoder has failed\n", p->name);
+				eprintf ("%s Shellcode has failed\n", p->name);
 				return false;
 			}
 			r_egg_raw (egg, b->buf, b->length);

--- a/libr/egg/p/egg_exec.c
+++ b/libr/egg/p/egg_exec.c
@@ -51,6 +51,10 @@ static ut8 arm_linux_binsh[] =
 	"\x04\x10\x8d\xe2\x01\x20\xc3\xe5\x0b\x0b\x90\xef"
 	"\x2f\x62\x69\x6e\x2f\x73\x68"; // "/bin/sh";
 
+static ut8 thumb_linux_binsh[] =
+	"\x01\x30\x8f\xe2\x13\xff\x2f\xe1\x78\x46\x0c\x30\xc0\x46\x01\x90"
+	"\x49\x1a\x92\x1a\x0b\x27\x01\xdf\x2f\x62\x69\x6e\x2f\x73\x68"; // "/bin/sh";
+
 static RBuffer *build (REgg *egg) {
 	RBuffer *buf = r_buf_new ();
 	const ut8 *sc = NULL;
@@ -85,20 +89,35 @@ static RBuffer *build (REgg *egg) {
 		switch (egg->arch) {
 		case R_SYS_ARCH_X86:
 			switch (egg->bits) {
-			case 32: sc = x86_linux_binsh; break;
-			case 64: sc = x86_64_linux_binsh; break;
-			default: eprintf ("Unsupportted\n");
+			case 32: 
+				sc = x86_linux_binsh; 
+				break;
+			case 64: 
+				sc = x86_64_linux_binsh; 
+				break;
+			default: 
+				eprintf ("Unsupported arch %d bits\n", egg->bits);
 			}
 			break;
 		case R_SYS_ARCH_ARM:
-			sc = arm_linux_binsh;
+			switch (egg->bits) {
+			case 16:
+				sc = thumb_linux_binsh;
+				break;
+			case 32:
+				sc = arm_linux_binsh;
+				break;
+			default:
+				eprintf ("Unsupported arch %d bits\n", egg->bits);
+			}
 			break;
 		}
 		break;
 	default:
-		eprintf ("unsupported os %x\n", egg->os);
-		break;
+		eprintf ("Unsupported os %x\n", egg->os);
+		break;		
 	}
+
 	if (sc) {
 		r_buf_set_bytes (buf, sc, strlen ((const char *)sc));
 		if (shell && *shell) {


### PR DESCRIPTION
Fixed the shellcode generation, this was the issue

```
[0x00000000]> gs bind
48c7c0310000000f05ccc3
[0x00000000]> gs write
48c7c0310000000f05ccc3
```
the syscall number is the same for different syscall.

Added also some architecture checks.


