### PR TITLE
Few improvements to 8051 memory mapping

### DIFF
--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -84,18 +84,27 @@ static void map_cpu_memory (RAnal *anal, int entry, ut32 addr, ut32 size) {
 	if (desc && anal->iob.fd_get_name (anal->iob.io, desc->fd)) {
 		if (addr != mem_map[entry].addr) {
 			// reallocate mapped memory if address changed
+			eprintf ("realloc %s to 0x%08x\n", mem_map[entry].name, addr);
 			anal->iob.fd_remap (anal->iob.io, desc->fd, addr);
 		}
 	} else {
 		// allocate memory for address space
-		char *mstr = r_str_newf ("malloc://%d", size);
+		eprintf ("alloc %s to 0x%08x\n", mem_map[entry].name, addr);
+		char *mstr = r_str_newf ("malloc://%d", size);		
 		desc = anal->iob.open_at (anal->iob.io, mstr, R_IO_READ | R_IO_WRITE, 0, addr);		
 		r_str_free (mstr);
 		// set 8051 address space as name of mapped memory
-		int 
-		char *cmdstr = r_str_newf ("omni %d %s", entry+1, mem_map[entry].name);
-		anal->coreb.cmd (anal->coreb.core, cmdstr);
-		r_str_free (cmdstr);
+		if (false && desc && anal->iob.fd_get_name (anal->iob.io, desc->fd)) {
+			RList *maps = anal->iob.fd_get_map (anal->iob.io, desc->fd);
+			RIOMap *current_map;
+			RListIter *iter;
+			r_list_foreach (maps, iter, current_map) {
+				char *cmdstr = r_str_newf ("omni %d %s", current_map->id, mem_map[entry].name);
+				anal->coreb.cmd (anal->coreb.core, cmdstr);
+				r_str_free (cmdstr);
+			}
+			r_list_free (maps);
+		}
 	}
 	mem_map[entry].desc = desc;
 	mem_map[entry].addr = addr;

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -92,7 +92,7 @@ static void map_cpu_memory (RAnal *anal, int entry, ut32 addr, ut32 size, bool f
 		desc = anal->iob.open_at (anal->iob.io, mstr, R_IO_READ | R_IO_WRITE, 0, addr);		
 		r_str_free (mstr);
 		// set 8051 address space as name of mapped memory
-		if (false && desc && anal->iob.fd_get_name (anal->iob.io, desc->fd)) {
+		if (desc && anal->iob.fd_get_name (anal->iob.io, desc->fd)) {
 			RList *maps = anal->iob.fd_get_map (anal->iob.io, desc->fd);
 			RIOMap *current_map;
 			RListIter *iter;
@@ -143,7 +143,7 @@ static void set_cpu_model(RAnal *anal, bool force) {
 		i8051_reg_write (anal->reg, "_pdata", cpu_models[i].map_pdata);
 	} else {
 		addr_idata = i8051_reg_read (anal->reg, "_idata");
-		addr_sfr = i8051_reg_read (anal->reg, "_sfr" + 0x80);
+		addr_sfr = i8051_reg_read (anal->reg, "_sfr") + 0x80;
 		addr_xdata = i8051_reg_read (anal->reg, "_xdata");
 	}
 

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -63,21 +63,47 @@ static ut32 i8051_reg_read (RReg *reg, const char *regname) {
 	return 0;
 }
 
-static RIODesc *mem_idata = 0;
-static RIODesc *mem_sfr = 0;
-static RIODesc *mem_xdata = 0;
+typedef struct {
+	RIODesc *desc;
+	ut32 addr;
+	const char *name;
+} i8051_map_entry;
 
-static RIODesc* cpu_memory_map (RIOBind *iob, RIODesc *desc, ut32 addr, ut32 size) {
-	char *mstr = r_str_newf ("malloc://%d", size);
-	if (desc && iob->fd_get_name (iob->io, desc->fd)) {
-		iob->fd_remap (iob->io, desc->fd, addr);
+static const int I8051_IDATA = 0;
+static const int I8051_SFR = 1;
+static const int I8051_XDATA = 2;
+
+static i8051_map_entry mem_map[3] = {
+	{ NULL, UT32_MAX, "idata" },
+	{ NULL, UT32_MAX, "sfr" },
+	{ NULL, UT32_MAX, "xdata" }
+};
+
+static void map_cpu_memory (RAnal *anal, int entry, ut32 addr, ut32 size) {
+	RIODesc *desc = mem_map[entry].desc;
+	if (desc && anal->iob.fd_get_name (anal->iob.io, desc->fd)) {
+		if (addr != mem_map[entry].addr) {
+			// reallocate mapped memory if address changed
+			anal->iob.fd_remap (anal->iob.io, desc->fd, addr);
+		}
 	} else {
-		desc = iob->open_at (iob->io, mstr, R_IO_READ | R_IO_WRITE, 0, addr);
+		// allocate memory for address space
+		char *mstr = r_str_newf ("malloc://%d", size);
+		desc = anal->iob.open_at (anal->iob.io, mstr, R_IO_READ | R_IO_WRITE, 0, addr);		
+		r_str_free (mstr);
+		// set 8051 address space as name of mapped memory
+		int 
+		char *cmdstr = r_str_newf ("omni %d %s", entry+1, mem_map[entry].name);
+		anal->coreb.cmd (anal->coreb.core, cmdstr);
+		r_str_free (cmdstr);
 	}
-	return desc;
+	mem_map[entry].desc = desc;
+	mem_map[entry].addr = addr;
 }
 
 static void set_cpu_model(RAnal *anal, bool force) {
+	ut32 addr_idata, addr_sfr, addr_xdata;
+
 	if (!anal->reg) {
 		return;
 	}
@@ -97,21 +123,28 @@ static void set_cpu_model(RAnal *anal, bool force) {
 		}
 		cpu_curr_model = &cpu_models[i];
 
-		// (Re)allocate memory as needed.
-		// We assume that code is already allocated with firmware image
-		mem_idata = cpu_memory_map (&anal->iob, mem_idata, cpu_models[i].map_idata, 0x100);
-		mem_sfr = cpu_memory_map (&anal->iob, mem_sfr, cpu_models[i].map_sfr, 0x80);
-		mem_xdata = cpu_memory_map (&anal->iob, mem_xdata, cpu_models[i].map_xdata, 0x10000);
-
 		// TODO: Add flags as needed - seek using pseudo registers works w/o flags
 
 		// set memory map registers
+		addr_idata = cpu_models[i].map_idata;
+		addr_sfr = cpu_models[i].map_sfr - 0x80;
+		addr_xdata = cpu_models[i].map_xdata;
 		i8051_reg_write (anal->reg, "_code", cpu_models[i].map_code);
-		i8051_reg_write (anal->reg, "_idata", cpu_models[i].map_idata);
-		i8051_reg_write (anal->reg, "_sfr", cpu_models[i].map_sfr - 0x80);
-		i8051_reg_write (anal->reg, "_xdata", cpu_models[i].map_xdata);
+		i8051_reg_write (anal->reg, "_idata", addr_idata);
+		i8051_reg_write (anal->reg, "_sfr", addr_sfr);
+		i8051_reg_write (anal->reg, "_xdata", addr_xdata);
 		i8051_reg_write (anal->reg, "_pdata", cpu_models[i].map_pdata);
+	} else {
+		addr_idata = i8051_reg_read (anal->reg, "_idata");
+		addr_sfr = i8051_reg_read (anal->reg, "_sfr");
+		addr_xdata = i8051_reg_read (anal->reg, "_xdata");
 	}
+
+	// (Re)allocate memory as needed.
+	// We assume that code is allocated with firmware image
+	map_cpu_memory (anal, I8051_IDATA, addr_idata, 0x100);
+	map_cpu_memory (anal, I8051_SFR, addr_sfr, 0x80);
+	map_cpu_memory (anal, I8051_XDATA, addr_xdata, 0x10000);
 }
 
 static ut8 bitindex[] = {

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -251,6 +251,7 @@ typedef int (*RIOFdReadAt) (RIO *io, int fd, ut64 addr, ut8 *buf, int len);
 typedef int (*RIOFdWriteAt) (RIO *io, int fd, ut64 addr, const ut8 *buf, int len);
 typedef bool (*RIOFdIsDbg) (RIO *io, int fd);
 typedef const char *(*RIOFdGetName) (RIO *io, int fd);
+typedef RList *(*RIOFdGetMap) (RIO *io, int fd);
 typedef bool (*RIOFdRemap) (RIO *io, int fd, ut64 addr);
 typedef void (*RIOAlSort) (RIOAccessLog *log);
 typedef void (*RIOAlFree) (RIOAccessLog *log);
@@ -284,6 +285,7 @@ typedef struct r_io_bind_t {
 	RIOFdWriteAt fd_write_at;
 	RIOFdIsDbg fd_is_dbg;
 	RIOFdGetName fd_get_name;
+	RIOFdGetMap fd_get_map;
 	RIOFdRemap fd_remap;
 	RIOAlSort al_sort;	//needed for esil
 	RIOAlFree al_free;	//needed for esil

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -740,6 +740,7 @@ R_API int r_io_bind(RIO* io, RIOBind* bnd) {
 	bnd->fd_write_at = r_io_fd_write_at;
 	bnd->fd_is_dbg = r_io_fd_is_dbg;
 	bnd->fd_get_name = r_io_fd_get_name;
+	bnd->fd_get_map = r_io_map_get_for_fd;
 	bnd->fd_remap = r_io_map_remap_fd;
 	bnd->al_sort = r_io_accesslog_sort;
 	bnd->al_free = r_io_accesslog_free;


### PR DESCRIPTION
- Update io map when address space registers change
- Assign name of 8051 address space to io map (invoking omni)
- Added callback to RIOBind to get list of maps for fd (required for invoking omni)
- Fixed leaked string (mstr)

Before:
```
[0x00000000]> om
 4 fd: 6 +0x00000000 0x00000000 - 0x0000270f -rwx 
 3 fd: 5 +0x00000000 0x20000000 - 0x2000ffff -rw- 
 2 fd: 4 +0x00000000 0x10000180 - 0x100001ff -rw- 
 1 fd: 3 +0x00000000 0x10000000 - 0x100000ff -rw- 
```
After:
```
[0x00000000]> om
 4 fd: 6 +0x00000000 0x00000000 - 0x0000270f -rwx 
 3 fd: 5 +0x00000000 0x20000000 - 0x2000ffff -rw- xdata
 2 fd: 4 +0x00000000 0x10000180 - 0x100001ff -rw- sfr
 1 fd: 3 +0x00000000 0x10000000 - 0x100000ff -rw- idata
```
