### PR TITLE
Report error if write fails.

### DIFF
--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -321,7 +321,7 @@ R_API bool r_core_write_at(RCore *core, ut64 addr, const ut8 *buf, int size) {
 		return false;
 	}
 	ret = r_io_write_at (core->io, addr, buf, size);
-	if (addr >= core->offset && addr <= core->offset + core->blocksize) {
+	if (addr >= core->offset && addr <= core->offset + core->blocksize - 1) {
 		r_core_block_read (core);
 	}
 	return ret;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -120,6 +120,7 @@ static st64 on_map_skyline(RIO *io, ut64 vaddr, ut8 *buf, int len, int match_flg
 			break;
 		} else {
 			addr += len1;
+			ret = false;
 		}
 		// Reaches the end
 		if (addr == vaddr + len) {


### PR DESCRIPTION
```
% ~/Dev/Bin/radare2/debug/binr/radare2/radare2 a
[0x00000000]> wa nop
Failed to write
^D
% ~/Dev/Bin/radare2/debug/binr/radare2/radare2 -w a
[0x00000000]> wa nop
Written 1 byte(s) (nop) = wx 90
[0x00000000]>
```

Before, it claimed to succeed disregarding `-w`