### PR TITLE
Fix shell error if docker isn't present

### DIFF
--- a/sys/r2-docker.sh
+++ b/sys/r2-docker.sh
@@ -21,7 +21,7 @@ showHelp() {
 }
 
 # Check if docker is present
-[[ ! $(command -v docker) ]] && (
+[ -z "$(command -v docker)" ] && (
 	echo "You must install docker first. (see https://docs.docker.com/engine/installation/)"
 ) && exit 1
 


### PR DESCRIPTION
If the docker binary isn't present on the system, the r2-docker script fails with the following error message (instead of displaying the proper warning message).

    # /usr/bin/r2-docker -p
    /usr/bin/r2-docker: 25: /usr/bin/r2-docker: [[: not found
    /usr/bin/r2-docker: 37: /usr/bin/r2-docker: docker: not found
    /usr/bin/r2-docker: 39: /usr/bin/r2-docker: docker: not found