### PR TITLE
Prevent loop in env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -7,6 +7,11 @@ getabsolutepath() {
 
 pfx=$(getabsolutepath "$1")
 
+if [ "0$RADARE2_ENV_INIT_COUNT" -gt 5 ]; then
+    echo "Loop detected in the wrapper, please check your installation"
+    exit 1
+fi
+
 if [ -z "$1" ]; then
 	echo "Usage: ./env.sh [destdir|prefix] [program]"
 	exit 1
@@ -22,12 +27,14 @@ if [ -d "$pfx/usr/bin" ]; then
 	pfx="$pfx/usr"
 fi
 
+RADARE2_ENV_INIT_COUNT=$(( RADARE2_ENV_INIT_COUNT + 1 ))
 new_env='
 LIBR_PLUGINS=${pfx}/lib/radare2
 PATH=$pfx/bin:${PATH}
 LD_LIBRARY_PATH=$pfx/lib:$LD_LIBRARY_PATH
 DYLD_LIBRARY_PATH=$pfx/lib:$DYLD_LIBRARY_PATH
 PKG_CONFIG_PATH=$pfx/lib/pkgconfig:$PKG_CONFIG_PATH
+RADARE2_ENV_INIT_COUNT=${RADARE2_ENV_INIT_COUNT}
 '
 
 shift


### PR DESCRIPTION
When someone use "make user-install" without "make install", the
installed wrapper in ~/bin will result into a fork-bomb. Since
the wrapper is just a call to env.sh, env.sh will then call the
wrapper again (since r2 is not installed), that will call itself.

This loop detection prevent that.

However, this also prevent from running radare2 from within radare2 (or any others tools), which is why this is just WIP, and that PR is here to start the discussion, as asked on the chat.

