### PR TITLE
Fix Segmentation fault in io_zip for IPA files

### DIFF
--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -391,7 +391,7 @@ static RIODesc *r_io_zip_open(RIO *io, const char *file, int rw, int mode) {
 							const char *slash = r_str_rchr (name, bin_name, '/');
 							if (slash) {
 								bin_name = r_str_ndup (slash + 1, (bin_name - slash) -1);
-								char *chkstr = r_str_newf ("Payload/%s.app/%s", bin_name);
+								char *chkstr = r_str_newf ("Payload/%s.app/%s", bin_name, bin_name);
 								if (!strcmp (name, chkstr)) {
 									zip_filename = r_str_newf ("//%s", chkstr);
 									free (chkstr);


### PR DESCRIPTION
Opening IPA files using the io_zip throws a segmentation file for any IPA I've tried.

The command executed is:
```
r2 ipa://test.ipa 
Segmentation fault
```

The backtrace is clear, the r_str_newf function has two "%s" but only one argument after the format, this can be fixed just passing "bin_name" twice. 

```
(gdb) bt
#0  strlen () at ../sysdeps/x86_64/strlen.S:106
#1  0x00007ffff3727d78 in _IO_vfprintf_internal (s=s@entry=0x7fffffffd190, format=<optimized out>, format@entry=0x7ffff5bb27d2 "Payload/%s.app/%s", 
    ap=ap@entry=0x7fffffffd318) at vfprintf.c:1637
#2  0x00007ffff374ee59 in _IO_vsnprintf (string=0x7fffffffd330 "Payload/Test.app/", maxlen=<optimized out>, 
    format=0x7ffff5bb27d2 "Payload/%s.app/%s", args=0x7fffffffd318) at vsnprintf.c:114
#3  0x00007ffff3cdb17e in r_str_newf (fmt=0x7ffff5bb27d2 "Payload/%s.app/%s") at str.c:658
#4  0x00007ffff5b801a8 in r_io_zip_open (io=0x55555584a750, file=0x7fffffffe177 "ipa://test.ipa", rw=5, mode=420)
    at p/io_zip.c:394
#5  0x00007ffff5b86c7f in r_io_desc_open (io=0x55555584a750, uri=0x7fffffffe177 "ipa://test.ipa", flags=5, mode=420)
    at desc.c:105
#6  0x00007ffff5b81911 in r_io_open_nomap (io=0x55555584a750, uri=0x7fffffffe177 "ipa://test.ipa", flags=5, mode=420)
    at io.c:259
#7  0x00007ffff7af3c55 in r_core_file_open (r=0x55555575d540 <r>, file=0x7fffffffe177 "ipa://test.ipa", flags=5, 
    loadaddr=0) at file.c:718
#8  0x0000555555559ce9 in main (argc=2, argv=0x7fffffffddd8, envp=0x7fffffffddf0) at radare2.c:1007
```

A test with an IPA file should be added to r2r, but I don't have any public, open-source and small IPA for r2r. @radare: You was working with several r2 apps for IOs ifrc, could we use one of those for testing?

Thanks