### PR TITLE
Fix increment in pxrj command (cmd_print.c)

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -5130,7 +5130,7 @@ static int cmd_print(void *data, const char *input) {
 					const char *comma = "";
 					const ut8 *buf = core->block;
 					int withref = 0;
-					for (i = 0; i < core->blocksize; i += (base / 4)) {
+					for (i = 0; i < core->blocksize; i += (base / 8)) {
 						ut64 addr = core->offset + i;
 						ut64 *foo = (ut64 *) (buf + i);
 						ut64 val = *foo;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -5130,7 +5130,8 @@ static int cmd_print(void *data, const char *input) {
 					const char *comma = "";
 					const ut8 *buf = core->block;
 					int withref = 0;
-					for (i = 0; i < core->blocksize; i += (base / 8)) {
+					const int wordsize = base / 8;
+					for (i = 0; i < core->blocksize; i += wordsize) {
 						ut64 addr = core->offset + i;
 						ut64 *foo = (ut64 *) (buf + i);
 						ut64 val = *foo;


### PR DESCRIPTION
`pxr 0x40 @ rsp` differed from `pxrj 0x40 @ rsp`:
```
$ r2 -d /bin/ls
[0x7f796814fc30]> pxr 0x20 @ rsp
0x7fffd270fe50  0x0000000000000001   ........ @rsp
0x7fffd270fe58  0x00007fffd2710c8e   ..q..... stack R W 0x736c2f6e69622f (/bin/ls) -->  ascii
0x7fffd270fe60  0x0000000000000000   ........ rbp
0x7fffd270fe68  0x00007fffd2710c96   ..q..... stack R W 0x524e54565f474458 (XDG_VTNR=7) -->  ascii
[0x7f796814fc30]> pxrj 0x20 @ rsp~{}
[
  {
    "addr": 140736724008528,
    "value": 1
  },
  {
    "addr": 140736724008544,
    "value": 0,
    "ref": "rbp"
  }
]
```