### PR TITLE
Fix temporary modifiers

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2636,8 +2636,9 @@ next_arroba:
 						r_core_seek (core, addr, 1);
 						r_core_block_read (core);
 					}
-					ret = r_cmd_call (core->rcmd, r_str_trim_head (cmd));
 				}
+				ret = r_cmd_call (core->rcmd, r_str_trim_head (cmd));
+
 			}
 			if (tmpseek) {
 				// restore ranges

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2386,7 +2386,6 @@ repeat_arroba:
 				eprintf ("TODO: what do you expect for @. import offset from file maybe?\n");
 			}
 		} else if (ptr[0] && ptr[1] == ':' && ptr[2]) {
-			usemyblock = true;
 			switch (ptr[0]) {
 			case 'F': // "@F:" // temporary flag space
 				flgspc = r_flag_space_get (core->flags, ptr + 2);
@@ -2406,6 +2405,7 @@ repeat_arroba:
 							ut16 inst_off = r_anal_bb_offset_inst (bb, index);
 							r_core_seek (core, bb->addr + inst_off, 1);
 							core->tmpseek = true;
+							usemyblock = true;
 						} else {
 							eprintf("The current basic block has %d instructions\n", bb->ninstr);
 						}
@@ -2424,6 +2424,7 @@ repeat_arroba:
 						core->block = buf;
 						core->blocksize = sz;
 						memcpy (core->block, f, sz);
+						usemyblock = true;
 					} else {
 						eprintf ("cannot alloc %d", sz);
 					}
@@ -2450,6 +2451,7 @@ repeat_arroba:
 					}
 					r_core_seek (core, regval, 1);
 					free (mander);
+					usemyblock = true;
 				}
 				break;
 			case 'b': // "@b:" // bits
@@ -2460,6 +2462,7 @@ repeat_arroba:
 					ut64 addr = r_num_math (core->num, ptr + 2);
 					if (addr) {
 						r_core_cmdf (core, "so %s", ptr + 2);
+						usemyblock = true;
 					}
 				}
 				break;
@@ -2482,6 +2485,7 @@ repeat_arroba:
 						r_core_block_size (core, R_ABS(len));
 						memcpy (core->block, buf, core->blocksize);
 						core->fixedblock = true;
+						usemyblock = true;
 						free (buf);
 					} else {
 						eprintf ("cannot allocate\n");
@@ -2496,6 +2500,7 @@ repeat_arroba:
 					if (out) {
 						r_core_seek (core, r_num_math (core->num, out), 1);
 						free (out);
+						usemyblock = true;
 					}
 				 }
 				break;
@@ -2522,6 +2527,7 @@ repeat_arroba:
 				len = strlen (ptr + 2);
 				r_core_block_size (core, len);
 				memcpy (core->block, ptr + 2, len);
+				usemyblock = true;
 				break;
 			default:
 				goto ignore;


### PR DESCRIPTION
When using @b @a @e or any other local modifier that do not work on their own temporary block, the temporary seek (@0x...) was not seek to.
```
[0x00000000]> pd 8 @ 0x0
            0x00000000      0000a0e1       mov r0, r0
            0x00000004      010000eb       bl 0x10
        `-> 0x00000008      feffffea       b 8
            0x0000000c      01207047       ldrbmi r2, [r0, -r1]!
            0x00000010      00c09fe5       ldr ip, [pc]                ; [0x18:4]=13 ; 24
            0x00000014      1cff2fe1       bx ip
            0x00000018      0d000000       andeq r0, r0, sp
            0x0000001c      ffffffff       invalid
[0x00000000]> pd 4 @b:32 @ 0xc
            0x0000000c      0000a0e1       mov r0, r0
            0x00000010      010000eb       bl 0x1c
        `-> 0x00000014      feffffea       b 0x14
            0x00000018      01207047       ldrbmi r2, [r0, -r1]!
```
