### PR TITLE
Removed c99 declaration in for loop

### DIFF
--- a/libr/core/blaze.c
+++ b/libr/core/blaze.c
@@ -493,6 +493,7 @@ R_API bool core_anal_bbs_range (RCore *core, const char* input) {
 	bool debug = r_config_get_i (core->config, "cfg.debug");
 	ut64 lista[1024] = { 0 };
 	int idx = 0;
+	int x;
 
 	block_list = r_list_new ();
 	if (!block_list) {
@@ -503,7 +504,7 @@ R_API bool core_anal_bbs_range (RCore *core, const char* input) {
 		eprintf ("Creating basic blocks\b");
 	}
 	lista[idx++] = b_start;
-	for (int x = 0; x < 1024; x++) {
+	for (x = 0; x < 1024; x++) {
 		if (lista[x] != 0) {
 			cur =0;
 			b_start = lista[x];


### PR DESCRIPTION
Hi,

I Could not compile in Debian 3.16.51-2 x86_64 due to this line and changing the makefile to be c99-compliant would just result in segfaults.

Let me know if I should do something else/amend my PR.

Ayowel