### PR TITLE
Implemented JSON output for all fd* commands

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -872,25 +872,25 @@ rep:
 			core->flags->space_strict = space_strict;
 			f = r_flag_get_at (core->flags, addr, !strict_offset);
 			core->flags->space_strict = false;
-            if (f) {
-                if (f->offset != addr) {
-                    // if input contains 'j' print json
-                    if (strchr(input, 'j') != NULL) {
-                        r_cons_printf ("{\"name\":\"%s\",\"offset\":%d}\n",
-                                       f->name, (int)(addr - f->offset));
-                    } else {
-                        r_cons_printf ("%s + %d\n", f->name,
-                                       (int)(addr - f->offset));
-                    }
-                } else {
-                    if (strchr(input, 'j') != NULL) {
-                        r_cons_printf ("{\"name\":\"%s\"}\n",
-                                       f->name);
-                    } else {
-                        r_cons_println (f->name);
-                    }
-                }
-            }
+			if (f) {
+				if (f->offset != addr) {
+					// if input contains 'j' print json
+					if (strchr (input, 'j')) {
+						r_cons_printf ("{\"name\":\"%s\",\"offset\":%d}\n",
+									   f->name, (int)(addr - f->offset));
+					} else {
+						r_cons_printf ("%s + %d\n", f->name,
+									   (int)(addr - f->offset));
+					}
+				} else {
+					if (strchr(input, 'j')) {
+						r_cons_printf ("{\"name\":\"%s\"}\n",
+									   f->name);
+					} else {
+						r_cons_println (f->name);
+					}
+				}
+			}
 		}
 		break;
 	case '?':

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -867,20 +867,30 @@ rep:
 				return 0;
 				}	
 			default:
-				addr = r_num_math (core->num, input + 2);
 				break;
 			}
 			core->flags->space_strict = space_strict;
 			f = r_flag_get_at (core->flags, addr, !strict_offset);
 			core->flags->space_strict = false;
-			if (f) {
-				if (f->offset != addr) {
-					r_cons_printf ("%s + %d\n", f->name,
-						(int)(addr - f->offset));
-				} else {
-					r_cons_println (f->name);
-				}
-			}
+            if (f) {
+                if (f->offset != addr) {
+                    // if input contains 'j' print json
+                    if (strchr(input, 'j') != NULL) {
+                        r_cons_printf ("{\"name\":\"%s\",\"offset\":%d}\n",
+                                       f->name, (int)(addr - f->offset));
+                    } else {
+                        r_cons_printf ("%s + %d\n", f->name,
+                                       (int)(addr - f->offset));
+                    }
+                } else {
+                    if (strchr(input, 'j') != NULL) {
+                        r_cons_printf ("{\"name\":\"%s\"}\n",
+                                       f->name);
+                    } else {
+                        r_cons_println (f->name);
+                    }
+                }
+            }
 		}
 		break;
 	case '?':


### PR DESCRIPTION
Implemented JSON output for all the _fd*_ commands. I removed the line for the default case, because it overrides the `addr` variable so that _r_flag_get_at()_ would always return _x0_ as the flag.