### PR TITLE
io: Add DDC2Bi3 protocol wrapper to gprobe plugin

### DIFF
--- a/doc/gprobe.md
+++ b/doc/gprobe.md
@@ -14,15 +14,17 @@ Gprobe got some public attention with the
 What is implemented?
 --------------------
 - Serial1 protocol wrapper
+- DDC2Bi3 protocol wrapper (Linux only)
 - RAM read-/write-access
 - Reset
 - DebugOn/DebugOff
 - RunCode
 - GetDeviceId
+- GetInformation
 
 TODOs
 -----
-- DDC2Bi3 and DisplayPort AUX Channel protocol wrappers
+- DisplayPort AUX Channel protocol wrapper
 - Flash commands
 
 What is tested?
@@ -30,7 +32,9 @@ What is tested?
 - building with sys/user.sh and sys/mingw32.sh on linux
 - running radare2 on Linux and Windows
 - communication via FTDI USB serial adaptor
+- communication via DDC2Bi3
 - controlling a MegaChips RD1-4320 DisplayPort 1.2a splitter reference board
+- controlling a DELL U2410 connected via DVI
 
 How to use for dummies?
 -----------------------
@@ -38,6 +42,11 @@ radare2 -n -w gprobe:///dev/ttyUSB0
 - "/dev/ttyUSB0" is the serial connection, use something like "COM3" on Windows
 - "-n" is important to avoid an initial 32k read to identify the binary type
 - "-w" if you want to allow writing to RAM
+
+radare2 -n -w gprobe://i2c-4
+- i2c-4 is the i2c bus where the GProbe device is connected
+- find the appropriate bus with "ddcutil detect"
+- make sure the i2c-dev kernel module is loaded
 
 Setup for Turbo186 processor core:
 - e asm.bits=16


### PR DESCRIPTION
The DDC2Bi3 wrapper is used for both DDC2Bi3 and I2C
communication channels, for example HDMI DDC or
I2C Host Interface.

Using this wrapper you can communicate with displays
that are based on Genesis chipsets like the Dell U2410.

Signed-off-by: Dirk Eibach <dirk.eibach@gdsys.cc>