### PR TITLE
fixed segfault due to uninitialized pointers

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -837,7 +837,7 @@ rep:
 						ut64 loff = 0; 
 						ut64 uoff = 0;
 						ut64 curseek = core->offset;
-						char *lmatch , *umatch;
+						char *lmatch = NULL , *umatch = NULL;
 						RFlagItem *flag;
 						RListIter *iter;
 						r_list_foreach (f->flags, iter, flag) { // creating a local copy


### PR DESCRIPTION
running `while true; do r2 /bin/ls -q -c 'fdw 0xfffffffff' ; done` crashes sometimes due to uninitialized pointers lmatch and umatch in line 862.