### PR TITLE
Fix#10186

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -224,6 +224,7 @@ dotherax:
 			fflush (stdout);
 			free (buf);
 		}
+		printf ("\n");
 		return true;
 	}
 	if (flags & (1 << 2)) { // -S


### PR DESCRIPTION
Fix#10186 end the result with '\n'