### PR TITLE
Fix: omn wasn't expecting an id

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -93,7 +93,8 @@ static const char *help_msg_om[] = {
 	"om", " fd vaddr [size] [paddr] [rwx] [name]", "create new io map",
 	"omm"," [fd]", "create default map for given fd. (omm `oq`)",
 	"om.", "", "show map, that is mapped to current offset",
-	"omn", " mapid [name]", "set/delete name for map with mapid",
+	"omn", " mapaddr [name]", "set/delete name for map which spans mapaddr",
+	"omni", " mapid [name]", "set/delete name for map with mapid",
 	"omn.", "([-|name])", "show/set/delete name for current map",
 	"omf", " [mapid] rwx", "change flags/perms for current/given map",
 	"omfg", "[+-]rwx", "change flags/perms for all maps (global)",
@@ -537,6 +538,7 @@ static void cmd_omf (RCore *core, const char *input) {
 static void cmd_open_map(RCore *core, const char *input) {
 	ut64 fd = 0LL;
 	ut32 id = 0;
+	ut64 addr = 0;
 	char *s = NULL, *p = NULL, *q = NULL;
 	ut64 new;
 	RIOMap *map = NULL;
@@ -678,10 +680,13 @@ static void cmd_open_map(RCore *core, const char *input) {
 				}
 			}
 		} else {
-			if (!(s = strdup (&input[2]))) {
+			bool use_id = (input[2] == 'i') ? true : false;
+			s = strdup ( use_id ? &input[3] : &input[2]);
+			if (!s) {
 				break;
 			}
 			p = s;
+
 			while (*s == ' ') {
 				s++;
 			}
@@ -690,16 +695,26 @@ static void cmd_open_map(RCore *core, const char *input) {
 				break;
 			}
 			if (!(q = strchr (s, ' '))) {
-				id = (ut32)r_num_math (core->num, s);
-				map = r_io_map_get (core->io, id);
+				if (use_id) {
+					id = (ut32)r_num_math (core->num, s);
+					map = r_io_map_resolve (core->io, id);
+				} else {
+					addr = r_num_math (core->num, s);
+					map = r_io_map_get (core->io, addr);
+				}
 				r_io_map_del_name (map);
 				s = p;
 				break;
 			}
 			*q = '\0';
 			q++;
-			id = (ut32)r_num_math (core->num, s);
-			map = r_io_map_get (core->io, id);
+			if (use_id) {
+				id = (ut32)r_num_math (core->num, s);
+				map = r_io_map_resolve (core->io, id);
+			} else {
+				addr = r_num_math (core->num, s);
+				map = r_io_map_get (core->io, addr);
+			}
 			if (*q) {
 				r_io_map_set_name (map, q);
 			} else {


### PR DESCRIPTION
While dealing with something else, I realized that <b>omn</b>'s help said that a name together with an <b>id</b> were expected, but this proved to be false when I looked at the code.
<b>omn</b> was ready to handle an addr since there was no <pre>r_io_map_resolve</pre> involved but a <pre>r_io_map_get</pre> (which looks for maps that contains certain addr).

So I added <b>omni</b> to handle the case where we want to specify an id:

<pre>
> r2 -
 -- Follow the white rabbit
[0x00000000]> o elf.c 0x2000 r
4
[0x00000000]> o elf.c 0x8000 r
5
[0x00000000]> om
 3 fd: 5 +0x00000000 0x00008000 - 0x00008351 -r-x 
 2 fd: 4 +0x00000000 0x00002000 - 0x00002351 -r-x 
 1 fd: 3 +0x00000000 0x00000000 - 0x000001ff -rwx 
[0x00000000]> omn 0x00002000 addr
[0x00000000]> omni 3 id
[0x00000000]> om
 3 fd: 5 +0x00000000 0x00008000 - 0x00008351 -r-x id
 2 fd: 4 +0x00000000 0x00002000 - 0x00002351 -r-x addr
 1 fd: 3 +0x00000000 0x00000000 - 0x000001ff -rwx 
[0x00000000]>
</pre>