### PR TITLE
substitute jmp, call, branch target based on analop

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2263,6 +2263,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.bbline", "false", "Show empty line after every basic block");
 	SETPREF ("asm.comments", "true", "Show comments in disassembly view");
 	SETPREF ("asm.jmphints", "true", "Show jump hints [numbers] in disasm");
+	SETPREF ("asm.jmpsub", "false", "Always substitute jump, call and branch targets in disassembly");
 	SETPREF ("asm.leahints", "false", "Show LEA hints [numbers] in disasm");
 	SETPREF ("asm.slow", "true", "Perform slow analysis operations in disasm");
 	SETPREF ("asm.decode", "false", "Use code analysis as a disassembler");


### PR DESCRIPTION
Substitutes targets of jmp, call and branch ops in disassembly based on jump target in RAnalOp structure. This should lead to more robust substitution with fewer false positives, even for addresses below 0x100. As per discussion in #9138 

Enable with "e asm.jmpsub = true" (default false)

Currently only implemented for pd command. I will add more after this approach is approved by @radare  
