### PR TITLE
Fixing Dockerfile dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN DEBIAN_FRONTEND=noninteractive dpkg --add-architecture i386 && \
   libc6:i386 \
   libncurses5:i386 \
   libstdc++6:i386 \
+  gnupg2 \
   sudo && \
   curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   apt-get install -y nodejs python-pip && \


### PR DESCRIPTION
Looks like there's one dependency change missing for Debian 9. Added that and it builds fine locally.