### PR TITLE
Fix markdown formatting to show a list instead of a blob of text.

### DIFF
--- a/doc/macos.md
+++ b/doc/macos.md
@@ -25,29 +25,29 @@ After Mac OS X 10.6, binaries that need permissions to debug require to be signe
 
 (Based on https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt)
 
-#. Launch /Applications/Utilities/Keychain Access.app
-#. In Keychain Access select the "login" keychain in the "Keychains" list in the upper left hand corner of the window.
-#. Select the following menu item:
-#. Keychain Access->Certificate Assistant->Create a Certificate...
-#. Set the following settings
-#. Name = org.radare.radare2
-#. Identity Type = Self Signed Root
-#. Certificate Type = Code Signing
-#. Click Create
-#. Click Continue
-#. Click Done
-#. Click on the "My Certificates"
-#. Double click on your new org.radare.radare2 certificate
-#. Turn down the "Trust" disclosure triangle, scroll to the "Code Signing" trust pulldown menu and select "Always Trust" and authenticate as needed using your username and password.
-#. Drag the new "org.radare.radare2" code signing certificate (not the public or private keys of the same name) from the "login" keychain to the "System" keychain in the Keychains pane on the left hand side of the main Keychain Access window. This will move this certificate to the "System" keychain. You'll have to authorize a few more times, set it to be "Always trusted" when asked.
-#. In the Keychain Access GUI, click and drag "org.radare.radare2" in the "System" keychain onto the desktop. The drag will create a "~/Desktop/org.radare.radare2.cer" file used in the next step.
-#. Switch to Terminal, and run the following:
-#. $ sudo security add-trust -d -r trustRoot -p basic -p codeSign -k /Library/Keychains/System.keychain ~/Desktop/org.radare.radare2.cer
-#. $ rm -f ~/Desktop/org.radare.radare2.cer
-#. Drag the "org.radare.radare2" certificate from the "System" keychain back into the "login" keychain
-#. Quit Keychain Access
-#. Reboot
-#. Run sys/install.sh (or follow the next steps if you want to install and sign radare2 manually)
+1. Launch /Applications/Utilities/Keychain Access.app
+1. In Keychain Access select the "login" keychain in the "Keychains" list in the upper left hand corner of the window.
+1. Select the following menu item:
+1. Keychain Access->Certificate Assistant->Create a Certificate...
+1. Set the following settings
+1. Name = org.radare.radare2
+1. Identity Type = Self Signed Root
+1. Certificate Type = Code Signing
+1. Click Create
+1. Click Continue
+1. Click Done
+1. Click on the "My Certificates"
+1. Double click on your new org.radare.radare2 certificate
+1. Turn down the "Trust" disclosure triangle, scroll to the "Code Signing" trust pulldown menu and select "Always Trust" and authenticate as needed using your username and password.
+1. Drag the new "org.radare.radare2" code signing certificate (not the public or private keys of the same name) from the "login" keychain to the "System" keychain in the Keychains pane on the left hand side of the main Keychain Access window. This will move this certificate to the "System" keychain. You'll have to authorize a few more times, set it to be "Always trusted" when asked.
+1. In the Keychain Access GUI, click and drag "org.radare.radare2" in the "System" keychain onto the desktop. The drag will create a "~/Desktop/org.radare.radare2.cer" file used in the next step.
+1. Switch to Terminal, and run the following:
+1. $ sudo security add-trust -d -r trustRoot -p basic -p codeSign -k /Library/Keychains/System.keychain ~/Desktop/org.radare.radare2.cer
+1. $ rm -f ~/Desktop/org.radare.radare2.cer
+1. Drag the "org.radare.radare2" certificate from the "System" keychain back into the "login" keychain
+1. Quit Keychain Access
+1. Reboot
+1. Run sys/install.sh (or follow the next steps if you want to install and sign radare2 manually)
 
 As said before, the signing process can also be done manually following the next process. First, you will need to sign the radare2 binary:
 


### PR DESCRIPTION
The [original doc](https://github.com/radare/radare2/blob/master/doc/macos.md#code-signing) isn't particularly readable. I formatted it so it looks like [this](https://github.com/chrihala/radare2/blob/master/doc/macos.md#code-signing). 

I think this is more readable now. 