### PR TITLE
Fixed the help of pa? to include paD

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3890,7 +3890,7 @@ static int cmd_print(void *data, const char *input) {
 				}
 			}
 		} else if (input[1] == '?') {
-			r_cons_printf ("|Usage: pa[ed] [hex|asm]  assemble (pa) disasm (pad)"
+			r_cons_printf ("|Usage: pa[edD] [asm|hex]  assemble (pa), disasm (pa[dD]),"
 				" esil (pae) from hexpairs\n");
 		} else {
 			RAsmCode *acode;


### PR DESCRIPTION
from:
```
[0x00000000]> pa?
|Usage: pa[ed] [hex|asm]  assemble (pa) disasm (pad) esil (pae) from hexpairs
```

to:
```
[0x00000000]> pa?
|Usage: pa[edD] [asm|hex]  assemble (pa), disasm (pa[dD]), esil (pae) from hexpairs
```