### PR TITLE
Add r_anal_op_partial() to optimize analysis

### DIFF
--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -30,7 +30,7 @@ static int show_analinfo(const char *arg, ut64 offset) {
 	}
 	for (ret = 0; ret < len;) {
 		aop.size = 0;
-		if (r_anal_op (anal, &aop, offset, buf + ret, len - ret) > 0) {
+		if (r_anal_op (anal, &aop, offset, buf + ret, len - ret, R_ANAL_OP_MASK_ALL) > 0) {
 			//printf ("%s\n", R_STRBUF_SAFEGET (&aop.esil));
 		}
 		if (aop.size < 1) {
@@ -148,7 +148,7 @@ static int showanal(RAnal *lanal, RAnalOp *op, ut64 offset, ut8 *buf, int len, b
 	char *bytes, *stackop = NULL;
 	int ret;
 
-	ret = r_anal_op (anal, op, offset, buf, len);
+	ret = r_anal_op (anal, op, offset, buf, len, R_ANAL_OP_MASK_ALL);
 	if (ret) {
 		stackop = stackop2str (op->stackop);
 		optype = r_anal_optype_to_string (op->type);
@@ -273,7 +273,7 @@ static int rasm_disasm(char *buf, ut64 offset, int len, int bits, int ascii, int
 		RAnalOp aop = { 0 };
 		while (ret < len) {
 			aop.size = 0;
-			if (r_anal_op (anal, &aop, offset, data + ret, len - ret) > 0) {
+			if (r_anal_op (anal, &aop, offset, data + ret, len - ret, R_ANAL_OP_MASK_ALL) > 0) {
 				printf ("%s\n", R_STRBUF_SAFEGET (&aop.esil));
 			}
 			if (aop.size < 1) {

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -329,7 +329,7 @@ R_API ut8 *r_anal_mask(RAnal *anal, int size, const ut8 *data, ut64 at) {
 	memset (ret, 0xff, size);
 
 	while (idx < size) {
-		if ((oplen = r_anal_op (anal, op, at, data + idx, size - idx)) < 1) {
+		if ((oplen = r_anal_op (anal, op, at, data + idx, size - idx, R_ANAL_OP_MASK_ALL)) < 1) {
 			break;
 		}
 		if ((op->ptr != UT64_MAX || op->jump != UT64_MAX) && op->nopcode != 0) {
@@ -384,7 +384,7 @@ R_API RAnalOp *r_anal_op_hexstr(RAnal *anal, ut64 addr, const char *str) {
 		return NULL;
 	}
 	len = r_hex_str2bin (str, buf);
-	r_anal_op (anal, op, addr, buf, len);
+	r_anal_op (anal, op, addr, buf, len, R_ANAL_OP_MASK_ALL);
 	free (buf);
 	return op;
 }
@@ -591,7 +591,7 @@ bool noreturn_recurse(RAnal *anal, ut64 addr) {
 		return false;
 	}
 	// TODO: check return value
-	(void)r_anal_op (anal, &op, addr, bbuf, sizeof (bbuf));
+	(void)r_anal_op (anal, &op, addr, bbuf, sizeof (bbuf), R_ANAL_OP_MASK_ALL);
 	switch (op.type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_JMP:
 		if (op.jump == UT64_MAX) {

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -87,7 +87,7 @@ R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb, ut64 addr, ut8 *buf, ut64 len, 
 			eprintf ("Error: new (op)\n");
 			return R_ANAL_RET_ERROR;
 		}
-		if ((oplen = r_anal_op (anal, op, addr + idx, buf + idx, len - idx)) == 0) {
+		if ((oplen = r_anal_op (anal, op, addr + idx, buf + idx, len - idx, R_ANAL_OP_MASK_ALL)) == 0) {
 			r_anal_op_free (op);
 			op = NULL;
 			if (idx == 0) {

--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -70,7 +70,7 @@ R_API int r_anal_diff_fingerprint_bb(RAnal *anal, RAnalBlock *bb) {
 				return false;
 			}
 			while (idx < bb->size) {
-				if ((oplen = r_anal_op (anal, op, 0, buf+idx, bb->size-idx)) < 1) {
+				if ((oplen = r_anal_op (anal, op, 0, buf+idx, bb->size-idx, R_ANAL_OP_MASK_ALL)) < 1) {
 					break;
 				}
 				if (op->nopcode != 0) {

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -489,7 +489,7 @@ static ut64 search_reg_val(RAnal *anal, ut8 *buf, ut64 len, ut64 addr, char *reg
 	const int addrbytes = anal->iob.io ? anal->iob.io->addrbytes : 1;
 	for (offs = 0; offs < len; offs += addrbytes * oplen) {
 		r_anal_op_fini (&op);
-		if ((oplen = r_anal_op (anal, &op, addr + offs, buf + offs, len - offs)) < 1) {
+		if ((oplen = r_anal_op (anal, &op, addr + offs, buf + offs, len - offs, R_ANAL_OP_MASK_ALL)) < 1) {
 			break;
 		}
 		if (op.dst && op.dst->reg && op.dst->reg->name && !strcmp (op.dst->reg->name, regsz)) {
@@ -588,7 +588,7 @@ static bool is_delta_pointer_table(RAnal *anal, ut64 addr, ut64 ptr) {
 	RAnalOp aop = {0};
 	bool isValid = false;
 	for (i = 0; i + 8 < 64; i++) {
-		int len = r_anal_op (anal, &aop, addr + i, buf + i, 64 - i);
+		int len = r_anal_op (anal, &aop, addr + i, buf + i, 64 - i, R_ANAL_OP_MASK_ALL);
 		if (len < 1) {
 			len = 1;
 		}
@@ -647,7 +647,7 @@ R_API int r_anal_case(RAnal *anal, RAnalFunction *fcn, ut64 addr_bbsw, ut64 addr
 			break;
 		}
 		r_anal_op_fini (&op);
-		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + idx, len - idx)) < 1) {
+		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + idx, len - idx, R_ANAL_OP_MASK_ALL)) < 1) {
 			return 0;
 		}
 		switch (op.type) {
@@ -765,7 +765,7 @@ repeat:
 		}
 		// check if opcode is in another basic block
 		// in that case we break
-		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + addrbytes * idx, len - addrbytes * idx)) < 1) {
+		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + addrbytes * idx, len - addrbytes * idx, 0)) < 1) {
 			VERBOSE_ANAL eprintf ("Unknown opcode at 0x%08"PFMT64x "\n", addr + idx);
 			if (!idx) {
 				gotoBeach (R_ANAL_RET_END);
@@ -1307,7 +1307,7 @@ R_API bool r_anal_check_fcn(RAnal *anal, ut8 *buf, ut16 bufsz, ut64 addr, ut64 l
 	}
 	for (i = 0; i < bufsz && opcnt < 10; i += oplen, opcnt++) {
 		r_anal_op_fini (&op);
-		if ((oplen = r_anal_op (anal, &op, addr + i, buf + i, bufsz - i)) < 1) {
+		if ((oplen = r_anal_op (anal, &op, addr + i, buf + i, bufsz - i, R_ANAL_OP_MASK_ALL)) < 1) {
 			return false;
 		}
 		switch (op.type) {
@@ -1990,7 +1990,7 @@ R_API ut32 r_anal_fcn_cost(RAnal *anal, RAnalFunction *fcn) {
 		int idx = 0;
 		for (at = bb->addr; at < end;) {
 			memset (&op, 0, sizeof (op));
-			(void) r_anal_op (anal, &op, at, buf + idx, bb->size - idx);
+			(void) r_anal_op (anal, &op, at, buf + idx, bb->size - idx, R_ANAL_OP_MASK_ALL);
 			if (op.size < 1) {
 				op.size = 1;
 			}

--- a/libr/anal/meson.build
+++ b/libr/anal/meson.build
@@ -64,7 +64,7 @@ files = [
   'p/anal_x86_cs.c',
   'p/anal_xap.c',
   'p/anal_xcore_cs.c',
-  #'p/anal_xtensa.c',
+  'p/anal_xtensa.c',
   'p/anal_z80.c',
   'pin.c',
   'ref.c',

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -77,11 +77,14 @@ static RAnalVar *get_used_var(RAnal *anal, RAnalOp *op) {
 	return res;
 }
 
-R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, int mask) {
 	//len will end up in memcmp so check for negative
 	if (!anal || len < 0) {
 		return -1;
 	}
+
+	anal->decode = mask & R_ANAL_OP_MASK_ESIL ? true : false;
+
 	if (anal->pcalign) {
 		if (addr % anal->pcalign) {
 			memset (op, 0, sizeof (RAnalOp));

--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -11,6 +11,9 @@
 #define CM ","
 #define XTENSA_MAX_LENGTH 8
 
+#if defined(_MSC_VER)
+__declspec(dllimport)
+#endif
 extern xtensa_isa xtensa_default_isa;
 
 static int xtensa_length(const ut8 *insn) {
@@ -1754,7 +1757,171 @@ static void esil_extract_unsigned(xtensa_isa isa, xtensa_opcode opcode,
 	);
 }
 
-static void analop_esil (RAnal *a, RAnalOp *op, ut64 addr, ut8 *buffer, size_t len) {
+static void analop_esil (xtensa_isa isa, xtensa_opcode opcode, xtensa_format format,
+						 size_t i, xtensa_insnbuf slot_buffer, RAnalOp *op) {
+	switch (opcode) {
+	case 26: /* add.n */
+	case 41: /* add */
+	case 43: /* addx2 */
+	case 44: /* addx4 */
+	case 45: /* addx8 */
+	case 42: /* sub */
+	case 46: /* subx2 */
+	case 47: /* subx4 */
+	case 48: /* subx8 */
+		esil_add_sub (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 32: /* mov.n */
+		esil_move (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 90: /* movi */
+	case 33: /* movi.n */
+		esil_move_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 0:  /* excw */
+	case 34: /* nop.n */
+		r_strbuf_setf (&op->esil, "");
+		break;
+	// TODO: s32cli (s32c1i) is conditional (CAS)
+	// should it be handled here?
+	case 453: /* s32c1i */
+	case 36:  /* s32i.n */
+	case 100: /* s32i */
+	case 99:  /* s16i */
+	case 101: /* s8i */
+		esil_store_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 27: /* addi.n */
+	case 39: /* addi */
+		xtensa_check_stack_op (isa, opcode, format, i, slot_buffer, op);
+		esil_add_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 98: /* ret */
+	case 35: /* ret.n */
+		r_strbuf_setf (&op->esil, "a0,pc,=");
+		break;
+	case 82: /* l16ui */
+	case 83: /* l16si */
+	case 84: /* l32i */
+	case 31: /* l32i.n */
+	case 86: /* l8ui */
+		esil_load_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	// TODO: s32r
+	// l32r is different because it is relative to LITBASE
+	// which also may or may not be present
+	case 85: /* l32r */
+		esil_load_relative (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 40: /* addmi */
+		break;
+	case 49: /* and */
+	case 50: /* or */
+	case 51: /* xor */
+		esil_bitwise_op (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 52: /* beqi */
+	case 53: /* bnei */
+	case 54: /* bgei */
+	case 55: /* blti */
+	case 58: /* bgeui */
+	case 59: /* bltui */
+		esil_branch_compare_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 56: /* bbci */
+	case 57: /* bbsi */
+		esil_branch_check_bit_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 60: /* beq */
+	case 61: /* bne */
+	case 62: /* bge */
+	case 63: /* blt */
+	case 64: /* bgeu */
+	case 65: /* bltu */
+		esil_branch_compare (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 66: /* bany */
+	case 67: /* bnone */
+	case 68: /* ball */
+	case 69: /* bnall */
+		esil_branch_check_mask (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 70: /* bbc */
+	case 71: /* bbs */
+		esil_branch_check_bit (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 72: /* beqz */
+	case 73: /* bnez */
+	case 28: /* beqz.n */
+	case 29: /* bnez.n */
+	case 74: /* bgez */
+	case 75: /* bltz */
+		esil_branch_compare_single (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 78: /* extui */
+		esil_extract_unsigned (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 79: /* ill */
+		r_strbuf_setf (&op->esil, "");
+		break;
+	// TODO: windowed calls?
+	case 7: /* call4 */
+		break;
+	case 76: /* call0 */
+	case 80: /* j */
+		esil_call (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 81: /* jx */
+	case 77: /* callx0 */
+		esil_callx (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 91: /* moveqz */
+	case 92: /* movnez */
+	case 93: /* movltz */
+	case 94: /* movgez */
+		esil_move_conditional (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 96: /* abs */
+	case 95: /* neg */
+		esil_abs_neg (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 102: /* ssr */
+	case 103: /* ssl */
+		esil_set_shift_amount (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 111: /* slli */
+	case 113: /* srli */
+		esil_shift_logic_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 106: /* ssai */
+		esil_set_shift_amount_imm (isa, opcode, format, i, slot_buffer, op);
+		break;
+	case 107: /* sll */
+	case 109: /* srl */
+		esil_shift_logic_sar (isa, opcode, format, i, slot_buffer, op);
+		break;
+	}
+}
+
+static int xtensa_op (RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf_original, int len_original) {
+	if (!op)
+		return 1;
+	memset (op, 0, sizeof (RAnalOp));
+	r_strbuf_init (&op->esil);
+
+	op->size = xtensa_length (buf_original);
+	if (op->size > len_original)
+		return 1;
+
+	xtensa_op0_fns[(buf_original[0] & 0xf)] (anal, op, addr, buf_original);
+
+	if (anal->decode) {
+	}
+
+	ut8 buffer[XTENSA_MAX_LENGTH] = { 0 };
+	int len = R_MIN(op->size, XTENSA_MAX_LENGTH);
+	memcpy (buffer, buf_original, len);
+
 	unsigned int i;
 	if (!xtensa_default_isa) {
 		xtensa_default_isa = xtensa_isa_init (0, 0);
@@ -1782,179 +1949,25 @@ static void analop_esil (RAnal *a, RAnalOp *op, ut64 addr, ut8 *buffer, size_t l
 	format = xtensa_format_decode (isa, insn_buffer);
 
 	if (format == XTENSA_UNDEFINED) {
-		return;
+		return op->size;
 	}
 
 	nslots = xtensa_format_num_slots (isa, format);
 	if (nslots < 1) {
-		return;
+		return op->size;
 	}
 
 	for (i = 0; i < nslots; i++) {
 		xtensa_format_get_slot (isa, format, i, insn_buffer, slot_buffer);
 		opcode = xtensa_opcode_decode (isa, format, i, slot_buffer);
 
-		switch (opcode) {
-		case 26: /* add.n */
-		case 41: /* add */
-		case 43: /* addx2 */
-		case 44: /* addx4 */
-		case 45: /* addx8 */
-		case 42: /* sub */
-		case 46: /* subx2 */
-		case 47: /* subx4 */
-		case 48: /* subx8 */
-			esil_add_sub (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 32: /* mov.n */
-			esil_move (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 90: /* movi */
-		case 33: /* movi.n */
-			esil_move_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 0:  /* excw */
-		case 34: /* nop.n */
-			r_strbuf_setf (&op->esil, "");
-			break;
-		// TODO: s32cli (s32c1i) is conditional (CAS)
-		// should it be handled here?
-		case 453: /* s32c1i */
-		case 36:  /* s32i.n */
-		case 100: /* s32i */
-		case 99:  /* s16i */
-		case 101: /* s8i */
-			esil_store_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 27: /* addi.n */
-		case 39: /* addi */
+		if (opcode == 39) { /* addi */
 			xtensa_check_stack_op (isa, opcode, format, i, slot_buffer, op);
-			esil_add_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 98: /* ret */
-		case 35: /* ret.n */
-			r_strbuf_setf (&op->esil, "a0,pc,=");
-			break;
-		case 82: /* l16ui */
-		case 83: /* l16si */
-		case 84: /* l32i */
-		case 31: /* l32i.n */
-		case 86: /* l8ui */
-			esil_load_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		// TODO: s32r
-		// l32r is different because it is relative to LITBASE
-		// which also may or may not be present
-		case 85: /* l32r */
-			esil_load_relative (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 40: /* addmi */
-			break;
-		case 49: /* and */
-		case 50: /* or */
-		case 51: /* xor */
-			esil_bitwise_op (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 52: /* beqi */
-		case 53: /* bnei */
-		case 54: /* bgei */
-		case 55: /* blti */
-		case 58: /* bgeui */
-		case 59: /* bltui */
-			esil_branch_compare_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 56: /* bbci */
-		case 57: /* bbsi */
-			esil_branch_check_bit_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 60: /* beq */
-		case 61: /* bne */
-		case 62: /* bge */
-		case 63: /* blt */
-		case 64: /* bgeu */
-		case 65: /* bltu */
-			esil_branch_compare (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 66: /* bany */
-		case 67: /* bnone */
-		case 68: /* ball */
-		case 69: /* bnall */
-			esil_branch_check_mask (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 70: /* bbc */
-		case 71: /* bbs */
-			esil_branch_check_bit (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 72: /* beqz */
-		case 73: /* bnez */
-		case 28: /* beqz.n */
-		case 29: /* bnez.n */
-		case 74: /* bgez */
-		case 75: /* bltz */
-			esil_branch_compare_single (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 78: /* extui */
-			esil_extract_unsigned (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 79: /* ill */
-			r_strbuf_setf (&op->esil, "");
-			break;
-		// TODO: windowed calls?
-		case 7: /* call4 */
-			break;
-		case 76: /* call0 */
-		case 80: /* j */
-			esil_call (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 81: /* jx */
-		case 77: /* callx0 */
-			esil_callx (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 91: /* moveqz */
-		case 92: /* movnez */
-		case 93: /* movltz */
-		case 94: /* movgez */
-			esil_move_conditional (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 96: /* abs */
-		case 95: /* neg */
-			esil_abs_neg (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 102: /* ssr */
-		case 103: /* ssl */
-			esil_set_shift_amount (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 111: /* slli */
-		case 113: /* srli */
-			esil_shift_logic_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 106: /* ssai */
-			esil_set_shift_amount_imm (isa, opcode, format, i, slot_buffer, op);
-			break;
-		case 107: /* sll */
-		case 109: /* srl */
-			esil_shift_logic_sar (isa, opcode, format, i, slot_buffer, op);
-			break;
 		}
-	}
-}
 
-static int xtensa_op (RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
-	if (!op)
-		return 1;
-	memset (op, 0, sizeof (RAnalOp));
-	r_strbuf_init (&op->esil);
-
-	op->size = xtensa_length (buf);
-	if (op->size > len)
-		return 1;
-
-	xtensa_op0_fns[(buf[0] & 0xf)] (anal, op, addr, buf);
-
-	if (anal->decode) {
-		ut8 copy[XTENSA_MAX_LENGTH] = { 0 };
-		memcpy (copy, buf, R_MIN(op->size, XTENSA_MAX_LENGTH));
-		analop_esil (anal, op, addr, copy, op->size);
+		if (anal->decode) {
+			analop_esil (isa, opcode, format, i, slot_buffer, op);
+		}
 	}
 
 	return op->size;

--- a/libr/anal/reflines.c
+++ b/libr/anal/reflines.c
@@ -131,7 +131,7 @@ R_API RList *r_anal_reflines_get(RAnal *anal, ut64 addr, const ut8 *buf, ut64 le
 		addr += sz;
 		// This can segfault if opcode length and buffer check fails
 		r_anal_op_fini (&op);
-		sz = r_anal_op (anal, &op, addr, ptr, (int)(end - ptr));
+		sz = r_anal_op (anal, &op, addr, ptr, (int)(end - ptr), R_ANAL_OP_MASK_ALL);
 		if (sz <= 0) {
 			sz = 1;
 			goto __next;

--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -136,7 +136,7 @@ static int vtable_is_addr_vtable_start(RVTableContext *context, ut64 curAddress)
 			context->anal->iob.read_at (context->anal->iob.io, xref->addr, buf, sizeof(buf));
 
 			RAnalOp analop = { 0 };
-			r_anal_op (context->anal, &analop, xref->addr, buf, sizeof(buf));
+			r_anal_op (context->anal, &analop, xref->addr, buf, sizeof(buf), R_ANAL_OP_MASK_ALL);
 
 			if (analop.type == R_ANAL_OP_TYPE_MOV
 				|| analop.type == R_ANAL_OP_TYPE_LEA) {

--- a/libr/asm/arch/xtensa/gnu/elf32-xtensa.c
+++ b/libr/asm/arch/xtensa/gnu/elf32-xtensa.c
@@ -144,7 +144,7 @@ typedef struct xtensa_relax_info_struct xtensa_relax_info;
 
 #endif
 
-xtensa_isa xtensa_default_isa;
+R_API xtensa_isa xtensa_default_isa;
     // xtensa_default_isa = xtensa_isa_init (0, 0);
 
 int

--- a/libr/asm/arch/xtensa/gnu/xtensa-dis.c
+++ b/libr/asm/arch/xtensa/gnu/xtensa-dis.c
@@ -30,6 +30,10 @@
 #include "dis-asm.h"
 #include "libiberty.h"
 
+
+#if defined(_MSC_VER)
+__declspec(dllimport)
+#endif
 extern xtensa_isa xtensa_default_isa;
 
 #ifndef MAX

--- a/libr/core/asm.c
+++ b/libr/core/asm.c
@@ -120,7 +120,7 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 			r_asm_set_pc (core->assembler, addr);
 			if (mode == 'e') {
 				RAnalOp analop = {0};
-				if (r_anal_op (core->anal, &analop, addr, buf + idx, 15) < 1) {
+				if (r_anal_op (core->anal, &analop, addr, buf + idx, 15, R_ANAL_OP_MASK_ALL) < 1) {
 					idx ++; // TODO: honor mininstrsz
 					continue;
 				}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -810,7 +810,7 @@ R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr) {
 		ptr = buf;
 		len = sizeof (buf);
 	}
-	if (r_anal_op (core->anal, op, addr, ptr, len) < 1) {
+	if (r_anal_op (core->anal, op, addr, ptr, len, R_ANAL_OP_MASK_ALL) < 1) {
 		goto err_op;
 	}
 
@@ -2575,14 +2575,14 @@ static bool opiscall(RCore *core, RAnalOp *aop, ut64 addr, const ut8* buf, int l
 		}
 		//if is not bl do not analyze
 		if (buf[3] == 0x94) {
-			if (r_anal_op (core->anal, aop, addr, buf, len)) {
+			if (r_anal_op (core->anal, aop, addr, buf, len, R_ANAL_OP_MASK_ALL)) {
 				return true;
 			}
 		}
 		return false;
 	default:
 		aop->size = 1;
-		if (!r_anal_op (core->anal, aop, addr, buf, len)) {
+		if (!r_anal_op (core->anal, aop, addr, buf, len, R_ANAL_OP_MASK_ALL)) {
 			switch (aop->type) {
 			case R_ANAL_OP_TYPE_CALL:
 			case R_ANAL_OP_TYPE_CCALL:
@@ -2665,7 +2665,7 @@ R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode
 				case 'x':
 					{
 						RAnalOp op ={0};
-						r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i);
+						r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, R_ANAL_OP_MASK_ALL);
 						int mask = mode=='r' ? 1 : mode == 'w' ? 2: mode == 'x' ? 4: 0;
 						if (op.direction == mask) {
 							i += op.size;
@@ -2675,7 +2675,7 @@ R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode
 					}
 					break;
 				default:
-					if (!r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i)) {
+					if (!r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, R_ANAL_OP_MASK_ALL)) {
 						r_anal_op_fini (&op);
 						continue;
 					}
@@ -2804,7 +2804,7 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 		while (at < (at + bsz) && !r_cons_is_breaked ()) {
 			RAnalRefType type;
 			ut64 xref_to;
-			ret = r_anal_op (core->anal, &op, at, buf + i, bsz - i);
+			ret = r_anal_op (core->anal, &op, at, buf + i, bsz - i, 0);
 			ret = ret > 0 ? ret : 1;
 			i += ret;
 			if (ret <= 0 || i > bsz) {
@@ -3626,7 +3626,7 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 
 	// TODO Hardcoding for 2 instructions (mov e_p,[esp];ret). More work needed
 	idx = 0;
-	if (r_anal_op (core->anal, &op, cur, buf + idx, size - idx) <= 0 ||
+	if (r_anal_op (core->anal, &op, cur, buf + idx, size - idx, R_ANAL_OP_MASK_ALL) <= 0 ||
 			op.size <= 0 ||
 			(op.type != R_ANAL_OP_TYPE_MOV && op.type != R_ANAL_OP_TYPE_CMOV)) {
 		goto err_anal_op;
@@ -3665,7 +3665,7 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 
 	cur = addr + idx;
 	r_anal_op_fini (&op);
-	if (r_anal_op (core->anal, &op, cur, buf + idx, size - idx) <= 0 ||
+	if (r_anal_op (core->anal, &op, cur, buf + idx, size - idx, R_ANAL_OP_MASK_ALL) <= 0 ||
 			op.size <= 0 ||
 			(op.type != R_ANAL_OP_TYPE_RET && op.type != R_ANAL_OP_TYPE_CRET)) {
 		goto err_anal_op;
@@ -3797,7 +3797,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 			cur -= (cur % opalign);
 		}
 		r_anal_op_fini (&op);
-		if (!r_anal_op (core->anal, &op, cur, buf + i, iend - i)) {
+		if (!r_anal_op (core->anal, &op, cur, buf + i, iend - i, R_ANAL_OP_MASK_ALL)) {
 			i += minopsize - 1;
 		}
 		// if (op.type & 0x80000000 || op.type == 0) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -801,7 +801,7 @@ static int cmd_an(RCore *core, bool use_json, const char *name)
 	}
 
 	r_anal_op (core->anal, &op, off,
-			core->block + off - core->offset, 32);
+			core->block + off - core->offset, 32, R_ANAL_OP_MASK_ALL);
 
 	tgt_addr = op.jump != UT64_MAX ? op.jump : op.ptr;
 	if (op.var) {
@@ -1292,7 +1292,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 		hint = r_anal_hint_get (core->anal, addr);
 		r_asm_set_pc (core->assembler, addr);
 		ret = r_asm_disassemble (core->assembler, &asmop, buf + idx, len - idx);
-		ret = r_anal_op (core->anal, &op, core->offset + idx, buf + idx, len - idx);
+		ret = r_anal_op (core->anal, &op, core->offset + idx, buf + idx, len - idx, R_ANAL_OP_MASK_ALL);
 		esilstr = R_STRBUF_SAFEGET (&op.esil);
 		opexstr = R_STRBUF_SAFEGET (&op.opex);
 		char *mnem = strdup (asmop.buf_asm);
@@ -3181,7 +3181,7 @@ repeat:
 	}
 	(void)r_io_read_at (core->io, addr, code, sizeof (code));
 	// TODO: sometimes this is dupe
-	ret = r_anal_op (core->anal, &op, addr, code, sizeof (code));
+	ret = r_anal_op (core->anal, &op, addr, code, sizeof (code), R_ANAL_OP_MASK_ALL);
 // if type is JMP then we execute the next N instructions
 	// update the esil pointer because RAnal.op() can change it
 	esil = core->anal->esil;
@@ -3222,7 +3222,7 @@ repeat:
 			r_anal_esil_set_pc (esil, naddr);
 			(void)r_io_read_at (core->io, naddr, code2, sizeof (code2));
 			// TODO: sometimes this is dupe
-			ret = r_anal_op (core->anal, &op2, naddr, code2, sizeof (code2));
+			ret = r_anal_op (core->anal, &op2, naddr, code2, sizeof (code2), R_ANAL_OP_MASK_ALL);
 			switch (op2.type) {
 			case R_ANAL_OP_TYPE_CJMP:
 			case R_ANAL_OP_TYPE_JMP:
@@ -3800,7 +3800,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 	esil->cb.hook_mem_read = mymemread;
 	esil->nowrite = true;
 	for (ops = ptr = 0; ptr < buf_sz && hasNext (mode); ops++, ptr += len) {
-		len = r_anal_op (core->anal, &aop, addr + ptr, buf + ptr, buf_sz - ptr);
+		len = r_anal_op (core->anal, &aop, addr + ptr, buf + ptr, buf_sz - ptr, R_ANAL_OP_MASK_ALL);
 		esilstr = R_STRBUF_SAFEGET (&aop.esil);
 		if (len < 1) {
 			eprintf ("Invalid 0x%08"PFMT64x" instruction %02x %02x\n",
@@ -3934,7 +3934,7 @@ static void cmd_aespc(RCore *core, ut64 addr, int off) {
 		if (!i) {
 			r_core_read_at (core, addr, buf, bsize);
 		}
-		ret = r_anal_op (core->anal, &aop, addr, buf + i, bsize - i);
+		ret = r_anal_op (core->anal, &aop, addr, buf + i, bsize - i, R_ANAL_OP_MASK_ALL);
 		instr_size += ret;
 		int inc = (core->search->align > 0)? core->search->align - 1: ret - 1;
 		if (inc < 0) {
@@ -4240,7 +4240,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 				while (pc < end) {
 					left = R_MIN (end - pc, 32);
 					r_asm_set_pc (core->assembler, pc);
-					ret = r_anal_op (core->anal, &op, addr, buf, left); // read overflow
+					ret = r_anal_op (core->anal, &op, addr, buf, left, R_ANAL_OP_MASK_ALL); // read overflow
 					if (ret) {
 						r_reg_set_value_by_role (core->anal->reg, R_REG_NAME_PC, pc);
 						r_anal_esil_parse (esil, R_STRBUF_SAFEGET (&op.esil));
@@ -4357,7 +4357,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		RAnalOp aop = R_EMPTY;
 		bufsz = r_hex_str2bin (hex, (ut8*)hex);
 		ret = r_anal_op (core->anal, &aop, core->offset,
-			(const ut8*)hex, bufsz);
+			(const ut8*)hex, bufsz, R_ANAL_OP_MASK_ALL);
 		if (ret>0) {
 			const char *str = R_STRBUF_SAFEGET (&aop.esil);
 			char *str2 = r_str_newf (" %s", str);
@@ -4517,7 +4517,7 @@ static void cmd_anal_aftertraps(RCore *core, const char *input) {
 		if (!bufi) {
 			r_io_read_at (core->io, addr, buf, 4096);
 		}
-		if (r_anal_op (core->anal, &op, addr, buf + bufi, 4096 - bufi)) {
+		if (r_anal_op (core->anal, &op, addr, buf + bufi, 4096 - bufi, R_ANAL_OP_MASK_ALL)) {
 			if (op.size < 1) {
 				// XXX must be +4 on arm/mips/.. like we do in disasm.c
 				op.size = minop;
@@ -4643,7 +4643,7 @@ static void _anal_calls(RCore *core, ut64 addr, ut64 addr_end) {
 			addr += bsz;
 			continue;
 		}
-		if (r_anal_op (core->anal, &op, addr, buf + bufi, bsz - bufi)) {
+		if (r_anal_op (core->anal, &op, addr, buf + bufi, bsz - bufi, 0)) {
 			if (op.size < 1) {
 				// XXX must be +4 on arm/mips/.. like we do in disasm.c
 				op.size = minop;
@@ -5236,7 +5236,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 
 					if (ref->type == R_ANAL_REF_TYPE_CALL) {
 						RAnalOp aop;
-						r_anal_op (core->anal, &aop, ref->at, buf, 12);
+						r_anal_op (core->anal, &aop, ref->at, buf, 12, R_ANAL_OP_MASK_ALL);
 						if (aop.type == R_ANAL_OP_TYPE_UCALL) {
 							cmd_anal_ucall_ref (core, ref->addr);
 						}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -842,7 +842,7 @@ static int step_until_optype(RCore *core, const char *_optypes) {
 			res = false;
 			goto cleanup_after_push;
 		}
-		if (!r_anal_op (core->dbg->anal, &op, pc, buf, sizeof (buf))) {
+		if (!r_anal_op (core->dbg->anal, &op, pc, buf, sizeof (buf), R_ANAL_OP_MASK_ALL)) {
 			eprint("ERROR\n");
 			res = false;
 			goto cleanup_after_push;
@@ -1110,7 +1110,7 @@ static void cmd_debug_backtrace(RCore *core, const char *input) {
 			/* XXX Bottleneck..we need to reuse the bytes read by traptrace */
 			// XXX Do asm.arch should define the max size of opcode?
 			r_core_read_at (core, addr, buf, 32); // XXX longer opcodes?
-			r_anal_op (core->anal, &analop, addr, buf, sizeof (buf));
+			r_anal_op (core->anal, &analop, addr, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 		} while (r_bp_traptrace_at (core->dbg->bp, addr, analop.size));
 		r_bp_traptrace_enable (core->dbg->bp, false);
 	}
@@ -3403,7 +3403,7 @@ static void do_debug_trace_calls(RCore *core, ut64 from, ut64 to, ut64 final_add
 		addr_in_range = addr >= from && addr < to;
 
 		r_io_read_at (core->io, addr, buf, sizeof (buf));
-		r_anal_op (core->anal, &aop, addr, buf, sizeof (buf));
+		r_anal_op (core->anal, &aop, addr, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 		eprintf ("%d %"PFMT64x"\r", n++, addr);
 		switch (aop.type) {
 		case R_ANAL_OP_TYPE_UCALL:
@@ -3995,7 +3995,7 @@ static int cmd_debug_step (RCore *core, const char *input) {
 			r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, false);
 			addr = r_debug_reg_get (core->dbg, "PC");
 			r_io_read_at (core->io, addr, buf, sizeof (buf));
-			r_anal_op (core->anal, &aop, addr, buf, sizeof (buf));
+			r_anal_op (core->anal, &aop, addr, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 			if (aop.type == R_ANAL_OP_TYPE_CALL) {
 				RIOSection *s = r_io_section_vget (core->io, aop.jump);
 				if (!s) {
@@ -4016,7 +4016,7 @@ static int cmd_debug_step (RCore *core, const char *input) {
 			for (i = 0; i < times; i++) {
 				r_debug_reg_sync (core->dbg, R_REG_TYPE_GPR, false);
 				r_io_read_at (core->io, addr, buf, sizeof (buf));
-				r_anal_op (core->anal, &aop, addr, buf, sizeof (buf));
+				r_anal_op (core->anal, &aop, addr, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 				if (aop.jump != UT64_MAX && aop.fail != UT64_MAX) {
 					eprintf ("Don't know how to skip this instruction\n");
 					if (bpi) r_core_cmd0 (core, delb);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1547,7 +1547,7 @@ static int cmd_print_pxA(RCore *core, int len, const char *data) {
 		bgcolor = Color_BGBLACK;
 		fgcolor = Color_WHITE;
 		text = NULL;
-		if (r_anal_op (core->anal, &op, core->offset + i, core->block + i, len - i) <= 0) {
+		if (r_anal_op (core->anal, &op, core->offset + i, core->block + i, len - i, R_ANAL_OP_MASK_ALL) <= 0) {
 			op.type = 0;
 			bgcolor = Color_BGRED;
 			op.size = 1;
@@ -2994,7 +2994,7 @@ static void disasm_recursive(RCore *core, ut64 addr, char type_print) {
 	while (count-- > 0) {
 		r_io_read_at (core->io, addr, buf, sizeof (buf));
 		r_anal_op_fini (&aop);
-		ret = r_anal_op (core->anal, &aop, addr, buf, sizeof (buf));
+		ret = r_anal_op (core->anal, &aop, addr, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 		if (ret < 0 || aop.size < 1) {
 			addr++;
 			continue;
@@ -3771,7 +3771,7 @@ static int cmd_print(void *data, const char *input) {
 
 				bufsz = r_hex_str2bin (arg, (ut8 *) hex_arg);
 				ret = r_anal_op (core->anal, &aop, core->offset,
-					(const ut8 *) hex_arg, bufsz);
+					(const ut8 *) hex_arg, bufsz, R_ANAL_OP_MASK_ALL);
 				if (ret > 0) {
 					str = R_STRBUF_SAFEGET (&aop.esil);
 					r_cons_println (str);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1046,7 +1046,7 @@ static void print_rop(RCore *core, RList *hitlist, char mode, bool *json_first) 
 			r_core_read_at (core, hit->addr, buf, hit->len);
 			r_asm_set_pc (core->assembler, hit->addr);
 			r_asm_disassemble (core->assembler, &asmop, buf, hit->len);
-			r_anal_op (core->anal, &analop, hit->addr, buf, hit->len);
+			r_anal_op (core->anal, &analop, hit->addr, buf, hit->len, R_ANAL_OP_MASK_ALL);
 			size += hit->len;
 			if (analop.type != R_ANAL_OP_TYPE_RET) {
 				char *opstr_n = r_str_newf (" %s", R_STRBUF_SAFEGET (&analop.esil));
@@ -1079,7 +1079,7 @@ static void print_rop(RCore *core, RList *hitlist, char mode, bool *json_first) 
 			r_core_read_at (core, hit->addr, buf, hit->len);
 			r_asm_set_pc (core->assembler, hit->addr);
 			r_asm_disassemble (core->assembler, &asmop, buf, hit->len);
-			r_anal_op (core->anal, &analop, hit->addr, buf, hit->len);
+			r_anal_op (core->anal, &analop, hit->addr, buf, hit->len, R_ANAL_OP_MASK_ALL);
 			size += hit->len;
 			const char *opstr = R_STRBUF_SAFEGET (&analop.esil);
 			if (analop.type != R_ANAL_OP_TYPE_RET) {
@@ -1119,7 +1119,7 @@ static void print_rop(RCore *core, RList *hitlist, char mode, bool *json_first) 
 			r_core_read_at (core, hit->addr, buf, hit->len);
 			r_asm_set_pc (core->assembler, hit->addr);
 			r_asm_disassemble (core->assembler, &asmop, buf, hit->len);
-			r_anal_op (core->anal, &analop, hit->addr, buf, hit->len);
+			r_anal_op (core->anal, &analop, hit->addr, buf, hit->len, R_ANAL_OP_MASK_ALL);
 			size += hit->len;
 			if (analop.type != R_ANAL_OP_TYPE_RET) {
 				char *opstr_n = r_str_newf (" %s", R_STRBUF_SAFEGET (&analop.esil));
@@ -1349,7 +1349,7 @@ static int r_core_search_rop(RCore *core, RInterval search_itv, int opt, const c
 			RAnalOp end_gadget = R_EMPTY;
 			// Disassemble one.
 			if (r_anal_op (core->anal, &end_gadget, from + i, buf + i,
-				    delta - i) <= 0) {
+				    delta - i, R_ANAL_OP_MASK_ALL) <= 0) {
 				r_anal_op_fini (&end_gadget);
 				continue;
 			}
@@ -1653,7 +1653,7 @@ static int emulateSyscallPrelude(RCore *core, ut64 at, ut64 curpc) {
 		if (!i) {
 			r_core_read_at (core, curpc, arr, bsize);
 		}
-		inslen = r_anal_op (core->anal, &aop, curpc, arr + i, bsize - i);
+		inslen = r_anal_op (core->anal, &aop, curpc, arr + i, bsize - i, R_ANAL_OP_MASK_ALL);
 		if (inslen) {	
  			int incr = (core->search->align > 0)? core->search->align - 1:  inslen - 1;
 			if (incr < 0) {
@@ -1733,7 +1733,7 @@ static void do_syscall_search(RCore *core, struct search_parameters *param) {
 			if (!i) {
 				r_core_read_at (core, at, buf, bsize);
 			}
-			ret = r_anal_op (core->anal, &aop, at, buf + i, bsize - i);
+			ret = r_anal_op (core->anal, &aop, at, buf + i, bsize - i, R_ANAL_OP_MASK_ALL);
 			curpos = idx++ % (MAXINSTR + 1);
 			previnstr[curpos] = ret; // This array holds prev n instr size + cur instr size
 			if ((aop.type == R_ANAL_OP_TYPE_SWI) && ret && (aop.val > 10)) {
@@ -1892,7 +1892,7 @@ static void do_anal_search(RCore *core, struct search_parameters *param, const c
 			if (!i) {
 				r_core_read_at (core, at, buf, bsize);
 			}
-			ret = r_anal_op (core->anal, &aop, at, buf + i, bsize - i);
+			ret = r_anal_op (core->anal, &aop, at, buf + i, bsize - i, R_ANAL_OP_MASK_ALL);
 			if (ret) {
 				bool match = false;
 				if (chk_family) {

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -660,7 +660,7 @@ static int cmd_seek(void *data, const char *input) {
 				RAnalOp op;
 
 				ret = r_anal_op (core->anal, &op,
-					core->offset, core->block, core->blocksize);
+					core->offset, core->block, core->blocksize, R_ANAL_OP_MASK_ALL);
 				if (ret < 1) {
 					ret = 1;
 				}

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -639,7 +639,7 @@ static int cmd_type(void *data, const char *input) {
 			(void)r_io_read_at (core->io, core->offset, code, sizeof (code));
 			r_asm_set_pc (core->assembler, addr);
 			int ret = r_asm_disassemble (core->assembler, &asmop, code, core->blocksize);
-			ret = r_anal_op (core->anal, &op, core->offset, code, core->blocksize);
+			ret = r_anal_op (core->anal, &op, core->offset, code, core->blocksize, R_ANAL_OP_MASK_ALL);
 			if (ret >= 0) {
 				// HACK: Just convert only the first imm seen
 				for (i = 0; i < 3; i++) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -497,7 +497,7 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 			*ok = 1;
 		}
 		// TODO: group analop-dependant vars after a char, so i can filter
-		r_anal_op (core->anal, &op, core->offset, core->block, core->blocksize);
+		r_anal_op (core->anal, &op, core->offset, core->block, core->blocksize, R_ANAL_OP_MASK_ALL);
 		r_anal_op_fini (&op); // we dont need strings or pointers, just values, which are not nullified in fini
 		switch (str[1]) {
 		case '.': // can use pc, sp, a0, a1, ...
@@ -2242,7 +2242,7 @@ R_API RAnalOp *r_core_op_anal(RCore *core, ut64 addr) {
 	ut8 buf[64];
 	RAnalOp *op = R_NEW (RAnalOp);
 	r_core_read_at (core, addr, buf, sizeof (buf));
-	r_anal_op (core->anal, op, addr, buf, sizeof (buf));
+	r_anal_op (core->anal, op, addr, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 	return op;
 }
 

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1100,7 +1100,7 @@ static void ds_show_refs(RDisasmState *ds) {
 			RAnalOp aop;
 			ut8 buf[12];
 			r_core_read_at (ds->core, ref->at, buf, sizeof (buf));
-			r_anal_op (ds->core->anal, &aop, ref->at, buf, sizeof (buf));
+			r_anal_op (ds->core->anal, &aop, ref->at, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 			if ((aop.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_UCALL) {
 				RAnalFunction * fcn = r_anal_get_fcn_at (ds->core->anal,
 					ref->addr, R_ANAL_FCN_TYPE_NULL);
@@ -4269,7 +4269,7 @@ toro:
 		// TODO: support in-the-middle-of-instruction too
 		r_anal_op_fini (&ds->analop);
 		if (r_anal_op (core->anal, &ds->analop, core->offset + core->print->cur,
-			buf + core->print->cur, (int)(len - core->print->cur))) {
+			buf + core->print->cur, (int)(len - core->print->cur), R_ANAL_OP_MASK_ALL)) {
 			// TODO: check for ds->analop.type and ret
 			ds->dest = ds->analop.jump;
 		}
@@ -4310,7 +4310,7 @@ toro:
 			r_asm_set_pc (core->assembler, ds->at);
 			ds_update_ref_lines (ds);
 			r_anal_op_fini (&ds->analop);
-			r_anal_op (core->anal, &ds->analop, ds->at, buf + addrbytes * idx, (int)(len - addrbytes * idx));
+			r_anal_op (core->anal, &ds->analop, ds->at, buf + addrbytes * idx, (int)(len - addrbytes * idx), R_ANAL_OP_MASK_ALL);
 		if (ds_must_strip (ds)) {
 			inc = ds->analop.size;
 			// inc = ds->asmop.payload + (ds->asmop.payload % ds->core->assembler->dataalign);
@@ -4402,7 +4402,7 @@ toro:
 #else
 		if (ds->analop.addr != ds->at) {
 			r_anal_op_fini (&ds->analop);
-			r_anal_op (core->anal, &ds->analop, ds->at, buf + addrbytes * idx, (int)(len - addrbytes * idx));
+			r_anal_op (core->anal, &ds->analop, ds->at, buf + addrbytes * idx, (int)(len - addrbytes * idx), R_ANAL_OP_MASK_ALL);
 		}
 #endif
 		if (ret < 1) {
@@ -4715,7 +4715,7 @@ R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opc
 		}
 		r_anal_op_fini (&ds->analop);
 		if (ds->show_color && !hasanal) {
-			r_anal_op (core->anal, &ds->analop, ds->at, core->block + addrbytes * i, core->blocksize - addrbytes * i);
+			r_anal_op (core->anal, &ds->analop, ds->at, core->block + addrbytes * i, core->blocksize - addrbytes * i, R_ANAL_OP_MASK_ALL);
 			hasanal = true;
 		}
 		if (ds_must_strip (ds)) {
@@ -4741,7 +4741,7 @@ R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opc
 			if (ds->decode && !ds->immtrim) {
 				free (ds->opstr);
 				if (!hasanal) {
-					r_anal_op (core->anal, &ds->analop, ds->at, core->block+i, core->blocksize-i);
+					r_anal_op (core->anal, &ds->analop, ds->at, core->block+i, core->blocksize-i, R_ANAL_OP_MASK_ALL);
 					hasanal = true;
 				}
 				tmpopstr = r_anal_op_to_string (core->anal, &ds->analop);
@@ -4753,7 +4753,7 @@ R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opc
 				if (!hasanal) {
 					r_anal_op (core->anal, &ds->analop,
 						ds->at, core->block + i,
-						core->blocksize - i);
+						core->blocksize - i, R_ANAL_OP_MASK_ALL);
 					hasanal = true;
 				}
 				if (*R_STRBUF_SAFEGET (&ds->analop.esil)) {
@@ -4938,7 +4938,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 
 		ds->has_description = false;
 		r_anal_op_fini (&ds->analop);
-		r_anal_op (core->anal, &ds->analop, at, buf + i, nb_bytes - i);
+		r_anal_op (core->anal, &ds->analop, at, buf + i, nb_bytes - i, R_ANAL_OP_MASK_ALL);
 
 		if (ds->pseudo) {
 			r_parse_parse (core->parser, asmop.buf_asm, asmop.buf_asm);
@@ -5145,7 +5145,7 @@ R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mo
 				if (scr_color) {
 					char *buf_asm;
 					RAnalOp aop;
-					r_anal_op (core->anal, &aop, addr, buf+i, l-i);
+					r_anal_op (core->anal, &aop, addr, buf+i, l-i, R_ANAL_OP_MASK_ALL);
 					buf_asm = r_print_colorize_opcode (core->print, str,
 							core->cons->pal.reg, core->cons->pal.num, false);
 					r_cons_printf ("%s%s\n",
@@ -5317,7 +5317,7 @@ R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int 
 			if (!ds->lastfail) {
 				r_anal_op (core->anal, &ds->analop,
 					ds->at+bb_size_consumed, buf+idx,
-					len-bb_size_consumed);
+					len-bb_size_consumed, R_ANAL_OP_MASK_ALL);
 			}
 			if (ret < 1) {
 				r_strbuf_init (&ds->analop.esil);
@@ -5597,7 +5597,7 @@ toro:
 				};
 				char *tmpopstr, *opstr = NULL;
 				r_anal_op (core->anal, &analop, core->offset + i,
-					core->block + addrbytes * i, core->blocksize - addrbytes * i);
+					core->block + addrbytes * i, core->blocksize - addrbytes * i, R_ANAL_OP_MASK_ALL);
 				tmpopstr = r_anal_op_to_string (core->anal, &analop);
 				if (fmt == 'e') { // pie
 					char *esil = (R_STRBUF_SAFEGET (&analop.esil));
@@ -5635,7 +5635,7 @@ toro:
 						0
 					};
 					r_anal_op (core->anal, &aop, core->offset + i,
-						core->block + addrbytes * i, core->blocksize - addrbytes * i);
+						core->block + addrbytes * i, core->blocksize - addrbytes * i, R_ANAL_OP_MASK_ALL);
 					asm_str = r_print_colorize_opcode (core->print, asm_str, color_reg, color_num, false);
 					r_cons_printf ("%s%s"Color_RESET "\n",
 						r_print_color_op_type (core->print, aop.type),

--- a/libr/core/hack.c
+++ b/libr/core/hack.c
@@ -255,7 +255,7 @@ R_API int r_core_hack(RCore *core, const char *op) {
 	}
 	if (hack) {
 		RAnalOp analop;
-		if (!r_anal_op (core->anal, &analop, core->offset, core->block, core->blocksize)) {
+		if (!r_anal_op (core->anal, &analop, core->offset, core->block, core->blocksize, R_ANAL_OP_MASK_ALL)) {
 			eprintf ("anal op fail\n");
 			return false;
 		}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -788,7 +788,7 @@ static ut64 prevop_addr(RCore *core, ut64 addr) {
 	r_core_read_at (core, base, buf, sizeof (buf));
 	for (i = 0; i < sizeof (buf); i++) {
 		ret = r_anal_op (core->anal, &op, base + i,
-			buf + i, sizeof (buf) - i);
+			buf + i, sizeof (buf) - i, R_ANAL_OP_MASK_ALL);
 		if (!ret) {
 			continue;
 		}

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -152,7 +152,7 @@ R_API bool r_core_visual_esil(RCore *core) {
 		// bool use_color = core->print->flags & R_PRINT_FLAGS_COLOR;
 		(void) r_asm_disassemble (core->assembler, &asmop, buf, sizeof (ut64));
 		analop.type = -1;
-		(void)r_anal_op (core->anal, &analop, core->offset, buf, sizeof (ut64));
+		(void)r_anal_op (core->anal, &analop, core->offset, buf, sizeof (ut64), R_ANAL_OP_MASK_ALL);
 		analopType = analop.type & R_ANAL_OP_TYPE_MASK;
 		r_cons_printf ("r2's esil debugger:\n\n");
 		r_cons_printf ("pos: %d\n", x);
@@ -291,7 +291,7 @@ static bool edit_bits (RCore *core) {
 		bool use_color = core->print->flags & R_PRINT_FLAGS_COLOR;
 		(void) r_asm_disassemble (core->assembler, &asmop, buf, sizeof (ut64));
 		analop.type = -1;
-		(void)r_anal_op (core->anal, &analop, core->offset, buf, sizeof (ut64));
+		(void)r_anal_op (core->anal, &analop, core->offset, buf, sizeof (ut64), R_ANAL_OP_MASK_ALL);
 		analopType = analop.type & R_ANAL_OP_TYPE_MASK;
 		r_cons_printf ("r2's bit editor:\n\n");
 		{
@@ -2587,7 +2587,7 @@ R_API void r_core_seek_next(RCore *core, const char *type) {
 	ut64 next = UT64_MAX;
 	if (strstr (type, "opc")) {
 		RAnalOp aop;
-		if (r_anal_op (core->anal, &aop, core->offset, core->block, core->blocksize)) {
+		if (r_anal_op (core->anal, &aop, core->offset, core->block, core->blocksize, R_ANAL_OP_MASK_ALL)) {
 			next = core->offset + aop.size;
 		} else {
 			eprintf ("Invalid opcode\n");
@@ -2864,7 +2864,7 @@ repeat:
 		}
 		// TODO: get the aligned instruction even if the cursor is in the middle of it.
 		r_anal_op (core->anal, &op, off,
-			core->block + off - core->offset, 32);
+			core->block + off - core->offset, 32, R_ANAL_OP_MASK_ALL);
 
 		tgt_addr = op.jump != UT64_MAX ? op.jump : op.ptr;
 		if (op.var) {
@@ -2967,7 +2967,7 @@ repeat:
 			RAnalOp op;
 			ut64 size;
 			if (r_anal_op (core->anal, &op, off, core->block+delta,
-					core->blocksize-delta)) {
+					core->blocksize-delta, R_ANAL_OP_MASK_ALL)) {
 				size = off - fcn->addr + op.size;
 				r_anal_fcn_resize (fcn, size);
 			}

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -708,7 +708,7 @@ R_API int r_debug_step_soft(RDebug *dbg) {
 	if (!dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf))) {
 		return false;
 	}
-	if (!r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf))) {
+	if (!r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf), R_ANAL_OP_MASK_ALL)) {
 		return false;
 	}
 	if (op.type == R_ANAL_OP_TYPE_ILL) {
@@ -892,7 +892,7 @@ R_API int r_debug_step_over(RDebug *dbg, int steps) {
 			dbg->iob.read_at (dbg->iob.io, buf_pc, buf, sizeof (buf));
 		}
 		// Analyze the opcode
-		if (!r_anal_op (dbg->anal, &op, pc, buf + (pc - buf_pc), sizeof (buf) - (pc - buf_pc))) {
+		if (!r_anal_op (dbg->anal, &op, pc, buf + (pc - buf_pc), sizeof (buf) - (pc - buf_pc), R_ANAL_OP_MASK_ALL)) {
 			eprintf ("Decode error at %"PFMT64x"\n", pc);
 			return steps_taken;
 		}
@@ -1108,7 +1108,7 @@ repeat:
 				RAnalOp op = {0};
 				ut64 pc = r_debug_reg_get (dbg, "PC");
 				dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf));
-				r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf));
+				r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 				if (op.size > 0) {
 					const char *signame = r_signal_to_string (dbg->reason.signum);
 					r_debug_reg_set (dbg, "PC", pc+op.size);
@@ -1178,7 +1178,7 @@ R_API int r_debug_continue_until_optype(RDebug *dbg, int type, int over) {
 			dbg->iob.read_at (dbg->iob.io, buf_pc, buf, sizeof (buf));
 		}
 		// Analyze the opcode
-		if (!r_anal_op (dbg->anal, &op, pc, buf + (pc - buf_pc), sizeof (buf) - (pc - buf_pc))) {
+		if (!r_anal_op (dbg->anal, &op, pc, buf + (pc - buf_pc), sizeof (buf) - (pc - buf_pc), R_ANAL_OP_MASK_ALL)) {
 			eprintf ("Decode error at %"PFMT64x"\n", pc);
 			return false;
 		}

--- a/libr/debug/esil.c
+++ b/libr/debug/esil.c
@@ -242,7 +242,7 @@ R_API int r_debug_esil_stepi (RDebug *d) {
 		//	npc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 	}
 
-	if (r_anal_op (dbg->anal, &op, opc, obuf, sizeof (obuf))) {
+	if (r_anal_op (dbg->anal, &op, opc, obuf, sizeof (obuf), R_ANAL_OP_MASK_ALL)) {
 		if (esilbreak_check_pc (dbg, opc)) {
 			eprintf ("STOP AT 0x%08"PFMT64x"\n", opc);
 			ret = 0;

--- a/libr/debug/p/debug_esil.c
+++ b/libr/debug/p/debug_esil.c
@@ -33,7 +33,7 @@ static int __esil_step(RDebug *dbg) {
 	//memset (buf, 0, sizeof (buf));
 	dbg->iob.read_at (dbg->iob.io, pc, buf, 64);
 	eprintf ("READ 0x%08"PFMT64x" %02x %02x %02x\n", pc, buf[0], buf[1], buf[2]);
-	oplen = r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf));
+	oplen = r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf), R_ANAL_OP_MASK_ALL);
 	if (oplen > 0) {
 		if (*R_STRBUF_SAFEGET (&op.esil)) {
 			eprintf ("ESIL: %s\n", R_STRBUF_SAFEGET (&op.esil));

--- a/libr/debug/p/native/bt/fuzzy-all.c
+++ b/libr/debug/p/native/bt/fuzzy-all.c
@@ -15,12 +15,12 @@ static int iscallret(RDebug *dbg, ut64 addr) {
 	} else {
 		RAnalOp op;
 		(void) dbg->iob.read_at (dbg->iob.io, addr-8, buf, 8);
-		(void) r_anal_op (dbg->anal, &op, addr-8, buf, 8);
+		(void) r_anal_op (dbg->anal, &op, addr-8, buf, 8, R_ANAL_OP_MASK_ALL);
 		if (op.type == R_ANAL_OP_TYPE_CALL || op.type == R_ANAL_OP_TYPE_UCALL) {
 			return 1;
 		}
 		/* delay slot */
-		(void) r_anal_op (dbg->anal, &op, addr-4, buf, 4);
+		(void) r_anal_op (dbg->anal, &op, addr-4, buf, 4, R_ANAL_OP_MASK_ALL);
 		if (op.type == R_ANAL_OP_TYPE_CALL || op.type == R_ANAL_OP_TYPE_UCALL) {
 			return 1;
 		}

--- a/libr/debug/trace.c
+++ b/libr/debug/trace.c
@@ -54,7 +54,7 @@ R_API int r_debug_trace_pc(RDebug *dbg, ut64 pc) {
 		return false;
 	}
 	(void)dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf));
-	if (r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf)) < 1) {
+	if (r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf), R_ANAL_OP_MASK_ALL) < 1) {
 		eprintf ("trace_pc: cannot get opcode size at 0x%"PFMT64x"\n", pc);
 		return false;
 	}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -465,6 +465,11 @@ typedef enum {
 #endif
 } _RAnalOpType;
 
+typedef enum {
+	R_ANAL_OP_MASK_ESIL       = 1,
+	R_ANAL_OP_MASK_ALL        = R_ANAL_OP_MASK_ESIL
+} RAnalOpMask;
+
 /* TODO: what to do with signed/unsigned conditionals? */
 typedef enum {
 	R_ANAL_COND_AL = 0,        // Always executed (no condition)
@@ -1301,7 +1306,7 @@ R_API bool r_anal_op_fini(RAnalOp *op);
 R_API bool r_anal_op_is_eob (RAnalOp *op);
 R_API RList *r_anal_op_list_new(void);
 R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr,
-		const ut8 *data, int len);
+		const ut8 *data, int len, int mask);
 R_API RAnalOp *r_anal_op_hexstr(RAnal *anal, ut64 addr,
 		const char *hexstr);
 R_API char *r_anal_op_to_string(RAnal *anal, RAnalOp *op);

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -38,6 +38,7 @@ anal = [
   'x86_cs',
   'xap',
   'xcore_cs',
+  'xtensa',
   'z80',
 ]
 
@@ -95,6 +96,7 @@ asm = [
   'x86_nz',
   'xap',
   'xcore_cs',
+  'xtensa',
   'z80',
 ]
 


### PR DESCRIPTION
The idea is to skip esil generation when not needed at all. With only these small changes, I was able to get the time for `aaa` (most time taken in `aac` in this case) for a relatively big dll I have from about 40 seconds to 35 seconds.
Better name suggestions for `r_anal_op_partial()` are welcome :)