### PR TITLE
Exclude meson.build from the list of color schemes

### DIFF
--- a/libr/cons/d/Makefile
+++ b/libr/cons/d/Makefile
@@ -14,7 +14,7 @@ CWD=$(shell pwd)
 symstall install-symlink:
 	mkdir -p "$P"
 	for FILE in * ; do \
-		if [ $$FILE != Makefile -a -f $$FILE ]; then \
+		if [ $$FILE != Makefile -a $$FILE != meson.build -a -f $$FILE ]; then \
 			ln -fs "${CWD}/$$FILE" "$P/$$FILE" ; \
 		fi ; \
 	done


### PR DESCRIPTION
Fixing issue in radare2 and Cutter showing 'meson.build' in the list of available colour theme.