### PR TITLE
 Support for using variable name in tp 

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -366,6 +366,25 @@ R_API void r_anal_var_free(RAnalVar *av) {
 	}
 }
 
+R_API ut64 r_anal_var_addr(RAnal *a, RAnalFunction *fcn, const char *name) {
+	const char *regname = NULL;
+	ut64 ret = UT64_MAX;
+	if (!a || !fcn) {
+		return ret;
+	}
+	RAnalVar *v1 = r_anal_var_get_byname (a, fcn, name);
+	if (v1) {
+		if (v1->kind == R_ANAL_VAR_KIND_BPV) {
+			regname = r_reg_get_name (a->reg, R_REG_NAME_BP);
+		} else if (v1->kind == R_ANAL_VAR_KIND_SPV) {
+			regname = r_reg_get_name (a->reg, R_REG_NAME_SP);
+		}
+		ret = r_reg_getv (a->reg, regname) + v1->delta;
+	}
+	r_anal_var_free (v1);
+	return ret;
+}
+
 /* (columns) elements in the array value */
 #define R_ANAL_VAR_SDB_KIND 0 /* char */
 #define R_ANAL_VAR_SDB_TYPE 1 /* string */

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -25,7 +25,7 @@ static const char *help_msg_t[] = {
 	"to", " -", "Open cfg.editor to load types",
 	"to", " <path>", "Load types from C header file",
 	"tos", " <path>", "Load types from parsed Sdb database",
-	"tp", "  <type> [addr]", "cast data at <address> to <type> and print it",
+	"tp", "  <type> [addr|varname]", "cast data at <address> to <type> and print it",
 	"tpx", " <type> <hexpairs>", "Show value for type with specified byte sequence",
 	"ts", "[?]", "print loaded struct types",
 	"tu", "[?]", "print loaded union types",
@@ -985,7 +985,13 @@ static int cmd_type(void *data, const char *input) {
 				r_core_cmdf (core, "pf %s @x: %s", fmt, arg);
 			} else {
 				ut64 addr = arg ? r_num_math (core->num, arg): core->offset;
-				r_core_cmdf (core, "pf %s @ 0x%08" PFMT64x "\n", fmt, addr);
+				if (!addr && arg) {
+					RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, -1);
+					addr = r_anal_var_addr (core->anal, fcn, arg);
+				}
+				if (addr != UT64_MAX) {
+					r_core_cmdf (core, "pf %s @ 0x%08" PFMT64x "\n", fmt, addr);
+				}
 			}
 			free (fmt);
 		} else {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1100,6 +1100,27 @@ static int autocomplete(RLine *line) {
 			r_list_free (themes);
 			line->completion.argc = i;
 			line->completion.argv = tmp_argv;
+		} else if (!strncmp (line->buffer.data, "t ", 2)
+		|| !strncmp (line->buffer.data, "t- ", 3)) {
+			int i = 0;
+			SdbList *l = sdb_foreach_list (core->anal->sdb_types, true);
+			SdbListIter *iter;
+			SdbKv *kv;
+			int chr = (line->buffer.data[1] == ' ')? 2: 3;
+			ls_foreach (l, iter, kv) {
+				int len = strlen (line->buffer.data + chr);
+				if (!len || !strncmp (line->buffer.data + chr, kv->key, len)) {
+					if (!strcmp (kv->value, "type") || !strcmp (kv->value, "enum")
+					|| !strcmp (kv->value, "struct")) {
+						tmp_argv[i++] = strdup (kv->key);
+					}
+				}
+			}
+			if (i > 0) tmp_argv_heap = true;
+			tmp_argv[i] = NULL;
+			ls_free (l);
+			line->completion.argc = i;
+			line->completion.argv = tmp_argv;
 		} else if ((!strncmp (line->buffer.data, "te ", 3))) {
 			int i = 0;
 			SdbList *l = sdb_foreach_list (core->anal->sdb_types, true);
@@ -1120,7 +1141,10 @@ static int autocomplete(RLine *line) {
 			line->completion.argc = i;
 			line->completion.argv = tmp_argv;
 		} else if (!strncmp (line->buffer.data, "ts ", 3)
+		|| !strncmp (line->buffer.data, "ta ", 3)
+		|| !strncmp (line->buffer.data, "tp ", 3)
 		|| !strncmp (line->buffer.data, "tl ", 3)
+		|| !strncmp (line->buffer.data, "tpx ", 4)
 		|| !strncmp (line->buffer.data, "tss ", 4)
 		|| !strncmp (line->buffer.data, "ts* ", 4)) {
 			int i = 0;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1451,6 +1451,7 @@ R_API int r_anal_var_delete (RAnal *a, ut64 var_addr, const char kind, int scope
 R_API bool r_anal_var_delete_byname (RAnal *a, RAnalFunction *fcn, int type, const char *name);
 R_API bool r_anal_var_add (RAnal *a, ut64 addr, int scope, int delta, char kind, const char *type, int size, bool isarg, const char *name);
 R_API int r_anal_var_del(RAnal *anal, RAnalFunction *fcn, int delta, int scope);
+R_API ut64 r_anal_var_addr(RAnal *a, RAnalFunction *fcn, const char *name);
 R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int index);
 R_API const char *r_anal_var_scope_to_str(RAnal *anal, int scope);
 R_API int r_anal_var_access_add(RAnal *anal, RAnalVar *var, ut64 from, int set);


### PR DESCRIPTION
Now u can use `tp` like this : 

```
[0x00000560]> "td struct Books {char  title[50];char  author[50]; char  subject[100];};"

[0x00000560]> tp Books local_e0h

   title : 0x00177f18 = Radare2
  author : 0x00177f4a = pancake
 subject : 0x00177f7c = Reversing
``` 

Added test in r2r [#1346](https://github.com/radare/radare2-regressions/pull/1346)