### PR TITLE
Add MACH0_(new_buf_steal)

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -1272,12 +1272,12 @@ struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, bool verbose) {
 }
 
 struct MACH0_(obj_t)* MACH0_(new_buf)(RBuffer *buf, bool verbose) {
-	RBuffer * buf_copy = r_buf_new ();
-	if (!buf_copy) {
+	if (!buf) {
 		return NULL;
 	}
 
-	if (!r_buf_set_bytes (buf_copy, buf->buf, buf->length)) {
+	RBuffer * buf_copy = r_buf_new_with_buf (buf);
+	if (!buf_copy) {
 		return NULL;
 	}
 

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -618,6 +618,7 @@ static int parse_thread(struct MACH0_(obj_t)* bin, struct load_command *lc, ut64
 	ut8 *arw_ptr = NULL;
 	int arw_sz, len = 0;
 	ut8 thc[sizeof (struct thread_command)] = {0};
+	ut8 tmp[4];
 
 	if (off > bin->size || off + sizeof (struct thread_command) > bin->size)
 		return false;
@@ -628,7 +629,8 @@ static int parse_thread(struct MACH0_(obj_t)* bin, struct load_command *lc, ut64
 	}
 	bin->thread.cmd = r_read_ble32 (&thc[0], bin->big_endian);
 	bin->thread.cmdsize = r_read_ble32 (&thc[4], bin->big_endian);
-	flavor = r_read_ble32 (bin->b->buf + off + sizeof (struct thread_command), bin->big_endian);
+	r_buf_read_at (bin->b, off + sizeof (struct thread_command), tmp, 4);
+	flavor = r_read_ble32 (tmp, bin->big_endian);
 	if (len == -1)
 		goto wrong_read;
 
@@ -637,8 +639,8 @@ static int parse_thread(struct MACH0_(obj_t)* bin, struct load_command *lc, ut64
 		return false;
 
 	// TODO: use count for checks
-	count = r_read_ble32 (bin->b->buf + off + sizeof (struct thread_command) + sizeof (flavor),
-				bin->big_endian);
+	r_buf_read_at (bin->b, off + sizeof (struct thread_command) + sizeof (flavor), tmp, 4);
+	count = r_read_ble32 (tmp, bin->big_endian);
 	ptr_thread = off + sizeof (struct thread_command) + sizeof (flavor) + sizeof (count);
 
 	if (ptr_thread > bin->size)
@@ -1266,20 +1268,27 @@ struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, bool verbose) {
 }
 
 struct MACH0_(obj_t)* MACH0_(new_buf)(RBuffer *buf, bool verbose) {
+	RBuffer * buf_copy = r_buf_new ();
+	if (!buf_copy) {
+		return NULL;
+	}
+
+	if (!r_buf_set_bytes (buf_copy, buf->buf, buf->length)) {
+		return NULL;
+	}
+
+	return MACH0_(new_buf_steal) (buf_copy, verbose);
+}
+
+struct MACH0_(obj_t)* MACH0_(new_buf_steal)(RBuffer *buf, bool verbose) {
 	struct MACH0_(obj_t) *bin = R_NEW0 (struct MACH0_(obj_t));
 	if (!bin) {
 		return NULL;
 	}
 	bin->kv = sdb_new (NULL, "bin.mach0", 0);
-	bin->size = buf->length;
+	bin->size = r_buf_size (buf);
 	bin->verbose = verbose;
-// 	bin->b = r_buf_ref (buf);
-#if 1
-	bin->b = r_buf_new ();
-	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)) {
-		return MACH0_(mach0_free) (bin);
-	}
-#endif
+	bin->b = buf;
 	if (!init (bin)) {
 		return MACH0_(mach0_free)(bin);
 	}

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -629,7 +629,9 @@ static int parse_thread(struct MACH0_(obj_t)* bin, struct load_command *lc, ut64
 	}
 	bin->thread.cmd = r_read_ble32 (&thc[0], bin->big_endian);
 	bin->thread.cmdsize = r_read_ble32 (&thc[4], bin->big_endian);
-	r_buf_read_at (bin->b, off + sizeof (struct thread_command), tmp, 4);
+	if (r_buf_read_at (bin->b, off + sizeof (struct thread_command), tmp, 4) < 4) {
+		goto wrong_read;
+	}
 	flavor = r_read_ble32 (tmp, bin->big_endian);
 	if (len == -1)
 		goto wrong_read;
@@ -639,7 +641,9 @@ static int parse_thread(struct MACH0_(obj_t)* bin, struct load_command *lc, ut64
 		return false;
 
 	// TODO: use count for checks
-	r_buf_read_at (bin->b, off + sizeof (struct thread_command) + sizeof (flavor), tmp, 4);
+	if (r_buf_read_at (bin->b, off + sizeof (struct thread_command) + sizeof (flavor), tmp, 4) < 4) {
+		goto wrong_read;
+	}
 	count = r_read_ble32 (tmp, bin->big_endian);
 	ptr_thread = off + sizeof (struct thread_command) + sizeof (flavor) + sizeof (count);
 

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -138,6 +138,7 @@ struct MACH0_(obj_t) {
 
 struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, bool verbose);
 struct MACH0_(obj_t)* MACH0_(new_buf)(struct r_buf_t *buf, bool verbose);
+struct MACH0_(obj_t)* MACH0_(new_buf_steal)(struct r_buf_t *buf, bool verbose);
 void* MACH0_(mach0_free)(struct MACH0_(obj_t)* bin);
 struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin);
 struct symbol_t* MACH0_(get_symbols)(struct MACH0_(obj_t)* bin);


### PR DESCRIPTION
This is a step towards avoiding unnecessary copies of the buffer, not ready yet to be used instead of `MACH0_(new_buf)` everywhere because of `r_buf_fcpy_at not supported yet for r_buf_new_file` is still an issue when used with an io buffer directly.

Also fixed a couple of reads which assumed all the buffer is loaded in memory.

I'm experimenting with this here: https://github.com/mrmacete/r2-ios-kernelcache

but will be useful in near future for dyld cache too.