### PR TITLE
[ppc:ps] fixed bad load/store

### DIFF
--- a/libr/asm/arch/ppc/libps/libps.c
+++ b/libr/asm/arch/ppc/libps/libps.c
@@ -189,7 +189,7 @@ void libps_snprint(char* str, int size, ut64 addr, ppcps_t* instr) {
 		} else if (instr->operands[i].type == TYPE_IMM) {
 			add += snprintf (str + add, bufsize - add, " 0x%x", instr->operands[i].value);
 		} else if (instr->operands[i].type == TYPE_MEM) {
-			add += snprintf (str + add, bufsize - add, " 0x%x(r%d)", instr->operands[i + 1].value, instr->operands[i].value);
+			add += snprintf (str + add, bufsize - add, " 0x%x(r%d)", instr->operands[i].value, instr->operands[i + 1].value);
 			i++;
 		} else if (instr->operands[i].type == TYPE_CR) {
 			add += snprintf (str + add, bufsize - add, " cr%u", instr->operands[i].value);

--- a/libr/asm/p/asm_ppc_cs.c
+++ b/libr/asm/p/asm_ppc_cs.c
@@ -67,11 +67,11 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		if (ret >= 0) {
 			return op->size;
 		}
-	} else if (a->cpu && strncmp (a->cpu, "ppcps", 3) == 0) {
+	} else if (a->cpu && strncmp (a->cpu, "ps", 2) == 0) {
 		// libps is big-endian only
-		//if (!a->big_endian) {
-		//	return -1;
-		//}
+		if (!a->big_endian) {
+			return -1;
+		}
 		ret = decompile_ps (a, op, buf, len);
 		if (ret >= 0) {
 			return op->size;
@@ -112,7 +112,7 @@ RAsmPlugin r_asm_plugin_ppc_cs = {
 	.desc = "Capstone PowerPC disassembler",
 	.license = "BSD",
 	.arch = "ppc",
-	.cpus = "ppc,vle,ppcps",
+	.cpus = "ppc,vle,ps",
 	.bits = 32 | 64,
 	.endian = R_SYS_ENDIAN_LITTLE | R_SYS_ENDIAN_BIG,
 	.fini = the_end,


### PR DESCRIPTION
i've made a small mistake on the load/store asm for ppc.
i've also changed the cpu name to `ps`

> https://github.com/radare/radare2-regressions/pull/1134 tests