### PR TITLE
Fix #9886, Add flag at both offset and value for /V

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -2414,7 +2414,8 @@ void _CbInRangeSearchV(RCore *core, ut64 from, ut64 to, int vsize, bool asterisk
 		r_cons_printf ("{\"offset\":%"PFMT64d ",\"value\":%"PFMT64d "}",
 				from, to);
 	}
-	r_core_cmdf (core, "f %s.0x%08"PFMT64x" %d = 0x%08"PFMT64x "# from 0x%"PFMT64x "\n", prefix, to, vsize, to, from);
+	r_core_cmdf (core, "f %s.value.0x%08"PFMT64x" %d = 0x%08"PFMT64x" \n", prefix, to, vsize, to); // flag at value of hit
+	r_core_cmdf (core, "f %s.offset.0x%08"PFMT64x" %d = 0x%08"PFMT64x " \n", prefix, from, vsize, from); // flag at offset of hit
 	const char *cmdHit = r_config_get (core->config, "cmd.hit");
 	if (cmdHit && *cmdHit) {
 		ut64 addr = core->offset;


### PR DESCRIPTION
The output should like this : 
```
> /V4 0x2000050 0x20000f0

hits: 1
0x14ca6: 0x20000be

> f ~ hit

0x020000be 4 hit.value.0x020000be
0x00014ca6 4 hit.offset.0x00014ca6

> pd 1 @ 0x00014ca6
            ;-- hit.offset.0x00014ca6:
            0x00014ca6      be00000200     mov esi, 0x20000

> pd 1 @ 0x020000be
            ;-- hit.value.0x020000be:
            0x020000be      ff             invalid

[0x00005600]>
```