### PR TITLE
Remove end slash in ROOT

### DIFF
--- a/sys/user.sh
+++ b/sys/user.sh
@@ -31,7 +31,7 @@ if [ ! -d "${HOME}" ]; then
 	exit 1
 fi
 
-ROOT="${HOME}/bin/prefix/radare2/"
+ROOT="${HOME}/bin/prefix/radare2"
 mkdir -p "${ROOT}/lib"
 
 if [ "${M32}" = 1 ]; then


### PR DESCRIPTION
The slash does not cause any bugs but may looks ugly when displaying output.

Example:
```bash
ln -fs "/home/user/radare2-2.5.0/doc/hud" "/home/user/bin/prefix/radare2//share/radare2/2.5.0/hud/main"
mkdir -p "/home/user/bin/prefix/radare2//share/radare2/2.5.0/"
```