### PR TITLE
Always return sorted xref/ref lists

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -77,6 +77,22 @@ static bool mylistrefs_cb(RList *list, const char *k, SdbHash *ht) {
 	return true;
 }
 
+static int ref_cmp(const RAnalRef *a, const RAnalRef *b) {
+	if (a->at < b->at) {
+		return -1;
+	}
+	if (a->at > b->at) {
+		return 1;
+	}
+	if (a->addr < b->addr) {
+		return -1;
+	}
+	if (a->addr > b->addr) {
+		return 1;
+	}
+	return 0;
+}
+
 static void listxrefs(SdbHash *m, ut64 addr, RList *list) {
 	if (addr == UT64_MAX) {
 		ht_foreach (m, (HtForeachCallback)mylistrefs_cb, list);
@@ -89,6 +105,7 @@ static void listxrefs(SdbHash *m, ut64 addr, RList *list) {
 
 		ht_foreach (d, (HtForeachCallback)appendRef, list);
 	}
+	r_list_sort (list, (RListComparator)ref_cmp);
 }
 
 static void setxref(SdbHash *m, ut64 from, ut64 to, int type) {
@@ -304,22 +321,6 @@ R_API int r_anal_xrefs_count(RAnal *anal) {
 	return anal->dict_xrefs->count;
 }
 
-static int ref_cmp(const RAnalRef *a, const RAnalRef *b) {
-	if (a->at < b->at) {
-		return -1;
-	}
-	if (a->at > b->at) {
-		return 1;
-	}
-	if (a->addr < b->addr) {
-		return -1;
-	}
-	if (a->addr > b->addr) {
-		return 1;
-	}
-	return 0;
-}
-
 static RList *fcn_get_refs(RAnalFunction *fcn, SdbHash *ht) {
 	RListIter *iter;
 	RAnalBlock *bb;
@@ -345,16 +346,4 @@ R_API RList *r_anal_fcn_get_refs(RAnal *anal, RAnalFunction *fcn) {
 
 R_API RList *r_anal_fcn_get_xrefs(RAnal *anal, RAnalFunction *fcn) {
 	return fcn_get_refs (fcn, anal->dict_xrefs);
-}
-
-R_API RList *r_anal_fcn_get_refs_sorted(RAnal *anal, RAnalFunction *fcn) {
-	RList *l = r_anal_fcn_get_refs (anal, fcn);
-	r_list_sort (l, (RListComparator)ref_cmp);
-	return l;
-}
-
-R_API RList *r_anal_fcn_get_xrefs_sorted(RAnal *anal, RAnalFunction *fcn) {
-	RList *l = r_anal_fcn_get_xrefs (anal, fcn);
-	r_list_sort (l, (RListComparator)ref_cmp);
-	return l;
 }

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -335,7 +335,7 @@ static char *anal_fcn_autoname(RCore *core, RAnalFunction *fcn, int dump) {
 	char *do_call = NULL;
 	RAnalRef *ref;
 	RListIter *iter;
-	RList *refs = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+	RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 	r_list_foreach (refs, iter, ref) {
 		RFlagItem *f = r_flag_get_i (core->flags, ref->addr);
 		if (f) {
@@ -1714,7 +1714,7 @@ R_API void r_core_anal_coderefs(RCore *core, ut64 addr) {
 		const char *me = fcn->name;
 		RListIter *iter;
 		RAnalRef *ref;
-		RList *refs = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+		RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 		r_cons_printf ("ag-\n");
 		r_cons_printf ("agn %s\n", me);
 		r_list_foreach (refs, iter, ref) {
@@ -1799,7 +1799,7 @@ repeat:
 		if (addr != UT64_MAX && addr != fcni->addr) {
 			continue;
 		}
-		RList *refs = r_anal_fcn_get_refs_sorted (core->anal, fcni);
+		RList *refs = r_anal_fcn_get_refs (core->anal, fcni);
 		if (!fmt) {
 			r_cons_printf ("0x%08"PFMT64x"\n", fcni->addr);
 		} else if (fmt == 1 && isGML) {
@@ -1929,7 +1929,7 @@ repeat:
 				}
 			} else if (fmt == 2) {
 				if (fr) {
-					RList *refs1 = r_anal_fcn_get_refs_sorted (core->anal, fr);
+					RList *refs1 = r_anal_fcn_get_refs (core->anal, fr);
 					if (!hideempty || (hideempty && r_list_length (refs1) > 0)) {
 						if (usenames) {
 							r_cons_printf ("%s\"%s\"", first2?",":"", fr->name);
@@ -2216,7 +2216,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 				fcn->diff->type == R_ANAL_DIFF_TYPE_UNMATCH?"UNMATCH":"NEW");
 	}
 	int outdegree = 0;
-	refs = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+	refs = r_anal_fcn_get_refs (core->anal, fcn);
 	if (!r_list_empty (refs)) {
 		r_cons_printf (",\"callrefs\":[");
 		r_list_foreach (refs, iter, refi) {
@@ -2248,7 +2248,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 	r_list_free (refs);
 
 	int indegree = 0;
-	xrefs = r_anal_fcn_get_xrefs_sorted (core->anal, fcn);
+	xrefs = r_anal_fcn_get_xrefs (core->anal, fcn);
 	if (!r_list_empty (xrefs)) {
 		first = true;
 		r_cons_printf (",\"codexrefs\":[");
@@ -2352,7 +2352,7 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	/* Show references */
 	RListIter *refiter;
 	RAnalRef *refi;
-	RList *refs = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+	RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 	r_list_foreach (refs, refiter, refi) {
 		switch (refi->type) {
 		case R_ANAL_REF_TYPE_CALL:
@@ -2406,7 +2406,7 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn) {
 	r_cons_printf ("\nend-bbs: %d", ebbs);
 	r_cons_printf ("\ncall-refs: ");
 	int outdegree = 0;
-	refs = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+	refs = r_anal_fcn_get_refs (core->anal, fcn);
 	r_list_foreach (refs, iter, refi) {
 		if (refi->type == R_ANAL_REF_TYPE_CALL) {
 			outdegree++;
@@ -2426,7 +2426,7 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn) {
 
 	int indegree = 0;
 	r_cons_printf ("\ncode-xrefs: ");
-	xrefs = r_anal_fcn_get_xrefs_sorted (core->anal, fcn);
+	xrefs = r_anal_fcn_get_xrefs (core->anal, fcn);
 	r_list_foreach (xrefs, iter, refi) {
 		if (refi->type == R_ANAL_REF_TYPE_CODE || refi->type == R_ANAL_REF_TYPE_CALL) {
 			indegree++;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2600,7 +2600,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 				if (fcn) {
 					RAnalRef *ref;
 					RListIter *iter;
-					RList *refs = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+					RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 					r_list_foreach (refs, iter, ref) {
 						if (input[2] == 'j') {
 							r_cons_printf ("{\"type\":\"%c\",\"from\":%"PFMT64d",\"to\":%"PFMT64d"}%s",
@@ -2677,7 +2677,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			if (fcn) {
 				RAnalRef *ref;
 				RListIter *iter;
-				RList *refs = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+				RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 				r_list_foreach (refs, iter, ref) {
 					if (ref->addr == UT64_MAX) {
 						//eprintf ("Warning: ignore 0x%08"PFMT64x" call 0x%08"PFMT64x"\n", ref->at, ref->addr);
@@ -2697,7 +2697,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 					if (f) {
 						RListIter *iter;
 						RAnalRef *ref;
-						RList *refs1 = r_anal_fcn_get_refs_sorted (core->anal, f);
+						RList *refs1 = r_anal_fcn_get_refs (core->anal, f);
 						r_list_foreach (refs1, iter, ref) {
 							if (!r_io_is_valid_offset (core->io, ref->addr, !core->anal->opt.noncode)) {
 								continue;
@@ -5269,7 +5269,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 			list = list_ = r_anal_xrefs_get_from (core->anal, addr);
 			if (!list) {
 				RAnalFunction * fcn = r_anal_get_fcn_in (core->anal, addr, 0);
-				list = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+				list = r_anal_fcn_get_refs (core->anal, fcn);
 			}
 		} else {
 			list = r_anal_refs_get (core->anal, addr);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -327,9 +327,9 @@ static ut64 getref (RCore *core, int n, char t, int type) {
 	}
 #if FCN_OLD
 	if (t == 'r') {
-		list = r_anal_fcn_get_refs_sorted (core->anal, fcn);
+		list = r_anal_fcn_get_refs (core->anal, fcn);
 	} else {
-		list = r_anal_fcn_get_xrefs_sorted (core->anal, fcn);
+		list = r_anal_fcn_get_xrefs (core->anal, fcn);
 	}
 	r_list_foreach (list, iter, r) {
 		if (r->type == type) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1434,8 +1434,6 @@ R_API RList *r_anal_xrefs_get_from(RAnal *anal, ut64 from);
 R_API void r_anal_xrefs_list(RAnal *anal, int rad);
 R_API RList *r_anal_fcn_get_refs(RAnal *anal, RAnalFunction *fcn);
 R_API RList *r_anal_fcn_get_xrefs(RAnal *anal, RAnalFunction *fcn);
-R_API RList *r_anal_fcn_get_refs_sorted(RAnal *anal, RAnalFunction *fcn);
-R_API RList *r_anal_fcn_get_xrefs_sorted(RAnal *anal, RAnalFunction *fcn);
 R_API int r_anal_xrefs_from(RAnal *anal, RList *list, const char *kind, const RAnalRefType type, ut64 addr);
 R_API int r_anal_xrefs_set(RAnal *anal, ut64 from, ut64 to, const RAnalRefType type);
 R_API int r_anal_xrefs_deln(RAnal *anal, ut64 from, ut64 to, const RAnalRefType type);


### PR DESCRIPTION
I was bothered that output of xrefs in the disassembly was not sorted. 

Instead of adding yet another "get_*_sorted" variant to xrefs.c, I think generally returning sorted lists will lead to more consistent behavior across r2.  