### PR TITLE
run objcopy --localize-hidden on BSD too

### DIFF
--- a/libr/Makefile
+++ b/libr/Makefile
@@ -65,6 +65,9 @@ endif
 ifeq ($(OSTYPE),android)
 	for LIB in .libr/* ; do $(OBJCOPY) --localize-hidden $$LIB ; done
 endif
+ifeq ($(OSTYPE),bsd)
+	for LIB in .libr/* ; do $(OBJCOPY) --localize-hidden $$LIB ; done
+endif
 
 libr.${EXT_AR}: .libr
 	${AR} crs $@ .libr/*.o


### PR DESCRIPTION
required since `Bring back libr.* targets in libr even without BUILD_MERGED` efda76cc1