### PR TITLE
feat(anal_avr): implement opcode masking for improved zignatures

### DIFF
--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -45,7 +45,7 @@ typedef struct _opcodes_tag_ {
 	ut64 type;
 } OPCODE_DESC;
 
-static int avr_op_analyze(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, CPU_MODEL *cpu);
+static OPCODE_DESC* avr_op_analyze(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, CPU_MODEL *cpu);
 
 #define CPU_MODEL_DECL(model, pc, consts)				\
 	{								\
@@ -1495,7 +1495,7 @@ OPCODE_DESC opcodes[] = {
 	INST_LAST
 };
 
-static int avr_op_analyze(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, CPU_MODEL *cpu) {
+static OPCODE_DESC* avr_op_analyze(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, CPU_MODEL *cpu) {
 	OPCODE_DESC *opcode_desc;
 	ut16 ins = (buf[1] << 8) | buf[0];
 	int fail;
@@ -1542,7 +1542,7 @@ static int avr_op_analyze(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, C
 				}
 			}
 
-			return op->size;
+			return opcode_desc;
 		}
 	}
 
@@ -1568,7 +1568,7 @@ INVALID_OP:
 	// and stinky situation
 	r_strbuf_set (&op->esil, "1,$");
 
-	return op->size;
+	return NULL;
 }
 
 static int avr_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
@@ -1945,6 +1945,53 @@ static int archinfo(RAnal *anal, int q) {
 	return 2; // XXX
 }
 
+
+static ut8 *anal_mask_avr(RAnal *anal, int size, const ut8 *data, ut64 at) {
+	RAnalOp *op = NULL;
+	ut8 *ret = NULL;
+
+	if (!(op = r_anal_op_new ())) {
+		return NULL;
+	}
+
+	if (!(ret = malloc (size))) {
+		r_anal_op_free (op);
+		return NULL;
+	}
+
+	memset (ret, 0xff, size);
+
+	CPU_MODEL *cpu = get_cpu_model (anal->cpu);
+
+	for (int idx = 0; idx + 1 < size; idx += op->size) {
+		OPCODE_DESC* opcode_desc = avr_op_analyze (anal, op, at + idx, data + idx, cpu);
+
+		if (op->size < 1) {
+			break;
+		}
+
+		if (!opcode_desc) { // invalid instruction
+			continue;
+		}
+
+		// the additional data for "long" opcodes (4 bytes) is usually something we want to ignore for matching
+		// (things like memory offsets or jump addresses)
+		if (op->size == 4) {
+			ret[idx + 2] = 0;
+			ret[idx + 3] = 0;
+		}
+
+		if (op->ptr != UT64_MAX || op->jump != UT64_MAX) {
+			ret[idx] = opcode_desc->mask;
+			ret[idx + 1] = opcode_desc->mask >> 8;
+		}
+	}
+
+	r_anal_op_free (op);
+
+	return ret;
+}
+
 RAnalPlugin r_anal_plugin_avr = {
 	.name = "avr",
 	.desc = "AVR code analysis plugin",
@@ -1957,6 +2004,7 @@ RAnalPlugin r_anal_plugin_avr = {
 	.set_reg_profile = &set_reg_profile,
 	.esil_init = esil_avr_init,
 	.esil_fini = esil_avr_fini,
+	.anal_mask = anal_mask_avr,
 };
 
 #ifndef CORELIB


### PR DESCRIPTION
AVR instruction encoding is weird, we really need custom masking to get useful
zignatures.

This works best in combination with #9568