### PR TITLE
Fix #5570 , Add dword/qword and stop analyzing PE imports

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2920,6 +2920,9 @@ R_API int r_core_anal_all(RCore *core) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
+			if (strstr (symbol->name, ".dll_")) { // Stop analyzing PE imports further
+				continue;
+			}
 			if (isValidSymbol (symbol)) {
 				ut64 addr = r_bin_get_vaddr (core->bin, symbol->paddr,
 					symbol->vaddr);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1686,6 +1686,7 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 	int i = 0;
 
 	RList *imports = r_bin_get_imports (r->bin);
+	int cdsz = info? (info->bits == 64? 8: info->bits == 32? 4: info->bits == 16 ? 4: 0): 0;
 	if (IS_MODE_JSON (mode)) {
 		r_cons_print ("[");
 	} else if (IS_MODE_RAD (mode)) {
@@ -1714,6 +1715,10 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 		}
 		if (IS_MODE_SET (mode)) {
 			// TODO(eddyb) symbols that are imports.
+			// Add a dword/qword for PE imports
+			if (strstr(symname, ".dll_") && cdsz) {
+				r_meta_add (r->anal, R_META_TYPE_DATA, addr, addr + cdsz, NULL);
+			}
 		} else if (IS_MODE_SIMPLE (mode)) {
 			r_cons_println (symname);
 		} else if (IS_MODE_JSON (mode)) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1716,7 +1716,7 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 		if (IS_MODE_SET (mode)) {
 			// TODO(eddyb) symbols that are imports.
 			// Add a dword/qword for PE imports
-			if (strstr(symname, ".dll_") && cdsz) {
+			if (strstr (symname, ".dll_") && cdsz) {
 				r_meta_add (r->anal, R_META_TYPE_DATA, addr, addr + cdsz, NULL);
 			}
 		} else if (IS_MODE_SIMPLE (mode)) {


### PR DESCRIPTION
Fixes issue #5570 and these regression : 

[ radare/radare2-regressions@8ab8a95](https://github.com/radare/radare2-regressions/commit/8ab8a95841713e9646f450cea9fbb272e6874caa)

[radare/radare2-regressions@5e7f739](https://github.com/radare/radare2-regressions/commit/5e7f739a9fb73ac4c3dd98ccab280b8d5fea5ec6)