### PR TITLE
Jmptable fixes + information propagation

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -532,12 +532,12 @@ static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut
 		// if we don't check for 0 here, the next check with ptr+jmpptr
 		// will obviously be a good offset since it will be the start
 		// of the table, which is not what we want
-		// TODO: why is the double dereference even there?
 		if (jmpptr == 0) {
 			break;
 		}
 
 		if (!anal->iob.is_valid_offset (anal->iob.io, jmpptr, 0)) {
+			// jump tables where sign extended movs are used
 			jmpptr = ptr + (st32) jmpptr;
 			if (!anal->iob.is_valid_offset (anal->iob.io, jmpptr, 0)) {
 				break;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -749,8 +749,7 @@ R_API int r_anal_case(RAnal *anal, RAnalFunction *fcn, ut64 addr_bbsw, ut64 addr
 static int walk_switch(RAnal *anal, RAnalFunction *fcn, ut64 from, ut64 at) {
 	ut8 buf[1024];
 	int i;
-	eprintf ("WALK_SWITCH ujmp at 0x%"PFMT64x " to 0x%"PFMT64x "\n", from, at);
-	// eprintf ("WALK SWITCH TABLE INTO (0x%"PFMT64x ") %"PFMT64x "\n", from, at);
+	eprintf ("WALK SWITCH TABLE INTO (0x%"PFMT64x ") %"PFMT64x "\n", from, at);
 	for (i = 0; i < 10; i++) {
 		anal->iob.read_at (anal->iob.io, at, buf, sizeof (buf));
 		int sz = r_anal_case (anal, fcn, from, at, buf, sizeof (buf), 0);
@@ -1285,6 +1284,7 @@ repeat:
 					// walk_switch (anal, fcn, op.addr, op.addr + op.size);
 				}
 				// op.ireg since rip relative addressing produces way too many false positives otherwise
+				// op.ireg is 0 for rip relative, "rax", etc otherwise
 				if (op.ptr != UT64_MAX && op.ireg) {       // direct jump
 					ret = try_walkthrough_jmptbl (anal, fcn, depth, op.addr, op.ptr, ret);
 				} else {        // indirect jump: table pointer is unknown

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -489,14 +489,17 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 static void queue_case(RAnal *anal, ut64 switch_addr, ut64 case_addr, ut64 id, ut64 case_addr_loc) {
 	// eprintf("\tqueue_case: 0x%"PFMT64x " from 0x%"PFMT64x "\n", case_addr, case_addr_loc);
 	anal->cmdtail = r_str_appendf (anal->cmdtail,
-		"ax 0x%"PFMT64x " 0x%"PFMT64x "\n",
+		"axc 0x%"PFMT64x " 0x%"PFMT64x "\n",
 		case_addr, switch_addr);
+	// anal->cmdtail = r_str_appendf (anal->cmdtail,
+	// 	"aho case %d: from 0x%"PFMT64x " @ 0x%"PFMT64x "\n",
+	// 	id, switch_addr, case_addr_loc);
+	// anal->cmdtail = r_str_appendf (anal->cmdtail,
+	// 	"CCu case %d: @ 0x%"PFMT64x "\n",
+	// 	id, case_addr);
 	anal->cmdtail = r_str_appendf (anal->cmdtail,
-		"aho case %d: from 0x%"PFMT64x " @ 0x%"PFMT64x "\n",
-		id, switch_addr, case_addr_loc);
-	anal->cmdtail = r_str_appendf (anal->cmdtail,
-		"CCu case %d: @ 0x%"PFMT64x "\n",
-		id, case_addr);
+		"f case.%d.0x%"PFMT64x " 1 @ 0x%08"PFMT64x "\n",
+		id, case_addr, case_addr);
 }
 
 static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut64 ip, ut64 ptr, int ret0) {
@@ -555,6 +558,9 @@ static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut
 		anal->cmdtail = r_str_appendf (anal->cmdtail,
 			"CCu switch table (%d cases) at 0x%"PFMT64x " @ 0x%"PFMT64x "\n",
 			offs/sz, ptr, ip);
+		anal->cmdtail = r_str_appendf (anal->cmdtail,
+			"f switch.0x%08"PFMT64x" 1 @ 0x%08"PFMT64x"\n",
+			ip, ip);
 	}
 
 	free (jmptbl);
@@ -994,17 +1000,17 @@ repeat:
 			}
 			if (anal->opt.jmptbl) {
 				if (is_delta_pointer_table (anal, op.addr, op.ptr)) {
-					char *str = r_str_newf ("pxt. 0x%08" PFMT64x" @ 0x%08"PFMT64x "\n", op.addr, op.ptr);
-					if (!anal->cmdtail) {
-						anal->cmdtail = r_str_appendf (anal->cmdtail, str);
-					}
-					if (anal->cmdtail && !strstr (anal->cmdtail, str)) {
-						anal->cmdtail = r_str_appendf (anal->cmdtail, str);
-					} 
-					free (str);
+					// char *str = r_str_newf ("pxt. 0x%08" PFMT64x" @ 0x%08"PFMT64x "\n", op.addr, op.ptr);
+					// if (!anal->cmdtail) {
+					// 	anal->cmdtail = r_str_appendf (anal->cmdtail, str);
+					// }
+					// if (anal->cmdtail && !strstr (anal->cmdtail, str)) {
+					// 	anal->cmdtail = r_str_appendf (anal->cmdtail, str);
+					// } 
+					// free (str);
 					// jmptbl_addr = op.ptr;
 					// jmptbl_size = -1;
-					// ret = try_walkthrough_jmptbl (anal, fcn, depth, op.addr, op.ptr, 4);
+					ret = try_walkthrough_jmptbl (anal, fcn, depth, op.addr, op.ptr, 4);
 				}
 			}
 			break;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -530,8 +530,9 @@ static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut
 		// will obviously be a good offset since it will be the start
 		// of the table, which is not what we want
 		// TODO: why is the double dereference even there?
-		if (jmpptr == 0)
+		if (jmpptr == 0) {
 			break;
+		}
 
 		if (!anal->iob.is_valid_offset (anal->iob.io, jmpptr, 0)) {
 			jmpptr = ptr + (st32) jmpptr;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -734,7 +734,7 @@ R_API int r_anal_case(RAnal *anal, RAnalFunction *fcn, ut64 addr_bbsw, ut64 addr
 		case R_ANAL_OP_TYPE_TRAP:
 		case R_ANAL_OP_TYPE_RET:
 		case R_ANAL_OP_TYPE_JMP:
-			eprintf ("CASE AT 0x%llx size %d\n", addr, idx + oplen);
+			// eprintf ("CASE AT 0x%llx size %d\n", addr, idx + oplen);
 			anal->cmdtail = r_str_appendf (anal->cmdtail, "afb+ 0x%"PFMT64x " 0x%"PFMT64x " %d\n",
 				fcn->addr, addr, idx + oplen);
 			anal->cmdtail = r_str_appendf (anal->cmdtail, "afbe 0x%"PFMT64x " 0x%"PFMT64x "\n",

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -663,7 +663,7 @@ static bool isInvalidMemory(const ut8 *buf, int len) {
 	// return buf[0]==buf[1] && buf[0]==0xff && buf[2]==0xff && buf[3] == 0xff;
 }
 
-static bool is_delta_pointer_table(RAnal *anal, ut64 addr, ut64 ptr) {
+static bool is_delta_pointer_table(RAnal *anal, ut64 addr, ut64 ptr, ut64 *jmp_addr) {
 	int i;
 	ut64 dst;
 	st32 jmptbl[64] = {
@@ -698,6 +698,7 @@ static bool is_delta_pointer_table(RAnal *anal, ut64 addr, ut64 ptr) {
 			return false;
 		}
 	}
+	*jmp_addr = aop.addr;
 	return true;
 }
 
@@ -999,18 +1000,9 @@ repeat:
 				}
 			}
 			if (anal->opt.jmptbl) {
-				if (is_delta_pointer_table (anal, op.addr, op.ptr)) {
-					// char *str = r_str_newf ("pxt. 0x%08" PFMT64x" @ 0x%08"PFMT64x "\n", op.addr, op.ptr);
-					// if (!anal->cmdtail) {
-					// 	anal->cmdtail = r_str_appendf (anal->cmdtail, str);
-					// }
-					// if (anal->cmdtail && !strstr (anal->cmdtail, str)) {
-					// 	anal->cmdtail = r_str_appendf (anal->cmdtail, str);
-					// } 
-					// free (str);
-					// jmptbl_addr = op.ptr;
-					// jmptbl_size = -1;
-					ret = try_walkthrough_jmptbl (anal, fcn, depth, op.addr, op.ptr, 4);
+				ut64 jmp_addr = 0;
+				if (is_delta_pointer_table (anal, op.addr, op.ptr, &jmp_addr)) {
+					ret = try_walkthrough_jmptbl (anal, fcn, depth, jmp_addr, op.ptr, 4);
 				}
 			}
 			break;


### PR DESCRIPTION
`try_walkthrough_jmptbl` was already working pretty well but wasn't actually propagating the info through xrefs/comments.
I think I fixed some issues where the jump table would be detected as bigger than it should be, see `if (jmpptr == 0)` check with comment. I am not sure why the double dereference is even a thing.

The information now looks like this:
<img src="https://i.imgur.com/UazZJQ0.png">

Possible improvements:
- ~~also add flags, not sure which format to use though (see cmd_print.c `_pointer_table`)~~
- ~~references are currently added as null/unknown. Should probably change it to code~~