### PR TITLE
Fix #9512, restore asm.emu in pds

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -660,8 +660,6 @@ static int cb_emustr(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *) data;
 	if (node->i_value) {
 		r_config_set (core->config, "asm.emu", "true");
-	} else {
-		r_config_set (core->config, "asm.emu", "false");
 	}
 	return true;
 }

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -660,6 +660,8 @@ static int cb_emustr(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *) data;
 	if (node->i_value) {
 		r_config_set (core->config, "asm.emu", "true");
+	} else {
+		r_config_set (core->config, "asm.emu", "false");
 	}
 	return true;
 }

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1972,6 +1972,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	bool asm_tabs = r_config_get_i (core->config, "asm.tabs");
 	bool asm_flags = r_config_get_i (core->config, "asm.flags");
 	bool asm_cmt_right = r_config_get_i (core->config, "asm.cmt.right");
+	bool asm_emu = r_config_get_i (core->config, "asm.emu");
 	bool asm_emustr = r_config_get_i (core->config, "asm.emu.str");
 	r_config_set_i (core->config, "asm.emu.str", true);
 	RConsPrintablePalette *pal = &core->cons->pal;
@@ -2228,6 +2229,7 @@ restore_conf:
 	r_config_set_i (core->config, "asm.offset", show_offset);
 	r_config_set_i (core->config, "asm.tabs", asm_tabs);
 	r_config_set_i (core->config, "asm.emu.str", asm_emustr);
+	r_config_set_i (core->config, "asm.emu", asm_emu);
 }
 
 static void algolist(int mode) {

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3571,8 +3571,6 @@ static void rotateColor(RCore *core) {
 R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int is_interactive) {
 	int o_asmqjmps_letter = core->is_asmqjmps_letter;
 	int o_scrinteractive = r_config_get_i (core->config, "scr.interactive");
-	bool asm_pseudo = r_config_get_i (core->config, "asm.pseudo");
-	bool asm_esil = r_config_get_i (core->config, "asm.esil");
 	int o_vmode = core->vmode;
 	int exit_graph = false, is_error = false;
 	struct agraph_refresh_data *grd;
@@ -3585,6 +3583,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	ut64 oldseek = core->offset;
 	int ret, invscroll;
 	RConfigHold *hc = r_config_hold_new (core->config);
+	r_config_save_num (hc, "asm.pseudo", "asm.esil", "asm.cmt.right", NULL);
 	if (!hc) {
 		return false;
 	}
@@ -3606,7 +3605,6 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	can->linemode = r_config_get_i (core->config, "graph.linemode");
 	can->color = r_config_get_i (core->config, "scr.color");
 
-	r_config_save_num (hc, "asm.cmt.right", NULL);
 	if (!g) {
 		graph_allocated = true;
 		fcn = _fcn? _fcn: r_anal_get_fcn_in (core->anal, core->offset, 0);
@@ -3903,10 +3901,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			visual_offset (g, core);
 			break;
 		case 'O':
-			disMode++;
-			if (disMode > 2) {
-				disMode = 0;
-			}
+			disMode = (disMode + 1) % 3;
 			applyDisMode (core);
 			g->need_reload_nodes = true;
 			get_bbupdate (g, core, fcn);
@@ -4301,9 +4296,6 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	} else {
 		g->can = o_can;
 	}
-	// Restore values
-	r_config_set_i (core->config, "asm.pseudo", asm_pseudo);
-	r_config_set_i (core->config, "asm.esil", asm_esil);
 	r_core_seek (core, oldseek, 0);
 	r_config_restore (hc);
 	r_config_hold_free (hc);

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3571,6 +3571,8 @@ static void rotateColor(RCore *core) {
 R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int is_interactive) {
 	int o_asmqjmps_letter = core->is_asmqjmps_letter;
 	int o_scrinteractive = r_config_get_i (core->config, "scr.interactive");
+	bool asm_pseudo = r_config_get_i (core->config, "asm.pseudo");
+	bool asm_esil = r_config_get_i (core->config, "asm.esil");
 	int o_vmode = core->vmode;
 	int exit_graph = false, is_error = false;
 	struct agraph_refresh_data *grd;
@@ -3902,15 +3904,10 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			break;
 		case 'O':
 			disMode++;
-			if (disMode > 3) {
+			if (disMode > 2) {
 				disMode = 0;
 			}
 			applyDisMode (core);
-			if (disMode == 3) {
-				g->mode = R_AGRAPH_MODE_SUMMARY;
-			} else {
-				g->mode = 0;
-			}
 			g->need_reload_nodes = true;
 			get_bbupdate (g, core, fcn);
 			break;	
@@ -4304,6 +4301,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	} else {
 		g->can = o_can;
 	}
+	// Restore values
+	r_config_set_i (core->config, "asm.pseudo", asm_pseudo);
+	r_config_set_i (core->config, "asm.esil", asm_esil);
 	r_core_seek (core, oldseek, 0);
 	r_config_restore (hc);
 	r_config_hold_free (hc);


### PR DESCRIPTION
1) The main problem was lying with asm.emu.str config var 

**Enabling asm.emu.str , also enabled asm.emu** (which is expected) : 
```
[0x100001058]> e asm.emu.str = true
[0x100001058]> e asm.emu.str
true
[0x100001058]> e asm.emu
true
```
**Disabling it , didin't restore asm.emu** : 
```
[0x100001058]> e asm.emu.str = false
[0x100001058]> e asm.emu.str
false
[0x100001058]> e asm.emu
false
```
2) The "O" command in graph was only supposed to toggle  asm.esil and asm.pseudo , but it was also toggling between summary mode (which in turn uses pds that uses asm.emu.str) , now i have remove that !!