### PR TITLE
Improve dyldcache

### DIFF
--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -82,6 +82,11 @@ struct super_blob_t {
 	struct blob_index_t index[];
 };
 
+struct MACH0_(opts_t) {
+	bool verbose;
+	ut64 header_at;
+};
+
 struct MACH0_(obj_t) {
 	struct MACH0_(mach_header) hdr;
 	struct MACH0_(segment_command)* segs;
@@ -134,11 +139,14 @@ struct MACH0_(obj_t) {
 	int uuidn;
 	int func_size;
 	bool verbose;
+	ut64 header_at;
+	void * user;
+	ut64 (*va2pa)(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf);
 };
 
-struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, bool verbose);
-struct MACH0_(obj_t)* MACH0_(new_buf)(struct r_buf_t *buf, bool verbose);
-struct MACH0_(obj_t)* MACH0_(new_buf_steal)(struct r_buf_t *buf, bool verbose);
+void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile * bf);
+struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, struct MACH0_(opts_t) *options);
+struct MACH0_(obj_t)* MACH0_(new_buf)(RBuffer *buf, struct MACH0_(opts_t) *options);
 void* MACH0_(mach0_free)(struct MACH0_(obj_t)* bin);
 struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin);
 struct symbol_t* MACH0_(get_symbols)(struct MACH0_(obj_t)* bin);

--- a/libr/bin/format/mach0/mach0_specs.h
+++ b/libr/bin/format/mach0/mach0_specs.h
@@ -243,4 +243,50 @@ typedef struct {
 	uint32_t pad;
 } cache_img_t;
 
+typedef struct {
+	uint32_t version;
+	uint32_t page_size;
+	uint32_t page_starts_offset;
+	uint32_t page_starts_count;
+	uint32_t page_extras_offset;
+	uint32_t page_extras_count;
+	uint64_t delta_mask;
+	uint64_t value_add;
+} cache_slide2_t;
+
+typedef struct
+{
+	uint32_t version;
+	uint32_t imageExtrasCount;
+	uint32_t imagesExtrasOffset;
+	uint32_t bottomUpListOffset;
+	uint32_t dylibTrieOffset;
+	uint32_t dylibTrieSize;
+	uint32_t initializersOffset;
+	uint32_t initializersCount;
+	uint32_t dofSectionsOffset;
+	uint32_t dofSectionsCount;
+	uint32_t reExportListOffset;
+	uint32_t reExportCount;
+	uint32_t depListOffset;
+	uint32_t depListCount;
+	uint32_t rangeTableOffset;
+	uint32_t rangeTableCount;
+	uint64_t dyldSectionAddr;
+} cache_accel_t;
+
+typedef struct
+{
+	uint64_t exportsTrieAddr;
+	uint64_t weakBindingsAddr;
+	uint32_t exportsTrieSize;
+	uint32_t weakBindingsSize;
+	uint32_t dependentsStartArrayIndex;
+	uint32_t reExportsStartArrayIndex;
+} cache_imgxtr_t;
+
+#define DYLD_CACHE_SLIDE_PAGE_ATTRS 0xC000
+#define DYLD_CACHE_SLIDE_PAGE_ATTR_EXTRA 0x8000
+#define DYLD_CACHE_SLIDE_PAGE_ATTR_NO_REBASE 0x4000
+#define DYLD_CACHE_SLIDE_PAGE_ATTR_END 0x8000
 #endif

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -3,6 +3,7 @@
 #include "mach0_classes.h"
 
 #define RO_META (1 << 0)
+#define MAX_CLASS_NAME_LEN 256
 
 struct MACH0_(SMethodList) {
 	ut32 entsize;
@@ -88,7 +89,6 @@ static void get_objc_property_list(mach0_ut p, RBinFile *bf, RBinClass *klass);
 static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinClass *klass, bool is_static);
 static void get_protocol_list_t(mach0_ut p, RBinFile *bf, RBinClass *klass);
 static void get_class_ro_t(mach0_ut p, RBinFile *bf, ut32 *is_meta_class, RBinClass *klass);
-static void get_class_t(mach0_ut p, RBinFile *bf, RBinClass *klass, bool dupe);
 static bool is_thumb(RBinFile *bf) {
 	struct MACH0_(obj_t) *bin = (struct MACH0_(obj_t) *)bf->o->bin_obj;
 	if (bin->hdr.cputype == 12) {
@@ -110,6 +110,15 @@ static mach0_ut get_pointer(mach0_ut p, ut32 *offset, ut32 *left, RBinFile *bf) 
 	if (!obj) {
 		return 0;
 	}
+	if (!obj->bin_obj) {
+		return 0;
+	}
+
+	struct MACH0_(obj_t) *bin = (struct MACH0_(obj_t)*) obj->bin_obj;
+	if (bin->va2pa) {
+		return bin->va2pa (p, offset, left, bf);
+	}
+
 	if (!sctns) {
 		sctns = r_bin_plugin_mach.sections (bf);
 		if (!sctns) {
@@ -278,14 +287,15 @@ static void get_ivar_list_t(mach0_ut p, RBinFile *bf, RBinClass *klass) {
 				name = strdup ("some_encrypted_data");
 				left = strlen (name) + 1;
 			} else {
-				name = malloc (left + 1);
-				len = r_buf_read_at (bf->buf, r, (ut8 *)name, left);
+				int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
+				name = malloc (name_len + 1);
+				len = r_buf_read_at (bf->buf, r, (ut8 *)name, name_len);
 				if (len < 1) {
 					eprintf ("Error reading\n");
 					R_FREE (name);
 					goto error;
 				}
-				name[left] = 0;
+				name[name_len] = 0;
 			}
 			field->name = r_str_newf ("%s::%s%s", klass->name, "(ivar)", name);
 			R_FREE (name);
@@ -305,9 +315,10 @@ static void get_ivar_list_t(mach0_ut p, RBinFile *bf, RBinClass *klass) {
 				type = strdup ("some_encrypted_data");
 			// 	left = strlen (name) + 1;
 			} else {
-				type = calloc (1, left);
-				r_buf_read_at (bf->buf, r, (ut8 *)type, left);
-				type[left - 1] = 0;
+				int type_len = R_MIN (MAX_CLASS_NAME_LEN, left);
+				type = calloc (1, type_len + 1);
+				r_buf_read_at (bf->buf, r, (ut8 *)type, type_len);
+				type[type_len] = 0;
 			}
       			field->type = strdup (type);
 			R_FREE (type);
@@ -420,11 +431,12 @@ static void get_objc_property_list(mach0_ut p, RBinFile *bf, RBinClass *klass) {
 				name = strdup ("some_encrypted_data");
 				left = strlen (name) + 1;
 			} else {
-				name = calloc (1, left + 1);
+				int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
+				name = calloc (1, name_len + 1);
 				if (!name) {
 					goto error;
 				}
-				if (r_buf_read_at (bf->buf, r, (ut8 *)name, left) != left) {
+				if (r_buf_read_at (bf->buf, r, (ut8 *)name, name_len) != name_len) {
 					goto error;
 				}
 			}
@@ -562,9 +574,10 @@ static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinCl
 				name = strdup ("some_encrypted_data");
 				left = strlen (name) + 1;
 			} else {
-				name = malloc (left + 1);
-				len = r_buf_read_at (bf->buf, r, (ut8 *)name, left);
-				name[left] = 0;
+				int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
+				name = malloc (name_len + 1);
+				len = r_buf_read_at (bf->buf, r, (ut8 *)name, name_len);
+				name[name_len] = 0;
 				if (len < 1) {
 					goto error;
 				}
@@ -584,7 +597,7 @@ static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinCl
 				rtype = strdup ("some_encrypted_data");
 				left = strlen (rtype) + 1;
 			} else {
-        			left = 1;
+				left = 1;
 				rtype = malloc (left + 1);
 				if (!rtype) {
 					goto error;
@@ -744,15 +757,16 @@ static void get_protocol_list_t(mach0_ut p, RBinFile *bf, RBinClass *klass) {
 				name = strdup ("some_encrypted_data");
 				left = strlen (name) + 1;
 			} else {
-				name = malloc (left + 1);
+				int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
+				name = malloc (name_len + 1);
 				if (!name) {
 					return;
 				}
-				if (r_buf_read_at (bf->buf, r, (ut8 *)name, left) != left) {
+				if (r_buf_read_at (bf->buf, r, (ut8 *)name, name_len) != name_len) {
 					R_FREE (name);
 					return;
 				}
-				name[left] = 0;
+				name[name_len] = 0;
 			}
 			class_name = r_str_newf ("%s::%s%s", klass->name, "(protocol)", name);
 			R_FREE (name);
@@ -881,10 +895,11 @@ static void get_class_ro_t(mach0_ut p, RBinFile *bf, ut32 *is_meta_class, RBinCl
 			klass->name = strdup ("some_encrypted_data");
 			left = strlen (klass->name) + 1;
 		} else {
-			char *name = malloc (left + 1);
+			int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
+			char *name = malloc (name_len + 1);
 			if (name) {
-				int rc = r_buf_read_at (bf->buf, r, (ut8 *)name, left);
-				if (rc != left) {
+				int rc = r_buf_read_at (bf->buf, r, (ut8 *)name, name_len);
+				if (rc != name_len) {
 					rc = 0;
 				}
 				name[rc] = 0;
@@ -927,7 +942,7 @@ static mach0_ut get_isa_value() {
 	return 0;
 }
 
-static void get_class_t(mach0_ut p, RBinFile *bf, RBinClass *klass, bool dupe) {
+void MACH0_(get_class_t)(mach0_ut p, RBinFile *bf, RBinClass *klass, bool dupe) {
 	struct MACH0_(SClass) c = { 0 };
 	const int size = sizeof (struct MACH0_(SClass));
 	mach0_ut r = 0;
@@ -985,7 +1000,7 @@ static void get_class_t(mach0_ut p, RBinFile *bf, RBinClass *klass, bool dupe) {
 	if (!is_meta_class && !dupe) {
 		mach0_ut isa_n_value = get_isa_value ();
 		ut64 tmp = klass->addr;
-		get_class_t (c.isa + isa_n_value, bf, klass, true);
+		MACH0_(get_class_t) (c.isa + isa_n_value, bf, klass, true);
 		klass->addr = tmp;
 	}
 }
@@ -1030,8 +1045,6 @@ RList *MACH0_(parse_classes)(RBinFile *bf) {
 	RList /*<RBinClass>*/ *ret = NULL;
 	ut64 num_of_unnamed_class = 0;
 	RBinClass *klass = NULL;
-	RListIter *iter = NULL;
-	RBinSection *s = NULL;
 	RBinObject *obj = bf ? bf->o : NULL;
 	ut32 i = 0, size = 0;
 	RList *sctns = NULL;
@@ -1040,6 +1053,7 @@ RList *MACH0_(parse_classes)(RBinFile *bf) {
 	ut32 left = 0;
 	int len;
 	ut64 paddr;
+	ut64 s_size;
 	bool bigendian;
 	ut8 pp[sizeof (mach0_ut)] = {0};
 
@@ -1052,18 +1066,22 @@ RList *MACH0_(parse_classes)(RBinFile *bf) {
 	// ret = parse_swift_classes (bf);
 
 	// sebfing of section with name __objc_classlist
-	if (!(sctns = r_bin_plugin_mach.sections (bf))) {
-		// retain just for debug
-		// eprintf ("there is no sections\n");
+
+	struct section_t *sections = NULL;
+	if (!(sections = MACH0_(get_sections) (obj->bin_obj))) {
 		return ret;
 	}
 
-	r_list_foreach (sctns, iter, s) {
-		if (strstr (s->name, "__objc_classlist") != NULL) {
+	for (i = 0; !sections[i].last; i++) {
+		if (strstr (sections[i].name, "__objc_classlist")) {
 			is_found = true;
+			paddr = sections[i].offset;
+			s_size = sections[i].size;
 			break;
 		}
 	}
+
+	R_FREE (sections);
 
 	if (!is_found) {
 		// retain just for debug
@@ -1078,9 +1096,8 @@ RList *MACH0_(parse_classes)(RBinFile *bf) {
 		goto get_classes_error;
 	}
 	// start of getting information about each class in file
-	paddr = s->paddr - obj->boffset;
-	for (i = 0; i < s->size; i += sizeof (mach0_ut)) {
-		left = s->size - i;
+	for (i = 0; i < s_size; i += sizeof (mach0_ut)) {
+		left = s_size - i;
 		if (left < sizeof (mach0_ut)) {
 			eprintf ("Chopped classlist data\n");
 			break;
@@ -1112,7 +1129,7 @@ RList *MACH0_(parse_classes)(RBinFile *bf) {
 			goto get_classes_error;
 		}
 		p = r_read_ble (&pp[0], bigendian, 8 * sizeof (mach0_ut));
-		get_class_t (p, bf, klass, false);
+		MACH0_(get_class_t) (p, bf, klass, false);
 		if (!klass->name) {
 			klass->name = r_str_newf ("UnnamedClass%" PFMT64d, num_of_unnamed_class);
 			if (!klass->name) {
@@ -1122,7 +1139,6 @@ RList *MACH0_(parse_classes)(RBinFile *bf) {
 		}
 		r_list_append (ret, klass);
 	}
-	r_list_free (sctns);
 	return ret;
 
 get_classes_error:

--- a/libr/bin/format/objc/mach0_classes.h
+++ b/libr/bin/format/objc/mach0_classes.h
@@ -18,5 +18,6 @@
 #define MACH0_CLASSES_H
 
 R_API RList* MACH0_(parse_classes)(RBinFile *bf);
+R_API void MACH0_(get_class_t)(mach0_ut p, RBinFile *bf, RBinClass *klass, bool dupe);
 
 #endif // MACH0_CLASSES_H

--- a/libr/bin/mangling/swift-sd.c
+++ b/libr/bin/mangling/swift-sd.c
@@ -175,6 +175,7 @@ R_API char *r_bin_demangle_swift(const char *s, int syscmd) {
 	const char *attr2 = NULL;
 	const char *q, *p = s;
 	const char *q_end = p + strlen (p);
+	const char *q_start = p;
 
 	if (strchr (s, '\'') || strchr (s, ' ')) {
 		return NULL;
@@ -351,7 +352,7 @@ R_API char *r_bin_demangle_swift(const char *s, int syscmd) {
 		} else {
 			/* parse function parameters here */
 			// type len value/
-			for (i = 0; q && q < q_end; i++) {
+			for (i = 0; q && q < q_end && q >= q_start; i++) {
 				if (*q == 'f') {
 					q++;
 				}

--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -223,8 +223,8 @@ R_API int r_bin_object_set_items(RBinFile *binfile, RBinObject *o) {
 			r_bin_filter_classes (o->classes);
 		}
 		// cache addr=class+method
-		if (cp->classes) {
-			RList *klasses = cp->classes (binfile);
+		if (o->classes) {
+			RList *klasses = o->classes;
 			RListIter *iter, *iter2;
 			RBinClass *klass;
 			RBinSymbol *method;

--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -4,29 +4,386 @@
 #include <r_util.h>
 #include <r_lib.h>
 #include <r_bin.h>
+#include <r_core.h>
+#include <r_io.h>
 // #include "../format/mach0/mach0_defines.h"
 #define R_BIN_MACH064 1
 #include "../format/mach0/mach0.h"
+#include "objc/mach0_classes.h"
 
-static ut64 va2pa(uint64_t addr, cache_hdr_t *hdr, RBuffer *cache_buf) {
+typedef struct {
+	ut64 start_of_data;
+	ut16 *page_starts;
+	ut32 page_starts_count;
+	ut16 *page_extras;
+	ut32 page_extras_count;
+	ut64 delta_mask;
+	ut64 value_mask;
+	ut32 delta_shift;
+	ut64 value_add;
+	ut32 page_size;
+	ut64 slide;
+	ut8 *one_page_buf;
+} RDyldRebaseInfo;
+
+typedef struct _r_dyldcache {
+	ut8 magic[8];
+	RList *bins;
+	RBuffer *buf;
+	int (*original_io_read)(RIO *io, RIODesc *fd, ut8 *buf, int count);
+	RDyldRebaseInfo *rebase_info;
+	cache_hdr_t *hdr;
+	cache_map_t *maps;
+	cache_accel_t *accel;
+} RDyldCache;
+
+typedef struct _r_bin_image {
+	char *file;
+	ut64 header_at;
+} RDyldBinImage;
+
+static void free_bin(RDyldBinImage *bin) {
+	if (!bin) {
+		return;
+	}
+
+	if (bin->file) {
+		free (bin->file);
+		bin->file = NULL;
+	}
+
+	R_FREE (bin);
+}
+
+static void rebase_info_free(RDyldRebaseInfo *rebase_info) {
+	if (!rebase_info) {
+		return;
+	}
+
+	if (rebase_info->page_starts) {
+		free (rebase_info->page_starts);
+		rebase_info->page_starts = NULL;
+	}
+
+	if (rebase_info->page_extras) {
+		free (rebase_info->page_extras);
+		rebase_info->page_extras = NULL;
+	}
+
+	if (rebase_info->one_page_buf) {
+		free (rebase_info->one_page_buf);
+		rebase_info->one_page_buf = NULL;
+	}
+
+	R_FREE (rebase_info);
+}
+
+static void r_dyldcache_free(RDyldCache *cache) {
+	if (!cache) {
+		return;
+	}
+
+	if (cache->bins) {
+		r_list_free (cache->bins);
+		cache->bins = NULL;
+	}
+
+	if (cache->buf) {
+		r_buf_free (cache->buf);
+		cache->buf = NULL;
+	}
+
+	if (cache->rebase_info) {
+		rebase_info_free (cache->rebase_info);
+		cache->rebase_info = NULL;
+	}
+
+	if (cache->hdr) {
+		free (cache->hdr);
+		cache->hdr = NULL;
+	}
+
+	if (cache->maps) {
+		free (cache->maps);
+		cache->maps = NULL;
+	}
+
+	if (cache->accel) {
+		free (cache->accel);
+		cache->accel = NULL;
+	}
+
+	R_FREE (cache);
+}
+
+static ut64 va2pa(uint64_t addr, cache_hdr_t *hdr, cache_map_t *maps, RBuffer *cache_buf, ut64 slide, ut32 *offset, ut32 *left) {
 	ut64 res = UT64_MAX;
 	uint32_t i;
 
-	cache_map_t *map = R_NEWS0 (cache_map_t, hdr->mappingCount);
-	r_buf_read_at (cache_buf, hdr->mappingOffset, (ut8*)map, sizeof (cache_map_t) * hdr->mappingCount);
+	addr -= slide;
 
 	for (i = 0; i < hdr->mappingCount; ++i) {
-		if (addr >= map[i].address && addr < map[i].address + map[i].size) {
-			res = map[i].fileOffset + addr - map[i].address;
+		if (addr >= maps[i].address && addr < maps[i].address + maps[i].size) {
+			res = maps[i].fileOffset + addr - maps[i].address;
+			if (offset) {
+				*offset = addr - maps[i].address;
+			}
+			if (left) {
+				*left = maps[i].size - (addr - maps[i].address);
+			}
 			break;
 		}
 	}
 
-	R_FREE (map);
 	return res;
 }
 
-static bool dyld64 = false;
+static ut64 bin_obj_va2pa(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf) {
+	if (!bf || !bf->o || !bf->o->bin_obj) {
+		return 0;
+	}
+
+	RDyldCache *cache = (RDyldCache*) ((struct MACH0_(obj_t)*)bf->o->bin_obj)->user;
+	if (!cache) {
+		return 0;
+	}
+
+	ut64 res = va2pa (p, cache->hdr, cache->maps, cache->buf, cache->rebase_info->slide, offset, left);
+	if (res == UT64_MAX) {
+		res = 0;
+	}
+	return res;
+}
+
+static struct MACH0_(obj_t) *bin_to_mach0(RBinFile *bf, RDyldBinImage *bin) {
+	if (!bin || !bf) {
+		return NULL;
+	}
+
+	RDyldCache *cache = (RDyldCache*) bf->o->bin_obj;
+	if (!cache) {
+		return NULL;
+	}
+
+	struct MACH0_(opts_t) opts;
+	MACH0_(opts_set_default) (&opts, bf);
+	opts.header_at = bin->header_at;
+	struct MACH0_(obj_t) *mach0 = MACH0_(new_buf) (cache->buf, &opts);
+	mach0->user = cache;
+	mach0->va2pa = &bin_obj_va2pa;
+	return mach0;
+}
+
+static int prot2perm(int x) {
+	int r = 0;
+	if (x&1) r |= 4;
+	if (x&2) r |= 2;
+	if (x&4) r |= 1;
+	return r;
+}
+
+static ut32 dumb_ctzll(ut64 x) {
+	ut64 result = 0;
+	int i,j;
+	for (i = 0; i < 64; i += 8) {
+		ut8 byte = (x >> i) & 0xff;
+		if (!byte) {
+			result += 8;
+		} else {
+			for (j = 0; j < 8; j++) {
+				if (!((byte >> j) & 1)) {
+					result++;
+				} else {
+					break;
+				}
+			}
+			break;
+		}
+	}
+	return result;
+}
+
+static ut64 estimate_slide(RBinFile *bf, RDyldCache *cache, ut64 value_mask) {
+	ut64 slide = 0;
+	ut64 *classlist = malloc (64);
+	if (!classlist) {
+		goto beach;
+	}
+
+	RListIter *iter;
+	RDyldBinImage *bin;
+	r_list_foreach (cache->bins, iter, bin) {
+		bool found_sample = false;
+
+		struct MACH0_(opts_t) opts;
+		opts.verbose = bf->rbin->verbose;
+		opts.header_at = bin->header_at;
+
+		struct MACH0_(obj_t) *mach0 = MACH0_(new_buf) (cache->buf, &opts);
+		if (!mach0) {
+			goto beach;
+		}
+
+		struct section_t *sections = NULL;
+		if (!(sections = MACH0_(get_sections) (mach0))) {
+			MACH0_(mach0_free) (mach0);
+			goto beach;
+		}
+
+		int i;
+		int incomplete = 2;
+		int classlist_idx, data_idx;
+		for (i = 0; !sections[i].last && incomplete; i++) {
+			if (sections[i].size == 0) {
+				continue;
+			}
+			if (strstr (sections[i].name, "__objc_classlist")) {
+				incomplete--;
+				classlist_idx = i;
+				continue;
+			}
+			if (strstr (sections[i].name, "__objc_data")) {
+				incomplete--;
+				data_idx = i;
+				continue;
+			}
+		}
+
+		if (incomplete) {
+			goto next_bin;
+		}
+
+		int classlist_sample_size = R_MIN (64, sections[classlist_idx].size);
+		int n_classes = classlist_sample_size / 8;
+
+		if (r_buf_fread_at (cache->buf, sections[classlist_idx].offset, (ut8*) classlist, "l", n_classes) < classlist_sample_size) {
+			goto next_bin;
+		}
+
+		ut64 data_addr = sections[data_idx].addr;
+		for (i = 0; i < n_classes; i++) {
+			if ((classlist[i] & 0xfff) == (data_addr & 0xfff)) {
+				slide = (classlist[i] & value_mask) - (data_addr & value_mask);
+				found_sample = true;
+				break;
+			}
+		}
+
+next_bin:
+		MACH0_(mach0_free) (mach0);
+		R_FREE (sections);
+
+		if (found_sample) {
+			break;
+		}
+	}
+
+beach:
+	R_FREE (classlist);
+	return slide;
+}
+
+static RDyldRebaseInfo *get_rebase_info(RBinFile *bf, RDyldCache *cache) {
+	ut16 *page_starts = NULL;
+	ut16 *page_extras = NULL;
+	ut8 *one_page_buf = NULL;
+	RBuffer *cache_buf = cache->buf;
+
+	ut64 start_of_data = 0;
+
+	int i;
+	for (i = 0; i < cache->hdr->mappingCount; ++i) {
+		int perm = prot2perm (cache->maps[i].initProt);
+		if (!(perm & R_BIN_SCN_EXECUTABLE)) {
+			start_of_data = cache->maps[i].fileOffset;// + bf->o->boffset;
+			break;
+		}
+	}
+
+	if (!start_of_data) {
+		return NULL;
+	}
+
+	cache_slide2_t slide_info;
+	ut64 offset = cache->hdr->slideInfoOffset;
+	ut64 size = sizeof (cache_slide2_t);
+	if (r_buf_fread_at (cache_buf, offset, (ut8*) &slide_info, "6i2l", 1) != size) {
+		return NULL;
+	}
+
+	if (slide_info.version != 2) {
+		return NULL;
+	}
+
+	if (slide_info.page_starts_offset == 0 ||
+		slide_info.page_starts_offset > cache->hdr->slideInfoSize ||
+		slide_info.page_starts_offset + slide_info.page_starts_count * 2 > cache->hdr->slideInfoSize) {
+		return NULL;
+	}
+
+	if (slide_info.page_extras_offset == 0 ||
+		slide_info.page_extras_offset > cache->hdr->slideInfoSize ||
+		slide_info.page_extras_offset + slide_info.page_extras_count * 2 > cache->hdr->slideInfoSize) {
+		return NULL;
+	}
+
+	if (slide_info.page_starts_count > 0) {
+		ut64 size = slide_info.page_starts_count * 2;
+		ut64 at = cache->hdr->slideInfoOffset + slide_info.page_starts_offset;
+		page_starts = malloc (size);
+		if (r_buf_fread_at (cache_buf, at, (ut8*) page_starts, "s", slide_info.page_starts_count) != size) {
+			R_FREE (page_starts);
+			return NULL;
+		}
+	}
+
+	if (slide_info.page_extras_count > 0) {
+		ut64 size = slide_info.page_extras_count * 2;
+		ut64 at = cache->hdr->slideInfoOffset + slide_info.page_extras_offset;
+		page_extras = malloc (size);
+		if (r_buf_fread_at (cache_buf, at, (ut8*) page_extras, "s", slide_info.page_extras_count) != size) {
+			R_FREE (page_starts);
+			R_FREE (page_extras);
+			return NULL;
+		}
+	}
+
+	if (slide_info.page_size > 0) {
+		one_page_buf = malloc (slide_info.page_size);
+		if (!one_page_buf) {
+			goto beach;
+		}
+	}
+
+	RDyldRebaseInfo *rebase_info = R_NEW0 (RDyldRebaseInfo);
+	if (!rebase_info) {
+		goto beach;
+	}
+
+	rebase_info->start_of_data = start_of_data;
+	rebase_info->page_starts = page_starts;
+	rebase_info->page_starts_count = slide_info.page_starts_count;
+	rebase_info->page_extras = page_extras;
+	rebase_info->page_extras_count = slide_info.page_extras_count;
+	rebase_info->value_add = slide_info.value_add;
+	rebase_info->delta_mask = slide_info.delta_mask;
+	rebase_info->value_mask = ~rebase_info->delta_mask;
+	rebase_info->delta_shift = dumb_ctzll (rebase_info->delta_mask) - 2;
+	rebase_info->page_size = slide_info.page_size;
+	rebase_info->one_page_buf = one_page_buf;
+	rebase_info->slide = estimate_slide (bf, cache, rebase_info->value_mask);
+	if (rebase_info->slide) {
+		eprintf ("dyldcache is slid: 0x%"PFMT64x"\n", rebase_info->slide);
+	}
+
+	return rebase_info;
+
+beach:
+	R_FREE (page_starts);
+	R_FREE (page_extras);
+	R_FREE (one_page_buf);
+	return NULL;
+}
 
 static bool check_bytes(const ut8 *buf, ut64 length) {
 	bool rc = false;
@@ -35,16 +392,428 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 		strncpy (arch, (const char *) buf + 9, R_MIN (length, sizeof (arch) - 1));
 		rc = !memcmp (buf, "dyld", 4);
 		if (rc) {
-			dyld64 = strstr (arch, "64") != NULL;
 			if (*arch) {
 				eprintf ("Arch: %s\n", arch);
+				if (!strstr (arch, "arm64")) {
+					return false;
+				}
 			}
 		}
 	}
 	return rc;
 }
 
-static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb * sdb) {
+static cache_img_t *read_cache_images(RBuffer *cache_buf, cache_hdr_t *hdr) {
+	if (!cache_buf || !hdr || !hdr->imagesCount || !hdr->imagesOffset) {
+		return NULL;
+	}
+
+	ut64 size = sizeof (cache_img_t) * hdr->imagesCount;
+	cache_img_t *images = R_NEWS0 (cache_img_t, hdr->imagesCount);
+	if (!images) {
+		return NULL;
+	}
+
+	if (r_buf_fread_at (cache_buf, hdr->imagesOffset, (ut8*) images, "3l2i", hdr->imagesCount) != size) {
+		R_FREE (images);
+		return NULL;
+	}
+
+	return images;
+}
+
+static cache_imgxtr_t *read_cache_imgextra(RBuffer *cache_buf, cache_hdr_t *hdr, cache_accel_t *accel) {
+	if (!cache_buf || !hdr || !hdr->imagesCount || !accel || !accel->imageExtrasCount || !accel->imagesExtrasOffset) {
+		return NULL;
+	}
+
+	ut64 size = sizeof (cache_imgxtr_t) * accel->imageExtrasCount;
+	cache_imgxtr_t *images = R_NEWS0 (cache_imgxtr_t, accel->imageExtrasCount);
+	if (!images) {
+		return NULL;
+	}
+
+	if (r_buf_fread_at (cache_buf, accel->imagesExtrasOffset, (ut8*) images, "ll4i", accel->imageExtrasCount) != size) {
+		R_FREE (images);
+		return NULL;
+	}
+
+	return images;
+}
+
+static char *get_lib_name(RBuffer *cache_buf, cache_img_t *img) {
+	char file[256];
+	char *lib_name = file;
+	if (r_buf_read_at (cache_buf, img->pathFileOffset, (ut8*) &file, sizeof (file)) == sizeof (file)) {
+		file[255] = 0;
+		/*char * last_slash = strrchr (file, '/');
+		if (last_slash && *last_slash) {
+			lib_name = last_slash + 1;
+		}*/
+		return strdup (lib_name);
+	}
+	return strdup ("FAIL");
+}
+
+static int string_contains(const void *a, const void *b) {
+	return !strstr ((const char*) a, (const char*) b);
+}
+
+static RList *create_cache_bins(RBinFile *bf, RBuffer *cache_buf, cache_hdr_t *hdr, cache_map_t *maps, cache_accel_t *accel) {
+	RList *bins = r_list_newf ((RListFree)free_bin);
+	if (!bins) {
+		return NULL;
+	}
+
+	cache_img_t *img = read_cache_images (cache_buf, hdr);
+	if (!img) {
+		r_list_free (bins);
+		return NULL;
+	}
+
+	int i;
+	int *deps = NULL;
+	char *target_libs = NULL;
+	target_libs = r_sys_getenv ("R_DYLDCACHE_FILTER");
+	if (target_libs) {
+		RList *target_lib_names = r_str_split_list (target_libs, ":");
+		if (!target_lib_names) {
+			R_FREE (target_libs);
+			r_list_free (bins);
+			return NULL;
+		}
+
+		deps = R_NEWS0 (int, hdr->imagesCount);
+		if (!deps) {
+			r_list_free (target_lib_names);
+			R_FREE (target_libs);
+			r_list_free (bins);
+			return NULL;
+		}
+
+		ut16 *depArray = R_NEWS0 (ut16, accel->depListCount);
+		if (!depArray) {
+			r_list_free (target_lib_names);
+			R_FREE (target_libs);
+			r_list_free (bins);
+			R_FREE (deps);
+			return NULL;
+		}
+
+		if (r_buf_fread_at (cache_buf, accel->depListOffset, (ut8*) depArray, "s", accel->depListCount) != accel->depListCount * 2) {
+			r_list_free (target_lib_names);
+			R_FREE (target_libs);
+			r_list_free (bins);
+			R_FREE (deps);
+			R_FREE (depArray);
+			return NULL;
+		}
+
+		cache_imgxtr_t *extras = read_cache_imgextra (cache_buf, hdr, accel);
+		if (!extras) {
+			r_list_free (target_lib_names);
+			R_FREE (target_libs);
+			r_list_free (bins);
+			R_FREE (deps);
+			R_FREE (depArray);
+			return NULL;
+		}
+
+		for (i = 0; i < hdr->imagesCount; i++) {
+			char *lib_name = get_lib_name (cache_buf, &img[i]);
+			if (!r_list_find (target_lib_names, lib_name, string_contains)) {
+				R_FREE (lib_name);
+				continue;
+			}
+			eprintf ("FILTER: %s\n", lib_name);
+			R_FREE (lib_name);
+			deps[i]++;
+
+			ut32 j;
+			for (j = extras[i].dependentsStartArrayIndex; depArray[j] != 0xffff; j++) {
+				bool upward = depArray[j] & 0x8000;
+				ut16 dep_index = depArray[j] & 0x7fff;
+				if (!upward) {
+					deps[dep_index]++;
+
+					char *dep_name = get_lib_name (cache_buf, &img[dep_index]);
+					eprintf ("-> %s\n", dep_name);
+					R_FREE (dep_name);
+				}
+			}
+		}
+
+		R_FREE (depArray);
+		R_FREE (extras);
+		R_FREE (target_libs);
+		r_list_free (target_lib_names);
+	}
+
+	for (i = 0; i < hdr->imagesCount; i++) {
+		if (deps && !deps[i]) {
+			continue;
+		}
+		ut64 pa = va2pa (img[i].address, hdr, maps, cache_buf, 0, NULL, NULL);
+		if (pa == UT64_MAX) {
+			continue;
+		}
+		ut8 magicbytes[4];
+		r_buf_read_at (cache_buf, pa, magicbytes, 4);
+		int magic = r_read_le32 (magicbytes);
+		switch (magic) {
+		case MH_MAGIC:
+			// parse_mach0 (ret, *ptr, bf);
+			break;
+		case MH_MAGIC_64:
+		{
+			char file[256];
+			RDyldBinImage *bin = R_NEW0 (RDyldBinImage);
+			if (!bin) {
+				r_list_free (bins);
+				R_FREE (img);
+				return NULL;
+			}
+			bin->header_at = pa;
+			if (r_buf_read_at (cache_buf, img[i].pathFileOffset, (ut8*) &file, sizeof (file)) == sizeof (file)) {
+				file[255] = 0;
+				char *last_slash = strrchr (file, '/');
+				if (last_slash && *last_slash) {
+					if (last_slash > file) {
+						char *scan = last_slash - 1;
+						while (scan > file && *scan != '/') {
+							scan--;
+						}
+						if (*scan == '/') {
+							bin->file = strdup (scan + 1);
+						} else {
+							bin->file = strdup (last_slash + 1);
+						}
+					} else {
+						bin->file = strdup (last_slash + 1);
+					}
+				} else {
+					bin->file = strdup (file);
+				}
+			}
+			r_list_append (bins, bin);
+			break;
+		}
+		default:
+			eprintf ("Unknown sub-bin\n");
+			break;
+		}
+	}
+
+	R_FREE (deps);
+	R_FREE (img);
+	return bins;
+}
+
+static void rebase_bytes(RDyldRebaseInfo *rebase_info, ut8 *buf, ut64 offset, int count, ut64 start_of_write) {
+	if (!rebase_info || !buf) {
+		return;
+	}
+
+	int in_buf = 0;
+	while (in_buf < count) {
+		ut64 offset_in_data = offset - rebase_info->start_of_data;
+		ut64 page_index = offset_in_data / rebase_info->page_size;
+		ut64 page_offset = offset_in_data % rebase_info->page_size;
+		ut64 to_next_page = rebase_info->page_size - page_offset;
+
+		if (page_index >= rebase_info->page_starts_count) {
+			goto next_page;
+		}
+		ut16 page_flag = rebase_info->page_starts[page_index];
+
+		if (page_flag == DYLD_CACHE_SLIDE_PAGE_ATTR_NO_REBASE) {
+			goto next_page;
+		}
+
+		if (!(page_flag & DYLD_CACHE_SLIDE_PAGE_ATTR_EXTRA)) {
+			ut64 first_rebase_off = rebase_info->page_starts[page_index] * 4;
+			if (first_rebase_off >= page_offset && first_rebase_off < page_offset + count) {
+				ut32 delta = 1;
+				while (delta) {
+					ut64 position = in_buf + first_rebase_off - page_offset;
+					if (position >= count) {
+						break;
+					}
+					ut64 raw_value = r_read_le64 (buf + position);
+					delta = ((raw_value & rebase_info->delta_mask) >> rebase_info->delta_shift);
+					if (position >= start_of_write) {
+						ut64 new_value = raw_value & rebase_info->value_mask;
+						if (new_value != 0) {
+							new_value += rebase_info->value_add;
+							new_value += rebase_info->slide;
+						}
+						r_write_le64 (buf + position, new_value);
+					}
+					first_rebase_off += delta;
+				}
+			}
+		}
+next_page:
+		in_buf += to_next_page;
+		offset += to_next_page;
+	}
+}
+
+static int dyldcache_io_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
+	if (!io) {
+		return -1;
+	}
+	RCore *core = (RCore*) io->user;
+
+	if (!core || !core->bin || !core->bin->binfiles) {
+		return -1;
+	}
+
+	RDyldCache *cache = NULL;
+	RListIter *iter;
+	RBinFile *bf;
+	r_list_foreach (core->bin->binfiles, iter, bf) {
+		if (bf->fd == fd->fd ) {
+			if (!strncmp ((char*) bf->o->bin_obj, "dyldcac", 7)) {
+				cache = bf->o->bin_obj;
+			} else {
+				cache = ((struct MACH0_(obj_t)*) bf->o->bin_obj)->user;
+			}
+			break;
+		}
+	}
+	if (!cache || !cache->original_io_read) {
+		return fd->plugin->read (io, fd, buf, count);
+	}
+
+	bool includes_data = io->off > cache->rebase_info->start_of_data ||
+		(io->off + count) > cache->rebase_info->start_of_data;
+
+	int result = 0;
+
+	if (includes_data && count > 0) {
+		RDyldRebaseInfo *rebase_info = cache->rebase_info;
+
+		ut64 offset_in_data = io->off - rebase_info->start_of_data;
+		ut64 page_offset = offset_in_data % rebase_info->page_size;
+
+		ut64 internal_offset = io->off & ~(rebase_info->page_size - 1);
+		ut64 internal_end = io->off + count;
+		int rounded_count = internal_end - internal_offset;
+
+		ut8 *internal_buf = rebase_info->one_page_buf;
+		if (rounded_count > rebase_info->page_size) {
+			internal_buf = malloc (rounded_count);
+		}
+
+		ut64 original_off = io->off;
+		io->off = internal_offset;
+
+		int internal_result = cache->original_io_read (io, fd, internal_buf, rounded_count);
+
+		io->off = original_off;
+
+		if (internal_result >= page_offset + count) {
+			rebase_bytes (cache->rebase_info, internal_buf, internal_offset, internal_result, page_offset);
+			result = R_MIN (count, internal_result);
+			memcpy (buf, internal_buf + page_offset, result);
+		} else {
+			eprintf ("ERROR rebasing\n");
+			result = cache->original_io_read (io, fd, buf, count);
+		}
+
+		if (internal_buf != rebase_info->one_page_buf) {
+			R_FREE (internal_buf);
+		}
+	} else {
+		result = cache->original_io_read (io, fd, buf, count);
+	}
+
+	return result;
+}
+
+static void swizzle_io_read(RDyldCache *cache, RIO *io) {
+	if (!io || !io->desc || !io->desc->plugin) {
+		return;
+	}
+
+	RIOPlugin *plugin = io->desc->plugin;
+	cache->original_io_read = plugin->read;
+	plugin->read = &dyldcache_io_read;
+}
+
+static cache_hdr_t *read_cache_header(RBuffer *cache_buf) {
+	if (!cache_buf) {
+		return NULL;
+	}
+
+	cache_hdr_t *hdr = R_NEW0 (cache_hdr_t);
+	if (!hdr) {
+		return NULL;
+	}
+
+	ut64 size = sizeof (cache_hdr_t);
+	if (r_buf_fread_at (cache_buf, 0, (ut8*) hdr, "16c4i7l16clii4l", 1) != size) {
+		R_FREE (hdr);
+		return NULL;
+	}
+
+	return hdr;
+}
+
+static cache_map_t *read_cache_maps(RBuffer *cache_buf, cache_hdr_t *hdr) {
+	if (!cache_buf || !hdr || !hdr->mappingCount || !hdr->mappingOffset) {
+		return NULL;
+	}
+
+	ut64 size = sizeof (cache_map_t) * hdr->mappingCount;
+	cache_map_t *maps = R_NEWS0 (cache_map_t, hdr->mappingCount);
+	if (!maps) {
+		return NULL;
+	}
+
+	if (r_buf_fread_at (cache_buf, hdr->mappingOffset, (ut8*) maps, "3l2i", hdr->mappingCount) != size) {
+		R_FREE (maps);
+		return NULL;
+	}
+
+	return maps;
+}
+
+static cache_accel_t *read_cache_accel(RBuffer *cache_buf, cache_hdr_t *hdr, cache_map_t *maps) {
+	if (!cache_buf || !hdr || !hdr->accelerateInfoSize || !hdr->accelerateInfoAddr) {
+		return NULL;
+	}
+
+	ut64 offset = va2pa (hdr->accelerateInfoAddr, hdr, maps, cache_buf, 0, NULL, NULL);
+	if (!offset) {
+		return NULL;
+	}
+
+	ut64 size = sizeof (cache_accel_t);
+	cache_accel_t *accel = R_NEW0 (cache_accel_t);
+	if (!accel) {
+		return NULL;
+	}
+
+	if (r_buf_fread_at (cache_buf, offset, (ut8*) accel, "16il", 1) != size) {
+		R_FREE (accel);
+		return NULL;
+	}
+
+	accel->imagesExtrasOffset += offset;
+	accel->bottomUpListOffset += offset;
+	accel->dylibTrieOffset += offset;
+	accel->initializersOffset += offset;
+	accel->dofSectionsOffset += offset;
+	accel->reExportListOffset += offset;
+	accel->depListOffset += offset;
+	accel->rangeTableOffset += offset;
+
+	return accel;
+}
+
+static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
 	RBuffer *fbuf = r_buf_new_with_io (&bf->rbin->iob, bf->fd);
 	ut8 bytes_to_check[32];
 	r_buf_read_at (fbuf, 0, (ut8*)bytes_to_check, 32);
@@ -52,7 +821,44 @@ static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb * sdb) {
 		r_buf_free (fbuf);
 		return NULL;
 	}
-	return fbuf;
+
+	RDyldCache *cache = R_NEW0 (RDyldCache);
+	strncpy ((char*) cache->magic, "dyldcac", 7);
+	cache->buf = fbuf;
+	cache->hdr = read_cache_header (fbuf);
+	if (!cache->hdr) {
+		r_dyldcache_free (cache);
+		return NULL;
+	}
+
+	cache->maps = read_cache_maps (fbuf, cache->hdr);
+	if (!cache->maps) {
+		r_dyldcache_free (cache);
+		return NULL;
+	}
+
+	cache->accel = read_cache_accel (fbuf, cache->hdr, cache->maps);
+	if (!cache->accel) {
+		r_dyldcache_free (cache);
+		return NULL;
+	}
+
+	cache->bins = create_cache_bins (bf, fbuf, cache->hdr, cache->maps, cache->accel);
+	if (!cache->bins) {
+		r_dyldcache_free (cache);
+		return NULL;
+	}
+
+	cache->rebase_info = get_rebase_info (bf, cache);
+	if (!cache->rebase_info) {
+		r_dyldcache_free (cache);
+		return NULL;
+	}
+
+	if (!cache->rebase_info->slide) {
+		swizzle_io_read (cache, bf->rbin->iob.io);
+	}
+	return cache;
 }
 
 static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
@@ -80,6 +886,16 @@ static RList *entries(RBinFile *bf) {
 
 static RBinInfo *info(RBinFile *bf) {
 	RBinInfo *ret = NULL;
+
+	if (!bf || !bf->o) {
+		return NULL;
+	}
+
+	RDyldCache *cache = (RDyldCache*) bf->o->bin_obj;
+	if (!cache) {
+		return NULL;
+	}
+
 	bool big_endian = 0;
 	if (!(ret = R_NEW0 (RBinInfo))) {
 		return NULL;
@@ -92,6 +908,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->machine = strdup (ret->arch);
 	ret->subsystem = strdup ("xnu");
 	ret->type = strdup ("library-cache");
+	bool dyld64 = strstr(cache->hdr->magic, "arm64") != NULL;
 	ret->bits = dyld64? 64: 32;
 	ret->has_va = true;
 	ret->big_endian = big_endian;
@@ -110,27 +927,22 @@ static ut64 baddr(RBinFile *bf) {
 	return 0x180000000;
 }
 
-#define USE_R2_API 0
-
-void parse_mach064 (RList *ret, ut64 paddr, RBinFile *bf) {
-	// eprintf ("MACH0 AT 0x%"PFMT64x"\n", paddr);
-	RBuffer *cache_buf = (RBuffer*) bf->o->bin_obj;
-	int sz;
-#if USE_R2_API
-	// XXX r2 api cannot load those mach0s because addresses are messed up
-	sz = 1024*1024*1; // 1MB limit file size to 1MB to avoid slow copies.. this is a nice place to optimize unnecessary r_buf_new_from_bytes
-	RBuffer *buf = r_buf_new_with_pointers (ptr, sz);
-	struct MACH0_(obj_t) *res = MACH0_(new_buf) (buf, bf->rbin->verbose);
-	if (!res) {
+void symbols_from_bin(RList *ret, RBinFile *bf, RDyldBinImage *bin) {
+	struct MACH0_(obj_t) *mach0 = bin_to_mach0 (bf, bin);
+	if (!mach0) {
 		return;
 	}
-	struct symbol_t *symbols = MACH0_(get_symbols) (res);
-	eprintf ("mach0-64: b:%p r:%p s:%p\n", buf, res, symbols);
+
+	struct symbol_t *symbols = MACH0_(get_symbols) (mach0);
 	if (!symbols) {
 		return;
 	}
+	int i;
 	for (i = 0; !symbols[i].last; i++) {
 		if (!symbols[i].name[0] || symbols[i].addr < 100) {
+			continue;
+		}
+		if (strstr (symbols[i].name, "<redacted>")) {
 			continue;
 		}
 		RBinSymbol *sym = R_NEW0 (RBinSymbol);
@@ -139,130 +951,338 @@ void parse_mach064 (RList *ret, ut64 paddr, RBinFile *bf) {
 		}
 		sym->name = strdup (symbols[i].name);
 		sym->vaddr = symbols[i].addr;
+		if (sym->name[0] == '_') {
+			char *dn = r_bin_demangle (bf, sym->name, sym->name, sym->vaddr);
+			if (dn) {
+				sym->dname = dn;
+				char *p = strchr (dn, '.');
+				if (p) {
+					if (IS_UPPER (sym->name[0])) {
+						sym->classname = strdup (sym->name);
+						sym->classname[p - sym->name] = 0;
+					} else if (IS_UPPER (p[1])) {
+						sym->classname = strdup (p + 1);
+						p = strchr (sym->classname, '.');
+						if (p) {
+							*p = 0;
+						}
+					}
+				}
+			}
+		}
+		sym->forwarder = r_str_const ("NONE");
+		sym->bind = r_str_const ((symbols[i].type == R_BIN_MACH0_SYMBOL_TYPE_LOCAL)?
+			"LOCAL": "GLOBAL");
+		sym->type = r_str_const ("FUNC");
 		sym->paddr = symbols[i].offset + bf->o->boffset;
 		sym->size = symbols[i].size;
 		sym->ordinal = i;
 		r_list_append (ret, sym);
 	}
 	free (symbols);
-	r_buf_free (buf);
-	MACH0_(free)(res);
-#else
-	sz = r_buf_size (cache_buf);
-	struct MACH0_(mach_header) h64;
-	r_buf_read_at (cache_buf, paddr, (ut8*)&h64, sizeof (struct MACH0_(mach_header)));
-
-	struct load_command *cmds = (struct load_command*) malloc (h64.sizeofcmds);
-	struct load_command *cmd = cmds;
-	struct load_command *end = (struct load_command*)((const ut8*)cmds + h64.sizeofcmds);
-	r_buf_read_at (cache_buf, paddr + 0x20, (ut8*)cmd, h64.sizeofcmds);
-
-	for (; cmd < end; cmd = (void *)((const ut8*)cmd + cmd->cmdsize)) {
-		if (cmd->cmd != LC_SYMTAB) {
-			continue;
-		}
-		struct symtab_command *stab = (struct symtab_command*)(cmd);
-		if (stab->nsyms == 0 || stab->strsize == 0) {
-			continue;
-		}
-		ut64 syms_sz = sizeof (struct MACH0_(nlist)) * stab->nsyms;
-		if (stab->symoff + syms_sz >= sz || stab->stroff + stab->strsize >= sz) {
-			continue;
-		}
-
-		struct MACH0_(nlist) *syms = (struct MACH0_(nlist)*)malloc (syms_sz);
-		r_buf_read_at (cache_buf, stab->symoff, (ut8*)syms, syms_sz);
-
-		char *strs = (char*)malloc (stab->strsize);
-		r_buf_read_at (cache_buf, stab->stroff, (ut8*)strs, stab->strsize);
-
-		size_t n;
-		for (n = 0; n < stab->nsyms; n++) {
-			if ((syms[n].n_type & N_TYPE) != N_UNDF && (syms[n].n_type & N_EXT)) {
-				RBinSymbol *sym = R_NEW0 (RBinSymbol);
-				if (sym) {
-					sym->name = strdup (&strs [ syms[n].n_strx + 1]);
-					sym->vaddr = syms[n].n_value;
-					sym->paddr = syms[n].n_value;
-					// XXX THIs is unnecessarily slow! must be enums
-					sym->bind = "PUBLIC";
-					sym->type = "SYM";
-					r_list_append (ret, sym);
-				}
-			}
-		}
-		R_FREE (strs);
-		R_FREE (syms);
-		if ((int)cmd->cmdsize < 1) {
-			eprintf ("CMD Size FAIL %d\n", cmd->cmdsize);
-			break;
-		}
-	}
-
-	R_FREE (cmds);
-#endif
+	MACH0_(mach0_free) (mach0);
 }
 
-static RList* sections(RBinFile *bf) {
-	RList *ret = NULL;
-	RBinSection *ptr = NULL;
-	RBinObject *obj = bf ? bf->o : NULL;
-
-	ut64 vaddr = 0x180000000;
-	if (!obj || !obj->bin_obj || !(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
+static void handle_data_sections(RBinSection *sect) {
+	if (strstr (sect->name, "_cstring")) {
+		sect->is_data = true;
+	} else if (strstr (sect->name, "_os_log")) {
+		sect->is_data = true;
+	} else if (strstr (sect->name, "_objc_methname")) {
+		sect->is_data = true;
+	} else if (strstr (sect->name, "_objc_classname")) {
+		sect->is_data = true;
+	} else if (strstr (sect->name, "_objc_methtype")) {
+		sect->is_data = true;
 	}
-	if (!(ptr = R_NEW0 (RBinSection))) {
-		return NULL;
-	}
-
-	RBuffer *cache_buf = (RBuffer*) obj->bin_obj;
-	r_str_ncpy (ptr->name, (char*)"text", R_BIN_SIZEOF_STRINGS);
-	ptr->size = r_buf_size (cache_buf);
-	ptr->vsize = ptr->size;
-	ptr->paddr = 0;
-	ptr->vaddr = vaddr;
-	ptr->add = true;
-	if (!ptr->vaddr) {
-		ptr->vaddr = ptr->paddr;
-	}
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_EXECUTABLE;
-	r_list_append (ret, ptr);
-	return ret;
 }
 
-static RList* symbols(RBinFile *bf) {
-	RList *ret = r_list_newf (free);
-	RBuffer *cache_buf = (RBuffer*) bf->o->bin_obj;
-	cache_hdr_t hdr;
-	r_buf_read_at (cache_buf, 0, (ut8*)&hdr, sizeof (cache_hdr_t));
+static void sections_from_bin(RList *ret, RBinFile *bf, RDyldBinImage *bin) {
+	struct MACH0_(obj_t) *mach0 = bin_to_mach0 (bf, bin);
+	if (!mach0) {
+		return;
+	}
 
-	cache_img_t *img = R_NEWS0 (cache_img_t, hdr.imagesCount);
-	r_buf_read_at (cache_buf, hdr.imagesOffset, (ut8*)img, sizeof (cache_img_t) * hdr.imagesCount);
+	struct section_t *sections = NULL;
+	if (!(sections = MACH0_(get_sections) (mach0))) {
+		return;
+	}
+
 	int i;
-	for (i = 0; i < hdr.imagesCount; i++) {
-		ut64 pa = va2pa (img[i].address, &hdr, cache_buf);
-		if (pa == UT64_MAX) {
-			continue;
+	for (i = 0; !sections[i].last; i++) {
+		RBinSection *ptr;
+		if (!(ptr = R_NEW0 (RBinSection))) {
+			break;
 		}
-		ut8 magicbytes[4];
-		r_buf_read_at (cache_buf, pa, magicbytes, 4);
-		int magic = r_read_le32 (magicbytes);
-		switch (magic) {
-		case MH_MAGIC:
-			// parse_mach0 (ret, *ptr, bf);
-			break;
-		case MH_MAGIC_64:
-			parse_mach064 (ret, pa, bf);
-			break;
-		default:
-			eprintf ("Unknown sub-bin\n");
-			break;
+		if (bin->file) {
+			r_snprintf (ptr->name, R_BIN_SIZEOF_STRINGS, "%s.%s", bin->file, (char*)sections[i].name);
+		} else {
+			r_snprintf (ptr->name, R_BIN_SIZEOF_STRINGS, "%s", (char*)sections[i].name);
+		}
+		if (strstr (ptr->name, "la_symbol_ptr")) {
+			int len = sections[i].size / 8;
+			ptr->format = r_str_newf ("Cd %d[%d]", 8, len);
+		}
+		ptr->name[R_BIN_SIZEOF_STRINGS] = 0;
+		handle_data_sections (ptr);
+		ptr->size = sections[i].size;
+		ptr->vsize = sections[i].vsize;
+		ptr->paddr = sections[i].offset + bf->o->boffset;
+		ptr->vaddr = sections[i].addr;
+		ptr->add = true;
+		if (!ptr->vaddr) {
+			ptr->vaddr = ptr->paddr;
+		}
+		ptr->srwx = sections[i].srwx;
+		r_list_append (ret, ptr);
+	}
+	free (sections);
+	MACH0_(mach0_free) (mach0);
+}
+
+static RList *sections(RBinFile *bf) {
+	RDyldCache *cache = (RDyldCache*) bf->o->bin_obj;
+	if (!cache) {
+		return NULL;
+	}
+
+	RList *ret = r_list_newf (free);
+	if (!ret) {
+		return NULL;
+	}
+
+	RListIter *iter;
+	RDyldBinImage *bin;
+	r_list_foreach (cache->bins, iter, bin) {
+		sections_from_bin (ret, bf, bin);
+	}
+
+	RBinSection *ptr = NULL;
+	int i;
+	for (i = 0; i < cache->hdr->mappingCount; ++i) {
+		if (!(ptr = R_NEW0 (RBinSection))) {
+			return NULL;
+		}
+		r_snprintf (ptr->name, R_BIN_SIZEOF_STRINGS, "cache_map.%d", i);
+		ptr->size = cache->maps[i].size;
+		ptr->vsize = ptr->size;
+		ptr->paddr = cache->maps[i].fileOffset;// + bf->o->boffset;
+		ptr->vaddr = cache->maps[i].address;
+		ptr->add = true;
+		ptr->srwx = prot2perm (cache->maps[i].initProt);
+		r_list_append (ret, ptr);
+	}
+
+	if (cache->rebase_info->slide > 0) {
+		RBinSection *section;
+		r_list_foreach (ret, iter, section) {
+			section->vaddr += cache->rebase_info->slide;
 		}
 	}
 
-	R_FREE (img);
 	return ret;
+}
+
+static RList *symbols(RBinFile *bf) {
+	RDyldCache *cache = (RDyldCache*) bf->o->bin_obj;
+	if (!cache) {
+		return NULL;
+	}
+
+	RList *ret = r_list_newf (free);
+	if (!ret) {
+		return NULL;
+	}
+
+	RListIter *iter;
+	RDyldBinImage *bin;
+	r_list_foreach (cache->bins, iter, bin) {
+		symbols_from_bin (ret, bf, bin);
+	}
+
+	if (cache->rebase_info->slide > 0) {
+		RBinSymbol *sym;
+		r_list_foreach (ret, iter, sym) {
+			sym->vaddr += cache->rebase_info->slide;
+		}
+	}
+
+	return ret;
+}
+
+/* static void unswizzle_io_read(RDyldCache *cache, RIO *io) {
+	if (!io || !io->desc || !io->desc->plugin || !cache->original_io_read) {
+		return;
+	}
+
+	RIOPlugin *plugin = io->desc->plugin;
+	plugin->read = cache->original_io_read;
+	cache->original_io_read = NULL;
+} */
+
+static int destroy(RBinFile *bf) {
+	RDyldCache *cache = (RDyldCache*) bf->o->bin_obj;
+	// unswizzle_io_read (cache, bf->rbin->iob.io); // XXX io may be dead here
+	r_dyldcache_free (cache);
+	return true;
+}
+
+static RList *classes(RBinFile *bf) {
+	RDyldCache *cache = (RDyldCache*) bf->o->bin_obj;
+	if (!cache) {
+		return NULL;
+	}
+
+	RList *ret = r_list_newf (free);
+	if (!ret) {
+		return NULL;
+	}
+
+	RListIter *iter;
+	RDyldBinImage *bin;
+
+	RBuffer *orig_buf = bf->buf;
+	ut32 num_of_unnamed_class = 0;
+	r_list_foreach (cache->bins, iter, bin) {
+		struct MACH0_(obj_t) *mach0 = bin_to_mach0 (bf, bin);
+		if (!mach0) {
+			goto beach;
+		}
+
+		struct section_t *sections = NULL;
+		if (!(sections = MACH0_(get_sections) (mach0))) {
+			MACH0_(mach0_free) (mach0);
+			goto beach;
+		}
+
+		int i;
+		for (i = 0; !sections[i].last; i++) {
+			if (sections[i].size == 0) {
+				continue;
+			}
+			if (!strstr (sections[i].name, "__objc_classlist")) {
+				continue;
+			}
+
+			ut8 *pointers = malloc (sections[i].size);
+			if (r_buf_read_at (cache->buf, sections[i].offset, pointers, sections[i].size) < sections[i].size) {
+				R_FREE (pointers);
+				continue;
+			}
+			ut8 *cursor = pointers;
+			ut8 *pointers_end = pointers + sections[i].size;
+
+			for (; cursor < pointers_end; cursor += 8) {
+				ut64 pointer_to_class = r_read_le64 (cursor);
+
+				RBinClass *klass;
+				if (!(klass = R_NEW0 (RBinClass)) ||
+					!(klass->methods = r_list_new ()) ||
+					!(klass->fields = r_list_new ())) {
+					R_FREE (klass);
+					R_FREE (pointers);
+					R_FREE (sections);
+					MACH0_(mach0_free) (mach0);
+					goto beach;
+				}
+
+				bf->o->bin_obj = mach0;
+				bf->buf = cache->buf;
+				MACH0_(get_class_t) ((ut64) pointer_to_class, bf, klass, false);
+				bf->o->bin_obj = cache;
+				bf->buf = orig_buf;
+
+				if (!klass->name) {
+					klass->name = r_str_newf ("UnnamedClass%" PFMT64d, num_of_unnamed_class);
+					if (!klass->name) {
+						R_FREE (klass);
+						R_FREE (pointers);
+						R_FREE (sections);
+						MACH0_(mach0_free) (mach0);
+						goto beach;
+					}
+					num_of_unnamed_class++;
+				}
+				r_list_append (ret, klass);
+			}
+
+			R_FREE (pointers);
+		}
+
+		R_FREE (sections);
+		MACH0_(mach0_free) (mach0);
+	}
+
+	return ret;
+
+beach:
+	r_list_free (ret);
+	return NULL;
+}
+
+static void header(RBinFile *bf) {
+	if (!bf || !bf->o) {
+		return;
+	}
+
+	RDyldCache *cache = (RDyldCache*) bf->o->bin_obj;
+	if (!cache) {
+		return;
+	}
+
+	RBin *bin = bf->rbin;
+	ut64 slide = cache->rebase_info->slide;
+
+	bin->cb_printf ("dyld cache header:\n");
+	bin->cb_printf ("magic: %s\n", cache->hdr->magic);
+	bin->cb_printf ("mappingOffset: 0x%"PFMT64x"\n", cache->hdr->mappingOffset);
+	bin->cb_printf ("mappingCount: 0x%"PFMT64x"\n", cache->hdr->mappingCount);
+	bin->cb_printf ("imagesOffset: 0x%"PFMT64x"\n", cache->hdr->imagesOffset);
+	bin->cb_printf ("imagesCount: 0x%"PFMT64x"\n", cache->hdr->imagesCount);
+	bin->cb_printf ("dyldBaseAddress: 0x%"PFMT64x"\n", cache->hdr->dyldBaseAddress);
+	bin->cb_printf ("codeSignatureOffset: 0x%"PFMT64x"\n", cache->hdr->codeSignatureOffset);
+	bin->cb_printf ("codeSignatureSize: 0x%"PFMT64x"\n", cache->hdr->codeSignatureSize);
+	bin->cb_printf ("slideInfoOffset: 0x%"PFMT64x"\n", cache->hdr->slideInfoOffset);
+	bin->cb_printf ("slideInfoSize: 0x%"PFMT64x"\n", cache->hdr->slideInfoSize);
+	bin->cb_printf ("localSymbolsOffset: 0x%"PFMT64x"\n", cache->hdr->localSymbolsSize);
+	char uuidstr[128];
+	r_hex_bin2str ((ut8*)cache->hdr->uuid, 16, uuidstr);
+	bin->cb_printf ("uuid: %s\n", uuidstr);
+	bin->cb_printf ("cacheType: 0x%"PFMT64x"\n", cache->hdr->cacheType);
+	bin->cb_printf ("branchPoolsOffset: 0x%"PFMT64x"\n", cache->hdr->branchPoolsOffset);
+	bin->cb_printf ("branchPoolsCount: 0x%"PFMT64x"\n", cache->hdr->branchPoolsCount);
+	bin->cb_printf ("accelerateInfoAddr: 0x%"PFMT64x"\n", cache->hdr->accelerateInfoAddr + slide);
+	bin->cb_printf ("accelerateInfoSize: 0x%"PFMT64x"\n", cache->hdr->accelerateInfoSize);
+	bin->cb_printf ("imagesTextOffset: 0x%"PFMT64x"\n", cache->hdr->imagesTextOffset);
+	bin->cb_printf ("imagesTextCount: 0x%"PFMT64x"\n", cache->hdr->imagesTextCount);
+
+	bin->cb_printf ("\nacceleration info:\n");
+	bin->cb_printf ("version: 0x%"PFMT64x"\n", cache->accel->version);
+	bin->cb_printf ("imageExtrasCount: 0x%"PFMT64x"\n", cache->accel->imageExtrasCount);
+	bin->cb_printf ("imagesExtrasOffset: 0x%"PFMT64x"\n", cache->accel->imagesExtrasOffset);
+	bin->cb_printf ("bottomUpListOffset: 0x%"PFMT64x"\n", cache->accel->bottomUpListOffset);
+	bin->cb_printf ("dylibTrieOffset: 0x%"PFMT64x"\n", cache->accel->dylibTrieOffset);
+	bin->cb_printf ("dylibTrieSize: 0x%"PFMT64x"\n", cache->accel->dylibTrieSize);
+	bin->cb_printf ("initializersOffset: 0x%"PFMT64x"\n", cache->accel->initializersOffset);
+	bin->cb_printf ("initializersCount: 0x%"PFMT64x"\n", cache->accel->initializersCount);
+	bin->cb_printf ("dofSectionsOffset: 0x%"PFMT64x"\n", cache->accel->dofSectionsOffset);
+	bin->cb_printf ("dofSectionsCount: 0x%"PFMT64x"\n", cache->accel->dofSectionsCount);
+	bin->cb_printf ("reExportListOffset: 0x%"PFMT64x"\n", cache->accel->reExportListOffset);
+	bin->cb_printf ("reExportCount: 0x%"PFMT64x"\n", cache->accel->reExportCount);
+	bin->cb_printf ("depListOffset: 0x%"PFMT64x"\n", cache->accel->depListOffset);
+	bin->cb_printf ("depListCount: 0x%"PFMT64x"\n", cache->accel->depListCount);
+	bin->cb_printf ("rangeTableOffset: 0x%"PFMT64x"\n", cache->accel->rangeTableOffset);
+	bin->cb_printf ("rangeTableCount: 0x%"PFMT64x"\n", cache->accel->rangeTableCount);
+	bin->cb_printf ("dyldSectionAddr: 0x%"PFMT64x"\n", cache->accel->dyldSectionAddr + slide);
+
+	bin->cb_printf ("\nslide info:\n");
+	bin->cb_printf ("page_starts_count: 0x%"PFMT64x"\n", cache->rebase_info->page_starts_count);
+	bin->cb_printf ("page_extras_count: 0x%"PFMT64x"\n", cache->rebase_info->page_extras_count);
+	bin->cb_printf ("delta_mask: 0x%"PFMT64x"\n", cache->rebase_info->delta_mask);
+	bin->cb_printf ("value_mask: 0x%"PFMT64x"\n", cache->rebase_info->value_mask);
+	bin->cb_printf ("delta_shift: 0x%"PFMT64x"\n", cache->rebase_info->delta_shift);
+	bin->cb_printf ("page_size: 0x%"PFMT64x"\n", cache->rebase_info->page_size);
+	bin->cb_printf ("slide: 0x%"PFMT64x"\n", slide);
 }
 
 RBinPlugin r_bin_plugin_dyldcache = {
@@ -277,6 +1297,9 @@ RBinPlugin r_bin_plugin_dyldcache = {
 	.symbols = &symbols,
 	.sections = &sections,
 	.check_bytes = &check_bytes,
+	.destroy = &destroy,
+	.classes = &classes,
+	.header = &header,
 	.info = &info,
 };
 

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -39,7 +39,9 @@ static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, S
 	}
 	RBuffer *tbuf = r_buf_new ();
 	r_buf_set_bytes (tbuf, buf, sz);
-	res = MACH0_(new_buf) (tbuf, bf->rbin->verbose);
+	struct MACH0_(opts_t) opts;
+	MACH0_(opts_set_default) (&opts, bf);
+	res = MACH0_(new_buf) (tbuf, &opts);
 	if (res) {
 		sdb_ns_set (sdb, "info", res->kv);
 	}
@@ -52,7 +54,9 @@ static void * load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb){
 	if (!buf) {
 		return NULL;
 	}
-	res = MACH0_(new_buf) (buf, bf->rbin->verbose);
+	struct MACH0_(opts_t) opts;
+	MACH0_(opts_set_default) (&opts, bf);
+	res = MACH0_(new_buf) (buf, &opts);
 	if (res) {
 		sdb_ns_set (sdb, "info", res->kv);
 	}


### PR DESCRIPTION
- still supports only 64-bit caches (but now in theory it's possible to port it to 32-bit too)
- use MACH0_ functions
- parse symbols, sections and classes
- use R_DYLDCACHE_FILTER env variable to symbolicate only a subset of the cache
- rebase unslid caches on-the-fly, properly slide slid caches symbols

Usage: `r2 -e bin.usextr=false path/to/dyldcache/file`

Without tricks it can be very slow to parse all the stuff, but usually the result is worth the waiting.

To speedup things it's possible to avoid loading strings `-e bin.strings=false` if they're not needed.

Otherwise when knowing what to look for, the `R_DYLDCACHE_FILTER` env variable is useful to symbolicate only one sub bin **plus all its direct dependencies**, example:

```
R_DYLDCACHE_FILTER=libsystem_network.dylib r2 -e bin.usextr=false ~/Library/Developer/Xcode/iOS\ DeviceSupport/10.2\ \(14C92\)/Symbols/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64
Arch:  arm64
Arch:  arm64
FILTER: /usr/lib/system/libsystem_network.dylib
-> /usr/lib/system/libdyld.dylib
-> /usr/lib/system/libcompiler_rt.dylib
-> /usr/lib/system/libunwind.dylib
-> /usr/lib/system/libdispatch.dylib
-> /usr/lib/system/libsystem_asl.dylib
-> /usr/lib/system/libsystem_blocks.dylib
-> /usr/lib/system/libsystem_platform.dylib
-> /usr/lib/system/libsystem_malloc.dylib
-> /usr/lib/system/libsystem_c.dylib
-> /usr/lib/system/libsystem_dnssd.dylib
-> /usr/lib/system/libsystem_m.dylib
-> /usr/lib/system/libsystem_symptoms.dylib
-> /usr/lib/system/libsystem_kernel.dylib
-> /usr/lib/system/libxpc.dylib
-> /usr/lib/system/libsystem_notify.dylib
-> /usr/lib/system/libsystem_pthread.dylib
-> /usr/lib/system/libsystem_networkextension.dylib
-> /usr/lib/system/libcorecrypto.dylib
-> /usr/lib/system/libcommonCrypto.dylib
-> /usr/lib/system/libsystem_configuration.dylib
-> /usr/lib/system/libsystem_trace.dylib
-> /usr/lib/system/libsystem_sandbox.dylib
dyldcache is slid: 0xd838000
 -- Run your own r2 scripts in awk using the r2awk program.
[0x00000000]>
```

The sections of all sub bins (or only the filtered ones) are loaded and parsed, and named after the containing sub-bin:
```
[0x00000000]> iS~__TEXT.__text
00 0x00483db0 40404 0x18dcbbdb0 40404 -r-x system_libcommonCrypto.dylib.0.__TEXT.__text
09 0x0048f7cc 13812 0x18dcc77cc 13812 -r-x system_libcompiler_rt.dylib.0.__TEXT.__text
18 0x00000c80 291152 0x18dcd3c80 291152 -r-x system_libcorecrypto.dylib.0.__TEXT.__text
30 0x004fe10c 170888 0x18dd3610c 170888 -r-x system_libdispatch.dylib.0.__TEXT.__text
59 0x0052e0ac 13588 0x18dd660ac 13588 -r-x system_libdyld.dylib.0.__TEXT.__text
74 0x0053c450 85356 0x18dd74450 85356 -r-x system_libsystem_asl.dylib.0.__TEXT.__text
89 0x00553880  1596 0x18dd8b880  1596 -r-x system_libsystem_blocks.dylib.0.__TEXT.__text
100 0x00555380 487136 0x18dd8d380 487136 -r-x system_libsystem_c.dylib.0.__TEXT.__text
117 0x005d47a8 11656 0x18de0c7a8 11656 -r-x system_libsystem_configuration.dylib.0.__TEXT.__text
130 0x005f9bc4 18500 0x18de31bc4 18500 -r-x system_libsystem_dnssd.dylib.0.__TEXT.__text
141 0x00624f48 131528 0x18de5cf48 131528 -r-x system_libsystem_kernel.dylib.0.__TEXT.__text
152 0x00649f40 143740 0x18de81f40 143740 -r-x system_libsystem_m.dylib.0.__TEXT.__text
160 0x00677200 94344 0x18deaf200 94344 -r-x system_libsystem_malloc.dylib.0.__TEXT.__text
178 0x006940b8 237656 0x18decc0b8 237656 -r-x system_libsystem_network.dylib.0.__TEXT.__text
206 0x006eb0f0 28556 0x18df230f0 28556 -r-x system_libsystem_networkextension.dylib.0.__TEXT.__text
219 0x006f5650 37304 0x18df2d650 37304 -r-x system_libsystem_notify.dylib.0.__TEXT.__text
228 0x00700480 20488 0x18df38480 20488 -r-x system_libsystem_platform.dylib.0.__TEXT.__text
241 0x00706d08 33904 0x18df3ed08 33904 -r-x system_libsystem_pthread.dylib.0.__TEXT.__text
255 0x00711828  7696 0x18df49828  7696 -r-x system_libsystem_sandbox.dylib.0.__TEXT.__text
267 0x00715150 21096 0x18df4d150 21096 -r-x system_libsystem_symptoms.dylib.0.__TEXT.__text
278 0x0071dc50 102656 0x18df55c50 102656 -r-x system_libsystem_trace.dylib.0.__TEXT.__text
304 0x0073be2c 17420 0x18df73e2c 17420 -r-x system_libunwind.dylib.0.__TEXT.__text
315 0x00743ae0 126616 0x18df7bae0 126616 -r-x system_libxpc.dylib.0.__TEXT.__text
```

In this way it's possible to emulate one section at a time, depending on what's the user's target, like:

```
[0x00000000]> f~nw_channel_create
0x18df0e170 18 str.nw_channel_create
0x18ded5120 0 sym._nw_channel_create_with_nexus
[0x00000000]> s sym._nw_channel_create_with_nexus
[0x18ded5120]> aae $SS @ $S
[0x18ded5120]> axt str.nw_channel_create
(nofunc) 0x18ded5514 [DATA] add x20, x20, 0x170
(nofunc) 0x18ded5540 [DATA] add x21, x21, 0x170
(nofunc) 0x18ded5634 [DATA] add x8, x8, 0x170
(nofunc) 0x18ded55d8 [DATA] add x22, x22, 0x170
(nofunc) 0x18ded56a0 [DATA] add x22, x22, 0x170
```

and this is very fast and pretty accurate.