### PR TITLE
Fix loading of lang-python plugin

### DIFF
--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -23,10 +23,8 @@ R_API char *r_hex_from_py_str(char *out, const char *code) {
 	if (!strncmp (code, "'''", 3)) {
 		const char *s = code + 2;
 		return r_hex_from_c_str (out, &s);
-	} else {
-		return r_hex_from_c_str (out, &code);
 	}
-	return out;
+	return r_hex_from_c_str (out, &code);
 }
 
 static const char *skip_comment_py(const char *code) {

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -11,7 +11,7 @@ R_LIB_VERSION(r_lib);
 
 #if __UNIX__
 #include <dlfcn.h>
-  #define DLOPEN(x)  dlopen(x, RTLD_GLOBAL | RTLD_NOW)
+  #define DLOPEN(x)  dlopen(x, RTLD_GLOBAL)
   #define DLSYM(x,y) dlsym(x,y)
   #define DLCLOSE(x) dlclose(x)
 #elif __WINDOWS__


### PR DESCRIPTION
Otherwise the plugin can't be loaded because of this:

dlerror(~/.config/radare2/plugins/lang_python2.dylib):
dlopen(~/.config/radare2/plugins/lang_python2.dylib, 6):
 Symbol not found: _PyUnicode_1BYTE_DATA
  Referenced from: ~/.config/radare2/plugins/lang_python2.dylib
  Expected in: flat namespace
 in ~/.config/radare2/plugins/lang_python2.dylib