### PR TITLE
Fix potential free on random value in r_anal_diff_fingerprint_bb

### DIFF
--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -80,8 +80,8 @@ R_API int r_anal_diff_fingerprint_bb(RAnal *anal, RAnalBlock *bb) {
 			}
 			free (op);
 		}
+		free (buf);
 	}
-	free (buf);
 	return bb->size;
 }
 


### PR DESCRIPTION
Since buf is not initilized, if anal->iob.read_at fail, memcpy is
not executed, so buf would stay uninitilized and then a random pointer
might be freed, which is likely incorrect.