### PR TITLE
Adding XRAM and IRAM base address to anal ptr 

### DIFF
--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -316,7 +316,8 @@ static void analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf) {
 		emit ("a,pc,--,+,[1]," XW(A) FLAG_P);
 		break;
 	case 0x84: /* div ab */
-		emit ("b,0,==,ov,=,b,a,%%,b,a,/=,b,=,0,c,=," FLAG_P);
+		// note: escape % if this becomes a format string
+		emit ("b,0,==,ov,=,b,a,%,b,a,/=,b,=,0,c,=," FLAG_P);
 		break;
 	case 0x85: /* mov direct, direct */
 		h (XR(IB1) XW(IB2));

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -731,7 +731,11 @@ static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case OP_JBC:
 	case OP_JNB:
 		op->type = R_ANAL_OP_TYPE_CJMP;
-		op->jump = arg_offset (addr + op->size, buf[1]);
+		if (op->size == 2) {
+			op->jump = arg_offset (addr + 2, buf[1]);
+		} else if (op->size == 3) {
+			op->jump = arg_offset (addr + 3, buf[2]);
+		}
 		op->fail = addr + op->size;
 		break;
 	case OP_INVALID:

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -316,7 +316,7 @@ static void analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf) {
 		emit ("a,pc,--,+,[1]," XW(A) FLAG_P);
 		break;
 	case 0x84: /* div ab */
-		emit ("b,0,==,ov,=,b,a,\%,b,a,/=,b,=,0,c,=," FLAG_P);
+		emit ("b,0,==,ov,=,b,a,%%,b,a,/=,b,=,0,c,=," FLAG_P);
 		break;
 	case 0x85: /* mov direct, direct */
 		h (XR(IB1) XW(IB2));

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -9,6 +9,7 @@
 #include <8051_ops.h>
 
 #define IRAM 0x10000
+#define XRAM 0x10100
 #define IRAM_BASE  "0x10000"
 #define XRAM_BASE  "0x10100"
 
@@ -618,7 +619,7 @@ static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case A_IMM16:
 		op->val = buf[1] * 256 + buf[2];
-		op->ptr = IRAM + op->val;	// best guess, it's a IRAM pointer
+		op->ptr = XRAM + op->val;	// best guess, it's a XRAM pointer
 		break;
 	default:
 		break;


### PR DESCRIPTION
With this fix, DATA XREFs and data access comments will resolve to the correct address space for ops with direct and imm16 arguments. Reducing the false positives cluttering code below 0x100