### PR TITLE
Fixes #9318

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -654,7 +654,7 @@ static void type_cmd(RCore *core, const char *input) {
 	case 'a': // "afta"
 		if (r_config_get_i (core->config, "cfg.debug")) {
 			eprintf ("TOFIX: afta can't run in debugger mode.\n");
-			return;
+			break;
 		}
 		seek = core->offset;
 		r_core_cmd0 (core, "aei");


### PR DESCRIPTION
Replace return by break, fixing the infinite loop (input* wasn't consumed entirely)