### PR TITLE
Add stop address info to the "di" command

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4645,6 +4645,7 @@ static int cmd_debug(void *data, const char *input) {
 					P ("baddr=0x%"PFMT64x"\n", r_debug_get_baddr (core->dbg, NULL));
 					P ("pid=%d\n", rdi->pid);
 					P ("tid=%d\n", rdi->tid);
+					P ("stopaddr=0x%"PFMT64x"\n", core->dbg->stopaddr);
 					if (rdi->uid != -1) {
 						P ("uid=%d\n", rdi->uid);
 					}

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -75,7 +75,7 @@ int linux_handle_signals (RDebug *dbg) {
 		//ptrace (PTRACE_SETSIGINFO, dbg->pid, 0, &siginfo);
 		dbg->reason.type = R_DEBUG_REASON_SIGNAL;
 		dbg->reason.signum = siginfo.si_signo;
-		//dbg->stopaddr = siginfo.si_addr;
+		dbg->stopaddr = siginfo.si_addr;
 		//dbg->errno = siginfo.si_errno;
 		// siginfo.si_code -> HWBKPT, USER, KERNEL or WHAT
 #warning DO MORE RDEBUGREASON HERE

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -277,6 +277,7 @@ typedef struct r_debug_t {
 	int steps; /* counter of steps done */
 	RDebugReason reason; /* stop reason */
 	RDebugRecoilMode recoil_mode; /* what did the user want to do? */
+	ut64 stopaddr;  /* stop address  */
 
 	/* tracing vars */
 	RDebugTrace *trace;


### PR DESCRIPTION
Add the stop address field to the "di" command

```
[0x7fca80368c30]> dc
child stopped with signal 11
[+] SIGNAL 11 errno=0 addr=0x00b4f000 code=2 ret=0
[0x00b4f000]> di
type=segfault
signal=SIGSEGV
signum=11
sigpid=2730
addr=0x0
bp_addr=0x0
inbp=false
baddr=0x400000
pid=2730
tid=2730
stopaddr=0xb4f000
```