### PR TITLE
fix ood whitespace (#9302)

### DIFF
--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -417,6 +417,40 @@ static int fork_and_ptraceme_for_mac(RIO *io, int bits, const char *cmd) {
 }
 #endif
 
+static char *get_and_escape_path (char *str)
+{
+	char *path_bin = strdup (str);
+	char *final = NULL;
+
+	if (path_bin) {
+		char *p = r_str_lchr (str, '/');
+		char *pp = r_str_tok (p, ' ', -1);
+		char *args;
+
+		if (!pp) {
+			// There is nothing more to parse
+			return str;
+		}
+
+		path_bin[pp - str] = '\0';
+		if (strstr (path_bin, "\\ ")) {
+		        path_bin = r_str_replace (path_bin, "\\ ", " ", true);
+		}
+		args = path_bin + (pp - str) + 1;
+
+		char *path_bin_escaped = r_str_arg_escape (path_bin);
+		int len = strlen (path_bin_escaped);
+
+		path_bin_escaped[len] = ' ';
+		path_bin_escaped[len + 1] = '\0';
+
+		final = r_str_append (path_bin_escaped, args);
+		free (path_bin);
+       }
+
+       return final;
+}
+
 static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 #if __APPLE__ && !__POWERPC__
 	return fork_and_ptraceme_for_mac(io, bits, cmd);
@@ -449,10 +483,14 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 			char *_cmd = io->args ?
 				r_str_appendf (strdup (cmd), " %s", io->args) :
 				strdup (cmd);
-
+			char *path_escaped = get_and_escape_path (_cmd);
 			trace_me ();
-			argv = r_str_argv (_cmd, NULL);
+			argv = r_str_argv (path_escaped, NULL);
+			if (strstr (argv[0], "\\ ")) {
+				argv[0] = r_str_replace (argv[0], "\\ ", " ", true);
+			}
 			if (!argv) {
+				free (path_escaped);
 				free (_cmd);
 				return -1;
 			}
@@ -469,6 +507,7 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 				eprintf ("Invalid execvp\n");
 			}
 			r_str_argv_free (argv);
+			free (path_escaped);
 			free (_cmd);
 		}
 		perror ("fork_and_attach: execv");


### PR DESCRIPTION
This aims to fix #9302 

<pre>
$ pwd
/home/osalvador/lab/r2/test1 2
$ r2 -d ./test
Process with PID 15663 started...
= attach 15663 15663
bin.baddr 0x00400000
Using 0x400000
Unknown DW_FORM 0x06
asm.bits 64
 -- Finnished a beer
[0x7f1ab197a1f0]> ood arg arg2
Wait event received by different pid 15663
Process with PID 15666 started...
File dbg:///home/osalvador/lab/r2/test1 2/test  arg arg2 reopened in read-write mode
= attach 15666 15666
Unknown DW_FORM 0x06
15666
[0x7f802224a1f0]> dc
argv[0]: /home/osalvador/lab/r2/test1 2/test
argv[1]: arg
argv[2]: arg2
[0x7f8021f604a9]>
</pre>

<pre>
$ r2 -d ~/lab/r2/test1\ 2/test
Process with PID 15694 started...
= attach 15694 15694
bin.baddr 0x00400000
Using 0x400000
Unknown DW_FORM 0x06
asm.bits 64
 -- Disable these messages with 'e cfg.fortunes = false' in your ~/.radare2rc
0x7ff36a4381f0]> ood arg3 arg4
Wait event received by different pid 15694
Process with PID 15696 started...
File dbg:///home/osalvador/lab/r2/test1 2/test  arg3 arg4 reopened in read-write mode
= attach 15696 15696
Unknown DW_FORM 0x06
15696
[0x7f63b85a91f0]> dc
argv[0]: /home/osalvador/lab/r2/test1 2/test
argv[1]: arg3
argv[2]: arg4
[0x7f63b82bf4a9]>
</pre>

I tried to test it as much as possible.