### PR TITLE
Fix #10165 compact cross references

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2425,7 +2425,8 @@ R_API int r_core_config_init(RCore *core) {
 	n = NODECB ("asm.os", R_SYS_OS, &cb_asmos);
 	SETDESC (n, "Select operating system (kernel)");
 	SETOPTIONS (n, "ios", "dos", "darwin", "linux", "freebsd", "openbsd", "netbsd", "windows", NULL);
-	SETI ("asm.maxrefs", 5,  "Maximum number of xrefs to be displayed as list (use columns above)");
+	SETI ("asm.xrefs.fold", 5,  "Maximum number of xrefs to be displayed as list (use columns above)");
+	SETI ("asm.xrefs.max", 20,  "Maximum number of xrefs to be displayed without folding");
 	SETCB ("asm.invhex", "false", &cb_asm_invhex, "Show invalid instructions as hexadecimal numbers");
 	SETPREF ("asm.meta", "true", "Display the code/data/format conversions in disasm");
 	SETPREF ("asm.bytes", "true", "Display the bytes of each instruction");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -240,6 +240,7 @@ typedef struct {
 	const ut8 *buf;
 	int len;
 	int maxrefs;
+	int foldxrefs;
 	char *prev_ins;
 	bool prev_ins_eq;
 	int prev_ins_count;
@@ -596,7 +597,8 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->show_vars = r_config_get_i (core->config, "asm.var");
 	ds->show_varsum = r_config_get_i (core->config, "asm.var.summary");
 	ds->show_varaccess = r_config_get_i (core->config, "asm.var.access");
-	ds->maxrefs = r_config_get_i (core->config, "asm.maxrefs");
+	ds->maxrefs = r_config_get_i (core->config, "asm.xrefs.max");
+	ds->foldxrefs = r_config_get_i (core->config, "asm.xrefs.fold");
 	ds->show_lines = r_config_get_i (core->config, "asm.lines");
 	ds->linesright = r_config_get_i (core->config, "asm.lines.right");
 	ds->show_indent = r_config_get_i (core->config, "asm.indent");
@@ -1147,18 +1149,18 @@ static void ds_show_xrefs(RDisasmState *ds) {
 	if (!xrefs) {
 		return;
 	}
-	if (ds->maxrefs < 1) {
+	if (r_list_length (xrefs) > ds->maxrefs) {
 		ds_pre_xrefs (ds, false);
 		ds_comment (ds, false, "%s; XREFS(%d)\n",
 			ds->show_color? ds->pal_comment: "",
 			r_list_length (xrefs));
 		r_list_free (xrefs);
 		return;
-	}
-	if (r_list_length (xrefs) > ds->maxrefs) {
+	} else if (r_list_length (xrefs) > ds->foldxrefs) {
 		int cols = r_cons_get_size (NULL);
 		cols -= 15;
 		cols /= 23;
+		cols = cols > 5 ? 5 : cols;
 		ds_pre_xrefs (ds, false);
 		ds_comment (ds, false, "%s; XREFS: ", ds->show_color? ds->pal_comment: "");
 		r_list_foreach (xrefs, iter, refi) {


### PR DESCRIPTION
Closes https://github.com/radare/radare2/issues/10165. Split up `asm.maxrefs` into `asm.xrefs.fold` and `asm.xrefs.max`.

`asm.xrefs.fold`: controls how much xrefs can be displayed before folding them in a table like manner (just like how asm.maxrefs did)

`asm.xrefs.max`: controls how much xrefs can be displayed before displaying only the `XREFS (n)` counter.

Also limited the max number of columns in the table like folding to 5 in order to avoid having graph nodes too large (see first screen in https://github.com/radare/radare2/issues/10165) 


