### PR TITLE
Fix colorizing real-mode addresses twice #9572

### DIFF
--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1619,6 +1619,10 @@ static bool issymbol(char c) {
 	}
 }
 
+static bool ishexprefix(char *p) {
+	return (p[0] == '0' && p[1] == 'x');
+}
+
 R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, const char *num, bool partial_reset) {
 	int i, j, k, is_mod, is_float = 0, is_arg = 0;
 	char *reset = partial_reset ? Color_NOBGRESET:Color_RESET;
@@ -1641,7 +1645,7 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 	memset (o, 0, COLORIZE_BUFSIZE);
 	for (i = j = 0; p[i]; i++, j++) {
 		/* colorize numbers */
-		if ((p[i] == '0' && p[i+1] == 'x') || (isdigit (p[i]) && issymbol (previous))) {
+		if ((ishexprefix (&p[i]) && previous != ':') || (isdigit (p[i]) && issymbol (previous))) {
 			int nlen = strlen (num);
 			if (nlen + j >= sizeof (o)) {
 				eprintf ("Colorize buffer is too small\n");


### PR DESCRIPTION
r_print_colorize_opcode() inserts ANSI codes twice into real-mode addresses. This causes the address to be parsed correctly when printing with scr.color.ops = true. Full description and test binary in #9572 

I'm not 100% sure this is the ideal fix but I'm happy to make other changes if you point me in the right direction.