### PR TITLE
fix jump substitution within functions when asm.jmpsub=true

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4229,7 +4229,7 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 	}
 	addr = ds->analop.jump;
 
-	fcn = r_anal_get_fcn_in (anal, addr, 0);
+	fcn = r_anal_get_fcn_at (anal, addr, 0);
 	if (fcn) {
 		name = fcn->name;
 	} else if (f) {


### PR DESCRIPTION
When asm.jmpsub was enabled, local branches within functions were substituted with function name instead of label.