### PR TITLE
Fix #9925, some illegal instructions were actually assembled

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4272,7 +4272,7 @@ static int parseOperand(RAsm *a, const char *str, Operand *op, bool isrepop) {
 
 				// Still going to need to know the size if not specified
 				if (!explicit_size) {
-					op->type |= reg_type;
+					op->type = OT_UNKNOWN;
 				}
 				// Addressing only via general purpose registers
 				if (!(reg_type & OT_GPREG)) {


### PR DESCRIPTION
The x86.nz assembler would accept instructions like:
* inc [reg]
* mov [reg], imm

When should actually be throwing errors since the size of the destination is unspecified.

Now those instructions end up as invalid, while `mov [reg], reg` still works because size is inferred from the destination.