### PR TITLE
fixed windows crash in ROP search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1228,7 +1228,6 @@ static int r_core_search_rop(RCore *core, RInterval search_itv, int opt, const c
 	RListIter *itermap = NULL;
 	char *tok, *gregexp = NULL;
 	char *grep_arg = NULL, *grep_dup = NULL;
-	char *grepstr = NULL;
 	bool json_first = true;
 	char *rx = NULL;
 	int delta = 0;
@@ -1276,8 +1275,8 @@ static int r_core_search_rop(RCore *core, RInterval search_itv, int opt, const c
 		}
 	}
 	if (grep_arg) {
-		grep_dup = strdup (grep_arg);
-		grep_arg = grepstr = r_str_replace (grep_dup, ",,", ";", true);
+		grep_dup = r_str_dup (NULL, grep_arg);
+		grep_arg = r_str_replace (grep_dup, ",,", ";", true);
 		grep = grep_arg;
 	}
 


### PR DESCRIPTION
Fixes issue https://github.com/radareorg/cutter/issues/454.

The crash was caused by the free of a strdup'ed variable in https://github.com/radare/radare2/blob/eff427e59109f74ab3292d71c21682f158a0fb21/libr/core/cmd_search.c#L1521 and only occurred in Windows. Apparently there are some issues with strdup and free in windows.

@pelijah ping