### PR TITLE
Ag argument handling + fix agj @ 0

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2721,6 +2721,11 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 	if (!hc) {
 		return false;
 	}
+
+	eprintf ("%lld\n", addr);
+	eprintf ("%lld\n", UT64_MAX);
+	/*return NULL;*/
+
 	r_config_save_num (hc, "asm.lines", "asm.bytes", "asm.dwarf", NULL);
 	//opts |= R_CORE_ANAL_GRAPHBODY;
 	r_config_set_i (core->config, "asm.lines", 0);
@@ -2753,8 +2758,8 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 	r_list_foreach (core->anal->fcns, iter, fcni) {
 		if (fcni->type & (R_ANAL_FCN_TYPE_SYM | R_ANAL_FCN_TYPE_FCN |
 		                  R_ANAL_FCN_TYPE_LOC) &&
-		    (!addr || r_anal_fcn_in (fcni, addr))) {
-			if (!addr && (from != UT64_MAX && to != UT64_MAX)) {
+		    (addr == UT64_MAX || r_anal_fcn_in (fcni, addr))) {
+			if (addr == UT64_MAX && (from != UT64_MAX && to != UT64_MAX)) {
 				if (fcni->addr < from || fcni->addr > to) {
 					continue;
 				}
@@ -2763,7 +2768,7 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 				r_cons_printf (",");
 			}
 			nodes += core_anal_graph_nodes (core, fcni, opts);
-			if (addr != 0) {
+			if (addr != UT64_MAX) {
 				break;
 			}
 		}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1826,10 +1826,10 @@ repeat:
 		if (base == UT64_MAX) {
 			base = fcni->addr;
 		}
-		if (from != UT64_MAX && addr < from) {
+		if (from != UT64_MAX && fcni->addr < from) {
 			continue;
 		}
-		if (to != UT64_MAX && addr > to) {
+		if (to != UT64_MAX && fcni->addr > to) {
 			continue;
 		}
 		if (addr != UT64_MAX && addr != fcni->addr) {
@@ -2721,10 +2721,6 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 	if (!hc) {
 		return false;
 	}
-
-	eprintf ("%lld\n", addr);
-	eprintf ("%lld\n", UT64_MAX);
-	/*return NULL;*/
 
 	r_config_save_num (hc, "asm.lines", "asm.bytes", "asm.dwarf", NULL);
 	//opts |= R_CORE_ANAL_GRAPHBODY;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2719,7 +2719,6 @@ R_API int r_core_config_init(RCore *core) {
 
 
 	/* cmd */
-	r_config_desc (cfg, "cmd.graph", "Command executed by 'agv' command to view graphs");
 	SETPREF ("cmd.xterm", "xterm -bg black -fg gray -e", "xterm command to spawn with V@");
 	SETICB ("cmd.depth", 10, &cb_cmddepth, "Maximum command depth");
 	SETPREF ("cmd.bp", "", "Run when a breakpoint is hit");
@@ -2824,8 +2823,8 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("graph.font", "Courier", "Font for dot graphs");
 	SETPREF ("graph.offset", "false", "Show offsets in graphs");
 	SETPREF ("graph.web", "false", "Display graph in web browser (VV)");
-	SETI ("graph.from", UT64_MAX, "");
-	SETI ("graph.to", UT64_MAX, "");
+	SETI ("graph.from", UT64_MAX, "Lower bound address when drawing global graphs");
+	SETI ("graph.to", UT64_MAX, "Upper bound address when drawing global graphs");
 	SETI ("graph.scroll", 5, "Scroll speed in ascii-art graph");
 	SETPREF ("graph.invscroll", "false", "Invert scroll direction in ascii-art graph");
 	SETPREF ("graph.title", "", "Title of the graph");
@@ -2835,9 +2834,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("graph.gv.graph", "", "Graphviz global style attributes. (bgcolor=white)");
 	SETPREF ("graph.gv.current", "false", "Highlight the current node in graphviz graph.");
 	SETPREF ("graph.nodejmps", "true", "Enables shortcuts for every node.");
-	char *cmd = r_core_graph_cmd (core, "ag $$");
-	r_config_set (cfg, "cmd.graph", cmd);
-	free (cmd);
 
 	/* hud */
 	SETPREF ("hud.path", "", "Set a custom path for the HUD file");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5989,10 +5989,14 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 			}
 		case '*': {
+			ut64 from = r_config_get_i (core->config, "graph.from");
+			ut64 to = r_config_get_i (core->config, "graph.to");
 			RListIter *it;
 			RAnalFunction *fcn;
 			r_list_foreach (core->anal->fcns, it, fcn) {
-				r_core_anal_coderefs (core, fcn->addr);
+				if ((from == UT64_MAX && to == UT64_MAX) || R_BETWEEN (from, fcn->addr, to)) {
+					r_core_anal_coderefs (core, fcn->addr);
+				}
 			}
 			break;
 			}
@@ -6163,10 +6167,14 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 			}
 		case '*': {
+			ut64 from = r_config_get_i (core->config, "graph.from");
+			ut64 to = r_config_get_i (core->config, "graph.to");
 			RListIter *it;
 			RAnalFunction *fcn;
 			r_list_foreach (core->anal->fcns, it, fcn) {
-				r_core_anal_datarefs (core, fcn->addr);
+				if ((from == UT64_MAX && to == UT64_MAX) || R_BETWEEN (from, fcn->addr, to)) {
+					r_core_anal_datarefs (core, fcn->addr);
+				}
 			}
 			break;
 			}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5800,24 +5800,32 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 	switch (input[0]) {
 	case 'f': // "agf"
 		switch (input[1]) {
-		case 0:// "agf"
+		case 0: // "agf"
 			r_core_visual_graph (core, NULL, NULL, false);
 			break;
-		case 'v':// "agfv"
+		case ' ':{ // "agf "
+			ut64 off_fcn = (*(input + 2)) ? r_num_math (core->num, input + 2) : core->offset;
+			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, off_fcn, 0);
+			r_core_visual_graph (core, NULL, fcn, false);
+			break;
+			}
+		case 'v': // "agfv"
 			eprintf ("\rRendering graph...");
 			ut64 off_fcn = (*(input + 2)) ? r_num_math (core->num, input + 2) : core->offset;
 			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, off_fcn, 0);
 			if (fcn) {
-				eprintf ("%s\n", fcn->name);
 				r_core_visual_graph (core, NULL, fcn, 1);
 			}
 			r_cons_enable_mouse (false);
 			r_cons_show_cursor (true);
 			break;
-		case 't':// "agft" - tiny graph
-			r_core_visual_graph (core, NULL, NULL, 2);
+		case 't': { // "agft" - tiny graph
+			ut64 off_fcn = (*(input + 2)) ? r_num_math (core->num, input + 2) : core->offset;
+			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, off_fcn, 0);
+			r_core_visual_graph (core, NULL, fcn, 2);
 			break;
-		case 'd':// "agfd"
+			}
+		case 'd': // "agfd"
 			if (input[2] == 'm') {
 				r_core_anal_graph (core, r_num_math (core->num, input + 3),
 					R_CORE_ANAL_GRAPHLINES);
@@ -5826,21 +5834,24 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 					R_CORE_ANAL_GRAPHBODY);
 			}
 			break;
-		case 'j':// "agfj"
-			r_core_anal_graph (core, r_num_math (core->num, input + 1), R_CORE_ANAL_JSON);
+		case 'j': // "agfj"
+			r_core_anal_graph (core, r_num_math (core->num, input + 2), R_CORE_ANAL_JSON);
 			break;
-		case 'J':// "agfJ"
-			r_core_anal_graph (core, r_num_math (core->num, input + 1),
+		case 'J': // "agfJ"
+			r_core_anal_graph (core, r_num_math (core->num, input + 2),
 				R_CORE_ANAL_JSON | R_CORE_ANAL_JSON_FORMAT_DISASM);
-		case 'g':{// "agfg"
+			break;
+		case 'g':{ // "agfg"
 			ut64 off_fcn = (*(input + 2)) ? r_num_math (core->num, input + 2) : core->offset;
 			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, off_fcn, 0);
 			r_core_print_bb_gml (core, fcn);
 			break;
 			}
-		case 'k':// "agfk"
-			r_core_cmd0 (core, "ag-; .agf*; aggk");
+		case 'k':{ // "agfk"
+			ut64 addr = (*(input + 2)) ? r_num_math (core->num, input + 2) : core->offset;
+			r_core_cmdf (core, "ag-; .agf* %lld; aggk", addr);
 			break;
+			}
 		case '*':{// "agf*"
 			ut64 off_fcn = (*(input + 2)) ? r_num_math (core->num, input + 2) : core->offset;
 			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, off_fcn, 0);
@@ -6092,14 +6103,14 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 		}
 		break;
-	case 'j': // "agj"
-		r_core_anal_graph (core, r_num_math (core->num, input + 1), R_CORE_ANAL_JSON);
+	case 'j': // "agj" alias for agfj
+		r_core_cmdf (core, "agfj%s", input + 1);
 		break;
-	case 'J': // "agJ"
-		r_core_anal_graph (core, r_num_math (core->num, input + 1), R_CORE_ANAL_JSON | R_CORE_ANAL_JSON_FORMAT_DISASM);
+	case 'J': // "agJ" alias for agfJ
+		r_core_cmdf (core, "agfJ%s", input + 1);
 		break;
-	case 'k': // "agk"
-		r_core_anal_graph (core, r_num_math (core->num, input + 1), R_CORE_ANAL_KEYVALUE);
+	case 'k': // "agk" alias for agfk
+		r_core_cmdf (core, "agfk%s", input + 1);
 		break;
 	case 'l': // "agl"
 		r_core_anal_graph (core, r_num_math (core->num, input + 1), R_CORE_ANAL_GRAPHLINES);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5805,7 +5805,12 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 		case 'v':// "agfv"
 			eprintf ("\rRendering graph...");
-			r_core_visual_graph (core, NULL, NULL, 1);
+			ut64 off_fcn = (*(input + 2)) ? r_num_math (core->num, input + 2) : core->offset;
+			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, off_fcn, 0);
+			if (fcn) {
+				eprintf ("%s\n", fcn->name);
+				r_core_visual_graph (core, NULL, fcn, 1);
+			}
 			r_cons_enable_mouse (false);
 			r_cons_show_cursor (true);
 			break;
@@ -5814,10 +5819,10 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 		case 'd':// "agfd"
 			if (input[2] == 'm') {
-				r_core_anal_graph (core, r_num_math (core->num, input + 2),
+				r_core_anal_graph (core, r_num_math (core->num, input + 3),
 					R_CORE_ANAL_GRAPHLINES);
 			} else {
-				r_core_anal_graph (core, r_num_math (core->num, input + 1),
+				r_core_anal_graph (core, r_num_math (core->num, input + 2),
 					R_CORE_ANAL_GRAPHBODY);
 			}
 			break;
@@ -5846,11 +5851,13 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			if (r_config_get_i (core->config, "graph.web")) {
 				r_core_cmd0 (core, "=H /graph/");
 			} else {
-				char *cmd = r_core_graph_cmd (core, "agfd");
+				char *cmdargs = r_str_newf ("agfd %lld", r_num_math (core->num, input + 2));
+				char *cmd = r_core_graph_cmd (core, cmdargs);
 				if (cmd && *cmd) {
 					r_core_cmd0 (core, cmd);
 				}
 				free (cmd);
+				free (cmdargs);
 			}
 			break;
 		default:

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3170,10 +3170,6 @@ static int agraph_refresh(struct agraph_refresh_data *grd) {
 	RAnalFunction *f = NULL;
 	RAnalFunction **fcn = grd->fcn;
 
-	/*if (fcn) eprintf ("%s\n", (*fcn)->name);*/
-	/*else eprintf ("NULL\n");*/
-	/*return NULL;*/
-
 	if (!fcn) {
 		return agraph_print (g, grd->fs, core, NULL);
 	}
@@ -3231,7 +3227,6 @@ static void agraph_toggle_speed(RAGraph *g, RCore *core) {
 
 static void agraph_init(RAGraph *g) {
 	g->is_callgraph = false;
-	g->follow_offset = false;
 	g->is_instep = false;
 	g->need_reload_nodes = true;
 	g->force_update_seek = true;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -287,7 +287,7 @@ static int visual_help() {
 		" T        enter textlog chat console (TT)\n"
 		" uU       undo/redo seek\n"
 		" v        visual function/vars code analysis menu\n"
-		" V        (V)iew graph using cmd.graph (agv?)\n"
+		" V        (V)iew interactive ascii art graph (agfv)\n"
 		" wW       seek cursor to next/prev word\n"
 		" xX       show xrefs/refs of current function from/to data/code\n"
 		" yY       copy and paste selection\n"


### PR DESCRIPTION
Fixes #8385 and fixes #9716 

Now ag* commands correctly support arguments (there are some exceptions, like for example the import graph, but the ag? help specifies which commands don't take any arguments).

Also, agj and other commands won't print all the functions of the file when provided with the 0 argument: now the special address is `UT64_MAX` (`0xffffffffffffffff` or `-1`) that was already used by `agC` global callgraph

Also, global graphs now work only in the `[graph.from, graph.to]` range.