### PR TITLE
rap: list open connections with full host

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1572,7 +1572,7 @@ R_API void r_core_rtr_add(RCore *core, const char *_input) {
 			continue;
 		}
 		rtr_host[i].proto = proto;
-		strncpy (rtr_host[i].host, host, sizeof (rtr_host[i].proto)-1);
+		strncpy (rtr_host[i].host, host, sizeof (rtr_host[i].host)-1);
 		rtr_host[i].port = r_num_get (core->num, port);
 		strncpy (rtr_host[i].file, file, sizeof (rtr_host[i].file)-1);
 		rtr_host[i].fd = fd;


### PR DESCRIPTION
Before:
```
[0x00000000]> =+ rap://127.0.0.1:1234//bin/ls
Connected to 127.0.0.1 at port 1234
waiting... ok
[0x00000000]> =
6 - rap://127:1234//bin/ls
```

After:
```
[0x00000000]> =+ rap://127.0.0.1:1234//bin/ls
Connected to 127.0.0.1 at port 1234
waiting... ok
[0x00000000]> =
6 - rap://127.0.0.1:1234//bin/ls
```