### PR TITLE
Remove compressed symsrv symbol support

### DIFF
--- a/libr/bin/pdb/pdb_downloader.h
+++ b/libr/bin/pdb/pdb_downloader.h
@@ -20,7 +20,6 @@ typedef struct SPDBDownloaderOpt {
 	char *dbg_file;
 	char *guid;
 	char *path;
-	ut64 extract;
 } SPDBDownloaderOpt;
 
 typedef struct SPDBDownloader {


### PR DESCRIPTION
Fixes #9309

Microsoft made changes server-side and has obsoleted compressed symbol support for all newer binaries (to speed up the process). (https://twitter.com/WithinRafael/status/960050544684384256)

Rather than futz with more failback code, I yanked compressed symbol support. There's no guarantee compressed symbols will exist now or in the future so radare2 shouldn't bother trying.