### PR TITLE
Ignore files from CLion and CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ r2-static/*
 binr/rasign2/rasign2
 binr/rasign2/rasign2.exe
 compile_commands.json
+# CLion
+.idea/
+CMakeLists.txt
+*.cmake
+cmake-build-*


### PR DESCRIPTION
I personally use CLion + a small CMakeLists.txt wrapping around meson.
It would be convenient for me to add that to .gitignore.