### PR TITLE
[Issue #9656] Add support for extended regex in asm search

### DIFF
--- a/libr/core/asm.c
+++ b/libr/core/asm.c
@@ -145,7 +145,9 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 					matches = strstr (opst, tokens[matchcount]) != NULL;
 				} else {
 					rx = r_regex_new (tokens[matchcount], "");
-					matches = r_regex_exec (rx, opst, 0, 0, 0) == 0;
+					if (r_regex_comp (rx, tokens[matchcount], R_REGEX_EXTENDED|R_REGEX_NOSUB) == 0) {
+						matches = r_regex_exec (rx, opst, 0, 0, 0) == 0;
+					}
 					r_regex_free (rx);
 				}
 			}


### PR DESCRIPTION
Issue #9656
An evaluable var was not worth it, it's easier to compile the regex and by doing this we make sure it's a valid regular expresion