### PR TITLE
jemalloc: Fix whitespace errors

### DIFF
--- a/shlr/heap/include/r_jemalloc/internal/tsd.h
+++ b/shlr/heap/include/r_jemalloc/internal/tsd.h
@@ -231,9 +231,6 @@ a_attr void								\
 a_name##tsd_set(a_type *val)						\
 {									\
 									\
-
-
-
 	assert(a_name##tsd_booted);					\
 	a_name##tsd_tls = (*val);					\
 	if (a_cleanup != malloc_tsd_no_cleanup)				\
@@ -430,9 +427,6 @@ a_name##tsd_set(a_type *val)						\
 {									\
 	a_name##tsd_wrapper_t *wrapper;					\
 									\
-
-
-
 	assert(a_name##tsd_booted);					\
 	wrapper = a_name##tsd_wrapper_get(true);			\
 	wrapper->val = *(val);						\


### PR DESCRIPTION
Pull request #9429 introduced some whitespace errors into
shlr/heap/include/r_jemalloc/internal/tsd.h

This breaks building sys/mingw32.sh for me.

Signed-off-by: Dirk Eibach <dirk.eibach@gdsys.cc>