### PR TITLE
[v850] V850_ADD_IMM5 fix #8308

### DIFF
--- a/libr/anal/p/anal_v850.c
+++ b/libr/anal/p/anal_v850.c
@@ -215,10 +215,7 @@ static int v850_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len)
 		op->type = R_ANAL_OP_TYPE_ADD;
 		if (F6_REG2(word1) == V850_SP) {
 			op->stackop = R_ANAL_STACK_INC;
-			// Not so sure about the fix but
-			// F6_IMM works only for 32 bit words.
-			// word1 is 16 bits long.
-			op->stackptr = F2_IMM (word1);
+			op->stackptr = (st64) word2;
 			op->val = op->stackptr;
 		}
 		r_strbuf_appendf (&op->esil, "%hd,%s,+,%s,=", word2, F6_RN1 (word1), F6_RN2 (word1));

--- a/libr/anal/p/anal_v850.c
+++ b/libr/anal/p/anal_v850.c
@@ -218,7 +218,7 @@ static int v850_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len)
 			op->stackptr = (st64) word2;
 			op->val = op->stackptr;
 		}
-		r_strbuf_appendf (&op->esil, "%hd,%s,+,%s,=", word2, F6_RN1 (word1), F6_RN2 (word1));
+		r_strbuf_appendf (&op->esil, "%hd,%s,+,%s,=", (st32) word2, F6_RN1 (word1), F6_RN2 (word1));
 		update_flags (op, -1);
 		break;
 	case V850_SHR_IMM5:

--- a/libr/anal/p/anal_v850.c
+++ b/libr/anal/p/anal_v850.c
@@ -218,7 +218,7 @@ static int v850_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len)
 			op->stackptr = (st64) word2;
 			op->val = op->stackptr;
 		}
-		r_strbuf_appendf (&op->esil, "%hd,%s,+,%s,=", (st32) word2, F6_RN1 (word1), F6_RN2 (word1));
+		r_strbuf_appendf (&op->esil, "%d,%s,+,%s,=", (st32) word2, F6_RN1 (word1), F6_RN2 (word1));
 		update_flags (op, -1);
 		break;
 	case V850_SHR_IMM5:


### PR DESCRIPTION
in the code `word1` is the higher 16 bits and `word2` is the lower 16 bits.

```
ADDI imm16, reg1, reg2
GR [reg2] <- GR [reg1] + sign-extend (imm16) 
+------------------+------------------+
| rrrrr110000RRRRR | iiiiiiiiiiiiiiii |
+------------------+------------------+

rrrrr = reg2
RRRRR = reg1
iiiiiiiiiiiiiiii = imm16
```

Page 66 -> https://www.renesas.com/en-eu/doc/products/mpumcu/doc/v850/r01us0037ej0100_v850e2.pdf
