### PR TITLE
fixed panels blinking all the time when scrolling

### DIFF
--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -428,6 +428,7 @@ R_API int r_cons_readchar_timeout(ut32 usec) {
 // TODO: support binary? buf+len
 static char *readbuffer = NULL;
 static int readbuffer_length = 0;
+static bool bufactive = true;
 
 R_API bool r_cons_readpush(const char *str, int len) {
 	char *res = (len + readbuffer_length > 0) ? realloc (readbuffer, len + readbuffer_length) : NULL;
@@ -443,6 +444,10 @@ R_API bool r_cons_readpush(const char *str, int len) {
 R_API void r_cons_readflush() {
 	R_FREE (readbuffer);
 	readbuffer_length = 0;
+}
+
+R_API void r_cons_switchbuf(bool active) {
+	bufactive = active;
 }
 
 R_API int r_cons_readchar() {
@@ -475,7 +480,9 @@ R_API int r_cons_readchar() {
 	if (read (0, buf, 1) == -1) {
 		return -1;
 	}
-	r_cons_set_raw (0);
+	if (bufactive) {
+		r_cons_set_raw (0);
+	}
 #endif
 	return r_cons_controlz (buf[0]);
 }

--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -554,6 +554,7 @@ R_API RPanels *r_panels_new(RCore* core) {
 }
 
 R_API void r_panels_free(RPanels *panels) {
+	r_cons_switchbuf(true);
 	if (panels) {
 		free (panels);
 	}
@@ -565,6 +566,9 @@ R_API int r_core_visual_panels(RCore *core, RPanels *panels) {
 	int asm_comments = 0;
 	int asm_bytes = 0;
 	int have_utf8 = 0;
+
+	r_cons_switchbuf(false);
+
 	if (!_core) {
 		_core = core;
 	}
@@ -572,6 +576,7 @@ R_API int r_core_visual_panels(RCore *core, RPanels *panels) {
 	if (!panels) {
 		panels = r_panels_new (_core);
 		if (!panels) {
+			r_panels_free (panels);
 			return false;
 		}
 	}
@@ -581,6 +586,7 @@ R_API int r_core_visual_panels(RCore *core, RPanels *panels) {
 		return false;
 	}
 
+	r_cons_switchbuf(false);
 	core->panels = panels;
 
 	asm_comments = r_config_get_i (core->config, "asm.comments");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -692,6 +692,7 @@ R_API int r_cons_controlz(int ch);
 R_API int r_cons_readchar(void);
 R_API bool r_cons_readpush(const char *str, int len);
 R_API void r_cons_readflush();
+R_API void r_cons_switchbuf(bool active);
 R_API int r_cons_readchar_timeout(ut32 usec);
 R_API int r_cons_any_key(const char *msg);
 R_API int r_cons_eof(void);


### PR DESCRIPTION
currently panels blink all the time when you scroll them down. try V! and scroll.

it is caused by tcsetattr tries to manipulate terminal when the panels are refreshed up, so just turned it off by adding some code.