### PR TITLE
Manage types enum more properly

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -947,7 +947,6 @@ static void cmd_print_format(RCore *core, const char *_input, const ut8* block, 
 	core->print->reg = core->dbg->reg;
 	core->print->get_register = r_reg_get;
 	core->print->get_register_value = r_reg_get_value;
-	core->print->sdb_types = core->anal->sdb_types;
 
 	int o_blocksize = core->blocksize;
 

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -493,7 +493,7 @@ static int cmd_type(void *data, const char *input) {
 		}
 	} break;
 	case 'e': { // "te"
-		char *res, *temp = strchr(input, ' ');
+		char *res = NULL, *temp = strchr(input, ' ');
 		Sdb *TDB = core->anal->sdb_types;
 		char *name = temp ? strdup (temp + 1): NULL;
 		char *member_name = name ? strchr (name, ' '): NULL;
@@ -503,6 +503,7 @@ static int cmd_type(void *data, const char *input) {
 		}
 		if (name && !r_type_isenum (TDB, name)) {
 			eprintf ("%s is not an enum\n", name);
+			break;
 		}
 		switch (input[1]) {
 		case '?' :
@@ -514,7 +515,6 @@ static int cmd_type(void *data, const char *input) {
 		case ' ' : {
 			RListIter *iter;
 			RTypeEnum *member = R_NEW0 (RTypeEnum);
-			//char *value = sdb_fmt ("0x%x", (ut32)r_num_math (core->num, member));
 			if (member_name) {
 				res = r_type_enum_member (TDB, name, NULL, r_num_math (core->num, member_name));
 			} else {
@@ -538,7 +538,6 @@ static int cmd_type(void *data, const char *input) {
 					}
 				}
 			}
-			free (name);
 			ls_free (l);
 		} break;
 		}

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -50,8 +50,6 @@ typedef struct r_print_t {
 	char *(*cb_color)(int idx, int last, bool bg);
 	int (*disasm)(void *p, ut64 addr);
 	void (*oprintf)(const char *str, ...);
-	char* (*get_bitfield)(void *user, const char *name, ut64 value);
-	char* (*get_enumname)(void *user, const char *name, ut64 value);
 	int interrupt;
 	int big_endian;
 	int width;

--- a/libr/include/r_util/r_ctypes.h
+++ b/libr/include/r_util/r_ctypes.h
@@ -5,8 +5,17 @@
 extern "C" {
 #endif
 
+typedef struct r_type_enum {
+	const char *name;
+	const char *val;
+}RTypeEnum;
+
 R_API int r_type_set(Sdb *TDB, ut64 at, const char *field, ut64 val);
 R_API void r_type_del(Sdb *TDB, const char *name);
+R_API bool r_type_isenum(Sdb *TDB, const char *name);
+R_API char *r_type_enum_member(Sdb *TDB, const char *name, const char *member, ut64 val);
+R_API char *r_type_enum_getbitfield(Sdb *TDB, const char *name, ut64 val);
+R_API RList* r_type_get_enum (Sdb *TDB, const char *name);
 R_API int r_type_get_bitsize (Sdb *TDB, const char *type);
 R_API RList* r_type_get_by_offset(Sdb *TDB, ut64 offset);
 R_API int r_type_link (Sdb *TDB, const char *val, ut64 addr);

--- a/libr/util/p_format.c
+++ b/libr/util/p_format.c
@@ -1110,9 +1110,7 @@ static void r_print_format_bitfield(const RPrint* p, ut64 seeki, char* fmtname,
 	if (MUSTSEE && !SEEVALUE) {
 		p->cb_printf ("0x%08"PFMT64x" = ", seeki);
 	}
-	if (p->get_bitfield) {
-		bitfield = p->get_bitfield (p->user, fmtname, addr);
-	}
+	bitfield = r_type_enum_getbitfield (p->sdb_types, fmtname, addr);
 	if (bitfield && *bitfield) {
 		if (MUSTSEEJSON) p->cb_printf ("\"%s\"}", bitfield);
 		else if (MUSTSEE) p->cb_printf (" %s (bitfield) = %s\n", fieldname, bitfield);
@@ -1135,9 +1133,7 @@ static void r_print_format_enum (const RPrint* p, ut64 seeki, char* fmtname,
 	if (MUSTSEE && !SEEVALUE) {
 		p->cb_printf ("0x%08"PFMT64x" = ", seeki);
 	}
-	if (p->get_enumname) {
-		enumvalue = p->get_enumname (p->user, fmtname, addr);
-	}
+	enumvalue = r_type_enum_member (p->sdb_types, fmtname, NULL, addr);
 	if (enumvalue && *enumvalue) {
 		if (mode & R_PRINT_DOT) {
 			p->cb_printf ("%s.%s", fmtname, enumvalue);

--- a/shlr/tcc/tccgen.c
+++ b/shlr/tcc/tccgen.c
@@ -991,8 +991,6 @@ do_decl:
 			if (!strcmp (name, "{")) {
 				// UNNAMED
 				fprintf (stderr, "anonymous enums are ignored\n");
-			} else {
-				tcc_appendf ("%s=enum\n", name);
 			}
 			for (;;) {
 				v = tok;
@@ -1006,9 +1004,10 @@ do_decl:
 				}
 				if (strcmp (name, "{")) {
 					char *varstr = get_tok_str (v, NULL);
-					// eprintf("%s.%s @ 0x%"PFMT64x"\n", name, varstr, c);
-					tcc_appendf ("%s.%s=0x%"PFMT64x "\n", name, varstr, c);
-					tcc_appendf ("%s.0x%"PFMT64x "=%s\n", name, c, varstr);
+					tcc_appendf ("%s=enum\n", name);
+					tcc_appendf ("[+]enum.%s=%s\n",name, varstr);
+					tcc_appendf ("enum.%s.%s=0x%"PFMT64x "\n", name, varstr, c);
+					tcc_appendf ("enum.%s.0x%"PFMT64x "=%s\n", name, c, varstr);
 					// TODO: if token already defined throw an error
 					// if (varstr isInside (arrayOfvars)) { erprintf ("ERROR: DUP VAR IN ENUM\n"); }
 				}


### PR DESCRIPTION
Fixes #6479 

Changes made : 

#### * SDB (to be consistent with rest of type storage)
```diff
 Foo=enum
- Foo.0x1=COW
- Foo.0x2=BAR
- Foo.BAR=0x2
- Foo.COW=0x1
+ enum.Foo=COW,BAR
+ enum.Foo.0x1=COW
+ enum.Foo.0x2=BAR
+ enum.Foo.BAR=0x2
+ enum.Foo.COW=0x1
```
#### * Command  changes

* Moved cmd `tb` under `teb`
* Now `te foo` list all values of foo
```
[0x00000000]> "td enum Foo {COW=1,BAR=2};"
[0x00000000]> te Foo

COW = 0x1
BAR = 0x2
```
Added tests in r2r [#1316](https://github.com/radare/radare2-regressions/pull/1316)