### PR TITLE
Fix segfault caused by NULL deref

### DIFF
--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -612,7 +612,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 					r_config_get_i (r->config, "asm.bits"));
 		}
 	}
-	if (r_config_get_i (r->config, "io.exec")) {
+	if (desc && r_config_get_i (r->config, "io.exec")) {
 		desc->flags |= R_IO_EXEC;
 	}
 	if (plugin && plugin->name && !strcmp (plugin->name, "dex")) {


### PR DESCRIPTION
Fix segfault caused by NULL deref in `file.c`.

### Steps to reproduce the behaviour
```
mandlebro@machine:$ r2 /bin/ls -c 'oom;io'
Segmentation fault (core dumped)
```

The offending line is 616 of file.c
```c
615     	if (r_config_get_i (r->config, "io.exec")) {
616     		desc->flags |= R_IO_EXEC;
617     	}
```
where the `desc` is NULL.