### PR TITLE
Changed the endianness of the header symbols

### DIFF
--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -150,10 +150,10 @@ static RList *symbols(RBinFile *bf) {
 	ret->free = free;
 	// TODO: store all this stuff in SDB
 	hdr = (SMD_Header *) (bf->buf->buf + 0x100);
-	addsym (ret, "rom_start", hdr->RomStart);
-	addsym (ret, "rom_end", hdr->RomEnd);
-	addsym (ret, "ram_start", hdr->RamStart);
-	addsym (ret, "ram_end", hdr->RamEnd);
+	addsym (ret, "rom_start", r_read_be32 (&hdr->RomStart));
+	addsym (ret, "rom_end", r_read_be32 (&hdr->RomEnd));
+	addsym (ret, "ram_start", r_read_be32 (&hdr->RamStart));
+	addsym (ret, "ram_end", r_read_be32 (&hdr->RamEnd));
 	showstr ("Copyright", hdr->CopyRights, 32);
 	showstr ("DomesticName", hdr->DomesticName, 48);
 	showstr ("OverseasName", hdr->OverseasName, 48);
@@ -272,7 +272,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->paddr = ptr->vaddr = 0x100 + sizeof (SMD_Header);
 	{
 		SMD_Header *hdr = (SMD_Header *) (bf->buf->buf + 0x100);
-		ut64 baddr = hdr->RamStart;
+		ut64 baddr = hdr->RomStart;
 		ptr->vaddr += baddr;
 	}
 	ptr->size = ptr->vsize = bf->buf->length - ptr->paddr;
@@ -292,7 +292,7 @@ static RList *entries(RBinFile *bf) { // Should be 3 offsets pointed by NMI, RES
 		return ret;
 	}
 	SMD_Header *hdr = (SMD_Header *) (bf->buf->buf + 0x100);
-	ut64 baddr = hdr->RamStart;
+	ut64 baddr = hdr->RomStart;
 	ptr->paddr = ptr->vaddr = baddr + 0x100 + sizeof (SMD_Header); // vtable[1];
 	r_list_append (ret, ptr);
 	return ret;


### PR DESCRIPTION
Changed the endianness of the header symbols `rom_start`, `rom_end`, `ram_start`, and `ram_end` to big endian. This was causing the auto-generated symbol table to show incorrect addresses for those four symbols. The vtable addresses were already correctly interpreted as big endian.

Also changed section and entry addresses to be relative to rom_start rather than ram_start. This was having an effect on the entry point.