### PR TITLE
Fixes an issue with r_base64_decode w/ len =0

### DIFF
--- a/libr/util/ubase64.c
+++ b/libr/util/ubase64.c
@@ -47,7 +47,7 @@ static int b64_decode(const char in[4], ut8 out[3], int isz) {
 
 R_API int r_base64_decode(ut8 *bout, const char *bin, int len) {
 	int in, out, ret;
-	if (len < 0) {
+	if (len <= 0) {
 		len = strlen (bin);
 	}
 	for (in = out = 0; in + 3 < len; in += 4) {


### PR DESCRIPTION
r_base64_decode is being called with len = 0 from cmd_write.c:798 `w6d` command and thus not producing any output without the fix (as there is only a len < 0 contition).

Before the fix: `w6d cmFkYXJlMg==` -> nothing is written
After the fix: `w6d cmFkYXJlMg==` -> radare2 is correctly written to the memory