### PR TITLE
Find _main in MSVC-compiled MZ binaries

### DIFF
--- a/libr/bin/format/mz/mz.c
+++ b/libr/bin/format/mz/mz.c
@@ -297,3 +297,36 @@ struct r_bin_mz_obj_t* r_bin_mz_new_buf(const struct r_buf_t *buf) {
 	}
 	return r_bin_mz_init (bin) ? bin : r_bin_mz_free (bin);
 }
+
+ut64 r_bin_mz_get_main_vaddr(struct r_bin_mz_obj_t *bin) {
+	int entry;
+	int n;
+	ut8 b[512];
+	if (!bin || !bin->b) {
+		return 0LL;
+	}
+	entry = r_bin_mz_get_entrypoint (bin);
+	ZERO_FILL (b);
+	if (r_buf_read_at (bin->b, entry, b, sizeof (b)) < 0) {
+		eprintf ("Warning: Cannot read entry at 0x%08"PFMT64x "\n", entry);
+		return 0LL;
+	}
+	// MSVC
+	if (b[0] == 0xb4 && b[1] == 0x30) {
+		// ff 36 XX XX			push	XXXX
+		// ff 36 XX XX			push	argv
+		// ff 36 XX XX			push	argc
+		// 9a XX XX XX XX		lcall	_main
+		// 50				push	ax
+		for (n = 0; n < sizeof (b) - 18; n++) {
+			if (b[n] == 0xff && b[n + 4] == 0xff && b[n + 8] == 0xff && b[n + 12] == 0x9a && b[n + 17] == 0x50) {
+				const ut16 call_addr = r_read_ble16 (b + n + 13, 0);;
+				const ut16 call_seg = r_read_ble16 (b + n + 15, 0);;
+				const ut64 call_dst = r_bin_mz_seg_to_paddr (bin, call_seg) + call_addr;
+				return call_dst;
+			}
+		}
+	}
+
+	return 0LL;
+}

--- a/libr/bin/p/bin_mz.c
+++ b/libr/bin/p/bin_mz.c
@@ -109,6 +109,23 @@ static int destroy(RBinFile *bf) {
 	return true;
 }
 
+static RBinAddr* binsym(RBinFile *bf, int type) {
+	ut64 mzaddr = NULL;
+	RBinAddr *ret = NULL;
+	if (bf && bf->o && bf->o->bin_obj) {
+		switch(type) {
+		case R_BIN_SYM_MAIN:
+			mzaddr = r_bin_mz_get_main_vaddr (bf->o->bin_obj);
+			break;
+		}
+	}
+	if (mzaddr && (ret = R_NEW0 (RBinAddr))) {
+		ret->paddr = mzaddr;
+		ret->vaddr = mzaddr;
+	}
+	return ret;
+}
+
 static RList * entries(RBinFile *bf) {
 	RBinAddr *ptr = NULL;
 	RList *res = NULL;
@@ -255,6 +272,7 @@ RBinPlugin r_bin_plugin_mz = {
 	.load_bytes = &load_bytes,
 	.destroy = &destroy,
 	.check_bytes = &check_bytes,
+	.binsym = &binsym,
 	.entries = &entries,
 	.sections = &sections,
 	.info = &info,


### PR DESCRIPTION
Basic support for finding _main in MZ binaries.

Here's two sample binaries I tested the signature against.
[mzsamples.zip](https://github.com/radare/radare2/files/1779233/mzsamples.zip)
