### PR TITLE
Add rm r_version.h to make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ ifneq ($(USE_ZIP),NO)
 endif
 
 clean: rmd
-	rm -f libr/libr.a libr/libr.dylib
+	rm -f libr/libr.a libr/libr.dylib libr/include/r_version.h
 	rm -rf libr/.libr
 	for DIR in shlr libr binr ; do $(MAKE) -C "$$DIR" clean ; done
 


### PR DESCRIPTION
Right now only a `make mrproper` will delete the libr/include/r_version.h.

If you're doing a `make clean` everything has to re-build anyway so might as well update the compiled in commit version and all that with it.