### PR TITLE
sh: fix disassembly of branch opcodes

### DIFF
--- a/libr/asm/arch/sh/gnu/sh-dis.c
+++ b/libr/asm/arch/sh/gnu/sh-dis.c
@@ -90,7 +90,7 @@ print_insn_shx (bfd_vma memaddr, struct disassemble_info *info)
 	      imm = (nibs[2] << 4) | (nibs[3]);
 	      if (imm & 0x80)
 		imm |= ~0xff;
-	      imm = ((unsigned char)imm) * 2 + 4 ;
+	      imm = (imm * 2) + 4 ;
 	      goto ok;
 	    case BRANCH_12:
 	      imm = ((nibs[1]) << 8) | (nibs[2] << 4) | (nibs[3]);


### PR DESCRIPTION
The displacement field must be sign-extended and multiplied by 2, not
cast to an unsigned type.
This fixes #9235 . To be clear : issue is a regression caused by part of df82290  , but that commit was partly good. The test suite of https://github.com/radare/radare2-regressions/pull/1148/commits covers both issues.