### PR TITLE
Use system diff in graphdiff nodes if possible and improve graphviz style

### DIFF
--- a/binr/radiff2/radiff2.c
+++ b/binr/radiff2/radiff2.c
@@ -118,7 +118,7 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 				for (i = 0; i < len; i++) {
 					printf ("%02x", op->a_buf[i]);
 				}
-				char *p = r_str_escape((const char*)op->a_buf);
+				char *p = r_str_escape ((const char*)op->a_buf);
 				printf (" \"%s\"\n", p);
 				free (p);
 				if (!quiet) {
@@ -791,7 +791,9 @@ int main(int argc, char **argv) {
 		if (!c || !c2) {
 			eprintf ("Cannot open '%s'\n", r_str_get (file2));
 			return 1;
-		}	
+		}
+		c->c2 = c2;
+		c2->c2 = c;
 		if (arch) {
 			r_config_set (c->config, "asm.arch", arch);
 			r_config_set (c2->config, "asm.arch", arch);
@@ -914,7 +916,9 @@ int main(int argc, char **argv) {
 			write (1, "\x04", 1);
 		}
 		if (diffmode == 'U') {
-			r_diff_buffers_unified (d, bufa, sza, bufb, szb);
+			char * res = r_diff_buffers_unified (d, bufa, sza, bufb, szb);
+			printf ("%s\n", res);
+			free (res);
 		} else if (diffmode == 'B') {
 			r_diff_set_callback (d, &bcb, 0);
 			r_diff_buffers (d, bufa, sza, bufb, szb);

--- a/binr/radiff2/radiff2.c
+++ b/binr/radiff2/radiff2.c
@@ -917,7 +917,7 @@ int main(int argc, char **argv) {
 		}
 		if (diffmode == 'U') {
 			char * res = r_diff_buffers_unified (d, bufa, sza, bufb, szb);
-			printf ("%s\n", res);
+			printf ("%s", res);
 			free (res);
 		} else if (diffmode == 'B') {
 			r_diff_set_callback (d, &bcb, 0);

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2010-2016 - nibble, pancake */
+/* radare - LGPL - Copyright 2010-2018 - nibble, pancake */
 
 #include <stdio.h>
 #include <string.h>
@@ -90,7 +90,6 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
         int maxsize = 0;
         int digits = 1;
         int len;
-
 
         r_list_foreach (fcns, iter, f) {
                 if (f->name && (len = strlen (f->name)) > maxnamelen) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -207,6 +207,7 @@ typedef struct r_core_t {
 	RList *undos;
 	bool fixedbits;
 	bool fixedarch;
+	struct r_core_t *c2;
 } RCore;
 
 R_API int r_core_bind(RCore *core, RCoreBind *bnd);

--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -47,11 +47,12 @@ R_API int r_diff_buffers_static(RDiff *d, const ut8 *a, int la, const ut8 *b, in
 R_API int r_diff_buffers_radiff(RDiff *d, const ut8 *a, int la, const ut8 *b, int lb);
 R_API int r_diff_buffers_delta(RDiff *diff, const ut8 *sa, int la, const ut8 *sb, int lb);
 R_API int r_diff_buffers(RDiff *d, const ut8 *a, ut32 la, const ut8 *b, ut32 lb);
+R_API char *r_diff_buffers_to_string(RDiff *d, const ut8 *a, int la, const ut8 *b, int lb);
 R_API int r_diff_set_callback(RDiff *d, RDiffCallback callback, void *user);
 R_API bool r_diff_buffers_distance(RDiff *d, const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance, double *similarity);
 R_API bool r_diff_buffers_distance_myers(RDiff *diff, const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance, double *similarity);
 R_API bool r_diff_buffers_distance_levenstein(RDiff *d, const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance, double *similarity);
-R_API int r_diff_buffers_unified(RDiff *d, const ut8 *a, int la, const ut8 *b, int lb);
+R_API char *r_diff_buffers_unified(RDiff *d, const ut8 *a, int la, const ut8 *b, int lb);
 /* static method !??! */
 R_API int r_diff_lines(const char *file1, const char *sa, int la, const char *file2, const char *sb, int lb);
 R_API int r_diff_set_delta(RDiff *d, int delta);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -437,6 +437,10 @@ R_API int r_sys_chdir(const char *s) {
 
 #if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
 R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, int *len, char **sterr) {
+	char *mysterr = NULL;
+	if (!sterr) {
+		sterr = &mysterr;
+	}
 	char buffer[1024], *outputptr = NULL;
 	char *inputptr = (char *)input;
 	int pid, bytes = 0, status;
@@ -528,7 +532,7 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 				if (!(bytes = read (sh_out[0], buffer, sizeof (buffer)-1))) {
 					break;
 				}
-				buffer[sizeof(buffer) - 1] = '\0';
+				buffer[sizeof (buffer) - 1] = '\0';
 				if (len) {
 					*len += bytes;
 				}
@@ -537,7 +541,7 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 				if (!read (sh_err[0], buffer, sizeof (buffer)-1)) {
 					break;
 				}
-				buffer[sizeof(buffer) - 1] = '\0';
+				buffer[sizeof (buffer) - 1] = '\0';
 				*sterr = r_str_append (*sterr, buffer);
 			} else if (FD_ISSET (sh_in[1], &wfds) && inputptr && *inputptr) {
 				int inputptr_len = strlen (inputptr);
@@ -564,10 +568,11 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 		waitpid (pid, &status, 0);
 		bool ret = true;
 		if (status) {
-			char *escmd = r_str_escape (cmd);
-			eprintf ("error code %d\n", WEXITSTATUS(status));
-			//eprintf ("%s: failed command '%s'\n", __func__, escmd);
-			free (escmd);
+			// char *escmd = r_str_escape (cmd);
+			// eprintf ("error code %d (%s): %s\n", WEXITSTATUS (status), escmd, *sterr);
+			// eprintf ("(%s)\n", output);
+			// eprintf ("%s: failed command '%s'\n", __func__, escmd);
+			// free (escmd);
 			ret = false;
 		}
 


### PR DESCRIPTION
$ radiff2 -g sym._call -A  b c | dot -Tpng > a.png

- we need disasmdiff native in r2, as well as more inter-core commands

![a](https://user-images.githubusercontent.com/917142/39412068-be869c68-4c16-11e8-97d9-14b5171633b4.png)
