### PR TITLE
More build system improvements

### DIFF
--- a/libr/Makefile
+++ b/libr/Makefile
@@ -40,13 +40,9 @@ libr.${EXT_SO}:
 	rm -rf .libr/tcc # WHY
 	$(CC) $(LDFLAGS) -shared -dynamic -arch arm64 -o libr.${EXT_SO} .libr/*/*.o ../shlr/gdb/lib/libgdbr.a
 
-libr.${EXT_AR}: $(wildcard */libr_*.${EXT_AR}) $(shell find ../shlr -name '*.${EXT_AR}')
-	rm -rf .libr
-	mkdir .libr
-	for LIB in $^ ; do \
-		${PARTIALLD} -o .libr/$$(basename $${LIB} .a).o $${LIB} ; \
-	done
-	${AR} crs $@ .libr/*.o
+libr.${EXT_AR}: $(wildcard */libr_*.${EXT_AR})# $(shell find ../shlr -name '*.${EXT_AR}')
+	${PARTIALLD} -o libr.o $^
+	${AR} crs $@ libr.o
 
 $(LIBS):
 	@echo "DIR $@"

--- a/libr/anal/Makefile
+++ b/libr/anal/Makefile
@@ -33,11 +33,8 @@ OBJLIBS+=hint.o anal.o data.o xrefs.o esil.o sign.o
 OBJLIBS+=anal_ex.o switch.o state.o cycles.o
 OBJLIBS+=esil_stats.o esil_trace.o flirt.o labels.o
 OBJLIBS+=esil2reil.o pin.o session.o
-ASMOBJS+=$(LTOP)/asm/arch/xtensa/gnu/xtensa-modules.o
-ASMOBJS+=$(LTOP)/asm/arch/xtensa/gnu/xtensa-isa.o
-ASMOBJS+=$(LTOP)/asm/arch/xtensa/gnu/elf32-xtensa.o
 
-OBJS=${STATIC_OBJS} ${OBJLIBS} ${ASMOBJS}
+OBJS=${STATIC_OBJS} ${OBJLIBS}
 
 test tests: tests-esil
 

--- a/libr/anal/p/8051.mk
+++ b/libr/anal/p/8051.mk
@@ -2,10 +2,11 @@ OBJ_8051=anal_8051.o
 CFLAGS+=-I../asm/arch/8051
 
 STATIC_OBJ+=${OBJ_8051}
-#OBJ_8051+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/8051/8051.o
-#OBJ_8051+=${LTOP}/asm/arch/8051/8051.o
-#OBJ_8051+=../../asm/arch/8051/8051.o
 TARGET_8051=anal_8051.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_8051+=$(LIBR)/asm/arch/8051/8051.o
+endif
 
 ALL_TARGETS+=${TARGET_8051}
 

--- a/libr/anal/p/Makefile
+++ b/libr/anal/p/Makefile
@@ -8,12 +8,14 @@ LDFLAGS+=${LINK}
 CURDIR=
 
 ifeq ($(WITHPIC),1)
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 # TODO: rename to enabled plugins
 ARCHS=null.mk x86_udis.mk ppc_gnu.mk ppc_cs.mk arm_gnu.mk avr.mk xap.mk dalvik.mk sh.mk ebc.mk gb.mk malbolge.mk ws.mk h8300.mk cr16.mk v850.mk msp430.mk sparc_gnu.mk sparc_cs.mk x86_cs.mk cris.mk 6502.mk snes.mk riscv.mk vax.mk xtensa.mk rsp.mk
 include $(ARCHS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.${EXT_SO} *.o ${STATIC_OBJ}

--- a/libr/anal/p/anal_h8300.c
+++ b/libr/anal/p/anal_h8300.c
@@ -730,7 +730,7 @@ RAnalPlugin r_anal_plugin_h8300 = {
 };
 
 #ifndef CORELIB
-struct r_lib_sturct_t radare_plugin = {
+struct r_lib_struct_t radare_plugin = {
 	.type = R_LIB_TYPE_ANAL,
 	.data = &r_anal_plugin_h8300,
 	.version = R2_VERSION

--- a/libr/anal/p/arm_gnu.mk
+++ b/libr/anal/p/arm_gnu.mk
@@ -1,11 +1,16 @@
 N=anal_arm_gnu
-OBJ_ARM=anal_arm_gnu.o ../../asm/arch/arm/winedbg/be_arm.o
+OBJ_ARM=anal_arm_gnu.o
 
 STATIC_OBJ+=${OBJ_ARM}
 TARGET_ARM=$(N).${EXT_SO}
 
+CFLAGS+=-I$(LIBR)/asm/arch/include
+
+ifeq ($(WITHPIC),1)
+OBJ_ARM+=../../asm/arch/arm/winedbg/be_arm.o
+endif
+
 ALL_TARGETS+=${TARGET_ARM}
-CFLAGS +=-I$(LIBR)/asm/arch/include
 
 ${TARGET_ARM}: ${OBJ_ARM}
 	${CC} $(call libname,$(N)) ${LDFLAGS} ${CFLAGS} \

--- a/libr/anal/p/arm_gnu.mk
+++ b/libr/anal/p/arm_gnu.mk
@@ -5,7 +5,7 @@ STATIC_OBJ+=${OBJ_ARM}
 TARGET_ARM=$(N).${EXT_SO}
 
 ALL_TARGETS+=${TARGET_ARM}
-CFLAGS +=-I../asm/arch/include
+CFLAGS +=-I$(LIBR)/asm/arch/include
 
 ${TARGET_ARM}: ${OBJ_ARM}
 	${CC} $(call libname,$(N)) ${LDFLAGS} ${CFLAGS} \

--- a/libr/anal/p/cr16.mk
+++ b/libr/anal/p/cr16.mk
@@ -1,5 +1,5 @@
 OBJ_CR16=anal_cr16.o
-CFLAGS+=-I../asm/arch/cr16/
+CFLAGS+=-I$(LIBR)/asm/arch/cr16/
 
 STATIC_OBJ+=${OBJ_CR16}
 #OBJ_CR16+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/cr16/cr16_disas.o

--- a/libr/anal/p/cr16.mk
+++ b/libr/anal/p/cr16.mk
@@ -2,9 +2,11 @@ OBJ_CR16=anal_cr16.o
 CFLAGS+=-I$(LIBR)/asm/arch/cr16/
 
 STATIC_OBJ+=${OBJ_CR16}
-#OBJ_CR16+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/cr16/cr16_disas.o
-OBJ_CR16+=../../asm/arch/cr16/cr16_disas.o
 TARGET_CR16=anal_cr16.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_CR16+=$(LIBR)/asm/arch/cr16/cr16_disas.o
+endif
 
 ALL_TARGETS+=${TARGET_CR16}
 

--- a/libr/anal/p/ebc.mk
+++ b/libr/anal/p/ebc.mk
@@ -2,9 +2,11 @@ OBJ_EBC=anal_ebc.o
 CFLAGS+=-I$(LIBR)/asm/arch/ebc/
 
 STATIC_OBJ+=${OBJ_EBC}
-#OBJ_EBC+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/ebc/ebc_disas.o
-OBJ_EBC+=../../asm/arch/ebc/ebc_disas.o
 TARGET_EBC=anal_ebc.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_EBC+=$(LIBR)/asm/arch/ebc/ebc_disas.o
+endif
 
 ALL_TARGETS+=${TARGET_EBC}
 

--- a/libr/anal/p/ebc.mk
+++ b/libr/anal/p/ebc.mk
@@ -1,5 +1,5 @@
 OBJ_EBC=anal_ebc.o
-CFLAGS+=-I../asm/arch/ebc/
+CFLAGS+=-I$(LIBR)/asm/arch/ebc/
 
 STATIC_OBJ+=${OBJ_EBC}
 #OBJ_EBC+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/ebc/ebc_disas.o

--- a/libr/anal/p/gb.mk
+++ b/libr/anal/p/gb.mk
@@ -5,7 +5,7 @@ TARGET_GB=anal_gb.${EXT_SO}
 
 ALL_TARGETS+=${TARGET_GB}
 
-CFLAGS += -Iarch/gb/
+CFLAGS += -I$(LIBR)/anal/arch/gb/
 
 ${TARGET_GB}: ${OBJ_GB}
 	${CC} $(call libname,anal_gb) ${LDFLAGS} ${CFLAGS} \

--- a/libr/anal/p/h8300.mk
+++ b/libr/anal/p/h8300.mk
@@ -2,9 +2,11 @@ OBJ_H8300=anal_h8300.o
 CFLAGS+=-I$(LIBR)/asm/arch/h8300/
 
 STATIC_OBJ+=${OBJ_H8300}
-#OBJ_H8300+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/h8300/h8300_disas.o
-OBJ_H8300+=../../asm/arch/h8300/h8300_disas.o
 TARGET_H8300=anal_h8300.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_H8300+=$(LIBR)/asm/arch/h8300/h8300_disas.o
+endif
 
 ALL_TARGETS+=${TARGET_H8300}
 

--- a/libr/anal/p/h8300.mk
+++ b/libr/anal/p/h8300.mk
@@ -1,5 +1,5 @@
 OBJ_H8300=anal_h8300.o
-CFLAGS+=-I../asm/arch/h8300/
+CFLAGS+=-I$(LIBR)/asm/arch/h8300/
 
 STATIC_OBJ+=${OBJ_H8300}
 #OBJ_H8300+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/h8300/h8300_disas.o

--- a/libr/anal/p/msp430.mk
+++ b/libr/anal/p/msp430.mk
@@ -2,8 +2,11 @@ OBJ_msp430=anal_msp430.o
 CFLAGS+=-I$(LIBR)/asm/arch/msp430/
 
 STATIC_OBJ+=${OBJ_msp430}
-OBJ_msp430+=../../asm/arch/msp430/msp430_disas.o
 TARGET_msp430=anal_msp430.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_msp430+=../../asm/arch/msp430/msp430_disas.o
+endif
 
 ALL_TARGETS+=${TARGET_msp430}
 

--- a/libr/anal/p/msp430.mk
+++ b/libr/anal/p/msp430.mk
@@ -1,5 +1,5 @@
 OBJ_msp430=anal_msp430.o
-CFLAGS+=-I../asm/arch/msp430/
+CFLAGS+=-I$(LIBR)/asm/arch/msp430/
 
 STATIC_OBJ+=${OBJ_msp430}
 OBJ_msp430+=../../asm/arch/msp430/msp430_disas.o

--- a/libr/anal/p/ppc_cs.mk
+++ b/libr/anal/p/ppc_cs.mk
@@ -1,9 +1,13 @@
-OBJ_PPC_CS=anal_ppc_cs.o ../../asm/arch/ppc/libvle/vle.o
+OBJ_PPC_CS=anal_ppc_cs.o
 
 include $(CURDIR)capstone.mk
 
 STATIC_OBJ+=${OBJ_PPC_CS}
 TARGET_PPC_CS=anal_ppc_cs.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_PPC_CS+=../../asm/arch/ppc/libvle/vle.o
+endif
 
 ALL_TARGETS+=${TARGET_PPC_CS}
 

--- a/libr/anal/p/rsp.mk
+++ b/libr/anal/p/rsp.mk
@@ -1,6 +1,5 @@
 OBJ_RSP=anal_rsp.o
-#RSP_ROOT=$(LIBR)/asm/arch/rsp
-CFLAGS+=-I../asm/arch/rsp
+CFLAGS+=-I$(LIBR)/asm/arch/rsp
 
 STATIC_OBJ+=${OBJ_RSP}
 OBJ_RSP+=../../asm/arch/rsp/rsp_idec.o

--- a/libr/anal/p/rsp.mk
+++ b/libr/anal/p/rsp.mk
@@ -2,8 +2,11 @@ OBJ_RSP=anal_rsp.o
 CFLAGS+=-I$(LIBR)/asm/arch/rsp
 
 STATIC_OBJ+=${OBJ_RSP}
-OBJ_RSP+=../../asm/arch/rsp/rsp_idec.o
 TARGET_RSP=anal_rsp.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_RSP+=../../asm/arch/rsp/rsp_idec.o
+endif
 
 ALL_TARGETS+=${TARGET_RSP}
 

--- a/libr/anal/p/tms320.mk
+++ b/libr/anal/p/tms320.mk
@@ -2,18 +2,18 @@ OBJ_TMS320=anal_tms320.o
 OBJ_TMS320+=anal_tms320_c55x_plus.o
 
 STATIC_OBJ+=${OBJ_TMS320}
-#OBJ_TMS320+=../../../../../../../../../../../${LTOP}/asm/arch/tms320/tms320_dasm.o
-#ROOT=../../../../../../../../../../../../../../../../../../../../../${LTOP}
-ROOT=../../
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/tms320_dasm.o
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/c55x_plus/ins.o
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/c55x_plus/c55plus.o
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/c55x_plus/c55plus_decode.o
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/c55x_plus/decode_funcs.o
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/c55x_plus/utils.o
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/c55x_plus/hashtable.o
-OBJ_TMS320+=$(ROOT)/asm/arch/tms320/c55x_plus/hashvector.o
 TARGET_TMS320=anal_tms320.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/tms320_dasm.o
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/c55x_plus/ins.o
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/c55x_plus/c55plus.o
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/c55x_plus/c55plus_decode.o
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/c55x_plus/decode_funcs.o
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/c55x_plus/utils.o
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/c55x_plus/hashtable.o
+OBJ_TMS320+=$(LIBR)/asm/arch/tms320/c55x_plus/hashvector.o
+endif
 
 ALL_TARGETS+=${TARGET_TMS320}
 

--- a/libr/anal/p/v810.mk
+++ b/libr/anal/p/v810.mk
@@ -4,7 +4,7 @@ STATIC_OBJ+=${OBJ_V810}
 OBJ_V810+=../../asm/arch/v810/v810_disas.o
 TARGET_V810=anal_v810.${EXT_SO}
 
-CFLAGS+=-I../asm/arch/v810/
+CFLAGS+=-I$(LIBR)/asm/arch/v810/
 
 ALL_TARGETS+=${TARGET_V810}
 

--- a/libr/anal/p/v810.mk
+++ b/libr/anal/p/v810.mk
@@ -1,10 +1,13 @@
 OBJ_V810=anal_v810.o
 
 STATIC_OBJ+=${OBJ_V810}
-OBJ_V810+=../../asm/arch/v810/v810_disas.o
 TARGET_V810=anal_v810.${EXT_SO}
 
 CFLAGS+=-I$(LIBR)/asm/arch/v810/
+
+ifeq ($(WITHPIC),1)
+OBJ_V810+=$(LIBR)/asm/arch/v810/v810_disas.o
+endif
 
 ALL_TARGETS+=${TARGET_V810}
 

--- a/libr/anal/p/v850.mk
+++ b/libr/anal/p/v850.mk
@@ -1,11 +1,13 @@
 OBJ_V850=anal_v850.o
 
 STATIC_OBJ+=${OBJ_V850}
-#OBJ_V850+=../../../../../../../../../../../../../../../../../../../../${LTOP}/asm/arch/v850/v850_disas.o
-OBJ_V850+=../../asm/arch/v850/v850_disas.o
 TARGET_V850=anal_v850.${EXT_SO}
 
 CFLAGS+=-I$(LIBR)/asm/arch/v850/
+
+ifeq ($(WITHPIC),1)
+OBJ_V850+=$(LIBR)/asm/arch/v850/v850_disas.o
+endif
 
 ALL_TARGETS+=${TARGET_V850}
 

--- a/libr/anal/p/v850.mk
+++ b/libr/anal/p/v850.mk
@@ -5,7 +5,7 @@ STATIC_OBJ+=${OBJ_V850}
 OBJ_V850+=../../asm/arch/v850/v850_disas.o
 TARGET_V850=anal_v850.${EXT_SO}
 
-CFLAGS+=-I../asm/arch/v850/
+CFLAGS+=-I$(LIBR)/asm/arch/v850/
 
 ALL_TARGETS+=${TARGET_V850}
 

--- a/libr/anal/p/wasm.mk
+++ b/libr/anal/p/wasm.mk
@@ -1,10 +1,13 @@
-WASM_ROOT=../../asm/arch/wasm
+WASM_ROOT=$(LIBR)/asm/arch/wasm
 OBJ_WASM=anal_wasm.o
-OBJ_WASM+=$(WASM_ROOT)/wasm.o
 CFLAGS+=-I$(WASM_ROOT)
 
 STATIC_OBJ+=${OBJ_WASM}
 TARGET_WASM=anal_wasm.${EXT_SO}
+
+ifeq ($(WITHPIC),1)
+OBJ_WASM+=$(WASM_ROOT)/wasm.o
+endif
 
 ALL_TARGETS+=${TARGET_WASM}
 

--- a/libr/anal/p/x86_udis.mk
+++ b/libr/anal/p/x86_udis.mk
@@ -1,18 +1,22 @@
 OBJ_X86_UDIS86=anal_x86_udis.o
 OBJ_ESIL_UDIS86=esil_x86_udis.o
-SHARED_X86_UDIS86=../../shlr/udis86/decode.o
-SHARED_X86_UDIS86+=../../shlr/udis86/itab.o
-SHARED_X86_UDIS86+=../../shlr/udis86/syn-att.o
-SHARED_X86_UDIS86+=../../shlr/udis86/syn-intel.o
-SHARED_X86_UDIS86+=../../shlr/udis86/syn.o
-SHARED_X86_UDIS86+=../../shlr/udis86/udis86.o
 
 STATIC_OBJ+=${OBJ_X86_UDIS86} ${OBJ_ESIL_UDIS86}
 SHARED_OBJ+=${SHARED_X86_UDIS86}
 TARGET_X86_UDIS86=anal_x86_udis86.${EXT_SO}
 
-ALL_TARGETS+=${TARGET_X86_UDIS86}
 CFLAGS+=-I$(TOP)/shlr/ -DHAVE_STRING_H=1
+
+ifeq ($(WITHPIC),1)
+SHARED_X86_UDIS86=$(TOP)/shlr/udis86/decode.o
+SHARED_X86_UDIS86+=$(TOP)/shlr/udis86/itab.o
+SHARED_X86_UDIS86+=$(TOP)/shlr/udis86/syn-att.o
+SHARED_X86_UDIS86+=$(TOP)/shlr/udis86/syn-intel.o
+SHARED_X86_UDIS86+=$(TOP)/shlr/udis86/syn.o
+SHARED_X86_UDIS86+=$(TOP)/shlr/udis86/udis86.o
+endif
+
+ALL_TARGETS+=${TARGET_X86_UDIS86}
 
 ${TARGET_X86_UDIS86}: ${OBJ_X86_UDIS86}
 	${CC} ${CFLAGS} $(call libname,anal_x86) \

--- a/libr/anal/p/x86_udis.mk
+++ b/libr/anal/p/x86_udis.mk
@@ -12,7 +12,7 @@ SHARED_OBJ+=${SHARED_X86_UDIS86}
 TARGET_X86_UDIS86=anal_x86_udis86.${EXT_SO}
 
 ALL_TARGETS+=${TARGET_X86_UDIS86}
-CFLAGS+=-I../asm/arch/x86/udis86 -I../../asm/arch/x86/udis86 -DHAVE_STRING_H=1
+CFLAGS+=-I$(TOP)/shlr/ -DHAVE_STRING_H=1
 
 ${TARGET_X86_UDIS86}: ${OBJ_X86_UDIS86}
 	${CC} ${CFLAGS} $(call libname,anal_x86) \

--- a/libr/anal/p/xtensa.mk
+++ b/libr/anal/p/xtensa.mk
@@ -3,6 +3,12 @@ OBJ_XTENSA=anal_xtensa.o
 STATIC_OBJ+=${OBJ_XTENSA}
 TARGET_XTENSA=anal_xtensa.${EXT_SO}
 
+ifeq ($(WITHPIC),1)
+OBJ_XTENSA+=$(LTOP)/asm/arch/xtensa/gnu/xtensa-modules.o
+OBJ_XTENSA+=$(LTOP)/asm/arch/xtensa/gnu/xtensa-isa.o
+OBJ_XTENSA+=$(LTOP)/asm/arch/xtensa/gnu/elf32-xtensa.o
+endif
+
 ALL_TARGETS+=$(TARGET_XTENSA)
 
 $(TARGET_XTENSA): $(OBJ_XTENSA)

--- a/libr/asm/p/Makefile
+++ b/libr/asm/p/Makefile
@@ -13,7 +13,7 @@ endif
 CURDIR=
 
 ifeq ($(WITHPIC),1)
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 # TODO: rename to enabled plugins
@@ -25,6 +25,8 @@ ARCHS+=6502.mk h8300.mk cr16.mk v850.mk spc700.mk propeller.mk msp430.mk i4004.m
 ARCHS+=lh5801.mk v810.mk mcs96.mk lm32.mk
 ARCHS+=riscv.mk rsp.mk
 include $(ARCHS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.${EXT_SO} *.o ${STATIC_OBJ}

--- a/libr/asm/p/propeller.mk
+++ b/libr/asm/p/propeller.mk
@@ -1,6 +1,5 @@
 OBJ_PROPELLER=asm_propeller.o
-OBJ_PROPELLER+=../arch/propeller/propeller_disas.o
-CFLAGS+=-I./arch/propeller/
+CFLAGS+=-I$(LIBR)/asm/arch/propeller/
 
 STATIC_OBJ+=${OBJ_PROPELLER}
 TARGET_PROPELLER=asm_propeller.${EXT_SO}

--- a/libr/bin/p/Makefile
+++ b/libr/bin/p/Makefile
@@ -14,7 +14,7 @@ endif
 SHLR=$(LTOP)/../shlr
 
 ifeq ($(WITHPIC),1)
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 FORMATS=any.mk elf.mk elf64.mk pe.mk pe64.mk te.mk mach0.mk
@@ -28,6 +28,8 @@ FORMATS+=xtr_dyldcache.mk
 FORMATS+=xtr_fatmach0.mk
 
 include $(FORMATS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.so *.o ${STATIC_OBJ}

--- a/libr/bin/p/bin_xtr_dyldcache.c
+++ b/libr/bin/p/bin_xtr_dyldcache.c
@@ -184,7 +184,7 @@ RBinXtrPlugin r_bin_xtr_plugin_xtr_dyldcache = {
 #ifndef CORELIB
 RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_BIN_XTR,
-	.data = &r_bin_xtr_plugin_dyldcache,
+	.data = &r_bin_xtr_plugin_xtr_dyldcache,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/bp/p/Makefile
+++ b/libr/bp/p/Makefile
@@ -5,11 +5,13 @@ ifeq ($(WITHPIC),1)
 CFLAGS+=-I../../include -I../arch/ -I../arch/include -Wall ${PIC_CFLAGS} ${LDFLAGS_LIB}
 CFLAGS+=-D__UNIX__
 
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 ARCHS=x86.mk arm.mk
 include $(ARCHS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.so *.o ${STATIC_OBJ}

--- a/libr/core/p/Makefile
+++ b/libr/core/p/Makefile
@@ -23,11 +23,13 @@ include $(STOP)/windbg/deps.mk
 LDFLAGS+=${LINK}
 
 ifeq ($(WITHPIC),1)
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 PLUGS=java.mk anal.mk
 include $(PLUGS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.${EXT_SO} *.o ${STATIC_OBJ}

--- a/libr/crypto/p/Makefile
+++ b/libr/crypto/p/Makefile
@@ -5,12 +5,14 @@ LINK+=-L../../util -lr_util
 LDFLAGS+=${LINK}
 
 ifeq ($(WITHPIC),1)
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 CFLAGS+=-I../../include
 #ALGOS=aes.mk aes_cbc.mk
 include $(ALGOS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.${EXT_SO} *.o ${STATIC_OBJ}

--- a/libr/debug/Makefile
+++ b/libr/debug/Makefile
@@ -33,7 +33,6 @@ endif
 endif
 
 ifeq ($(OSTYPE),$(filter $(OSTYPE),gnulinux android))
-CFLAGS+=-I../bin/format/elf
 OBJS+=$(addprefix p/,$(NATIVE_OBJS))
 endif
 

--- a/libr/debug/p/Makefile
+++ b/libr/debug/p/Makefile
@@ -3,11 +3,13 @@ include ../../config.mk
 ifeq ($(WITHPIC),1)
 CFLAGS+=-I../../include -Wall ${PIC_FLAGS} ${LDFLAGS_LIB} ${LDFLAGS_LINKPATH}.. -DCORELIB
 
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 DEBUGS=native.mk gdb.mk qnx.mk windbg.mk bochs.mk
 include $(DEBUGS)
+
+all:: $(ALL_TARGETS)
 
 pre:
 	@cd libgdbwrap && ${MAKE}

--- a/libr/debug/p/Makefile
+++ b/libr/debug/p/Makefile
@@ -1,7 +1,7 @@
 include ../../config.mk
 
 ifeq ($(WITHPIC),1)
-CFLAGS+=-I../../include -Wall ${PIC_FLAGS} ${LDFLAGS_LIB} ${LDFLAGS_LINKPATH}.. -DCORELIB
+CFLAGS+=-I$(LIBR)/include -Wall ${PIC_FLAGS} ${LDFLAGS_LIB} ${LDFLAGS_LINKPATH}.. -DCORELIB
 
 all::
 

--- a/libr/debug/p/native.mk
+++ b/libr/debug/p/native.mk
@@ -10,6 +10,7 @@ NATIVE_OBJS=native/xnu/xnu_debug.o
 endif
 
 ifeq ($(OSTYPE),$(filter $(OSTYPE),gnulinux android))
+CFLAGS+=-I$(LIBR)/bin/format/elf
 NATIVE_OBJS=native/linux/linux_debug.o
 NATIVE_OBJS+=native/procfs.o
 endif

--- a/libr/fs/Makefile
+++ b/libr/fs/Makefile
@@ -10,17 +10,19 @@ LDFLAGS+=$(SHLR)/grub/libgrubfs.a
 
 EXTRA_TARGETS=plugins
 foo:
-	for TARGET in pre plugins ${LIBSO} ${LIBAR} ; do ${MAKE} $$TARGET ; done
+	make pre
+	make plugins
+	make ${LIBSO} ${LIBAR}
 
 include ${STATIC_FS_PLUGINS}
 STATIC_OBJS=$(subst ..,p/..,$(subst fs_,p/fs_,$(STATIC_OBJ)))
-OBJS=${STATIC_OBJS} fs.o file.o 
+OBJS=${STATIC_OBJS} fs.o file.o
 #p/grub/main.o
 
 #p/grub/libgrubfs.a:
 #	cd p/grub && ${MAKE} libgrubfs.a CC="${CC}"
 
-pre: 
+pre:
 	cd d && ${MAKE}
 #	@if [ ! -e libr_fs.${EXT_SO} ]; then if [ ! -e libr_fs.${EXT_AR} ]; then rm -f ${STATIC_OBJS} ; fi ; fi
 

--- a/libr/fs/p/Makefile
+++ b/libr/fs/p/Makefile
@@ -1,9 +1,7 @@
 include ../../config.mk
 include ../../../mk/platform.mk
 
-CFLAGS+=-I$(LIBR)/include -Wall -shared ${PIC_CFLAGS} ${LDFLAGS_LIB} ${LDFLAGS_LINKPATH}..
-GRUB=$(LIBR)../shlr/grub/libgrub.a
-#CFLAGS+=-I../../include
+CFLAGS+=-I$(LIBR)/include -Wall -shared ${PIC_CFLAGS} ${LDFLAGS_LIB}
 LDFLAGS+=${LINK}
 
 ifeq ($(WITHPIC),1)

--- a/libr/fs/p/Makefile
+++ b/libr/fs/p/Makefile
@@ -7,12 +7,15 @@ GRUB=$(LIBR)../shlr/grub/libgrub.a
 LDFLAGS+=${LINK}
 
 ifeq ($(WITHPIC),1)
-all:
+all::
 
+ALL_TARGETS=
 #FILESYSTEMS=hfs.mk iso9660.mk jfs.mk
 #FILESYSTEMS=hfsplus.mk
 FILESYSTEMS=ext2.mk fat.mk ntfs.mk reiserfs.mk tar.mk udf.mk ufs2.mk ufs.mk xfs.mk hfs.mk
 include $(FILESYSTEMS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.${EXT_SO} *.o ${STATIC_OBJ}

--- a/libr/fs/p/ext2.mk
+++ b/libr/fs/p/ext2.mk
@@ -1,12 +1,10 @@
 OBJ_EXT2=fs_ext2.o
-EXTRA=$(GRUB)
-CFLAGS+=-Igrub/include
+CFLAGS+=-I$(TOP)/shlr/grub/include
 
 STATIC_OBJ+=${OBJ_EXT2}
-#STATIC_OBJ+=${EXTRA}
 TARGET_EXT2=fs_ext2.${EXT_SO}
 
 ALL_TARGETS+=${TARGET_EXT2}
 
 ${TARGET_EXT2}: ${OBJ_EXT2}
-	${CC} $(call libname,fs_ext2) ${LDFLAGS} ${CFLAGS} -o ${TARGET_EXT2} ${OBJ_EXT2} ${EXTRA}
+	${CC} $(call libname,fs_ext2) ${LDFLAGS} ${CFLAGS} -o ${TARGET_EXT2} ${OBJ_EXT2}

--- a/libr/fs/p/fat.mk
+++ b/libr/fs/p/fat.mk
@@ -1,12 +1,10 @@
 OBJ_FAT=fs_fat.o
-EXTRA=$(GRUB)
 CFLAGS+=-Igrub/include
 
 STATIC_OBJ+=${OBJ_FAT}
-#STATIC_OBJ+=${EXTRA}
 TARGET_FAT=fs_fat.${EXT_SO}
 
 ALL_TARGETS+=${TARGET_FAT}
 
 ${TARGET_FAT}: ${OBJ_FAT}
-	${CC} $(call libname,fs_fat) ${LDFLAGS} ${CFLAGS} -o ${TARGET_FAT} ${OBJ_FAT} ${EXTRA}
+	${CC} $(call libname,fs_fat) ${LDFLAGS} ${CFLAGS} -o ${TARGET_FAT} ${OBJ_FAT}

--- a/libr/fs/p/ntfs.mk
+++ b/libr/fs/p/ntfs.mk
@@ -1,12 +1,10 @@
 OBJ_NTFS=fs_ntfs.o
-EXTRA=$(GRUB)
 CFLAGS+=-Igrub/include
 
 STATIC_OBJ+=${OBJ_NTFS}
-#STATIC_OBJ+=${EXTRA}
 TARGET_NTFS=fs_ntfs.${EXT_SO}
 
 ALL_TARGETS+=${TARGET_NTFS}
 
 ${TARGET_NTFS}: ${OBJ_NTFS}
-	${CC} $(call libname,fs_ntfs) ${LDFLAGS} ${CFLAGS} -o ${TARGET_NTFS} ${OBJ_NTFS} ${EXTRA}
+	${CC} $(call libname,fs_ntfs) ${LDFLAGS} ${CFLAGS} -o ${TARGET_NTFS} ${OBJ_NTFS}

--- a/libr/fs/p/reiserfs.mk
+++ b/libr/fs/p/reiserfs.mk
@@ -1,12 +1,10 @@
 OBJ_REISERFS=fs_reiserfs.o
-EXTRA=$(GRUB)
 CFLAGS+=-Igrub/include
 
 STATIC_OBJ+=${OBJ_REISERFS}
-#STATIC_OBJ+=${EXTRA}
 TARGET_REISERFS=fs_reiserfs.${EXT_SO}
 
 ALL_TARGETS+=${TARGET_REISERFS}
 
 ${TARGET_REISERFS}: ${OBJ_REISERFS}
-	${CC} $(call libname,fs_reiserfs) ${LDFLAGS} ${CFLAGS} -o ${TARGET_REISERFS} ${OBJ_REISERFS} ${EXTRA}
+	${CC} $(call libname,fs_reiserfs) ${LDFLAGS} ${CFLAGS} -o ${TARGET_REISERFS} ${OBJ_REISERFS}

--- a/libr/io/p/Makefile
+++ b/libr/io/p/Makefile
@@ -12,13 +12,15 @@ ifeq (${OSTYPE},windows)
 CFLAGS+=-lws2_32
 endif
 
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 PLUGINS=ptrace.mk debug.mk gdb.mk malloc.mk shm.mk mach.mk w32dbg.mk procpid.mk windbg.mk bochs.mk qnx.mk r2k.mk ar.mk rbuf.mk
 #zip.mk
 #PLUGINS=ptrace.mk debug.mk gdb.mk malloc.mk mach.mk w32dbg.mk procpid.mk
 include ${PLUGINS}
+
+all:: $(ALL_TARGETS)
 
 #ALL_TARGETS+=io_ewf.so
 

--- a/libr/parse/p/Makefile
+++ b/libr/parse/p/Makefile
@@ -8,13 +8,15 @@ CFLAGS+=-DCORELIB
 LDFLAGS+=${LINK}
 
 ifeq ($(WITHPIC),1)
-all: ${ALL_TARGETS}
+all::
 
 ALL_TARGETS=
 ARCHS=att2intel.mk x86_pseudo.mk mreplace.mk
 ARCHS+=arm_pseudo.mk z80_pseudo.mk ppc_pseudo.mk 6502_pseudo.mk
 ARCHS+=m68k_pseudo.mk sh_pseudo.mk avr_pseudo.mk
 include $(ARCHS)
+
+all:: $(ALL_TARGETS)
 
 clean:
 	-rm -f *.${EXT_SO} *.o ${STATIC_OBJ}


### PR DESCRIPTION
These were spurned by [this discovery](https://github.com/radareorg/cutter/pull/269#issuecomment-358936794), i.e. that libr.a has duplicate symbols and some linkers hate that.

A *lot* of fixes for plugins built as shared objects are included. Actually, it looks like no one is consistently trying to build plugins as shared objects, and some of them could not have possibly been ever successfully built. I've taken care to check that they do (at least, I think I checked all of them).