### PR TITLE
Loading Core (x86, x86_64, aarch64) (first part, analysis)

### DIFF
--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -19,7 +19,6 @@ static ut64 get_elf_vaddr64 (RBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr) {
 	//NOTE(aaSSfxxx): since RVA is vaddr - "official" image base, we just need to add imagebase to vaddr
 	struct Elf_(r_bin_elf_obj_t)* obj = bf->o->bin_obj;
 	return obj->baddr - obj->boffset + vaddr;
-
 }
 
 static void headers64(RBinFile *bf) {
@@ -143,6 +142,9 @@ RBinPlugin r_bin_plugin_elf64 = {
 	.create = &create,
 	.write = &r_bin_write_elf64,
 	.get_vaddr = &get_elf_vaddr64,
+	.file_type = &get_file_type,
+	.regstate = &regstate,
+	.maps = &maps,
 };
 
 #ifndef CORELIB

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -136,6 +136,11 @@ enum {
 	R_BIN_RELOC_64 = 64
 };
 
+enum {
+	R_BIN_TYPE_DEFAULT = 0,
+	R_BIN_TYPE_CORE = 1
+};
+
 typedef struct r_bin_addr_t {
 	ut64 vaddr;
 	ut64 paddr;
@@ -212,6 +217,8 @@ typedef struct r_bin_object_t {
 	RList/*<RBinClass>*/ *classes;
 	RList/*<RBinDwarfRow>*/ *lines;
 	RList/*<??>*/ *mem;	//RBinMem maybe?
+	RList/*<BinMap*/ *maps;
+	char *regstate;
 	RBinInfo *info;
 	RBinAddr *binsym[R_BIN_SYM_LAST];
 	struct r_bin_plugin_t *plugin;
@@ -372,6 +379,7 @@ typedef struct r_bin_plugin_t {
 	RList/*<RBinClass>*/* (*classes)(RBinFile *arch);
 	RList/*<RBinMem>*/* (*mem)(RBinFile *arch);
 	RList/*<RBinReloc>*/* (*patch_relocs)(RBin *bin);
+	RList/*<RBinMap>*/* (*maps)(RBinFile *arch);
 	void (*header)(RBinFile *arch);
 	char* (*signature)(RBinFile *arch, bool json);
 	int (*demangle_type)(const char *str);
@@ -382,6 +390,8 @@ typedef struct r_bin_plugin_t {
 	ut64 (*get_vaddr)(RBinFile *arch, ut64 baddr, ut64 paddr, ut64 vaddr);
 	RBuffer* (*create)(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
 	char* (*demangle)(const char *str);
+	char* (*regstate)(RBinFile *arch);
+	int (*file_type)(RBinFile *arch);
 	/* default value if not specified by user */
 	int minstrlen;
 	char strfilter;
@@ -514,6 +524,14 @@ typedef struct r_bin_mem_t {	//new toy for esil-init
 	int perms;
 	RList *mirrors;		//for mirror access; stuff here should only create new maps not new fds
 } RBinMem;
+
+typedef struct r_bin_map_t {
+	ut64 addr;
+	ut64 offset;
+	int size;
+	int perms;
+	char *file;
+} RBinMap;
 
 typedef struct r_bin_dbginfo_t {
 	int (*get_line)(RBinFile *arch, ut64 addr, char *file, int len, int *line);


### PR DESCRIPTION
This aims to be the first part of #9606, which means:

1. Retrieve map's information and create the ones we find
2. Get regstate and load it
3. Change asm.arch and asm.bits depending on the information we find in the ELF file

All this allows us to see the reg/memory state the binary had at the moment it was dumped, so we can dig in its memory for instance.

So far it supports x86, x86_64 and aarch64 for ELF.
arm support is pretty trivial, but I cannot get a board right now (hopefully tomorrow).

<pre>
$ for i in `ls gcore*` ; do readelf -h $i | grep Machine ; done
  Machine:                           AArch64
  Machine:                           Intel 80386
  Machine:                           Advanced Micro Devices X86-64

<b>[ARM64]</b>
> r2 gcore-aarch64
Setting up coredump: asm.arch <-> arm and asm.bits <-> 64
Setting up coredump: 11 maps have been found and created
Setting up coredump: Registers have been set
 -- Greetings, human.
[0x00000000]> om
11 fd: 3 +0x00013a34 0xffffdb15c000 - 0xffffdb17cfff -r-x 
10 fd: 3 +0x00012a34 0xffff81a23000 - 0xffff81a23fff -r-x 
 9 fd: 3 +0x00011a34 0xffff81a22000 - 0xffff81a22fff -r-x /lib64/ld-2.22.so
 8 fd: 3 +0x00010a34 0xffff81a21000 - 0xffff81a21fff -r-x /lib64/ld-2.22.so
 7 fd: 3 +0x0000fa34 0xffff81a20000 - 0xffff81a20fff -r-x 
 6 fd: 3 +0x0000ca34 0xffff81a1c000 - 0xffff81a1efff -r-x 
 5 fd: 3 +0x00008a34 0xffff819db000 - 0xffff819defff -r-x 
 4 fd: 3 +0x00006a34 0xffff819d9000 - 0xffff819dafff -r-x /lib64/libc-2.22.so
 3 fd: 3 +0x00002a34 0xffff819d5000 - 0xffff819d8fff -r-x /lib64/libc-2.22.so
 2 fd: 3 +0x00001a34 0x00420000 - 0x00420fff -r-x /root/repo/test
 1 fd: 3 +0x00000a34 0x0041f000 - 0x0041ffff -r-x /root/repo/test
[0x00000000]> ar
x0 = 0xffffdb17b0c8
x1 = 0xffffdb17b0c8
x2 = 0x00000000
x3 = 0x00000008
x4 = 0x00000000
x5 = 0x41a5b6d4117d0257
x6 = 0xffffdb17b260
x7 = 0xffff00000001
x8 = 0x00000065
x9 = 0xffffdb17b150
x10 = 0xffff819fea78
x11 = 0xffff81a1c000
x12 = 0x00000000
x13 = 0x00420008
x14 = 0x00000000
x15 = 0xffff81a0b000
x16 = 0x00000000
x17 = 0x00420008
x18 = 0xffff8187cc58
x19 = 0xffffdb17b0d8
x20 = 0xffffdb17b0c8
...
[0x00000000]> px @ 0xffffdb17b070
- offset -       0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0xffffdb17b070  70b2 17db ffff 0000 4006 4000 0000 0000  p.......@.@.....
0xffffdb17b080  0000 0000 0000 0000 0000 0000 0000 0000  ................
0xffffdb17b090  d004 4000 0000 0000 0000 0000 0000 0000  ..@.............

<b>[X86]</b>
> r2 gcore-x86
Setting up coredump: asm.arch <-> x86 and asm.bits <-> 32
Setting up coredump: 11 maps have been found and created
Setting up coredump: Registers have been set
 -- Documentation is for weak people.
[0x00000000]> om
11 fd: 3 +0x0003075c 0xbfab6000 - 0xbfad6fff -r-x 
10 fd: 3 +0x0002f75c 0xb77de000 - 0xb77defff -r-x /lib/i386-linux-gnu/ld-2.24.so
 9 fd: 3 +0x0002e75c 0xb77dd000 - 0xb77ddfff -r-x /lib/i386-linux-gnu/ld-2.24.so
 8 fd: 3 +0x0002c75c 0xb77b8000 - 0xb77b9fff -r-x 
 7 fd: 3 +0x0002975c 0xb77b3000 - 0xb77b5fff -r-x 
 6 fd: 3 +0x0002675c 0xb77aa000 - 0xb77acfff -r-x 
 5 fd: 3 +0x0002575c 0xb77a9000 - 0xb77a9fff -r-x /lib/i386-linux-gnu/libc-2.24.so
 4 fd: 3 +0x0002375c 0xb77a7000 - 0xb77a8fff -r-x /lib/i386-linux-gnu/libc-2.24.so
 3 fd: 3 +0x0000275c 0x00fc4000 - 0x00fe4fff -r-x 
 2 fd: 3 +0x0000175c 0x0048f000 - 0x0048ffff -r-x /home/osalvador/repo/arg
 1 fd: 3 +0x0000075c 0x0048e000 - 0x0048efff -r-x /home/osalvador/repo/arg
[0x00000000]> ar
oeax = 0x000000a2
eax = 0xfffffdfc
ebx = 0xbfad5fa8
ecx = 0xbfad5fa8
edx = 0x00000000
esi = 0x7fffffff
edi = 0xbfad5fa8
esp = 0xbfad5f6c
ebp = 0x00000000
eip = 0xb77b8cf9
eflags = 0x00000246
[0x00000000]> px @ 0xbfad5f6c
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0xbfad5f6c  0000 0000 0000 0000 a85f adbf d062 6ab7  ........._...bj.
0xbfad5f7c  2562 6ab7 a85f adbf a85f adbf a05f ad32  %bj.._..._..._.2
0xbfad5f8c  3137 3636 00e0 7db7 780b 60b7 7b72 63b7  1766..}.x.`.{rc.
...
...

<b>[X86_64]</b>
> r2 gcore-x86_64
Setting up coredump: asm.arch <-> x86 and asm.bits <-> 64
Setting up coredump: 13 maps have been found and created
Setting up coredump: Registers have been set
 -- I nodejs so hard my exams. What a nodejs!
[0x00000000]> om
13 fd: 3 +0x00037ee0 0xffffffffff600000 - 0xffffffffff600fff -r-x 
12 fd: 3 +0x00035ee0 0x7ffe187dd000 - 0x7ffe187defff -r-x 
11 fd: 3 +0x00014ee0 0x7ffe187ac000 - 0x7ffe187ccfff -r-x 
10 fd: 3 +0x00013ee0 0x7fa434f0e000 - 0x7fa434f0efff -r-x 
 9 fd: 3 +0x00012ee0 0x7fa434f0d000 - 0x7fa434f0dfff -r-x /lib64/ld-2.22.so
 8 fd: 3 +0x00011ee0 0x7fa434f0c000 - 0x7fa434f0cfff -r-x /lib64/ld-2.22.so
 7 fd: 3 +0x0000fee0 0x7fa434f0a000 - 0x7fa434f0bfff -r-x 
 6 fd: 3 +0x0000cee0 0x7fa434ee9000 - 0x7fa434eebfff -r-x 
 5 fd: 3 +0x00008ee0 0x7fa434ce8000 - 0x7fa434cebfff -r-x 
 4 fd: 3 +0x00006ee0 0x7fa434ce6000 - 0x7fa434ce7fff -r-x /lib64/libc-2.22.so
 3 fd: 3 +0x00002ee0 0x7fa434ce2000 - 0x7fa434ce5fff -r-x /lib64/libc-2.22.so
 2 fd: 3 +0x00001ee0 0x00601000 - 0x00601fff -r-x /home/osalvador/lab/r2/core/arg
 1 fd: 3 +0x00000ee0 0x00600000 - 0x00600fff -r-x /home/osalvador/lab/r2/core/arg
[0x00000000]> ar
rax = 0xfffffffffffffdfc
rbx = 0x7ffe187ca7a0
rcx = 0x7fa434a03040
rdx = 0x00000000
rsi = 0x7ffe187ca790
rdi = 0x7ffe187ca790
r8 = 0x7ffe187ca8a0
r9 = 0x7ffe187ca6e0
r10 = 0x00000008
r11 = 0x00000246
r12 = 0x7ffe187ca820
r13 = 0x7ffe187caa70
r14 = 0x00000000
r15 = 0x00000000
rip = 0x7fa434a03040
rbp = 0xffffffff
rflags = 0x00000246
rsp = 0x7ffe187ca788
[0x00000000]> px @ 0x7ffe187ca788
- offset -       0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x7ffe187ca788  f42e a034 a47f 0000 c300 0000 0000 0000  ...4............
0x7ffe187ca798  a71e c102 0000 0000 0000 0100 0000 0000  ................
...
...
</pre>



