### PR TITLE
 Intial work for union support 

### DIFF
--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -136,6 +136,8 @@ static const char *help_msg_ts[] = {
 static const char *help_msg_tu[] = {
 	"Usage: tu[...]", "", "",
 	"tu", "", "List all loaded unions",
+	"tu", " [type]", "Show pf format string for given union",
+	"tu*", " [type]", "Show pf.<name> format string for given union",
 	"tu?", "", "show this help",
 	NULL
 };

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -420,6 +420,7 @@ static void link_struct_offset(RCore *core, RAnalFunction *fcn) {
 	RAnalOp aop = {0};
 	bool ioCache = r_config_get_i (core->config, "io.cache");
 	bool stack_set = false;
+	const char *varpfx;
 	int dbg_follow = r_config_get_i (core->config, "dbg.follow");
 	Sdb *TDB = core->anal->sdb_types;
 	RAnalEsil *esil = core->anal->esil;
@@ -519,11 +520,16 @@ static void link_struct_offset(RCore *core, RAnalFunction *fcn) {
 			} else if (dlink) {
 				RAnalVar *var = aop.var;
 				if (dst_imm == 0 && var) {
+					if (r_type_kind (TDB, dlink) == R_TYPE_UNION) {
+						varpfx = "union";
+					} else {
+						varpfx = "struct";
+					}
 					// if a var addr matches with struct , change it's type and name
 					// var int local_e0h --> var struct foo
 					if (strcmp (var->name , dlink)) {
 						r_anal_var_retype (core->anal, fcn->addr, R_ANAL_VAR_SCOPE_LOCAL,
-								-1, var->kind, "struct", -1, var->isarg, var->name);
+								-1, var->kind, varpfx, -1, var->isarg, var->name);
 						r_anal_var_rename (core->anal, fcn->addr, R_ANAL_VAR_SCOPE_LOCAL,
 								var->kind, var->name, dlink);
 					}
@@ -563,6 +569,12 @@ static int cmd_type(void *data, const char *input) {
 		switch (input[1]) {
 		case '?':
 			r_core_cmd_help (core, help_msg_tu);
+			break;
+		case '*':
+			showFormat (core, input + 2, 1);
+			break;
+		case ' ':
+			showFormat (core, input + 2, 0);
 			break;
 		case 0:
 			sdb_foreach (TDB, stdprintifunion, core);
@@ -654,7 +666,7 @@ static int cmd_type(void *data, const char *input) {
 		if (member_name) {
 			*member_name++ = 0;
 		}
-		if (name && !r_type_isenum (TDB, name)) {
+		if (name && (r_type_kind (TDB, name) != R_TYPE_ENUM)) {
 			eprintf ("%s is not an enum\n", name);
 			break;
 		}

--- a/libr/include/r_util/r_ctypes.h
+++ b/libr/include/r_util/r_ctypes.h
@@ -10,9 +10,16 @@ typedef struct r_type_enum {
 	const char *val;
 }RTypeEnum;
 
+enum RTypeKind {
+	R_TYPE_BASIC = 0,
+	R_TYPE_ENUM = 1,
+	R_TYPE_STRUCT = 2,
+	R_TYPE_UNION = 3,
+};
+
 R_API int r_type_set(Sdb *TDB, ut64 at, const char *field, ut64 val);
 R_API void r_type_del(Sdb *TDB, const char *name);
-R_API bool r_type_isenum(Sdb *TDB, const char *name);
+R_API int r_type_kind(Sdb *TDB, const char *name);
 R_API char *r_type_enum_member(Sdb *TDB, const char *name, const char *member, ut64 val);
 R_API char *r_type_enum_getbitfield(Sdb *TDB, const char *name, ut64 val);
 R_API RList* r_type_get_enum (Sdb *TDB, const char *name);


### PR DESCRIPTION
### Changes : 

* Added `tu name` and `tu*` command

* Initial work on linking union using `tl` (It's not accurate due to some issue which i have commented here [#10032](https://github.com/radare/radare2/issues/10032))

```
[0x000006aa]> "td union Books {char  title[50];char  author[50]; char  subject[100];};"
[0x000006aa]> tl Books = 0x00177f88
[0x000006aa]> pdf
|   sym.main ();
|           ; var union Books @ rbp-0x70
|           ; var int local_8h @ rbp-0x8
|           0x000006aa      55             push rbp
|           0x000006ab      4889e5         mov rbp, rsp
|           0x000006ae      4883ec70       sub rsp, 0x70               ; 'p'
|           0x000006b2      64488b042528.  mov rax, qword fs:[0x28]    ; [0x28:8]=0x1958 ; '('
|           0x000006bb      488945f8       mov qword [local_8h], rax
|           0x000006bf      31c0           xor eax, eax
|           0x000006c1      488d4590       lea rax, [Books]
|           0x000006c5      48ba52616461.  movabs rdx, 0x32657261646152
|           0x000006cf      488910         mov qword [rax], rdx        ; Books
|           0x000006d2      488d4590       lea rax, [Books]
|           0x000006d6      4889c6         mov rsi, rax                ; Books
|           0x000006d9      488d3d240100.  lea rdi, str.Book_title_:__s ; 0x804 ; "Book title : %s\n"
|           0x000006e0      b800000000     mov eax, 0
|           0x000006e5      e896feffff     call sym.imp.printf         ; int printf(const char *format)

```

Added test to r2r [#1354](https://github.com/radare/radare2-regressions/pull/1354)