### PR TITLE
Ensure pdb path is stripped down to filename (fixes #9385)

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2717,6 +2717,7 @@ static void get_nb10(ut8* dbg_data, SCV_NB10_HEADER* res) {
 static int get_debug_info(struct PE_(r_bin_pe_obj_t)* bin, PE_(image_debug_directory_entry)* dbg_dir_entry, ut8* dbg_data, int dbg_data_len, SDebugInfo* res) {
 	#define SIZEOF_FILE_NAME 255
 	int i = 0;
+	const char* basename;
 	if (!dbg_data) {
 		return 0;
 	}
@@ -2743,8 +2744,9 @@ static int get_debug_info(struct PE_(r_bin_pe_obj_t)* bin, PE_(image_debug_direc
 				rsds_hdr.guid.data4[6],
 				rsds_hdr.guid.data4[7],
 				rsds_hdr.age);
+			basename = r_file_basename (rsds_hdr.file_name);
 			strncpy (res->file_name, (const char*)
-				rsds_hdr.file_name, sizeof (res->file_name));
+				basename, sizeof (res->file_name));
 			res->file_name[sizeof (res->file_name) - 1] = 0;
 			rsds_hdr.free ((struct SCV_RSDS_HEADER*) &rsds_hdr);
 		} else if (strncmp ((const char*) dbg_data, "NB10", 4) == 0) {


### PR DESCRIPTION
R2 currently assumes the CodeView structure contains only filename data, when it can also contain file path data, causing issues later in the program (e.g. when downloading PDBs, storing them in the symbol store, etc.)

This PR:
* Pulls base filename from paths (and filenames) passed in using `r_file_basename ` ([code](https://github.com/radare/radare2/compare/master...riverar:pdb_path_filename?expand=1#diff-15f63750bbf1cea750d78c8cfc33a916R2750))
* Reverts the previous attempt at tackling this issue