### PR TITLE
Fix mach0 segment name size

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -270,7 +270,6 @@ static int parse_segments(struct MACH0_(obj_t)* bin, ut64 off) {
 			memcpy (&bin->sects[k].sectname, &sec[i], 16);
 			i += 16;
 			memcpy (&bin->sects[k].segname, &sec[i], 16);
-			bin->sects[k].segname[15] = 0;
 			i += 16;
 #if R_BIN_MACH064
 			bin->sects[k].addr = r_read_ble64 (&sec[i], bin->big_endian);
@@ -1323,7 +1322,7 @@ static int prot2perm (int x) {
 
 struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
 	struct section_t *sections;
-	char segname[32], sectname[32];
+	char segname[32], sectname[32], raw_segname[17];
 	int i, j, to;
 
 	if (!bin) {
@@ -1343,7 +1342,8 @@ struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
 			sections[i].vsize = seg->vmsize;
 			sections[i].align = 4096;
 			sections[i].flags = seg->flags;
-			r_str_ncpy (sectname, seg->segname, sizeof (sectname));
+			r_str_ncpy (sectname, seg->segname, 16);
+			sectname[16] = 0;
 			r_str_filter (sectname, -1);
 			// hack to support multiple sections with same name
 			sections[i].srwx = prot2perm (seg->initprot);
@@ -1370,11 +1370,14 @@ struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
 		sections[i].vsize = (ut64)bin->sects[i].size;
 		sections[i].align = bin->sects[i].align;
 		sections[i].flags = bin->sects[i].flags;
-		r_str_ncpy (sectname, bin->sects[i].sectname, sizeof (sectname));
+		r_str_ncpy (sectname, bin->sects[i].sectname, 16);
+		sectname[16] = 0;
 		r_str_filter (sectname, -1);
 		// hack to support multiple sections with same name
 		// snprintf (segname, sizeof (segname), "%d", i); // wtf
-		snprintf (segname, sizeof (segname), "%d.%s", i, bin->sects[i].segname);
+		memcpy (raw_segname, bin->sects[i].segname, 16);
+		raw_segname[16] = 0;
+		snprintf (segname, sizeof (segname), "%d.%s", i, raw_segname);
 		for (j = 0; j < bin->nsegs; j++) {
 			if (sections[i].addr >= bin->segs[j].vmaddr &&
 				sections[i].addr < (bin->segs[j].vmaddr + bin->segs[j].vmsize)) {

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -1370,8 +1370,7 @@ struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
 		sections[i].vsize = (ut64)bin->sects[i].size;
 		sections[i].align = bin->sects[i].align;
 		sections[i].flags = bin->sects[i].flags;
-		r_str_ncpy (sectname, bin->sects[i].sectname, 16);
-		sectname[16] = 0;
+		r_str_ncpy (sectname, bin->sects[i].sectname, 17);
 		r_str_filter (sectname, -1);
 		// hack to support multiple sections with same name
 		// snprintf (segname, sizeof (segname), "%d", i); // wtf


### PR DESCRIPTION
- it can be 16-bytes long, in that case isn’t NUL-terminated
- so don’t kill the 16th char
- add terminator when needed

For example, in iOS kernel caches there's the `__PLK_DATA_CONST` segment which uses the full 16-bytes for the name