### PR TITLE
add every output support for agg graph + some agf fixes

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1667,10 +1667,10 @@ R_API int r_core_print_bb_gml(RCore *core, RAnalFunction *fcn) {
 	r_list_foreach (fcn->bbs, iter, bb) {
 		RFlagItem *flag = r_flag_get_i (core->flags, bb->addr);
 		char *msg = flag? strdup (flag->name): r_str_newf ("0x%08"PFMT64x, bb->addr);
-		r_cons_printf ("\tnode [\n"
-				"\t\tid\t%"PFMT64d"\n"
-				"\t\tlabel\t\"%s\"\n"
-				"\t]\n", bb->addr, msg);
+		r_cons_printf ("  node [\n"
+				"    id  %"PFMT64d"\n"
+				"    label  \"%s\"\n"
+				"  ]\n", bb->addr, msg);
 	}
 
 	r_list_foreach (fcn->bbs, iter, bb) {
@@ -1679,31 +1679,32 @@ R_API int r_core_print_bb_gml(RCore *core, RAnalFunction *fcn) {
 		}
 
 		if (bb->jump != UT64_MAX) {
-			r_cons_printf ("\tedge [\n"
-				"\t\tsource  %"PFMT64d"\n"
-				"\t\ttarget  %"PFMT64d"\n"
-				"\t]\n", bb->addr, bb->jump
+			r_cons_printf ("  edge [\n"
+				"    source  %"PFMT64d"\n"
+				"    target  %"PFMT64d"\n"
+				"  ]\n", bb->addr, bb->jump
 				);
 		}
 		if (bb->fail != UT64_MAX) {
-			r_cons_printf ("\tedge [\n"
-				"\t\tsource  %"PFMT64d"\n"
-				"\t\ttarget  %"PFMT64d"\n"
-				"\t]\n", bb->addr, bb->fail
+			r_cons_printf ("  edge [\n"
+				"    source  %"PFMT64d"\n"
+				"    target  %"PFMT64d"\n"
+				"  ]\n", bb->addr, bb->fail
 				);
 		}
 		if (bb->switch_op) {
 			RListIter *it;
 			RAnalCaseOp *cop;
 			r_list_foreach (bb->switch_op->cases, it, cop) {
-				r_cons_printf ("\tedge [\n"
-					"\t\tsource  %"PFMT64d"\n"
-					"\t\ttarget  %"PFMT64d"\n"
-					"\t]\n", bb->addr, cop->addr
+				r_cons_printf ("  edge [\n"
+					"    source  %"PFMT64d"\n"
+					"    target  %"PFMT64d"\n"
+					"  ]\n", bb->addr, cop->addr
 					);
 			}
 		}
 	}
+	r_cons_printf ("]\n");
 	return true;
 }
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2268,6 +2268,33 @@ static char *getViewerPath() {
 	return NULL;
 }
 
+R_API char* r_core_graph_cmd(char *r2_cmd) {
+	char *cmd = NULL;
+	char *xdotPath = r_file_path ("xdot");
+	if (r_file_exists (xdotPath)) {
+		cmd = r_str_newf ("%s > a.dot;!xdot a.dot", r2_cmd);
+	} else {
+		char *dotPath = r_file_path ("dot");
+		if (r_file_exists (dotPath)) {
+			R_FREE (dotPath);
+			char *viewer = getViewerPath();
+			if (viewer) {
+				cmd = r_str_newf ("%s > a.dot;!dot -Tgif -oa.gif a.dot;!%s a.gif", r2_cmd, viewer);
+				free (viewer);
+			} else {
+				cmd = "?e cannot find a valid picture viewer";
+			}
+		} else {
+			cmd = "agf";
+		}
+		free (dotPath);
+	}
+	free (xdotPath);
+	return cmd;
+}
+
+
+
 #define SLURP_LIMIT (10*1024*1024)
 R_API int r_core_config_init(RCore *core) {
 	int i;
@@ -2683,28 +2710,10 @@ R_API int r_core_config_init(RCore *core) {
 	SETICB ("dbg.trace.tag", 0, &cb_tracetag, "Trace tag");
 
 	/* cmd */
-	char *xdotPath = r_file_path ("xdot");
-	if (r_file_exists (xdotPath)) {
-		r_config_set (cfg, "cmd.graph", "ag $$ > a.dot;!xdot a.dot");
-	} else {
-		char *dotPath = r_file_path ("dot");
-		if (r_file_exists (dotPath)) {
-			R_FREE (dotPath);
-			char *viewer = getViewerPath();
-			if (viewer) {
-				char *cmd = r_str_newf ("ag $$>a.dot;!dot -Tgif -oa.gif a.dot;!%s a.gif", viewer);
-				r_config_set (cfg, "cmd.graph", cmd);
-				free (viewer);
-				free (cmd);
-			} else {
-				r_config_set (cfg, "cmd.graph", "?e cannot find a valid picture viewer");
-			}
-		} else {
-			r_config_set (cfg, "cmd.graph", "agf");
-		}
-		free (dotPath);
-	}
-	free (xdotPath);
+	char *cmd = r_core_graph_cmd ("ag $$");
+	r_config_set (cfg, "cmd.graph", cmd);
+	free (cmd);
+
 	r_config_desc (cfg, "cmd.graph", "Command executed by 'agv' command to view graphs");
 	SETPREF ("cmd.xterm", "xterm -bg black -fg gray -e", "xterm command to spawn with V@");
 	SETICB ("cmd.depth", 10, &cb_cmddepth, "Maximum command depth");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2285,7 +2285,7 @@ R_API char* r_core_graph_cmd(char *r2_cmd) {
 				cmd = "?e cannot find a valid picture viewer";
 			}
 		} else {
-			cmd = "agf";
+			cmd = r_str_new ("agf");
 		}
 		free (dotPath);
 	}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5516,6 +5516,36 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 	}
 }
 
+static void agraph_print_node_json(RANode *n, void *user) {
+	char *label = strdup (n->body);
+	r_cons_printf ("%s{\"id\":%d,\"title\":\"%s\",\"body\":\"%s\",\"out_nodes\":[",
+		n->gnode->idx > 0 ? "," : "", n->gnode->idx, n->title, label);
+	RListIter *it = NULL;
+	RGraphNode *node = NULL;
+	RList *nodes = n->gnode->out_nodes;
+	r_list_foreach (nodes, it, node) {
+		r_cons_printf ("%s%d", it == nodes->head ? "" : ",", node->idx);
+	}
+	r_cons_printf ("]}");
+	free (label);
+}
+
+
+static void agraph_print_node_gml(RANode *n, void *user) {
+	r_cons_printf ("  node [\n"
+		"    id  %d\n"
+		"    label  \"%s\"\n"
+		"  ]\n", n->gnode->idx, n->title);
+}
+
+static void agraph_print_edge_gml(RANode *from, RANode *to, void *user) {
+	r_cons_printf ("  edge [\n"
+		"    source  %d\n"
+		"    target  %d\n"
+		"  ]\n", from->gnode->idx, to->gnode->idx
+		);
+}
+
 static void agraph_print_node_dot(RANode *n, void *user) {
 	char *label = strdup (n->body);
 	//label = r_str_replace (label, "\n", "\\l", 1);
@@ -5653,6 +5683,18 @@ static void cmd_agraph_edge(RCore *core, const char *input) {
 
 static void cmd_agraph_print(RCore *core, const char *input) {
 	switch (*input) {
+	case 0:
+		core->graph->can->linemode = r_config_get_i (core->config, "graph.linemode");
+		core->graph->can->color = r_config_get_i (core->config, "scr.color");
+		r_agraph_set_title (core->graph,
+			r_config_get (core->config, "graph.title"));
+		r_agraph_print (core->graph);
+		break;
+	case 't':// "aggt" - tiny graph
+		core->graph->is_tiny = true;
+		r_core_visual_graph (core, core->graph, NULL, false);
+		core->graph->is_tiny = false;
+		break;
 	case 'k': // "aggk"
 	{
 		Sdb *db = r_agraph_get_sdb (core->graph);
@@ -5662,20 +5704,6 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		break;
 	}
 	case 'v': // "aggv"
-	{
-		const char *cmd = r_config_get (core->config, "cmd.graph");
-		if (cmd && *cmd) {
-			char *newCmd = strdup (cmd);
-			if (newCmd) {
-				newCmd = r_str_replace (newCmd, "ag $$", "aggd", 0);
-				r_core_cmd0 (core, newCmd);
-				free (newCmd);
-			}
-		} else {
-			r_core_cmd0 (core, "agf");
-		}
-		break;
-	}
 	case 'i': // "aggi" - open current core->graph in interactive mode
 	{
 		RANode *ran = r_agraph_get_first_node (core->graph);
@@ -5707,16 +5735,35 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		r_agraph_foreach (core->graph, agraph_print_node, NULL);
 		r_agraph_foreach_edge (core->graph, agraph_print_edge, NULL);
 		break;
+	case 'J': 
+	case 'j': 
+		r_cons_printf ("{\"nodes\":[");
+		r_agraph_foreach (core->graph, agraph_print_node_json, NULL);
+		r_cons_printf ("]}\n");
+		break;
+	case 'g':
+		r_cons_printf ("graph\n[\n" "hierarchic 1\n" "label \"\"\n" "directed 1\n");
+		r_agraph_foreach (core->graph, agraph_print_node_gml, NULL);
+		r_agraph_foreach_edge (core->graph, agraph_print_edge_gml, NULL);
+		r_cons_print ("]\n");
+		break;
+	case 'w':{ // "aggw"
+		if (r_config_get_i (core->config, "graph.web")) {
+			r_core_cmd0 (core, "=H /graph/");
+		} else {
+			char *cmd = r_core_graph_cmd ("aggd");
+			if (cmd && *cmd) {
+				r_core_cmd0 (core, cmd);
+			}
+			free (cmd);
+		}
+		break;
+	}
 	case '?':
 		r_core_cmd_help (core, help_msg_agg);
 		break;
 	default:
-		core->graph->can->linemode = r_config_get_i (core->config, "graph.linemode");
-		core->graph->can->color = r_config_get_i (core->config, "scr.color");
-		r_agraph_set_title (core->graph,
-			r_config_get (core->config, "graph.title"));
-		r_agraph_print (core->graph);
-		break;
+		eprintf ("Usage: see ag?\n");
 	}
 }
 
@@ -5771,16 +5818,15 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			if (r_config_get_i (core->config, "graph.web")) {
 				r_core_cmd0 (core, "=H /graph/");
 			} else {
-				const char *cmd = r_config_get (core->config, "cmd.graph");
+				char *cmd = r_core_graph_cmd ("agfd");
 				if (cmd && *cmd) {
 					r_core_cmd0 (core, cmd);
-				} else {
-					eprintf ("Command cmd.graph not valid\n");
 				}
+				free (cmd);
 			}
 			break;
 		default:
-			eprintf ("Usage: see ag?");
+			eprintf ("Usage: see ag?\n");
 			break;
 		}
 		break;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -239,6 +239,7 @@ R_API void r_core_wait(RCore *core);
 R_API RCore *r_core_ncast(ut64 p);
 R_API RCore *r_core_cast(void *p);
 R_API int r_core_config_init(RCore *core);
+R_API char* r_core_graph_cmd(char *r2_cmd);
 R_API int r_core_prompt(RCore *core, int sync);
 R_API int r_core_prompt_exec(RCore *core);
 R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr);


### PR DESCRIPTION
Support for the following output formats for `agg` custom graph:
```
- non interactive ascii-> blank 
- interactive ascii    -> v     
- tiny ascii           -> t
- graphviz dot         -> d  
- json                 -> j 
- gml                  -> g  
- SDB key-value        -> k 
- r2 commands          -> *  
- web/png              -> w  
```

*NOTE*: this pr will change the behaviour of the **`aggv`** command: now it is renamed to `aggw`. (this is because "v" format is for interactive ascii).

I also added some fixes to my previous pr (for the agf output format support), mostly to remove `\t` tabs in the terminal output.