### PR TITLE
Add a warning if no section is executable when using aap

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -382,8 +382,12 @@ R_API int r_core_search_preludes(RCore *core) {
 		eprintf ("done\n");
 	}
 	fc1 = count_functions (core);
+	if (list) {
+		eprintf ("Analyzed %d functions based on preludes\n", fc1 - fc0);
+	} else {
+		eprintf ("No executable section found, cannot analyze anything. Use 'S' to change or define permissions of sections\n");
+	}
 	r_list_free (list);
-	eprintf ("Analyzed %d functions based on preludes\n", fc1 - fc0);
 	return ret;
 }
 


### PR DESCRIPTION
While trying to RE a firmware, I didn't realize that section
must be marked as 'executable' for aap to work, and the error message
didn't seems to imply that aap wasn't able to find anything.