### PR TITLE
rtr: block on read() when receiveng a cmd output

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1796,7 +1796,7 @@ R_API void r_core_rtr_cmd(RCore *core, const char *input) {
 		eprintf ("Error: Allocating cmd output\n");
 		return;
 	}
-	r_socket_read (fh, (ut8*)cmd_output, cmd_len);
+	r_socket_read_block (fh, (ut8*)cmd_output, cmd_len);
 	//ensure the termination
 	cmd_output[cmd_len] = 0;
 	r_cons_println (cmd_output);


### PR DESCRIPTION
Otherwise data could be truncated and the socket might still have some
data left

During remote binary inspection using `=+ rap://host:port//bin/ls`, when I used `px` or any command that sends a lot of output, it would have been truncated and the next command's output read would most likely fail due to the rest of the data still present in the socket.