### PR TITLE
io: remove stropts.h from io_gprobe.c

### DIFF
--- a/libr/io/p/io_gprobe.c
+++ b/libr/io/p/io_gprobe.c
@@ -14,9 +14,6 @@
 #include <tchar.h>
 #include <windows.h>
 #else
-#if __linux__
-#include <stropts.h>
-#endif
 #include <termios.h>
 #endif
 


### PR DESCRIPTION
Do we really need stropts.h? I can compile even without it...