### PR TITLE
Add r_bin_elf_map_free to release elf's RBinMap correctly

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3379,9 +3379,16 @@ fail:
 	return false;
 }
 
+static void r_bin_elf_map_free (RBinMap *map) {
+	if (map) {
+		free (map->file);
+		free (map);
+	}
+}
+
 RList *Elf_(r_bin_elf_get_maps)(ELFOBJ *bin) {
 	ut16 ph, ph_num = bin->ehdr.e_phnum; //Skip PT_NOTE
-	RList *maps = r_list_newf (free); // we need r_bin_map_free
+	RList *maps = r_list_newf ((RListFree)r_bin_elf_map_free);
 
 	for (ph = 0; ph < ph_num; ph++) {
 		Elf_(Phdr) *p = &bin->phdr[ph];

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -688,6 +688,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 				map++;
 			}
 			r_list_free (maps);
+			o->maps = NULL;
 		}
 		eprintf ("Setting up coredump: %d maps have been found and created\n", map);
 		goto beach;


### PR DESCRIPTION
Added <b>r_bin_elf_map_free()</b> so we can free <b>map->file</b> as well and nothing gets leaked.