### PR TITLE
fix drx output hw breakpoint length

### DIFF
--- a/libr/debug/p/native/drx.c
+++ b/libr/debug/p/native/drx.c
@@ -129,7 +129,7 @@ ut64 drx_get(drxt *drx, int n, int *rwx, int *len, int *global, int *enabled) {
 		*global = I386_DR_IS_LOCAL_ENABLED (drx[7], n);
 	}
 	if (len) {
-		switch ((ret & 3) << 2) {
+		switch (ret & 0xA) {
 		case DR_LEN_1: *len = 1; break;
 		case DR_LEN_2: *len = 2; break;
 		case DR_LEN_4: *len = 4; break;


### PR DESCRIPTION
:> drx 1 0x558817382078 1 x                                                                                                                        
:> drx                                                                 
                                                                              
* dr1 Gx 0x558817382078 1                                              
    
- dr6 Lx 0x00000004 1                                                      
- dr7 Lx 0xb9000055 1                                                    
:> drx 1 0x558817382078 1 r                                                
:> drx                                                                   
                                           
* dr1 Gr 0x558817382078 4                                                

- dr6 Lx 0x00000004 1                                                    
- dr7 Lx 0xb9300055 1                                                       
:> drx 1 0x558817382078 1 w                                        
:> drx                                                                     
                                        
* dr1 Gw 0x558817382078 2          

length was taken from permissions