### PR TITLE
For ARM-Thumb mode instruction align changed to 1.

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -3160,7 +3160,7 @@ static int archinfo(RAnal *anal, int q) {
 	}
 	if (q == R_ANAL_ARCHINFO_ALIGN) {
 		if (anal && anal->bits == 16) {
-			return 2;
+			return 1;
 		}
 		return 4;
 	}

--- a/libr/anal/p/anal_arm_gnu.c
+++ b/libr/anal/p/anal_arm_gnu.c
@@ -446,7 +446,7 @@ static int set_reg_profile(RAnal *anal) {
 static int archinfo(RAnal *anal, int q) {
 	if (q == R_ANAL_ARCHINFO_ALIGN) {
 		if (anal && anal->bits == 16) {
-			return 2;
+			return 1;
 		}
 		return 4;
 	}


### PR DESCRIPTION
This is rare, but possible case.

For example, TI CC3200 chip use align 1 for ROM functions.