### PR TITLE
Second interpretation of imul

### DIFF
--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -52,6 +52,7 @@ static int replace (int argc, char *argv[], char *newstr) {
 		{ "fxch",  "#,# = #,#", {1, 2, 2, 1}},
 		{ "idiv",  "# /= #", {1, 2}},
 		{ "imul",  "# *= #", {1, 2}},
+		{ "imul",  "# *= #", {1, 3}},
 		{ "in",   "# = io[#]", {1, 2}},
 		{ "inc",  "#++", {1}},
 		{ "ja", "if (((unsigned) var) > 0) goto #", {1}},


### PR DESCRIPTION
imul is one of the few expressions that takes three arguments: `imul eax, eax, 0x16` is interpreted as `eax *= eax`, which is _wrong_. Also same case applies for `imul eax, ecx, 0x16` where it's supposed to be `eax = ecx * 0x16`
So as crowell said, imul should have **3** interpretations in total