### PR TITLE
Disable fcnlines if lines are disabled

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -655,7 +655,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->asm_meta = r_config_get_i (core->config, "asm.meta");
 	ds->show_reloff = r_config_get_i (core->config, "asm.reloff");
 	ds->show_reloff_flags = r_config_get_i (core->config, "asm.reloff.flags");
-	ds->show_lines_fcn = r_config_get_i (core->config, "asm.lines.fcn");
+	ds->show_lines_fcn = ds->show_lines ? r_config_get_i (core->config, "asm.lines.fcn") : false;
 	ds->show_comments = r_config_get_i (core->config, "asm.comments");
 	ds->show_jmphints = r_config_get_i (core->config, "asm.jmphints");
 	ds->show_leahints = r_config_get_i (core->config, "asm.leahints");


### PR DESCRIPTION
Function lines were displayed even if `asm.lines` was set to false.