### PR TITLE
Fix cmd /c/j to print json

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -2022,7 +2022,7 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 		if (!outmode) {
 			hits = NULL;
 		} else {
-			hits = r_core_asm_strsearch (core, input + 3,
+			hits = r_core_asm_strsearch (core, end_cmd,
 				from, to, maxhits, regexp, everyByte, mode);
 		}
 		if (hits) {

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1977,6 +1977,9 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 	if (!regexp && input[1] == 'a') {
 		everyByte = true;
 	}
+	if (regexp && input[2] == 'j') {
+		json = true;
+	}
 	if (!end_cmd) {
 		outmode = input[1];
 	} else {
@@ -2019,7 +2022,7 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 		if (!outmode) {
 			hits = NULL;
 		} else {
-			hits = r_core_asm_strsearch (core, input + 2,
+			hits = r_core_asm_strsearch (core, input + 3,
 				from, to, maxhits, regexp, everyByte, mode);
 		}
 		if (hits) {


### PR DESCRIPTION
The cmd /c/j was not printing any output before because json was not being set to true due to the check in line https://github.com/radare/radare2/blob/4ce73d2d44379e84e9dd1101ded88059c84ef2af/libr/core/cmd_search.c#L2523
was not met by this command 