### PR TITLE
Add more arm/arm64 REV variants

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -885,16 +885,33 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 	postfix = arm_prefix_cond (op, insn->detail->arm64.cc);
 
 	switch (insn->id) {
-	case ARM64_INS_REV: {
+	case ARM64_INS_REV:
+	{
+		const char *r0 = REG64(0);
+		const char *r1 = REG64(1);
+		int size = REGSIZE64(1);
+		r_strbuf_setf (&op->esil,
+			"0,%s,=,"                        // dst = 0
+			"%d,"                            // initial counter = size
+			"DUP,"                           // counter: size -> 0 (repeat here)
+				"DUP,1,SWAP,-,8,*,"          // counter to bits in source
+					"DUP,0xff,<<,%s,&,>>,"   // src byte moved to LSB
+				"SWAP,%d,-,8,*,"             // invert counter, calc dst bit
+				"SWAP,<<,%s,|=,"             // shift left to there and insert
+			"4,REPEAT",                      // goto 5th instruction
+			r0, size, r1, size, r0);
+		break;
+	}
+	case ARM64_INS_REV16:
+	{
 		const char *r0 = REG64(0);
 		const char *r1 = REG64(1);
 		r_strbuf_setf (&op->esil,
-			"24,0xff,%s,&,<<,%s,=,"
-			"16,0xff,8,%s,>>,&,<<,%s,|=,"
-			"8,0xff,16,%s,>>,&,<<,%s,|=,"
-			"0xff,24,%s,>>,&,%s,|=,",
-			r1, r0, r1, r0, r1, r0, r1, r0);
-		} break;
+			"8,0xff00ff00ff00ff00,%s,&,>>,%s,=,"
+			"8,0x00ff00ff00ff00ff,%s,&,<<,%s,|=,",
+			r1, r0, r1, r0);
+		break;
+	}
 	case ARM64_INS_ADR:
 		// TODO: must be 21bit signed
 		r_strbuf_setf (&op->esil,
@@ -2055,6 +2072,41 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 		// notmask,dst,&,dst,=
 		r_strbuf_setf (&op->esil, "%"PFMT64u",%s,&,0xffffffff,&,%s,=",
 			notmask, REG (0), REG (0));
+		break;
+	}
+	case ARM_INS_REV:
+	{
+		const char *r0 = REG (0);
+		const char *r1 = REG (1);
+		r_strbuf_setf (&op->esil,
+			"24,0xff,%s,&,<<,%s,=,"
+			"16,0xff,8,%s,>>,&,<<,%s,|=,"
+			"8,0xff,16,%s,>>,&,<<,%s,|=,"
+			"0xff,24,%s,>>,&,%s,|=,",
+			r1, r0, r1, r0, r1, r0, r1, r0);
+		break;
+	}
+	case ARM_INS_REV16:
+	{
+		const char *r0 = REG (0);
+		const char *r1 = REG (1);
+		r_strbuf_setf (&op->esil,
+			"8,0xff00ff00,%s,&,>>,%s,=,"
+			"8,0x00ff00ff,%s,&,<<,%s,|=,",
+			r1, r0, r1, r0);
+		break;
+	}
+	case ARM_INS_REVSH:
+	{
+		const char *r0 = REG (0);
+		const char *r1 = REG (1);
+		r_strbuf_setf (&op->esil,
+			"8,0xff00,%s,&,>>,%s,=,"
+			"8,0x00ff,%s,&,<<,%s,|=,"
+			"0x8000,%s,&,?{,"
+				"0xffff0000,%s,|=,"
+			"}",
+			r1, r0, r1, r0, r0, r0);
 		break;
 	}
 	default:


### PR DESCRIPTION
- arm/thumb: added REV, REV16, REVSH
- arm64: added REV16, tweaked REV to support any reg size

it's part of https://github.com/radare/radare2/issues/9885
related tests added: https://github.com/radare/radare2-regressions/pull/1276