### PR TITLE
asm.fcnlines > asm.lines.fcn

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1240,14 +1240,14 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 					//	fcn->addr, bbi->addr, difftype, str, fcn->name, bbi->addr);
 					RConfigHold *hc = r_config_hold_new (core->config);
 					r_config_save_num (hc, "scr.color", "scr.utf8", "asm.offset", "asm.lines",
-							"asm.cmt.right", "asm.fcnlines", "asm.bytes", NULL);
+							"asm.cmt.right", "asm.lines.fcn", "asm.bytes", NULL);
 					RDiff *d = r_diff_new ();
 					r_config_set_i (core->config, "scr.color", 0);
 					r_config_set_i (core->config, "scr.utf8", 0);
 					r_config_set_i (core->config, "asm.offset", 0);
 					r_config_set_i (core->config, "asm.lines", 0);
 					r_config_set_i (core->config, "asm.cmt.right", 0);
-					r_config_set_i (core->config, "asm.fcnlines", 0);
+					r_config_set_i (core->config, "asm.lines.fcn", 0);
 					r_config_set_i (core->config, "asm.bytes", 0);
 
 					if (bbi->diff && bbi->diff->type != R_ANAL_DIFF_TYPE_MATCH && core->c2) {
@@ -1592,7 +1592,7 @@ R_API int r_core_print_bb_custom(RCore *core, RAnalFunction *fcn) {
 
 	RConfigHold *hc = r_config_hold_new (core->config);
 	r_config_save_num (hc, "scr.color", "scr.utf8", "asm.marks", "asm.offset", "asm.lines",
-	  "asm.cmt.right", "asm.cmt.col", "asm.fcnlines", "asm.bytes", NULL);
+	  "asm.cmt.right", "asm.cmt.col", "asm.lines.fcn", "asm.bytes", NULL);
 	/*r_config_set_i (core->config, "scr.color", 0);*/
 	r_config_set_i (core->config, "scr.utf8", 0);
 	r_config_set_i (core->config, "asm.marks", 0);
@@ -1600,7 +1600,7 @@ R_API int r_core_print_bb_custom(RCore *core, RAnalFunction *fcn) {
 	r_config_set_i (core->config, "asm.lines", 0);
 	r_config_set_i (core->config, "asm.cmt.right", 0);
 	r_config_set_i (core->config, "asm.cmt.col", 0);
-	r_config_set_i (core->config, "asm.fcnlines", 0);
+	r_config_set_i (core->config, "asm.lines.fcn", 0);
 	r_config_set_i (core->config, "asm.bytes", 0);
 
 	r_list_foreach (fcn->bbs, iter, bb) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2467,7 +2467,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETOPTIONS (n, "d", "c", "s", "f", "m", "h", "C", "r", NULL);
 	SETPREF ("asm.filter", "true", "Replace numeric values by flags (e.g. 0x4003e0 -> sym.imp.printf)");
 	SETPREF ("asm.strip", "", "strip all instructions given comma separated types");
-	SETPREF ("asm.fcnlines", "true", "Show function boundary lines");
+	SETPREF ("asm.lines.fcn", "true", "Show function boundary lines");
 	SETPREF ("asm.flags", "true", "Show flags");
 	SETPREF ("asm.flags.offset", "false", "Show offset in flags");
 	SETPREF ("asm.flags.inbytes", "false",  "Display flags inside the bytes space");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -137,7 +137,7 @@ typedef struct {
 	bool show_leahints;
 	bool show_slow;
 	int cmtcol;
-	bool show_fcnlines;
+	bool show_lines_fcn;
 	bool show_calls;
 	bool show_cmtflgrefs;
 	bool show_cycles;
@@ -653,7 +653,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->asm_meta = r_config_get_i (core->config, "asm.meta");
 	ds->show_reloff = r_config_get_i (core->config, "asm.reloff");
 	ds->show_reloff_flags = r_config_get_i (core->config, "asm.reloff.flags");
-	ds->show_fcnlines = r_config_get_i (core->config, "asm.fcnlines");
+	ds->show_lines_fcn = r_config_get_i (core->config, "asm.lines.fcn");
 	ds->show_comments = r_config_get_i (core->config, "asm.comments");
 	ds->show_jmphints = r_config_get_i (core->config, "asm.jmphints");
 	ds->show_leahints = r_config_get_i (core->config, "asm.leahints");
@@ -1509,7 +1509,7 @@ static void ds_show_functions(RDisasmState *ds) {
 		}
 #endif
 		//ds_set_pre (ds, core->cons->vline[CORNER_TL]);
-		if (ds->show_fcnlines) {
+		if (ds->show_lines_fcn) {
 			ds->pre = DS_PRE_FCN_HEAD;
 		}
 		ds_print_pre (ds);
@@ -1527,7 +1527,7 @@ static void ds_show_functions(RDisasmState *ds) {
 		ds_newline (ds);
 	}
 	R_FREE (sign);
-	if (ds->show_fcnlines) {
+	if (ds->show_lines_fcn) {
 		ds->pre = DS_PRE_FCN_MIDDLE;
 	}
 	ds->stackptr = core->anal->stackptr;
@@ -1677,7 +1677,7 @@ static void ds_setup_print_pre(RDisasmState *ds, bool tail, bool middle) {
 
 static void ds_setup_pre(RDisasmState *ds, bool tail, bool middle) {
 	ds->cmtcount = 0;
-	if (!ds->show_functions || !ds->show_fcnlines) {
+	if (!ds->show_functions || !ds->show_lines_fcn) {
 		ds->pre = DS_PRE_NONE;
 		return;
 	}

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -1949,7 +1949,7 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 	if (!hc) {
 		return NULL;
 	}
-	r_config_save_num (hc, "asm.fcnlines", "asm.lines", "asm.bytes",
+	r_config_save_num (hc, "asm.lines.fcn", "asm.lines", "asm.bytes",
 		"asm.cmt.col", "asm.marks", "asm.marks", "asm.offset",
 		"asm.comments", "asm.cmt.right", NULL);
 	const bool o_comments = r_config_get_i (core->config, "graph.comments");
@@ -1960,7 +1960,7 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 	const char *cmd = (opts & BODY_SUMMARY)? "pds": "pD";
 
 	// configure options
-	r_config_set_i (core->config, "asm.fcnlines", false);
+	r_config_set_i (core->config, "asm.lines.fcn", false);
 	r_config_set_i (core->config, "asm.lines", false);
 	r_config_set_i (core->config, "asm.cmt.col", 0);
 	r_config_set_i (core->config, "asm.marks", false);

--- a/libr/core/pseudo.c
+++ b/libr/core/pseudo.c
@@ -176,7 +176,7 @@ R_API int r_core_pseudo_code(RCore *core, const char *input) {
 		return false;
 	}
 	r_config_save_num (hc, "asm.pseudo", "asm.decode", "asm.lines", "asm.bytes", NULL);
-	r_config_save_num (hc, "asm.offset", "asm.flags", "asm.fcnlines", "asm.comments", NULL);
+	r_config_save_num (hc, "asm.offset", "asm.flags", "asm.lines.fcn", "asm.comments", NULL);
 	r_config_save_num (hc, "asm.functions", "asm.section", "asm.cmt.col", "asm.filter", NULL);
 	r_config_save_num (hc, "scr.color", "emu.str", "asm.emu", "emu.write", NULL);
 	r_config_save_num (hc, "io.cache", NULL);
@@ -196,7 +196,7 @@ R_API int r_core_pseudo_code(RCore *core, const char *input) {
 	r_config_set_i (core->config, "asm.emu", 1);
 	r_config_set_i (core->config, "emu.str", 1);
 	r_config_set_i (core->config, "emu.write", 1);
-	r_config_set_i (core->config, "asm.fcnlines", 0);
+	r_config_set_i (core->config, "asm.lines.fcn", 0);
 	r_config_set_i (core->config, "asm.comments", 1);
 	r_config_set_i (core->config, "asm.functions", 0);
 	r_config_set_i (core->config, "asm.tabs", 0);


### PR DESCRIPTION
As suggested in https://github.com/radare/radare2/issues/9798 this PR changes `asm.fcnlines` in `asm.lines.fcn`