### PR TITLE
Updating to Debian 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@
 # $ r2 -d /bin/true
 #
 
-# Using debian 8 as base image.
-FROM debian:8
+# Using debian 9 as base image.
+FROM debian:9
 
 # Label base
 LABEL r2docker latest


### PR DESCRIPTION
I'm finding more binaries that require libraries that Debian Jessie just does not have (such as modern versions of glibc). Ticking the debian here up to 9.