### PR TITLE
Relocation improvements

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2685,9 +2685,7 @@ static RBinElfSymbol* get_symbols_from_phdr(ELFOBJ *bin, int type) {
 			}
 			tsize = 16;
 		} else if (type == R_BIN_ELF_SYMBOLS &&
-		           sym[i].st_shndx != STN_UNDEF &&
-		           ELF_ST_TYPE (sym[i].st_info) != STT_SECTION &&
-		           ELF_ST_TYPE (sym[i].st_info) != STT_FILE) {
+		           sym[i].st_shndx != STN_UNDEF) {
 			tsize = sym[i].st_size;
 			toffset = (ut64) sym[i].st_value;
 		} else {
@@ -2962,9 +2960,7 @@ static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type
 					}
 					tsize = 16;
 				} else if (type == R_BIN_ELF_SYMBOLS &&
-					   sym[k].st_shndx != STN_UNDEF &&
-					   ELF_ST_TYPE (sym[k].st_info) != STT_SECTION &&
-					   ELF_ST_TYPE (sym[k].st_info) != STT_FILE) {
+					   sym[k].st_shndx != STN_UNDEF) {
 					//int idx = sym[k].st_shndx;
 					tsize = sym[k].st_size;
 					toffset = (ut64)sym[k].st_value; 

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1211,9 +1211,9 @@ static void set_bin_relocs(RCore *r, RBinReloc *reloc, ut64 addr, Sdb **db, char
 		}
 		reloc_name = reloc->import->name;
 		if (r->bin->prefix) {
-			snprintf (str, R_FLAG_NAME_SIZE, "%s.reloc.%s_%d", r->bin->prefix, reloc_name, (int)(addr&0xff));
+			snprintf (str, R_FLAG_NAME_SIZE, "%s.reloc.%s", r->bin->prefix, reloc_name);
 		} else {
-			snprintf (str, R_FLAG_NAME_SIZE, "reloc.%s_%d", reloc_name, (int)(addr&0xff));
+			snprintf (str, R_FLAG_NAME_SIZE, "reloc.%s", reloc_name);
 		}
 		if (bin_demangle) {
 			demname = r_bin_demangle (r->bin->cur, lang, str, addr);


### PR DESCRIPTION
This PR does some things:
1. it does not add `Cd` metadata when the relocation is in an executable section
2. it fixes relocations that point to sections (before this patch indeed, sections were excluded by the symbol table)
3. it groups together relocs that have the same import function.