### PR TITLE
Was be fixed #10346

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1671,15 +1671,14 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 
 		if (op->operands[0].scale[0] > 1) {
 				data[l++] = op->operands[1].reg << 3 | 4;
-				if (op->operands[0].scale[0] > 2) {
-					data[l++] = getsib (op->operands[0].scale[0]) << 6 |
-										op->operands[0].regs[0] << 3 | 5;
+				data[l++] = getsib (op->operands[0].scale[0]) << 6 |
+						    op->operands[0].regs[0] << 3 | 5;
 
-					data[l++] = offset;
-					data[l++] = offset >> 8;
-					data[l++] = offset >> 16;
-					data[l++] = offset >> 24;
-				}
+				data[l++] = offset;
+				data[l++] = offset >> 8;
+				data[l++] = offset >> 16;
+				data[l++] = offset >> 24;
+
 				return l;
 			}
 


### PR DESCRIPTION
Removed condition `op->operands[0].scale[0] > 2` for solution problem #10346 