### PR TITLE
WIP: Added the '-l' option for rahash2

### DIFF
--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -687,12 +687,14 @@ int main(int argc, char **argv) {
 				return rt;
 			}
 		} else {
+			RIODesc *desc = NULL;
 			if (!strcmp (argv[i], "-")) {
 				int sz = 0;
 				ut8 *buf = (ut8 *) r_stdin_slurp (&sz);
 				char *uri = r_str_newf ("malloc://%d", sz);
 				if (sz > 0) {
-					if (!r_io_open_nomap (io, uri, R_IO_READ, 0)) {
+					desc = r_io_open_nomap (io, uri, R_IO_READ, 0);
+					if (!desc) {
 						eprintf ("rahash2: Cannot open malloc://1024\n");
 						return 1;
 					}
@@ -704,12 +706,15 @@ int main(int argc, char **argv) {
 					eprintf ("rahash2: Cannot hash directories\n");
 					return 1;
 				}
-				if (!r_io_open_nomap (io, argv[i], R_IO_READ, 0)) {
+				desc = r_io_open_nomap (io, argv[i], R_IO_READ, 0);
+				if (!desc) {
 					eprintf ("rahash2: Cannot open '%s'\n", argv[i]);
 					return 1;
 				}
 			}
 			ret |= do_hash (argv[i], algo, io, bsize, rad, ule, compareBin);
+			to = 0;	
+			r_io_desc_close (desc);
 		}
 	}
 	free (hashstr);

--- a/man/rahash2.1
+++ b/man/rahash2.1
@@ -5,7 +5,7 @@
 .Nd block based hashing utility
 .Sh SYNOPSIS
 .Nm rahash2
-.Op Fl BdDehjrkvq
+.Op Fl BbdDehjrklnvq
 .Op Fl a Ar algorithm
 .Op Fl b Ar size
 .Op Fl D Ar algo
@@ -53,6 +53,10 @@ Show output in JSON (see -r)
 Show per-block hash
 .It Fl k
 Show result using OpenSSH's VisualHostKey randomart algorithm
+.It Fl l
+Do not output the trailing newline
+.It Fl n
+Amount of blocks to hash
 .It Fl s Ar string
 Hash this string instead of using the 'source' and 'hash-file' arguments.
 .It Fl S Ar [^]s:string|hexstr


### PR DESCRIPTION
Rebased and up-to-date version of PR #8678 (now closed)

## Updates:
**binr/rahash2/rahash2.c**

* Added the functionality to not output the trailing newline. Until now, some of the algorithms outputted newlines (e.g. md5) and some was not (e.g base64, rot13). Now the flag "-l" is responsible for not printing newline.


**man/rahash2.1**

* Added to the manpage the flag "-l" for not trailing newline.
* Added the missing entry for "-n".