### PR TITLE
Prevent dcu to unknown address

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3688,8 +3688,8 @@ static bool cmd_dcu (RCore *core, const char *input) {
 			from = r_num_math (core->num, input + 3);
 		}
 	}
-	if (from == UT64_MAX) {
-		eprintf ("Cannot continue until unknown address\n");
+	if (core->num->nc.errors && r_cons_singleton ()->is_interactive) {
+		eprintf ("Cannot continue until unknown address '%s'\n", core->num->nc.calc_buf);
 		return false;
 	}
 	if (to == UT64_MAX) {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3688,7 +3688,7 @@ static bool cmd_dcu (RCore *core, const char *input) {
 			from = r_num_math (core->num, input + 3);
 		}
 	}
-	if (from == UT64_MAX) {
+	if (from == UT64_MAX || from == 0LL) {
 		eprintf ("Cannot continue until address 0\n");
 		return false;
 	}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3688,8 +3688,8 @@ static bool cmd_dcu (RCore *core, const char *input) {
 			from = r_num_math (core->num, input + 3);
 		}
 	}
-	if (from == UT64_MAX || from == 0LL) {
-		eprintf ("Cannot continue until address 0\n");
+	if (from == UT64_MAX) {
+		eprintf ("Cannot continue until unknown address\n");
 		return false;
 	}
 	if (to == UT64_MAX) {

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -32,6 +32,7 @@ typedef struct r_num_calc_t {
 	int calc_i;
 	const char *calc_buf;
 	int calc_len;
+	bool under_calc;
 } RNumCalc;
 
 typedef struct r_num_t {

--- a/libr/util/calc.c
+++ b/libr/util/calc.c
@@ -384,6 +384,7 @@ R_API ut64 r_num_calc(RNum *num, const char *str, const char **err) {
 	nc->calc_i = 0;
 	nc->calc_len = 0;
 	nc->calc_buf = NULL;
+	nc->under_calc = true;
 
 	load_token (num, nc, str);
 	get_token (num, nc);
@@ -394,6 +395,7 @@ R_API ut64 r_num_calc(RNum *num, const char *str, const char **err) {
 	if (num) {
 		num->fvalue = n.d;
 	}
+	nc->under_calc = false;
 	return n.n;
 }
 

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -113,6 +113,9 @@ R_API ut64 r_num_get(RNum *num, const char *str) {
 	ut64 ret = 0LL;
 	ut32 s, a;
 
+	if (num && !num->nc.under_calc) {
+		num->nc.errors = 0;
+	}
 	if (!str) {
 		return 0;
 	}


### PR DESCRIPTION
Can prevent accidental termination of program due to missing `sym.` prefix.