### PR TITLE
Add r_buf_new_slice

### DIFF
--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -23,9 +23,9 @@ typedef struct r_buf_t {
 	// RIOBind *iob;
 	// forward declaration
 	void *iob;
-    ut64 offset;
-    ut64 limit;
-    struct r_buf_t * parent;
+	ut64 offset;
+	ut64 limit;
+	struct r_buf_t * parent;
 } RBuffer;
 
 typedef struct r_buf_cache_t {

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -23,6 +23,9 @@ typedef struct r_buf_t {
 	// RIOBind *iob;
 	// forward declaration
 	void *iob;
+    ut64 offset;
+    ut64 limit;
+    struct r_buf_t * parent;
 } RBuffer;
 
 typedef struct r_buf_cache_t {
@@ -46,6 +49,7 @@ R_API RBuffer *r_buf_new_slurp(const char *file);
 R_API RBuffer *r_buf_new_empty (ut64 len);
 R_API RBuffer *r_buf_mmap(const char *file, int flags);
 R_API RBuffer *r_buf_new_sparse(ut8 Oxff);
+R_API RBuffer *r_buf_new_slice(RBuffer *b, ut64 offset, ut64 size);
 R_API bool r_buf_dump (RBuffer *buf, const char *file);
 R_API RBuffer *r_buf_ref(RBuffer *b);
 /* methods */

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -109,7 +109,7 @@ static bool sparse_limits(RList *l, ut64 *min, ut64 *max) {
 R_API RBuffer *r_buf_new_with_io(void *iob, int fd) {
 	RBuffer *b = r_buf_new ();
 	b->iob = iob;
-	b->fd = fd; 
+	b->fd = fd;
 	return b;
 }
 
@@ -170,9 +170,31 @@ R_API RBuffer *r_buf_new_sparse(ut8 Oxff) {
 	return b;
 }
 
+R_API RBuffer *r_buf_new_slice(RBuffer *b, ut64 offset, ut64 size) {
+	if (b && b->sparse) {
+		eprintf ("r_buf_new_slice not supported yet for sparse buffers\n");
+		return NULL;
+	}
+	RBuffer *buf = R_NEW0 (RBuffer);
+	if (!buf) {
+		return NULL;
+	}
+	memcpy (buf, b, sizeof (RBuffer));
+	buf->parent = r_buf_ref (b);
+	buf->ro = true;
+	buf->offset = offset;
+	if (buf->base > 0) {
+		buf->base += offset;
+	}
+	buf->limit = size;
+	return buf;
+}
+
 R_API RBuffer *r_buf_new() {
 	RBuffer *b = R_NEW0 (RBuffer);
 	if (b) {
+		b->offset = 0;
+		b->limit = UT64_MAX;
 		b->fd = -1;
 		b->Oxff = 0xff;
 	}
@@ -189,10 +211,10 @@ R_API ut64 r_buf_size (RBuffer *b) {
 	}
 	if (b->iob) {
 		RIOBind *iob = b->iob;
-		return iob->fd_size (iob->io, b->fd);
+		return R_MIN (b->limit, R_MAX (0, iob->fd_size (iob->io, b->fd) - b->offset));
 	}
 	if (b->fd != -1) {
-		return b->length;
+		return R_MIN (b->limit, R_MAX (0, b->length - b->offset));
 	}
 	if (b->sparse) {
 		ut64 max = 0LL;
@@ -201,7 +223,7 @@ R_API ut64 r_buf_size (RBuffer *b) {
 		}
 		return 0LL;
 	}
-	return b->empty? 0: b->length;
+	return b->empty? 0: R_MIN (b->limit, R_MAX (0, b->length - b->offset));
 }
 
 // rename to new?
@@ -266,15 +288,16 @@ R_API bool r_buf_dump(RBuffer *b, const char *file) {
 
 R_API int r_buf_seek (RBuffer *b, st64 addr, int whence) {
 	ut64 min = 0LL, max = 0LL;
+	ut64 pa = addr - b->base + b->offset;
 	if (b->fd != -1) {
-		if (r_sandbox_lseek (b->fd, addr, whence) == -1) {
+		if (r_sandbox_lseek (b->fd, pa, whence) == -1) {
 			// seek failed - print error here?
 			return -1;
 		}
 	} else if (b->sparse) {
 		sparse_limits (b->sparse, &min, &max);
 		switch (whence) {
-		case R_IO_SEEK_SET: b->cur = addr; break;
+		case R_IO_SEEK_SET: b->cur = pa; break;
 		case R_IO_SEEK_CUR: b->cur = b->cur + addr; break;
 		case R_IO_SEEK_END:
 			    if (sparse_limits (b->sparse, NULL, &max)) {
@@ -283,13 +306,14 @@ R_API int r_buf_seek (RBuffer *b, st64 addr, int whence) {
 			    b->cur = max + addr; break; //b->base + b->length + addr; break;
 		}
 	} else {
+		ut64 effective_size = r_buf_size (b);
 		min = b->base;
-		max = b->base + b->length;
+		max = b->base + effective_size;
 		switch (whence) {
 		//case 0: b->cur = b->base + addr; break;
-		case R_IO_SEEK_SET: b->cur = addr; break;
+		case R_IO_SEEK_SET: b->cur = pa; break;
 		case R_IO_SEEK_CUR: b->cur = b->cur + addr; break;
-		case R_IO_SEEK_END: b->cur = b->base + b->length + addr; break;
+		case R_IO_SEEK_END: b->cur = max + addr; break;
 		}
 	}
 	/* avoid out-of-bounds */
@@ -363,7 +387,7 @@ R_API char *r_buf_to_string(RBuffer *b) {
 }
 
 R_API bool r_buf_append_bytes(RBuffer *b, const ut8 *buf, int length) {
-	if (!b) {
+	if (!b || b->ro) {
 		return false;
 	}
 	if (b->fd != -1) {
@@ -384,7 +408,9 @@ R_API bool r_buf_append_bytes(RBuffer *b, const ut8 *buf, int length) {
 }
 
 R_API bool r_buf_append_nbytes(RBuffer *b, int length) {
-	if (!b) return false;
+	if (!b || b->ro) {
+		return false;
+	}
 	if (b->fd != -1) {
 		ut8 *buf = calloc (1, length);
 		if (buf) {
@@ -404,7 +430,9 @@ R_API bool r_buf_append_nbytes(RBuffer *b, int length) {
 }
 
 R_API bool r_buf_append_ut16(RBuffer *b, ut16 n) {
-	if (!b) return false;
+	if (!b || b->ro) {
+		return false;
+	}
 	if (b->fd != -1) {
 		return r_buf_append_bytes (b, (const ut8*)&n, sizeof (n));
 	}
@@ -417,6 +445,9 @@ R_API bool r_buf_append_ut16(RBuffer *b, ut16 n) {
 }
 
 R_API bool r_buf_append_ut32(RBuffer *b, ut32 n) {
+	if (!b || b->ro) {
+		return false;
+	}
 	if (b->empty) {
 		b->length = b->empty = 0;
 	}
@@ -432,7 +463,9 @@ R_API bool r_buf_append_ut32(RBuffer *b, ut32 n) {
 }
 
 R_API bool r_buf_append_ut64(RBuffer *b, ut64 n) {
-	if (!b) return false;
+	if (!b || b->ro) {
+		return false;
+	}
 	if (b->fd != -1) {
 		return r_buf_append_bytes (b, (const ut8*)&n, sizeof (n));
 	}
@@ -445,7 +478,9 @@ R_API bool r_buf_append_ut64(RBuffer *b, ut64 n) {
 }
 
 R_API bool r_buf_append_buf(RBuffer *b, RBuffer *a) {
-	if (!b) return false;
+	if (!b || b->ro) {
+		return false;
+	}
 	if (b->fd != -1) {
 		r_buf_append_bytes (b, a->buf, a->length);
 		return true;
@@ -464,82 +499,88 @@ R_API bool r_buf_append_buf(RBuffer *b, RBuffer *a) {
 
 // ret copied length if successful, -1 if failed
 static int r_buf_cpy(RBuffer *b, ut64 addr, ut8 *dst, const ut8 *src, int len, int write) {
-	int end;
 	if (!b || b->empty) {
+		return 0;
+	}
+	ut64 start = addr - b->base + b->offset;
+	ut64 effective_size = r_buf_size (b);
+	int real_len = len;
+	if (start + len > effective_size) {
+		real_len = effective_size - start;
+	}
+	if (real_len < 1) {
 		return 0;
 	}
 	if (b->iob) {
 		RIOBind *iob = b->iob;
 		if (b->fd != -1) {
 			return write
-				? iob->fd_write_at (iob->io, b->fd, addr, src, len)
-				: iob->fd_read_at (iob->io, b->fd, addr, dst, len);
+				? iob->fd_write_at (iob->io, b->fd, start, src, real_len)
+				: iob->fd_read_at (iob->io, b->fd, start, dst, real_len);
 		}
 		return write
-			? iob->write_at (iob->io, addr, src, len)
-			: iob->read_at (iob->io, addr, dst, len);
+			? iob->write_at (iob->io, start, src, real_len)
+			: iob->read_at (iob->io, start, dst, real_len);
 	}
 	if (b->fd != -1) {
-		if (r_sandbox_lseek (b->fd, addr, SEEK_SET) == -1) {
+		if (r_sandbox_lseek (b->fd, start, SEEK_SET) == -1) {
 			// seek failed - print error here?
 			// return 0;
 		}
 		if (write) {
-			return r_sandbox_write (b->fd, src, len);
+			return r_sandbox_write (b->fd, src, real_len);
 		}
-		memset (dst, 0, len);
-		return r_sandbox_read (b->fd, dst, len);
+		memset (dst, 0, real_len);
+		return r_sandbox_read (b->fd, dst, real_len);
 	}
 	if (b->sparse) {
 		if (write) {
 			// create new with src + len
-			if (sparse_write (b->sparse, addr, src, len) < 0) {
+			if (sparse_write (b->sparse, start, src, real_len) < 0) {
 				return -1;
 			}
 		} else {
 			// read from sparse and write into dst
 			memset (dst, b->Oxff, len);
-			(void)sparse_read (b->sparse, addr, dst, len);
-			len = R_MIN (len , r_buf_size (b) - addr);
+			(void)sparse_read (b->sparse, start, dst, real_len);
+			len = R_MIN (real_len , r_buf_size (b) - addr);
 		}
-		return len;
+		return real_len;
 	}
-	addr = (addr == R_BUF_CUR) ? b->cur : addr - b->base;
-	if (len < 1 || !dst || addr > b->length) {
+	addr = (addr == R_BUF_CUR) ? b->cur : start;
+	if (len < 1 || !dst || addr > effective_size) {
 		return -1;
-	}
- 	end = (int)(addr + len);
-	if (end > b->length) {
-		len -= end-b->length;
 	}
 	if (write) {
 		dst += addr;
 	} else {
 		src += addr;
 	}
-	memmove (dst, src, len);
-	b->cur = addr + len;
-	return len;
+	memmove (dst, src, real_len);
+	b->cur = addr + real_len;
+	return real_len;
 }
 
 static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n, int write) {
 	ut64 len, check_len;
-	ut8 *mybuf = NULL;
 	int i, j, k, tsize, m = 1;
 	bool bigendian = true;
 	if (!b || b->empty) {
 		return 0;
 	}
-	if (b->iob || b->fd != -1) {
-		eprintf ("r_buf_fcpy_at not supported yet for r_buf_new_file\n");
+	if ((b->iob || b->fd != -1) && write) {
+		eprintf ("r_buf_fcpy_at write not supported yet for r_buf_new_file\n");
 		return 0;
 	}
+	ut64 vaddr;
 	if (addr == R_BUF_CUR) {
-		addr = b->cur;
+		vaddr = addr = b->cur;
 	} else {
-		addr -= b->base;
+		vaddr = addr;
+		addr = addr - b->base + b->offset;
 	}
-	if (addr == UT64_MAX || addr > b->length) {
+	ut64 effective_size = r_buf_size (b);
+	if (addr == UT64_MAX || addr > effective_size) {
 		return -1;
 	}
 	tsize = 2;
@@ -575,9 +616,8 @@ static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 		if (!UT64_ADD (&check_len, check_len, addr)) {
 			return -1;
 		}
-		if (check_len > b->length) {
+		if (check_len > effective_size) {
 			return check_len;
-			// return -1;
 		}
 
 		for (k = 0; k < m; k++) {
@@ -585,19 +625,20 @@ static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 			ut8 _dest2[sizeof (ut64)] = {0};
 			int left1, left2;
 			ut64 addr1 = len + (k * tsize);
-			ut64 addr2 = addr + addr1;
-			ut8 *src1 = r_buf_get_at (b, addr1, &left1);
-			ut8 *src2 = r_buf_get_at (b, addr2, &left2);
+			ut64 addr2 = vaddr + addr1;
+			ut8 *src1=NULL, *src2=NULL;
+			if (b->fd == -1) {
+				src1 = r_buf_get_at (b, addr1, &left1);
+				src2 = r_buf_get_at (b, addr2, &left2);
+			}
 			if (!src1 || !src2) {
 				left1 = r_buf_read_at (b, addr1, _dest1, sizeof (_dest1));
 				left2 = r_buf_read_at (b, addr2, _dest2, sizeof (_dest2));
 				src1 = _dest1;
 				src2 = _dest2;
 			}
-			//ut8* src1 = &b->buf[len+(k*tsize)];
-			//ut8* src2 = &b->buf[addr+len+(k*tsize)];
-			void* dest1 = buf + addr + addr1; //&buf[addr+len+(k*tsize)];
-			void* dest2 = buf + addr1; //&buf[len+(k*tsize)];
+			void* dest1 = buf + addr + addr1; // shouldn't this be an address in b ?
+			void* dest2 = buf + addr1;
 			ut8* dest1_8 = (ut8*)dest1;
 			ut16* dest1_16 = (ut16*)dest1;
 			ut32* dest1_32 = (ut32*)dest1;
@@ -641,8 +682,7 @@ static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 		len += tsize * m;
 		m = 1;
 	}
-	b->cur = addr + len;
-	free (mybuf);
+	b->cur = vaddr + len;
 	return len;
 }
 
@@ -665,13 +705,14 @@ R_API ut8 *r_buf_get_at (RBuffer *b, ut64 addr, int *left) {
 	if (addr == R_BUF_CUR) {
 		addr = b->cur;
 	} else {
-		addr -= b->base;
+		addr = addr - b->base + b->offset;
 	}
-	if (addr == UT64_MAX || addr > b->length) {
+	ut64 effective_size = r_buf_size (b);
+	if (addr == UT64_MAX || addr > effective_size) {
 		return NULL;
 	}
 	if (left) {
-		*left = b->length - addr;
+		*left = effective_size - addr;
 	}
 	return b->buf + addr;
 }
@@ -679,7 +720,6 @@ R_API ut8 *r_buf_get_at (RBuffer *b, ut64 addr, int *left) {
 //ret 0 if failed; ret copied length if successful
 R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, int len) {
 	RIOBind *iob = b->iob;
-	st64 pa;
 	if (!b || !buf || len < 1) {
 		return 0;
 	}
@@ -689,33 +729,37 @@ R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, int len) {
 	if (addr == R_BUF_CUR) {
 		addr = b->cur;
 	}
+	ut64 start = addr - b->base + b->offset;
+	ut64 effective_size = r_buf_size (b);
+	int real_len = len;
+	if (start + len > effective_size) {
+		real_len = effective_size - start;
+	}
 	if (iob) {
 		if (b->fd != -1) {
-			return iob->fd_read_at (iob->io, b->fd, addr - b->base, buf, len);
+			return iob->fd_read_at (iob->io, b->fd, start, buf, real_len);
 		}
-		return iob->read_at (iob->io, addr - b->base, buf, len);
+		return iob->read_at (iob->io, start, buf, real_len);
 	}
 	if (b->fd != -1) {
-		if (r_sandbox_lseek (b->fd, addr, SEEK_SET) == -1) {
+		if (r_sandbox_lseek (b->fd, start, SEEK_SET) == -1) {
 			return 0;
 		}
-		return r_sandbox_read (b->fd, buf, len);
+		return r_sandbox_read (b->fd, buf, real_len);
 	}
 	if (!b->sparse) {
 		if (addr < b->base || len < 1) {
 			return 0;
 		}
-		pa = addr - b->base;
-		if (pa + len > b->length) {
+		if (real_len != len) {
 			memset (buf, b->Oxff, len);
-			len = b->length - pa;
+			len = real_len;
 			if (len < 0) {
 				return 0;
 			}
 		}
 	}
-	// must be +pa, but maybe its missused?
-	//return r_buf_cpy (b, addr, buf, b->buf+pa, len, false);
+	// addr will be converted to pa inside r_buf_cpy
 	return r_buf_cpy (b, addr, buf, b->buf, len, false);
 }
 
@@ -729,24 +773,32 @@ R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len) {
 	if (!b || !buf || len < 1) {
 		return 0;
 	}
+	ut64 start = addr - b->base + b->offset;
+	ut64 effective_size = r_buf_size (b);
+	int real_len = len;
+	if (start + len > effective_size) {
+		real_len = effective_size - start;
+	}
 	if (iob) {
 		if (b->fd != -1) {
-			return iob->fd_write_at (iob->io, b->fd, addr - b->base, buf, len);
+			return iob->fd_write_at (iob->io, b->fd, start, buf, real_len);
 		}
-		return iob->write_at (iob->io, addr - b->base, buf, len);
+		return iob->write_at (iob->io, start, buf, real_len);
 	}
 	if (b->fd != -1) {
-		ut64 newlen = addr + len;
-		if (r_sandbox_lseek (b->fd, addr, SEEK_SET) == -1) {
+		ut64 newlen = start + len;
+		if (r_sandbox_lseek (b->fd, start, SEEK_SET) == -1) {
 			return 0;
 		}
-		if (newlen > b->length) {
+		if (newlen > effective_size && !b->ro) {
 			b->length = newlen;
 #ifdef _MSC_VER
 			_chsize (b->fd, newlen);
 #else
 			ftruncate (b->fd, newlen);
 #endif
+		} else {
+			len = real_len;
 		}
 		return r_sandbox_write (b->fd, buf, len);
 	}
@@ -754,6 +806,9 @@ R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len) {
 		return (sparse_write (b->sparse, addr, buf, len) < 0) ? -1 : len;
 	}
 	if (b->empty) {
+		if (b->ro) {
+			return 0;
+		}
 		b->empty = 0;
 		free (b->buf);
 		b->buf = (ut8 *) malloc (addr + len);
@@ -786,6 +841,10 @@ R_API void r_buf_free(RBuffer *b) {
 	if (!b) {
 		return;
 	}
+	if (b->parent) {
+		r_buf_free (b->parent);
+		b->parent = NULL;
+	}
 	if (b->refctr > 0) {
 		b->refctr--;
 		return;
@@ -811,7 +870,7 @@ R_API char *r_buf_free_to_string(RBuffer *b) {
 		r_buf_append_bytes (b, (const ut8*)"", 1);
 		p = malloc (b->length + 1);
 		if (!p) {
-			return NULL;	
+			return NULL;
 		}
 		memmove (p, b->buf, b->length);
 		p[b->length] = 0;
@@ -821,6 +880,9 @@ R_API char *r_buf_free_to_string(RBuffer *b) {
 }
 
 R_API bool r_buf_resize (RBuffer *b, ut64 newsize) {
+	if (!b || b->ro) {
+		return false;
+	}
 	if (b->mmap) {
 		return false;
 	}


### PR DESCRIPTION
Returns a new buffer which is a "slice" of the given one, while sharing its memory. The idea is to be similar to this semantic: https://nodejs.org/api/buffer.html#buffer_buf_slice_start_end

With the following limitations (for now):
- this doesn't work with sparse buffers
- a sliced buffer is `ro`, in the sense it can be written to but not resized (or any other operation which reallocs its bytes) because the underlying memory layout must remain the same (shared with `parent` buffer)

plus:
- fix vaddr / paddr translations (and make them meaningful on slices)
- fix r_buf_fcpy_at to work with slices and with file-backed buffers (at least for reading)

This feature is super useful when dealing with sub-binaries and in general it relaxes the need to make copies of big buffers.