### PR TITLE
Meson: Add version info for shared libs

### DIFF
--- a/libr/anal/meson.build
+++ b/libr/anal/meson.build
@@ -112,7 +112,8 @@ r_anal = library('r_anal', files,
     r_util, r_reg, r_asm, r_syscall, r_search, r_cons, r_flag, libr_shlr
   ],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/asm/meson.build
+++ b/libr/asm/meson.build
@@ -167,7 +167,8 @@ r_asm = library('r_asm', files,
     r_util, r_syscall, r_parse, r_lang, r_flag, r_socket, libr_shlr
   ],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -122,7 +122,8 @@ r_bin = library('r_bin', files,
   c_args: ['-DCORELIB=1', '-DR_API_BIN_ONLY=1'],
   link_with: [r_util, r_io, r_socket, r_magic, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/bp/meson.build
+++ b/libr/bp/meson.build
@@ -17,7 +17,8 @@ r_bp = library('r_bp', files,
   c_args: ['-DCORELIB=1'],
   link_with: [r_util],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/config/meson.build
+++ b/libr/config/meson.build
@@ -7,7 +7,8 @@ r_config = library('r_config', files,
   include_directories: [platform_inc],
   link_with: [r_util, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/cons/meson.build
+++ b/libr/cons/meson.build
@@ -21,7 +21,8 @@ r_cons = library('r_cons', files,
   include_directories: [platform_inc],
   link_with: [r_util, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/core/meson.build
+++ b/libr/core/meson.build
@@ -79,7 +79,8 @@ r_core = library('r_core', files,
   ],
   dependencies: [platform_deps],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/crypto/meson.build
+++ b/libr/crypto/meson.build
@@ -25,7 +25,8 @@ r_crypto = library('r_crypto', files,
   link_with: [r_util],
   c_args: ['-DCORELIB=1'],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkg = import('pkgconfig')

--- a/libr/debug/meson.build
+++ b/libr/debug/meson.build
@@ -69,7 +69,8 @@ r_debug = library('r_debug', files,
     r_cons, r_lang, r_egg, r_socket, libr_shlr
   ],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/egg/meson.build
+++ b/libr/egg/meson.build
@@ -20,7 +20,8 @@ r_egg = library('r_egg', files,
   c_args: ['-DCORELIB=1'],
   link_with: [r_util, r_asm, r_syscall, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/flag/meson.build
+++ b/libr/flag/meson.build
@@ -9,7 +9,8 @@ r_flag = library('r_flag', files,
   include_directories: [platform_inc],
   link_with: [r_util, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/fs/meson.build
+++ b/libr/fs/meson.build
@@ -33,7 +33,8 @@ r_fs = library('r_fs', files,
   c_args: ['-DCORELIB=1'],
   link_with: [r_util, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/hash/meson.build
+++ b/libr/hash/meson.build
@@ -19,7 +19,8 @@ r_hash = library('r_hash', files,
   dependencies: [mth],
   link_with: [r_util],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/io/meson.build
+++ b/libr/io/meson.build
@@ -72,7 +72,8 @@ r_io = library('r_io', files,
   ],
   c_args: ['-DCORELIB=1'],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/lang/meson.build
+++ b/libr/lang/meson.build
@@ -13,7 +13,8 @@ r_lang = library('r_lang', files,
   c_args: ['-DCORELIB=1'],
   link_with: [r_util, r_cons],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/magic/meson.build
+++ b/libr/magic/meson.build
@@ -14,7 +14,8 @@ r_magic = library('r_magic', files,
   c_args: ['-DCORELIB=1'],
   link_with: [r_util],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/parse/meson.build
+++ b/libr/parse/meson.build
@@ -27,7 +27,8 @@ r_parse = library('r_parse', files,
   c_args: ['-DCORELIB=1'],
   link_with: [r_util, r_flag, r_syscall, r_reg, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/reg/meson.build
+++ b/libr/reg/meson.build
@@ -11,7 +11,8 @@ r_reg = library('r_reg', files,
   include_directories: [platform_inc],
   link_with: [r_util],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/search/meson.build
+++ b/libr/search/meson.build
@@ -14,7 +14,8 @@ r_search = library('r_search', files,
   include_directories: [platform_inc],
   link_with: [r_util],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/socket/meson.build
+++ b/libr/socket/meson.build
@@ -15,7 +15,8 @@ r_socket = library('r_socket', files,
   link_with: [r_util],
   c_args: ['-DCORELIB=1'],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(

--- a/libr/syscall/meson.build
+++ b/libr/syscall/meson.build
@@ -7,7 +7,8 @@ r_syscall = library('r_syscall', files,
   include_directories: [platform_inc],
   link_with: [r_util, libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(libraries: [r_syscall],

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -90,7 +90,8 @@ r_util = library('r_util', files,
   dependencies: [ldl, pth, utl],
   link_with: [libr_shlr],
   install: true,
-  implicit_include_directories: false
+  implicit_include_directories: false,
+  soversion: r2version
 )
 
 pkgconfig_mod.generate(


### PR DESCRIPTION
Related issue: https://github.com/radare/radare2/issues/9636

Name example for Windows: `r_util-2.5.0-git.dll`

Name&Soname example for Linux:
```sh
objdump -x build2/libr/asm/libr_asm.so.2.5.0-git | grep SONAME
  SONAME               libr_asm.so.2.5.0-git
```
Meson on Linux also generates relative symlink `libr_blah.so` to `libr_blah.so.XXX` which is installed together with lib.