### PR TITLE
fixed the bug where the stack pane in V! mode gets stuck when it scrolls down.

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1524,21 +1524,24 @@ R_API char *r_str_ansi_crop(const char *str, ut32 x, ut32 y, ut32 x2, ut32 y2) {
 			str++;
 			ch++;
 			cw = 0;
-		} else if (*str == 0x1b && *(str + 1) == '[') {
-			const char *ptr = str;
-			if ((r_end - r) > 2) {
-				/* copy 0x1b and [ */
-				*r++ = *str++;
-				*r++ = *str++;
-				for (ptr = str; *ptr && *ptr != 'J' && *ptr != 'm' && *ptr != 'H'; ++ptr) {
-					*r++ = *ptr;
-				}
-				*r++ = *ptr++;
-			}
-			str = ptr;
 		} else {
 			if (ch >= y && ch < y2 && cw >= x && cw < x2) {
-				*r++ = *str;
+				if (*str == 0x1b && *(str + 1) == '[') {
+					const char *ptr = str;
+					if ((r_end - r) > 2) {
+						/* copy 0x1b and [ */
+						*r++ = *str++;
+						*r++ = *str++;
+						for (ptr = str; *ptr && *ptr != 'J' && *ptr != 'm' && *ptr != 'H'; ++ptr) {
+							*r++ = *ptr;
+						}
+						*r++ = *ptr++;
+					}
+					str = ptr;
+					continue;
+				} else {
+					*r++ = *str;
+				}
 			}
 
 			/* skip until newline */


### PR DESCRIPTION
how to reproduce the bug

1. go to V! mode
2. tab until reach to the stack pane
3. scroll down and you will see the screen completely gets stuck

it's caused by ansi_crop which didn't chop the string properly.
mainly the ansi part of codes in the string passed in the function never gets ripped off and stays in the new string created, so i made the function work properly.