### PR TITLE
Force @b @a over hints

### DIFF
--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -269,14 +269,14 @@ static void choose_bits_anal_hints(RCore *core, ut64 addr, int *bits) {
 R_API void r_core_seek_archbits(RCore *core, ut64 addr) {
 	int bits = 0;
 	const char *arch = r_io_section_get_archbits (core->io, addr, &bits);
-	if (!bits) {
+	if (!bits && !core->fixedbits) {
 		//if we found bits related with anal hints pick it up
 		choose_bits_anal_hints (core, addr, &bits);
 	}
-	if (bits) {
+	if (bits && !core->fixedbits) {
 		r_config_set_i (core->config, "asm.bits", bits);
 	}
-	if (arch) {
+	if (arch && !core->fixedarch) {
 		r_config_set (core->config, "asm.arch", arch);
 	}
 }

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1010,13 +1010,13 @@ R_API RAnalHint *r_core_hint_begin(RCore *core, RAnalHint* hint, ut64 at) {
 	}
 	if (hint) {
 		/* arch */
-		if (hint->arch) {
+		if (hint->arch && !core->fixedarch) {
 			if (!hint_arch) {
 				hint_arch = strdup (r_config_get (core->config, "asm.arch"));
 			}
 			r_config_set (core->config, "asm.arch", hint->arch);
 		}
-		/* arch */
+		/* syntax */
 		if (hint->syntax) {
 			if (!hint_syntax) {
 				hint_syntax = strdup (r_config_get (core->config, "asm.syntax"));

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -203,6 +203,8 @@ typedef struct r_core_t {
 	bool break_loop;
 	RThreadLock *lock;
 	RList *undos;
+	bool fixedbits;
+	bool fixedarch;
 } RCore;
 
 R_API int r_core_bind(RCore *core, RCoreBind *bnd);


### PR DESCRIPTION
Fix for  #9750 and #9751 

Adding a flag in RCore to keep track of temporary bit/arch set by @a and @b directives