### PR TITLE
Fixed wrong int output format in izzj

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -230,8 +230,8 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 		} else if (IS_MODE_JSON (mode)) {
 			int *block_list;
 			q = r_base64_encode_dyn (string->string, -1);
-			r_cons_printf ("%s{\"vaddr\":%"PFMT64d
-				",\"paddr\":%"PFMT64d",\"ordinal\":%d"
+			r_cons_printf ("%s{\"vaddr\":%"PFMT64u
+				",\"paddr\":%"PFMT64u",\"ordinal\":%d"
 				",\"size\":%d,\"length\":%d,\"section\":\"%s\","
 				"\"type\":\"%s\",\"string\":\"%s\"",
 				last_processed ? ",": "",


### PR DESCRIPTION
It was using signed integer, which caused the offset to become negative.
Might fix https://github.com/radareorg/cutter/issues/516