### PR TITLE
Fix coredump generation

### DIFF
--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -648,12 +648,11 @@ static int get_info_mappings(linux_map_entry_t *me_head, size_t *maps_size) {
 	linux_map_entry_t *p;
 	int n_entries;
 	for (n_entries = 0, p = me_head; p; p = p->n) {
-		if (p->dumpeable) {
-			*maps_size += p->end_addr - p->start_addr;
-		}
 		/* We don't count maps which does not have r/w perms */
-		if ((p->perms & R_IO_READ) || (p->perms & R_IO_WRITE))
+		if ((p->perms & R_IO_READ) || (p->perms & R_IO_WRITE) && p->dumpeable) {
+			*maps_size += p->end_addr - p->start_addr;
 			n_entries++;
+		}
 	}
 	return n_entries;
 }
@@ -755,7 +754,6 @@ static bool dump_elf_map_content(RDebug *dbg, RBuffer *dest, linux_map_entry_t *
 	linux_map_entry_t *p;
 	ut8 *map_content;
 	size_t size;
-	size_t rbytes;
 	bool ret;
 
 	eprintf ("dump_elf_map_content starting\n\n");
@@ -769,9 +767,9 @@ static bool dump_elf_map_content(RDebug *dbg, RBuffer *dest, linux_map_entry_t *
 		if (!map_content) {
 			return false;
 		}
-		rbytes = dbg->iob.read_at (dbg->iob.io, p->start_addr, map_content, size);
-		if (rbytes != size) {
-			eprintf ("dump_elf_map_content: size not equal\n");
+		ret = dbg->iob.read_at (dbg->iob.io, p->start_addr, map_content, size);
+		if (!ret) {
+			eprintf ("Problems reading %d bytes at %"PFMT64x"\n", size, p->start_addr);
 		} else {
 			ret = r_buf_append_bytes (dest, (const ut8*)map_content, size);
 			if (!ret) {

--- a/libr/debug/p/native/linux/linux_coredump.h
+++ b/libr/debug/p/native/linux/linux_coredump.h
@@ -47,7 +47,7 @@
 
 #define XSTATE_SSE_MASK         (X87_BIT|SSE_BIT)
 #define XSTATE_AVX_MASK         (XSTATE_SSE_MASK|AVX_BIT)
-#define XSTATE_MPX_MASK         MPX_BIT
+#define XSTATE_MPX_MASK         (MPX_BIT|XSTATE_AVX_MASK|XSTATE_SSE_MASK)
 #define XSTATE_AVX512_MASK      (XSTATE_AVX_MASK|AVX512_FULL_BIT)
 /*********************************/
 #endif


### PR DESCRIPTION
Coredumps were not being generated correctly (something might have changed behind)