### PR TITLE
dbg.btalgo=trace: trace calls for backtrace

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2631,7 +2631,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("dbg.forks", "false", &cb_dbg_forks, "Stop execution if fork() is done (see dbg.threads)");
 	n = NODECB ("dbg.btalgo", "fuzzy", &cb_dbg_btalgo);
 	SETDESC (n, "Select backtrace algorithm");
-	SETOPTIONS (n, "default", "fuzzy", "anal", NULL);
+	SETOPTIONS (n, "default", "fuzzy", "anal", "trace", NULL);
 	SETCB ("dbg.threads", "false", &cb_stopthreads, "Stop all threads when debugger breaks (see dbg.forks)");
 	SETCB ("dbg.clone", "false", &cb_dbg_clone, "Stop execution if new thread is created");
 	SETCB ("dbg.aftersyscall", "true", &cb_dbg_aftersc, "Stop execution before the syscall is executed (see dcs)");

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -324,6 +324,7 @@ R_API RDebug *r_debug_new(int hard) {
 	dbg->maps = r_debug_map_list_new ();
 	dbg->maps_user = r_debug_map_list_new ();
 	dbg->q_regs = NULL;
+	dbg->call_frames = NULL;
 	r_debug_signal_init (dbg);
 	if (hard) {
 		dbg->bp = r_bp_new ();
@@ -361,6 +362,7 @@ R_API RDebug *r_debug_free(RDebug *dbg) {
 		sdb_foreach (dbg->tracenodes, (SdbForeachCallback)free_tracenodes_entry, dbg);
 		sdb_free (dbg->tracenodes);
 		r_list_free (dbg->plugins);
+		r_list_free (dbg->call_frames);
 		free (dbg->btalgo);
 		r_debug_trace_free (dbg->trace);
 		dbg->trace = NULL;

--- a/libr/debug/p/native/bt.c
+++ b/libr/debug/p/native/bt.c
@@ -43,7 +43,7 @@ static RList *r_debug_native_frames(RDebug *dbg, ut64 at) {
 		}
 	}
 
-	list = cb (dbg, at);
+	list = !strcmp (dbg->btalgo, "trace") ? r_list_clone (dbg->call_frames) : cb (dbg, at);
 	prepend_current_pc (dbg, list);
 
 	return list;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -282,6 +282,7 @@ typedef struct r_debug_t {
 	RDebugTrace *trace;
 	Sdb *tracenodes;
 	RTree *tree;
+	RList *call_frames;
 
 	RReg *reg;
 	RList *q_regs;


### PR DESCRIPTION
- Needed because some code manipulate the stack pointer in unnatural ways (e.g. glibc ELF i386 loader)
- Only for 32-bit x86 (for now)
- Somewhat slow

Screenshot:
![dbg btalgo trace](https://user-images.githubusercontent.com/12002672/39404903-3435e9c6-4bce-11e8-9306-8e123d3599c2.png)
