### PR TITLE
Fix aav arm/thumb detection

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6010,7 +6010,7 @@ static bool archIsArmOrThumb(RCore *core) {
 			return true;
 		}
 		if (r_str_startswith (as->cur->arch, "arm")) {
-			if (as->cur->bits < 64) {
+			if (as->bits < 64) {
 				return true;
 			}
 		}


### PR DESCRIPTION
In aav, arm/thumb detection is made within archIsArmOrThumb() if bits is set to 16 or 32 (actually, < 64)
The current implementation check the current plugin capabilities (which is a bitfield) instead of the actual bits value set (either with asm.bits or @b: modificator).