### PR TITLE
fix(anal_avr): calculate offset of ldd/std correctly

### DIFF
--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -841,18 +841,18 @@ INST_HANDLER (ldd) {	// LD Rd, Y	LD Rd, Z
 		op, "ram",
 		buf[0] & 0x8 ? 'y' : 'z',	// index register Y/Z
 		0,				// no use RAMP* registers
-		!(buf[1] & 0x1)
+		!(buf[1] & 0x10)
 			? 0			// no increment
 			: buf[0] & 0x1
 				? 1		// post incremented
 				: -1,		// pre decremented
-		!(buf[1] & 0x1) ? offset : 0,	// offset or not offset
+		!(buf[1] & 0x10) ? offset : 0,	// offset or not offset
 		0);				// load operation (!st)
 	// load register
 	ESIL_A ("r%d,=,", ((buf[1] & 1) << 4) | ((buf[0] >> 4) & 0xf));
 	// cycles
 	op->cycles =
-		(buf[1] & 0x1) == 0
+		(buf[1] & 0x10) == 0
 			? (!offset ? 1 : 3)		// LDD
 			: (buf[0] & 0x3) == 0
 				? 1			// LD Rd, X
@@ -1335,12 +1335,12 @@ INST_HANDLER (std) {	// ST Y, Rr	ST Z, Rr
 		op, "ram",
 		buf[0] & 0x8 ? 'y' : 'z',	// index register Y/Z
 		0,				// no use RAMP* registers
-		!(buf[1] & 0x1)
+		!(buf[1] & 0x10)
 			? 0			// no increment
 			: buf[0] & 0x1
 				? 1		// post incremented
 				: -1,		// pre decremented
-		!(buf[1] & 0x1)
+		!(buf[1] & 0x10)
 			? (buf[1] & 0x20)	// offset
 			| ((buf[1] & 0xc) << 1)
 			| (buf[0] & 0x7)


### PR DESCRIPTION
The offset/not offset bit is the last bit of the first nibble, not the last
of the second nibble (see AVR instruction set manual).