### PR TITLE
Refactor Disassembly pre and fix indent (Fix #9316)

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1799,11 +1799,7 @@ static void ds_show_flags(RDisasmState *ds) {
 		}
 		ds_begin_json_line (ds);
 		if (ds->show_flgoff) {
-			if (f) {
-				ds_beginline (ds);
-			} else {
-				ds_setup_print_pre (ds, false, false);
-			}
+			ds_beginline (ds);
 			ds_print_offset (ds);
 			r_cons_printf (" ");
 		} else {


### PR DESCRIPTION
I did quite a lot of refactoring. `ds->pre` is now an enum instead of a string itself and only converted to the corresponding string when eventually getting printed.
This way, it is much better to maintain in my opinion.

Some tests are broken in the current state, because they actually rely on the broken indentation. See https://github.com/radare/radare2-regressions/pull/1167 for the fixes and two additional tests for the indentation.