### PR TITLE
Test PRs with radare2-regressions PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${USER_NAME}/g")
   - echo "${R2R_REPO}"
   - export R2R_BRANCH=$([ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ] && echo "${TRAVIS_PULL_REQUEST_BRANCH}" || echo "master")
-  - echo "${R2R_REPO} - branch: ${R2R_BRANCH}"
+  - echo "${R2R_BRANCH}"
   - git clone --depth 1 --branch "${R2R_BRANCH}" "${R2R_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null
   - make -s -j2 > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_script:
 script:
   - export PR_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${PR_NAME}/g")
+  - echo ${R2R_REPO}
   - git clone --depth 1 "${R2R_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null
   - make -s -j2 > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,14 @@ before_script:
 
 script:
   - export PR_NAME=$(echo $TRAVIS_PULL_REQUEST_SLUG | cut -d'/' -f1)
-  - echo "${PR_NAME}"
   - export DEFAULT_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
-  - echo "${DEFAULT_NAME}"
+  - export R2R_DEFAULT_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${DEFAULT_NAME}/g")
+  - export R2R_DEFAULT_BRANCH=master
   - export USER_NAME=$([ -n "${PR_NAME}" ] && echo "${PR_NAME}" || echo "${DEFAULT_NAME}")
-  - echo "${USER_NAME}"
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${USER_NAME}/g")
-  - echo "${R2R_REPO}"
-  - export R2R_BRANCH=$([ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ] && echo "${TRAVIS_PULL_REQUEST_BRANCH}" || echo "master")
-  - echo "${R2R_BRANCH}"
+  - export R2R_BRANCH=$([ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ] && echo "${TRAVIS_PULL_REQUEST_BRANCH}" || echo "${R2R_DEFAULT_BRANCH}")
   - git clone --depth 1 --branch "${R2R_BRANCH}" "${R2R_REPO}"
+  - ls radare2-regressions || git clone --depth 1 --branch "${R2R_DEFAULT_BRANCH}" "${R2R_DEFAULT_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null
   - make -s -j2 > /dev/null
   - make install > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,9 @@ script:
   - export DEFAULT_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
   - export USER_NAME=$([ -n "$PR_NAME" ] && echo "$PR_NAME" || echo "$DEFAULT_NAME")
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${USER_NAME}/g")
-  - echo ${R2R_REPO}
-  - git clone --depth 1 "${R2R_REPO}"
+  - export R2R_BRANCH=$([ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && echo $TRAVIS_PULL_REQUEST_BRANCH || echo "master")
+  - echo "${R2R_REPO} - branch: ${R2R_BRANCH}"
+  - git clone --depth 1 --branch "${R2R_BRANCH}" "${R2R_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null
   - make -s -j2 > /dev/null
   - make install > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - export NOOK=1
   - export NOREPORT=1
   - cd radare2-regressions
-  - $TRAVIS_PULL_REQUEST_BRANCH && git checkout $TRAVIS_PULL_REQUEST_BRANCH
+  - git checkout $TRAVIS_PULL_REQUEST_BRANCH
   - git rev-parse HEAD
   - VERBOSE=1 make -k all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ before_script:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 7
 
 script:
-  - export PR_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
+  - export PR_NAME=$(echo $TRAVIS_PULL_REQUEST_SLUG | cut -d'/' -f1)
+  - export DEFAULT_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
+  - export USER_NAME=${PR_NAME:-DEFAULT_NAME}
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${PR_NAME}/g")
   - echo ${R2R_REPO}
   - git clone --depth 1 "${R2R_REPO}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ before_script:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 7
 
 script:
-  - git clone --depth 1 `doc/repo REGRESSIONS`
+  - export PR_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
+  - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${PR_NAME}/g")
+  - git clone --depth 1 "${R2R_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null
   - make -s -j2 > /dev/null
   - make install > /dev/null
@@ -58,6 +60,7 @@ script:
   - export NOOK=1
   - export NOREPORT=1
   - cd radare2-regressions
+  - $TRAVIS_PULL_REQUEST_BRANCH && git checkout $TRAVIS_PULL_REQUEST_BRANCH
   - git rev-parse HEAD
   - VERBOSE=1 make -k all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - export PR_NAME=$(echo $TRAVIS_PULL_REQUEST_SLUG | cut -d'/' -f1)
   - export DEFAULT_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
   - export USER_NAME=$([ -n "$PR_NAME" ] && echo "$PR_NAME" || echo "$DEFAULT_NAME")
-  - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${PR_NAME}/g")
+  - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${USER_NAME}/g")
   - echo ${R2R_REPO}
   - git clone --depth 1 "${R2R_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,6 @@ script:
   - export NOOK=1
   - export NOREPORT=1
   - cd radare2-regressions
-  - git checkout $TRAVIS_PULL_REQUEST_BRANCH
   - git rev-parse HEAD
   - VERBOSE=1 make -k all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
 script:
   - export PR_NAME=$(echo $TRAVIS_PULL_REQUEST_SLUG | cut -d'/' -f1)
   - export DEFAULT_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
-  - export USER_NAME=${PR_NAME:-DEFAULT_NAME}
+  - export USER_NAME=$([ -n "$PR_NAME" ] && echo "$PR_NAME" || echo "$DEFAULT_NAME")
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${PR_NAME}/g")
   - echo ${R2R_REPO}
   - git clone --depth 1 "${R2R_REPO}"
@@ -63,7 +63,7 @@ script:
   - export NOOK=1
   - export NOREPORT=1
   - cd radare2-regressions
-  - git checkout $TRAVIS_PULL_REQUEST_BRANCH
+  - [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && git checkout $TRAVIS_PULL_REQUEST_BRANCH
   - git rev-parse HEAD
   - VERBOSE=1 make -k all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,14 @@ before_script:
 
 script:
   - export PR_NAME=$(echo $TRAVIS_PULL_REQUEST_SLUG | cut -d'/' -f1)
+  - echo "${PR_NAME}"
   - export DEFAULT_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f1)
-  - export USER_NAME=$([ -n "$PR_NAME" ] && echo "$PR_NAME" || echo "$DEFAULT_NAME")
+  - echo "${DEFAULT_NAME}"
+  - export USER_NAME=$([ -n "${PR_NAME}" ] && echo "${PR_NAME}" || echo "${DEFAULT_NAME}")
+  - echo "${USER_NAME}"
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${USER_NAME}/g")
-  - export R2R_BRANCH=$([ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && echo $TRAVIS_PULL_REQUEST_BRANCH || echo "master")
+  - echo "${R2R_REPO}"
+  - export R2R_BRANCH=$([ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ] && echo "${TRAVIS_PULL_REQUEST_BRANCH}" || echo "master")
   - echo "${R2R_REPO} - branch: ${R2R_BRANCH}"
   - git clone --depth 1 --branch "${R2R_BRANCH}" "${R2R_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${USER_NAME}/g")
   - export R2R_BRANCH=$([ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ] && echo "${TRAVIS_PULL_REQUEST_BRANCH}" || echo "${R2R_DEFAULT_BRANCH}")
   - git clone --depth 1 --branch "${R2R_BRANCH}" "${R2R_REPO}"
-  - [ -d "radare2-regressions" ] || git clone --depth 1 --branch "${R2R_DEFAULT_BRANCH}" "${R2R_DEFAULT_REPO}"
+  - ls radare2-regressions >/dev/null 2>&1 || git clone --depth 1 --branch "${R2R_DEFAULT_BRANCH}" "${R2R_DEFAULT_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null
   - make -s -j2 > /dev/null
   - make install > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - export R2R_REPO=$(doc/repo PR_REGRESSIONS | sed "s/__USER__/${USER_NAME}/g")
   - export R2R_BRANCH=$([ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ] && echo "${TRAVIS_PULL_REQUEST_BRANCH}" || echo "${R2R_DEFAULT_BRANCH}")
   - git clone --depth 1 --branch "${R2R_BRANCH}" "${R2R_REPO}"
-  - ls radare2-regressions || git clone --depth 1 --branch "${R2R_DEFAULT_BRANCH}" "${R2R_DEFAULT_REPO}"
+  - [ -d "radare2-regressions" ] || git clone --depth 1 --branch "${R2R_DEFAULT_BRANCH}" "${R2R_DEFAULT_REPO}"
   - ./configure --prefix=`pwd`/install > /dev/null
   - make -s -j2 > /dev/null
   - make install > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ script:
   - export NOOK=1
   - export NOREPORT=1
   - cd radare2-regressions
+  - git remote -v
+  - git branch
   - git rev-parse HEAD
   - VERBOSE=1 make -k all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - export NOOK=1
   - export NOREPORT=1
   - cd radare2-regressions
-  - [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] && git checkout $TRAVIS_PULL_REQUEST_BRANCH
+  - git checkout $TRAVIS_PULL_REQUEST_BRANCH
   - git rev-parse HEAD
   - VERBOSE=1 make -k all
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,10 @@ try to keep the codebase consistent and clean.
 * When relevant, write a test for
   [radare2-regressions](https://github.com/radare/radare2-regressions) and
   submit a PR also there. Use the same branch name in both repositories, so
-  Travis will be able to use your new tests together with new changes. NOTE: when
-  merging PRs, *always* merge the radare2-regressions PR first.
+  Travis will be able to use your new tests together with new changes. 
+  AppVeyor (for now) still uses radare/radare2-regressions repo with branch
+  master. NOTE: when merging PRs, *always* merge the radare2-regressions PR
+  first.
 
 ## Coding Style guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,11 @@ try to keep the codebase consistent and clean.
 * Make commits of logical units.
 * Check for unnecessary whitespace with ```git diff --check``` and be sure to follow the CODINGSTYLE (more on this in the next section).
 * Submit the Pull Request(PR) on Github.
-* When relevant, write a test for [radare2-regressions](https://github.com/radare/radare2-regressions) and submit a PR also there.
+* When relevant, write a test for
+  [radare2-regressions](https://github.com/radare/radare2-regressions) and
+  submit a PR also there. Use the same branch name in both repositories, so
+  Travis will be able to use your new tests together with new changes. NOTE: when
+  merging PRs, *always* merge the radare2-regressions PR first.
 
 ## Coding Style guidelines
 

--- a/doc/repo
+++ b/doc/repo
@@ -5,4 +5,5 @@ EXTRAS=https://github.com/radare/radare2-extras
 CAPSTONE=https://github.com/radare/radare2-capstone
 BINDINGS=https://github.com/radare/radare2-bindings
 REGRESSIONS=https://github.com/radare/radare2-regressions
+PR_REGRESSIONS=https://github.com/__USER__/radare2-regressions
 [ -z "$1" ] && grep -h $0 | grep -v grep || eval echo \$$1


### PR DESCRIPTION
This PR adds the support to test changes together with related changes in radare2-regressions.
In particular, instead of always using the master branch of https://github.com/radare/radare2-regressions.git, it uses the radare2-regressions repo of the user who created the PR, with the branch that has the same name as the branch in radare2. If not available, it uses the default repo/branch.