### PR TITLE
bin.strpurge: use ',' instead of '+' to separate args

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2372,7 +2372,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("bin.usextr", "true", &cb_usextr, "Use extract plugins when loading files");
 	SETCB ("bin.useldr", "true", &cb_useldr, "Use loader plugins when loading files");
 	SETCB ("bin.strpurge", "", &cb_strpurge, "Try to purge false positive strings (true: use the classifier in "
-	       "r_core_bin_strpurge(), [+addr]*: specific string addresses to purge)");
+	       "r_core_bin_strpurge(), [,addr]*: specific string addresses to purge)");
 	SETPREF ("bin.b64str", "false", "Try to debase64 the strings");
 	SETPREF ("bin.libs", "false", "Try to load libraries after loading main binary");
 	n = NODECB ("bin.strfilter", "", &cb_strfilter);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3028,7 +3028,7 @@ static void ds_print_str(RDisasmState *ds, const char *str, int len, ut64 refadd
 	if (ds->core->bin->strpurge_addrs) {
 		char *addrs = strdup (ds->core->bin->strpurge_addrs);
 		if (addrs) {
-			int splits = r_str_split (addrs, '+');
+			int splits = r_str_split (addrs, ',');
 			int i;
 			char *ptr;
 			ut64 addr;


### PR DESCRIPTION
This is because ranges are naturally specified using a hyphen aka the minus sign e.g. 0x00-0xff.