### PR TITLE
Added a show command, and some fixes

### DIFF
--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -21,6 +21,8 @@ static const char *help_msg_g[] = {
 	NULL
 };
 
+static RList *configList = NULL;
+
 static void cmd_egg_init(RCore *core) {
 	DEFINE_CMD_DESCRIPTOR (core, g);
 
@@ -230,9 +232,9 @@ static int cmd_egg(void *data, const char *input) {
 			}
 		}
 		eprintf ("\nTarget options\n");
-		eprintf ("%s : %s\n", "arch", core->anal->cpu);
-		eprintf ("%s : %s\n", "os", core->anal->os);
-		eprintf ("%s : %d\n", "bits", core->anal->bits);
+		eprintf ("arch : %s\n", core->anal->cpu);
+		eprintf ("os   : %s\n", core->anal->os);
+		eprintf ("bits : %d\n", core->anal->bits);
 	}
 	break;
 	case 'r': // "gr"

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -23,6 +23,18 @@ static const char *help_msg_g[] = {
 
 static void cmd_egg_init(RCore *core) {
 	DEFINE_CMD_DESCRIPTOR (core, g);
+
+	if (!(configList = r_list_new ())) {
+		return NULL;
+	}
+
+	r_list_append (configList, "egg.shellcode");
+	r_list_append (configList, "egg.encoder");
+	r_list_append (configList, "egg.padding");
+	r_list_append (configList, "key");
+	r_list_append (configList, "cmd");
+	r_list_append (configList, "suid");
+
 }
 
 static void cmd_egg_option(REgg *egg, const char *key, const char *input) {
@@ -206,13 +218,23 @@ static int cmd_egg(void *data, const char *input) {
 	}
 	break;
 	case 'S': // "gS"
-		eprintf ("shellcode: '%s'\n", r_egg_option_get (egg, "egg.shellcode"));
-		eprintf ("encoder: '%s'\n", r_egg_option_get (egg, "egg.encoder"));
-		eprintf ("padding: '%s'\n", r_egg_option_get (egg, "egg.padding"));
-		eprintf ("key: '%s'\n", r_egg_option_get (egg, "key"));
-		eprintf ("cmd: '%s'\n", r_egg_option_get (egg, "cmd"));
-		eprintf ("suid: '%s'\n", r_egg_option_get (egg, "suid"));
-		break;
+	{
+		RListIter *iter;
+		char *p;
+		eprintf ("Configuration options\n");
+		r_list_foreach (configList, iter, p) {
+			if (r_egg_option_get (egg, p)) {
+				eprintf ("%s : %s\n", p, r_egg_option_get (egg, p));
+			} else {
+				eprintf ("%s : %s\n", p, "");
+			}
+		}
+		eprintf ("\nTarget options\n");
+		eprintf ("%s : %s\n", "arch", core->anal->cpu);
+		eprintf ("%s : %s\n", "os", core->anal->os);
+		eprintf ("%s : %d\n", "bits", core->anal->bits);
+	}
+	break;
 	case 'r': // "gr"
 		cmd_egg_option (egg, "egg.padding", "");
 		cmd_egg_option (egg, "egg.shellcode", "");

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -16,6 +16,7 @@ static const char *help_msg_g[] = {
 	"gp", " padding", "Define padding for command",
 	"ge", " xor", "Specify an encoder",
 	"gr", "", "Reset r_egg",
+	"gS", "", "Show the current configuration",
 	"EVAL VARS:", "", "asm.arch, asm.bits, asm.os",
 	NULL
 };
@@ -84,11 +85,17 @@ static int cmd_egg_compile(REgg *egg) {
 	char *p = r_egg_option_get (egg, "egg.shellcode");
 	if (p && *p) {
 		if (!r_egg_shellcode (egg, p)) {
+			eprintf ("Unknown shellcode '%s'\n", p);
 			free (p);
 			return false;
 		}
 		free (p);
+	} else {
+		eprintf ("Setup a shellcode before (gi command)\n");
+		free (p);
+		return false;
 	}
+
 	r_egg_compile (egg);
 	if (!r_egg_assemble (egg)) {
 		eprintf ("r_egg_assemble: invalid assembly\n");
@@ -110,6 +117,11 @@ static int cmd_egg_compile(REgg *egg) {
 	}
 	// we do not own this buffer!!
 	// r_buf_free (b);
+	r_egg_option_set (egg, "egg.shellcode", "");
+	r_egg_option_set (egg, "egg.padding", "");
+	r_egg_option_set (egg, "egg.encoder", "");
+	r_egg_option_set (egg, "key", "");
+
 	r_egg_reset (egg);
 	return ret;
 }
@@ -193,6 +205,14 @@ static int cmd_egg(void *data, const char *input) {
 		}
 	}
 	break;
+	case 'S': // "gS"
+		eprintf ("shellcode: '%s'\n", r_egg_option_get (egg, "egg.shellcode"));
+		eprintf ("encoder: '%s'\n", r_egg_option_get (egg, "egg.encoder"));
+		eprintf ("padding: '%s'\n", r_egg_option_get (egg, "egg.padding"));
+		eprintf ("key: '%s'\n", r_egg_option_get (egg, "key"));
+		eprintf ("cmd: '%s'\n", r_egg_option_get (egg, "cmd"));
+		eprintf ("suid: '%s'\n", r_egg_option_get (egg, "suid"));
+		break;
 	case 'r': // "gr"
 		cmd_egg_option (egg, "egg.padding", "");
 		cmd_egg_option (egg, "egg.shellcode", "");

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -223,18 +223,18 @@ static int cmd_egg(void *data, const char *input) {
 	{
 		RListIter *iter;
 		char *p;
-		eprintf ("Configuration options\n");
+		r_cons_printf ("Configuration options\n");
 		r_list_foreach (configList, iter, p) {
 			if (r_egg_option_get (egg, p)) {
-				eprintf ("%s : %s\n", p, r_egg_option_get (egg, p));
+				r_cons_printf ("%s : %s\n", p, r_egg_option_get (egg, p));
 			} else {
-				eprintf ("%s : %s\n", p, "");
+				r_cons_printf ("%s : %s\n", p, "");
 			}
 		}
-		eprintf ("\nTarget options\n");
-		eprintf ("arch : %s\n", core->anal->cpu);
-		eprintf ("os   : %s\n", core->anal->os);
-		eprintf ("bits : %d\n", core->anal->bits);
+		r_cons_printf ("\nTarget options\n");
+		r_cons_printf ("arch : %s\n", core->anal->cpu);
+		r_cons_printf ("os   : %s\n", core->anal->os);
+		r_cons_printf ("bits : %d\n", core->anal->bits);
 	}
 	break;
 	case 'r': // "gr"

--- a/libr/include/r_egg.h
+++ b/libr/include/r_egg.h
@@ -19,8 +19,6 @@ R_LIB_VERSION_HEADER(r_egg);
 #define R_EGG_PLUGIN_SHELLCODE 0
 #define R_EGG_PLUGIN_ENCODER 1
 
-RList *configList;
-
 typedef struct r_egg_plugin_t {
 	const char *name;
 	const char *desc;

--- a/libr/include/r_egg.h
+++ b/libr/include/r_egg.h
@@ -19,6 +19,8 @@ R_LIB_VERSION_HEADER(r_egg);
 #define R_EGG_PLUGIN_SHELLCODE 0
 #define R_EGG_PLUGIN_ENCODER 1
 
+RList *configList;
+
 typedef struct r_egg_plugin_t {
 	const char *name;
 	const char *desc;


### PR DESCRIPTION
Added a show command in order to see the current status of the r_egg_option variables

```
[0x00000000]> gi exec
[0x00000000]> gc cmd=/bin/ls
[0x00000000]> ge xor 10
[0x00000000]> gS
shellcode: 'exec'
encoder: 'xor'
padding: '(null)'
Key: '10'
cmd: '/bin/ls'
suid: '(null)'
```