### PR TITLE
Added ability to rename variables far from cursor

### DIFF
--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -3142,7 +3142,7 @@ repeat:
 		}
 		if (!end_off || end_off == endptr) {
 			eprintf ("Invalid numeric input\n");
-			r_cons_anykey();
+			r_cons_any_key (NULL);
 			break;
 		}
 		free (end_off);
@@ -3188,15 +3188,15 @@ repeat:
 					}
 				} else {
 					eprintf ("Cannot find variable\n");
-					r_cons_anykey();
+					r_cons_any_key (NULL);
 				}
 			} else {
 				eprintf ("Cannot find function\n");
-				r_cons_anykey();
+				r_cons_any_key (NULL);
 			}
 		} else {
 			eprintf ("Cannot find instruction with a variable\n");
-			r_cons_anykey();
+			r_cons_any_key (NULL);
 		}
 
 		r_anal_op_fini (&op);


### PR DESCRIPTION
I added the possibility to rename a variable in Visual mode even without the need of selecting it through the cursor (which is what `dn` does already).

For example, in order to change `local_378h`:
```
[0x00402a02 8% 290 /bin/ls]> pd $r @ main+2 # 0x402a02                                                                                                                     
|           0x00402a02      4156           push r14                                                                                                                        
|           0x00402a04      4155           push r13                                                                                                                        
|           0x00402a06      4154           push r12                                                                                                                        
|           0x00402a08      55             push rbp                                                                                                                        
|           0x00402a09      53             push rbx                                                                                                                        
|           0x00402a0a      89fb           mov ebx, edi                                                                                                                    
|           0x00402a0c      4889f5         mov rbp, rsi                                                                                                                    
|           0x00402a0f      4881ec880300.  sub rsp, 0x388                                                                                                                  
|           0x00402a16      488b3e         mov rdi, qword [rsi]                                                                                                            
|           0x00402a19      64488b042528.  mov rax, qword fs:[0x28]    ; [0x28:8]=-1 ; '(' ; 40                                                                            
|           0x00402a22      488984247803.  mov qword [local_378h], rax                                                                                                     
|           0x00402a2a      31c0           xor eax, eax                                                                                                                    
|           0x00402a2c      e8cfb00000     call sub.strrchr_b00        ;[1] ; char *strrchr(const char *s, int c)                                                          
|           0x00402a31      bec19a4100     mov esi, 0x419ac1                                                                                                               
|           0x00402a36      bf06000000     mov edi, 6      
```
The user can type `dv`, then specify '22'.  The function will look for the first instruction containing a variable whose address ends in '22'. If such an instruction is found, the variable will be renamed.