### PR TITLE
fixed a problem concerned with dbg.trace and ood  and dcu

### DIFF
--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -306,12 +306,10 @@ R_API int r_io_section_set_archbits(RIO *io, ut32 id, const char *arch, int bits
 }
 
 R_API const char *r_io_section_get_archbits(RIO *io, ut64 vaddr, int *bits) {
-	//cache section so we avoid making so many looks up
-	// this may crash if we remove this section, we need a way to invalidate this cache
-	static RIOSection *s = NULL;
-	if (!s || (vaddr < s->vaddr) || (s->vaddr + s->vsize < vaddr)) {
-		s = r_io_section_vget (io, vaddr);
+	if (!io) {
+		return NULL;
 	}
+	RIOSection *s = r_io_section_vget (io, vaddr);
 	if (!s || !s->arch || !s->bits) {
 		return NULL;
 	}


### PR DESCRIPTION
reproduce:

sys/asan.sh

1. r2 debug mode
2. e dbg.trace = true
3. dcu main
4. ood
5. dcu main
then crash

occurred by ood carrying out io_section_cleanup that cleans up all sections, yet the weird RIOSection cache working in some API does not know that and eventually use-after-free happens. 
Actually the caching wasn't that effective in there anyway so I just ripped it off instead of coming up the new way to cache it (i actually came up some but they did not do much so i just totally ripped it off)
