### PR TITLE
Add r_userconf.h back to include/r_types.h

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -3,6 +3,7 @@
 
 // defines like IS_DIGIT, etc'
 #include "r_util/r_str_util.h"
+#include "r_userconf.h"
 
 // TODO: fix this to make it crosscompile-friendly: R_SYS_OSTYPE ?
 /* operating system */


### PR DESCRIPTION
Fixes regression issue #10313

Not sure why it was removed in the first place? make tests seems to pass so I think its safe to put back.