### PR TITLE
Fix reloc symbols not loaded correctly

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2767,7 +2767,7 @@ static RBinElfSymbol* get_symbols_from_phdr(ELFOBJ *bin, int type) {
 				toffset = 0;
 			}
 			tsize = 16;
-		} else if (type == R_BIN_ELF_SYMBOLS && sym[i].st_shndx != STN_UNDEF) {
+		} else if (type == R_BIN_ELF_SYMBOLS) {
 			tsize = sym[i].st_size;
 			toffset = (ut64) sym[i].st_value;
 		} else {


### PR DESCRIPTION
When SHDR missing failed to load symbols only existing in PHDR.

Discovered while working a crackme (ELF32).
IDA Freeware loaded symbols fine but I have dedicated myself to solve it with Radare2 as a learning process.

This makes the symbols appear again as "call reloc.memset_77" instead of "call 0x......"

