### PR TITLE
Fix #9870 , fix r_anal_type_get_size and handle enum type

### DIFF
--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -118,7 +118,7 @@ R_API int r_anal_type_get_size(RAnal *anal, const char *type) {
 					if (elements == 0) {
 						elements = 1;
 					}
-					ret += (r_anal_type_get_size (anal, subtype) / 8) * elements;
+					ret += r_anal_type_get_size (anal, subtype) * elements;
 				}
 				free (subtype);
 				ptr = next;

--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -81,11 +81,15 @@ R_API int r_anal_type_get_size(RAnal *anal, const char *type) {
 	}
 	const char *t = sdb_const_get (anal->sdb_types, tmptype, 0);
 	if (!t) {
+		if (!strncmp (tmptype, "enum ", 5)) {
+			//XXX: Need a proper way to determine size of enum
+			return 32;
+		}
 		return 0;
 	}
 	if (!strcmp (t, "type")){
 		query = sdb_fmt ("type.%s.size", tmptype);
-		return sdb_num_get (anal->sdb_types, query, 0);
+		return sdb_num_get (anal->sdb_types, query, 0); // returns size in bits
 	}
 	if (!strcmp (t, "struct")) {
 		query = sdb_fmt ("struct.%s", tmptype);
@@ -114,7 +118,7 @@ R_API int r_anal_type_get_size(RAnal *anal, const char *type) {
 					if (elements == 0) {
 						elements = 1;
 					}
-					ret += r_anal_type_get_size (anal, subtype) * elements;
+					ret += (r_anal_type_get_size (anal, subtype) / 8) * elements;
 				}
 				free (subtype);
 				ptr = next;

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -483,7 +483,7 @@ static int cmd_type(void *data, const char *input) {
 			break;
 		case 's':
 			if (input[2] == ' ') {
-				r_cons_printf ("%d\n", r_anal_type_get_size (core->anal, input + 3));
+				r_cons_printf ("%d\n", (r_anal_type_get_size (core->anal, input + 3) / 8));
 			} else {
 				r_core_cmd_help (core, help_msg_ts);
 			}

--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -1279,6 +1279,7 @@ static void r_print_format_num (const RPrint *p, int endian, int mode, const cha
 int r_print_format_struct_size(const char *f, RPrint *p, int mode, int n) {
 	char *end, *args, *fmt;
 	int size = 0, tabsize = 0, i, idx = 0, biggest = 0, fmt_len = 0;
+	bool tabsize_set = false;
 	if (!f) {
 		return -1;
 	}
@@ -1325,6 +1326,7 @@ int r_print_format_struct_size(const char *f, RPrint *p, int mode, int n) {
 				continue;
 			}
 			*end = '\0';
+			tabsize_set = true;
 			tabsize = r_num_math (NULL, fmt + i + 1);
 			*end = ']';
 			while (fmt[i++] != ']');
@@ -1370,14 +1372,18 @@ int r_print_format_struct_size(const char *f, RPrint *p, int mode, int n) {
 			break;
 		case 'B':
 		case 'E':
-			switch (tabsize) {
-			case 1: size += 1; break;
-			case 2: size += 2; break;
-			case 4: size += 4; break;
-			case 8: size += 8; break;
-			default:
-				eprintf ("Unknown enum format size: %d\n", tabsize);
-				break;
+			if (tabsize_set) {
+				switch (tabsize) {
+				case 1: size += 1; break;
+				case 2: size += 2; break;
+				case 4: size += 4; break;
+				case 8: size += 8; break;
+				default:
+					eprintf ("Unknown enum format size: %d\n", tabsize);
+					break;
+				}
+			} else {
+				size += 4; // Assuming by default enum as int
 			}
 			break;
 		case '?':


### PR DESCRIPTION
After this fix u get 

```
[0x00000000]> to ./pcap.h
[0x00000000]> ts
pcap_pktrec_tcp
pcap_file_hdr
pcap_pktrec_ether
pcak_pktrec_hdr
pcap_pktrec_ipv6
pcap_pktrec_ipv4 
[0x00000000]> tss pcap_file_hdr
24
```
pfs output : 
```
[0x00000000]> .ts*pcap_file_hdr
[0x00000000]> pfs.pcap_file_hdr
24
```