### PR TITLE
Refactoring 8051 esil macros

### DIFF
--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2013-2017 - pancake, dkreuter, astuder  */
+/* radare - LGPL - Copyright 2013-2018 - pancake, dkreuter, astuder  */
 
 #include <string.h>
 #include <r_types.h>
@@ -8,10 +8,8 @@
 
 #include <8051_ops.h>
 
-#define IRAM 0x10000
-#define XRAM 0x10100
-#define IRAM_BASE  "0x10000"
-#define XRAM_BASE  "0x10100"
+#define IRAM_BASE 0x10000
+#define XRAM_BASE 0x10100
 
 static bool i8051_is_init = false;
 // doesnt needs to be global, but anyway :D
@@ -34,6 +32,8 @@ typedef struct {
 	ut8 isdptr : 1;
 } RI8051Reg;
 
+#if 0
+// custom reg read/write temporarily disabled - see r2 issue #9242
 static RI8051Reg registers[] = {
 	// keep these sorted
 	{"a",     0xE0, 0x00, 1, 0},
@@ -67,119 +67,215 @@ static RI8051Reg registers[] = {
 	{"tl1",   0x8B, 0x00, 1, 0},
 	{"tmod",  0x89, 0x00, 1, 0}
 };
+#endif
 
-#define emit(frag) r_strbuf_appendf(&op->esil, frag)
-#define emitf(...) r_strbuf_appendf(&op->esil, __VA_ARGS__)
+#define e(frag) r_strbuf_append(&op->esil, frag)
+#define ef(frag, ...) r_strbuf_appendf(&op->esil, frag, __VA_ARGS__)
 
-#define j(frag) emitf(frag, 1 & buf[0], buf[1], buf[2], op->jump, op->fail, op->val)
-#define h(frag) emitf(frag, 7 & buf[0], buf[1], buf[2], op->jump, op->fail, op->val)
-#define k(frag) emitf(frag, bitindex[buf[1]>>3], buf[1] & 7, buf[2], op->jump, op->fail, op->val)
+#define flag_c "$c7,c,=,"
+#define flag_b "$b8,c,=,"
+#define flag_ac "$c3,ac,=,"
+#define flag_ab "$b3,ac,=,"
+#define flag_ov "$c6,ov,=,"
+#define flag_ob "$b7,$b6,^,ov,=,"
+#define flag_p "0xff,a,&=,$p,!,p,=,"
 
-#define FLAG_C "$c7,c,=,"
-#define FLAG_B "$b8,c,=,"
-#define FLAG_AC "$c3,ac,=,"
-#define FLAG_AB "$b3,ac,=,"
-#define FLAG_OV "$c6,ov,=,"
-#define FLAG_OB "$b7,$b6,^,ov,=,"
-#define FLAG_P "0xff,a,&=,$p,!,p,=,"
+#define ev_a 0
+#define ev_bit bitindex[buf[1]>>3]
+#define ev_c 0
+#define ev_dir1 buf[1]
+#define ev_dir2 buf[2]
+#define ev_dp 0
+#define ev_dpx 0
+#define ev_imm1 buf[1]
+#define ev_imm2 buf[2]
+#define ev_imm16 op->val
+#define ev_ri 1 & buf[0]
+#define ev_rix 1 & buf[0]
+#define ev_rn 7 & buf[0]
+#define ev_sp2 0
+#define ev_sp1 0
 
-#define ES_IB1 IRAM_BASE ",%2$d,+,"
-#define ES_IB2 IRAM_BASE ",%3$d,+,"
-#define ES_BIT IRAM_BASE ",%1$d,+,"
-#define ES_RI  IRAM_BASE ",r%1$d,+,"
-#define ES_SP  IRAM_BASE ",sp,+,"
-#define ES_SP2 IRAM_BASE ",sp,+,"
-#define ES_DPI IRAM_BASE ",dptr,+,"
-#define ES_R0X XRAM_BASE ",r%1$d,+,"
-#define ES_DPX XRAM_BASE ",dptr,+,"
-#define ES_RN  "r%1$d,"
-#define ES_A   "a,"
-#define ES_L1  "%2$d,"
-#define ES_L2  "%3$d,"
-#define ES_L16 "%6$d,"
-#define ES_C   "c,"
-#define ES_DP  "dptr,"
+static void exr_a(RAnalOp *op, ut8 dummy) {
+	e ("a,");
+}
 
-#define ER_IB1 "[1],"
-#define ER_IB2 "[1],"
-#define ER_BIT "[1],"
-#define ER_RI  "[1],"
-#define ER_DPI "[1],"
-#define ER_SP  "[1],"
-#define ER_SP2 "[2],"
-#define ER_R0X "[1],"
-#define ER_DPX "[1],"
-#define ER_RN  ""
-#define ER_A   ""
-#define ER_L1  ""
-#define ER_L2  ""
-#define ER_L16 ""
-#define ER_C   ""
-#define ER_DP  ""
+static void exr_bit(RAnalOp *op, ut8 addr) {
+	ef ("%d,%d,+,[1],", IRAM_BASE, addr);
+}
 
-#define EW_IB1 "[1],"
-#define EW_IB2 "[1],"
-#define EW_BIT "[1],"
-#define EW_RI  "[1],"
-#define EW_DPI "[1],"
-#define EW_SP  "[1],"
-#define EW_SP2 "[2],"
-#define EW_R0X "[1],"
-#define EW_DPX "[1],"
-#define EW_RN  ","
-#define EW_A   ","
-#define EW_L1  ","
-#define EW_L2  ","
-#define EW_L16 ","
-#define EW_C   ","
-#define EW_DP  ","
+static void exr_dir1(RAnalOp *op, ut8 addr) {
+	ef ("%d,%d,+,[1],", IRAM_BASE, addr);
+}
 
-#define XR(subject)            ES_##subject               ER_##subject
-#define XW(subject)            ES_##subject "="           EW_##subject
-#define XI(subject, operation) ES_##subject operation "=" EW_##subject
+static void exr_dpx (RAnalOp *op, ut8 dummy) {
+	ef ("%d,dptr,+,[1],", XRAM_BASE);
+}
 
-#define BIT_SET "%2$d,1,<<,"
-#define BIT_MASK BIT_SET "255,^,"
-#define BIT_R "%2$d," XR(BIT) ">>,1,&,"
-#define BIT_C "%2$d,c,<<,"
+static void exr_imm1(RAnalOp *op, ut8 val) {
+	ef ("%d,", val);
+}
 
-// on 8051 the stack grows upward and lsb is pushed first meaning
-// that on little-endian esil vms =[2] works as indended
-#define PUSH1 "1,sp,+=," XW(SP)
-#define POP1  XR(SP) "1,sp,-=,"
-#define PUSH2 "1,sp,+=," XW(SP2) "1,sp,+=,"
-#define POP2  "1,sp,-=," XR(SP2) "1,sp,-=,"
+static void exr_imm2(RAnalOp *op, ut8 val) {
+	ef ("%d,", val);
+}
 
-#define CALL "%5$d," PUSH2
-#define JMP "%4$d,pc,="
-#define CJMP "?{," JMP ",}"
+static void exr_imm16(RAnalOp *op, ut16 val) {
+	ef ("%d,", val);
+}
 
-#define TEMPLATE_ALU_C(base, op, flags) \
+static void exr_ri(RAnalOp *op, ut8 reg) {
+	ef ("%d,r%d,+,[1],", IRAM_BASE, reg);
+}
+
+static void exr_rix(RAnalOp *op, ut8 reg) {
+	ef ("%d,r%d,+,[1],", XRAM_BASE, reg);
+}
+
+static void exr_rn(RAnalOp *op, ut8 reg) {
+	ef ("r%d,", reg);
+}
+
+static void exr_sp1(RAnalOp *op, ut8 dummy) {
+	ef ("%d,sp,+,[1],", IRAM_BASE);
+	e ("1,sp,-=,");
+}
+
+static void exr_sp2(RAnalOp *op, ut8 dummy) {
+	e ("1,sp,-=,");
+	ef ("%d,sp,+,[2],", IRAM_BASE);
+	e ("1,sp,-=,");
+}
+
+static void exw_a(RAnalOp *op, ut8 dummy) {
+	e ("a,=,");
+}
+
+static void exw_c(RAnalOp *op, ut8 dummy) {
+	e ("c,=,");
+}
+
+static void exw_bit(RAnalOp *op, ut8 addr) {
+	ef ("%d,%d,+,=[1],", IRAM_BASE, addr);
+}
+
+static void exw_dir1(RAnalOp *op, ut8 addr) {
+	ef ("%d,%d,+,=[1],", IRAM_BASE, addr);
+}
+
+static void exw_dir2(RAnalOp *op, ut8 addr) {
+	ef ("%d,%d,+,=[1],", IRAM_BASE, addr);
+}
+
+static void exw_dp (RAnalOp *op, ut8 dummy) {
+	e ("dptr,=,");
+}
+
+static void exw_dpx (RAnalOp *op, ut8 dummy) {
+	ef ("%d,dptr,+,=[1],", XRAM_BASE);
+}
+
+static void exw_ri(RAnalOp *op, ut8 reg) {
+	ef ("%d,r%d,+,=[1],", IRAM_BASE, reg);
+}
+
+static void exw_rix(RAnalOp *op, ut8 reg) {
+	ef ("%d,r%d,+,=[1],", XRAM_BASE, reg);
+}
+
+static void exw_rn(RAnalOp *op, ut8 reg) {
+	ef ("r%d,=,", reg);
+}
+
+static void exw_sp1(RAnalOp *op, ut8 dummy) {
+	e ("1,sp,+=,");
+	ef ("%d,sp,+,=[1],", IRAM_BASE);
+}
+
+static void exw_sp2(RAnalOp *op, ut8 dummy) {
+	e ("1,sp,+=,");
+	ef ("%d,sp,+,=[2],", IRAM_BASE);
+	e ("1,sp,+=,");
+}
+
+static void exi_a(RAnalOp *op, ut8 dummy, const char* operation) {
+	ef ("a,%s=,", operation);
+}
+
+static void exi_bit (RAnalOp *op, ut8 addr, const char *operation) {
+	ef ("%d,%d,+,%s=[1],", IRAM_BASE, addr, operation);
+}
+
+static void exi_c(RAnalOp *op, ut8 dummy, const char* operation) {
+	ef ("c,%s=,", operation);
+}
+
+static void exi_dp (RAnalOp *op, ut8 dummy, const char *operation) {
+	ef ("dptr,%s=,", operation);
+}
+
+static void exi_dir1 (RAnalOp *op, ut8 addr, const char *operation) {
+	ef ("%d,%d,+,%s=[1],", IRAM_BASE, addr, operation);
+}
+
+static void exi_ri(RAnalOp *op, ut8 reg, const char *operation) {
+	ef ("%d,r%d,+,%s=[1],", IRAM_BASE, reg, operation);
+}
+
+static void exi_rn(RAnalOp *op, ut8 reg, const char *operation) {
+	ef ("r%d,%s=,", reg, operation);
+}
+
+#define xr(subject) exr_##subject (op, ev_##subject)
+#define xw(subject) exw_##subject (op, ev_##subject)
+#define xi(subject, operation) exi_##subject (op, ev_##subject, operation)
+
+#define bit_set ef ("%d,1,<<,", buf[1] & 7)
+#define bit_mask bit_set; e ("255,^,")
+#define bit_r ef ("%d,", buf[1] & 7); xr (bit); e (">>,1,&,")
+#define bit_c ef ("%d,c,<<,", buf[1] & 7);
+
+#define jmp ef ("%d,pc,=", op->jump)
+#define cjmp e ("?{,"); jmp; e (",}")
+#define call ef ("%d,", op->fail); xw (sp2); jmp
+
+#define alu_op(val, aluop, flags) xr (val); e ("a," aluop "=," flags)
+#define alu_op_c(val, aluop, flags) e ("c,"); xr (val); e ("+,a," aluop "=," flags)
+#define alu_op_d(val, aluop) xr (val); xi (dir1, aluop)
+
+#define template_alu4_c(base, aluop, flags) \
 	case base + 0x4: \
-		h ("c," XR(L1) "+," XI(A, op) flags); break; \
+		alu_op_c (imm1, aluop, flags); break; \
 	case base + 0x5: \
-		h ("c," XR(IB1) "+," XI(A, op) flags); break; \
+		alu_op_c (dir1, aluop, flags); break; \
 	case base + 0x6: \
 	case base + 0x7: \
-		j ("c," XR(RI) "+," XI(A, op) flags); break; \
+		alu_op_c (ri, aluop, flags); break; \
 	case base + 0x8: case base + 0x9: \
 	case base + 0xA: case base + 0xB: \
 	case base + 0xC: case base + 0xD: \
 	case base + 0xE: case base + 0xF: \
-		h ("c," XR(RN) "+," XI(A, op) flags); break;
-#define TEMPLATE_ALU(base, op, flags) \
+		alu_op_c (rn, aluop, flags); break;
+
+#define template_alu2(base, aluop) \
+	case base + 0x2: \
+		alu_op_d (a, aluop); break; \
+	case base + 0x3: \
+		alu_op_d (imm2, aluop); break; \
+
+#define template_alu4(base, aluop, flags) \
 	case base + 0x4: \
-		h (XR(L1) XI(A, op) flags); break; \
+		alu_op (imm1, aluop, flags); break; \
 	case base + 0x5: \
-		h (XR(IB1) XI(A, op) flags); break; \
+		alu_op (dir1, aluop, flags); break; \
 	case base + 0x6: \
 	case base + 0x7: \
-		j (XR(RI) XI(A, op) flags); break; \
+		alu_op (ri, aluop, flags); break; \
 	case base + 0x8: case base + 0x9: \
 	case base + 0xA: case base + 0xB: \
 	case base + 0xC: case base + 0xD: \
 	case base + 0xE: case base + 0xF: \
-		h (XR(RN) XI(A, op) flags); break;
+		alu_op (rn, aluop, flags); break;
 
 static void analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf) {
 	r_strbuf_init (&op->esil);
@@ -188,293 +284,283 @@ static void analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf) {
 	switch (buf[0]) {
 	// Irregulars sorted by lower nibble
 	case 0x00: /* nop */
-		emit (",");
+		e (",");
 		break;
 
 	case 0x10: /* jbc bit, offset */
-		k (BIT_R "?{," BIT_MASK XI(BIT, "&") JMP ",}");
+		bit_r; e ("?{,"); bit_mask; xi (bit, "&"); jmp; e (",}");
 		break;
 	case 0x20: /* jb bit, offset */
-		k (BIT_R CJMP);
+		bit_r; cjmp;
 		break;
 	case 0x30: /* jnb bit, offset */
-		k (BIT_R "!," CJMP);
+		bit_r; e ("!,"); cjmp;
 		break;
 	case 0x40: /* jc offset */
-		h ("c,1,&," CJMP);
+		e ("c,1,&,"); cjmp;
 		break;
 	case 0x50: /* jnc offset */
-		h ("c,1,&,!," CJMP );
+		e ("c,1,&,!,"); cjmp;
 		break;
 	case 0x60: /* jz offset */
-		h ("a,0,==," CJMP);
+		e ("a,0,==,"); cjmp;
 		break;
 	case 0x70: /* jnz offset */
-		h ("a,0,==,!," CJMP);
+		e ("a,0,==,!,"); cjmp;
 		break;
 
 	case 0x11: case 0x31: case 0x51: case 0x71:
 	case 0x91: case 0xB1: case 0xD1: case 0xF1: /* acall addr11 */
 	case 0x12: /* lcall addr16 */
-		j (CALL);
-		/* fall through */
+		call;
+		break;
 	case 0x01: case 0x21: case 0x41: case 0x61:
 	case 0x81: case 0xA1: case 0xC1: case 0xE1: /* ajmp addr11 */	
 	case 0x02: /* ljmp addr16 */
 	case 0x80: /* sjmp offset */
-		j (JMP);
+		jmp;
 		break;
 
 	case 0x22: /* ret */
 	case 0x32: /* reti */
-		emitf (POP2 "pc,=");
+		xr (sp2); e ("pc,=");
 		break;
 
 	case 0x03: /* rr a */
-		emit ("1,a,0x101,*,>>,a,=," FLAG_P);
+		e ("1,a,0x101,*,>>,a,=," flag_p);
 		break;
 	case 0x04: /* inc a */
-		h (XI(A, "++") FLAG_P);
+		xi (a, "++"); e (flag_p);
 		break;
 	case 0x05: /* inc direct */
-		h (XI(IB1, "++"));
+		xi (dir1, "++");
 		break;
 	case 0x06: case 0x07: /* inc @Ri */
-		j (XI(RI, "++"));
+		xi (ri, "++");
 		break;
 	case 0x08: case 0x09: case 0x0A: case 0x0B:
-	case 0x0C: case 0x0D: case 0x0E: case 0x0F: /* dec @Rn */
-		h (XI(RN, "++"));
+	case 0x0C: case 0x0D: case 0x0E: case 0x0F: /* inc @Rn */
+		xi (rn, "++");
 		break;
 	case 0x13: /* rrc a */
-		emit ("7,c,<<,1,a,&,c,=,0x7f,1,a,>>,&,+,a,=," FLAG_P);
+		e ("7,c,<<,1,a,&,c,=,0x7f,1,a,>>,&,+,a,=," flag_p);
 		break;
 	case 0x14: /* dec a */
-		h (XI(A, "--") FLAG_P);
+		xi (a, "--"); e (flag_p);
 		break;
 	case 0x15: /* dec direct */
-		h (XI(IB1, "--"));
+		xi (dir1, "--"); e (flag_p);
 		break;
 	case 0x16: case 0x17: /* dec @Ri */
-		j (XI(RI, "--"));
+		xi (ri, "--");
 		break;
 	case 0x18: case 0x19: case 0x1A: case 0x1B:
 	case 0x1C: case 0x1D: case 0x1E: case 0x1F: /* dec @Rn */
-		h (XI(RN, "--"));
+		xi (rn, "--");
 		break;
 	case 0x23: /* rl a */
-		h ("7,a,0x101,*,>>,a,=," FLAG_P);
+		e ("7,a,0x101,*,>>,a,=," flag_p);
 		break;
-	TEMPLATE_ALU (0x20, "+", FLAG_C FLAG_AC FLAG_OV FLAG_P) /* 0x24..0x2f add a,.. */
+	template_alu4 (0x20, "+", flag_c flag_ac flag_ov flag_p) /* 0x24..0x2f add a,.. */
 	case 0x33: /* rlc a */
-		h ("c,1,&,a,a,+=,$c7,c,=,a,+=," FLAG_P);
+		e ("c,1,&,a,a,+=,$c7,c,=,a,+=," flag_p);
 		break;
-	TEMPLATE_ALU_C (0x30, "+", FLAG_C FLAG_AC FLAG_OV FLAG_P) /* 0x34..0x2f addc a,.. */
-	case 0x42: /* orl direct, a */
-		h (XR(A) XI(IB1, "|"));
-		break;
-	case 0x43: /* orl direct, imm */
-		h (XR(L2) XI(IB1, "|"));
-		break;
-	TEMPLATE_ALU (0x40, "|", FLAG_P) /* 0x44..0x4f orl a,.. */
-	case 0x52: /* anl direct, a */
-		h (XR(A) XI(IB1, "&"));
-		break;
-	case 0x53: /* anl direct, imm */
-		h (XR(L2) XI(IB1, "&"));
-		break;
-	TEMPLATE_ALU (0x50, "&", FLAG_P) /* 0x54..0x5f anl a,.. */
-	case 0x62: /* xrl direct, a */
-		h (XR(A) XI(IB1, "^"));
-		break;
-	case 0x63: /* xrl direct, imm */
-		h (XR(L2) XI(IB1, "^"));
-		break;
-	TEMPLATE_ALU (0x60, "^", FLAG_P) /* 0x64..0x6f xrl a,.. */
+	template_alu4_c (0x30, "+", flag_c flag_ac flag_ov flag_p) /* 0x34..0x3f addc a,.. */
+	template_alu2 (0x40, "|") /* 0x42..0x43 orl direct,.. */
+	template_alu4 (0x40, "|", flag_p) /* 0x44..0x4f orl a,.. */
+	template_alu2 (0x50, "&") /* 0x52..0x53 anl direct,.. */
+	template_alu4 (0x50, "&", flag_p) /* 0x54..0x5f anl a,.. */
+	template_alu2 (0x60, "^") /* 0x62..0x63 xrl direct,.. */
+	template_alu4 (0x60, "^", flag_p) /* 0x64..0x6f xrl a,.. */
 	case 0x72: /* orl C, bit */
-		k (BIT_R XI(C, "|"));
+		bit_r; xi (c, "|");
 		break;
 	case 0x73: /* jmp @a+dptr */
-		emit ("dptr,a,+,pc,="); break;
+		e ("dptr,a,+,pc,=");
+		break;
 	case 0x74: /* mov a, imm */
-		h (XR(L1) XW(A) FLAG_P);
+		xr (imm1); xw (a); e (flag_p);
 		break;
 	case 0x75: /* mov direct, imm */
-		h (XR(L2) XW(IB1));
+		xr (imm2); xw (dir1);
 		break;
 	case 0x76: case 0x77: /* mov @Ri, imm */
-		j (XR(L1) XW(RI));
+		xr (imm1); xw (ri);
 		break;
 	case 0x78: case 0x79: case 0x7A: case 0x7B:
 	case 0x7C: case 0x7D: case 0x7E: case 0x7F: /* mov Rn, imm */
-		h (XR(L1) XW(RN));
+		xr (imm1); xw (rn);
 		break;
 	case 0x82: /* anl C, bit */
-		k (BIT_R XI(C, "&"));
+		bit_r; xi (c, "&");
 		break;
 	case 0x83: /* movc a, @a+pc */
-		emit ("a,pc,--,+,[1]," XW(A) FLAG_P);
+		e ("a,pc,--,+,[1],a,=," flag_p);
 		break;
 	case 0x84: /* div ab */
 		// note: escape % if this becomes a format string
-		emit ("b,0,==,ov,=,b,a,%,b,a,/=,b,=,0,c,=," FLAG_P);
+		e ("b,0,==,ov,=,b,a,%,b,a,/=,b,=,0,c,=," flag_p);
 		break;
 	case 0x85: /* mov direct, direct */
-		h (XR(IB1) XW(IB2));
+		xr (dir1); xw (dir2);
 		break;
 	case 0x86: case 0x87: /* mov direct, @Ri */
-		j (XR(RI) XW(IB1));
+		xr (ri); xw (dir1);
 		break;
 	case 0x88: case 0x89: case 0x8A: case 0x8B:
 	case 0x8C: case 0x8D: case 0x8E: case 0x8F: /* mov direct, Rn */
-		h (XR(RN) XW(IB1));
+		xr (rn); xw (dir1);
 		break;
 	case 0x90: /* mov dptr, imm */
-		h (XR(L16) XW(DP));
+		xr (imm16); xw (dp);
 		break;
 	case 0x92: /* mov bit, C */
-		k (BIT_C BIT_MASK XR(BIT) "&,|," XW(BIT));
+		bit_c; bit_mask; xr (bit); e ("&,|,"); xw(bit);
 		break;
 	case 0x93: /* movc a, @a+dptr */
-		h ("a,dptr,+,[1]," XW(A) FLAG_P);
+		e ("a,dptr,+,[1],a,=," flag_p);
 		break;
-	TEMPLATE_ALU_C (0x90, "-", FLAG_B FLAG_AB FLAG_OB FLAG_P) /* 0x94..0x9f subb a,.. */
+	template_alu4_c (0x90, "-", flag_b flag_ab flag_ob flag_p) /* 0x94..0x9f subb a,.. */
 	case 0xA0: /* orl C, /bit */
-		k (BIT_R "!," XI(C, "|"));
+		bit_r; e ("!,"); xi (c, "|");
 		break;
 	case 0xA2: /* mov C, bit */
-		k (BIT_R XW(C));
+		bit_r; xw (c);
 		break;
 	case 0xA3: /* inc dptr */
-		h (XI(DP, "++"));
+		xi (dp, "++");
 		break;
 	case 0xA4: /* mul ab */
-		emit ("8,a,b,*,DUP,a,=,>>,DUP,b,=,0,==,!,ov,=,0,c,=," FLAG_P);
+		e ("8,a,b,*,DUP,a,=,>>,DUP,b,=,0,==,!,ov,=,0,c,=," flag_p);
 		break;
 	case 0xA5: /* "reserved" */
-		emit ("0,trap");
+		e ("0,trap");
 		break;
 	case 0xA6: case 0xA7: /* mov @Ri, direct */
-		j (XR(IB1) XW(RI));
+		xr (dir1); xw (ri);
 		break;
 	case 0xA8: case 0xA9: case 0xAA: case 0xAB:
 	case 0xAC: case 0xAD: case 0xAE: case 0xAF: /* mov Rn, direct */
-		h (XR(IB1) XW(RN));
+		xr (dir1); xw (rn);
 		break;
 	case 0xB0: /* anl C, /bit */
-		k (BIT_R "!," XI(C, "&"));
+		bit_r; e ("!,"); xi (c, "&");
 		break;
 	case 0xB2: /* cpl bit */
-		k (BIT_SET XI(BIT, "^"));
+		bit_set; xi (bit, "^");
 		break;
 	case 0xB3: /* cpl C */
-		h ("1," XI(C, "^"));
+		e ("1,"); xi (c, "^");
 		break;
 	case 0xB4: /* cjne a, imm, offset */
-		h (XR(L1) XR(A) "-," FLAG_B CJMP);
+		xr (imm1); xr (a); e ("-," flag_b); cjmp;
 		break;
 	case 0xB5: /* cjne a, direct, offset */
-		h (XR(IB1) XR(A) "-," FLAG_B CJMP);
+		xr (dir1); xr (a); e ("-," flag_b); cjmp;
 		break;
 	case 0xB6: case 0xB7: /* cjne @ri, imm, offset */
-		j (XR(L1) XR(RI) "-," FLAG_B CJMP);
+		xr (imm1); xr (ri); e ("-," flag_b); cjmp;
 		break;
 	case 0xB8: case 0xB9: case 0xBA: case 0xBB:
 	case 0xBC: case 0xBD: case 0xBE: case 0xBF: /* cjne Rn, imm, offset */
-		h (XR(L1) XR(RN) "-," FLAG_B CJMP);
+		xr (imm1); xr (rn); e ("-," flag_b); cjmp;
 		break;
 	case 0xC0: /* push direct */
-		h (XR(IB1) PUSH1);
+		xr (dir1); xw (sp1);
 		break;
 	case 0xC2: /* clr bit */
-		k (BIT_MASK XI(BIT, "&"));
+		bit_mask; xi (bit, "&");
 		break;
 	case 0xC3: /* clr C */
-		h ("0," XW(C));
+		e ("0,"); xw (c);
 		break;
 	case 0xC4: /* swap a */
-		h ("0xff,4,a,0x101,*,>>,&," XW(A) FLAG_P);
+		e ("0xff,4,a,0x101,*,>>,&,a,=," flag_p);
 		break;
 	case 0xC5: /* xch a, direct */
-		h (XR(A) "0,+," XR(IB1) XW(A) XW(IB1) FLAG_P);
+		xr (a); e ("0,+,"); xr (dir1); xw (a); xw (dir1); e (flag_p);
 		break;
 	case 0xC6: case 0xC7: /* xch a, @Ri */ 
-		j (XR(A) "0,+," XR(RI) XW(A) XW(RI) FLAG_P);
+		xr (a); e ("0,+,"); xr (ri); xw (a); xw (ri); e (flag_p);
 		break;
 	case 0xC8: case 0xC9: case 0xCA: case 0xCB:
 	case 0xCC: case 0xCD: case 0xCE: case 0xCF: /* xch a, Rn */
-		h (XR(A) "0,+," XR(RN) XW(A) XW(RN) FLAG_P);
+		xr (a); e ("0,+,"); xr (rn); xw (a); xw (rn); e (flag_p);
 		break;
 	case 0xD0: /* pop direct */
-		h (POP1 XW(IB1));
+		xr (sp1); xw (dir1);
 		break;
 	case 0xD2: /* setb bit */
-		k (BIT_SET XI(BIT, "|"));
+		bit_set; xi (bit, "|");
 		break;
 	case 0xD3: /* setb C */
-		h ("1," XW(C));
+		e ("1,"); xw (c);
 		break;
 	case 0xD4: /* da a */
 		// BCD adjust after add:
 		// if (lower nibble > 9) or (AC == 1) add 6
 		// if (higher nibble > 9) or (C == 1) add 0x60
 		// carry |= carry caused by this operation
-		emit ("a,0x0f,&,9,<,ac,|,?{,6,a,+=,$c7,c,|=,},a,0xf0,&,0x90,<,c,|,?{,0x60,a,+=,$c7,c,|=,}," FLAG_P);
+		e ("a,0x0f,&,9,<,ac,|,?{,6,a,+=,$c7,c,|=,},a,0xf0,&,0x90,<,c,|,?{,0x60,a,+=,$c7,c,|=,}," flag_p);
 		break;
 	case 0xD5: /* djnz direct, offset */
-		h (XI(IB1, "--") XR(IB1) "0,==,!," CJMP);
+		xi (dir1, "--"); xr (dir1); e ("0,==,!,"); cjmp;
 		break;
 	case 0xD6:
 	case 0xD7: /* xchd a, @Ri*/
-		j (XR(A) "0xf0,&," XR(RI) "0x0f,&,|," XR(RI) "0xf0,&," XR(A) "0x0f,&,|," XW(RI) XW(A) FLAG_P);
+		xr (a); e ("0xf0,&,"); xr (ri); e ("0x0f,&,|,");
+		xr (ri); e ("0xf0,&,"); xr (a); e ("0x0f,&,|,");
+		xw (ri); xw (a); e (flag_p);
 		break;
 	case 0xD8: case 0xD9: case 0xDA: case 0xDB:
 	case 0xDC: case 0xDD: case 0xDE: case 0xDF: /* djnz Rn, offset */
-		h (XI(RN, "--") XR(RN) "0,==,!," CJMP);
+		xi (rn, "--"); xr (rn); e ("0,==,!,"); cjmp;
 		break;
 	case 0xE0: /* movx a, @dptr */
-		h (XR(DPX) XW(A) FLAG_P);
+		xr (dpx); xw (a); e (flag_p);
 		break;
 	case 0xE2: case 0xE3: /* movx a, @Ri */
-		j (XR(R0X) XW(A) FLAG_P);
+		xr (rix); xw (a); e (flag_p);
 		break;
 	case 0xE4: /* clr a */
-		emit ("0," XW(A) FLAG_P);
+		e ("0,"); xw (a); e (flag_p);
 		break;
 	case 0xE5: /* mov a, direct */
-		h (XR(IB1) XW(A) FLAG_P);
+		xr (dir1); xw (a); e (flag_p);
 		break;
 	case 0xE6: case 0xE7: /* mov a, @Ri */
-		j (XR(RI) XW(A) FLAG_P);
+		xr (ri); xw (a); e (flag_p);
 		break;
 	case 0xE8: case 0xE9: case 0xEA: case 0xEB:
 	case 0xEC: case 0xED: case 0xEE: case 0xEF: /* mov a, Rn */
-		h (XR(RN) XW(A) FLAG_P);
+		xr (rn); xw (a); e (flag_p);
 		break;
 	case 0xF0: /* movx @dptr, a */
-		h (XR(A) XW(DPX));
+		xr (a); xw (dpx);
 		break;
 	case 0xF2: case 0xF3: /* movx @Ri, a */
-		j (XR(A) XW(R0X));
+		xr (a); xw (rix);
 		break;
 	case 0xF4: /* cpl a */
-		h ("255," XI(A, "^") FLAG_P);
+		e ("255,"); xi (a, "^"); e (flag_p);
 		break;
 	case 0xF5: /* mov direct, a */
-		h (XR(A) XW(IB1));
+		xr (a); xw (dir1);
 		break;
 	case 0xF6: case 0xF7: /* mov  @Ri, a */
-		j (XR(A) XW(RI));
+		xr (a); xw (ri);
 		break;
 	case 0xF8: case 0xF9: case 0xFA: case 0xFB:
 	case 0xFC: case 0xFD: case 0xFE: case 0xFF: /* mov Rn, a */
-		h (XR(A) XW(RN));
+		xr (a); xw (rn);
 		break;
 	default:
 		break;
 	}
 }
 
+#if 0
+// custom reg read/write temporarily disabled - see r2 issue #9242
 static int i8051_hook_reg_read(RAnalEsil *, const char *, ut64 *, int *);
 
 static int i8051_reg_compare(const void *name, const void *reg) {
@@ -512,7 +598,7 @@ static int i8051_hook_reg_read(RAnalEsil *esil, const char *name, ut64 *res, int
 
 	if ((ri = i8051_reg_find (name))) {
 		ut8 offset = i8051_reg_get_offset(esil, ri);
-		ret = r_anal_esil_mem_read (esil, IRAM + offset, (ut8*)res, ri->num_bytes);
+		ret = r_anal_esil_mem_read (esil, IRAM_BASE + offset, (ut8*)res, ri->num_bytes);
 	}
 	esil->cb = ocbs;
 	if (!ret && ocbs.hook_reg_read) {
@@ -532,7 +618,7 @@ static int i8051_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	RAnalEsilCallbacks cbs = esil->cb;
 	if ((ri = i8051_reg_find (name))) {
 		ut8 offset = i8051_reg_get_offset(esil, ri);
-		ret = r_anal_esil_mem_write (esil, IRAM + offset, (ut8*)val, ri->num_bytes);
+		ret = r_anal_esil_mem_write (esil, IRAM_BASE + offset, (ut8*)val, ri->num_bytes);
 	}
 	esil->cb = ocbs;
 	if (!ret && ocbs.hook_reg_write) {
@@ -541,6 +627,7 @@ static int i8051_hook_reg_write(RAnalEsil *esil, const char *name, ut64 *val) {
 	esil->cb = cbs;
 	return ret;
 }
+#endif
 
 static int esil_i8051_init (RAnalEsil *esil) {
 	if (esil->cb.user) {
@@ -610,17 +697,17 @@ static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 
 	switch (arg1) {
 	case A_DIRECT:
-		op->ptr = buf[1] + IRAM;
+		op->ptr = buf[1] + IRAM_BASE;
 		break;
 	case A_BIT:
-		op->ptr = arg_bit (buf[1]) + IRAM;
+		op->ptr = arg_bit (buf[1]) + IRAM_BASE;
 		break;
 	case A_IMMEDIATE:
 		op->val = buf[1];
 		break;
 	case A_IMM16:
 		op->val = buf[1] * 256 + buf[2];
-		op->ptr = XRAM + op->val;	// best guess, it's a XRAM pointer
+		op->ptr = XRAM_BASE + op->val;	// best guess, it's a XRAM pointer
 		break;
 	default:
 		break;
@@ -629,14 +716,14 @@ static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	switch (arg2) {
 	case A_DIRECT:
 		if (arg1 == A_RI || arg1 == A_RN) {
-			op->ptr = IRAM + buf[1];
+			op->ptr = IRAM_BASE + buf[1];
 		} else if (arg1 != A_DIRECT) {
-			op->ptr = IRAM + buf[2];
+			op->ptr = IRAM_BASE + buf[2];
 		}
 		break;
 	case A_BIT:
 		op->ptr = arg_bit ((arg1 == A_RI || arg1 == A_RN) ? buf[1] : buf[2]);
-		op->ptr += IRAM;
+		op->ptr += IRAM_BASE;
 		break;
 	case A_IMMEDIATE:
 		op->val = (arg1 == A_RI || arg1 == A_RN) ? buf[1] : buf[2];


### PR DESCRIPTION
Refactored macros to generate esil. Removed all uses of %N$, which should fix issue #3944

This is also in preparation for cpu specific IRAM and XRAM mapping, support for SFR, and other memory mapping quirks of the 8051.

8051 esil regressions tested successfully.