### PR TITLE
Make linker happy again

### DIFF
--- a/libr/hash/Makefile
+++ b/libr/hash/Makefile
@@ -1,6 +1,8 @@
 include ../config.mk
 
 NAME=r_hash
+DEPS=r_util
+
 # HACK
 ifneq ($(OSTYPE),darwin)
 ifneq ($(OSTYPE),haiku)


### PR DESCRIPTION
Fix for this problem:

```
Undefined symbols for architecture x86_64:
  "_r_str_newf", referenced from:
      _r_hash_to_string in hash.o
ld: symbol(s) not found for architecture x86_64
```

introduced by commit: https://github.com/radare/radare2/commit/2520fd4e73aa56632cb6f42470a60e223df90d80