### PR TITLE
fix #9545: allow subsequently loaded cpython modules to access libpyt…

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -11,7 +11,7 @@ R_LIB_VERSION(r_lib);
 
 #if __UNIX__
 #include <dlfcn.h>
-  #define DLOPEN(x)  dlopen(x, RTLD_LOCAL | RTLD_NOW)
+  #define DLOPEN(x)  dlopen(x, RTLD_GLOBAL | RTLD_NOW)
   #define DLSYM(x,y) dlsym(x,y)
   #define DLCLOSE(x) dlclose(x)
 #elif __WINDOWS__


### PR DESCRIPTION
…hon symbols

this is a simple fix for issue #9545.
