### PR TITLE
Fix -Wexpansion-to-defined and -Wunused-variable

### DIFF
--- a/libr/io/p/io_r2k_linux.c
+++ b/libr/io/p/io_r2k_linux.c
@@ -843,9 +843,6 @@ int run_new_command(RIO *io, RIODesc *iodesc, const char *buf) {
 }
 
 int run_ioctl_command(RIO *io, RIODesc *iodesc, const char *buf) {
-	int ret, inphex, ioctl_n;
-	size_t pid, addr, len;
-	ut8 *databuf = NULL;
 	buf = r_str_ichr ((char *) buf, ' ');
 
 	if (!run_new_command (io, iodesc, buf)) {

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -54,7 +54,7 @@
 #include <process.h>  // to compile execv in msvc windows
 #endif
 
-#define HAVE_PTY __UNIX__ && !__ANDROID__ && LIBC_HAVE_FORK && !defined(__sun)
+#define HAVE_PTY __UNIX__ && !__ANDROID__ && LIBC_HAVE_FORK && !__sun
 
 #if EMSCRIPTEN
 #undef HAVE_PTY


### PR DESCRIPTION
gcc/clang and MSVC have different behavior when defined(...) is generated as a macro replacement. Here the issue is benign but it does not hurt to fix it.

```c
#define FOO
#define BAR defined(FOO)
#if BAR
// gcc, clang
int foo() {return 3;}
#else
// MSVC
int bar() {return 4;}
#endif
```