### PR TITLE
Fix pd syntax (also aex and pa)

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1742,6 +1742,38 @@ static void tmpenvs_free(void *item) {
 	free (item);
 }
 
+static bool set_tmp_arch(RCore *core, char *arch, char **tmparch, char **tmphintarch) {
+	assert (tmparch != NULL && tmphintarch != NULL);
+
+	RAnalHint *hint = r_anal_hint_get (core->anal, core->offset);
+	// temporarily overwrite anal hints if there's any
+	if (hint) {
+		*tmphintarch = hint->arch ? strdup (hint->arch) : NULL;
+		r_anal_hint_set_arch (core->anal, core->offset, arch);
+	}
+	r_anal_hint_free (hint);
+
+	*tmparch = strdup (r_config_get (core->config, "asm.arch"));
+	r_config_set (core->config, "asm.arch", arch);
+	return true;
+}
+
+static bool set_tmp_bits(RCore *core, int bits, char **tmpbits, int *tmphintbits) {
+	assert (tmpbits != NULL && tmphintbits != NULL);
+
+	RAnalHint *hint = r_anal_hint_get (core->anal, core->offset);
+	// temporarily overwrite bits hint if there's any
+	if (hint) {
+		*tmphintbits = hint->bits;
+		r_anal_hint_set_bits (core->anal, core->offset, bits);
+	}
+	r_anal_hint_free (hint);
+
+	*tmpbits = strdup (r_config_get (core->config, "asm.bits"));
+	r_config_set_i (core->config, "asm.bits", bits);
+	return true;
+}
+
 static int r_core_cmd_subst_i(RCore *core, char *cmd, char *colon) {
 	RList *tmpenvs = r_list_newf (tmpenvs_free);
 	const char *quotestr = "`";
@@ -2240,8 +2272,11 @@ next2:
 		char *tmpbits = NULL;
 		const char *offstr = NULL;
 		ut64 tmpbsz = core->blocksize;
+		bool is_bits_set = false;
+		bool is_arch_set = false;
 		char *tmpeval = NULL;
-		char *tmpasm = NULL;
+		char *tmpasm = NULL, *tmphintasm = NULL;
+		int tmphintbits = -1;
 		int flgspc = -123;
 		int tmpfd = -1;
 		int sz, len;
@@ -2360,9 +2395,7 @@ repeat_arroba:
 				}
 				break;
 			case 'b': // "@b:" // bits
-				tmpbits = strdup (r_config_get (core->config, "asm.bits"));
-				r_config_set_i (core->config, "asm.bits",
-					r_num_math (core->num, ptr + 2));
+				is_bits_set = set_tmp_bits (core, r_num_math (core->num, ptr + 2), &tmpbits, &tmphintbits);
 				break;
 			case 'i': // "@i:"
 				{
@@ -2417,14 +2450,12 @@ repeat_arroba:
 			case 'a': // "@a:"
 				if (ptr[1] == ':') {
 					char *q = strchr (ptr + 2, ':');
-					tmpasm = strdup (r_config_get (core->config, "asm.arch"));
 					if (q) {
 						*q++ = 0;
-						tmpbits = strdup (r_config_get (core->config, "asm.bits"));
-						r_config_set (core->config, "asm.bits", q);
+						int bits = r_num_math (core->num, q);
+						is_bits_set = set_tmp_bits (core, bits, &tmpbits, &tmphintbits);
 					}
-					r_config_set (core->config, "asm.arch", ptr + 2);
-					// TODO: handle asm.bits
+					is_arch_set = set_tmp_arch (core, ptr + 2, &tmpasm, &tmphintasm);
 				} else {
 					eprintf ("Usage: pd 10 @a:arm:32\n");
 				}
@@ -2558,16 +2589,30 @@ next_arroba:
 			*ptr2 = '!';
 			r_core_block_size (core, tmpbsz);
 		}
-		if (tmpasm) {
+		if (is_arch_set) {
 			r_config_set (core->config, "asm.arch", tmpasm);
-			tmpasm = NULL;
+			if (tmphintasm) {
+				r_anal_hint_set_arch (core->anal, core->offset, tmphintasm);
+			} else {
+				r_anal_hint_unset_arch (core->anal, core->offset);
+			}
+			R_FREE (tmpasm);
+			R_FREE (tmphintasm);
+			is_arch_set = false;
 		}
 		if (tmpfd != -1) {
 			r_io_use_fd (core->io, tmpfd);
 		}
-		if (tmpbits) {
+		if (is_bits_set) {
 			r_config_set (core->config, "asm.bits", tmpbits);
-			tmpbits = NULL;
+			if (tmphintbits != -1) {
+				r_anal_hint_set_bits (core->anal, core->offset, tmphintbits);
+			} else {
+				r_anal_hint_unset_bits (core->anal, core->offset);
+			}
+			R_FREE (tmpbits);
+			tmphintbits = -1;
+			is_bits_set = false;
 		}
 		if (tmpeval) {
 			r_core_cmd0 (core, tmpeval);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1743,7 +1743,9 @@ static void tmpenvs_free(void *item) {
 }
 
 static bool set_tmp_arch(RCore *core, char *arch, char **tmparch, char **tmphintarch) {
-	assert (tmparch != NULL && tmphintarch != NULL);
+	if (tmparch == NULL || tmphintarch == NULL) {
+		eprintf ("tmparch and tmphintarch should be set\n");
+	}
 
 	RAnalHint *hint = r_anal_hint_get (core->anal, core->offset);
 	// temporarily overwrite anal hints if there's any
@@ -1759,7 +1761,9 @@ static bool set_tmp_arch(RCore *core, char *arch, char **tmparch, char **tmphint
 }
 
 static bool set_tmp_bits(RCore *core, int bits, char **tmpbits, int *tmphintbits) {
-	assert (tmpbits != NULL && tmphintbits != NULL);
+	if (tmpbits == NULL || tmphintbits == NULL) {
+		eprintf ("tmpbits and tmphintbits should be set\n");
+	}
 
 	RAnalHint *hint = r_anal_hint_get (core->anal, core->offset);
 	// temporarily overwrite bits hint if there's any

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4352,9 +4352,11 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		char *hex;
 		int ret, bufsz;
 
-		input++;
-		while (*input == ' ') input++;
+		input = r_str_trim_ro (input + 1);
 		hex = strdup (input);
+		if (!hex) {
+			break;
+		}
 
 		RAnalOp aop = R_EMPTY;
 		bufsz = r_hex_str2bin (hex, (ut8*)hex);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4349,35 +4349,13 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		}
 		break;
 	case 'x': { // "aex"	
-		ut32 new_bits = -1;
-		int segoff, old_bits, pos = 0;
-		char *new_arch = NULL, *old_arch = NULL, *hex = NULL;
-		old_arch = strdup (r_config_get (core->config, "asm.arch"));
-		old_bits = r_config_get_i (core->config, "asm.bits");
-		segoff = r_config_get_i (core->config, "asm.segoff");
-
-		if (input[0]) {
-			for (pos = 1; pos < R_BIN_SIZEOF_STRINGS && input[pos]; pos++)
-				if (input[pos] == ' ') {
-					break;
-				}
-		}
-
-		if (!r_core_process_input_pade (core, input+pos, &hex, &new_arch, &new_bits)) {
-			// XXX - print help message
-			//return false;
-		}
-
-		if (!new_arch) {
-			new_arch = strdup (old_arch);
-		}
-		if (new_bits == -1) {new_bits = old_bits;
-		}
-
-		if (strcmp (new_arch, old_arch) || new_bits != old_bits) {
-			r_core_set_asm_configs (core, new_arch, new_bits, segoff);
-		}
+		char *hex;
 		int ret, bufsz;
+
+		input++;
+		while (*input == ' ') input++;
+		hex = strdup (input);
+
 		RAnalOp aop = R_EMPTY;
 		bufsz = r_hex_str2bin (hex, (ut8*)hex);
 		ret = r_anal_op (core->anal, &aop, core->offset,
@@ -4389,9 +4367,8 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			free (str2);
 		}
 		r_anal_op_fini (&aop);
-		free (old_arch);
-		}
 		break;
+	}
 	case '?': // "ae?"
 		if (input[1] == '?') {
 			r_core_cmd_help (core, help_detail_ae);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3714,8 +3714,7 @@ static int cmd_print(void *data, const char *input) {
 		const char *arg = NULL;
 
 		if (input[1] != '\0') {
-			arg = input + 2;
-			while (*arg != ' ') arg++;
+			arg = r_str_trim_ro (input + 2);
 		}
 
 		if (input[1] == 'e') { // "pae"

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -365,7 +365,6 @@ R_API RAnalOp *r_core_op_anal(RCore *core, ut64 addr);
 R_API char *r_core_disassemble_instr(RCore *core, ut64 addr, int l);
 R_API char *r_core_disassemble_bytes(RCore *core, ut64 addr, int b);
 
-R_API int r_core_process_input_pade(RCore *core, const char *input, char** hex, char **asm_arch, ut32 *bits);
 R_API RList *r_core_get_func_args(RCore *core, const char *func_name);
 R_API void r_core_print_func_args(RCore *core);
 


### PR DESCRIPTION
Removes tmparch/tmpbits from command syntax because we have `@a` and `@b` now.
Moreover, it improves `@a`/`@b` usages, because it also correctly sets/restores anal hints.