### PR TITLE
[WIP] Xrefs fixes

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -205,7 +205,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 		switch (rad) {
 		case '*':
 			anal->cb_printf ("ax%c 0x%"PFMT64x" 0x%"PFMT64x"\n",
-				t, ref->at, ref->addr);
+				t, ref->addr, ref->at);
 			break;
 		case '\0':
 			{
@@ -234,7 +234,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 				} else {
 					anal->cb_printf (",");
 				}
-				anal->cb_printf ("\"%"PFMT64d"\":%"PFMT64d, ref->at, ref->addr);
+				anal->cb_printf ("%"PFMT64d":%"PFMT64d, ref->at, ref->addr);
 			}
 			break;
 		default:

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -196,7 +196,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 	RListIter *iter;
 	RAnalRef *ref;
 	RList *list = r_anal_ref_list_new();
-	listxrefs (anal->dict_xrefs, UT64_MAX, list);
+	listxrefs (anal->dict_refs, UT64_MAX, list);
 	if (rad == 'j') {
 		anal->cb_printf ("{");
 	}

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -60,23 +60,6 @@ void xrefs_ref_free(HtKv *kv) {
 	free (kv);
 }
 
-static const char *analref_toString(RAnalRefType type) {
-	switch (type) {
-	case R_ANAL_REF_TYPE_NULL:
-		/* do nothing */
-		break;
-	case R_ANAL_REF_TYPE_CODE:
-		return "code jmp";
-	case R_ANAL_REF_TYPE_CALL:
-		return "code call";
-	case R_ANAL_REF_TYPE_DATA:
-		return "data mem";
-	case R_ANAL_REF_TYPE_STRING:
-		return "data string";
-	}
-	return "unk";
-}
-
 static bool appendRef(RList *list, const char *k, RAnalRef *ref) {
 	RAnalRef *cloned = r_anal_ref_new ();
 	if (!cloned) {
@@ -230,7 +213,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 				r_str_replace_char (name, ' ', 0);
 				anal->cb_printf ("%40s", name? name: "");
 				free (name);
-				anal->cb_printf (" 0x%"PFMT64x" -> %9s -> 0x%"PFMT64x, ref->at, analref_toString (t), ref->addr);
+				anal->cb_printf (" 0x%"PFMT64x" -> %9s -> 0x%"PFMT64x, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
 				r_str_replace_char (name, ' ', 0);
 				if (name && *name) {
@@ -242,7 +225,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 			}
 			break;
 		case 'q':
-			anal->cb_printf ("0x%08"PFMT64x" -> 0x%08"PFMT64x"  %s\n", ref->at, ref->addr, analref_toString (t));
+			anal->cb_printf ("0x%08"PFMT64x" -> 0x%08"PFMT64x"  %s\n", ref->at, ref->addr, r_anal_xrefs_type_tostring (t));
 			break;
 		case 'j':
 			{
@@ -267,7 +250,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 R_API const char *r_anal_xrefs_type_tostring(RAnalRefType type) {
 	switch (type) {
 	case R_ANAL_REF_TYPE_CODE:
-		return "JMP";
+		return "CODE";
 	case R_ANAL_REF_TYPE_CALL:
 		return "CALL";
 	case R_ANAL_REF_TYPE_DATA:

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2215,13 +2215,20 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	r_list_foreach (refs, refiter, refi) {
 		switch (refi->type) {
 		case R_ANAL_REF_TYPE_CALL:
-			r_cons_printf ("afxC 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->at, refi->addr);
+			r_cons_printf ("axC 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->addr, refi->at);
 			break;
 		case R_ANAL_REF_TYPE_DATA:
-			r_cons_printf ("afxd 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->at, refi->addr);
+			r_cons_printf ("axd 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->addr, refi->at);
 			break;
 		case R_ANAL_REF_TYPE_CODE:
-			r_cons_printf ("afxc 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->at, refi->addr);
+			r_cons_printf ("axc 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->addr, refi->at);
+			break;
+		case R_ANAL_REF_TYPE_STRING:
+			r_cons_printf ("axs 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->addr, refi->at);
+			break;
+		case R_ANAL_REF_TYPE_NULL:
+		default:
+			r_cons_printf ("ax 0x%"PFMT64x" 0x%"PFMT64x"\n", refi->addr, refi->at);
 			break;
 		}
 	}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -380,7 +380,8 @@ static const char *help_msg_afx[] = {
 	"Usage:", "afx[-cCd?] [src] [dst]", " manage function references (see also ar?)",
 	"afxc", " sym.main+0x38 sym.printf", "add code ref",
 	"afxC", " sym.main sym.puts", "add call ref",
-	"afxd", " sym.main str.helloworld", "add data ref",
+	"afxd", " sym.main obj.count", "add data ref",
+	"afxs", " sym.main str.helloworld", "add string ref",
 	"afx-", " sym.main str.helloworld", "remove reference",
 	NULL
 };
@@ -559,10 +560,11 @@ static const char *help_msg_av[] = {
 static const char *help_msg_ax[] = {
 	"Usage:", "ax[?d-l*]", " # see also 'afx?'",
 	"ax", "", "list refs",
+	"ax*", "", "output radare commands",
 	"ax", " addr [at]", "add code ref pointing to addr (from curseek)",
 	"ax-", " [at]", "clean all refs/refs from addr",
 	"ax-*", "", "clean all refs/refs",
-	"axc", " addr [at]", "add code jmp ref // unused?",
+	"axc", " addr [at]", "add generic code ref",
 	"axC", " addr [at]", "add code call ref",
 	"axg", " [addr]", "show xrefs graph to reach current function",
 	"axgj", " [addr]", "show xrefs graph to reach current function in json format",
@@ -572,7 +574,7 @@ static const char *help_msg_ax[] = {
 	"axF", " [flg-glob]", "find data/code references of flags",
 	"axt", " [addr]", "find data/code references to this address",
 	"axf", " [addr]", "find data/code references from this address",
-	"ax*", "", "output radare commands",
+	"axs", " addr [at]", "add string ref",
 	NULL
 };
 
@@ -2559,11 +2561,9 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		case '\0': // "afx"
 		case 'j': // "afxj"
 		case ' ': // "afx "
-#if FCN_OLD
 			if (input[2] == 'j') {
 				r_cons_printf ("[");
 			}
-			// TODO: sdbize!
 			// list xrefs from current address
 			{
 				ut64 addr = input[2]==' '? r_num_math (core->num, input + 2): core->offset;
@@ -2589,10 +2589,6 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			if (input[2] == 'j') {
 				r_cons_printf ("]\n");
 			}
-#else
-#warning TODO_ FCNOLD sdbize xrefs here
-			eprintf ("TODO\n");
-#endif
 			break;
 		case 'c': // "afxc" add code xref
 		case 'd': // "afxd"
@@ -5347,6 +5343,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case 'C': // "axC"
 	case 'c': // "axc"
 	case 'd': // "axd"
+	case 's': // "axs"
 	case ' ': // "ax "
 		{
 		char *ptr = strdup (r_str_trim_head ((char *)input + 1));

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2643,7 +2643,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 						//eprintf ("Warning: ignore 0x%08"PFMT64x" call 0x%08"PFMT64x"\n", ref->at, ref->addr);
 						continue;
 					}
-					if (ref->type != 'c' && ref->type != 'C') {
+					if (ref->type != R_ANAL_REF_TYPE_CODE && ref->type != R_ANAL_REF_TYPE_CALL) {
 						/* only follow code/call references */
 						continue;
 					}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -226,7 +226,7 @@ static const char *help_msg_af[] = {
 	"aft", "[?]", "type matching, type propagation",
 	"afu", " [addr]", "resize and analyze function from current address until addr",
 	"afv[bsra]", "?", "manipulate args, registers and variables in function",
-	"afx", "[cCd-] src dst", "add/remove code/Call/data/string reference",
+	"afx", "", "list function references",
 	NULL
 };
 
@@ -373,16 +373,6 @@ static const char *help_msg_afvs[] = {
 	"afvs-", " [name]", "delete stack based argument or locals with the given name",
 	"afvsg", " [idx] [addr]", "define var get reference",
 	"afvss", " [idx] [addr]", "define var set reference",
-	NULL
-};
-
-static const char *help_msg_afx[] = {
-	"Usage:", "afx[-cCd?] [src] [dst]", " manage function references (see also ar?)",
-	"afxc", " sym.main+0x38 sym.printf", "add code ref",
-	"afxC", " sym.main sym.puts", "add call ref",
-	"afxd", " sym.main obj.count", "add data ref",
-	"afxs", " sym.main str.helloworld", "add string ref",
-	"afx-", " sym.main str.helloworld", "remove reference",
 	NULL
 };
 
@@ -601,7 +591,6 @@ static void cmd_anal_init(RCore *core) {
 	DEFINE_CMD_DESCRIPTOR (core, afvb);
 	DEFINE_CMD_DESCRIPTOR (core, afvr);
 	DEFINE_CMD_DESCRIPTOR (core, afvs);
-	DEFINE_CMD_DESCRIPTOR (core, afx);
 	DEFINE_CMD_DESCRIPTOR (core, ag);
 	DEFINE_CMD_DESCRIPTOR (core, age);
 	DEFINE_CMD_DESCRIPTOR (core, agg);
@@ -2590,44 +2579,8 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 				r_cons_printf ("]\n");
 			}
 			break;
-		case 'c': // "afxc" add code xref
-		case 'd': // "afxd"
-		case 's': // "afxs"
-		case 'C': { // "afxC"
-			char *p;
-			ut64 a, b;
-			char *mi = strdup (input);
-			if (mi && mi[3] == ' ' && (p = strchr (mi + 4, ' '))) {
-				RAnalRefType reftype = r_anal_xrefs_type (input[2]);
-				*p = 0;
-				a = r_num_math (core->num, mi + 3);
-				b = r_num_math (core->num, p + 1);
-				r_anal_xrefs_set (core->anal, a, b, reftype);
-			} else {
-				r_core_cmd_help (core, help_msg_afx);
-			}
-			free (mi);
-			}
-			break;
-		case '-': // "afx-"
-			{
-			char *p;
-			ut64 a, b;
-			char *mi = strdup (input + 3);
-			if (mi && *mi == ' ' && (p = strchr (mi + 1, ' '))) {
-				*p = 0;
-				a = r_num_math (core->num, mi);
-				b = r_num_math (core->num, p + 1);
-				r_anal_xrefs_deln (core->anal, a, b, -1);
-			} else {
-				eprintf ("Usage: afx- [src] [dst]\n");
-			}
-			free (mi);
-			}
-			break;
 		default:
-		case '?': // "afx?"
-			r_core_cmd_help (core, help_msg_afx);
+			eprintf ("Wrong command. Look at af?\n");
 			break;
 		}
 		break;

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2215,9 +2215,6 @@ static int get_cgnodes(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 
 	refs = r_anal_fcn_get_refs (core->anal, fcn);
 	r_list_foreach (refs, iter, ref) {
-		/* XXX: something is broken, why there are duplicated
-		 *      nodes here?! goto check fcn->refs!! */
-		/* avoid dups wtf */
 		title = get_title (ref->addr);
 		if (r_agraph_get_node (g, title) != NULL) {
 			continue;


### PR DESCRIPTION
* uniform xref output (CODE,CALL,DATA,STRING)
* avoid confusion in `ax` command (e.g. arrows direction)
* introduce `axs`
* remove `afxX` commands. Keep only `afx` to list function references, but remove afx-, afxC, afxc, etc. because there are no "function references" anymore. There are just references in the whole binary, not per-function.