### PR TITLE
[WIP]  Support RAnalop.dst/src in all archs 

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -85,6 +85,7 @@ R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	}
 
 	anal->decode = mask & R_ANAL_OP_MASK_ESIL ? true : false;
+	anal->fillval = mask & R_ANAL_OP_MASK_VAL ? true : false;
 
 	if (anal->pcalign) {
 		if (addr % anal->pcalign) {

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2670,6 +2670,22 @@ jmp $$ + 4 + ( [delta] * 2 )
 	}
 }
 
+static void op_fillval (RAnalOp *op , cs_insn *insn, int bits) {
+	ut64 disp = (bits == 32)? MEMDISP(1): MEMDISP64(1);
+	switch (op->type) {
+	case R_ANAL_OP_TYPE_LOAD:
+		op->src[0] = r_anal_value_new ();
+		op->src[0]->delta = disp;
+		break;
+	case R_ANAL_OP_TYPE_STORE:
+		op->dst = r_anal_value_new ();
+		op->dst->delta = disp;
+		break;
+	default:
+		break;
+	}
+}
+
 static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	static csh handle = 0;
 	static int omode = -1;
@@ -2725,6 +2741,9 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			if (a->decode) {
 				analop_esil (a, op, addr, buf, len, &handle, insn, thumb);
 			}
+		}
+		if (a->fillval) {
+			op_fillval (op, insn, a->bits);
 		}
 		cs_free (insn, n);
 	}

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -682,6 +682,13 @@ static int cmd_type(void *data, const char *input) {
 						}
 					}
 				}
+				if (!offimm && op.dst) {
+					if (op.dst->imm) {
+						offimm = op.dst->imm;
+					} else if (op.dst->delta) {
+						offimm = op.dst->delta;
+					}
+				}
 				if (offimm != 0) {
 					// TODO: Allow to select from multiple choices
 					RList* otypes = r_type_get_by_offset (TDB, offimm);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -461,7 +461,8 @@ typedef enum {
 
 typedef enum {
 	R_ANAL_OP_MASK_ESIL       = 1,
-	R_ANAL_OP_MASK_ALL        = R_ANAL_OP_MASK_ESIL
+	R_ANAL_OP_MASK_VAL        = 2,
+	R_ANAL_OP_MASK_ALL        = R_ANAL_OP_MASK_ESIL | R_ANAL_OP_MASK_VAL
 } RAnalOpMask;
 
 /* TODO: what to do with signed/unsigned conditionals? */
@@ -686,6 +687,7 @@ typedef struct r_anal_t {
 	RList /*RAnalRange*/ *bits_ranges;
 	RListComparator columnSort;
 	int stackptr;
+	bool fillval;
 	bool (*log)(struct r_anal_t *anal, const char *msg);
 	bool (*read_at)(struct r_anal_t *anal, ut64 addr, ut8 *buf, int len);
 	char *cmdtail;


### PR DESCRIPTION
Fixes #9078 

Currently fixed for archs : 

* X86
* ARM 64/32
* MIPS
* GB (it was already fully implemented)

### TODO 

* Add support for more archs
* Include this for more op type if needed
* Add test for different arch 
* Currently the `R_ANAL_OP_MASK_ALL` used in many place , have to clean that and change to appropriate mask

```
$ git grep "R_ANAL_OP_MASK_ALL" | wc -l
88
``` 