### PR TITLE
Rop gadgets are now stored in sdb

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -2644,6 +2644,9 @@ reread:
 
 				ls_foreach (sdb_list, sdb_iter, kv) {
 					RList *hitlist = r_core_asm_hit_list_new ();
+					if (!hitlist) {
+						goto beach;
+					}
 
 					char *s = kv->value;
 					ut64 addr;
@@ -2658,6 +2661,10 @@ reread:
 
 					do {
 						RCoreAsmHit *hit = r_core_asm_hit_new ();
+						if (!hit) {
+							r_list_free (hitlist);
+							goto beach;
+						}
 						sscanf (s, "%"PFMT64x"(%"PFMT32d")", &addr, &opsz);
 						hit->addr = addr;
 						hit->len = opsz;
@@ -2665,6 +2672,7 @@ reread:
 					} while (*(s = strchr (s, ')') + 1) != '\0');
 
 					print_rop (core, hitlist, mode, &json_first);
+					r_list_free (hitlist);
 				}
 			}
 


### PR DESCRIPTION
This is a first attempt to store rop gadgets in a sdb, not a real PR but more a PRFC (a pull request for comments :-)
Gadgets are stored in the following way : 
key: addr_of_instruct_1
value: addr_of_instruct_1(len_op_code_instruct_1)addr_of_instruct_2(len_op_code_instruct_2)...

I started to change the portion of code that calls r_core_search_rop, because the idea would be to call this function only one time, and simply use the sdb to print gadgets once it has been called (and not do the whole search again).
There is quite a few things still to change : 
  - Recreate a hitlist from the sdb elements in order to call print_rop with it (or reimplement print_rop to work directly with sdb ?)
  - Reimplement the grep functionnality with the sdb (but it sounds a bit weird to do with the way I stored gadgets for the moment ?)
  - ...
