### PR TITLE
util: when writing to a format value, overwrite all bytes

### DIFF
--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -870,7 +870,7 @@ static void r_print_format_word(const RPrint* p, int endian, int mode,
 		? (*(buf + i)) << 8 | (*(buf + i + 1))
 		: (*(buf + i + 1)) << 8 | (*(buf + i));
 	if (MUSTSET) {
-		p->cb_printf ("wx %s @ 0x%08"PFMT64x"\n", setval, seeki+((elem>=0)?elem*2:0));
+		p->cb_printf ("wv2 %s @ 0x%08"PFMT64x"\n", setval, seeki+((elem>=0)?elem*2:0));
 	} else if (mode & R_PRINT_DOT) {
 		if (size == -1) {
 			p->cb_printf ("0x%04x", addr);


### PR DESCRIPTION
Before this patch, when you did:

pf.test xww v1 v2 v3
pf.test.v2=0x1

only the first byte was overwritten, leaving whatever was in the high
byte of v2 there.