### PR TITLE
Correct interpretation of imul and mul

### DIFF
--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -51,8 +51,7 @@ static int replace (int argc, char *argv[], char *newstr) {
 		{ "fsub",  "# = # - #", {1, 1, 2}},
 		{ "fxch",  "#,# = #,#", {1, 2, 2, 1}},
 		{ "idiv",  "# /= #", {1, 2}},
-		{ "imul",  "# *= #", {1, 2}},
-		{ "imul",  "# *= #", {1, 3}},
+		{ "imul",  "# = # * #", {1, 2, 3}},
 		{ "in",   "# = io[#]", {1, 2}},
 		{ "inc",  "#++", {1}},
 		{ "ja", "if (((unsigned) var) > 0) goto #", {1}},
@@ -78,7 +77,7 @@ static int replace (int argc, char *argv[], char *newstr) {
 		{ "pextrb", "# = (byte) # [#]", {1, 2, 3}},
 		{ "palignr", "# = # align #", {1, 2, 3}},
 		{ "pxor", "# ^= #", {1, 2}},
-		{ "mul",  "# *= #", {1, 2}},
+		{ "mul",  "# = # * #", {1, 2, 3}},
 		{ "neg",  "# ~= #", {1, 1}},
 		{ "nop",  "", {0}},
 		{ "not",  "# = !#", {1, 1}},
@@ -209,29 +208,45 @@ static int parse (RParse *p, const char *data, char *str) {
 			nw++;
 		}
 	}
-	if (strstr (w0, "mul") && nw == 2 ) {
-		r_str_ncpy (wa[2], wa[1], sizeof (w2));
+	/* TODO: interpretation of memory location fails*/
+	//ensure imul & mul interpretations works
+	if (strstr (w0, "mul")) {
+		if (nw == 2)
+		{
+			r_str_ncpy (wa[3], wa[1], sizeof (w3));
 
-		switch (wa[2][0]) {
-		case 'q':
-		case 'r': //qword, r..
-			r_str_ncpy (wa[1], "rax", sizeof (w1));
-			break;
-		case 'd':
-		case 'e': //dword, e..
-			if (strlen (wa[2]) > 2) {
-				r_str_ncpy (wa[1], "eax", sizeof (w1));
+			switch (wa[3][0]) {
+			case 'q':
+			case 'r': //qword, r..
+				r_str_ncpy (wa[1], "rax", sizeof (w1));
+				r_str_ncpy (wa[2], "rax", sizeof (w2));
 				break;
-			}
-		default : // .x, .p, .i or word
-			if (wa[2][1] == 'x' || wa[2][1] == 'p' || \
-				wa[2][1] == 'i' || wa[2][0] == 'w') {
-				r_str_ncpy (wa[1], "ax", sizeof (w1));
-			} else { // byte and lowest 8 bit registers
-				r_str_ncpy (wa[1], "al", sizeof (w1));
+			case 'd':
+			case 'e': //dword, e..
+				if (strlen (wa[3]) > 2) {
+					r_str_ncpy (wa[1], "eax", sizeof (w1));
+					r_str_ncpy (wa[2], "eax", sizeof (w2));
+					break;
+				}
+			default : // .x, .p, .i or word
+				if (wa[3][1] == 'x' || wa[3][1] == 'p' || \
+					wa[3][1] == 'i' || wa[3][0] == 'w') {
+					r_str_ncpy (wa[1], "ax", sizeof (w1));
+					r_str_ncpy (wa[2], "ax", sizeof (w2));
+				} else { // byte and lowest 8 bit registers
+					r_str_ncpy (wa[1], "al", sizeof (w1));
+					r_str_ncpy (wa[2], "al", sizeof (w2));
+				}
 			}
 		}
+		else if (nw == 3)
+		{
+			r_str_ncpy (wa[3], wa[2], sizeof (w3));
+			r_str_ncpy (wa[2], wa[1], sizeof (w2));
+		}
+		
 		replace (nw, wa, str);
+
 	} else if ((strstr (w1, "ax") || strstr (w1, "ah") || strstr (w1, "al")) && !p->retleave_asm) {
 		if (!(p->retleave_asm = (char *) malloc (sz))) {
 			return false;


### PR DESCRIPTION
I had to loosen  the contraction `*=`  to allow 3-operand imul to work with minor modifications. No SIMD(MMX,SSE*,...) or x87 floating-point instructions are tested.
Even if it's not written, bear in mind that `imul r32` stores the result in `edx:eax`, not only `eax`