### PR TITLE
Use return value hint for struct offset propgation

### DIFF
--- a/libr/anal/hint.c
+++ b/libr/anal/hint.c
@@ -90,6 +90,10 @@ R_API void r_anal_hint_set_pointer(RAnal *a, ut64 addr, ut64 ptr) {
 	setHint (a, "ptr:", addr, NULL, ptr);
 }
 
+R_API void r_anal_hint_set_ret(RAnal *a, ut64 addr, ut64 val) {
+	setHint (a, "ret:", addr, NULL, val);
+}
+
 R_API void r_anal_hint_set_arch(RAnal *a, ut64 addr, const char *arch) {
 	setHint (a, "arch:", addr, r_str_trim_ro (arch), 0);
 }
@@ -148,6 +152,10 @@ R_API void r_anal_hint_unset_pointer(RAnal *a, ut64 addr) {
 	unsetHint(a, "ptr:", addr);
 }
 
+R_API void r_anal_hint_unset_ret(RAnal *a, ut64 addr) {
+	unsetHint(a, "ret:", addr);
+}
+
 R_API void r_anal_hint_unset_offset(RAnal *a, ut64 addr) {
 	unsetHint (a, "Offset:", addr);
 }
@@ -180,6 +188,7 @@ R_API RAnalHint *r_anal_hint_from_string(RAnal *a, ut64 addr, const char *str) {
 	}
 	hint->jump = UT64_MAX;
 	hint->fail = UT64_MAX;
+	hint->ret = UT64_MAX;
 	char *s = strdup (str);
 	if (!s) {
 		free (hint);
@@ -199,6 +208,7 @@ R_API RAnalHint *r_anal_hint_from_string(RAnal *a, ut64 addr, const char *str) {
 			case 'j': hint->jump = sdb_atoi (nxt); break;
 			case 'f': hint->fail = sdb_atoi (nxt); break;
 			case 'p': hint->ptr  = sdb_atoi (nxt); break;
+			case 'r': hint->ret  = sdb_atoi (nxt); break;
 			case 'b': hint->bits = sdb_atoi (nxt); break;
 			case 'B': hint->new_bits = sdb_atoi (nxt); break;
 			case 's': hint->size = sdb_atoi (nxt); break;

--- a/libr/core/blaze.c
+++ b/libr/core/blaze.c
@@ -242,7 +242,7 @@ R_API bool core_anal_bbs(RCore *core, const char* input) {
 		if (block_score < invalid_instruction_barrier) {
 			break;
 		}
-		op = r_core_anal_op (core, start + cur);
+		op = r_core_anal_op (core, start + cur, R_ANAL_OP_MASK_BASIC);
 
 		if (!op || !op->mnemonic) {
 			block_score -= 10;
@@ -533,7 +533,7 @@ R_API bool core_anal_bbs_range (RCore *core, const char* input) {
 				}
 
 				if (!bFound) {
-					op = r_core_anal_op (core, b_start + cur);
+					op = r_core_anal_op (core, b_start + cur, R_ANAL_OP_MASK_BASIC);
 
 					if (!op || !op->mnemonic) {
 						block_score -= 10;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -872,6 +872,9 @@ static void print_hint_h_format(RAnalHint* hint) {
 	if (hint->jump != UT64_MAX) {
 		r_cons_printf (" jump: 0x%"PFMT64x, hint->jump);
 	}
+	if (hint->ret != UT64_MAX) {
+		r_cons_printf (" ret: 0x%"PFMT64x, hint->ret);
+	}
 	r_cons_newline ();
 }
 

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -816,7 +816,7 @@ error:
 }
 
 /* decode and return the RANalOp at the address addr */
-R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr) {
+R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr, int mask) {
 	int len;
 	RAnalOp *op;
 	ut8 buf[128];
@@ -844,7 +844,7 @@ R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr) {
 		ptr = buf;
 		len = sizeof (buf);
 	}
-	if (r_anal_op (core->anal, op, addr, ptr, len, R_ANAL_OP_MASK_ALL) < 1) {
+	if (r_anal_op (core->anal, op, addr, ptr, len, mask) < 1) {
 		goto err_op;
 	}
 
@@ -1455,7 +1455,7 @@ R_API int r_core_anal_esil_fcn(RCore *core, ut64 at, ut64 from, int reftype, int
 	eprintf ("TODO\n");
 	while (1) {
 		// TODO: Implement the proper logic for doing esil analysis
-		op = r_core_anal_op (core, at);
+		op = r_core_anal_op (core, at, R_ANAL_OP_MASK_ESIL);
 		if (!op) {
 			break;
 		}
@@ -2643,7 +2643,7 @@ R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-			op = r_core_anal_op (core, pos);
+			op = r_core_anal_op (core, pos, R_ANAL_OP_MASK_ESIL);
 			if (!op) {
 	//			eprintf ("Cannot get op\n");
 				break;
@@ -3410,7 +3410,7 @@ R_API RList* r_core_anal_cycles(RCore *core, int ccl) {
 	cf = r_anal_cycle_frame_new ();
 	r_cons_break_push (NULL, NULL);
 	while (cf && !r_cons_is_breaked ()) {
-		if ((op = r_core_anal_op (core, addr)) && (op->cycles) && (ccl > 0)) {
+		if ((op = r_core_anal_op (core, addr, R_ANAL_OP_MASK_BASIC)) && (op->cycles) && (ccl > 0)) {
 			r_cons_clear_line (1);
 			eprintf ("%i -- ", ccl);
 			addr += op->size;
@@ -4269,7 +4269,7 @@ static void analPaths (RCoreAnalPaths *p) {
 			int i;
 			for (i = 0; i < cur->op_pos_size; i++) {
 				ut64 addr = cur->addr + cur->op_pos[i];
-				RAnalOp *op = r_core_anal_op (p->core, addr);
+				RAnalOp *op = r_core_anal_op (p->core, addr, R_ANAL_OP_MASK_BASIC);
 				if (op && op->type == R_ANAL_OP_TYPE_CALL) {
 					cur = c;
 					analPathFollow (p, op->jump);

--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -151,7 +151,7 @@ R_API void r_core_print_func_args(RCore *core) {
 	}
 	const char *pc = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 	ut64 cur_addr = r_reg_getv (core->anal->reg, pc);
-	RAnalOp *op = r_core_anal_op (core, cur_addr);
+	RAnalOp *op = r_core_anal_op (core, cur_addr, R_ANAL_OP_MASK_BASIC);
 	if (!op) {
 		return;
 	}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -450,6 +450,7 @@ static const char *help_msg_ah[] = {
 	"ahj", "", "list hints in JSON",
 	"aho", " foo a0,33", "replace opcode string",
 	"ahp", " addr", "set pointer hint",
+	"ahr", " val",  "set hint for return value of a function"
 	"ahs", " 4", "set opcode size=4",
 	"ahS", " jz", "set asm.syntax=jz for this opcode",
 	NULL
@@ -5543,6 +5544,12 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 			r_anal_hint_unset_pointer (core->anal, core->offset);
 		}
 		break;
+	case 'r': // "ahr"
+		if (input[1] == ' ') {
+			r_anal_hint_set_ret (core->anal, core->offset, r_num_math (core->num, input + 1));
+		} else if (input[1] == '-') { // "ahr-"
+			r_anal_hint_unset_ret (core->anal, core->offset);
+		}
 	case '*': // "ah*"
 		if (input[1] == ' ') {
 			char *ptr = strdup (r_str_trim_ro (input + 2));

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4132,8 +4132,8 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		case 'l': // "aesl"
 		{
 			ut64 pc = r_debug_reg_get (core->dbg, "PC");
-			RAnalOp *op = r_core_anal_op (core, pc);
-// TODO: honor hint
+			RAnalOp *op = r_core_anal_op (core, pc, R_ANAL_OP_MASK_BASIC);
+			// TODO: honor hint
 			if (!op) {
 				break;
 			}
@@ -4141,6 +4141,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			r_debug_reg_set (core->dbg, "PC", pc + op->size);
 			r_anal_esil_set_pc (esil, pc + op->size);
 			r_core_cmd0 (core, ".ar*");
+			r_anal_op_free (op);
 		} break;
 		case 'b': // "aesb"
 			if (!r_core_esil_step_back (core)) {
@@ -4160,7 +4161,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		case 'o': // "aeso"
 			// step over
 			op = r_core_anal_op (core, r_reg_getv (core->anal->reg,
-				r_reg_get_name (core->anal->reg, R_REG_NAME_PC)));
+				r_reg_get_name (core->anal->reg, R_REG_NAME_PC)), R_ANAL_OP_MASK_BASIC);
 			if (op && op->type == R_ANAL_OP_TYPE_CALL) {
 				until_addr = op->addr + op->size;
 			}
@@ -4202,7 +4203,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 			ut64 newaddr;
 			int ret;
 			for (;;) {
-				op = r_core_anal_op (core, addr);
+				op = r_core_anal_op (core, addr, R_ANAL_OP_MASK_BASIC);
 				if (!op) {
 					break;
 				}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4310,7 +4310,7 @@ static int cmd_debug(void *data, const char *input) {
 				if (!addr) {
 					addr = core->offset;
 				}
-				op = r_core_anal_op (core, addr);
+				op = r_core_anal_op (core, addr, R_ANAL_OP_MASK_ESIL);
 				if (op) {
 					r_anal_esil_trace (core->anal->esil, op);
 				}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2338,7 +2338,7 @@ static ut8 *analBars(RCore *core, int type, int nblocks, int blocksize, int skip
 		}
 		ut64 off = from + (i + skipblocks) * blocksize;
 		for (j = 0; j < blocksize ; j++) {
-			RAnalOp *op = r_core_anal_op (core, off + j);
+			RAnalOp *op = r_core_anal_op (core, off + j, R_ANAL_OP_MASK_BASIC);
 			if (op) {
 				if (op->size < 1) {
 					// do nothing
@@ -3022,7 +3022,7 @@ static void disasm_until_ret(RCore *core, ut64 addr, char type_print) {
 	}
 	(void)r_io_read_at (core->io, addr, buf, core->blocksize);
 	while (p + 4 < core->blocksize) {
-		RAnalOp *op = r_core_anal_op (core, addr + p);
+		RAnalOp *op = r_core_anal_op (core, addr + p, R_ANAL_OP_MASK_BASIC);
 		if (op) {
 			r_cons_printf ("0x%08"PFMT64x"  %10s %s\n", addr + p, "", op->mnemonic);
 			if (op->type == R_ANAL_OP_TYPE_RET) {

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -356,7 +356,7 @@ static void typesList(RCore *core, int mode) {
 	}
 }
 
-static void set_offset_hint (RCore *core, RAnalOp op, const char *type, ut64 addr, int offimm) {
+static void set_offset_hint(RCore *core, RAnalOp op, const char *type, ut64 addr, int offimm) {
 	const char *res = r_type_get_struct_memb (core->anal->sdb_types, type, offimm);
 	const char *cmt = ((offimm == 0) && res)? res: type;
 	if (offimm > 0) {
@@ -368,7 +368,29 @@ static void set_offset_hint (RCore *core, RAnalOp op, const char *type, ut64 add
 	}
 }
 
-static void link_struct_offset (RCore *core, RAnalFunction *fcn) {
+static int get_stacksz (RCore *core, ut64 from, ut64 to, int minopcode) {
+	int ret = 0;
+	ut64 at = from;
+
+	if (from >= to) {
+		return 0;
+	}
+	while (at < to) {
+		RAnalOp *op = r_core_anal_op (core, at, R_ANAL_OP_MASK_BASIC);
+		if (!op || op->size <= 0) {
+			at += minopcode;
+			continue;
+		}
+		if ((op->stackop == R_ANAL_STACK_INC) && R_ABS (op->stackptr) < 8096) {
+			ret += op->stackptr;
+		}
+		at += op->size;
+		r_anal_op_fini (op);
+	}
+	return ret;
+}
+
+static void link_struct_offset(RCore *core, RAnalFunction *fcn) {
 	RAnalBlock *bb;
 	RListIter *it;
 	RAnalOp aop = {0};
@@ -394,7 +416,6 @@ static void link_struct_offset (RCore *core, RAnalFunction *fcn) {
 	int i, ret, bsize = R_MAX (64, core->blocksize);
 	const int mininstrsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
 	const int minopcode = R_MAX (1, mininstrsz);
-	const int maxopcode = R_MAX (16, r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE));
 	ut8 *buf = malloc (bsize);
 	if (!buf) {
 		free (buf);
@@ -408,9 +429,10 @@ static void link_struct_offset (RCore *core, RAnalFunction *fcn) {
 		// reset stack pointer to intial value
 		RRegItem *sp = r_reg_get (esil->anal->reg, sp_name, -1);
 		ut64 curpc = r_reg_getv (esil->anal->reg, pc_name);
-		int delta = (curpc > fcn->addr)? curpc - fcn->addr: 0;
-		if (delta > maxopcode) {
-			r_reg_set_value (esil->anal->reg, sp, spval + fcn->maxstack);
+		int stacksz = get_stacksz (core, fcn->addr, curpc, minopcode);
+		if (stacksz > 0) {
+			r_reg_arena_zero (esil->anal->reg); // clear prev reg values
+			r_reg_set_value (esil->anal->reg, sp, spval + stacksz);
 		}
 	} else {
 		// intialize stack

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3831,7 +3831,7 @@ static void ds_pre_emulation(RDisasmState *ds) {
 	esil->cb.hook_reg_write = NULL;
 	for (i = 0; i < end; i++) {
 		ut64 addr = base + i;
-		RAnalOp* op = r_core_anal_op (ds->core, addr);
+		RAnalOp* op = r_core_anal_op (ds->core, addr, R_ANAL_OP_MASK_ESIL);
 		if (op) {
 			if (do_esil) {
 				r_anal_esil_set_pc (esil, addr);

--- a/libr/core/p/core_anal.c
+++ b/libr/core/p/core_anal.c
@@ -139,7 +139,7 @@ ut64 analyzeStackBased(RCore *core, Sdb *db, ut64 addr, RList *delayed_commands)
 		free (value);
 		cur = 0;
 		while (!block_end) {
-			op = r_core_anal_op (core, addr + cur);
+			op = r_core_anal_op (core, addr + cur, R_ANAL_OP_MASK_BASIC);
 			if (!op || !op->mnemonic) {
 				eprintf ("Cannot analyze opcode at %"PFMT64d"\n", addr+cur);
 				oaddr = UT64_MAX;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1732,7 +1732,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 				r_cons_enable_mouse (true);
 			}
 			do {
-				op = r_core_anal_op (core, core->offset + core->print->cur);
+				op = r_core_anal_op (core, core->offset + core->print->cur, R_ANAL_OP_MASK_BASIC);
 				if (op) {
 					if (op->type == R_ANAL_OP_TYPE_JMP ||
 					op->type == R_ANAL_OP_TYPE_CJMP ||

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -2841,7 +2841,7 @@ repeat:
 		{
 			char *man = NULL;
 			/* check for manpage */
-			RAnalOp *op = r_core_anal_op (core, off);
+			RAnalOp *op = r_core_anal_op (core, off, R_ANAL_OP_MASK_BASIC);
 			if (op) {
 				if (op->jump != UT64_MAX) {
 					RFlagItem *item = r_flag_get_i (core->flags, op->jump);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -707,6 +707,7 @@ typedef struct r_anal_hint_t {
 	ut64 ptr;
 	ut64 jump;
 	ut64 fail;
+	ut64 ret; // hint for function ret values
 	char *arch;
 	char *opcode;
 	char *syntax;
@@ -1581,6 +1582,7 @@ R_API void r_anal_hint_set_size (RAnal *a, ut64 addr, int length);
 R_API void r_anal_hint_set_opcode (RAnal *a, ut64 addr, const char *str);
 R_API void r_anal_hint_set_esil (RAnal *a, ut64 addr, const char *str);
 R_API void r_anal_hint_set_pointer (RAnal *a, ut64 addr, ut64 jump);
+R_API void r_anal_hint_set_ret(RAnal *a, ut64 addr, ut64 val);
 R_API void r_anal_hint_set_high(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_high(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_size(RAnal *a, ut64 addr);
@@ -1590,6 +1592,7 @@ R_API void r_anal_hint_unset_opcode(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_arch(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_syntax(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_pointer(RAnal *a, ut64 addr);
+R_API void r_anal_hint_unset_ret(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_offset(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_jump(RAnal *a, ut64 addr);
 R_API void r_anal_hint_unset_fail(RAnal *a, ut64 addr);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -400,7 +400,7 @@ R_API void r_core_print_func_args(RCore *core);
 R_API char *resolve_fcn_name(RAnal *anal, const char * func_name);
 
 /* anal.c */
-R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr);
+R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr, int mask);
 R_API void r_core_anal_esil(RCore *core, const char *str, const char *addr);
 R_API void r_core_anal_fcn_merge (RCore *core, ut64 addr, ut64 addr2);
 R_API const char *r_core_anal_optype_colorfor(RCore *core, ut64 addr, bool verbose);


### PR DESCRIPTION
Fixes #10248 

### Changes made : 

* Calculate stacksize till pc addr instead of using fcn->maxstack 

* Implemented a new command `ahr` to set hint for return value of a function  (usefull in cases like malloc , where emulating it is atm not possible)

* And use the hint to propgate struct offset 

Added test in r2r [#1343](https://github.com/radare/radare2-regressions/pull/1343)