### PR TITLE
Fix fcn maxstack issue in variable recovery

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -580,7 +580,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		ptr = (st64) r_num_get (NULL, addr);
 	}
 	//XXX: This won't work for stack based var/arg
-	int rw = (op.stackop == R_ANAL_STACK_SET) ? 1 : 0;
+	int rw = (op->stackop == R_ANAL_STACK_SET) ? 1 : 0;
 	if (*sign == '+') {
 		const char *pfx = ((ptr < fcn->maxstack) && (type == 's')) ? VARPREFIX : ARGPREFIX;
 		bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -975,7 +975,7 @@ repeat:
 		}
 		// check if opcode is in another basic block
 		// in that case we break
-		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + addrbytes * idx, len - addrbytes * idx, 0)) < 1) {
+		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + addrbytes * idx, len - addrbytes * idx, R_ANAL_OP_MASK_ALL)) < 1) {
 			VERBOSE_ANAL eprintf ("Unknown opcode at 0x%08"PFMT64x "\n", addr + idx);
 			if (!idx) {
 				gotoBeach (R_ANAL_RET_END);
@@ -1065,30 +1065,10 @@ repeat:
 		case R_ANAL_STACK_RESET:
 			bb->stackptr = 0;
 			break;
-		// TODO: use fcn->maxstack to know our stackframe
-		case R_ANAL_STACK_SET:
-			if ((int) op.ptr > 0) {
-				varname = get_varname (anal, fcn, 'b', ARGPREFIX, R_ABS (op.ptr));
-			} else {
-				varname = get_varname (anal, fcn, 'b', VARPREFIX, R_ABS (op.ptr));
-			}
-			r_anal_var_add (anal, fcn->addr, 1, op.ptr, 'b', NULL, anal->bits / 8, varname);
-			r_anal_var_access (anal, fcn->addr, 'b', 1, op.ptr, 1, op.addr);
-			free (varname);
-			break;
-		// TODO: use fcn->maxstack to know our stackframe
-		case R_ANAL_STACK_GET:
-			if (((int) op.ptr) > 0) {
-				varname = get_varname (anal, fcn, 'b', ARGPREFIX, R_ABS (op.ptr));
-			} else {
-				varname = get_varname (anal, fcn, 'b', VARPREFIX, R_ABS (op.ptr));
-			}
-			r_anal_var_add (anal, fcn->addr, 1, op.ptr, 'b', NULL, anal->bits / 8, varname);
-			r_anal_var_access (anal, fcn->addr, 'b', 1, op.ptr, 0, op.addr);
-			free (varname);
-			break;
 		}
-
+		if (anal->opt.vars) {
+			r_anal_fcn_fill_args (anal, fcn, &op);
+		}
 		if (op.ptr && op.ptr != UT64_MAX && op.ptr != UT32_MAX) {
 			// swapped parameters wtf
 			r_anal_xrefs_set (anal, op.addr, op.ptr, R_ANAL_REF_TYPE_DATA);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -561,37 +561,40 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		free (esil_buf);
 		return;
 	}
-#if 1
 	*ptr_end = 0;
 	addr = ptr_end;
 	while ((addr[0] != '0' || addr[1] != 'x') && addr >= esil_buf + 1 && *addr != ',') {
 		addr--;
 	}
 	if (strncmp (addr, "0x", 2)) {
-		free (esil_buf);
-		return;
+		//XXX: This is a workaround for inconsistent esil
+		if ((op->stackop == R_ANAL_STACK_SET) || (op->stackop == R_ANAL_STACK_GET)) {
+			ptr = R_ABS (op->ptr);
+			if (ptr%4) {
+				goto beach;
+			}
+		} else {
+			goto beach;
+		}
+	} else {
+		ptr = (st64) r_num_get (NULL, addr);
 	}
-	ptr = (st64) r_num_get (NULL, addr);
-#else
-	ptr = -op->ptr;
-	if (ptr%4) {
-		free (esil_buf);
-		return;
-	}
-#endif
+	//XXX: This won't work for stack based var/arg
+	int rw = (op.stackop == R_ANAL_STACK_SET) ? 1 : 0;
 	if (*sign == '+') {
 		const char *pfx = ((ptr < fcn->maxstack) && (type == 's')) ? VARPREFIX : ARGPREFIX;
 		bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;
 		char *varname = get_varname (anal, fcn, type, pfx, R_ABS (ptr));
 		r_anal_var_add (anal, fcn->addr, 1, ptr, type, NULL, anal->bits / 8, isarg, varname);
-		r_anal_var_access (anal, fcn->addr, type, 1, ptr, 0, op->addr);
+		r_anal_var_access (anal, fcn->addr, type, 1, ptr, rw, op->addr);
 		free (varname);
 	} else {
 		char *varname = get_varname (anal, fcn, type, VARPREFIX, R_ABS (ptr));
 		r_anal_var_add (anal, fcn->addr, 1, -ptr, type, NULL, anal->bits / 8, 0, varname);
-		r_anal_var_access (anal, fcn->addr, type, 1, -ptr, 1, op->addr);
+		r_anal_var_access (anal, fcn->addr, type, 1, -ptr, rw, op->addr);
 		free (varname);
 	}
+beach:
 	free (esil_buf);
 }
 
@@ -1071,21 +1074,6 @@ repeat:
 		case R_ANAL_STACK_RESET:
 			bb->stackptr = 0;
 			break;
-		case R_ANAL_STACK_SET:
-		case R_ANAL_STACK_GET:
-			{
-				if (anal->opt.vars) {
-					int rw = (op.stackop == R_ANAL_STACK_SET) ? 1 : 0;
-					int delta = -op.ptr;
-					char *pfx = (delta > 0) ? ARGPREFIX : VARPREFIX;
-					bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;
-					char *varname = get_varname (anal, fcn, 'b', pfx, R_ABS (op.ptr));
-					r_anal_var_add (anal, fcn->addr, 1, delta, 'b', NULL, anal->bits / 8, isarg, varname);
-					r_anal_var_access (anal, fcn->addr, 'b', 1, delta, rw, op.addr);
-					free (varname);
-				}
-				break;
-			}
 		}
 		if (anal->opt.vars) {
 			r_anal_fcn_fill_args (anal, fcn, &op);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1074,14 +1074,16 @@ repeat:
 		case R_ANAL_STACK_SET:
 		case R_ANAL_STACK_GET:
 			{
-				int rw = (op.stackop == R_ANAL_STACK_SET) ? 1 : 0;
-				int delta = -op.ptr;
-				char *pfx = (delta > 0) ? ARGPREFIX : VARPREFIX;
-				bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;
-				char *varname = get_varname (anal, fcn, 'b', pfx, R_ABS (op.ptr));
-				r_anal_var_add (anal, fcn->addr, 1, delta, 'b', NULL, anal->bits / 8, isarg, varname);
-				r_anal_var_access (anal, fcn->addr, 'b', 1, delta, rw, op.addr);
-				free (varname);
+				if (anal->opt.vars) {
+					int rw = (op.stackop == R_ANAL_STACK_SET) ? 1 : 0;
+					int delta = -op.ptr;
+					char *pfx = (delta > 0) ? ARGPREFIX : VARPREFIX;
+					bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;
+					char *varname = get_varname (anal, fcn, 'b', pfx, R_ABS (op.ptr));
+					r_anal_var_add (anal, fcn->addr, 1, delta, 'b', NULL, anal->bits / 8, isarg, varname);
+					r_anal_var_access (anal, fcn->addr, 'b', 1, delta, rw, op.addr);
+					free (varname);
+				}
 				break;
 			}
 		}

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -52,13 +52,13 @@ static void type_match_var(RAnal *anal , Sdb *trace, ut64 addr,const char *type,
 		if (bp_name) {
 			int bp_idx = sdb_array_get_num (trace, key, i, 0) - bp;
 			if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_BPV, 1, bp_idx))) {
-				r_anal_var_retype (anal, addr, 1, bp_idx, R_ANAL_VAR_KIND_BPV, type, -1, v->name);
+				r_anal_var_retype (anal, addr, 1, bp_idx, R_ANAL_VAR_KIND_BPV, type, -1, v->isarg, v->name);
 				r_anal_var_free (v);
 			}
 		}
 		int sp_idx = sdb_array_get_num (trace, key, i, 0) - sp;
 		if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_SPV, 1, sp_idx))) {
-			r_anal_var_retype (anal, addr, 1, sp_idx, R_ANAL_VAR_KIND_SPV, type, -1, v->name);
+			r_anal_var_retype (anal, addr, 1, sp_idx, R_ANAL_VAR_KIND_SPV, type, -1, v->isarg, v->name);
 			r_anal_var_free (v);
 		}
 	}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3228,12 +3228,6 @@ R_API int r_core_anal_all(RCore *core) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-			if (r_config_get_i (core->config, "anal.vars")) {
-				r_anal_var_delete_all (core->anal, fcni->addr, 'r');
-				r_anal_var_delete_all (core->anal, fcni->addr, 'b');
-				r_anal_var_delete_all (core->anal, fcni->addr, 's');
-				fcn_callconv (core, fcni);
-			}
 			if (!strncmp (fcni->name, "sym.", 4) || !strncmp (fcni->name, "main", 4)) {
 				fcni->type = R_ANAL_FCN_TYPE_SYM;
 			}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -205,6 +205,13 @@ static int cb_analafterjmp(void *user, void *data) {
 	return true;
 }
 
+static int cb_analvars(void *user, void *data) {
+        RCore *core = (RCore*) user;
+        RConfigNode *node = (RConfigNode*) data;
+        core->anal->opt.vars = node->i_value;
+        return true;
+}
+
 static int cb_analstrings(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
@@ -2361,7 +2368,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("anal.hasnext", "false", "Continue analysis after each function");
 	SETPREF ("anal.esil", "false", "Use the new ESIL code analysis");
 	SETCB ("anal.strings", "false", &cb_analstrings, "Identify and register strings during analysis (aar only)");
-	SETPREF ("anal.vars", "true",  "Analyze local variables and arguments");
+	SETCB ("anal.vars", "true", &cb_analvars, "Analyze local variables and arguments");
 	SETPREF ("anal.vinfun", "true",  "Search values in functions (aav) (false by default to only find on non-code)");
 	SETPREF ("anal.vinfunrange", "false",  "Search values outside function ranges (requires anal.vinfun=false)\n");
 	SETCB ("anal.nopskip", "true", &cb_analnopskip, "Skip nops at the beginning of functions");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1003,19 +1003,7 @@ static int var_cmd(RCore *core, const char *str) {
 					free (a);
 					a = strdup ("\n");
 				}
-				r_cons_printf ("var %s = %s", p->name, a);
-				free (a);
-			}
-			r_list_free (list);
-			// args
-			list = r_anal_var_list (core->anal, fcn, 1);
-			r_list_foreach (list, iter, p) {
-				char *a = r_core_cmd_strf (core, ".afvd %s", p->name);
-				if ((a && !*a) || !a) {
-					free (a);
-					a = strdup ("\n");
-				}
-				r_cons_printf ("arg %s = %s", p->name, a);
+				r_cons_printf ("%s %s = %s", p->isarg ? "arg": "var", p->name, a);
 				free (a);
 			}
 			r_list_free (list);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -331,6 +331,7 @@ static const char *help_msg_afv[] = {
 	"afvr", "[?]", "manipulate register based arguments",
 	"afvb", "[?]", "manipulate bp based arguments/locals",
 	"afvs", "[?]", "manipulate sp based arguments/locals",
+	"afv*", "", "output r2 command to add args/locals to flagspace",
 	"afvR", " [varname]", "list addresses where vars are accessed (READ)",
 	"afvW", " [varname]", "list addresses where vars are accessed (WRITE)",
 	"afva", "", "analyze function arguments/locals",

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2665,9 +2665,6 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		//r_core_anal_undefine (core, core->offset);
 		r_core_anal_fcn (core, addr, UT64_MAX, R_ANAL_REF_TYPE_NULL, depth);
 		fcn = r_anal_get_fcn_in (core->anal, addr, 0);
-		if (fcn && r_config_get_i (core->config, "anal.vars")) {
-			fcn_callconv (core, fcn);
-		}
 		if (fcn) {
 			/* ensure we use a proper name */
 			setFunctionName (core, addr, fcn->name, false);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -331,8 +331,8 @@ static const char *help_msg_afv[] = {
 	"afvr", "[?]", "manipulate register based arguments",
 	"afvb", "[?]", "manipulate bp based arguments/locals",
 	"afvs", "[?]", "manipulate sp based arguments/locals",
-	"afvR", " [varname]", "list addresses where vars are accessed",
-	"afvW", " [varname]", "list addresses where vars are accessed",
+	"afvR", " [varname]", "list addresses where vars are accessed (READ)",
+	"afvW", " [varname]", "list addresses where vars are accessed (WRITE)",
 	"afva", "", "analyze function arguments/locals",
 	"afvd", " name", "output r2 command for displaying the value of args/locals in the debugger",
 	"afvn", " [old_name] [new_name]", "rename argument/local",
@@ -764,7 +764,7 @@ static void var_accesses_list(RAnal *a, RAnalFunction *fcn, int delta, const cha
 static void list_vars(RCore *core, RAnalFunction *fcn, int type, const char *name) {
 	RAnalVar *var;
 	RListIter *iter;
-	RList *list = r_anal_var_list (core->anal, fcn, 0);
+	RList *list = r_anal_var_all_list (core->anal, fcn);
 	if (type == '*') {
 		const char *bp = r_reg_get_name (core->anal->reg, R_REG_NAME_BP);
 		r_cons_printf ("f-fcnvar*\n");
@@ -778,9 +778,17 @@ static void list_vars(RCore *core, RAnalFunction *fcn, int type, const char *nam
 		return;
 	}
 	const char *typestr = type == 'R'?"reads":"writes";
-	r_list_foreach (list, iter, var) {
-		r_cons_printf ("%10s  ", var->name);
-		var_accesses_list (core->anal, fcn, var->delta, typestr);
+	if (name && *name) {
+		var = r_anal_var_get_byname (core->anal, fcn, name);
+		if (var) {
+			r_cons_printf ("%10s  ", var->name);
+			var_accesses_list (core->anal, fcn, var->delta, typestr);
+		}
+	} else {
+		r_list_foreach (list, iter, var) {
+			r_cons_printf ("%10s  ", var->name);
+			var_accesses_list (core->anal, fcn, var->delta, typestr);
+		}
 	}
 }
 
@@ -926,8 +934,11 @@ static int var_cmd(RCore *core, const char *str) {
 	case 'R': // "afvR"
 	case 'W': // "afvW"
 	case '*': // "afv*"
-		list_vars (core, fcn, str[0], str + 1);
-		break;
+		{
+			char *name = r_str_trim_head (strchr (ostr, ' '));
+			list_vars (core, fcn, str[0], name);
+			return true;
+		}
 	case 'a': // "afva"
 		r_anal_var_delete_all (core->anal, fcn->addr, R_ANAL_VAR_KIND_REG);
 		r_anal_var_delete_all (core->anal, fcn->addr, R_ANAL_VAR_KIND_BPV);
@@ -961,7 +972,7 @@ static int var_cmd(RCore *core, const char *str) {
 		} else {
 			RListIter *iter;
 			RAnalVar *v;
-			RList *list = r_anal_var_list (core->anal, fcn, 0);
+			RList *list = r_anal_var_all_list (core->anal, fcn);
 			r_list_foreach (list, iter, v) {
 				r_cons_printf ("%s\n", v->name);
 			}
@@ -985,7 +996,7 @@ static int var_cmd(RCore *core, const char *str) {
 		} else {
 			RListIter *iter;
 			RAnalVar *p;
-			RList *list = r_anal_var_list (core->anal, fcn, 0);
+			RList *list = r_anal_var_all_list (core->anal, fcn);
 			r_list_foreach (list, iter, p) {
 				char *a = r_core_cmd_strf (core, ".afvd %s", p->name);
 				if ((a && !*a) || !a) {
@@ -1030,14 +1041,14 @@ static int var_cmd(RCore *core, const char *str) {
 			return false;
 		}
 		r_anal_var_retype (core->anal, fcn->addr,
-			R_ANAL_VAR_SCOPE_LOCAL, -1, v1->kind, type, -1, p);
+			R_ANAL_VAR_SCOPE_LOCAL, -1, v1->kind, type, -1, v1->isarg, p);
 		r_anal_var_free (v1);
 		free (ostr);
 		return true;
 
 	}
 	}
-	switch (str[1]) {
+	switch (str[1]) { // afv[bsr]
 	case '\0':
 	case '*':
 	case 'j':
@@ -1070,20 +1081,28 @@ static int var_cmd(RCore *core, const char *str) {
 	case 'g':
 		if (str[2] != '\0') {
 			int rw = 0; // 0 = read, 1 = write
+			int idx = r_num_math (core->num, str + 2);
+			char *vaddr;
+			char *p = r_str_trim (strchr (ostr, ' '));
+			if (!p) {
+				var_help (core, type);
+				break;
+			}
+			ut64 addr = core->offset;
+			if ((vaddr = strchr (p , ' '))) {
+				addr = r_num_math (core->num, vaddr);
+			}
 			RAnalVar *var = r_anal_var_get (core->anal, fcn->addr,
-							(char)type, atoi (str + 2), R_ANAL_VAR_SCOPE_LOCAL);
+							str[0], R_ANAL_VAR_SCOPE_LOCAL, idx);
 			if (!var) {
-				eprintf ("Cannot find variable in: '%s'\n", str);
+				eprintf ("Cannot find variable with delta %d\n", idx);
 				res = false;
 				break;
 			}
-			if (var != NULL) {
-				int scope = (str[1] == 'g')? 0: 1;
-				r_anal_var_access (core->anal, fcn->addr, (char)type,
-						scope, atoi (str + 2), rw, core->offset);
-				r_anal_var_free (var);
-				break;
-			}
+			rw = (str[1] == 'g')? 0: 1;
+			r_anal_var_access (core->anal, fcn->addr, str[0],
+					R_ANAL_VAR_SCOPE_LOCAL, idx, rw, addr);
+			r_anal_var_free (var);
 		} else {
 			eprintf ("Missing argument\n");
 		}
@@ -1093,7 +1112,7 @@ static int var_cmd(RCore *core, const char *str) {
 		char *vartype;
 		int size = 4;
 		int scope = 1;
-			for (str++; *str == ' ';) str++;
+		for (str++; *str == ' ';) str++;
 		p = strchr (str, ' ');
 		if (!p) {
 			var_help (core, type);
@@ -1116,7 +1135,7 @@ static int var_cmd(RCore *core, const char *str) {
 			*vartype++ = 0;
 			r_anal_var_add (core->anal, fcn->addr,
 					scope, delta, type,
-					vartype, size, name);
+					vartype, size, 0, name);
 		} else {
 			eprintf ("Missing name\n");
 		}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1382,7 +1382,7 @@ static void printVarSummary(RDisasmState *ds, RList *list) {
 	const char *sp_args_color = COLOR_RESET (ds);
 	const char *rg_args_color = COLOR_RESET (ds);
 	r_list_foreach (list, iter, var) {
-		if (var->delta > 0) {
+		if (var->isarg) {
 			switch (var->kind) {
 			case 'b':
 				bp_args++;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1580,7 +1580,7 @@ static void ds_show_functions(RDisasmState *ds) {
 			}
 			comma = true;
 			r_list_foreach (sp_vars, iter, var) {
-				if (var->delta > f->maxstack) {
+				if (var->isarg) {
 					if ((arg_bp || !r_list_empty (regs)) && comma) {
 						comma = false;
 						r_cons_printf (", ");
@@ -1638,7 +1638,7 @@ static void ds_show_functions(RDisasmState *ds) {
 				}
 				break;
 			case 's': {
-				bool is_var = var->delta < f->maxstack;
+				bool is_var = !var->isarg;
 				ds_show_functions_argvar (ds, var,
 					anal->reg->name[R_REG_NAME_SP],
 					is_var, '+');

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -2200,11 +2200,7 @@ static void variable_rename (RCore *core, ut64 addr, int vindex, const char *nam
 	ut64 a_tmp = core->offset;
 	int i = 0;
 	RListIter *iter;
-	// arguments.
-	RList* list2 = r_anal_var_list (core->anal, fcn, true);
-	// variables.
-	RList* list = r_anal_var_list (core->anal, fcn, false);
-	r_list_join (list, list2);
+	RList *list = r_anal_var_all_list (core->anal, fcn);
 	RAnalVar* var;
 
 	r_list_foreach (list, iter, var) {
@@ -2217,7 +2213,6 @@ static void variable_rename (RCore *core, ut64 addr, int vindex, const char *nam
 		++i;
 	}
 	r_list_free (list);
-	r_list_free (list2);
 }
 
 // In visual mode, display function list
@@ -2261,11 +2256,7 @@ static ut64 var_variables_show(RCore* core, int idx, int *vindex, int show) {
 	int window;
 	int wdelta = (idx > 5) ? idx - 5 : 0;
 	RListIter *iter;
-	// arguments.
-	RList* list2 = r_anal_var_list (core->anal, fcn, true);
-	// variables.
-	RList* list = r_anal_var_list (core->anal, fcn, false);
-	r_list_join (list, list2);
+	RList *list = r_anal_var_all_list (core->anal, fcn);
 	RAnalVar* var;
 	// Adjust the window size automatically.
 	(void)r_cons_get_size (&window);
@@ -2298,7 +2289,6 @@ static ut64 var_variables_show(RCore* core, int idx, int *vindex, int show) {
 		++i;
 	}
 	r_list_free (list);
-	r_list_free (list2);
 	return addr;
 }
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -736,10 +736,11 @@ typedef struct r_anal_var_access_t {
 typedef struct r_anal_var_t {
 	char *name;  /* name of the variable */
 	char *type;  // cparse type of the variable
-	char kind;   // 'a'rg, 'v'ar ..
+	char kind;   // reg , stack ...
 	ut64 addr;   // not used correctly?
 	ut64 eaddr;  // not used correctly?
 	int size;
+	bool isarg;
 	int delta;   /* delta offset inside stack frame */
 	int scope;   /* global, local... | in, out... */
 	/* probably dupped or so */
@@ -1452,7 +1453,7 @@ R_API int r_anal_var_access (RAnal *a, ut64 var_addr, char kind, int scope, int 
 
 R_API RAnalVar *r_anal_var_new(void);
 R_API int r_anal_var_rename (RAnal *a, ut64 var_addr, int scope, char kind, const char *old_name, const char *new_name);
-R_API int r_anal_var_retype (RAnal *a, ut64 addr, int scope, int delta, char kind, const char *type, int size, const char *name);
+R_API int r_anal_var_retype (RAnal *a, ut64 addr, int scope, int delta, char kind, const char *type, int size, bool isarg, const char *name);
 R_API RAnalVarAccess *r_anal_var_access_new(void);
 R_API RList *r_anal_var_list_new(void);
 R_API RList *r_anal_var_access_list_new(void);
@@ -1463,7 +1464,7 @@ R_API void r_anal_var_access_free(void *access);
 R_API int r_anal_var_delete_all (RAnal *a, ut64 addr, const char kind);
 R_API int r_anal_var_delete (RAnal *a, ut64 var_addr, const char kind, int scope, int delta);
 R_API bool r_anal_var_delete_byname (RAnal *a, RAnalFunction *fcn, int type, const char *name);
-R_API bool r_anal_var_add (RAnal *a, ut64 addr, int scope, int delta, char kind, const char *type, int size, const char *name);
+R_API bool r_anal_var_add (RAnal *a, ut64 addr, int scope, int delta, char kind, const char *type, int size, bool isarg, const char *name);
 R_API int r_anal_var_del(RAnal *anal, RAnalFunction *fcn, int delta, int scope);
 R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int index);
 R_API const char *r_anal_var_scope_to_str(RAnal *anal, int scope);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -585,6 +585,7 @@ typedef struct r_anal_callbacks_t {
 
 typedef struct r_anal_options_t {
 	int depth;
+	bool vars; //analyze local var and arguments
 	int cjmpref;
 	int jmpref;
 	int jmpabove;


### PR DESCRIPTION
Fixes #6970

### Before fix

```
(fcn) loc.good_arg_anal 12
|   loc.good_arg_anal ();
|           ; arg int arg_8h @ esp+0x8
|           ; CALL XREF from 0x08048066 (entry0)
|           0x08048071      55             push ebp
|           0x08048072      89e5           mov ebp, esp
|           0x08048074      8b442408       mov eax, dword [esp + arg_8h] ; [0x8:4]=0
|           0x08048078      6a00           push 0
|           0x0804807a      58             pop eax
|           0x0804807b      5d             pop ebp
\           0x0804807c      c3             ret
/ (fcn) loc.bad_arg_anal 15
|   loc.bad_arg_anal ();
|           ; var int local_8h @ esp+0x8
|           ; CALL XREF from 0x0804806b (entry0)
|           0x0804807d      55             push ebp
|           0x0804807e      89e5           mov ebp, esp
|           0x08048080      8b442408       mov eax, dword [esp + local_8h] ; [0x8:4]=0
|           0x08048084      6a00           push 0
|           0x08048086      6a00           push 0
|           0x08048088      58             pop eax
|           0x08048089      58             pop eax
|           0x0804808a      5d             pop ebp
\           0x0804808b      c3             ret
```

### After fix  

```
/ (fcn) fcn.08048071 12
|   fcn.08048071 (int arg_8h);
|           ; arg int arg_8h @ esp+0x8
|           ; CALL XREF from 0x08048066 (entry0)
|           0x08048071      55             push ebp
|           0x08048072      89e5           mov ebp, esp
|           0x08048074      8b442408       mov eax, dword [arg_8h]     ; [0x8:4]=-1 ; 8
|           0x08048078      6a00           push 0
|           0x0804807a      58             pop eax
|           0x0804807b      5d             pop ebp
\           0x0804807c      c3             ret
/ (fcn) fcn.0804807d 15
|   fcn.0804807d (int arg_8h);
|           ; arg int arg_8h @ esp+0x8
|           ; CALL XREF from 0x0804806b (entry0)
|           0x0804807d      55             push ebp
|           0x0804807e      89e5           mov ebp, esp
|           0x08048080      8b442408       mov eax, dword [arg_8h]     ; [0x8:4]=-1 ; 8
|           0x08048084      6a00           push 0
|           0x08048086      6a00           push 0
|           0x08048088      58             pop eax
|           0x08048089      58             pop eax
|           0x0804808a      5d             pop ebp
[0x08048060]> 

```

* It also fixes some inconsistency between af and aaa in variable recovery
* It also fixes many afv commands