### PR TITLE
Make aea output less obscure

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -164,7 +164,7 @@ static const char *help_detail_ae[] = {
 
 static const char *help_msg_aea[] = {
 	"Examples:", "aea", " show regs used in a range",
-	"aea", " [ops]", "Show regs used in N instructions",
+	"aea", " [ops]", "Show regs used in N instructions (all,read,{no,}written,memreads,memwrites)",
 	"aea*", " [ops]", "Create mem.* flags for memory accesses",
 	"aeaf", "", "Show regs used in current function",
 	"aear", " [ops]", "Show regs read in N instructions",
@@ -3853,13 +3853,13 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	} else if ((mode >> 5) & 1) {
 		// nothing
 	} else {
-		r_cons_printf ("A: ");
+		r_cons_printf (" A: ");
 		showregs (stats.regs);
-		r_cons_printf ("R: ");
+		r_cons_printf (" R: ");
 		showregs (stats.regread);
-		r_cons_printf ("W: ");
+		r_cons_printf (" W: ");
 		showregs (stats.regwrite);
-		r_cons_printf ("N: ");
+		r_cons_printf ("NW: ");
 		if (r_list_length (regnow)) {
 			showregs (regnow);
 		} else {
@@ -3869,11 +3869,11 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 		ut64 *n;
 		int c = 0;
 		r_list_foreach (mymemxsr, iter, n) {
-			r_cons_printf ("L%d: 0x%08"PFMT64x"\n", c++, *n);
+			r_cons_printf ("R%d: 0x%08"PFMT64x"\n", c++, *n);
 		}
 		c = 0;
 		r_list_foreach (mymemxsw, iter, n) {
-			r_cons_printf ("L%d: 0x%08"PFMT64x"\n", c++, *n);
+			r_cons_printf ("W%d: 0x%08"PFMT64x"\n", c++, *n);
 		}
 	}
 	r_list_free (mymemxsr);


### PR DESCRIPTION
What about
```
$ r2 ./radare2-regressions/bins/elf/bomb
[0x00400c90]> aea
 A: ebp zf pf sf cf of rbp
 R: ebp rbp
 W: ebp zf pf sf cf of rbp
NW: 
[0x00400c90]> aea 10
 A: ebp zf pf sf cf of rbp rdx r9 rsp rsi rax r8 rcx rdi
 R: ebp rbp rdx rsp rax
 W: ebp zf pf sf cf of rbp r9 rsi rsp rdx r8 rcx rdi
NW: rax
R0: 0x00000000
W0: 0xfffffffffffffff8
W1: 0xfffffffffffffff0
[0x00400c90]> aea?
|Examples: aea show regs used in a range
| aea [ops]   Show regs used in N instructions (all,read,{no,}written,memreads,memwrites)
| aea* [ops]  Create mem.* flags for memory accesses
| aeaf        Show regs used in current function
...
```
instead of current
```
$ r2 ./radare2-regressions/bins/elf/bomb 
[0x00400c90]> aea
A: ebp zf pf sf cf of rbp
R: ebp rbp
W: ebp zf pf sf cf of rbp
N: 
[0x00400c90]> aea 10
A: ebp zf pf sf cf of rbp rdx r9 rsp rsi rax r8 rcx rdi
R: ebp rbp rdx rsp rax
W: ebp zf pf sf cf of rbp r9 rsi rsp rdx r8 rcx rdi
N: rax
L0: 0x00000000
L0: 0xfffffffffffffff8
L1: 0xfffffffffffffff0
[0x00400c90]> aea?
|Examples: aea show regs used in a range
| aea [ops]   Show regs used in N instructions
| aea* [ops]  Create mem.* flags for memory accesses
| aeaf        Show regs used in current function
...
```

Test case changed in https://github.com/radare/radare2-regressions/pull/1173

JSON output has not been changed. Assuming that's mainly parsed by other software, a change on that  would only achieve breaking them. This pull is meant to make output clearer to users.