### PR TITLE
Incbin

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -156,7 +156,13 @@ static inline int r_asm_pseudo_incbin(RAsmOp *op, char *input) {
 	} else {
 		count = bytes_read;
 	}
-	memcpy (op->buf_hex, content + skip, count);
+	if (op->buf_test) {
+		//free (op->buf_test);
+	}
+	op->buf_test = (char*)calloc (count + 1, sizeof(char*));
+	op->buf_hex[0] = '\0';
+	memcpy (op->buf_test, content + skip, count);
+	printf("buf %s\n", op->buf_test);
 	free (content);
 	return count;
 }
@@ -968,13 +974,28 @@ R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf) {
 					return r_asm_code_free (acode);
 				}
 				acode->buf = (ut8*)newbuf;
-				newbuf = realloc (acode->buf_hex, strlen (acode->buf_hex) + strlen (op.buf_hex) + 1);
+				printf ("1 %s\n", op.buf_test);
+				int x = 0;
+				if (op.buf_test) {
+					x = strlen (op.buf_test) + 1;
+				}
+				newbuf = realloc (acode->buf_hex, strlen (acode->buf_hex) + strlen (op.buf_hex) + x + 1);
 				if (!newbuf) {
 					return r_asm_code_free (acode);
 				}
+				printf ("2\n");
+
 				acode->buf_hex = newbuf;
 				memcpy (acode->buf + idx, op.buf, ret);
+				printf ("3\n");
 				strcat (acode->buf_hex, op.buf_hex);
+				printf ("4\n");
+				if (op.buf_test) {
+					strcat (acode->buf_hex, "\n");
+					strcat (acode->buf_hex, op.buf_test);
+				}
+				printf ("5\n");
+				printf ("catting %s, %s\n", acode->buf_hex, op.buf_hex);
 			}
 		}
 	}

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -138,21 +138,15 @@ static inline int r_asm_pseudo_fill(RAsmOp *op, char *input) {
 }
 
 static inline int r_asm_pseudo_incbin(RAsmOp *op, char *input) {
-	int skip, count = 0;
-	char *args = r_str_lchr (input, ',');
-	if (args) {
-		args[0] = '\0';
-		args++;
-		skip = (int)r_num_math (NULL, args);
-		args = r_str_lchr (input, ',');
-		if (args) {
-			args[0] = '\0';
-			args++;
-			count = skip;
-			skip = (int)r_num_math (NULL, args);
-		}
-	}
+	int skip = 0;
+	int count = 0;
 	int bytes_read = 0;
+	r_str_replace_char (input, ',', ' ');
+	int len = r_str_word_count (input);
+	r_str_word_set0 (input);
+	char *filename = r_str_word_get0 (input, 0);
+	skip = (int)r_num_math (NULL, r_str_word_get0 (input, 1));
+	count = (int)r_num_math (NULL,r_str_word_get0 (input, 2));
 	char *content = r_file_slurp (input, &bytes_read);
 	if (skip > 0) {
 		skip = skip > bytes_read ? bytes_read : skip;
@@ -164,7 +158,7 @@ static inline int r_asm_pseudo_incbin(RAsmOp *op, char *input) {
 	}
 	memcpy (op->buf_hex, content + skip, count);
 	free (content);
-	return bytes_read;
+	return count;
 }
 
 static void plugin_free(RAsmPlugin *p) {

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -157,8 +157,8 @@ static inline int r_asm_pseudo_incbin(RAsmOp *op, char *input) {
 		count = bytes_read;
 	}
 	// Need to handle arbitrary amount of data
-	r_buf_free(op->buf_inc);
-	op->buf_inc = r_buf_new_with_string(content + skip);
+	r_buf_free (op->buf_inc);
+	op->buf_inc = r_buf_new_with_string (content + skip);
 	// Terminate the original buffer
 	op->buf_hex[0] = '\0';
 	free (content);
@@ -983,7 +983,7 @@ R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf) {
 					if (strlen (acode->buf_hex) > 0) {
 						strcat (acode->buf_hex, "\n");
 					}
-					strcat (acode->buf_hex, r_buf_free_to_string(op.buf_inc));
+					strcat (acode->buf_hex, r_buf_free_to_string (op.buf_inc));
 				}
 
 			}

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -73,6 +73,8 @@ typedef struct r_asm_op_t {
 	ut8  buf[R_ASM_BUFSIZE + 1];
 	char buf_asm[R_ASM_BUFSIZE + 1];
 	char buf_hex[R_ASM_BUFSIZE + 1];
+	RBuffer *buf_inc;
+
 } RAsmOp;
 
 typedef struct r_asm_code_t {


### PR DESCRIPTION
Implement incbin directive in assembler.

    .incbin "file"[, skip[, count]]

Supports directive to skip `skip` number of bytes from the beginning of the file and only include `count` number of bytes