### PR TITLE
Fix panels horizontal scroll glitch + fix some coverity defects

### DIFF
--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -286,7 +286,6 @@ static int expand_line (RConsCanvas *c, int real_len, int utf8_len) {
 			int newsize = R_MAX (c->bsize[c->y] * 1.5, c->blen[c->y] + padding);
 			char * newline = realloc (c->b[c->y], sizeof (*c->b[c->y])*(newsize)); 
 			if (!newline) {
-				r_cons_canvas_free (c);
 				return false;
 			}
 			memset (newline + c->bsize[c->y], 0, newsize - c->bsize[c->y]);
@@ -340,7 +339,7 @@ R_API void r_cons_canvas_write(RConsCanvas *c, const char *s) {
 		int utf8_len = utf8len_fixed (s_part, slen); 
 
 		if (!expand_line (c, real_len, utf8_len)) {
-			return;
+			break;
 		}
 
 		if (G (c->x - c->sx, c->y - c->sy)) {
@@ -478,7 +477,6 @@ R_API int r_cons_canvas_resize(RConsCanvas *c, int w, int h) {
 			for (j = 0; j <= i; j++) {
 				free (c->b[i]);
 			}
-			free (c->bsize);
 			free (c->attrs);
 			free (c->blen);
 			free (c->bsize);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1553,7 +1553,11 @@ R_API char *r_str_ansi_crop(const char *str, ut32 x, ut32 y, ut32 x2, ut32 y2) {
 		} else {
 			if (ch >= y && ch < y2) {
 				if ((*str & 0xc0) == 0x80) {
-					*r++ = *str++;
+					if (cw > x) {
+						*r++ = *str++;
+					} else {
+						str++;
+					}
 					continue;
 				}
 				if (*str == 0x1b && *(str + 1) == '[') {


### PR DESCRIPTION
This should close #10339 

Also fixes some coverity issues in canvas.c:
if the realloc() inside `expand_line` fails, instead of freeing the entire canvas, just abort the write, or else all future writes will fail (and from what I understand there were many defects just for this problem)

Before considering merging, I would like to wait to check if #10339 is really fixed (I was only able to reproduce it in a virtual machine)