### PR TITLE
Fix afvR and afvW by using RAnalOp.direction 

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -580,8 +580,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 	} else {
 		ptr = (st64) r_num_get (NULL, addr);
 	}
-	//XXX: This won't work for stack based var/arg
-	int rw = (op->stackop == R_ANAL_STACK_SET) ? 1 : 0;
+	int rw = (op->direction == R_ANAL_OP_DIR_WRITE) ? 1 : 0;
 	if (*sign == '+') {
 		const char *pfx = ((ptr < fcn->maxstack) && (type == 's')) ? VARPREFIX : ARGPREFIX;
 		bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2734,7 +2734,7 @@ static int parse_reg64_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_nu
 }
 
 static void set_opdir(RAnalOp *op) {
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		op->direction = R_ANAL_OP_DIR_READ;
 		break;

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2733,6 +2733,28 @@ static int parse_reg64_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_nu
 	return 0;
 }
 
+static void set_opdir(RAnalOp *op) {
+	switch (op->type) {
+	case R_ANAL_OP_TYPE_LOAD:
+		op->direction = R_ANAL_OP_DIR_READ;
+		break;
+	case R_ANAL_OP_TYPE_STORE:
+		op->direction = R_ANAL_OP_DIR_WRITE;
+		break;
+	case R_ANAL_OP_TYPE_LEA:
+		op->direction = R_ANAL_OP_DIR_REF;
+		break;
+	case R_ANAL_OP_TYPE_CALL:
+	case R_ANAL_OP_TYPE_JMP:
+	case R_ANAL_OP_TYPE_UJMP:
+	case R_ANAL_OP_TYPE_UCALL:
+		op->direction = R_ANAL_OP_DIR_EXEC;
+		break;
+	default:
+		break;
+        }
+}
+
 static void op_fillval(RAnalOp *op , csh handle, cs_insn *insn, int bits) {
 	static RRegItem reg;
 	switch (op->type) {
@@ -2821,6 +2843,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 				analop_esil (a, op, addr, buf, len, &handle, insn, thumb);
 			}
 		}
+		set_opdir (op);
 		if (a->fillval) {
 			op_fillval (op, handle, insn, a->bits);
 		}

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -650,6 +650,28 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh *handle, cs_insn *insn) {
 	}
 }
 
+static void set_opdir(RAnalOp *op) {
+        switch (op->type) {
+        case R_ANAL_OP_TYPE_LOAD:
+                op->direction = R_ANAL_OP_DIR_READ;
+                break;
+        case R_ANAL_OP_TYPE_STORE:
+                op->direction = R_ANAL_OP_DIR_WRITE;
+                break;
+        case R_ANAL_OP_TYPE_LEA:
+                op->direction = R_ANAL_OP_DIR_REF;
+                break;
+        case R_ANAL_OP_TYPE_CALL:
+        case R_ANAL_OP_TYPE_JMP:
+        case R_ANAL_OP_TYPE_UJMP:
+        case R_ANAL_OP_TYPE_UCALL:
+                op->direction = R_ANAL_OP_DIR_EXEC;
+                break;
+        default:
+                break;
+        }
+}
+
 static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	int n, ret, opsize = -1;
 	static csh hndl = 0;
@@ -974,7 +996,8 @@ static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 		SET_VAL (op,2);
 		break;
 	}
-	beach:
+beach:
+	set_opdir (op);
 	if (anal->decode) {
 		if (analop_esil (anal, op, addr, buf, len, &hndl, insn) != 0)
 			r_strbuf_fini (&op->esil);
@@ -984,7 +1007,7 @@ static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 	}
 	cs_free (insn, n);
 	//cs_close (&handle);
-	fin:
+fin:
 	return opsize;
 }
 

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -651,7 +651,7 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh *handle, cs_insn *insn) {
 }
 
 static void set_opdir(RAnalOp *op) {
-        switch (op->type) {
+        switch (op->type & R_ANAL_OP_TYPE_MASK) {
         case R_ANAL_OP_TYPE_LOAD:
                 op->direction = R_ANAL_OP_DIR_READ;
                 break;

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1713,7 +1713,7 @@ static void op_fillval (RAnal *a, RAnalOp *op, csh *handle, cs_insn *insn){
 }
 
 static void set_opdir(RAnalOp *op, cs_insn *insn) {
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
 		switch (INSOP(0).type) {
 		case X86_OP_MEM:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -722,13 +722,9 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 				dst = getarg (&gop, 0, 1, NULL, DST_AR);
 				esilprintf (op, "%s,%s", src, dst);
 			}
-			op->direction = 2; // write
 			break;
 		case X86_OP_REG:
 		default:
-			if (INSOP(0).type == X86_OP_MEM) {
-				op->direction = 1; // read
-			}
 			{
 				src = getarg (&gop, 1, 0, NULL, SRC_AR);
 				dst = getarg (&gop, 0, 0, NULL, DST_AR);
@@ -1716,6 +1712,36 @@ static void op_fillval (RAnal *a, RAnalOp *op, csh *handle, cs_insn *insn){
 	}
 }
 
+static void set_opdir(RAnalOp *op, cs_insn *insn) {
+	switch (op->type) {
+	case R_ANAL_OP_TYPE_MOV:
+		switch (INSOP(0).type) {
+		case X86_OP_MEM:
+			op->direction = R_ANAL_OP_DIR_WRITE;
+			break;
+		case X86_OP_REG:
+			if (INSOP(1).type == X86_OP_MEM) {
+				op->direction = R_ANAL_OP_DIR_READ;
+			}
+			break;
+		default:
+			break;
+		}
+		break;
+	case R_ANAL_OP_TYPE_LEA:
+		op->direction = R_ANAL_OP_DIR_REF;
+		break;
+	case R_ANAL_OP_TYPE_CALL:
+	case R_ANAL_OP_TYPE_JMP:
+	case R_ANAL_OP_TYPE_UJMP:
+	case R_ANAL_OP_TYPE_UCALL:
+		op->direction = R_ANAL_OP_DIR_EXEC;
+		break;
+	default:
+		break;
+	}
+}
+
 static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn) {
 	struct Getarg gop = {
 		.handle = *handle,
@@ -2641,6 +2667,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			break;
 		}
 		anop (a, op, addr, buf, len, &handle, insn);
+		set_opdir (op, insn);
 		if (a->decode) {
 			anop_esil (a, op, addr, buf, len, &handle, insn);
 		}


### PR DESCRIPTION
Fixes #10122 

### Before fix

```
|   sym.main ();
|           ; var int local_78h @ ebp-0x78
|           ; var int local_4h @ esp+0x4
|           0x08048540      55             push ebp
|           ...
|           0x08048577      8d4588         lea eax, [local_78h]
|           0x0804857a      89442404       mov dword [local_4h], eax
|           0x0804857e      c70424b28604.  mov dword [esp], 0x80486b2
|           ...
|           0x0804858a      8d4588         lea eax, [local_78h]
|           0x0804858d      890424         mov dword [esp], eax
[0x08048540]> afvR
 local_78h  0x8048577,0x804858a
  local_4h  0x0804857a
[0x08048540]> afvW
 local_78h  
 local_4h 
```

### After Fix

```
[0x08048540]> afvR
 local_78h  0x8048577,0x804858a
  local_4h
[0x08048540]> afvW
 local_78h  
  local_4h  0x804857a
```
Added test in r2r [#1340](https://github.com/radare/radare2-regressions/pull/1340)