### PR TITLE
Fix: coredump generation for huge programs

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4538,12 +4538,11 @@ static int cmd_debug(void *data, const char *input) {
 			char *corefile = get_corefile_name (input + 1, core->dbg->pid);
 			eprintf ("Writing to file '%s'\n", corefile);
 			r_file_rm (corefile);
-			RBuffer *dst = r_buf_new ();
+			RBuffer *dst = r_buf_new_file (corefile, true);
 			if (dst) {
 				if (!core->dbg->h->gcore (core->dbg, dst)) {
 					eprintf ("dg: coredump failed\n");
 				}
-				r_file_dump (corefile, dst->buf, dst->length, 1);
 				r_buf_free (dst);
 			} else {
 				perror ("r_buf_new_file");

--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -723,7 +723,7 @@ static bool dump_elf_pheaders(RBuffer *dest, linux_map_entry_t *maps, elf_offset
 
 	/* write program headers */
 	for (me_p = maps; me_p; me_p = me_p->n) {
-		if (!(me_p->perms & R_IO_READ) && !(me_p->perms & R_IO_WRITE)) {
+		if ((!(me_p->perms & R_IO_READ) && !(me_p->perms & R_IO_WRITE)) || !me_p->dumpeable) {
 			continue;
 		}
 		phdr.p_type = PT_LOAD;
@@ -774,10 +774,6 @@ static bool dump_elf_map_content(RDebug *dbg, RBuffer *dest, linux_map_entry_t *
 			ret = r_buf_append_bytes (dest, (const ut8*)map_content, size);
 			if (!ret) {
 				eprintf ("r_buf_append_bytes - failed\n");
-				/* Huge map files can be a problem here:
-					Because sometimes r_buf_append_bytes fails reallocing new size due to a high memory usage.
-					Little trick for freeing some mem would be flush everything to disk and start from scratch. */
-				/* We need a trick */
 			}
 		}
 		free (map_content);


### PR DESCRIPTION
When dumping huge programs, it might be that <b>r_buf_append_bytes()</b> fails because <b>realloc()</b> is not able to get us more memory, and we end up with a "broken" coredump.
In order to workaround this, let's create the buf with <b>r_buf_new_file()</b>, so every time we call <b>r_buf_append_bytes()</b> the buffer will be written into the file instead of calling <b>realloc()</b> to expand it.
Coredumps can get really big:

<pre>
$ readelf -h firefox | grep "Number of program headers"
  Number of program headers:         933
$ du -sh firefox
3.5G	firefox
$
</pre>
