### PR TITLE
`oj` command now shows the correct info, fix #10174

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -938,8 +938,8 @@ static bool desc_list_cb(void *user, void *data, ut32 id) {
 static bool desc_list_json_cb(void *user, void *data, ut32 id) {
 	RPrint *p = (RPrint *)user;
 	RIODesc *desc = (RIODesc *)data;
-    // TODO: from is always 0? See libr/core/file.c:945
-    ut64 from = 0LL;
+	// TODO: from is always 0? See libr/core/file.c:945
+	ut64 from = 0LL;
 	p->cb_printf ("{\"raised\":%s,\"fd\":%d,\"uri\":\"%s\",\"from\":%"
             PFMT64d ",\"writable\":%s,\"size\":%" PFMT64d "}%s",
 			(desc->io && (desc->io->desc == desc)) ? "true" : "false",
@@ -1225,9 +1225,9 @@ static int cmd_open(void *data, const char *input) {
 			r_core_cmd_help (core, help_msg_oj);
 			break;
 		}
-        core->print->cb_printf("[");
+		core->print->cb_printf("[");
 		r_id_storage_foreach (core->io->files, desc_list_json_cb, core->print);
-        core->print->cb_printf("]\n");
+		core->print->cb_printf("]\n");
 		break;
 	case 'L': // "oL"
 		if (r_sandbox_enable (0)) {

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -941,11 +941,11 @@ static bool desc_list_json_cb(void *user, void *data, ut32 id) {
 	// TODO: from is always 0? See libr/core/file.c:945
 	ut64 from = 0LL;
 	p->cb_printf ("{\"raised\":%s,\"fd\":%d,\"uri\":\"%s\",\"from\":%"
-            PFMT64d ",\"writable\":%s,\"size\":%" PFMT64d "}%s",
+			PFMT64d ",\"writable\":%s,\"size\":%" PFMT64d "}%s",
 			(desc->io && (desc->io->desc == desc)) ? "true" : "false",
-            desc->fd, desc->uri, from,
-            (desc->flags & R_IO_WRITE ? "true": "false"),
-            r_io_desc_size (desc), (desc->io->files->top_id == id) ? "" : ",");
+			desc->fd, desc->uri, from,
+			(desc->flags & R_IO_WRITE ? "true": "false"),
+			r_io_desc_size (desc), (desc->io->files->top_id == id) ? "" : ",");
 	return true;
 }
 

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -935,6 +935,20 @@ static bool desc_list_cb(void *user, void *data, ut32 id) {
 	return true;
 }
 
+static bool desc_list_json_cb(void *user, void *data, ut32 id) {
+	RPrint *p = (RPrint *)user;
+	RIODesc *desc = (RIODesc *)data;
+    // TODO: from is always 0? See libr/core/file.c:945
+    ut64 from = 0LL;
+	p->cb_printf ("{\"raised\":%s,\"fd\":%d,\"uri\":\"%s\",\"from\":%"
+            PFMT64d ",\"writable\":%s,\"size\":%" PFMT64d "}%s",
+			(desc->io && (desc->io->desc == desc)) ? "true" : "false",
+            desc->fd, desc->uri, from,
+            (desc->flags & R_IO_WRITE ? "true": "false"),
+            r_io_desc_size (desc), (desc->io->files->top_id == id) ? "" : ",");
+	return true;
+}
+
 static int cmd_open(void *data, const char *input) {
 	RCore *core = (RCore*)data;
 	int perms = R_IO_READ;
@@ -1211,7 +1225,9 @@ static int cmd_open(void *data, const char *input) {
 			r_core_cmd_help (core, help_msg_oj);
 			break;
 		}
-		r_core_file_list (core, (int)(*input));
+        core->print->cb_printf("[");
+		r_id_storage_foreach (core->io->files, desc_list_json_cb, core->print);
+        core->print->cb_printf("]\n");
 		break;
 	case 'L': // "oL"
 		if (r_sandbox_enable (0)) {


### PR DESCRIPTION
`from` is always 0 like in the original function, probably that should be changed but idk where to get that information.

```
[0x00000000]> aeim
[0x00000000]> oj~{}
[
  {
    "raised": true,
    "fd": 3,
    "uri": "malloc://512",
    "from": 0,
    "writable": true,
    "size": 512
  },
  {
    "raised": false,
    "fd": 4,
    "uri": "malloc://983040",
    "from": 0,
    "writable": true,
    "size": 983040
  }
]
```