### PR TITLE
fix segfault caused by NULL deref in pdb.c

### DIFF
--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -1179,6 +1179,10 @@ R_API bool init_pdb_parser(R_PDB *pdb, const char *filename) {
 		pdb->cb_printf = (PrintfCallback) printf;
 	}
 	pdb->buf = r_buf_new_slurp (filename);
+	if (!pdb->buf) {
+		eprintf ("File reading error/empty file\n");		
+		goto error;
+	}	
 // pdb->fp = r_sandbox_fopen (filename, "rb");
 // if (!pdb->fp) {
 // eprintf ("file %s can not be open\n", filename);


### PR DESCRIPTION
### TLDR
Fix segfault caused by NULL deref

### Steps to reproduce the behaviour
```
mandlebro@machine:$ touch beef
mandlebro@machine:$ r2 - -c 'idp beef'
Segmentation fault (core dumped)
```

## Cause
The offending line is 661 of `buf.c`
```c
660	R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, int len) {
661		RIOBind *iob = b->iob;
```
where `b` is NULL.

This buffer comes from `pdb.c:1181`
```c
1181     	pdb->buf = r_buf_new_slurp (filename);
```
which is not checked for null deref.