### PR TITLE
Fix hexdump output of radiff2

### DIFF
--- a/binr/radiff2/radiff2.c
+++ b/binr/radiff2/radiff2.c
@@ -429,6 +429,7 @@ static void dump_cols(ut8 *a, int as, ut8 *b, int bs, int w) {
 	ut32 sz = R_MIN (as, bs);
 	ut32 i, j;
 	int ctx = DUMP_CONTEXT;
+	int pad = 0;
 	switch (w) {
 	case 8:
 		r_cons_printf ("  offset     0 1 2 3 4 5 6 7 01234567    0 1 2 3 4 5 6 7 01234567\n");
@@ -443,6 +444,10 @@ static void dump_cols(ut8 *a, int as, ut8 *b, int bs, int w) {
 		return;
 	}
 	for (i = 0; i < sz; i += w) {
+		if (i + w >= sz) {
+			pad = w - sz + i;
+			w = sz - i;
+		}
 		bool eq = !memcmp (a + i, b + i, w);
 		if (eq) {
 			ctx--;
@@ -470,6 +475,9 @@ static void dump_cols(ut8 *a, int as, ut8 *b, int bs, int w) {
 				r_cons_printf (Color_RESET);
 			}
 		}
+		for (j = 0; j < pad; j++) {
+			r_cons_printf ("  ");
+		}
 		r_cons_printf (" ");
 		for (j = 0; j < w; j++) {
 			bool eq2 = a[i + j] == b[i + j];
@@ -481,6 +489,9 @@ static void dump_cols(ut8 *a, int as, ut8 *b, int bs, int w) {
 				r_cons_printf (Color_RESET);
 			}
 		}
+		for (j = 0; j < pad; j++) {
+			r_cons_printf (" ");
+		}
 		r_cons_printf ("   ");
 		for (j = 0; j < w; j++) {
 			bool eq2 = a[i + j] == b[i + j];
@@ -491,6 +502,9 @@ static void dump_cols(ut8 *a, int as, ut8 *b, int bs, int w) {
 			if (!eq) {
 				r_cons_printf (Color_RESET);
 			}
+		}
+		for (j = 0; j < pad; j++) {
+			r_cons_printf ("  ");
 		}
 		r_cons_printf (" ");
 		for (j = 0; j < w; j++) {


### PR DESCRIPTION
When diffing two files with `radiff2 -x` bytes are compared beyond the filesize when the filesize is not a multiple of the output width.

For example when comparing two identical files each containing 50 times 0x61, the output of `radiff2 -x` (used master for the test) reads:
```
  offset     0 1 2 3 4 5 6 7 8 9 A B C D E F 0123456789ABCDEF    0 1 2 3 4 5 6 7 8 9 A B C D E F 0123456789ABCDEF
0x00000000  61616161616161616161616161616161 aaaaaaaaaaaaaaaa   61616161616161616161616161616161 aaaaaaaaaaaaaaaa
0x00000010  61616161616161616161616161616161 aaaaaaaaaaaaaaaa   61616161616161616161616161616161 aaaaaaaaaaaaaaaa
...
0x00000030! 61610a00000000004100000000000000 aa......A.......   61610a00000000003181010000000000 aa......1.......
```

With this pull request files are only compared up to the filesize of the smaller file. As an example the output of two files with 50 random bytes now reads:
```
  offset     0 1 2 3 4 5 6 7 8 9 A B C D E F 0123456789ABCDEF    0 1 2 3 4 5 6 7 8 9 A B C D E F 0123456789ABCDEF
0x00000000! c8312ad10b0d06f1d376b0441091372e .1*......v.D..7.   5056e5f9025281f60f0f0eb667921e1a PV...R......g...
0x00000010! 95669d6032cd2a4d02c3dea7558a0dce .f.`2.*M....U...   8cec77fac811073d88d8714450136935 ..w....=..qDP.i5
0x00000020! 2b8a46dd5d94dca202c06a5b1c7d6242 +.F.].....j[.}bB   a71e4aea4c48c1eef15b2f5e08ff1e69 ..J.LH...[/^...i
0x00000030! 2423                             $#                 70bb                             p.
```