### PR TITLE
Fixed off-by-one in entropy graph calculation

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2514,7 +2514,7 @@ static void cmd_print_bars(RCore *core, const char *input) {
 			for (i = 0; i < nblocks; i++) {
 				ut64 off = from + (blocksize * (i + skipblocks));
 				r_core_read_at (core, off, p, blocksize);
-				ptr[i] = (ut8) (256 * r_hash_entropy_fraction (p, blocksize));
+				ptr[i] = (ut8) (255 * r_hash_entropy_fraction (p, blocksize));
 			}
 			free (p);
 			r_print_columns (core->print, ptr, nblocks, 14);
@@ -2610,7 +2610,7 @@ static void cmd_print_bars(RCore *core, const char *input) {
 		for (i = 0; i < nblocks; i++) {
 			ut64 off = from + (blocksize * (i + skipblocks));
 			r_core_read_at (core, off, p, blocksize);
-			ptr[i] = (ut8) (256 * r_hash_entropy_fraction (p, blocksize));
+			ptr[i] = (ut8) (255 * r_hash_entropy_fraction (p, blocksize));
 		}
 		free (p);
 		print_bars = true;


### PR DESCRIPTION
There is an off-by-one bug in radare when creating entropy graphs. When the entropy of a block should be ```00ff```, radare (2.5.0) rolls it to ```0000```.

Here's an example comparison between radare2 and binwalk:

radare2:

![r2-entropy-graph](https://user-images.githubusercontent.com/1058704/38601335-d4185d42-3d6f-11e8-8361-490c98b71d00.png)

binwalk:

![binwalk-entropy](https://user-images.githubusercontent.com/1058704/38601313-c3d6006a-3d6f-11e8-9662-947430ff91a6.png)

Here's the problem areas in text:

radare2:

```
0x0000c800 32 00e2 | ____________________________________________|
0x0000cc00 33 0000 ||
0x0000d000 34 0000 ||
0x0000d400 35 0000 ||__________________________________________________
0x0000d800 36 00fd | __________________________________________________|
0x0000dc00 37 0000 ||
0x0000e000 38 0000 ||
0x0000e400 39 0000 ||__________________________________________________
0x0000e800 3a 00fd | __________________________________________________|
0x0000ec00 3b 0000 ||
0x0000f000 3c 0000 ||
0x0000f400 3d 0000 ||_______________________________________________
0x0000f800 3e 00ed |                                  _____________|
```

binwalk:

```
DECIMAL       HEXADECIMAL     ENTROPY
--------------------------------------------------------------------------------
51200         0xC800          0.885590
52224         0xCC00          1.000000
53248         0xD000          1.000000
54272         0xD400          1.000000
55296         0xD800          0.991415
56320         0xDC00          1.000000
57344         0xE000          1.000000
58368         0xE400          1.000000
59392         0xE800          0.990692
60416         0xEC00          1.000000
61440         0xF000          1.000000
62464         0xF400          1.000000
63488         0xF800          0.929575
```

Here's radare's graphs after applying the fix:

![r2-entropy-graph-fixed](https://user-images.githubusercontent.com/1058704/38601290-b263c628-3d6f-11e8-85c7-63465aba8495.png)

Steps to reproduce
------------------

* Open [Lab13-03.exe](https://github.com/radare/radare2/issues/8929#issuecomment-365745454) in radare
* Set block size to ```0x400```
* Print entropy graph (either ```p=e``` or ```p==e```)
* Observe the gaps in ```0xcc00 - 0xd400```, ```0xdc00 - 0xe400``` & ```0xec00 - 0xf400```