### PR TITLE
Autocomplete project open

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1311,6 +1311,11 @@ static int autocomplete(RLine *line) {
 			tmp_argv[R_MIN(i, TMP_ARGV_SZ - 1)] = NULL;
 			line->completion.argc = i;
 			line->completion.argv = tmp_argv;
+		} else if ( !strncmp (line->buffer.data, "Po ", 3)) {
+			char *projects_path = r_file_abspath (r_config_get (core->config, "dir.projects"));
+			char *paths[2] = { projects_path, NULL };
+			autocompleteFilename (line, paths, 1);
+			free (projects_path);
 		} else {
 			int i, j, cfg_newtab = r_config_get_i (core->config, "cfg.newtab");
 			if (cfg_newtab) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1312,9 +1312,23 @@ static int autocomplete(RLine *line) {
 			line->completion.argc = i;
 			line->completion.argv = tmp_argv;
 		} else if ( !strncmp (line->buffer.data, "Po ", 3)) {
-			char *projects_path = r_file_abspath (r_config_get (core->config, "dir.projects"));
-			char *paths[2] = { projects_path, NULL };
-			autocompleteFilename (line, paths, 1);
+			char *foo, *projects_path = r_file_abspath (r_config_get (core->config, "dir.projects"));
+			RList *list = r_sys_dir (path);
+			RListIter *iter;
+			int i = 0;
+
+			r_list_foreach (list, iter, foo) {
+				if (r_core_is_project (core, foo)) {
+					tmp_argv[i++] = foo;
+					if (i == TMP_ARGV_SZ - 1) {
+						break;
+					}	
+				}
+			}
+			tmp_argv[R_MIN(i, TMP_ARGV_SZ - 1)] = NULL;
+			line->completion.argc = i;
+			line->completion.argv = tmp_argv;
+			r_list_free (list);
 			free (projects_path);
 		} else {
 			int i, j, cfg_newtab = r_config_get_i (core->config, "cfg.newtab");

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1318,21 +1318,23 @@ static int autocomplete(RLine *line) {
 			RListIter *iter;
 			int n = strlen (line->buffer.data + 3);
 			int i = 0;
-			r_list_foreach (list, iter, foo) {
-				if (r_core_is_project (core, foo)) {
-					if (!strncmp (foo, line->buffer.data + 3, n)) {
-						tmp_argv[i++] = r_str_newf ("%s", foo);
-						if (i == TMP_ARGV_SZ - 1) {
-							break;
+			if (projects_path) {
+				r_list_foreach (list, iter, foo) {
+					if (r_core_is_project (core, foo)) {
+						if (!strncmp (foo, line->buffer.data + 3, n)) {
+							tmp_argv[i++] = r_str_newf ("%s", foo);
+							if (i == TMP_ARGV_SZ - 1) {
+								break;
+							}
 						}
 					}
 				}
+				free (projects_path);
+				r_list_free (list);
 			}
 			tmp_argv[R_MIN(i, TMP_ARGV_SZ - 1)] = NULL;
 			line->completion.argc = i;
 			line->completion.argv = tmp_argv;
-			r_list_free (list);
-			free (projects_path);
 		} else {
 			int i, j, cfg_newtab = r_config_get_i (core->config, "cfg.newtab");
 			if (cfg_newtab) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -24,6 +24,7 @@ static const char *tmp_argv[TMP_ARGV_SZ];
 static bool tmp_argv_heap = false;
 
 extern int r_is_heap (void *p);
+extern bool r_core_is_project (RCore *core, const char *name);
 
 static void r_line_free_autocomplete(RLine *line) {
 	int i;
@@ -1313,16 +1314,18 @@ static int autocomplete(RLine *line) {
 			line->completion.argv = tmp_argv;
 		} else if ( !strncmp (line->buffer.data, "Po ", 3)) {
 			char *foo, *projects_path = r_file_abspath (r_config_get (core->config, "dir.projects"));
-			RList *list = r_sys_dir (path);
+			RList *list = r_sys_dir (projects_path);
 			RListIter *iter;
+			int n = strlen (line->buffer.data + 3);
 			int i = 0;
-
 			r_list_foreach (list, iter, foo) {
 				if (r_core_is_project (core, foo)) {
-					tmp_argv[i++] = foo;
-					if (i == TMP_ARGV_SZ - 1) {
-						break;
-					}	
+					if (!strncmp (foo, line->buffer.data + 3, n)) {
+						tmp_argv[i++] = foo;
+						if (i == TMP_ARGV_SZ - 1) {
+							break;
+						}
+					}
 				}
 			}
 			tmp_argv[R_MIN(i, TMP_ARGV_SZ - 1)] = NULL;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1321,7 +1321,7 @@ static int autocomplete(RLine *line) {
 			r_list_foreach (list, iter, foo) {
 				if (r_core_is_project (core, foo)) {
 					if (!strncmp (foo, line->buffer.data + 3, n)) {
-						tmp_argv[i++] = foo;
+						tmp_argv[i++] = r_str_newf ("%s", foo);
 						if (i == TMP_ARGV_SZ - 1) {
 							break;
 						}

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -94,7 +94,7 @@ static int projectInit(RCore *core) {
 	return ret;
 }
 
-static bool r_core_is_project(RCore *core, const char *name) {
+R_API bool r_core_is_project(RCore *core, const char *name) {
 	bool ret = false;
 	if (name && *name && *name != '.') {
 		char *path = projectScriptPath (core, name);


### PR DESCRIPTION
This PR adds autocompletion for the "Po" command, so you don't have to type out the entire project name.
This is my first PR here, and in order to reuse written code I changed a 'r_core_is_project' in libr/core/project.c from static to R_API. If this should be done differently let me know.