### PR TITLE
Even More VTables and RTTI

### DIFF
--- a/libr/anal/rtti.c
+++ b/libr/anal/rtti.c
@@ -2,17 +2,17 @@
 
 #include "r_anal.h"
 
-R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr) {
+R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode) {
 	RVTableContext context;
 	r_anal_vtable_begin (anal, &context);
 	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
-		r_anal_rtti_msvc_print_at_vtable (&context, addr);
+		r_anal_rtti_msvc_print_at_vtable (&context, addr, mode);
 	} else {
 		eprint ("RTTI not supported yet for Itanium.\n");
 	}
 }
 
-static void rtti_msvc_print_all(RVTableContext *context) {
+static void rtti_msvc_print_all(RVTableContext *context, int mode) {
 	r_cons_break_push (NULL, NULL);
 	RList *vtables = r_anal_vtable_search (context);
 	RListIter *vtableIter;
@@ -23,7 +23,7 @@ static void rtti_msvc_print_all(RVTableContext *context) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-			r_anal_rtti_msvc_print_at_vtable (context, table->saddr);
+			r_anal_rtti_msvc_print_at_vtable (context, table->saddr, mode);
 			r_cons_print ("\n");
 		}
 	}
@@ -32,11 +32,11 @@ static void rtti_msvc_print_all(RVTableContext *context) {
 	r_cons_break_pop ();
 }
 
-R_API void r_anal_rtti_print_all(RAnal *anal) {
+R_API void r_anal_rtti_print_all(RAnal *anal, int mode) {
 	RVTableContext context;
 	r_anal_vtable_begin (anal, &context);
 	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
-		rtti_msvc_print_all (&context);
+		rtti_msvc_print_all (&context, mode);
 	} else {
 		eprint ("RTTI not supported yet for Itanium.\n");
 	}

--- a/libr/anal/rtti.c
+++ b/libr/anal/rtti.c
@@ -13,17 +13,23 @@ R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr) {
 }
 
 static void rtti_msvc_print_all(RVTableContext *context) {
+	r_cons_break_push (NULL, NULL);
 	RList *vtables = r_anal_vtable_search (context);
 	RListIter *vtableIter;
 	RVTableInfo *table;
 
 	if (vtables) {
 		r_list_foreach (vtables, vtableIter, table) {
-				r_anal_rtti_msvc_print_at_vtable (context, table->saddr);
-				r_cons_print ("\n");
+			if (r_cons_is_breaked ()) {
+				break;
 			}
+			r_anal_rtti_msvc_print_at_vtable (context, table->saddr);
+			r_cons_print ("\n");
+		}
 	}
 	r_list_free (vtables);
+
+	r_cons_break_pop ();
 }
 
 R_API void r_anal_rtti_print_all(RAnal *anal) {

--- a/libr/anal/rtti.c
+++ b/libr/anal/rtti.c
@@ -2,11 +2,35 @@
 
 #include "r_anal.h"
 
-R_API void r_anal_print_rtti (RAnal *anal) {
+R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr) {
 	RVTableContext context;
 	r_anal_vtable_begin (anal, &context);
 	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
-		r_anal_rtti_msvc_print_all (&context);
+		r_anal_rtti_msvc_print_at_vtable (&context, addr);
+	} else {
+		eprint ("RTTI not supported yet for Itanium.\n");
+	}
+}
+
+static void rtti_msvc_print_all(RVTableContext *context) {
+	RList *vtables = r_anal_vtable_search (context);
+	RListIter *vtableIter;
+	RVTableInfo *table;
+
+	if (vtables) {
+		r_list_foreach (vtables, vtableIter, table) {
+				r_anal_rtti_msvc_print_at_vtable (context, table->saddr);
+				r_cons_print ("\n");
+			}
+	}
+	r_list_free (vtables);
+}
+
+R_API void r_anal_rtti_print_all(RAnal *anal) {
+	RVTableContext context;
+	r_anal_vtable_begin (anal, &context);
+	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
+		rtti_msvc_print_all (&context);
 	} else {
 		eprint ("RTTI not supported yet for Itanium.\n");
 	}

--- a/libr/anal/rtti_msvc.c
+++ b/libr/anal/rtti_msvc.c
@@ -302,16 +302,6 @@ static void rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 	}
 }
 
-R_API void r_anal_rtti_msvc_print_all(RVTableContext *context) {
-	RList *vtables = r_anal_vtable_search (context);
-	RListIter *vtableIter;
-	RVTableInfo *table;
-
-	if (vtables) {
-		r_list_foreach (vtables, vtableIter, table) {
-			rtti_msvc_print_complete_object_locator_recurse (context, table->saddr);
-			r_cons_print ("\n");
-		}
-	}
-	r_list_free (vtables);
+R_API void r_anal_rtti_msvc_print_at_vtable(RVTableContext *context, ut64 addr) {
+	rtti_msvc_print_complete_object_locator_recurse (context, addr);
 }

--- a/libr/anal/rtti_msvc.c
+++ b/libr/anal/rtti_msvc.c
@@ -115,7 +115,12 @@ static RList *rtti_msvc_read_base_class_array(RVTableContext *context, ut32 num_
 	}
 	ret->free = free;
 
+	r_cons_break_push (NULL, NULL);
 	while (num_base_classes > 0) {
+		if (r_cons_is_breaked ()) {
+			break;
+		}
+
 		ut64 bcdAddr;
 		if (!context->read_addr (context->anal, addr, &bcdAddr)) {
 			break;
@@ -132,6 +137,7 @@ static RList *rtti_msvc_read_base_class_array(RVTableContext *context, ut32 num_
 		addr += context->word_size;
 		num_base_classes--;
 	}
+	r_cons_break_pop ();
 
 	if (num_base_classes > 0) {
 		// there was an error in the loop above

--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -166,9 +166,15 @@ R_API RList *r_anal_vtable_search(RVTableContext *context) {
 		return NULL;
 	}
 
+	r_cons_break_push (NULL, NULL);
+
 	RListIter *iter;
 	RBinSection *section;
 	r_list_foreach (sections, iter, section) {
+		if (r_cons_is_breaked ()) {
+			break;
+		}
+
 		if (!vtable_section_can_contain_vtables (context, section)) {
 			continue;
 		}
@@ -179,6 +185,10 @@ R_API RList *r_anal_vtable_search(RVTableContext *context) {
 		ut64 startAddress = section->vaddr;
 		ut64 endAddress = startAddress + (section->vsize) - context->word_size;
 		while (startAddress <= endAddress) {
+			if (r_cons_is_breaked ()) {
+				break;
+			}
+
 			if (vtable_is_addr_vtable_start (context, startAddress)) {
 				RVTableInfo *vtable = calloc (1, sizeof(RVTableInfo));
 				vtable->saddr = startAddress;
@@ -199,6 +209,8 @@ R_API RList *r_anal_vtable_search(RVTableContext *context) {
 			startAddress += 1;
 		}
 	}
+
+	r_cons_break_pop ();
 
 	if (r_list_empty (vtables)) {
 		// stripped binary?

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -609,6 +609,11 @@ static int bin_info(RCore *r, int mode) {
 				r_config_set (r->config, "bin.lang", info->lang);
 			}
 			r_config_set (r->config, "asm.os", info->os);
+			if (info->rclass && !strcmp (info->rclass, "pe")) {
+				r_config_set (r->config, "anal.cpp.abi", "msvc");
+			} else {
+				r_config_set (r->config, "anal.cpp.abi", "itanium");
+			}
 			r_config_set (r->config, "asm.arch", info->arch);
 			if (info->cpu && *info->cpu) {
 				r_config_set (r->config, "asm.cpu", info->cpu);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6417,10 +6417,10 @@ static bool anal_fcn_data_gaps (RCore *core, const char *input) {
 static void cmd_anal_rtti(RCore *core, const char *input) {
 	switch (input[0]) {
 	case '\0': // "avr"
-		r_anal_rtti_print_at_vtable (core->anal, core->offset);
+		r_anal_rtti_print_at_vtable (core->anal, core->offset, 0);
 		break;
 	case 'a': // "avra"
-		r_anal_rtti_print_all (core->anal);
+		r_anal_rtti_print_all (core->anal, input[1]);
 		break;
 	default :
 		r_core_cmd_help (core, help_msg_av);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -548,7 +548,8 @@ static const char *help_msg_av[] = {
 		"av", "", "search for vtables in data sections and show results",
 		"avj", "", "like av, but as json",
 		"av*", "", "like av, but as r2 commands",
-		"avr", "", "search for vtables and try to parse RTTI (see anal.cpp.abi)",
+		"avr", "[@addr]", "try to parse RTTI at vtable addr (see anal.cpp.abi)",
+		"avra", "", "search for vtables and try to parse RTTI at each of them",
 		NULL
 };
 
@@ -6413,6 +6414,20 @@ static bool anal_fcn_data_gaps (RCore *core, const char *input) {
 	return true;
 }
 
+static void cmd_anal_rtti(RCore *core, const char *input) {
+	switch (input[0]) {
+	case '\0': // "avr"
+		r_anal_rtti_print_at_vtable (core->anal, core->offset);
+		break;
+	case 'a': // "avra"
+		r_anal_rtti_print_all (core->anal);
+		break;
+	default :
+		r_core_cmd_help (core, help_msg_av);
+		break;
+	}
+}
+
 static void cmd_anal_virtual_functions(RCore *core, const char* input) {
 	switch (input[0]) {
 	case '\0': // "av"
@@ -6421,7 +6436,7 @@ static void cmd_anal_virtual_functions(RCore *core, const char* input) {
 		r_anal_list_vtables (core->anal, input[0]);
 		break;
 	case 'r': // "avr"
-		r_anal_print_rtti (core->anal);
+		cmd_anal_rtti (core, input + 1);
 		break;
 	default :
 		r_core_cmd_help (core, help_msg_av);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -543,6 +543,15 @@ static const char *help_msg_as[] = {
 	NULL
 };
 
+static const char *help_msg_av[] = {
+		"Usage:", "av[?jr*]", " C++ vtables and RTTI",
+		"av", "", "search for vtables in data sections and show results",
+		"avj", "", "like av, but as json",
+		"av*", "", "like av, but as r2 commands",
+		"avr", "", "search for vtables and try to parse RTTI (see anal.cpp.abi)",
+		NULL
+};
+
 static const char *help_msg_ax[] = {
 	"Usage:", "ax[?d-l*]", " # see also 'afx?'",
 	"ax", "", "list refs",
@@ -6405,12 +6414,9 @@ static bool anal_fcn_data_gaps (RCore *core, const char *input) {
 }
 
 static void cmd_anal_virtual_functions(RCore *core, const char* input) {
-	const char * help_msg[] = {
-		"Usage:", "av[*j] ", "analyze the .rodata section and list virtual function present",
-		NULL};
 	switch (input[0]) {
 	case '\0': // "av"
-	case '*':// "av*"
+	case '*': // "av*"
 	case 'j': // "avj"
 		r_anal_list_vtables (core->anal, input[0]);
 		break;
@@ -6418,7 +6424,7 @@ static void cmd_anal_virtual_functions(RCore *core, const char* input) {
 		r_anal_print_rtti (core->anal);
 		break;
 	default :
-		r_core_cmd_help (core, help_msg);
+		r_core_cmd_help (core, help_msg_av);
 		break;
 	}
 }

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1694,8 +1694,9 @@ R_API RList *r_anal_vtable_get_methods(RVTableContext *context, RVTableInfo *tab
 R_API void r_anal_list_vtables(RAnal *anal, int rad);
 
 /* rtti */
-R_API void r_anal_rtti_msvc_print_all(RVTableContext *context);
-R_API void r_anal_print_rtti(RAnal *anal);
+R_API void r_anal_rtti_msvc_print_at_vtable(RVTableContext *context, ut64 addr);
+R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr);
+R_API void r_anal_rtti_print_all(RAnal *anal);
 
 /* plugin pointers */
 extern RAnalPlugin r_anal_plugin_null;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1694,9 +1694,14 @@ R_API RList *r_anal_vtable_get_methods(RVTableContext *context, RVTableInfo *tab
 R_API void r_anal_list_vtables(RAnal *anal, int rad);
 
 /* rtti */
-R_API void r_anal_rtti_msvc_print_at_vtable(RVTableContext *context, ut64 addr);
-R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr);
-R_API void r_anal_rtti_print_all(RAnal *anal);
+R_API void r_anal_rtti_msvc_print_complete_object_locator(RVTableContext *context, ut64 addr, int mode);
+R_API void r_anal_rtti_msvc_print_type_descriptor(RVTableContext *context, ut64 addr, int mode);
+R_API void r_anal_rtti_msvc_print_class_hierarchy_descriptor(RVTableContext *context, ut64 addr, int mode);
+R_API void r_anal_rtti_msvc_print_base_class_descriptor(RVTableContext *context, ut64 addr, int mode);
+R_API void r_anal_rtti_msvc_print_at_vtable(RVTableContext *context, ut64 addr, int mode);
+
+R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode);
+R_API void r_anal_rtti_print_all(RAnal *anal, int mode);
 
 /* plugin pointers */
 extern RAnalPlugin r_anal_plugin_null;


### PR DESCRIPTION
- anal.cpp.abi is set to msvc automatically for PE
- More commands and better help message
- av, avr and avra can be canceled with Ctrl+C
- Support for MSVC x86_64 which is a bit different compared to 32bit
#6851