### PR TITLE
Revert to old graph edges positioning (added an option)

### DIFF
--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -378,7 +378,7 @@ R_API void r_cons_canvas_write(RConsCanvas *c, const char *s) {
 		s = s_part;
 		if (ch == '\n') {
 			c->attr = Color_RESET;
-			stamp_attr (c, c->y*c->w + attr_x, strlen (Color_RESET));
+			stamp_attr (c, c->y*c->w + attr_x, 0);
 			c->y++;
 			s++;
 			if (*s == '\0' || c->y  >= c->h) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2819,6 +2819,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("graph.extension", "gif", &cb_graphformat, "Graph extension when using 'w' format (png, jpg, pdf, ps, svg, json)");
 	SETPREF ("graph.refs", "false", "Graph references in callgraphs (.agc*;aggi)");
 	SETI ("graph.edges", 2, "0=no edges, 1=simple edges, 2=avoid collisions");
+	SETPREF ("graph.altedgepos", "false", "Switch to alternative (very experimental) positioning of edges");
 	SETI ("graph.layout", 0, "Graph layout (0=vertical, 1=horizontal)");
 	SETI ("graph.linemode", 1, "Graph edges (0=diagonal, 1=square)");
 	SETPREF ("graph.font", "Courier", "Font for dot graphs");

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2736,7 +2736,6 @@ static void agraph_print_edges(RAGraph *g) {
 			default:
 				style.symbol = a->is_dummy ? LINE_NOSYM_VERT : style.color;
 
-
 				a_x_inc = R_EDGES_X_INC + 2 * (out_nth + 1);
 				b_x_inc = R_EDGES_X_INC + 2 * (in_nth + 1);
 
@@ -2750,7 +2749,6 @@ static void agraph_print_edges(RAGraph *g) {
 
 				ay = a->y + a->h;
 				by = b->y - 1;
-
 
 				if (!a->is_dummy && itn == neighbours->head && out_nth == 0 && bx > ax) {
 					a_x_inc += 4;

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2736,18 +2736,25 @@ static void agraph_print_edges(RAGraph *g) {
 			default:
 				style.symbol = a->is_dummy ? LINE_NOSYM_VERT : style.color;
 
+
 				a_x_inc = R_EDGES_X_INC + 2 * (out_nth + 1);
 				b_x_inc = R_EDGES_X_INC + 2 * (in_nth + 1);
 
-				ax = a->is_dummy ? a->x : (a->x + a->w - a_x_inc);
-				ay = a->y + a->h;
+				if (g->altedgepos) {
+					ax = a->is_dummy ? a->x : (a->x + a->w - a_x_inc);
+					bx = b->is_dummy ? b->x : (b->x + b_x_inc);
+				} else {
+					ax = a->is_dummy ? a->x : (a->x + a_x_inc);
+					bx = b->is_dummy ? b->x : (b->x + a_x_inc);
+				}
 
-				bx = b->is_dummy ? b->x : (b->x + b_x_inc);
+				ay = a->y + a->h;
 				by = b->y - 1;
+
 
 				if (!a->is_dummy && itn == neighbours->head && out_nth == 0 && bx > ax) {
 					a_x_inc += 4;
-					ax -= 4;
+					ax += g->altedgepos ? -4 : 4;
 				}
 				if (a->h < a->layer_height) {
 					r_cons_canvas_line (g->can, ax, ay, ax, ay + a->layer_height - a->h, &style);
@@ -3726,6 +3733,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	g->on_curnode_change = (RANodeCallback) seek_to_node;
 	g->on_curnode_change_data = core;
 	g->edgemode = r_config_get_i (core->config, "graph.edges");
+	g->altedgepos = r_config_get_i (core->config, "graph.altedgepos");
 	g->is_interactive = is_interactive;
 	bool asm_comments = r_config_get_i (core->config, "asm.comments");
 	r_config_set (core->config, "asm.comments",

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -901,6 +901,7 @@ typedef struct r_ascii_graph_t {
 	bool is_tiny;
 	bool is_dis;
 	int edgemode;
+	bool altedgepos;
 	int mode;
 	bool is_callgraph;
 	bool is_interactive;


### PR DESCRIPTION
Closes #10400 

Added option that reverts to old method of positioning edges. This option is on by default, since old edges were better in most cases. I will continue and try to finish the new edges before release.

This is better than reverting my last graph edges pr since it fixed other small things too (like enlarging of nodes with many edges, and some improvements on vertical layout)


I had changed a test in that pr, so here is that test reverted: https://github.com/radare/radare2-regressions/pull/1364

ALSO I included a typo fix in canvas.c that I forgot in my last pr 