### PR TITLE
the remove breakpoint command should be unified into db-

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -46,7 +46,7 @@ static const char *help_msg_db[] = {
 	"db", "", "List breakpoints",
 	"db", " sym.main", "Add breakpoint into sym.main",
 	"db", " <addr>", "Add breakpoint",
-	"db-", " <addr>", "Remove breakpoint",
+	"db", " -<addr>", "Remove breakpoint",
 	"db.", "", "Show breakpoint info in current offset",
 	"dbj", "", "List breakpoints in JSON format",
 	// "dbi", " 0x848 ecx=3", "stop execution when condition matches",
@@ -83,6 +83,8 @@ static const char *help_msg_db[] = {
 	"dbw", " <addr> <rw>", "Add watchpoint",
 	"drx", " number addr len rwx", "Modify hardware breakpoint",
 	"drx-", "number", "Clear hardware breakpoint",
+	"db-", " <addr>", "Remove breakpoint",
+	"db-*", "", "Remove all the breakpoints",
 	NULL
 };
 

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -46,7 +46,7 @@ static const char *help_msg_db[] = {
 	"db", "", "List breakpoints",
 	"db", " sym.main", "Add breakpoint into sym.main",
 	"db", " <addr>", "Add breakpoint",
-	"db", " -<addr>", "Remove breakpoint",
+	"db-", " <addr>", "Remove breakpoint",
 	"db.", "", "Show breakpoint info in current offset",
 	"dbj", "", "List breakpoints in JSON format",
 	// "dbi", " 0x848 ecx=3", "stop execution when condition matches",

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -46,7 +46,8 @@ static const char *help_msg_db[] = {
 	"db", "", "List breakpoints",
 	"db", " sym.main", "Add breakpoint into sym.main",
 	"db", " <addr>", "Add breakpoint",
-	"db", " -<addr>", "Remove breakpoint",
+	"db-", " <addr>", "Remove breakpoint",
+	"db-*", "", "Remove all the breakpoints",
 	"db.", "", "Show breakpoint info in current offset",
 	"dbj", "", "List breakpoints in JSON format",
 	// "dbi", " 0x848 ecx=3", "stop execution when condition matches",
@@ -83,8 +84,6 @@ static const char *help_msg_db[] = {
 	"dbw", " <addr> <rw>", "Add watchpoint",
 	"drx", " number addr len rwx", "Modify hardware breakpoint",
 	"drx-", "number", "Clear hardware breakpoint",
-	"db-", " <addr>", "Remove breakpoint",
-	"db-*", "", "Remove all the breakpoints",
 	NULL
 };
 


### PR DESCRIPTION
in previous contribution, i made autocomplete for db- work but still help message suggest 'db -' to use, yet other commands, for example dbh- and drx- have got no space between command and '-', so i guess it is pretty safe to modify help message for "remove breakpoints" to be "db-" from "db -", and that is where my intention lies in when i made the autocomplete work for it anyway.