### PR TITLE
Offset history

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -313,7 +313,7 @@ static int r_line_hist_up() {
 	if (!I.history.data) {
 		inithist ();
 	}
-	if (!strcmp (r_line_get_prompt(), "[offset]> ")) {
+    if (I.offset_prompt) {
 		while (I.history.index > 0 && I.history.data[--I.history.index][0] != 's' );
 		int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
 		strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
@@ -345,7 +345,7 @@ static int r_line_hist_down() {
 		I.buffer.index = I.buffer.length = 0;
 		return false;
 	}
-	if (!strcmp (r_line_get_prompt(), "[offset]> ")) {
+    if (I.offset_prompt) {
 		while (I.history.index != I.history.top && I.history.data[I.history.index++][0] != 's' );
 		I.history.index--;
 		int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -313,14 +313,14 @@ static int r_line_hist_up() {
 	if (!I.history.data) {
 		inithist ();
 	}
-    if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
-        while (I.history.index > 0 && I.history.data[--I.history.index][0] != 's' );
-        int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
-        strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
-        I.buffer.index = I.buffer.length = strlen (I.buffer.data);
-        return true;
-    }
-    if (I.history.index > 0) {
+	if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
+		while (I.history.index > 0 && I.history.data[--I.history.index][0] != 's' );
+		int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
+		strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
+		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
+		return true;
+	}
+	if (I.history.index > 0) {
 		strncpy (I.buffer.data, I.history.data[--I.history.index], R_LINE_BUFSIZE - 1);
 		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
 		return true;
@@ -345,14 +345,14 @@ static int r_line_hist_down() {
 		I.buffer.index = I.buffer.length = 0;
 		return false;
 	}
-    if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
-        while (I.history.index != I.history.top && I.history.data[I.history.index++][0] != 's' );
-        I.history.index--;
-        int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
-        strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
-        I.buffer.index = I.buffer.length = strlen (I.buffer.data);
-        return true;
-    }
+	if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
+		while (I.history.index != I.history.top && I.history.data[I.history.index++][0] != 's' );
+		I.history.index--;
+		int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
+		strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
+		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
+		return true;
+	}
 	if (I.history.data[I.history.index]) {
 		strncpy (I.buffer.data, I.history.data[I.history.index], R_LINE_BUFSIZE - 1);
 		I.buffer.index = I.buffer.length = strlen (I.buffer.data);

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -313,16 +313,16 @@ static int r_line_hist_up() {
 	if (!I.history.data) {
 		inithist ();
 	}
-    if (I.offset_prompt) {
-        RCore *core = I.user;
-        RIOUndo *undo = &core->io->undo;
-        char line[R_LINE_BUFSIZE - 1];
-        if (I.offset_index <= -undo->undos) {
-            return false;
-        }
-        I.offset_index--;
-        sprintf(line, "0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
-        strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
+	if (I.offset_prompt) {
+		RCore *core = I.user;
+		RIOUndo *undo = &core->io->undo;
+		/*char line[R_LINE_BUFSIZE - 1];*/
+		if (I.offset_index <= -undo->undos) {
+		return false;
+		}
+		I.offset_index--;
+		char *line = r_str_newf("0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
+		strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
 		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
 		return true;
 	}
@@ -338,24 +338,23 @@ static int r_line_hist_down() {
 	if (I.hist_down) {
 		return I.hist_down (I.user);
 	}
-    if (I.offset_prompt) {
-        RCore *core = I.user;
-        RIOUndo *undo = &core->io->undo;
-        if (I.offset_index >= undo->redos) {
-            return false;
-        }
-        I.offset_index++;
-        if (I.offset_index == undo->redos) {
-            I.buffer.data[0] = '\0';
-            I.buffer.index = I.buffer.length = 0;
-            return false;
-        }
-        char line[R_LINE_BUFSIZE - 1];
-        sprintf(line, "0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
-        strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
-        I.buffer.index = I.buffer.length = strlen (I.buffer.data);
-        return true;
-    }
+	if (I.offset_prompt) {
+		RCore *core = I.user;
+		RIOUndo *undo = &core->io->undo;
+		if (I.offset_index >= undo->redos) {
+		return false;
+		}
+		I.offset_index++;
+		if (I.offset_index == undo->redos) {
+		I.buffer.data[0] = '\0';
+		I.buffer.index = I.buffer.length = 0;
+		return false;
+		}
+		char *line = r_str_newf("0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
+		strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
+		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
+		return true;
+	}
 	I.buffer.index = 0;
 	if (!I.history.data) {
 		inithist ();

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -313,7 +313,14 @@ static int r_line_hist_up() {
 	if (!I.history.data) {
 		inithist ();
 	}
-	if (I.history.index > 0) {
+    if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
+        while (I.history.index > 0 && I.history.data[--I.history.index][0] != 's' );
+        int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
+        strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
+        I.buffer.index = I.buffer.length = strlen (I.buffer.data);
+        return true;
+    }
+    else if (I.history.index > 0) {
 		strncpy (I.buffer.data, I.history.data[--I.history.index], R_LINE_BUFSIZE - 1);
 		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
 		return true;
@@ -338,6 +345,14 @@ static int r_line_hist_down() {
 		I.buffer.index = I.buffer.length = 0;
 		return false;
 	}
+    if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
+        while (I.history.index != I.history.top && I.history.data[I.history.index++][0] != 's' );
+        I.history.index--;
+        int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
+        strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
+        I.buffer.index = I.buffer.length = strlen (I.buffer.data);
+        return true;
+    }
 	if (I.history.data[I.history.index]) {
 		strncpy (I.buffer.data, I.history.data[I.history.index], R_LINE_BUFSIZE - 1);
 		I.buffer.index = I.buffer.length = strlen (I.buffer.data);

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -278,6 +278,52 @@ do_it_again:
 }
 #endif
 
+R_API int r_line_set_hist_callback(RLine *line, RLineHistoryUpCb up_cb, RLineHistoryDownCb down_cb) {
+	line->history_up_cb = up_cb;
+	line->history_down_cb = down_cb;
+	line->offset_index = 0;
+	return 1;
+}
+
+R_API int cmd_history_up(RLine *line) {
+	if (line->hist_up) {
+		return line->hist_up (line->user);
+	}
+	if (!line->history.data) {
+		inithist ();
+	}
+	if (line->history.index > 0) {
+		strncpy (line->buffer.data, line->history.data[--line->history.index], R_LINE_BUFSIZE - 1);
+		line->buffer.index = line->buffer.length = strlen (line->buffer.data);
+		return true;
+	}
+	return false;
+}
+
+R_API int cmd_history_down(RLine *line) {
+	if (line->hist_down) {
+		return line->hist_down (line->user);
+	}
+	line->buffer.index = 0;
+	if (!line->history.data) {
+		inithist ();
+	}
+	if (line->history.index == line->history.top) {
+		return false;
+	}
+	line->history.index++;
+	if (line->history.index == line->history.top) {
+		line->buffer.data[0] = '\0';
+		line->buffer.index = line->buffer.length = 0;
+		return false;
+	}
+	if (line->history.data[line->history.index]) {
+		strncpy (line->buffer.data, line->history.data[line->history.index], R_LINE_BUFSIZE - 1);
+		line->buffer.index = line->buffer.length = strlen (line->buffer.data);
+	}
+	return true;
+}
+
 R_API int r_line_hist_add(const char *line) {
 	if (!line || !*line) {
 		return false;
@@ -307,72 +353,17 @@ R_API int r_line_hist_add(const char *line) {
 }
 
 static int r_line_hist_up() {
-	if (I.hist_up) {
-		return I.hist_up (I.user);
+	if (!I.history_up_cb) {
+		r_line_set_hist_callback (&I, &cmd_history_up, &cmd_history_down);
 	}
-	if (!I.history.data) {
-		inithist ();
-	}
-	if (I.offset_prompt) {
-		RCore *core = I.user;
-		RIOUndo *undo = &core->io->undo;
-		/*char line[R_LINE_BUFSIZE - 1];*/
-		if (I.offset_index <= -undo->undos) {
-		return false;
-		}
-		I.offset_index--;
-		char *line = r_str_newf("0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
-		strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
-		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
-		return true;
-	}
-	if (I.history.index > 0) {
-		strncpy (I.buffer.data, I.history.data[--I.history.index], R_LINE_BUFSIZE - 1);
-		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
-		return true;
-	}
-	return false;
+	return I.history_up_cb (&I);
 }
 
 static int r_line_hist_down() {
-	if (I.hist_down) {
-		return I.hist_down (I.user);
+	if (!I.history_down_cb) {
+		r_line_set_hist_callback (&I, &cmd_history_up, &cmd_history_down);
 	}
-	if (I.offset_prompt) {
-		RCore *core = I.user;
-		RIOUndo *undo = &core->io->undo;
-		if (I.offset_index >= undo->redos) {
-		return false;
-		}
-		I.offset_index++;
-		if (I.offset_index == undo->redos) {
-		I.buffer.data[0] = '\0';
-		I.buffer.index = I.buffer.length = 0;
-		return false;
-		}
-		char *line = r_str_newf("0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
-		strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
-		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
-		return true;
-	}
-	I.buffer.index = 0;
-	if (!I.history.data) {
-		inithist ();
-	}
-	if (I.history.index == I.history.top) {
-		return false;
-	}
-	I.history.index++;
-	if (I.history.index == I.history.top) {
-		I.buffer.data[0] = '\0';
-		I.buffer.index = I.buffer.length = 0;
-		return false;
-	}
-	if (I.history.data[I.history.index]) {
-		strncpy (I.buffer.data, I.history.data[I.history.index], R_LINE_BUFSIZE - 1);
-		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
-	}
-	return true;
+	return I.history_down_cb (&I);
 }
 
 R_API const char *r_line_hist_get(int n) {

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -313,7 +313,7 @@ static int r_line_hist_up() {
 	if (!I.history.data) {
 		inithist ();
 	}
-	if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
+	if (!strcmp (r_line_get_prompt(), "[offset]> ")) {
 		while (I.history.index > 0 && I.history.data[--I.history.index][0] != 's' );
 		int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;
 		strncpy (I.buffer.data, I.history.data[I.history.index] + skip_whitespace, R_LINE_BUFSIZE - 1);
@@ -345,7 +345,7 @@ static int r_line_hist_down() {
 		I.buffer.index = I.buffer.length = 0;
 		return false;
 	}
-	if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {
+	if (!strcmp (r_line_get_prompt(), "[offset]> ")) {
 		while (I.history.index != I.history.top && I.history.data[I.history.index++][0] != 's' );
 		I.history.index--;
 		int skip_whitespace = I.history.data[I.history.index][1] == ' ' ? 2 : 1;

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -16,7 +16,6 @@
 #define USE_UTF8 1
 #endif
 
-
 static char *r_line_nullstr = "";
 static const char dl_basic_word_break_characters[] =  " \t\n\"\\'`@$><=;|&{(";
 

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -320,7 +320,7 @@ static int r_line_hist_up() {
         I.buffer.index = I.buffer.length = strlen (I.buffer.data);
         return true;
     }
-    else if (I.history.index > 0) {
+    if (I.history.index > 0) {
 		strncpy (I.buffer.data, I.history.data[--I.history.index], R_LINE_BUFSIZE - 1);
 		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
 		return true;

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -321,7 +321,7 @@ static int r_line_hist_up() {
             return false;
         }
         I.offset_index--;
-        sprintf(line, "0x%"PFMT64x, undo->seek[undo->idx + I.offset_index]);
+        sprintf(line, "0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
         strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
 		I.buffer.index = I.buffer.length = strlen (I.buffer.data);
 		return true;
@@ -351,7 +351,7 @@ static int r_line_hist_down() {
             return false;
         }
         char line[R_LINE_BUFSIZE - 1];
-        sprintf(line, "0x%"PFMT64x, undo->seek[undo->idx + I.offset_index]);
+        sprintf(line, "0x%"PFMT64x, undo->seek[undo->idx + I.offset_index].off);
         strncpy(I.buffer.data, line, R_LINE_BUFSIZE - 1);
         I.buffer.index = I.buffer.length = strlen (I.buffer.data);
         return true;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1230,9 +1230,11 @@ static int autocomplete(RLine *line) {
 		|| !strncmp (line->buffer.data, "agfl ", 5)
 		|| !strncmp (line->buffer.data, "aecu ", 5)
 		|| !strncmp (line->buffer.data, "aesu ", 5)
-		|| !strncmp (line->buffer.data, "aeim ", 5)) {
+		|| !strncmp (line->buffer.data, "aeim ", 5)
+		|| line->offset_prompt) {
 			int n, i = 0;
-			int sdelta = (line->buffer.data[1] == ' ')
+			int sdelta = line->offset_prompt 
+				? 0 : (line->buffer.data[1] == ' ')
 				? 2 : (line->buffer.data[2] == ' ')
 				? 3 : (line->buffer.data[3] == ' ')
 				? 4 : 5;

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3429,6 +3429,8 @@ static void visual_offset(RAGraph *g, RCore *core) {
 	r_cons_get_size (&rows);
 	r_cons_gotoxy (0, rows);
 	r_cons_flush ();
+	core->cons->line->offset_prompt = true;
+	r_line_set_hist_callback (core->cons->line, &offset_history_up, &offset_history_down);
 	r_line_set_prompt ("[offset]> ");
 	strcpy (buf, "s ");
 	if (r_cons_fgets (buf + 2, sizeof (buf) - 3, 0, NULL) > 0) {
@@ -3436,6 +3438,8 @@ static void visual_offset(RAGraph *g, RCore *core) {
 			buf[1] = '.';
 		}
 		r_core_cmd0 (core, buf);
+		r_line_set_hist_callback (core->cons->line, &cmd_history_up, &cmd_history_down);
+		core->cons->line->offset_prompt = false;
 	}
 }
 

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -850,7 +850,17 @@ static int offset_history_up(RLine *line) {
 		return false;
 	}
 	line->offset_index--;
-	char *command = r_str_newf ("0x%"PFMT64x, undo->seek[undo->idx + line->offset_index].off);
+	ut64 off = undo->seek[undo->idx + line->offset_index].off;
+	core->flags->space_strict = true;
+	RFlagItem *f = r_flag_get_at (core->flags, off, true);
+	core->flags->space_strict = false;
+	char *command;
+	if (f && f->offset == off) {
+		command = r_str_newf ("%s", f->name);
+	}
+	else {
+		command = r_str_newf ("0x%"PFMT64x, off);
+	}
 	strncpy (line->buffer.data, command, R_LINE_BUFSIZE - 1);
 	line->buffer.index = line->buffer.length = strlen (line->buffer.data);
 	return true;
@@ -868,7 +878,17 @@ static int offset_history_down(RLine *line) {
 		line->buffer.index = line->buffer.length = 0;
 		return false;
 	}
-	char *command = r_str_newf ("0x%"PFMT64x, undo->seek[undo->idx + line->offset_index].off);
+	ut64 off = undo->seek[undo->idx + line->offset_index].off;
+	core->flags->space_strict = true;
+	RFlagItem *f = r_flag_get_at (core->flags, off, true);
+	core->flags->space_strict = false;
+	char *command;
+	if (f && f->offset == off) {
+		command = r_str_newf ("%s", f->name);
+	}
+	else {
+		command = r_str_newf ("0x%"PFMT64x, off);
+	}
 	strncpy (line->buffer.data, command, R_LINE_BUFSIZE - 1);
 	line->buffer.index = line->buffer.length = strlen (line->buffer.data);
 	return true;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -846,6 +846,7 @@ static void visual_offset(RCore *core) {
 	char buf[256];
 	r_line_set_prompt ("[offset]> ");
 	core->cons->line->offset_prompt = true;
+	core->cons->line->offset_index = 0;
 	strcpy (buf, "s ");
 	if (r_cons_fgets (buf + 2, sizeof (buf) - 3, 0, NULL) > 0) {
 		if (buf[2] == '.') {

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -845,6 +845,7 @@ static void reset_print_cur(RPrint *p) {
 static void visual_offset(RCore *core) {
 	char buf[256];
 	r_line_set_prompt ("[offset]> ");
+	core->cons->line->offset_prompt = true;
 	strcpy (buf, "s ");
 	if (r_cons_fgets (buf + 2, sizeof (buf) - 3, 0, NULL) > 0) {
 		if (buf[2] == '.') {
@@ -852,6 +853,7 @@ static void visual_offset(RCore *core) {
 		}
 		r_core_cmd0 (core, buf);
 		reset_print_cur (core->print);
+		core->cons->line->offset_prompt = false;
 	}
 }
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -797,6 +797,7 @@ struct r_line_t {
 	char *contents;
 	bool zerosep;
 	bool offset_prompt;
+	int offset_index;
 }; /* RLine */
 
 #ifdef R_API

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -781,9 +781,14 @@ typedef struct r_line_comp_t {
 
 typedef char* (*RLineEditorCb)(void *core, const char *str);
 
+typedef int (*RLineHistoryUpCb)(RLine* line);
+typedef int (*RLineHistoryDownCb)(RLine* line);
+
 struct r_line_t {
 	RLineCompletion completion;
 	RLineHistory history;
+	RLineHistoryUpCb history_up_cb;
+	RLineHistoryDownCb history_down_cb;
 	RLineBuffer buffer;
 	RLineEditorCb editor_cb;
 	int echo;
@@ -821,6 +826,10 @@ R_API int r_line_hist_label(const char *label, void (*cb)(const char*));
 R_API void r_line_label_show(void);
 R_API int r_line_hist_list(void);
 R_API const char *r_line_hist_get(int n);
+
+R_API int r_line_set_hist_callback(RLine *line, RLineHistoryUpCb cb_up, RLineHistoryDownCb cb_down);
+R_API int cmd_history_up(RLine *line);
+R_API int cmd_history_down(RLine *line);
 
 #define R_CONS_INVERT(x,y) (y? (x?Color_INVERT: Color_INVERT_RESET): (x?"[":"]"))
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -796,6 +796,7 @@ struct r_line_t {
 	int (*hist_down)(void *user);
 	char *contents;
 	bool zerosep;
+	bool offset_prompt;
 }; /* RLine */
 
 #ifdef R_API

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -612,6 +612,9 @@ R_API void r_core_syscmd_ls(const char *input);
 R_API void r_core_syscmd_cat(const char *file);
 R_API void r_core_syscmd_mkdir(const char *dir);
 
+R_API int offset_history_up(RLine *line);
+R_API int offset_history_down(RLine *line);
+
 // TODO : move into debug or syscall++
 R_API char *cmd_syscall_dostr(RCore *core, int num);
 /* tasks */


### PR DESCRIPTION
Closes #6756.

When pressing the arrow keys while in "offset mode" (after pressing 'o' in visual) the history will only show seek commands, and truncate them to show only the offset.

Before: [asciinema](https://asciinema.org/a/DMbDWJBVLNN86ayrrhOMPeWvq)
After: [asciinema](https://asciinema.org/a/4HY5NXvXIPoi5v5Ew1RHpnrrd)

Inside `r_line_hist_up()`, to check if r2 is in offset mode, I used 
`if (strcmp(r_line_get_prompt(), "[offset]> ") == 0) {...}`
I know it's ugly, but it was just a test to see if it worked, as this is my first pull request here and I didn't want to change too much code without advice.

So, do you have any suggestions on how could I check more correctly if r2 is in "offset mode" or not? 
I was thinking about adding a flag like `offset_prompt` to struct `RLine`, and then doing 
`if (I.offset_prompt) {...}` 
to keep things as simple as possible, but please tell me if you have better ideas.

Feel free to tell me if it's wrong, I still have a lot to learn...