### PR TITLE
Fixed the parsing of the operand sign

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4309,6 +4309,10 @@ static int parseOperand(RAsm *a, const char *str, Operand *op, bool isrepop) {
 						op->offset_sign = -1;
 					}
 				}
+				//with SIB notation, we need to consider the right sign
+				if (strchr (str, '+') && strchr (str, '-')) {
+					op->offset_sign = -1;
+				}
 				// If there's a scale, we don't want to parse out the
 				// scale with the offset (scale + offset) otherwise the scale
 				// will be the sum of the two. This splits the numbers

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4310,7 +4310,10 @@ static int parseOperand(RAsm *a, const char *str, Operand *op, bool isrepop) {
 					}
 				}
 				//with SIB notation, we need to consider the right sign
-				if (strchr (str, '+') && strchr (str, '-')) {
+				char * plus = strchr (str, '+');
+				char * minus = strchr (str, '-');
+				char * closeB = strchr (str, ']');
+				if (plus && minus && plus < closeB && minus < closeB) {
 					op->offset_sign = -1;
 				}
 				// If there's a scale, we don't want to parse out the


### PR DESCRIPTION
When parsing an instruction like `mov [ebp+eax*4-0x200], N`, the sign of the offset would be parsed as '+' instead of '-' because it's the first sign it encounters.