### PR TITLE
Fix color bugs in panels + other coverity issues in panels.c

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -634,7 +634,9 @@ R_API void r_core_panels_refresh(RCore *core) {
 	}
 	if (panels->isResizing) {
 		panels->isResizing = false;
-		r_cons_canvas_resize (can, w, h);
+		if (!r_cons_canvas_resize (can, w, h)) {
+			return;
+		}
 		setRefreshAll (panels);
 	}
 #if 0


### PR DESCRIPTION
Fixed some color bugs in canvas.c 

This is a dump of the canvas output before:
![2018-06-16-115750_615x895_scrot](https://user-images.githubusercontent.com/3428362/41499097-342d0e6e-717b-11e8-8021-2fe9ef176322.png)

Notice how many useless color attr were there that slowed down things (most of the time there was an attr for every char in output).

After:
![2018-06-16-153639_626x925_scrot](https://user-images.githubusercontent.com/3428362/41499101-3bbc87ae-717b-11e8-93d0-51ff5abdc7e1.png)

Now it's a bit better but not perfect. Panels with color are still very slow and laggy, there is still a lot to do.

Fixed a crash when pressing `C` to disable color. Fixed also the 4 new coverity bugs in panels.c