### PR TITLE
fixed a small yet kinda significant bug

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -728,18 +728,16 @@ static void panelSingleStepIn(RCore *core) {
 }
 
 static void panelSingleStepOver(RCore *core) {
+	bool io_cache = r_config_get_i (core->config, "io.cache");
+	r_config_set_i (core->config, "io.cache", false);
 	if (r_config_get_i (core->config, "cfg.debug")) {
-		if (core->print->cur_enabled) {
-			r_core_cmd (core, "dcr", 0);
-			core->print->cur_enabled = 0;
-		} else {
-			r_core_cmd (core, "dso", 0);
-			r_core_cmd (core, ".dr*", 0);
-		}
+		r_core_cmd (core, "dso", 0);
+		r_core_cmd (core, ".dr*", 0);
 	} else {
 		r_core_cmd (core, "aeso", 0);
 		r_core_cmd (core, ".ar*", 0);
 	}
+	r_config_set_i (core->config, "io.cache", io_cache);
 }
 
 static void panelBreakpoint(RCore *core) {
@@ -1191,11 +1189,7 @@ repeat:
 		setRefreshAll (panels);
 		break;
 	case 'S':
-		if (r_config_get_i (core->config, "cfg.debug")) {
-			r_core_cmd0 (core, "dso;.dr*"); // ;sr PC");
-		} else {
-			panelSingleStepOver (core);
-		}
+		panelSingleStepOver (core);
 		setRefreshAll (panels);
 		break;
 	case ':':

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -431,6 +431,8 @@ static void visual_single_step_in(RCore *core) {
 }
 
 static void visual_single_step_over(RCore *core) {
+	bool io_cache = r_config_get_i (core->config, "io.cache");
+	r_config_set_i (core->config, "io.cache", false);
 	if (r_config_get_i (core->config, "cfg.debug")) {
 		if (core->print->cur_enabled) {
 			r_core_cmd (core, "dcr", 0);
@@ -443,6 +445,7 @@ static void visual_single_step_over(RCore *core) {
 		r_core_cmd (core, "aeso", 0);
 		r_core_cmd (core, ".ar*", 0);
 	}
+	r_config_set_i (core->config, "io.cache", io_cache);
 }
 
 static void visual_breakpoint(RCore *core) {


### PR DESCRIPTION
how to reproduce the bug

1. get this ctf question binary https://github.com/ctfs/write-ups-2016/tree/master/su-ctf-2016/reverse/serial-150
2. go r2 with r2 -dAA ./serial
3. dcu main
4. e io.cache=true
5. go to either Vpp(doesn't matter how many p in fact) or V!
6. after you enter the mode then you immediately switch to VV from the mode you are in
7. then go back to the original mode by q
8. then proceed step over debugging with S or go back to CLI and keep doing "dso;.dr*"
9. there are no 'hit the breakpoint at' and you will get an user prompt of std::cin at the inappropriate offset

according to my debugging, io.cache had been doing something back there and i fixed the problem by turning off io.cache temporarily when the step over happens then getting the original status back to it afterwards.