### PR TITLE
Reduce r2 default subdirs paths for Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,7 +89,7 @@ endif
 if host_machine.system() == 'windows'
   r2_prefix = '.'
   r2_libdir = 'lib'
-  r2_incdir = 'include/libr'
+  r2_incdir = 'include'
   r2_datdir = 'share'
 
   opts1 = ['r2_libdir', 'r2_incdir', 'r2_datdir']
@@ -100,12 +100,12 @@ if host_machine.system() == 'windows'
     endif
   endforeach
 
-  r2_wwwroot = join_paths(r2_datdir, 'radare2', r2_version, 'www')
-  r2_sdb = join_paths(r2_datdir, 'radare2', r2_version)
-  r2_zigns = join_paths(r2_datdir, 'radare2', r2_version, 'zigns')
-  r2_themes = join_paths(r2_datdir, 'radare2', r2_version, 'cons')
-  r2_fortunes = join_paths(r2_datdir, 'doc/radare2')
-  r2_hud = join_paths(r2_datdir, 'radare2', r2_version, 'hud')
+  r2_wwwroot = join_paths(r2_datdir, 'www')
+  r2_sdb = join_paths(r2_datdir)
+  r2_zigns = join_paths(r2_datdir, 'zigns')
+  r2_themes = join_paths(r2_datdir, 'cons')
+  r2_fortunes = join_paths(r2_datdir, 'doc')
+  r2_hud = join_paths(r2_datdir, 'hud')
 
   opts2 = ['r2_wwwroot', 'r2_sdb', 'r2_zigns', 'r2_themes', 'r2_fortunes', 'r2_hud']
   foreach opt : opts2

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -15,14 +15,14 @@ BACKENDS = ['ninja', 'vs2015', 'vs2017']
 PATH_FMT = {}
 R2_PATH = {
     'R2_LIBDIR': r'lib',
-    'R2_INCDIR': r'include\libr',
+    'R2_INCDIR': r'include',
     'R2_DATDIR': r'share',
-    'R2_WWWROOT': r'{R2_DATDIR}\radare2\{R2_VERSION}\www',
-    'R2_SDB': r'{R2_DATDIR}\radare2\{R2_VERSION}',
-    'R2_ZIGNS': r'{R2_DATDIR}\radare2\{R2_VERSION}\zigns',
-    'R2_THEMES': r'{R2_DATDIR}\radare2\{R2_VERSION}\cons',
-    'R2_FORTUNES': r'{R2_DATDIR}\doc\radare2',
-    'R2_HUD': r'{R2_DATDIR}\radare2\{R2_VERSION}\hud'
+    'R2_WWWROOT': r'{R2_DATDIR}\www',
+    'R2_SDB': r'{R2_DATDIR}',
+    'R2_ZIGNS': r'{R2_DATDIR}\zigns',
+    'R2_THEMES': r'{R2_DATDIR}\cons',
+    'R2_FORTUNES': r'{R2_DATDIR}\doc',
+    'R2_HUD': r'{R2_DATDIR}\hud'
 }
 
 MESON = None


### PR DESCRIPTION
R2_INCDIR: include\libr -> include
R2_WWWROOT': share\radare2\{R2_VERSION}\www -> share\www
R2_SDB': share\radare2\{R2_VERSION} -> share
R2_ZIGNS': share\radare2\{R2_VERSION}\zigns -> share\zigns
R2_THEMES': share\radare2\{R2_VERSION}\cons -> share\cons
R2_FORTUNES': share\doc\radare2 -> share\doc
R2_HUD': share\radare2\{R2_VERSION}\hud -> share\hud