### PR TITLE
Fix #6220 garbage print when clicking on graph

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -171,6 +171,18 @@ static void rotateAsmemu(RCore *core) {
 	}
 }
 
+static void showcursor(RCore *core, int x) {
+	if (!x) {
+		int wheel = r_config_get_i (core->config, "scr.wheel");
+		if (wheel) {
+			r_cons_enable_mouse (true);
+		}
+	} else {
+		r_cons_enable_mouse (false);
+	}
+	r_cons_show_cursor (x);
+}
+
 static char *get_title(ut64 addr) {
 	return r_str_newf ("0x%"PFMT64x, addr);
 }
@@ -3726,11 +3738,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			is_error = true;
 			break;
 		}
-		r_cons_show_cursor (false);
-		wheel = r_config_get_i (core->config, "scr.wheel");
-		if (wheel) {
-			r_cons_enable_mouse (true);
-		}
+		showcursor (core, false);
 
 		// r_core_graph_inputhandle()
 		okey = r_cons_readchar ();
@@ -3772,6 +3780,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			break;
 		case '|':
 		{         // TODO: edit
+			showcursor (core, true);
 			const char *buf = NULL;
 			const char *cmd = r_config_get (core->config, "cmd.gprompt");
 			r_line_set_prompt ("cmd.gprompt> ");
@@ -3779,6 +3788,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			buf = r_line_readline ();
 			core->cons->line->contents = NULL;
 			r_config_set (core->config, "cmd.gprompt", buf);
+			showcursor (core, false);
 		}
 		break;
 		case '=':
@@ -3953,7 +3963,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			goto_asmqjmps (g, core);
 			break;
 		case 'o':
+			showcursor (core, true);
 			visual_offset (g, core);
+			showcursor (core, false);
 			break;
 		case 'O':
 			if (!fcn) {
@@ -4022,12 +4034,14 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			break;
 		case ';':
 			if (fcn) {
+				showcursor (core, true);
 				char buf[256];
 				r_line_set_prompt ("[comment]> ");
 				if (r_cons_fgets (buf, sizeof (buf) - 1, 0, NULL) > 0) {
 					r_core_cmdf (core, "\"CC %s\"", buf);
 				}
 				g->need_reload_nodes = true;
+				showcursor (core, false);
 			}
 			break;
 		case 'C':
@@ -4059,17 +4073,12 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			break;
 		case 'd':
 			{
-				int wheel = r_config_get_i (core->config, "scr.wheel");
-				if (wheel) {
-					r_cons_enable_mouse (false);
-				}
+				showcursor (core, true);
 				// WTF?
 				r_config_set_i (core->config, "scr.interactive", true);
 				r_core_visual_define (core, "");
 				get_bbupdate (g, core, fcn);
-				if (wheel) {
-					r_cons_enable_mouse (true);
-				}
+				showcursor (core, false);
 			}
 			break;
 		case 'D':
@@ -4185,9 +4194,11 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			}
 			break;
 		case '/':
+			showcursor (core, true);
 			r_config_set_i (core->config, "scr.interactive", true);
 			r_core_cmd0 (core, "?i highlight;e scr.highlight=`?y`");
 			r_config_set_i (core->config, "scr.interactive", false);
+			showcursor (core, false);
 			break;
 		case ':':
 			r_core_visual_prompt_input (core);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -175,7 +175,7 @@ static void visual_repeat(RCore *core) {
 static void showcursor(RCore *core, int x) {
 	if (core && core->vmode) {
 		r_cons_show_cursor (x);
-		if (x) {
+		if (!x) {
 			// TODO: cache this
 			int wheel = r_config_get_i (core->config, "scr.wheel");
 			if (wheel) {
@@ -1824,6 +1824,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 		break;
 		case '=':
 		{ // TODO: edit
+			showcursor (core, true);
 			const char *buf = NULL;
 			#define I core->cons
 			const char *cmd = r_config_get (core->config, "cmd.vprompt");
@@ -1833,10 +1834,12 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 //		if (r_cons_fgets (buf, sizeof (buf)-4, 0, NULL) <0) buf[0]='\0';
 			I->line->contents = NULL;
 			(void)r_config_set (core->config, "cmd.vprompt", buf);
+			showcursor (core, false);
 		}
 		break;
 		case '|':
 		{ // TODO: edit
+			showcursor (core, true);
 			const char *buf = NULL;
 			#define I core->cons
 			const char *cmd = r_config_get (core->config, "cmd.cprompt");
@@ -1853,6 +1856,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 				R_FREE (I->line->contents);
 				(void)r_config_set (core->config, "cmd.cprompt", buf? buf: "");
 			}
+			showcursor (core, false);
 		}
 		break;
 		case '!':
@@ -1860,12 +1864,9 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			break;
 		case 'o':
 		{
-			r_cons_enable_mouse (false);
+			showcursor (core, true);
 			visual_offset (core);
-			int wheel = r_config_get_i (core->config, "scr.wheel");
-			if (wheel) {
-				r_cons_enable_mouse (true);
-			}
+			showcursor (core, false);
 		}
 		break;
 		case 'A':
@@ -1911,14 +1912,9 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			if (r_config_get_i (core->config, "asm.esil")) {
 				r_core_visual_esil (core);
 			} else {
-				int wheel = r_config_get_i (core->config, "scr.wheel");
-				if (wheel) {
-					r_cons_enable_mouse (false);
-				}
+				showcursor (core, true);
 				r_core_visual_define (core, arg + 1);
-				if (wheel) {
-					r_cons_enable_mouse (true);
-				}
+				showcursor (core, false);
 			}
 			break;
 		case 'D':
@@ -2556,6 +2552,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			r_core_visual_hudstuff (core);
 			break;
 		case ';':
+			r_cons_enable_mouse (false);
 			r_cons_gotoxy (0, 0);
 			r_cons_printf ("Enter a comment: ('-' to remove, '!' to use $EDITOR)\n");
 			showcursor (core, true);


### PR DESCRIPTION
Fixes #6220 

Also fixed the fact that on many visual modes like offset mode (`o`), comment mode (`;`) etc... there was no cursor. Now the mouse is disabled and the cursor is visible.