### PR TITLE
always show data refs when printing disasm, even if instr has no ptr

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3226,6 +3226,9 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 		if (ref->type == R_ANAL_REF_TYPE_STRING || ref->type == R_ANAL_REF_TYPE_DATA) {
 			if ((f = r_flag_get_i (core->flags, ref->addr))) {
 				refaddr = ref->addr;
+				if (p == UT64_MAX) {
+					p = 0;
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
We should trust the data references, if someone puts a data ref on an
instruction then we should use it. Before this patch, the data ref was only used
if anal_op.ptr was set.