### PR TITLE
Implement dietline history on mount-shell (#8806).

### DIFF
--- a/libr/core/cmd_mount.c
+++ b/libr/core/cmd_mount.c
@@ -264,7 +264,14 @@ static int cmd_mount(void *data, const char *_input) {
 			input++;
 		}
 		r_cons_set_raw (false);
-		r_fs_prompt (core->fs, input);
+		{
+			RFSShell shell = {
+				.set_prompt = r_line_set_prompt,
+				.readline = r_line_readline,
+				.hist_add = r_line_hist_add
+			};
+			r_fs_shell_prompt (&shell, core->fs, input);
+		}
 		break;
 	case 'y':
 		eprintf ("TODO\n");

--- a/libr/fs/fs.c
+++ b/libr/fs/fs.c
@@ -676,11 +676,13 @@ R_API char* r_fs_name(RFS* fs, ut64 offset) {
 
 #define PROMT_PATH_BUFSIZE 1024
 
-R_API int r_fs_prompt(RFS* fs, const char* root) {
+R_API int r_fs_shell_prompt(RFSShell* shell, RFS* fs, const char* root) {
 	char buf[PROMT_PATH_BUFSIZE];
 	char path[PROMT_PATH_BUFSIZE];
+	char prompt[PROMT_PATH_BUFSIZE];
 	char str[2048];
 	char* input;
+	const char* ptr;
 	RList* list = NULL;
 	RListIter* iter;
 	RFSFile* file = NULL;
@@ -700,13 +702,22 @@ R_API int r_fs_prompt(RFS* fs, const char* root) {
 	}
 
 	for (;;) {
-		printf ("[%s]> ", path);
-		fflush (stdout);
-		fgets (buf, sizeof (buf) - 1, stdin);
-		if (feof (stdin)) {
+		snprintf (prompt, sizeof (prompt), "[%.*s]> ", sizeof (prompt) - 5, 
+		  path);
+		if (!shell->set_prompt ||
+		  	!shell->readline ||
+			!shell->hist_add) {	    
+				goto beach;
+		}
+		shell->set_prompt (prompt);
+		ptr = shell->readline ();
+		shell->hist_add (ptr);
+
+		if (!ptr) {
 			break;
 		}
-		buf[strlen (buf) - 1] = '\0';
+	
+		r_str_ncpy (buf, ptr, sizeof (buf) - 1);
 		if (!strcmp (buf, "q") || !strcmp (buf, "exit")) {
 			r_list_free (list);
 			return true;

--- a/libr/fs/fs.c
+++ b/libr/fs/fs.c
@@ -704,20 +704,28 @@ R_API int r_fs_shell_prompt(RFSShell* shell, RFS* fs, const char* root) {
 	for (;;) {
 		snprintf (prompt, sizeof (prompt), "[%.*s]> ", sizeof (prompt) - 5, 
 		  path);
-		if (!shell->set_prompt ||
-		  	!shell->readline ||
-			!shell->hist_add) {	    
-				goto beach;
-		}
-		shell->set_prompt (prompt);
-		ptr = shell->readline ();
-		shell->hist_add (ptr);
 
-		if (!ptr) {
-			break;
+		if (shell == NULL) {
+			printf ("%s", prompt);
+			fgets (buf, sizeof (buf) - 1, stdin);
+			
+			if (feof (stdin)) {
+				break;
+			}
+
+			buf[strlen (buf) - 1] = '\0';
+		} else {
+			shell->set_prompt (prompt);
+			ptr = shell->readline ();
+			shell->hist_add (ptr);
+
+			if (!ptr) {
+				break;
+			}
+
+			r_str_ncpy (buf, ptr, sizeof (buf) - 1);
 		}
-	
-		r_str_ncpy (buf, ptr, sizeof (buf) - 1);
+
 		if (!strcmp (buf, "q") || !strcmp (buf, "exit")) {
 			r_list_free (list);
 			return true;

--- a/libr/include/r_fs.h
+++ b/libr/include/r_fs.h
@@ -75,6 +75,12 @@ typedef struct r_fs_partition_t {
 	int type;
 } RFSPartition;
 
+typedef struct r_fs_shell_t {
+	void (*set_prompt)(const char *prompt);
+	const char* (*readline)(void);
+	int (*hist_add)(const char *line);
+} RFSShell;
+
 #define R_FS_FILE_TYPE_MOUNTPOINT 'm'
 #define R_FS_FILE_TYPE_DIRECTORY 'd'
 #define R_FS_FILE_TYPE_REGULAR 'r'
@@ -119,6 +125,7 @@ R_API RList *r_fs_partitions(RFS* fs, const char *ptype, ut64 delta);
 R_API char *r_fs_name(RFS *fs, ut64 offset);
 R_API int r_fs_prompt(RFS *fs, const char *root);
 R_API bool r_fs_check(RFS *fs, const char *p);
+R_API int r_fs_shell_prompt(RFSShell *shell, RFS *fs, const char *root); 
 
 /* file.c */
 R_API RFSFile *r_fs_file_new(RFSRoot *root, const char *path);


### PR DESCRIPTION
Gives minimal dietline history support inside mount-shell. There is
still a need to implement autocompletion.