### PR TITLE
Add timeout for accept in HTTP Server

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -466,6 +466,9 @@ static int r_core_rtr_http_run(RCore *core, int launch, const char *path) {
 		eprintf ("Cannot listen on http.port\n");
 		return 1;
 	}
+
+	r_socket_block_time (s, 1, 1);
+
 	if (launch=='H') {
 		const char *browser = r_config_get (core->config, "http.browser");
 		r_sys_cmdf ("%s http://%s:%d/%s &",

--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -559,7 +559,10 @@ R_API RSocket *r_socket_accept(RSocket *s) {
 	//signal (SIGPIPE, SIG_DFL);
 	sock->fd = accept (s->fd, (struct sockaddr *)&s->sa, &salen);
 	if (sock->fd == -1) {
-		r_sys_perror ("accept");
+		if (errno != EWOULDBLOCK) {
+			// not just a timeout
+			r_sys_perror ("accept");
+		}
 		free (sock);
 		return NULL;
 	}


### PR DESCRIPTION
Adds a 1sec timeout for accept() to fix the hang on exit when using `=H&`.