### PR TITLE
axgj

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4927,8 +4927,8 @@ static void anal_axg (RCore *core, const char *input, int level, Sdb *db, int op
 		RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, -1);
 		if (fcn) {
 			if (is_json) {
-				r_cons_printf ("{\"0x%08"PFMT64x"\": {\"type\": \"fcn\"," 
-					"\"addr\": 0x%08"PFMT64x", \"name\": \"%s\", \"refs\": [",
+				r_cons_printf ("{\"%"PFMT64d"\":{\"type\":\"fcn\"," 
+					"\"fcn_addr\":%"PFMT64d",\"name\":\"%s\",\"refs\":[",
 					addr, fcn->addr, fcn->name);
 			} else {
 				//if (sdb_add (db, fcn->name, "1", 0)) {
@@ -4938,7 +4938,7 @@ static void anal_axg (RCore *core, const char *input, int level, Sdb *db, int op
 			}
 		} else {
 			if (is_json) {
-				r_cons_printf ("{\"0x%08"PFMT64x"\": {\"refs\": [", addr);
+				r_cons_printf ("{\"%"PFMT64d"\":{\"refs\":[", addr);
 			} else {
 			//snprintf (arg, sizeof (arg), "0x%08"PFMT64x, addr);
 			//if (sdb_add (db, arg, "1", 0)) {
@@ -4951,7 +4951,12 @@ static void anal_axg (RCore *core, const char *input, int level, Sdb *db, int op
 		RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, ref->addr, -1);
 		if (fcn) {
 			if (is_json) {
-				r_cons_printf ("{\"0x%08"PFMT64x"\": {\"type\": \"fcn\", \"addr\": 0x%08"PFMT64x", \"name\": \"%s\", \"refs\": [", ref->addr, fcn->addr, fcn->name);
+				if (level == 0) {
+					r_cons_printf ("{\"%"PFMT64d"\":{\"type\":\"fcn\",\"fcn_addr\": %"PFMT64d",\"name\":\"%s\",\"refs\":[", ref->addr, fcn->addr, fcn->name);
+				} else {
+					r_cons_printf ("]}},{\"%"PFMT64d"\":{\"type\":\"fcn\",\"fcn_addr\": %"PFMT64d",\"name\":\"%s\",\"refs\":[", ref->addr, fcn->addr, fcn->name);
+
+				}
 			} else {
 				r_cons_printf ("%s0x%08"PFMT64x" fcn 0x%08"PFMT64x" %s\n", pre, ref->addr, fcn->addr, fcn->name);
 			}
@@ -4970,7 +4975,7 @@ static void anal_axg (RCore *core, const char *input, int level, Sdb *db, int op
 			}
 		} else {
 			if (is_json) {
-				r_cons_printf ("{\"0x%08"PFMT64x"\": {\"type\": \"???\", \"refs\": [", ref->addr);
+				r_cons_printf ("{\"%"PFMT64d"\":{\"type\":\"???\",\"refs\":[", ref->addr);
 			} else {
 				r_cons_printf ("%s0x%08"PFMT64x" ???\n", pre, ref->addr);
 			}
@@ -4991,6 +4996,9 @@ static void anal_axg (RCore *core, const char *input, int level, Sdb *db, int op
 	}
 	if (is_json) {
 		r_cons_printf("]}}");
+		if (level == 0) {
+			r_cons_printf("\n");
+		}
 	}
 	r_list_free (xrefs);
 }

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -554,6 +554,7 @@ static const char *help_msg_ax[] = {
 	"axc", " addr [at]", "add code jmp ref // unused?",
 	"axC", " addr [at]", "add code call ref",
 	"axg", " [addr]", "show xrefs graph to reach current function",
+	"axgj", " [addr]", "show xrefs graph to reach current function in json format",
 	"axd", " addr [at]", "add data ref",
 	"axq", "", "list refs in quiet/human-readable format",
 	"axj", "", "list refs in json format",

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5047,7 +5047,11 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case 'g': // "axg"
 		{
 			Sdb *db = sdb_new0 ();
-			anal_axg (core, input[1] ? input + 2 : NULL, 0, db);
+			if(input[1] == '\0') {
+				anal_axg (core, input[1] ? input + 2 : NULL, 0, db, 0);
+			} else if(input[1] == 'j') {
+				anal_axg (core, input[1] ? input + 2 : NULL, 0, db, R_CORE_ANAL_JSON);
+			}
 			sdb_free (db);
 		}
 		break;


### PR DESCRIPTION
Implementation of axgj. 
I modified the function anal_axg in order to accept some options (interested in R_CORE_ANAL_JSON).
Output example:
- axg:
```bash
[0x100000f60]> axg @ sym._f2
- 0x100000ed0 fcn 0x100000ed0 sym._f2
  - 0x100000f19 fcn 0x100000f00 sym._f3
  - 0x100000f00 fcn 0x100000f00 sym._f3
    - 0x100000f64 fcn 0x100000f60 entry0
  - 0x100000f49 fcn 0x100000f30 sym._f4
  - 0x100000f30 fcn 0x100000f30 sym._f4
    - 0x100000f69 fcn 0x100000f60 entry0
```

- axgj:
```bash
[0x100000f60]> axgj @ sym._f2
{"4294971088":{"type":"fcn","fcn_addr":4294971088,"name":"sym._f2","refs":[{"4294971161":{"type":"fcn","fcn_addr": 4294971136,"name":"sym._f3","refs":[{"4294971136":{"type":"fcn","fcn_addr":4294971136,"name":"sym._f3","refs":[]}},{"4294971236":{"type":"fcn","fcn_addr": 4294971232,"name":"entry0","refs
":[]}}]}},{"4294971209":{"type":"fcn","fcn_addr": 4294971184,"name":"sym._f4","refs":[{"4294971184":{"type":"fcn","fcn_addr":4294971184,"name":"sym._f4","refs":[]}},{"4294971241":{"type":"fcn","fcn_addr": 4294971232,"name":"entry0","refs":[]}}]}}]}}
```

The output template is like this:
{"address_function_top_level": {"type": "", "fcn_addr": xxxxx,"name": "name_fcn","refs"[...]}}
Where the references are the same kind of json object.