### PR TITLE
Incorrectly defined base of SIB part

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1816,7 +1816,7 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 			if (op->operands[1].scale[0] > 1) {
 				data[l++] = op->operands[0].reg << 3 | 4;
 
-				if (op->operands[1].scale[0] > 2) {
+				if (op->operands[1].scale[0] >= 2) {
 					base = 5;
 				}
 				if (base) {


### PR DESCRIPTION
Was be fixed #10303 problem with SIB part at which base part is incorrectly defined.
```
1819 if (op->operands[1].scale[0] > 2) {
1820	base = 5;
1821 }
```
In case when second operand define as `[reg * 2 + disp]`, `scale = 2 => base = 0` what is wrong. `base` must be equal is `101` i.e. `5`