### PR TITLE
Add tcp.islocal to rtr

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2711,6 +2711,9 @@ R_API int r_core_config_init(RCore *core) {
 	free (tmpdir);
 	r_config_desc (cfg, "http.uproot", "Path where files are uploaded");
 
+	/* tcp */
+	SETPREF ("tcp.islocal", "false", "Bind a loopback for tcp command server");
+
 	/* graph */
 	SETPREF ("graph.comments", "true", "Show disasm comments in graph");
 	SETPREF ("graph.cmtright", "false", "Show comments at right");

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1847,6 +1847,8 @@ R_API int r_core_rtr_cmds (RCore *core, const char *port) {
 	}
 
 	s = r_socket_new (0);
+	s->local = r_config_get_i(core->config, "tcp.islocal");
+
 	if (!r_socket_listen (s, port, NULL)) {
 		eprintf ("Error listening on port %s\n", port);
 		r_socket_free (s);


### PR DESCRIPTION
  1. Currently, tcp server binds any interface. The option
    allows to restrict the binding to loopback interface only.
    e tcp.islocal=true.