### PR TITLE
Fixed asm.bytes on by default in cursor mode

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -251,6 +251,7 @@ static int visual_help() {
 		" =        set cmd.vprompt (top row)\n"
 		" |        set cmd.cprompt (right column)\n"
 		" .        seek to program counter\n"
+		" #        toggle bytes in disasm view\n"
 		" \\        toggle visual split mode\n"
 		" \"        toggle the column mode (uses pC..)\n"
 		" /        in cursor mode search in current block\n"
@@ -274,6 +275,7 @@ static int visual_help() {
 		" gG       go seek to begin and end of file (0-$s)\n"
 		" hjkl     move around (or HJKL) (left-down-up-right)\n"
 		" i        insert hex or string (in hexdump) use tab to toggle\n"
+		" I        insert hexpair block \n"
 		" mK/'K    mark/go to Key (any key)\n"
 		" M        walk the mounted filesystems\n"
 		" n/N      seek next/prev function/flag/hit (scr.nkey)\n"
@@ -2483,6 +2485,9 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			break;
 		case ')':
 			rotateAsmemu (core);
+			break;
+		case '#':
+			r_core_cmd0 (core, "e!asm.bytes");
 			break;
 		case '*':
 			if (core->print->cur_enabled) {

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2487,7 +2487,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			rotateAsmemu (core);
 			break;
 		case '#':
-			r_core_cmd0 (core, "e!asm.bytes");
+			r_config_toggle (core->config, "asm.bytes");
 			break;
 		case '*':
 			if (core->print->cur_enabled) {


### PR DESCRIPTION
Closes #9847 

__EDIT__: 

Remade this pr, now press # to toggle bytes when in disasm view. 
No more turning on by default when switching to cursor.

-----

__OLD_PR__:

When toggling the cursor, `asm.bytes` goes on and off.

However, if the user had specified before that `e asm.bytes = true`, then bytes are kept being shown even when exiting cursor mode.

This is done in a little hackish way:
 `asm.bytes = asm.bytes + 1` when switching to cursor mode
 `asm.bytes = asm.bytes - 1` when switching off cursor mode
(this means that `asm.bytes = 2` when it was set by the user and then switched to cursor mode),
 but doing like this avoids adding another config variable.

Tell me if it's too confusing.
