### PR TITLE
Fixed breakpoint infinite loop error

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -93,6 +93,40 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 # else
 	int pc_off = dbg->bpsize;
 	/* see if we really have a breakpoint here... */
+	if (!dbg->pc_at_bp_set) {
+		b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
+		if (!b) { /* we don't. nothing left to do */
+			/* Some targets set pc to breakpoint */
+			b = r_bp_get_at (dbg->bp, pc);
+			if (!b) {
+				/* Couldn't find the break point. Nothing more to do... */
+				return true;
+			}
+			else {
+				dbg->pc_at_bp_set = true;
+				dbg->pc_at_bp = true;
+			}
+		} else {
+			dbg->pc_at_bp_set = true;
+			dbg->pc_at_bp = false;
+		}
+	}
+	
+	if (!dbg->pc_at_bp_set) {
+		eprintf ("failed to determine position of pc after breakpoint");
+	}
+	
+	if (dbg->pc_at_bp) {
+		pc_off = 0;
+		b = r_bp_get_at (dbg->bp, pc);
+	} else {
+		b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
+	}
+	
+	if (!b) {
+		return true;
+	}
+	
 	b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
 	if (!b) { /* we don't. nothing left to do */
 		/* Some targets set pc to breakpoint */

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -298,6 +298,9 @@ typedef struct r_debug_t {
 	struct r_debug_plugin_t *h;
 	RList *plugins;
 
+	bool pc_at_bp; /* after a breakpoint, is the pc at the bp? */
+	bool pc_at_bp_set; /* is the pc_at_bp variable set already? */
+
 	RAnal *anal;
 	RList *maps; // <RDebugMap>
 	RList *maps_user; // <RDebugMap>


### PR DESCRIPTION
This is fundamentally a workaround for the fact that radare doesn't distinguish between user defined breakpoints and breakpoints set up as part of the recoil code.

Without this code, r2 will loop indefinitely in some cases when encountering a breakpoint at an instruction with the same length as the breakpoint op.