### PR TITLE
Change of r_mem_memzero signature. In a memory clearance context,

### DIFF
--- a/libr/include/r_util/r_mem.h
+++ b/libr/include/r_util/r_mem.h
@@ -37,7 +37,7 @@ R_API void* r_mem_pool_alloc(RMemoryPool *pool);
 R_API void *r_mem_dup(void *s, int l);
 R_API void *r_mem_alloc(int sz);
 R_API void r_mem_free(void *);
-R_API void* r_mem_memzero(void *, size_t);
+R_API void r_mem_memzero(void *, size_t);
 R_API void r_mem_reverse(ut8 *b, int l);
 R_API int r_mem_protect(void *ptr, int size, const char *prot);
 R_API int r_mem_set_num(ut8 *dest, int dest_size, ut64 num);

--- a/libr/util/mem.c
+++ b/libr/util/mem.c
@@ -327,17 +327,15 @@ R_API void r_mem_free(void *p) {
 	free (p);
 }
 
-R_API void* r_mem_memzero(void *dst, size_t l) {
+R_API void r_mem_memzero(void *dst, size_t l) {
 #ifdef _MSC_VER
-	return RtlSecureZeroMemory (dst, l);
+	RtlSecureZeroMemory (dst, l);
 #else
 #if HAVE_EXPLICIT_BZERO
 	explicit_bzero (dst, l);
-	return dst;
 #else
-	void *ret = memset (dst, 0, l);
+	memset (dst, 0, l);
 	__asm__ volatile ("" :: "r"(dst) : "memory");
-	return ret;
 #endif
 #endif
 }


### PR DESCRIPTION
we usually do not consider the destination buffer as such.