### PR TITLE
Add support for x86-32 gcc "mov r,[r*s+d];jmp r" jumptables

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -455,6 +455,7 @@ static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut
 	if (!jmptbl) {
 		return 0;
 	}
+	// eprintf ("JMPTBL AT 0x%"PFMT64x"\n", jmptbl_loc);
 	anal->iob.read_at (anal->iob.io, jmptbl_loc, jmptbl, jmptbl_size * sz);
 	for (offs = 0; offs + sz - 1 < jmptbl_size * sz; offs += sz) {
 		switch (sz) {
@@ -474,6 +475,7 @@ static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut
 			jmpptr = r_read_le64 (jmptbl + offs);
 			break;
 		}
+		// eprintf ("WALKING %llx\n", jmpptr);
 		// if we don't check for 0 here, the next check with ptr+jmpptr
 		// will obviously be a good offset since it will be the start
 		// of the table, which is not what we want
@@ -628,8 +630,7 @@ static bool isSymbolNextInstruction(RAnal *anal, RAnalOp *op) {
 static bool is_delta_pointer_table (RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 lea_ptr, ut64 *jmptbl_addr, RAnalOp *jmp_aop) {
 	int i;
 	ut64 dst;
-	st32 jmptbl[64] = {
-		0};
+	st32 jmptbl[64] = {0};
 	/* check if current instruction is followed by an ujmp */
 	ut8 buf[JMPTBL_LEA_SEARCH_SZ];
 	RAnalOp *aop = jmp_aop;
@@ -665,7 +666,13 @@ static bool is_delta_pointer_table (RAnal *anal, RAnalFunction *fcn, ut64 addr, 
 	// jmp reg2
 	if (mov_aop.type && add_aop.type && mov_aop.addr < add_aop.addr && add_aop.addr < jmp_aop->addr && mov_aop.ptr) {
 		// ptr in this case should be tbl_loc_off
+		// eprintf ("JMPTBL ADDR %llx\n", mov_aop.ptr);
 		*jmptbl_addr += mov_aop.ptr;
+	}
+	if (mov_aop.type && mov_aop.ptr) {
+		*jmptbl_addr += mov_aop.ptr;
+		// absjmptbl
+		lea_ptr = mov_aop.ptr;
 	}
 
 	/* check if jump table contains valid deltas */
@@ -799,7 +806,6 @@ static bool try_get_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 addr, RAna
 		// for operands in op, check if type is immediate and val is sane
 		// TODO: How? opex?
 
-
 		// for the time being, this seems to work
 		// might not actually have a value, let the next step figure out the size then
 		if (tmp_aop.val == UT64_MAX && tmp_aop.refptr == 0) {
@@ -814,7 +820,6 @@ static bool try_get_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 addr, RAna
 		}
 
 		// TODO: check the jmp for whether val is included in valid range or not (ja vs jae)
-
 		break;
 	}
 	free (bb_buf);
@@ -968,6 +973,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 	if (anal->limit && addr + idx < anal->limit->from) {
 		return R_ANAL_RET_END;
 	}
+	ut64 movptr = UT64_MAX; // used by jmptbl when coded as "mov reg,[R*4+B]"
 	while (addrbytes * idx < len) {
 		if (anal->limit && anal->limit->to <= addr + idx) {
 			break;
@@ -1092,6 +1098,11 @@ repeat:
 		case R_ANAL_OP_TYPE_CMOV:
 		case R_ANAL_OP_TYPE_MOV:
 			// skip mov reg,reg
+			if (anal->opt.jmptbl) {
+				if (op.scale && op.ireg) {
+					movptr = op.ptr;
+				}
+			}
 			if (anal->opt.hpskip && regs_exist (op.src[0], op.dst)
 			&& !strcmp (op.src[0]->reg->name, op.dst->reg->name)) {
 				skip_ret = skip_hp (anal, fcn, &op, bb, addr, tmp_buf, oplen, delay.un_idx, &idx);
@@ -1429,12 +1440,21 @@ repeat:
 			if (anal->opt.jmptbl) {
 				// op.ireg since rip relative addressing produces way too many false positives otherwise
 				// op.ireg is 0 for rip relative, "rax", etc otherwise
-				if (op.ptr != UT64_MAX && op.ireg) {       // direct jump
+				// if (op.ptr != UT64_MAX && op.ireg) { // direct jump
+				if (op.ptr != UT64_MAX && op.reg) { // direct jump
 					ut64 table_size, default_case;
 					if (try_get_jmptbl_info (anal, fcn, op.addr, bb, &table_size, &default_case)) {
 						ret = try_walkthrough_jmptbl (anal, fcn, depth, op.addr, op.ptr, op.ptr, anal->bits >> 3, table_size, default_case, ret);
 					}
-				}
+				} else if (movptr != UT64_MAX) {
+					ut64 table_size, default_case;
+
+					if (try_get_jmptbl_info (anal, fcn, op.addr, bb, &table_size, &default_case)) {
+						op.ptr = movptr;
+						ret = try_walkthrough_jmptbl (anal, fcn, depth, op.addr, op.ptr, op.ptr, anal->bits >> 3, table_size, default_case, ret);
+					}
+					movptr = UT64_MAX;
+	}
 			}
 #if 0
 			if (anal->cur) {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -731,9 +731,8 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 			if (INSOP(1).type == X86_OP_MEM) {
 				// MOV REG, [PTR + IREG*SCALE]
 				op->ireg = cs_reg_name (*handle, INSOP (1).mem.index);
-				op->ptr = INSOP(1).mem.disp; // XXX base ?
+				op->disp = INSOP(1).mem.disp;
 				op->scale = INSOP(1).mem.scale;
-				op->refptr = 4;
 			}
 			{
 				src = getarg (&gop, 1, 0, NULL, SRC_AR);

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -725,6 +725,16 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 			break;
 		case X86_OP_REG:
 		default:
+			if (INSOP(0).type == X86_OP_MEM) {
+				op->direction = 1; // read
+			}
+			if (INSOP(1).type == X86_OP_MEM) {
+				// MOV REG, [PTR + IREG*SCALE]
+				op->ireg = cs_reg_name (*handle, INSOP (1).mem.index);
+				op->ptr = INSOP(1).mem.disp; // XXX base ?
+				op->scale = INSOP(1).mem.scale;
+				op->refptr = 4;
+			}
 			{
 				src = getarg (&gop, 1, 0, NULL, SRC_AR);
 				dst = getarg (&gop, 0, 0, NULL, DST_AR);
@@ -733,8 +743,8 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 				if (a->bits == 64 && dst64) {
 					r_strbuf_appendf (&op->esil, ",0xffffffff,%s,&=", dst64);
 				}
-				break;
 			}
+			break;
 		}
 		}
 		break;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1406,6 +1406,12 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			if (op.reg) {
 				r_cons_printf ("\"reg\": \"%s\",", op.reg);
 			}
+			if (op.ireg) {
+				r_cons_printf ("\"ireg\": \"%s\",", op.ireg);
+			}
+			if (op.scale) {
+				r_cons_printf ("\"scale\":%d,", op.scale);
+			}
 			if (hint && hint->esil) {
 				r_cons_printf ("\"esil\": \"%s\",", hint->esil);
 			} else if (*esilstr) {
@@ -1500,6 +1506,12 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			}
 			if (op.reg) {
 				printline ("reg", "%s\n", op.reg);
+			}
+			if (op.ireg) {
+				printline ("ireg", "%s\n", op.ireg);
+			}
+			if (op.scale) {
+				printline ("scale", "%d\n", op.scale);
 			}
 			if (hint && hint->esil) {
 				printline ("esil", "%s\n", hint->esil);


### PR DESCRIPTION
Thanks @rlaemmert for providing test case

- This PR also improves the analysis of MOV instructions on X86
- And extends output of 'ao' to show ireg, scale, ...