### PR TITLE
libr: use openssl LDFLAGS at link time

### DIFF
--- a/libr/Makefile
+++ b/libr/Makefile
@@ -45,6 +45,7 @@ endif
 ifeq ($(OSTYPE),ios)
 MLFLAGS+=-install_name @rpath/libr2.dylib
 endif
+LDFLAGS+=${SSL_LDFLAGS}
 # XXX version-script only works with shlib as output
 #ifeq ($(OSTYPE),linux)
 #PLFLAGS+=--version-script ./ld.script


### PR DESCRIPTION
libr will have been compiled with openssl support if it was requested, so it also needs to use the openssl LDFLAGS. Otherwise it'll complain at link time about not being able to find the referenced libssl symbols.

Fixes #10154.