### PR TITLE
Enhancement of ar= command

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -323,6 +323,7 @@ R_API RDebug *r_debug_new(int hard) {
 	/* TODO: needs a redesign? */
 	dbg->maps = r_debug_map_list_new ();
 	dbg->maps_user = r_debug_map_list_new ();
+	dbg->q_regs = NULL;
 	r_debug_signal_init (dbg);
 	if (hard) {
 		dbg->bp = r_bp_new ();

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -146,6 +146,28 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 					continue;
 				}
 			}
+			// Is this register being asked?
+			if (dbg->q_regs) {
+				if (!r_list_empty (dbg->q_regs)) {
+					RListIter *iterreg;
+					RList *q_reg = dbg->q_regs;
+					char *q_name;
+					bool found = false;
+					r_list_foreach (q_reg, iterreg, q_name) {
+						if (!strcmp (item->name, q_name)) {
+							found = true;
+							break;
+						}
+					}
+					if (!found) {
+					        continue;
+					}
+					r_list_delete (q_reg, iterreg);
+				} else {
+					// List is empty, all requested regs were taken, no need to go further
+					goto beach;
+				}
+			}
 			int regSize = item->size;
 			if (regSize < 80) {
 				value = r_reg_get_value (dbg->reg, item);
@@ -253,6 +275,7 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 			n++;
 		}
 	}
+beach:
 	if (rad == 'j') {
 		dbg->cb_printf ("}\n");
 	} else if (n > 0 && rad == 2 && ((n%cols))) {

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -284,6 +284,7 @@ typedef struct r_debug_t {
 	RTree *tree;
 
 	RReg *reg;
+	RList *q_regs;
 	const char *creg; // current register value
 	RBreakpoint *bp;
 	void *user; // XXX(jjd): unused?? meant for caller's use??


### PR DESCRIPTION
This aims to be an enhancement of the command <b>ar=</b>. (#9710)
<b>dr=</b> will come shortly, but it needs more refactoring so that is why I did not manage to take it here yet (short of time).

<pre>
$ r2 gcore.11190 
Setting up coredump: asm.arch <-> x86 and asm.bits <-> 64
Setting up coredump: Registers have been set
Setting up coredump: 14 maps have been found and created
 -- Change the registers of the child process in this way: 'dr eax=0x333'
[0x00000000]> ar?
|Usage: ar # Analysis Registers
...
...
| ar=([size])(:[regs])  Show register values in columns
...
...
[0x00000000]> ar=32
 eax 0xfffffdfc           ebx 0xffffff80           ecx 0xd4019f11
 edx 0x00000000           esi 0x7ede3610           edi 0x7ede3610
 r8d 0x00000000           r9d 0x00000000          r10d 0x0000075b
r11d 0x00000246          r12d 0x00400510          r13d 0x7ede3760
r14d 0x00000000          r15d 0x00000000           ebp 0x00000000
 eflags 1PZI         esp 0x7ede3608          
[0x00000000]> ar=32:ebx eax
 eax 0xfffffdfc           ebx 0xffffff80          
[0x00000000]> ar=32:ebx rax
 ebx 0xffffff80          
[0x00000000]> ar=8:al cl
  al 0x000000fc            cl 0x00000011          
[0x00000000]>
</pre>