### PR TITLE
avoid cp -a: it isn't POSIX defined and doesn't exist on openbsd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ windist:
 	@cp -f libr/bin/d/trx "${WINDIST}/share/radare2/${VERSION}/format"
 	@cp -f libr/bin/d/dll/*.sdb "${WINDIST}/share/radare2/${VERSION}/format/dll"
 	@mkdir -p "${WINDIST}/share/radare2/${VERSION}/cons"
-	@cp -af libr/cons/d/* "${WINDIST}/share/radare2/${VERSION}/cons"
+	@cp -PRpf libr/cons/d/* "${WINDIST}/share/radare2/${VERSION}/cons"
 	@mkdir -p "${WINDIST}/share/radare2/${VERSION}/hud"
 	@cp -f doc/hud "${WINDIST}/share/radare2/${VERSION}/hud/main"
 	@mv "${WINDIST}" "radare2-${WINBITS}-${VERSION}"

--- a/binr/blob/Makefile
+++ b/binr/blob/Makefile
@@ -130,6 +130,6 @@ install:
 	mkdir -p "${DESTDIR}${BINDIR}"
 	for FILE in r2 ${BINS2} ; do \
 		rm -f "${DESTDIR}${BINDIR}/$$FILE" ; \
-		cp -af "$$FILE" "${DESTDIR}${BINDIR}/$$FILE" ; \
+		cp -PRpf "$$FILE" "${DESTDIR}${BINDIR}/$$FILE" ; \
 	done
 

--- a/libr/cons/d/Makefile
+++ b/libr/cons/d/Makefile
@@ -12,7 +12,7 @@ install: ${F_SDB}
 	mkdir -p "$P"
 	for FILE in * ; do \
 		if [ $$FILE != Makefile -a $$FILE != meson.build -a -f $$FILE ]; then \
-			cp -af "${CWD}/$$FILE" "$P/$$FILE" ; \
+			cp -PRpf "${CWD}/$$FILE" "$P/$$FILE" ; \
 		fi ; \
 	done
 


### PR DESCRIPTION
when using `cp`, avoid `-a` and replace it by the most similar arguments: `-PRp`

according to ubuntu man page:
* `-a` : same as `-dR --preserve=all`
* `-d` : --no-dereference --preserve=links
* `--no-dereference` is `-P` (never follow symbolic links in SOURCE)

and `--preserve=all` covers mode,ownership,timestamps,context,links,xattr. POSIX `-p` argument doesn't cover all of that, but I assume it is ok.