### PR TITLE
Fix SIGSEGV in the encoder execution

### DIFF
--- a/binr/ragg2/ragg2.c
+++ b/binr/ragg2/ragg2.c
@@ -430,6 +430,7 @@ int main(int argc, char **argv) {
 	if (encoder) {
 		if (!r_egg_encode (egg, encoder)) {
 			eprintf ("Invalid encoder '%s'\n", encoder);
+			return 1;
 		}
 	}
 

--- a/libr/egg/p/egg_xor.c
+++ b/libr/egg/p/egg_xor.c
@@ -33,6 +33,12 @@ static RBuffer *build (REgg *egg) {
 		return NULL;
 	}
 	sc = egg->bin; // hack
+	if (!sc->length) {
+		eprintf ("No shellcode found!\n");
+		free (key);
+		return NULL;
+	}
+
 	for (i = 0; i<sc->length; i++) {
 		// eprintf ("%02x -> %02x\n", sc->buf[i], sc->buf[i] ^nkey);
 		if ((sc->buf[i]^nkey)==0) {


### PR DESCRIPTION
This is the issue

```
$ ragg2 -e xor -c key=16 -x
Segmentation fault (core dumped)
```

I just add a check in order to verify the presence of the shellcode.

