### PR TITLE
Optimize ds_align_comment()

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3134,16 +3134,13 @@ static void ds_print_core_vmode(RDisasmState *ds, int pos) {
 static void ds_align_comment(RDisasmState *ds) {
 	if (ds->show_comment_right_default) {
 		const int cmtcol = ds->cmtcol - 1;
-		int cstrlen = 0;
-		char *ll = r_cons_lastline (&cstrlen);
+		int cells = 0;
+		char *ll = r_cons_lastline_utf8_ansi_len (&cells);
 		if (ll) {
-			int cols, ansilen = r_str_ansi_len (ll);
-			int utf8len = r_utf8_strlen ((const ut8*)ll);
-			int cells = utf8len - (cstrlen - ansilen);
-			if (cstrlen < 20) {
+			if (cells < 20) {
 				ds_print_pre (ds);
 			}
-			cols = ds->interactive ? ds->core->cons->columns : 1024;
+			int cols = ds->interactive ? ds->core->cons->columns : 1024;
 			if (cells < cmtcol) {
 				int len = cmtcol - cells;
 				if (len < cols && len > 0) {

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -629,6 +629,7 @@ R_API RCons *r_cons_new(void);
 R_API RCons *r_cons_singleton(void);
 R_API RCons *r_cons_free(void);
 R_API char *r_cons_lastline(int *size);
+R_API char *r_cons_lastline_utf8_ansi_len(int *len);
 
 typedef void (*RConsBreak)(void *);
 R_API void r_cons_break_end(void);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1322,20 +1322,11 @@ R_API char *r_str_escape_utf32le(const char *buf, int buf_size, bool show_asciid
 
 /* ansi helpers */
 R_API int r_str_ansi_len(const char *str) {
-	int ch, ch2, i = 0, len = 0, sub = 0;
+	int ch, i = 0, len = 0, sub = 0;
 	while (str[i]) {
 		ch = str[i];
-		ch2 = str[i + 1];
-		if (ch == 0x1b) {
-			if (ch2 == '\\') {
-				i++;
-			} else if (ch2 == ']') {
-				if (!strncmp (str + 2 + 5, "rgb:", 4)) {
-					i += 18;
-				}
-			} else if (ch2 == '[') {
-				for (++i; str[i] && str[i] != 'J' && str[i] != 'm' && str[i] != 'H'; i++);
-			}
+		if (ch == 0x1b && str[i + 1] == '[') {
+			for (++i; str[i] && str[i] != 'J' && str[i] != 'm' && str[i] != 'H'; i++);
 		} else {
 			len++;
 #if 0


### PR DESCRIPTION
`ds_align_comment()` is a bottleneck in disassembly printing. The difference with this is not huge, but it's measurable.

I also removed the "rgb:" check we talked about on Telegram. As far as I can tell, it was used for a different kind of ansi escape sequence for colors that is not used anywhere in r2 anymore, so this check is now unnecessary.