### PR TITLE
Some fixups for #9682

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2026,11 +2026,11 @@ R_API int r_anal_fcn_count_edges(RAnalFunction *fcn, int *ebbs) {
 }
 
 R_API RList *r_anal_fcn_get_refs(RAnal *anal, RAnalFunction *fcn) {
-	RList *ret = r_list_clone (fcn->refs);
+	RList *ret = (fcn) ? r_list_clone (fcn->refs) : NULL;
 	return ret;
 }
 
 R_API RList *r_anal_fcn_get_xrefs(RAnal *anal, RAnalFunction *fcn) {
-	RList *ret = r_list_clone (fcn->xrefs);
+	RList *ret = (fcn) ? r_list_clone (fcn->xrefs) : NULL;
 	return ret;
 }

--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -430,7 +430,7 @@ static char *readbuffer = NULL;
 static int readbuffer_length = 0;
 
 R_API bool r_cons_readpush(const char *str, int len) {
-	char *res = realloc (readbuffer, len + readbuffer_length);
+	char *res = (len + readbuffer_length > 0) ? realloc (readbuffer, len + readbuffer_length) : NULL;
 	if (res) {
 		readbuffer = res;
 		memmove (readbuffer + readbuffer_length, str, len);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4059,9 +4059,9 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			break;
 		case 'p': //"aesp"
 			n = strchr (input, ' ');
-			n1 = strchr (n + 1, ' ');
-			if (!(n + 1) || !(n1 + 1)){
-				eprintf ("aesp [offset] [num]");
+			n1 = n ? strchr (n + 1, ' ') : NULL;
+			if ((!n || !n1) || (!(n + 1) || !(n1 + 1))) {
+				eprintf ("aesp [offset] [num]\n");
 				break;
 			}
 			adr = r_num_math (core->num, n + 1);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2409,6 +2409,10 @@ static void cmd_print_bars(RCore *core, const char *input) {
 		nblocks = totalsize / blocksize;
 	} else {
 		blocksize = totalsize / nblocks;
+		 if (blocksize < 1) {
+			eprintf ("Invalid block size: %d\n", (int)blocksize);
+			return;
+		}
 	}
 	switch (mode) {
 	case '?': // bars

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -351,7 +351,7 @@ static void cmd_write_op (RCore *core, const char *input) {
 				}
 			}
 			algo = args;
-			if (algo && *algo) {
+			if (algo && *algo && key) {
 				encrypt_or_decrypt_block (core, algo, key, direction, iv);
 			} else {
 				eprintf ("Usage: wo%c [algo] [key] [IV]\n", ((!direction)?'E':'D'));

--- a/shlr/tcc/tccgen.c
+++ b/shlr/tcc/tccgen.c
@@ -2056,22 +2056,23 @@ tok_identifier:
 		}
 		if (!s) {
 			tcc_error ("invalid declaration '%s'", get_tok_str (t, NULL));
-		}
-		if ((s->type.t & (VT_STATIC | VT_INLINE | VT_BTYPE)) ==
-		    (VT_STATIC | VT_INLINE | VT_FUNC)) {
-			/* if referencing an inline function, then we generate a
-			   symbol to it if not already done. It will have the
-			   effect to generate code for it at the end of the
-			   compilation unit. */
-			r = VT_SYM | VT_CONST;
 		} else {
-			r = s->r;
-		}
-		vset (&s->type, r, s->c);
-		/* if forward reference, we must point to s */
-		if (vtop->r & VT_SYM) {
-			vtop->sym = s;
-			vtop->c.ul = 0;
+			if ((s->type.t & (VT_STATIC | VT_INLINE | VT_BTYPE)) ==
+			    (VT_STATIC | VT_INLINE | VT_FUNC)) {
+				/* if referencing an inline function, then we generate a
+				   symbol to it if not already done. It will have the
+				   effect to generate code for it at the end of the
+				   compilation unit. */
+				r = VT_SYM | VT_CONST;
+			} else {
+				r = s->r;
+			}
+			vset (&s->type, r, s->c);
+			/* if forward reference, we must point to s */
+			if (vtop->r & VT_SYM) {
+				vtop->sym = s;
+				vtop->c.ul = 0;
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
This should fix some of the reported issues in #9682 :

- axf.
- td B()17ecS? [
- woDwpsx@e:=oHf D and woDj01
- p==pv 1oom 6e
- ge;aespe
- 4< 

I could not reproduce <b>paadd [d,[,R,1d</b>
