### PR TITLE
Fix "simple edges" graph

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2596,7 +2596,9 @@ static void agraph_print_edges_simple(RAGraph *g) {
 				n2->x + sx2, n2->y, &style);
 
 			if (n2->is_dummy) {
-				r_cons_canvas_line (g->can, n2->x, n2->y - 1, n2->x, n2->y + n2->h, &style);
+				r_cons_canvas_line (g->can,
+					n2->x, n2->y - 1,
+					n2->x, n2->y + n2->h, &style);
 			}
 		}
 	}

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2594,6 +2594,10 @@ static void agraph_print_edges_simple(RAGraph *g) {
 			r_cons_canvas_line (g->can,
 				n->x + sx, n->y + sy,
 				n2->x + sx2, n2->y, &style);
+
+			if (n2->is_dummy) {
+				r_cons_canvas_line (g->can, n2->x, n2->y - 1, n2->x, n2->y + n2->h, &style);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #9434.

Simple edges were broken when going around a node:
![graph-before](https://user-images.githubusercontent.com/3428362/37034256-fb1236b8-2148-11e8-81d2-d1d6851a0a64.png)

Now they're fixed:
![graph-after](https://user-images.githubusercontent.com/3428362/37034316-32c39f3e-2149-11e8-8c6a-195a975ead02.png)

