### PR TITLE
Do not overwrite row_offsets while printing disassembly

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4207,6 +4207,7 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 	int continueoninvbreak = (len == l) && invbreak;
 	RAnalFunction *of = NULL;
 	RAnalFunction *f = NULL;
+	bool calc_row_offsets = p->calc_row_offsets;
 	int ret, i, inc, skip_bytes = 0, idx = 0;
 	int dorepeat = 1;
 	ut8 *nbuf = NULL;
@@ -4223,6 +4224,10 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 	ds->hint = NULL;
 	ds->use_json = json;
 	ds->first_line = true;
+
+	// disable row_offsets to prevent other commands to overwrite computed info
+	p->calc_row_offsets = false;
+
 	//r_cons_printf ("len =%d l=%d ib=%d limit=%d\n", len, l, invbreak, p->limit);
 	// TODO: import values from debugger is possible
 	// TODO: allow to get those register snapshots from traces
@@ -4405,7 +4410,7 @@ toro:
 		}
 		ds_print_bbline (ds, false);
 		if (ds->at >= addr) {
-			r_print_set_rowoff (core->print, ds->lines, ds->at - addr);
+			r_print_set_rowoff (core->print, ds->lines, ds->at - addr, calc_row_offsets);
 		}
 		if (ds->midflags) {
 			skip_bytes = handleMidFlags (core, ds, true);
@@ -4578,13 +4583,14 @@ toro:
 	if (ds->use_json) {
 		r_cons_print ("]");
 	}
-	r_print_set_rowoff (core->print, ds->lines, ds->at - addr);
-	r_print_set_rowoff (core->print, ds->lines + 1, UT32_MAX);
+	r_print_set_rowoff (core->print, ds->lines, ds->at - addr, calc_row_offsets);
+	r_print_set_rowoff (core->print, ds->lines + 1, UT32_MAX, calc_row_offsets);
 	// TODO: this too (must review)
 	ds_print_esil_anal_fini (ds);
 	ds_reflines_fini (ds);
 	ds_free (ds);
 	R_FREE (nbuf);
+	p->calc_row_offsets = calc_row_offsets;
 	/* used by asm.emu */
 	r_reg_arena_pop (core->anal->reg);
 	return addrbytes * idx; //-ds->lastfail;

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -89,6 +89,8 @@ typedef struct r_print_t {
 	int lines_abs;
 	bool esc_bslash;
 
+	// when true it uses row_offsets
+	bool calc_row_offsets;
 	// offset of the first byte of each printed row.
 	// Last elements is marked with a UT32_MAX.
 	ut32 *row_offsets;
@@ -170,7 +172,7 @@ R_API const char * r_print_color_op_type(RPrint *p, ut64 anal_type);
 R_API void r_print_set_interrupted(int i);
 R_API void r_print_init_rowoffsets(RPrint *p);
 R_API ut32 r_print_rowoff(RPrint *p, int i);
-R_API void r_print_set_rowoff(RPrint *p, int i, ut32 offset);
+R_API void r_print_set_rowoff(RPrint *p, int i, ut32 offset, bool overwrite);
 R_API int r_print_row_at_off(RPrint *p, ut32 offset);
 // WIP
 R_API int r_print_unpack7bit(const char *src, char *dest);

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -297,6 +297,7 @@ R_API RPrint* r_print_new() {
 	p->get_register = NULL;
 	p->get_register_value = NULL;
 	p->lines_cache = NULL;
+	p->calc_row_offsets = true;
 	p->row_offsets_sz = 0;
 	p->row_offsets = NULL;
 	p->vflush = true;
@@ -1787,12 +1788,17 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 
 // reset the status of row_offsets
 R_API void r_print_init_rowoffsets(RPrint *p) {
-	R_FREE (p->row_offsets);
-	p->row_offsets_sz = 0;
+	if (p->calc_row_offsets) {
+		R_FREE(p->row_offsets);
+		p->row_offsets_sz = 0;
+	}
 }
 
 // set the offset, from the start of the printing, of the i-th row
-R_API void r_print_set_rowoff(RPrint *p, int i, ut32 offset) {
+R_API void r_print_set_rowoff(RPrint *p, int i, ut32 offset, bool overwrite) {
+	if (!overwrite) {
+		return;
+	}
 	if (i < 0) {
 		return;
 	}


### PR DESCRIPTION
@radare It should fix #9469, but please test it with your own config file if you have a chance. It worked for me with asm.emu=true.