### PR TITLE
arm: Don't set bits hint in anop32

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2533,8 +2533,6 @@ jmp $$ + 4 + ( [delta] * 2 )
 			op->type = R_ANAL_OP_TYPE_CALL;
 			op->jump = IMM(0) & UT32_MAX;
 			op->fail = addr + op->size;
-			//switch instruction set always with blx label
-			r_anal_hint_set_bits (a, op->jump, a->bits == 32? 16 : 32);
 		}
 		break;
 	case ARM_INS_BL:


### PR DESCRIPTION
A hint was set in anop32 when seeing a blx instruction. This was causing glitches while disassembling raw arm32 code in visual mode: suddenly asm.bits would jump to 16, and it was unclear how to change it back: `e asm.bits=32` would not stick. See https://asciinema.org/a/dfkjBKx7jAlQqQ9rqfDRGpnmf for example.

Fix proposed by pancake on IRC.

The removed code was introduced in 2ec6722bfecfe02c41089339fa2940a1a9194deb.