### PR TITLE
Exclude Makefile and meson.build in libr/cons/d in install

### DIFF
--- a/libr/cons/d/Makefile
+++ b/libr/cons/d/Makefile
@@ -5,12 +5,17 @@ all clean:
 
 .PHONY: all clean install install-symlink symstall
 
+CWD=$(shell pwd)
+
 install: ${F_SDB}
 	rm -rf "$P"
 	mkdir -p "$P"
-	cp -af * "$P"
+	for FILE in * ; do \
+		if [ $$FILE != Makefile -a $$FILE != meson.build -a -f $$FILE ]; then \
+			cp -af "${CWD}/$$FILE" "$P/$$FILE" ; \
+		fi ; \
+	done
 
-CWD=$(shell pwd)
 symstall install-symlink:
 	mkdir -p "$P"
 	for FILE in * ; do \


### PR DESCRIPTION
Otherwise there will be Makefile and meson.build in /usr/local/share/radare2/.../cons or whatever when using install instead of symstall.