### PR TITLE
Make wopO stop when value isn't starting with 0x

### DIFF
--- a/binr/ragg2/ragg2.c
+++ b/binr/ragg2/ragg2.c
@@ -315,6 +315,12 @@ int main(int argc, char **argv) {
 
 	// catch this first
 	if (get_offset) {
+		if (strncmp (sequence, "0x", 2)) {
+			eprintf ("Need hex value with `0x' prefix e.g. 0x41414142\n");
+			free (sequence);
+			return 1;
+		}
+
 		get_offset = r_num_math (0, sequence);
 		printf ("Little endian: %d\n", r_debruijn_offset (get_offset, false));
 		printf ("Big endian: %d\n", r_debruijn_offset (get_offset, true));

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -286,6 +286,7 @@ static void cmd_write_inc(RCore *core, int size, st64 num) {
 static void cmd_write_op (RCore *core, const char *input) {
 	ut8 *buf;
 	int len;
+	int value;
 	if (!input[0])
 		return;
 	switch (input[1]) {
@@ -409,11 +410,13 @@ static void cmd_write_op (RCore *core, const char *input) {
 			}
 			break;
 		case 'O': // "wopO"
-			len = (int)(input[3]==' ')
-				? r_num_math (core->num, input + 3)
-				: core->blocksize;
-			core->num->value = r_debruijn_offset (len, r_config_get_i (core->config, "cfg.bigendian"));
-			r_cons_printf ("%"PFMT64d"\n", core->num->value);
+			if (strlen (input) > 4 && strncmp (input + 4, "0x", 2)) {
+				eprintf ("Need hex value with `0x' prefix e.g. 0x41414142\n");
+			} else if (input[3] == ' ') {
+				value = r_num_get (core->num, input + 4);
+				core->num->value = r_debruijn_offset (value, r_config_get_i (core->config, "cfg.bigendian"));
+				r_cons_printf ("%"PFMT64d"\n", core->num->value);
+			}
 			break;
 		case '\0':
 		case '?':


### PR DESCRIPTION
![screenshot fee7309cb57b84718b28d6604b8009ad](https://user-images.githubusercontent.com/4048120/36810765-fe548c8a-1ccb-11e8-82a7-84c745a91d13.png)

Tests: https://github.com/radare/radare2-regressions/pull/1213