### PR TITLE
Fix ihj PE

### DIFF
--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -1131,7 +1131,6 @@ static RList* fields(RBinFile *bf) {
 		#define ROW(nam,siz,val,fmt) \
 		r_list_append (ret, r_bin_field_new (addr, addr, siz, nam, sdb_fmt ("0x%08x", val), fmt));
 		ut64 addr = 0;
-		const ut8 *buf = r_buf_get_at (bf->buf, 0, NULL);
 		ROW ("ELF", 4, r_read_le32 (buf), "x"); addr+=0x10;
 		ROW ("Type", 2, r_read_le16 (buf + addr), "x"); addr+=0x2;
 		ROW ("Machine", 2, r_read_le16 (buf + addr), "x"); addr+=0x2;

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -676,31 +676,177 @@ static char *signature (RBinFile *bf, bool json) {
 	return c;
 }
 
-static RBinField *newField(const char *name, ut64 addr) {
-	RBinField *bf = R_NEW0 (RBinField);
-	bf->name = strdup (name);
-	bf->vaddr = bf->paddr = addr;
-	return bf;
-}
-
 static RList *fields(RBinFile *bf) {
-	const ut8 *buf = bf ? r_buf_buffer (bf->buf) : NULL;
+	RList *ret = NULL;
+	const ut8 *buf = NULL;
 
-	if (!buf) {
+	buf = bf ? r_buf_buffer (bf->buf) : NULL;
+	ret  = r_list_new ();
+
+	if (!buf || !ret) {
 		return NULL;
 	}
-	RList *list = r_list_new ();
+
+	#define ROWL(nam,siz,val,fmt) \
+	r_list_append (ret, r_bin_field_new (addr, addr, siz, nam, sdb_fmt ("0x%08x", val), fmt));
+	ut64 addr = 128;
+
 	struct PE_(r_bin_pe_obj_t) * bin = bf->o->bin_obj;
+	ROWL ("Signature", 4, bin->nt_headers->Signature, "x"); addr += 4;
+	ROWL ("Machine", 2, bin->nt_headers->file_header.Machine, "x"); addr += 2;
+	ROWL ("NumberOfSections", 2, bin->nt_headers->file_header.NumberOfSections, "x"); addr += 2;
+	ROWL ("TimeDateStamp", 4, bin->nt_headers->file_header.TimeDateStamp, "x"); addr += 4;
+	ROWL ("PointerToSymbolTable", 4, bin->nt_headers->file_header.PointerToSymbolTable, "x"); addr += 4;
+	ROWL ("NumberOfSymbols ", 4, bin->nt_headers->file_header.NumberOfSymbols, "x"); addr += 4;
+	ROWL ("SizeOfOptionalHeader", 2, bin->nt_headers->file_header.SizeOfOptionalHeader, "x"); addr += 2;
+	ROWL ("Characteristics", 2, bin->nt_headers->file_header.Characteristics, "x"); addr += 2;
+	ROWL ("Magic", 2, bin->nt_headers->optional_header.Magic, "x"); addr += 2;
+	ROWL ("MajorLinkerVersion", 1, bin->nt_headers->optional_header.MajorLinkerVersion, "x"); addr += 1;
+	ROWL ("MinorLinkerVersion", 1, bin->nt_headers->optional_header.MinorLinkerVersion, "x"); addr += 1;
+	ROWL ("SizeOfCode", 4, bin->nt_headers->optional_header.SizeOfCode, "x"); addr += 4;
+	ROWL ("SizeOfInitializedData", 4, bin->nt_headers->optional_header.SizeOfInitializedData, "x"); addr += 4;
+	ROWL ("SizeOfUninitializedData", 4, bin->nt_headers->optional_header.SizeOfUninitializedData, "x"); addr += 4;
+	ROWL ("AddressOfEntryPoint", 4, bin->nt_headers->optional_header.AddressOfEntryPoint, "x"); addr += 4;
+	ROWL ("BaseOfCode", 4, bin->nt_headers->optional_header.BaseOfCode, "x"); addr += 4;
+	ROWL ("BaseOfData", 4, bin->nt_headers->optional_header.BaseOfData, "x"); addr += 4;
+	ROWL ("ImageBase", 4, bin->nt_headers->optional_header.ImageBase, "x"); addr += 4;
+	ROWL ("SectionAlignment", 4, bin->nt_headers->optional_header.SectionAlignment, "x"); addr += 4;
+	ROWL ("FileAlignment", 4, bin->nt_headers->optional_header.FileAlignment, "x"); addr += 4;
+	ROWL ("MajorOperatingSystemVersion", 2, bin->nt_headers->optional_header.MajorOperatingSystemVersion, "x"); addr += 2;
+	ROWL ("MinorOperatingSystemVersion", 2, bin->nt_headers->optional_header.MinorOperatingSystemVersion, "x"); addr += 2;
+	ROWL ("MajorImageVersion", 2, bin->nt_headers->optional_header.MajorImageVersion, "x"); addr += 2;
+	ROWL ("MinorImageVersion", 2, bin->nt_headers->optional_header.MinorImageVersion, "x"); addr += 2;
+	ROWL ("MajorSubsystemVersion", 2, bin->nt_headers->optional_header.MajorSubsystemVersion, "x"); addr += 2;
+	ROWL ("MinorSubsystemVersion", 2, bin->nt_headers->optional_header.MinorSubsystemVersion, "x"); addr += 2;
+	ROWL ("Win32VersionValue", 4, bin->nt_headers->optional_header.Win32VersionValue, "x"); addr += 4;
+	ROWL ("SizeOfImage", 4, bin->nt_headers->optional_header.SizeOfImage, "x"); addr += 4;
+	ROWL ("SizeOfHeaders", 4, bin->nt_headers->optional_header.SizeOfHeaders, "x"); addr += 4;
+	ROWL ("CheckSum", 4, bin->nt_headers->optional_header.CheckSum, "x"); addr += 4;
+	ROWL ("Subsystem",24, bin->nt_headers->optional_header.Subsystem, "x"); addr += 2;
+	ROWL ("DllCharacteristics", 2, bin->nt_headers->optional_header.DllCharacteristics, "x"); addr += 2;
+	ROWL ("SizeOfStackReserve", 4, bin->nt_headers->optional_header.SizeOfStackReserve, "x"); addr += 4;
+	ROWL ("SizeOfStackCommit", 4, bin->nt_headers->optional_header.SizeOfStackCommit, "x"); addr += 4;
+	ROWL ("SizeOfHeapReserve", 4, bin->nt_headers->optional_header.SizeOfHeapReserve, "x"); addr += 4;
+	ROWL ("SizeOfHeapCommit", 4, bin->nt_headers->optional_header.SizeOfHeapCommit, "x"); addr += 4;
+	ROWL ("LoaderFlags", 4, bin->nt_headers->optional_header.LoaderFlags, "x"); addr += 4;
+	ROWL ("NumberOfRvaAndSizes", 4, bin->nt_headers->optional_header.NumberOfRvaAndSizes, "x"); addr += 4;
 
-	// TODO: we should use pf*
-	ut64 at = r_offsetof (PE_(image_nt_headers), Signature);
-	r_list_append (list, newField ("signature", at));
+	int i;
+	ut64 tmp = addr;
+	for (i = 0; i < PE_IMAGE_DIRECTORY_ENTRIES - 1; i++) {
+		if (bin->nt_headers->optional_header.DataDirectory[i].Size > 0) {
+			addr = tmp + i*8;
+			switch (i) {
+			case PE_IMAGE_DIRECTORY_ENTRY_EXPORT:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_EXPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_EXPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_IMPORT:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_IMPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_IMPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_RESOURCE:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_RESOURCE", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_RESOURCE", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_EXCEPTION:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_EXCEPTION", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_EXCEPTION", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_SECURITY:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_SECURITY", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_SECURITY", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_BASERELOC:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_BASERELOC", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_BASERELOC", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_DEBUG:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_DEBUG", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_DEBUG", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_COPYRIGHT:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_COPYRIGHT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_COPYRIGHT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_GLOBALPTR:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_GLOBALPTR", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_GLOBALPTR", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_TLS:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_TLS", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_TLS", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_IAT:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_IAT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_IAT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			case PE_IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR:
+				ROWL ("IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].VirtualAddress, "x");
+				addr += 4;
+				ROWL ("SIZE_IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR", 4, \
+				bin->nt_headers->optional_header.DataDirectory[i].Size, "x");
+				break;
+			}
+		}
+	}
 
-	at = r_offsetof (PE_(image_optional_header), AddressOfEntryPoint);
-	at += bin->dos_header->e_lfanew;
-	r_list_append (list, newField ("entrypoint", at));
-
-	return list;
+	return ret;
 }
 
 static void header(RBinFile *bf) {


### PR DESCRIPTION
Issue #9599
- Harmonize ihj and ih for PE
- Delete one useless line in static RList* fields for ELF format (from my last commit)
Example:
```
[0x00407134]> ihj~{}
[
  {
    "name": "Signature",
    "vaddr": 128,
    "paddr": 128,
    "comment": "0x00004550",
    "format": "x"
  },
  {
    "name": "Machine",
    "vaddr": 132,
    "paddr": 132,
    "comment": "0x0000014c",
    "format": "x"
  },
  {
    "name": "NumberOfSections",
    "vaddr": 134,
    "paddr": 134,
    "comment": "0x00000004",
    "format": "x"
  },
  {
    "name": "TimeDateStamp",
    "vaddr": 136,
    "paddr": 136,
    "comment": "0x5a6de570",
    "format": "x"
  },
  {
    "name": "PointerToSymbolTable",
    "vaddr": 140,
    "paddr": 140,
    "comment": "0x00000000",
    "format": "x"
  },
  {
    "name": "NumberOfSymbols ",
    "vaddr": 144,
    "paddr": 144,
    "comment": "0x00000000",
    "format": "x"
  },
  {
    "name": "SizeOfOptionalHeader",
    "vaddr": 148,
    "paddr": 148,
    "comment": "0x000000e0",
    "format": "x"
  },
  {
    "name": "Characteristics",
    "vaddr": 150,
    "paddr": 150,
    "comment": "0x0000012f",
    "format": "x"
  },
  {
    "name": "Magic",
    "vaddr": 152,
    "paddr": 152,
    "comment": "0x0000010b",
    "format": "x"
  },
...
```