### PR TITLE
Add alternative view for variables summary

### DIFF
--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -339,6 +339,9 @@ R_API ut64 r_config_get_i(RConfig *cfg, const char *name) {
 		if (node->i_value || !strcmp (node->value, "false")) {
 			return node->i_value;
 		}
+		if (!strcmp (node->value, "true")) {
+			return 1;
+		}
 		return (ut64) r_num_math (cfg->num, node->value);
 	}
 	return (ut64) 0LL;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2369,7 +2369,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.vars", "true", "Show local function variables in disassembly");
 	SETPREF ("asm.varxs", "false", "Show accesses of local variables");
 	SETPREF ("asm.varsub", "true", "Substitute variables in disassembly");
-	SETPREF ("asm.varsum", "false", "Show variables summary instead of full list in disasm");
+	SETI ("asm.varsum", 0, "Show variables summary instead of full list in disasm (0, 1, 2)");
 	SETPREF ("asm.varsub_only", "true", "Substitute the entire variable expression with the local variable name (e.g. [local10h] instead of [ebp+local10h])");
 	SETPREF ("asm.relsub", "true", "Substitute pc relative expressions in disasm");
 	SETPREF ("asm.cmtfold", "false", "Fold comments, toggle with Vz");


### PR DESCRIPTION
See #9239 . ~**Note that no colors are printed, unlike what's proposed in the issue.**~

```
[0x00000410]> e asm.varsum 
true
[0x00000410]> pdf
            ;-- section..text:
            ;-- eip:
╭ (fcn) entry0 49
│ bp: 0 (vars 0, args 0)
│ sp: 0 (vars 0, args 0)
│ rg: 0 (vars 0, args 0)
...
[0x00000410]> e asm.varsum=1
[0x00000410]> pdf
            ;-- section..text:
            ;-- eip:
╭ (fcn) entry0 49
│ bp: 0 (vars 0, args 0)
│ sp: 0 (vars 0, args 0)
│ rg: 0 (vars 0, args 0)
...
[0x00000410]> e asm.varsum=2
[0x00000410]> pdf
            ;-- section..text:
            ;-- eip:
╭ (fcn) entry0 49
│ vars: 0 0 0
│ args: 0 0 0
...
[0x00000410]> 
```

~[0x565d254d]> e asm.varsum.altern=true~
~[0x565d254d]> pdf|head -n6~
~╭ (fcn) sym.fn 30~
~│ vars: 1 0 0~
~│ args: 1 0 0~
~│           0x565d254d      55             push ebp~
~│           0x565d254e      89e5           mov ebp, esp~
~│           0x565d2550      83ec10         sub esp, 0x10~
~[0x565d254d]>~
~[0x565d254d]>~
~[0x565d254d]>~
~[0x565d254d]> e asm.varsum.altern=false~
~[0x565d254d]> pdf|head -n6~
~╭ (fcn) sym.fn 30~
~│ bp: 2 (vars 1, args 1)~
~│ sp: 0 (vars 0, args 0)~
~│ rg: 0 (vars 0, args 0)~
~│           0x565d254d      55             push ebp~
~│           0x565d254e      89e5           mov ebp, esp~