### PR TITLE
disasm.c: r_core_print_disasm_json prints a void object if it has not printed something else before

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5289,6 +5289,10 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 	core->offset = old_offset;
 	r_anal_op_fini (&ds->analop);
 	ds_free (ds);
+	if (result == false) {
+		r_cons_printf ("{}");
+		result = true;
+	}
 	return result;
 }
 


### PR DESCRIPTION
There is a flaw in the way pdfj prints the json object. 
For example, if you have an array of N elements, in some cases, you can have a trailing coma due to the fact that the element N-1 printed correctly with r_core_print_disasm_json and added a coma but element N hadn't printed something with r_core_print_disasm_json. So you end up basically with an array like this [{"foo":"bar"},] which is broken.
The solution here is to print an object even if it's empty in order to avoid this issue.