### PR TITLE
Fix #9470, fix fd. to print all flags at given offset

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -819,13 +819,23 @@ rep:
 					addr = r_num_math (core->num, arg + 1);
 				}
 				break;
-			case '.':
-				strict_offset = true;
+			case '.': // list all flags at given offset
+				{
+				RFlagItem *flag;
+				RListIter *iter;
+				const RList *flaglist;
 				arg = strchr (input, ' ');
 				if (arg) {
 					addr = r_num_math (core->num, arg + 1);
 				}
-				break;
+				flaglist = r_flag_get_list (core->flags, addr);
+				r_list_foreach (flaglist, iter, flag) {
+					if (flag) {
+						r_cons_println (flag->name);
+					}
+				}
+				return 0;
+				}
 			case 'w':
 				{
 				arg = strchr (input, ' ');


### PR DESCRIPTION
```
[0x00000000]> fd??
|Usage: fd[d]  [offset|flag|expression] # Describe flags
| fd $$         # describe flag + delta for given offset
| fd. $$        # check flags in current address (no delta)
| fdd $$        # describe flag without space restrictions
| fdw [string]  # filter closest flag by string for current offset

[0x00000000]> pd 10
            0x00000000      90             nop
            0x00000001      90             nop
            0x00000002      90             nop
            0x00000003      90             nop
            0x00000004      90             nop
            ;-- flag1:
            ;-- flag2:
            ;-- flag3:
            0x00000005      90             nop
            0x00000006      90             nop
            0x00000007      90             nop

[0x00000000]> fd. 0x5
flag1
flag2
flag3

```