### PR TITLE
8051: added configurable mapping of address spaces

### DIFF
--- a/libr/asm/p/asm_8051.c
+++ b/libr/asm/p/asm_8051.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2013-2017 - pancake, astuder */
+/* radare2 - LGPL - Copyright 2013-2018 - pancake, astuder */
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -26,7 +26,10 @@ RAsmPlugin r_asm_plugin_8051 = {
 	.endian = R_SYS_ENDIAN_NONE,
 	.desc = "8051 Intel CPU",
 	.disassemble = &disassemble,
-	.license = "PD"
+	.license = "PD",
+	.cpus =
+		"8051-generic," // First one is default
+		"8051-shared-code-xdata"
 };
 
 #ifndef CORELIB


### PR DESCRIPTION
- Replaced hard-coded mapping of address spaces with pseudo registers to configure emulation.
- Added support for asm.cpu to customize address mapping for different flavors of 8051
- Tested against existing 8051 esil regressions
