### PR TITLE
Shared libraries don't contain a PT_INTERP segment (#9331)

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1849,7 +1849,8 @@ int Elf_(r_bin_elf_get_static)(ELFOBJ *bin) {
 		return false;
 	}
 	for (i = 0; i < bin->ehdr.e_phnum; i++) {
-		if (bin->phdr[i].p_type == PT_INTERP) {
+		if (bin->phdr[i].p_type == PT_INTERP ||
+			bin->phdr[i].p_type == PT_DYNAMIC) {
 			return false;
 		}
 	}


### PR DESCRIPTION
This fixes #9331 

Shared libraries don't contain a PT_INTERP segment, only the executables that use those libraries have it.
(they need in order to load those libraries).

So for shared libraries we need to check for PT_DYNAMIC as well.

From the ELF specs:
<pre>
PT_DYNAMIC
The array element specifies dynamic linking information.  See ‘‘Dynamic Section’’ below
for more information.
</pre>