### PR TITLE
Fix ihj ELF

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3133,6 +3133,30 @@ RBinElfSymbol *Elf_(r_bin_elf_get_imports)(ELFOBJ *bin) {
 	return bin->g_imports;
 }
 
+RBinElfField* Elf_(r_bin_elf_get_fields)(ELFOBJ *bin) {
+	RBinElfField *ret = NULL;
+	int i = 0, j;
+	if (!bin || !(ret = calloc ((bin->ehdr.e_phnum + 3 + 1), sizeof (RBinElfField)))) {
+		return NULL;
+	}
+	strncpy (ret[i].name, "ehdr", ELF_STRING_LENGTH);
+	ret[i].offset = 0;
+	ret[i++].last = 0;
+	strncpy (ret[i].name, "shoff", ELF_STRING_LENGTH);
+	ret[i].offset = bin->ehdr.e_shoff;
+	ret[i++].last = 0;
+	strncpy (ret[i].name, "phoff", ELF_STRING_LENGTH);
+	ret[i].offset = bin->ehdr.e_phoff;
+	ret[i++].last = 0;
+	for (j = 0; bin->phdr && j < bin->ehdr.e_phnum; i++, j++) {
+		snprintf (ret[i].name, ELF_STRING_LENGTH, "phdr_%i", j);
+		ret[i].offset = bin->phdr[j].p_offset;
+		ret[i].last = 0;
+	}
+	ret[i].last = 1;
+	return ret;
+}
+
 void* Elf_(r_bin_elf_free)(ELFOBJ* bin) {
 	int i;
 	if (!bin) {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3133,30 +3133,6 @@ RBinElfSymbol *Elf_(r_bin_elf_get_imports)(ELFOBJ *bin) {
 	return bin->g_imports;
 }
 
-RBinElfField* Elf_(r_bin_elf_get_fields)(ELFOBJ *bin) {
-	RBinElfField *ret = NULL;
-	int i = 0, j;
-	if (!bin || !(ret = calloc ((bin->ehdr.e_phnum + 3 + 1), sizeof (RBinElfField)))) {
-		return NULL;
-	}
-	strncpy (ret[i].name, "ehdr", ELF_STRING_LENGTH);
-	ret[i].offset = 0;
-	ret[i++].last = 0;
-	strncpy (ret[i].name, "shoff", ELF_STRING_LENGTH);
-	ret[i].offset = bin->ehdr.e_shoff;
-	ret[i++].last = 0;
-	strncpy (ret[i].name, "phoff", ELF_STRING_LENGTH);
-	ret[i].offset = bin->ehdr.e_phoff;
-	ret[i++].last = 0;
-	for (j = 0; bin->phdr && j < bin->ehdr.e_phnum; i++, j++) {
-		snprintf (ret[i].name, ELF_STRING_LENGTH, "phdr_%i", j);
-		ret[i].offset = bin->phdr[j].p_offset;
-		ret[i].last = 0;
-	}
-	ret[i].last = 1;
-	return ret;
-}
-
 void* Elf_(r_bin_elf_free)(ELFOBJ* bin) {
 	int i;
 	if (!bin) {

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2470,12 +2470,12 @@ RList* MACH0_(mach_fields)(RBinFile *bf) {
 #define ROW(nam,siz,val,fmt) \
 	r_list_append (ret, r_bin_field_new (addr, addr, siz, nam, sdb_fmt ("0x%08x", val), fmt)); \
 	addr += 4;
-	ROW("Magic", 4, mh->magic, "x");
-	ROW("Cpu type", 4, mh->cputype, "x");
-	ROW("Cpu subtype", 4, mh->cpusubtype, "x");
-	ROW("File type", 4, mh->filetype, "x");
-	ROW("Nb cmds", 4, mh->ncmds, "x");
-	ROW("Size of cmds", 4, mh->sizeofcmds, "x");
+	ROW ("hdr.magic", 4, mh->magic, "x");
+	ROW ("hdr.cputype", 4, mh->cputype, "x");
+	ROW ("hdr.cpusubtype", 4, mh->cpusubtype, "x");
+	ROW ("hdr.filetype", 4, mh->filetype, "x");
+	ROW ("hdr.nbcmds", 4, mh->ncmds, "x");
+	ROW ("hdr.sizeofcmds", 4, mh->sizeofcmds, "x");
 	free (mh);
 	return ret;
 }

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2470,12 +2470,12 @@ RList* MACH0_(mach_fields)(RBinFile *bf) {
 #define ROW(nam,siz,val,fmt) \
 	r_list_append (ret, r_bin_field_new (addr, addr, siz, nam, sdb_fmt ("0x%08x", val), fmt)); \
 	addr += 4;
-	ROW("hdr.magic", 4, mh->magic, "x");
-	ROW("hdr.cputype", 4, mh->cputype, NULL);
-	ROW("hdr.cpusubtype", 4, mh->cpusubtype, NULL);
-	ROW("hdr.filetype", 4, mh->filetype, NULL);
-	ROW("hdr.ncmds", 4, mh->ncmds, NULL);
-	ROW("hdr.sizeofcmds", 4, mh->sizeofcmds, NULL);
+	ROW("Magic", 4, mh->magic, "x");
+	ROW("Cpu type", 4, mh->cputype, "x");
+	ROW("Cpu subtype", 4, mh->cpusubtype, "x");
+	ROW("File type", 4, mh->filetype, "x");
+	ROW("Nb cmds", 4, mh->ncmds, "x");
+	ROW("Size of cmds", 4, mh->sizeofcmds, "x");
 	free (mh);
 	return ret;
 }

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -1103,29 +1103,31 @@ static RBinInfo* info(RBinFile *bf) {
 }
 
 static RList* fields(RBinFile *bf) {
-	RList *ret = NULL;
-	RBinField *ptr = NULL;
-	struct r_bin_elf_field_t *field = NULL;
-	int i;
-
-	if (!(ret = r_list_new ())) {
+	RList *ret = r_list_new ();
+	if (!ret) {
 		return NULL;
 	}
 	ret->free = free;
-	if (!(field = Elf_(r_bin_elf_get_fields) (bf->o->bin_obj))) {
-		return ret;
+	ut64 addr = 0;
+
+	#define ROW(nam,siz,val,fmt) \
+	r_list_append (ret, r_bin_field_new (addr, addr, siz, nam, sdb_fmt ("0x%08x", val), fmt));
+	const ut8 *buf = r_buf_get_at (bf->buf, 0, NULL);
+	ROW("ELF", 4, r_read_le32 (buf), "x"); addr+=0x10;
+	ROW("Type", 2, r_read_le16 (buf + 0x10), "x"); addr+=0x2;
+	ROW("Machine", 2, r_read_le16 (buf + 0x12), "x"); addr+=0x2;
+	ROW("Version", 4, r_read_le32 (buf + 0x14), "x"); addr+=0x4;
+
+	if (r_read_le8(buf + 0x04) == 1){
+		ROW("Entry point", 4, r_read_le32 (buf + 0x18), "x"); addr+=0x4;
+		ROW("PhOff", 4, r_read_le32 (buf + 0x1c), "x"); addr+=0x4;
+		ROW("ShOff", 4, r_read_le32 (buf + 0x20), "x");
+	}else{
+		ROW("Entry point", 8, r_read_le64 (buf + 0x18), "x"); addr+=0x8;
+		ROW("PhOff", 8, r_read_le64 (buf + 0x20), "x"); addr+=0x8;
+		ROW("ShOff", 8, r_read_le64 (buf + 0x28), "x");
 	}
-	for (i = 0; !field[i].last; i++) {
-		if (!(ptr = R_NEW0 (RBinField))) {
-			break;
-		}
-		ptr->name = strdup (field[i].name);
-		ptr->comment = NULL;
-		ptr->vaddr = field[i].offset;
-		ptr->paddr = field[i].offset;
-		r_list_append (ret, ptr);
-	}
-	free (field);
+
 	return ret;
 }
 
@@ -1152,12 +1154,12 @@ static void headers32(RBinFile *bf) {
 #define p bf->rbin->cb_printf
 	const ut8 *buf = r_buf_get_at (bf->buf, 0, NULL);
 	p ("0x00000000  ELF MAGIC   0x%08x\n", r_read_le32 (buf));
-	p ("0x00000004  Type        0x%04x\n", r_read_le16 (buf + 4));
-	p ("0x00000006  Machine     0x%04x\n", r_read_le16 (buf + 6));
-	p ("0x00000008  Version     0x%08x\n", r_read_le32 (buf + 8));
-	p ("0x0000000c  Entrypoint  0x%08x\n", r_read_le32 (buf + 12));
-	p ("0x00000010  PhOff       0x%08x\n", r_read_le32 (buf + 16));
-	p ("0x00000014  ShOff       0x%08x\n", r_read_le32 (buf + 20));
+	p ("0x00000010  Type        0x%04x\n", r_read_le16 (buf + 0x10));
+	p ("0x00000012  Machine     0x%04x\n", r_read_le16 (buf + 0x12));
+	p ("0x00000014  Version     0x%08x\n", r_read_le32 (buf + 0x14));
+	p ("0x00000018  Entrypoint  0x%08x\n", r_read_le32 (buf + 0x18));
+	p ("0x0000001c  PhOff       0x%08x\n", r_read_le32 (buf + 0x1c));
+	p ("0x00000020  ShOff       0x%08x\n", r_read_le32 (buf + 0x20));
 }
 
 static bool check_bytes(const ut8 *buf, ut64 length) {


### PR DESCRIPTION
#9599 
- Harmonize ```ihj``` and ```ih``` ELF
- Fix ```ih``` ELF 32 bits (offsets were wrong)
- Change ```ihj``` mach0 (ex: hdr.magic now Magic)

Example ELF 32bits:
```
[0x0804938c]> ih
0x00000000  ELF MAGIC   0x464c457f
0x00000010  Type        0x0002
0x00000012  Machine     0x0003
0x00000014  Version     0x00000001
0x00000018  Entrypoint  0x0804938c
0x0000001c  PhOff       0x00000034
0x00000020  ShOff       0x00013504

[0x0804938c]> ihj~{}
[
  {
    "name": "ELF",
    "vaddr": 0,
    "paddr": 0,
    "comment": "0x464c457f",
    "format": "x"
  },
  {
    "name": "Type",
    "vaddr": 16,
    "paddr": 16,
    "comment": "0x00000002",
    "format": "x"
  },
  {
    "name": "Machine",
    "vaddr": 18,
    "paddr": 18,
    "comment": "0x00000003",
    "format": "x"
  },
  {
    "name": "Version",
    "vaddr": 20,
    "paddr": 20,
    "comment": "0x00000001",
    "format": "x"
  },
  {
    "name": "Entry point",
    "vaddr": 24,
    "paddr": 24,
    "comment": "0x0804938c",
    "format": "x"
  },
  {
    "name": "PhOff",
    "vaddr": 28,
    "paddr": 28,
    "comment": "0x00000034",
    "format": "x"
  },
  {
    "name": "ShOff",
    "vaddr": 32,
    "paddr": 32,
    "comment": "0x00013504",
    "format": "x"
  }
]
```