### PR TITLE
core-loading: Add support for arm32

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -50,7 +50,7 @@ typedef struct reginfo {
 static reginfo_t reginf[ARCH_LEN] = {
 					{160, 0x5c},
 					{216, 0x84},
-					{0, 0},
+					{72, 0x5c},
 					{272, 0x84}
 				};
 
@@ -3315,7 +3315,7 @@ static bool get_nt_file_maps (ELFOBJ *bin, RList *core_maps) {
 							bin->phdr[ph].p_offset + offset,
 							elf_nhdr, elf_nhdr_size);
 				if (ret != elf_nhdr_size) {
-					eprintf ("Cannot read NOTES header from CORE\n");
+					eprintf ("Cannot read more NOTES header from CORE\n");
 					free (elf_nhdr);
 					goto fail;
 				}
@@ -3399,7 +3399,7 @@ bool *Elf_(r_bin_elf_get_maps)(ELFOBJ *bin, RList *core_maps) {
 
 	if (core_maps->head) {
 		if (!get_nt_file_maps (bin, core_maps)) {
-			eprintf ("Could not retrieve maps from NT_FILE\n");
+			eprintf ("Could not retrieve the names of all maps from NT_FILE\n");
 		}
 	}
 

--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -226,7 +226,6 @@ R_API int r_bin_object_set_items(RBinFile *binfile, RBinObject *o) {
 	if (bin->filter_rules & (R_BIN_REQ_SYMBOLS | R_BIN_REQ_IMPORTS)) {
 		o->lang = r_bin_load_languages (binfile);
 	}
-beach:
 	binfile->o = old_o;
 	return true;
 }

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -40,6 +40,7 @@ static RList *maps(RBinFile *bf) {
 static char* regstate(RBinFile *bf) {
 	struct Elf_(r_bin_elf_obj_t) *obj = bf->o->bin_obj;
 	if (obj->ehdr.e_machine != EM_AARCH64 &&
+		obj->ehdr.e_machine != EM_ARM &&
 		obj->ehdr.e_machine != EM_386 &&
 		obj->ehdr.e_machine != EM_X86_64) {
 		eprintf ("Cannot retrieve regstate on: %s (not yet supported)\n",


### PR DESCRIPTION
This adds support for loading arm32 regs.
Somehow NT_FILE is not being generated for arm32 and the name of the maps can't be grabbed (I'll try to find out why).

<pre>
$ r2 gcore-arm32
Cannot read more NOTES header from CORE
Could not retrieve the names of all maps from NT_FILE
Setting up coredump: asm.arch <-> arm and asm.bits <-> 32
Setting up coredump: Registers have been set
Setting up coredump: 14 maps have been found and created
 -- Control the height of the terminal on serial consoles with e scr.height
[0x00000000]> ar
sb = 0x7fffffff
sl = 0xbea655a8
fp = 0xbea6551c
ip = 0x00000000
sp = 0xbea65518
lr = 0xb6ecdafc
pc = 0x00000000
r0 = 0xfffffffc
r1 = 0xbea656a8
r2 = 0x00000000
r3 = 0x00000008
r4 = 0x00000000
r5 = 0x00000078
r6 = 0xbea65628
r7 = 0x000000a2
r8 = 0xbea656a8
r9 = 0x7fffffff
r10 = 0xbea655a8
r11 = 0xbea6551c
r12 = 0x00000000
r13 = 0xbea65518
r14 = 0xb6ecdafc
r15 = 0x00000000
cpsr = 0x40000010
blank = 0xb6006100
[0x00000000]> om
14 fd: 8 +0x00000000 0x00008000 - 0x00008fff mr-x mmap.LOAD0
13 fd: 3 +0x00000508 0x00010000 - 0x00010fff -r-x fmap.LOAD1
12 fd: 3 +0x00001508 0xb6e30000 - 0xb6e30fff -r-x fmap.LOAD2
11 fd: 7 +0x00000000 0xb6e31000 - 0xb6f5dfff mr-x mmap.LOAD3
10 fd: 6 +0x00000000 0xb6f66000 - 0xb6f67fff mr-x mmap.LOAD4
 9 fd: 3 +0x00002508 0xb6f68000 - 0xb6f68fff -r-x fmap.LOAD5
 8 fd: 3 +0x00003508 0xb6f69000 - 0xb6f6bfff -r-x fmap.LOAD6
 7 fd: 3 +0x00006508 0xb6f6c000 - 0xb6f6cfff -r-x fmap.LOAD7
 6 fd: 5 +0x00000000 0xb6f6d000 - 0xb6f8afff mr-x mmap.LOAD8
 5 fd: 3 +0x00007508 0xb6f90000 - 0xb6f91fff -r-x fmap.LOAD9
 4 fd: 4 +0x00000000 0xb6f92000 - 0xb6f92fff mr-x mmap.LOAD10
 3 fd: 3 +0x00009508 0xb6f93000 - 0xb6f93fff -r-x fmap.LOAD11
 2 fd: 3 +0x0000a508 0xbea45000 - 0xbea65fff -r-- [stack]
 1 fd: 3 +0x0002b508 0xffff0000 - 0xffff0fff -r-x fmap.LOAD13
[0x00000000]>
</pre>