### PR TITLE
Fix regression introduced on eeef82c2

### DIFF
--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -126,7 +126,7 @@ static RList *sections(RBinFile *bf) {
 			ptr->srwx |= R_BIN_SCN_WRITABLE;
 		}
 		if (R_BIN_TE_SCN_IS_READABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_SHAREABLE;
+			ptr->srwx |= R_BIN_SCN_READABLE;
 		}
 		if (R_BIN_TE_SCN_IS_SHAREABLE (sections[i].flags)) {
 			ptr->srwx |= R_BIN_SCN_SHAREABLE;


### PR DESCRIPTION
R_BIN_TE_SCN_IS_READABLE should result into R_BIN_SCN_READABLE, not
R_BIN_SCN_SHAREABLE.