### PR TITLE
Added data graph (aga) + partial support for diff graph (agd) output formats

### DIFF
--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -225,6 +225,7 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 		}
 */
 		if (fcn->diff->type != R_ANAL_DIFF_TYPE_NULL) {
+			eprintf ("Function %s already diffed\n", fcn->name);
 			continue;
 		}
 		ot = 0;
@@ -239,10 +240,16 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 				maxsize = fcn2_size;
 				minsize = fcn_size;
 			}
-			if ((fcn2->type != R_ANAL_FCN_TYPE_FCN
-				&& fcn2->type != R_ANAL_FCN_TYPE_SYM) ||
-				fcn2->diff->type != R_ANAL_DIFF_TYPE_NULL ||
-				(maxsize * anal->diff_thfcn > minsize)) {
+			if (maxsize * anal->diff_thfcn > minsize) {
+				eprintf ("Exceeded anal threshold while diffing %s and %s\n", fcn->name, fcn2->name);
+				continue;
+			}
+			if (fcn2->diff->type != R_ANAL_DIFF_TYPE_NULL) {
+				eprintf ("Function %s already diffed\n", fcn2->name);
+				continue;
+			}
+			if ((fcn2->type != R_ANAL_FCN_TYPE_FCN && fcn2->type != R_ANAL_FCN_TYPE_SYM)) {
+				eprintf ("Function %s type not supported\n", fcn2->name);
 				continue;
 			}
 			r_diff_buffers_distance (NULL, fcn->fingerprint, fcn_size, fcn2->fingerprint, fcn2_size, NULL, &t);

--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -225,7 +225,6 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 		}
 */
 		if (fcn->diff->type != R_ANAL_DIFF_TYPE_NULL) {
-			eprintf ("Function %s already diffed\n", fcn->name);
 			continue;
 		}
 		ot = 0;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1732,11 +1732,11 @@ R_API void r_core_anal_datarefs(RCore *core, ut64 addr) {
 			}
 		}
 		if (!found) {
-			eprintf("No data refs in this function.\n");
+			eprintf ("No data refs in this function.\n");
 		}
 		r_list_free (refs);
 	} else {
-		eprintf("Not in a function. Use 'df' to define it.\n");
+		eprintf ("Not in a function. Use 'df' to define it.\n");
 	}
 }
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6051,7 +6051,36 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 		r_core_anal_graph (core, r_num_math (core->num, input + 1), R_CORE_ANAL_GRAPHLINES);
 		break;
 	case 'a': // "aga"
-		r_core_anal_graph (core, r_num_math (core->num, input + 1), 0);
+		switch (input[1]) {
+		case 'v':
+		case 't':
+		case 'k':
+		case 'w':
+		case 'g':
+		case 'j':
+		case 'J':
+		case 'd':
+		case ' ': {
+			char *cmd = r_str_newf ("ag-; .aga* %lld; agg%c;",
+				input[2] ? r_num_math (core->num, input + 2) : core->offset, input[1]);
+			if (cmd && *cmd) {
+				r_core_cmd0 (core, cmd);
+			}
+			free (cmd);
+			break;
+			}
+		case 0:
+			r_core_cmd0 (core, "ag-; .aga* $$; agg;");
+			break;
+		case '*': {
+			ut64 addr = input[2]? r_num_math (core->num, input + 2): core->offset;
+			r_core_anal_datarefs (core, addr);
+			break;
+			}
+		default:
+			 eprintf ("Usage: see ag?\n");
+			 break;
+		}
 		break;
 	case 'd': // "agd"
 		r_core_anal_graph (core, r_num_math (core->num, input + 1),

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6092,15 +6092,19 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 		case 'k':
 		case '*':
 		case ' ':
-			eprintf ("Currently the only supported formats for the diff graph are 'd' and 'w'\n");
-			break;
 		case 0:
-		case 'd':
-			r_core_anal_graph (core, r_num_math (core->num, input + 2), R_CORE_ANAL_GRAPHBODY | R_CORE_ANAL_GRAPHDIFF);
+			eprintf ("Currently the only supported formats for the diff graph are 'agdd' and 'agdw'\n");
 			break;
+		case 'd': {
+			ut64 addr = input[2]? r_num_math (core->num, input + 2): core->offset;
+			r_core_gdiff_fcn (core, addr, core->offset);
+			r_core_anal_graph (core, addr, R_CORE_ANAL_GRAPHBODY | R_CORE_ANAL_GRAPHDIFF);
+			break;
+			}
 		case 'w': {
-			char *cmdargs = r_str_newf ("agdd %lld", r_num_math (core->num, input + 2));
-			char *cmd = r_core_graph_cmd (cmdargs);
+			char *cmdargs = r_str_newf ("agdd %lld",
+				input[2] ? r_num_math (core->num, input + 2) : core->offset);
+			char *cmd = r_core_graph_cmd (core, cmdargs);
 			if (cmd && *cmd) {
 				r_core_cmd0 (core, cmd);
 			}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6083,8 +6083,32 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 		}
 		break;
 	case 'd': // "agd"
-		r_core_anal_graph (core, r_num_math (core->num, input + 1),
-				R_CORE_ANAL_GRAPHBODY | R_CORE_ANAL_GRAPHDIFF);
+		switch (input[1]) {
+		case 'v':
+		case 't':
+		case 'j':
+		case 'J':
+		case 'g':
+		case 'k':
+		case '*':
+		case ' ':
+			eprintf ("Currently the only supported formats for the diff graph are 'd' and 'w'\n");
+			break;
+		case 0:
+		case 'd':
+			r_core_anal_graph (core, r_num_math (core->num, input + 2), R_CORE_ANAL_GRAPHBODY | R_CORE_ANAL_GRAPHDIFF);
+			break;
+		case 'w': {
+			char *cmdargs = r_str_newf ("agdd %lld", r_num_math (core->num, input + 2));
+			char *cmd = r_core_graph_cmd (cmdargs);
+			if (cmd && *cmd) {
+				r_core_cmd0 (core, cmd);
+			}
+			free (cmd);
+			free (cmdargs);
+			break;
+			}
+		}
 		break;
 	case 'v': // "agv"
 		if (r_config_get_i (core->config, "graph.web")) {

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -11,6 +11,14 @@ R_API int r_core_gdiff_fcn(RCore *c, ut64 addr, ut64 addr2) {
 	RList *la, *lb;
 	RAnalFunction *fa = r_anal_get_fcn_at (c->anal, addr, 0);
 	RAnalFunction *fb = r_anal_get_fcn_at (c->anal, addr2, 0);
+	RAnalBlock *bb;
+	RListIter *iter;
+	r_list_foreach (fa->bbs, iter, bb) {
+		r_anal_diff_fingerprint_bb (c->anal, bb);
+	}
+	r_list_foreach (fb->bbs, iter, bb) {
+		r_anal_diff_fingerprint_bb (c->anal, bb);
+	}
 	la = r_list_new ();
 	r_list_append (la, fa);
 	lb = r_list_new ();

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -412,6 +412,7 @@ R_API void r_core_anal_hint_list (RAnal *a, int mode);
 R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode);
 R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad);
 R_API int r_core_anal_data (RCore *core, ut64 addr, int count, int depth, int wordsize);
+R_API void r_core_anal_datarefs(RCore *core, ut64 addr);
 R_API void r_core_anal_coderefs(RCore *core, ut64 addr);
 R_API void r_core_anal_codexrefs(RCore *core, ut64 addr);
 R_API void r_core_anal_callgraph(RCore *core, ut64 addr, int fmt);


### PR DESCRIPTION
Now the command `aga` (which before was a dupe of `ags`) represents the data graph, which is basically a refs graph to data sections.

Also, I thought a lot about `agd`, but only graphviz and png formats can be supported because they are the only one that can show nodes background color. I'll return to agd in the future when I'll have implemented node backgrounds in ascii graphs.

Finally, I found out that `agd` was unfinished, and I tried to fix it myself... but after some hours I found out that's a rabbit hole much deeper than I expected, and I only fixed a small bug related to the fingerprinting of the bb nodes before diffing and added some more verbose error handling. 

My doubts on `agd` are:
 - Right now it does the diff between the function in the current offset and the function given in argument in the same binary... but does that really make sense? I think the right way should be what radiff2 does, that is diffing the same function between two different binaries.
 - Found out that there is a command that does the diff of the function in the current offset and a function in a different file, that's called `cgf`, but it's broken and I think the name is wrong (Since it displays a graph it should be in the ag* family...)