### PR TITLE
Fix wrong `make uninstall` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,6 @@ deinstall uninstall:
 	cd binr && ${MAKE} uninstall PARENT=1
 	cd shlr && ${MAKE} uninstall PARENT=1
 	cd libr/syscall/d && ${MAKE} uninstall PARENT=1
-	cd libr/sysregs/d && ${MAKE} uninstall PARENT=1
 	cd libr/anal/d && ${MAKE} uninstall PARENT=1
 	@echo
 	@echo "Run 'make purge' to also remove installed files from previous versions of r2"


### PR DESCRIPTION
This should fix #9486

make tries to cd to a no longer-existent directory, using a never existed ./libr/sysregs/d/Makefile

Line was introduced at 18c633cb3626c887c31e7d1be88b7d464ed6106a, but `git log --all --full-history -- ./libr/sysregs/d/Makefile` doesn't return anything and the only reference to sysregs in a Makefile seems to be trying to copy files that are not found in sysregs/d
```
$ grep -Hrn '.*sysregs.*'|grep Makefile
.git/COMMIT_EDITMSG:4:using a never existed `./libr/sysregs/d/Makefile`
Makefile:131:	mkdir -p "${WINDIST}/share/radare2/${VERSION}/sysregs"
Makefile:132:	cp -f libr/sysregs/d/*.sdb "${WINDIST}/share/radare2/${VERSION}/sysregs"
```