### PR TITLE
Added ag autocompletion + final ag* fixes

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1232,16 +1232,15 @@ static int autocomplete(RLine *line) {
 		|| !strncmp (line->buffer.data, "afc ", 4)
 		|| !strncmp (line->buffer.data, "axt ", 4)
 		|| !strncmp (line->buffer.data, "axf ", 4)
-		|| !strncmp (line->buffer.data, "aga ", 4)
-		|| !strncmp (line->buffer.data, "agc ", 4)
-		|| !strncmp (line->buffer.data, "agl ", 4)
-		|| !strncmp (line->buffer.data, "agd ", 4)
 		|| !strncmp (line->buffer.data, "dcu ", 4)
 		|| !strncmp (line->buffer.data, "/re ", 4)
 		|| !strncmp (line->buffer.data, "agfl ", 5)
 		|| !strncmp (line->buffer.data, "aecu ", 5)
 		|| !strncmp (line->buffer.data, "aesu ", 5)
 		|| !strncmp (line->buffer.data, "aeim ", 5)
+		|| (!strncmp (line->buffer.data, "ag", 2)
+			&& (strlen (line->buffer.data) > 4  && line->buffer.data[4] == ' '
+				|| strlen (line->buffer.data) > 3  && line->buffer.data[3] == ' '))
 		|| line->offset_prompt) {
 			int n, i = 0;
 			int sdelta = line->offset_prompt 

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2131,7 +2131,7 @@ static int get_bbnodes(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 		char *title = get_title (bb->addr);
 
 		RANode *node = r_agraph_add_node (g, title, body);
-		shortcuts = r_config_get_i (core->config, "graph.nodejmps");
+		shortcuts = g->is_interactive ? r_config_get_i (core->config, "graph.nodejmps") : false;
 
 		if (shortcuts) {
 			shortcut = r_core_add_asmqjmp (core, bb->addr);
@@ -3709,6 +3709,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	g->on_curnode_change = (RANodeCallback) seek_to_node;
 	g->on_curnode_change_data = core;
 	g->edgemode = r_config_get_i (core->config, "graph.edges");
+	g->is_interactive = is_interactive;
 	bool asm_comments = r_config_get_i (core->config, "asm.comments");
 	r_config_set (core->config, "asm.comments",
 		r_str_bool (r_config_get_i (core->config, "graph.comments")));

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -891,6 +891,7 @@ typedef struct r_ascii_graph_t {
 	int edgemode;
 	int mode;
 	bool is_callgraph;
+	bool is_interactive;
 	int zoom;
 	int movspeed;
 


### PR DESCRIPTION
1. Added autocompletion for all commands starting with ag*

2. Renamed command "agt" to "abt" (this command found paths in the bb graph, and was decided to be renamed in the ag* pad)

3. Removed graph shortcuts when it's not interactive