### PR TITLE
Support every output format for the xrefs graph (agx)

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5890,7 +5890,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 	case 'C': // "agC"
 		r_core_anal_callgraph (core, UT64_MAX, input[1] == 'j'? 2 : 1);
 		break;
-	case 'r': // "refs"
+	case 'r': // agr "refs"
 		switch (input[1]) {
 		case 'v':
 		case 't':
@@ -5916,6 +5916,38 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 		case 0:
 			r_core_cmd0 (core, "ag-; .agr* $$; agg;");
+			break;
+		default:
+			eprintf ("Usage: see ag?\n");
+			break;
+		}
+		break;
+	case 'x': // agx "cross refs"
+		switch (input[1]) {
+		case 'v':
+		case 't':
+		case 'd':
+		case 'J':
+		case 'j':
+		case 'g':
+		case 'k':
+		case 'w':
+		case ' ': {
+			char *cmd = r_str_newf ("ag-; .agx* %lld; agg%c;", 
+				input[2] ? r_num_math (core->num, input + 2) : core->offset, input[1]);
+			if (cmd && *cmd) {
+				r_core_cmd0 (core, cmd);
+			}
+			free (cmd);
+			break;
+			}
+		case '*': {
+			ut64 addr = input[2] ? r_num_math (core->num, input + 2) : core->offset;
+			r_core_anal_codexrefs (core, addr);
+			}
+			break;
+		case 0:
+			r_core_cmd0 (core, "ag-; .agx* $$; agg;");
 			break;
 		default:
 			eprintf ("Usage: see ag?\n");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5745,6 +5745,7 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 			r_core_visual_graph (core, core->graph, NULL, true);
 			r_config_set_i (core->config, "scr.interactive", ov);
 			r_cons_show_cursor (true);
+			r_cons_enable_mouse (false);
 		} else {
 			eprintf ("This graph contains no nodes\n");
 		}
@@ -5806,6 +5807,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 		case 'v':// "agfv"
 			eprintf ("\rRendering graph...");
 			r_core_visual_graph (core, NULL, NULL, 1);
+			r_cons_enable_mouse (false);
 			r_cons_show_cursor (true);
 			break;
 		case 't':// "agft" - tiny graph

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3157,6 +3157,10 @@ static int agraph_refresh(struct agraph_refresh_data *grd) {
 	RAnalFunction *f = NULL;
 	RAnalFunction **fcn = grd->fcn;
 
+	if (!fcn) {
+		return agraph_print (g, grd->fs, core, NULL);
+	}
+
 	// allow to change the current function during debugging
 	if (g->is_instep && core->io->debug) {
 		// seek only when the graph node changes
@@ -3198,7 +3202,7 @@ static int agraph_refresh(struct agraph_refresh_data *grd) {
 		r_cons_flush ();
 	}
 
-	return agraph_print (g, grd->fs, core, fcn ? *fcn: NULL);
+	return agraph_print (g, grd->fs, core, *fcn);
 }
 
 static void agraph_toggle_speed(RAGraph *g, RCore *core) {
@@ -3816,13 +3820,15 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 #if 1
 // disabled for now, ultraslow in most situations
 		case '>':
-			if (r_cons_yesno ('y', "Compute function callgraph? (Y/n)")) {
+			if (fcn && r_cons_yesno ('y', "Compute function callgraph? (Y/n)")) {
 				r_core_cmd0 (core, "ag-;.agc* $$;.axtg $$;aggi");
 			}
 			break;
 		case '<':
 			// r_core_visual_refs (core, true);
-			r_core_cmd0 (core, "ag-;.axtg $$;aggi");
+			if (fcn) {
+				r_core_cmd0 (core, "ag-;.axtg $$;aggi");
+			}
 			break;
 #endif
 		case 'G':
@@ -3839,6 +3845,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			}
 			break;
 		case 's':
+			if (!fcn) {
+				break;
+			}
 			key_s = r_config_get (core->config, "key.s");
 			if (key_s && *key_s) {
 				r_core_cmd0 (core, key_s);
@@ -3847,6 +3856,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			}
 			break;
 		case 'S':
+			if (!fcn) {
+				break;
+			}
 			graph_single_step_over (core, g);
 			break;
 		case 'x':
@@ -3945,6 +3957,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			visual_offset (g, core);
 			break;
 		case 'O':
+			if (!fcn) {
+				break;
+			}
 			disMode = (disMode + 1) % 3;
 			applyDisMode (core);
 			g->need_reload_nodes = true;
@@ -4032,12 +4047,16 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			}
 			break;
 		case '(':
-			r_core_cmd0 (core, "wao recj@B:-1");
-			g->need_reload_nodes = true;
+			if (fcn) {
+				r_core_cmd0 (core, "wao recj@B:-1");
+				g->need_reload_nodes = true;
+			}
 			break;
 		case ')':
-			rotateAsmemu (core);
-			g->need_reload_nodes = true;
+			if (fcn) {
+				rotateAsmemu (core);
+				g->need_reload_nodes = true;
+			}
 			break;
 		case 'd':
 			{

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3856,10 +3856,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			}
 			break;
 		case 'S':
-			if (!fcn) {
-				break;
+			if (fcn) {
+				graph_single_step_over (core, g);
 			}
-			graph_single_step_over (core, g);
 			break;
 		case 'x':
 		case 'X':


### PR DESCRIPTION
Added the new command `agx` which displays the graph of all the references to the address given. For now it shows only hex offsets, but I was thinking on adding maybe more information in the body of the nodes (e.g. the disasm of the instruction or the which function the referencing instruction is in) in another pr.

Fixed also some bugs with `aggv` and `agfv`, in  particular the mouse wheel was broken (printed garbage) when exiting from them.