### PR TITLE
Add initial temp breakpoint support

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -119,10 +119,11 @@ R_API RBreakpointItem *r_bp_get_in(RBreakpoint *bp, ut64 addr, int rwx) {
 	return NULL;
 }
 
-R_API RBreakpointItem *r_bp_enable(RBreakpoint *bp, ut64 addr, int set) {
+R_API RBreakpointItem *r_bp_enable(RBreakpoint *bp, ut64 addr, int set, int count) {
 	RBreakpointItem *b = r_bp_get_in (bp, addr, 0);
 	if (b) {
 		b->enabled = set;
+		b->togglehits = count;
 		return b;
 	}
 	return NULL;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -52,8 +52,8 @@ static const char *help_msg_db[] = {
 	// "dbi", " 0x848 ecx=3", "stop execution when condition matches",
 	"dbc", " <addr> <cmd>", "Run command when breakpoint is hit",
 	"dbC", " <addr> <cmd>", "Run command but continue until <cmd> returns zero",
-	"dbd", " <addr>", "Disable breakpoint for count hits",
-	"dbe", " <addr>", "Enable breakpoint for count hits",
+	"dbd", " <addr>", "Disable breakpoint",
+	"dbe", " <addr>", "Enable breakpoint",
 	"dbs", " <addr>", "Toggle breakpoint",
 	"dbf", "", "Put a breakpoint into every no-return function",
 	//
@@ -62,8 +62,8 @@ static const char *help_msg_db[] = {
 	//
 	"dbi", "", "List breakpoint indexes",
 	"dbic", " <index> <cmd>", "Run command at breakpoint index",
-	"dbie", " <index>", "Enable breakpoint by index for count hits",
-	"dbid", " <index>", "Disable breakpoint by index for count hits",
+	"dbie", " <index>", "Enable breakpoint by index",
+	"dbid", " <index>", "Disable breakpoint by index",
 	"dbis", " <index>", "Swap Nth breakpoint",
 	"dbite", " <index>", "Enable breakpoint Trace by index",
 	"dbitd", " <index>", "Disable breakpoint Trace by index",

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -52,8 +52,8 @@ static const char *help_msg_db[] = {
 	// "dbi", " 0x848 ecx=3", "stop execution when condition matches",
 	"dbc", " <addr> <cmd>", "Run command when breakpoint is hit",
 	"dbC", " <addr> <cmd>", "Run command but continue until <cmd> returns zero",
-	"dbd", " <addr> [count]", "Disable breakpoint for count hits",
-	"dbe", " <addr> [count]", "Enable breakpoint for count hits",
+	"dbd", " <addr>", "Disable breakpoint for count hits",
+	"dbe", " <addr>", "Enable breakpoint for count hits",
 	"dbs", " <addr>", "Toggle breakpoint",
 	"dbf", "", "Put a breakpoint into every no-return function",
 	//
@@ -62,8 +62,8 @@ static const char *help_msg_db[] = {
 	//
 	"dbi", "", "List breakpoint indexes",
 	"dbic", " <index> <cmd>", "Run command at breakpoint index",
-	"dbie", " <index> [count]", "Enable breakpoint by index for count hits",
-	"dbid", " <index> [count]", "Disable breakpoint by index for count hits",
+	"dbie", " <index>", "Enable breakpoint by index for count hits",
+	"dbid", " <index>", "Disable breakpoint by index for count hits",
 	"dbis", " <index>", "Swap Nth breakpoint",
 	"dbite", " <index>", "Enable breakpoint Trace by index",
 	"dbitd", " <index>", "Disable breakpoint Trace by index",

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -52,6 +52,7 @@ typedef struct r_bp_item_t {
 	int trace;
 	int internal; /* used for internal purposes */
 	int enabled;
+	int togglehits; /* counter that toggles breakpoint on reaching 0 */
 	int hits;
 	ut8 *obytes; /* original bytes */
 	ut8 *bbytes; /* breakpoint bytes */
@@ -119,7 +120,7 @@ R_API int r_bp_size(RBreakpoint *bp);
 R_API int r_bp_get_bytes(RBreakpoint *bp, ut8 *buf, int len, int endian, int idx);
 R_API int r_bp_set_trace(RBreakpoint *bp, ut64 addr, int set);
 R_API int r_bp_set_trace_all(RBreakpoint *bp, int set);
-R_API RBreakpointItem *r_bp_enable(RBreakpoint *bp, ut64 addr, int set);
+R_API RBreakpointItem *r_bp_enable(RBreakpoint *bp, ut64 addr, int set, int count);
 R_API int r_bp_enable_all(RBreakpoint *bp, int set);
 
 /* index api */


### PR DESCRIPTION
This first attempt will not change functionality. This will add support for toggling a breakpoint for [count] hits. The commands to do this will be db[i](d|e) <addr> [count]. Count is assigned to bp->togglehits, which will be used to determine whether to stop or not. Each time a breakpoint is hit, decrement togglehits. Once togglehits reaches 0, toggle the bp. If togglehits is initially 0, the bp isn't affected.

The next step will be to implement the toggle behavior. I'm still new to the code, but I see a few potential areas I could implement this:
 - in r_debug_bp_hit, r_debug_recoil, and/or r_debug_continue_kill -- might not be a good way, since from what I understand, execution is already expected to stop 
 - let the breakpoint plugins handle it
Let me know any feedback or how it should be implemented differently, thanks.