### PR TITLE
Refactor and optimize afta

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -457,12 +457,6 @@ static char *get_varname(RAnal *a, RAnalFunction *fcn, char type, const char *pf
 	while (1) {
 		RAnalVar *v = r_anal_var_get_byname (a, fcn, varname);
 		if (!v) {
-			v = r_anal_var_get_byname (a, fcn, varname);
-		}
-		if (!v) {
-			v = r_anal_var_get_byname (a, fcn, varname);
-		}
-		if (!v) {
 			break;
 		}
 		if (v->kind == type && R_ABS (v->delta) == idx) {

--- a/libr/anal/types.c
+++ b/libr/anal/types.c
@@ -70,7 +70,7 @@ R_API void r_anal_type_del(RAnal *anal, const char *name) {
 	}
 }
 
-R_API int r_anal_type_get_size(RAnal *anal, const char *type) {
+R_API int r_anal_type_get_bitsize(RAnal *anal, const char *type) {
 	char *query;
 	/* Filter out the structure keyword if type looks like "struct mystruc" */
 	const char *tmptype;
@@ -118,7 +118,7 @@ R_API int r_anal_type_get_size(RAnal *anal, const char *type) {
 					if (elements == 0) {
 						elements = 1;
 					}
-					ret += r_anal_type_get_size (anal, subtype) * elements;
+					ret += r_anal_type_get_bitsize (anal, subtype) * elements;
 				}
 				free (subtype);
 				ptr = next;
@@ -172,7 +172,7 @@ static int get_types_by_offset(RAnal *anal, RList *offtypes, int offset, const c
 						sprintf (buf, "%s.%s", k, name);
 						r_list_append (offtypes, strdup (buf));
 					}
-					typesize += r_anal_type_get_size (anal, subtype) * elements;
+					typesize += r_anal_type_get_bitsize (anal, subtype) * elements;
 				}
 				free (subtype);
 				ptr = next;

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -513,7 +513,7 @@ static void var_add_structure_fields_to_list(RAnal *a, RAnalVar *av, const char 
 			char *field_type = sdb_array_get (TDB, field_key, 0, NULL);
 			ut64 field_offset = sdb_array_get_num (TDB, field_key, 1, NULL);
 			int field_count = sdb_array_get_num (TDB, field_key, 2, NULL);
-			int field_size = r_anal_type_get_size (a, field_type) * (field_count? field_count: 1);
+			int field_size = r_anal_type_get_bitsize (a, field_type) * (field_count? field_count: 1);
 			new_name = r_str_newf ( "%s.%s", base_name, field_name);
 			if (field_offset == 0) {
 				free (av->name);

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -132,12 +132,12 @@ R_API int r_anal_var_retype(RAnal *a, ut64 addr, int scope, int delta, char kind
 		eprintf ("Cant find function here\n");
 		return false;
 	}
-	if (size == -1) {
+	if ((size == -1) && (delta == -1) ) {
 		RList *list = r_anal_var_list (a, fcn, kind);
 		RListIter *iter;
 		RAnalVar *var;
 		r_list_foreach (list, iter, var) {
-			if (delta == -1 && !strcmp (var->name, name)) {
+			if (!strcmp (var->name, name)) {
 				delta = var->delta;
 				size = var->size;
 				break;
@@ -156,7 +156,7 @@ R_API int r_anal_var_retype(RAnal *a, ut64 addr, int scope, int delta, char kind
 	}
 	const char *var_def = sdb_fmt ("%c,%s,%d,%s", kind, type, size, name);
 	if (scope > 0) {
-		char *sign = delta> 0? "": "_";
+		char *sign = delta >= 0 ? "": "_";
 		/* local variable */
 		const char *fcn_key = sdb_fmt ("fcn.0x%"PFMT64x ".%c", fcn->addr, kind);
 		const char *var_key = sdb_fmt ("var.0x%"PFMT64x ".%c.%d.%s%d", fcn->addr, kind, scope, sign, R_ABS(delta));

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -123,7 +123,7 @@ static void type_match(RCore *core, ut64 addr, char *name, int prev_idx) {
 				break;
 			}
 		}
-		size += r_anal_type_get_size (anal, type) / 8;
+		size += r_anal_type_get_bitsize (anal, type) / 8;
 	}
 	r_cons_break_pop ();
 	free (fcn_name);

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -221,14 +221,17 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 	RListIter *it;
 	RAnalOp aop = {0};
 	ut64 prevpc;
-	int ret, bsize = R_MAX (64, core->blocksize);
-	const int mininstrsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
-	const int minopcode = R_MAX (1, mininstrsz);
-	int cur_idx , prev_idx = core->anal->esil->trace_idx;
 
 	if (!core|| !fcn) {
 		return;
 	}
+	if (!core->anal->esil) {
+		return;
+	}
+	int ret, bsize = R_MAX (64, core->blocksize);
+	const int mininstrsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
+	const int minopcode = R_MAX (1, mininstrsz);
+	int cur_idx , prev_idx = core->anal->esil->trace_idx;
 	RConfigHold *hc = r_config_hold_new (core->config);
 	if (!hc) {
 		return;

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -37,11 +37,48 @@ static void r_anal_emul_restore(RCore *core, RConfigHold *hc) {
 	r_config_hold_free (hc);
 }
 
+static void type_match_var(RAnal *anal , Sdb *trace, ut64 addr,const char *type, int idx) {
+	RAnalVar *v;
+	const char *sp_name = r_reg_get_name (anal->reg, R_REG_NAME_SP);
+	const char *bp_name = r_reg_get_name (anal->reg, R_REG_NAME_BP);
+	ut64 sp = r_reg_getv (anal->reg, sp_name);
+	ut64 bp = r_reg_getv (anal->reg, bp_name);
+	char *key = sdb_fmt ("%d.mem.read", idx);
+	int i, array_size = sdb_array_size (trace, key);
+
+	for (i = 0; i < array_size; i++) {
+		if (bp_name) {
+			int bp_idx = sdb_array_get_num (trace, key, i, 0) - bp;
+			if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_BPV, 1, bp_idx))) {
+				r_anal_var_retype (anal, addr, 1, bp_idx, R_ANAL_VAR_KIND_BPV, type, -1, v->name);
+				r_anal_var_free (v);
+			}
+		}
+		int sp_idx = sdb_array_get_num (trace, key, i, 0) - sp;
+		if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_SPV, 1, sp_idx))) {
+			r_anal_var_retype (anal, addr, 1, sp_idx, R_ANAL_VAR_KIND_SPV, type, -1, v->name);
+			r_anal_var_free (v);
+		}
+	}
+}
+
+static bool type_pos_hit(RAnal *anal, Sdb *trace, bool in_stack, int idx, int size, const char *place) {
+	if (in_stack) {
+		const char *sp_name = r_reg_get_name (anal->reg, R_REG_NAME_SP);
+		ut64 sp = r_reg_getv (anal->reg, sp_name);
+		ut64 write_addr = sdb_num_get (trace, sdb_fmt ("%d.mem.write", idx), 0);
+		return (write_addr == sp + size);
+	} else {
+		return sdb_array_contains (trace, sdb_fmt ("%d.reg.write", idx), place, 0);
+	}
+}
+
 static void type_match(RCore *core, ut64 addr, char *name) {
 	Sdb *trace = core->anal->esil->db_trace;
 	RAnal *anal = core->anal;
-	RAnalVar *v;
 	char *fcn_name;
+	bool stack_rev = false, in_stack = false;
+
 	if (r_anal_type_func_exist (anal, name)) {
 		fcn_name = strdup (name);
 	} else if (!(fcn_name = r_anal_type_func_guess (anal, name))) {
@@ -53,133 +90,36 @@ static void type_match(RCore *core, ut64 addr, char *name) {
 		//eprintf ("can't find %s calling convention %s\n", fcn_name, cc);
 		return;
 	}
-	int i, j, max = r_anal_type_func_args_count (anal, fcn_name);
-	int size = 0, idx = sdb_num_get (trace, "idx", 0);
-	const char *sp_name = r_reg_get_name (anal->reg, R_REG_NAME_SP);
-	const char *bp_name = r_reg_get_name (anal->reg, R_REG_NAME_BP);
-	ut64 sp = r_reg_getv (anal->reg, sp_name);
-	ut64 bp = r_reg_getv (anal->reg, bp_name);
+	int i, j, size = 0, max = r_anal_type_func_args_count (anal, fcn_name);
+	int idx = sdb_num_get (trace, "idx", 0);
+	const char *place = r_anal_cc_arg (anal, cc, 1);
 	r_cons_break_push (NULL, NULL);
-	for (i = 0; i < max; i++) {
-		if (r_cons_is_breaked ()) {
-			goto out_function;
-		}
-		char *type = r_anal_type_func_args_type (anal, fcn_name, i);
-		const char *name = r_anal_type_func_args_name (anal, fcn_name, i);
-		const char *place = r_anal_cc_arg (anal, cc, i + 1);
-		if (!strcmp (place, "stack")) {
-			// type_match_stack ();
-			for (j = idx; j >= 0; j--) {
-				if (r_cons_is_breaked ()) {
-					goto out_function;
-				}
-				ut64 write_addr = sdb_num_get (trace, sdb_fmt ("%d.mem.write", j), 0);
-				if (write_addr == sp + size) {
-					ut64 instr_addr = sdb_num_get (trace, sdb_fmt ("%d.addr", j), 0);
-					r_meta_set_string (core->anal, R_META_TYPE_COMMENT, instr_addr,
-						sdb_fmt ("%s %s", type, name));
-					char *tmp = sdb_fmt ("%d.mem.read", j);
-					int i2, array_size = sdb_array_size (trace, tmp);
-					for (i2 = 0; i2 < array_size; i2++) {
-						if (bp_name) {
-							int bp_idx = sdb_array_get_num (trace, tmp, i2, 0) - bp;
-							if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_BPV, 1, bp_idx))) {
-								r_anal_var_retype (anal, addr, 1, bp_idx, R_ANAL_VAR_KIND_BPV, type, -1, v->name);
-								r_anal_var_free (v);
-							}
-						}
-						int sp_idx = sdb_array_get_num (trace, tmp, i2, 0) - sp;
-						if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_SPV, 1, sp_idx))) {
-							r_anal_var_retype (anal, addr, 1, sp_idx, R_ANAL_VAR_KIND_SPV, type, -1, v->name);
-							r_anal_var_free (v);
-						}
-					}
-					break;
-				}
-			}
-			size += r_anal_type_get_size (anal, type) / 8;
-		} else if (!strcmp (place , "stack_rev")) {
-			// type_match_stack_rev ();
-			free (type);
-			int k;
-			for ( k = max -1; k >=i; k--) {
-				if (r_cons_is_breaked ()) {
-					goto out_function;
-				}
-				type = r_anal_type_func_args_type (anal, fcn_name, k);
-				name = r_anal_type_func_args_name (anal, fcn_name, k);
-				place = r_anal_cc_arg (anal, cc, k + 1);
-				if (strcmp (place ,"stack_rev")) {
-					break;
-				}
-				for (j = idx; j >= 0; j--) {
-					if (r_cons_is_breaked ()) {
-						goto out_function;
-					}
-					ut64 write_addr = sdb_num_get (trace, sdb_fmt ("%d.mem.write", j), 0);
-					if (write_addr == sp + size) {
-						ut64 instr_addr = sdb_num_get (trace, sdb_fmt ("%d.addr", j), 0);
-						r_meta_set_string (core->anal, R_META_TYPE_COMMENT, instr_addr,
-								sdb_fmt ("%s%s%s", type, r_str_endswith (type, "*") ? "" : " ", name));
-						char *tmp = sdb_fmt ("%d.mem.read", j);
-						int i2, array_size = sdb_array_size (trace, tmp);
-						for (i2 = 0; i2 < array_size; i2++) {
-							if (bp_name) {
-								int bp_idx = sdb_array_get_num (trace, tmp, i2, 0) - bp;
-								if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_BPV, 1, bp_idx))) {
-									r_anal_var_retype (anal, addr, 1, bp_idx, R_ANAL_VAR_KIND_BPV, type, -1, v->name);
-									r_anal_var_free (v);
-								}
-							}
-							int sp_idx = sdb_array_get_num (trace, tmp, i2, 0) - sp;
-							if ((v =r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_SPV, 1, sp_idx))) {
-								r_anal_var_retype (anal, addr, 1, sp_idx, R_ANAL_VAR_KIND_SPV, type, -1, v->name);
-								r_anal_var_free (v);
-							}
-						}
-						break;
-					}
 
-				}
-				size += r_anal_type_get_size (anal, type) / 8;
-			}
-			break;
-		} else {
-			// type_match_reg ();
-			for (j = idx; j >= 0; j--) {
-				if (r_cons_is_breaked ()) {
-					goto out_function;
-				}
-				if (sdb_array_contains (trace, sdb_fmt ("%d.reg.write", j), place, 0)) {
-					ut64 instr_addr = sdb_num_get (trace, sdb_fmt ("%d.addr", j), 0);
-					r_meta_set_string (core->anal, R_META_TYPE_COMMENT, instr_addr,
-						sdb_fmt ("%s %s", type, name));
-					char *tmp = sdb_fmt ("%d.mem.read", j);
-					int i2, array_size = sdb_array_size (trace, tmp);
-					for (i2 = 0; i2 < array_size; i2++) {
-						if (r_cons_is_breaked ()) {
-							goto out_function;
-						}
-						if (bp_name) {
-							int bp_idx = sdb_array_get_num (trace, tmp, i2, 0) - bp;
-							if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_BPV, 1, bp_idx))) {
-								r_anal_var_retype (anal, addr, 1, bp_idx, R_ANAL_VAR_KIND_BPV, type, -1, v->name);
-								r_anal_var_free (v);
-							}
-						}
-						int sp_idx = sdb_array_get_num (trace, tmp, i2, 0) - sp;
-						if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_SPV, 1, sp_idx))) {
-							r_anal_var_retype (anal, addr, 1, sp_idx, R_ANAL_VAR_KIND_SPV, type, -1, v->name);
-							r_anal_var_free (v);
-						}
-					}
-					break;
-				}
+	if (!strcmp (place, "stack_rev")) {
+		stack_rev = true;
+	}
+	if (!strncmp (place, "stack", 5)) {
+		// type_match_reg
+		in_stack = true;
+	}
+	for (i = 0; i < max; i++) {
+		int arg_num = stack_rev ? (max - 1 - i) : i;
+		char *type = r_anal_type_func_args_type (anal, fcn_name, arg_num);
+		const char *name = r_anal_type_func_args_name (anal, fcn_name, arg_num);
+		if (!in_stack) {
+			place = r_anal_cc_arg (anal, cc, arg_num + 1);
+		}
+		for (j = idx; j >= 0; j--) {
+			if (type_pos_hit (anal, trace, in_stack, j, size, place)) {
+				ut64 instr_addr = sdb_num_get (trace, sdb_fmt ("%d.addr", j), 0);
+				r_meta_set_string (anal, R_META_TYPE_COMMENT, instr_addr,
+						sdb_fmt ("%s%s%s", type, r_str_endswith (type, "*") ? "" : " ", name));
+				type_match_var (anal, trace, addr, type , j);
+				break;
 			}
 		}
-		free (type);
+		size += r_anal_type_get_size (anal, type) / 8;
 	}
-out_function:
 	r_cons_break_pop ();
 	free (fcn_name);
 }
@@ -240,7 +180,10 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 		r_reg_setv (core->dbg->reg, pc, bb->addr);
 		r_debug_reg_sync (core->dbg, R_REG_TYPE_ALL, true);
 		r_cons_break_push (NULL, NULL);
-		while (!r_cons_is_breaked ()) {
+		while (1) {
+			if (r_cons_is_breaked ()) {
+				goto out_function;
+			}
 			RAnalOp *op = r_core_anal_op (core, addr);
 			int loop_count = sdb_num_get (core->anal->esil->db_trace, sdb_fmt ("0x%"PFMT64x".count", addr), 0);
 			if (loop_count > LOOP_MAX || !op || op->type == R_ANAL_OP_TYPE_RET || addr >= bb->addr + bb->size || addr < bb->addr) {
@@ -279,6 +222,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 		}
 		r_cons_break_pop();
 	}
+out_function:
 	r_cons_break_pop ();
 	r_anal_emul_restore (core, hc);
 	sdb_reset (core->anal->esil->db_trace);

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -483,7 +483,7 @@ static int cmd_type(void *data, const char *input) {
 			break;
 		case 's':
 			if (input[2] == ' ') {
-				r_cons_printf ("%d\n", (r_anal_type_get_size (core->anal, input + 3) / 8));
+				r_cons_printf ("%d\n", (r_anal_type_get_bitsize (core->anal, input + 3) / 8));
 			} else {
 				r_core_cmd_help (core, help_msg_ts);
 			}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4539,7 +4539,7 @@ toro:
 			if (fmt) {
 				r_cons_printf ("(%s)\n", link_type);
 				r_core_cmdf (core, "pf %s @ 0x%08"PFMT64x"\n", fmt, ds->addr + idx);
-				inc += r_anal_type_get_size (core->anal, link_type) / 8;
+				inc += r_anal_type_get_bitsize (core->anal, link_type) / 8;
 				free (fmt);
 				r_anal_op_fini (&ds->analop);
 				continue;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1228,7 +1228,7 @@ R_API RAnalFunction *r_listrange_find_in_range(RListRange* s, ut64 addr);
 R_API RAnalFunction *r_listrange_find_root(RListRange* s, ut64 addr);
 /* --------- */ /* REFACTOR */ /* ---------- */
 /* type.c */
-R_API int r_anal_type_get_size (RAnal *anal, const char *type);
+R_API int r_anal_type_get_bitsize (RAnal *anal, const char *type);
 R_API RList* r_anal_type_get_by_offset(RAnal *anal, ut64 offset);
 R_API RAnalType *r_anal_type_new(void);
 R_API void r_anal_type_add(RAnal *l, RAnalType *t);


### PR DESCRIPTION
Fixes #9544 

#### Before my fix : 
```
$ r2 ./abdb (bin from issue #9544)

[0x00404d88]> aaa
[0x00404d88]> ?t afta
84.954996

$ r2 ./vim
[0x00055a40]> aaa
[0x00055a40]> ?t afta
150.363169
```

#### After my fix : 

```
$ r2 ./abdb
[0x00404d88]> aaa
[0x00404d88]> ?t afta
5.308898

$r2 ./vim
[0x00055a40]> aaa
[0x00055a40]> ?t afta
13.387865
```

* Refacored the code by spliiting functions and cleanning it up
* Optimized the code by avoiding whole function emulation rather by emulating prev N instr to call
* Avoid creating dupe vars
* Honored ^C , so now it could be stopped :D