### PR TITLE
Silent warning for exceeding max block size

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -753,8 +753,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 		}
 repeat:
 		if ((len - addrbytes * idx) < 5) {
-			eprintf (" WARNING : block size exceeding max block size at 0x%08"PFMT64x"\n", addr);
-			eprintf ("[+] Try changing it with e anal.bb.maxsize\n");
+			VERBOSE_ANAL eprintf ("WARNING: block size exceeding max block size at 0x%08"PFMT64x"\n", addr);
 			break;
 		}
 		r_anal_op_fini (&op);


### PR DESCRIPTION
Show it only when VERBOSE_ANAL