### PR TITLE
Fix #2639, added support for javascript byte arrays in rax2 -F

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -107,7 +107,7 @@ static int help() {
 		"  -D      base64 decode        ;\n"
 		"  -E      base64 encode        ;\n"
 		"  -f      floating point       ;  rax2 -f 6.3+2.1\n"
-		"  -F      stdin slurp code hex ;  rax2 -F < shellcode.[c(py]\n"
+		"  -F      stdin slurp code hex ;  rax2 -F < shellcode.[c/py/js]\n"
 		"  -h      help                 ;  rax2 -h\n"
 		"  -i      dump as C byte array ;  rax2 -i < bytes\n"
 		"  -k      keep base            ;  rax2 -k 33+3 -> 36\n"
@@ -541,7 +541,7 @@ static int use_stdin() {
 	if (!buf) {
 		return 0;
 	}
-	if (!(flags & 16384)) {
+	if (!(flags & (1<<14))) {
 		for (l = 0; l >= 0 && l < STDIN_BUFFER_SIZE; l++) {
 			// make sure we don't read beyond boundaries
 			int n = read (0, buf + l, STDIN_BUFFER_SIZE - l);

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -1,5 +1,4 @@
-/* radare - LGPL - Copyright 2007-2016 - pancake */
-
+/* radare - LGPL - Copyright 2007-2016 - pancake */ 
 #include "r_types.h"
 #include "r_util.h"
 #include <stdio.h>
@@ -255,10 +254,10 @@ R_API char *r_hex_from_js(const char *code) {
 	char * start, * end;
 	if (s1 < s2) {
 		start = s1;
-		end = strchr(start+1, '\'');
+		end = strchr (start + 1, '\'');
 	} else {
 		start = s2;
-		end = strchr(start+1, '"');
+		end = strchr (start + 1, '"');
 	}
 
 	/* the string isn't properly terminated */
@@ -266,15 +265,17 @@ R_API char *r_hex_from_js(const char *code) {
 		return NULL;
 	}
 
-	char * str = malloc (end-start);
-	strncpy (str, start+1, end-start-1);
-	str[end-start-1] = '\0';
+	char * str = r_str_ndup (start + 1, end - start - 1);
 
 	/* assuming base64 input, output will always be shorter */
-	ut8 * b64d = malloc (end-start);
+	ut8 * b64d = malloc (end - start);
+	if (!b64d) {
+		free (str);
+		return NULL;
+	}
 
-	r_base64_decode (b64d, str, end-start-1);
-	if (b64d <= 0) {
+	r_base64_decode (b64d, str, end - start - 1);
+	if (b64d < 1) {
 		free (str);
 		free (b64d);
 		return NULL;
@@ -282,6 +283,11 @@ R_API char *r_hex_from_js(const char *code) {
 
 	int i, len = strlen (b64d);
 	char * out = malloc (len * 2 + 1);
+	if (!out) {
+		free (str);
+		free (b64d);
+		return NULL;
+	}
 	for (i = 0; i < len; i++) {
 		sprintf (&out[i * 2], "%02x", b64d[i]);
 	}
@@ -327,16 +333,17 @@ R_API char *r_hex_no_code(const char *code) {
 R_API char *r_hex_from_code(const char *code) {
 	if (!strchr (code, '=')) {
 		return r_hex_no_code (code);
-	} else if (strstr (code, "char") || strstr (code, "int")) {
-		//C language
-		return r_hex_from_c (code);
-	} else if (strstr (code, "var")) {
-		// JavaScript
-		return r_hex_from_js (code);
-	} else {
-		// Python
-		return r_hex_from_py (code);
 	}
+	/* C language */
+	if (strstr (code, "char") || strstr (code, "int")) {
+		return r_hex_from_c (code);
+	}
+	/* JavaScript */
+	if (strstr (code, "var")) {
+		return r_hex_from_js (code);
+	}
+        /* Python */
+	return r_hex_from_py (code);
 }
 
 /* int byte = hexpair2bin("A0"); */


### PR DESCRIPTION
Rax2 -F now autodetects and transforms a js byte array into an hex string.
The expected input format is the one of 'pcJ' in r2, with some degree of flexibility