### PR TITLE
Added unknown type for rsrc

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2188,29 +2188,53 @@ static char* _resource_lang_str(int id) {
 }
 
 static char* _resource_type_str(int type) {
+	char * typeName;
 	switch (type) {
-	case 1: return strdup("CURSOR");
-	case 2: return strdup("BITMAP");
-	case 3: return strdup("ICON");
-	case 4: return strdup("MENU");
-	case 5: return strdup("DIALOG");
-	case 6: return strdup("STRING");
-	case 7: return strdup("FONTDIR");
-	case 8: return strdup("FONT");
-	case 9: return strdup("ACCELERATOR");
-	case 10: return strdup("RCDATA");
-	case 11: return strdup("MESSAGETABLE");
-	case 12: return strdup("GROUP_CURSOR");
-	case 14: return strdup("GROUP_ICON");
-	case 16: return strdup("VERSION");
-	case 17: return strdup("DLGINCLUDE");
-	case 19: return strdup("PLUGPLAY");
-	case 20: return strdup("VXD");
-	case 21: return strdup("ANICURSOR");
-	case 22: return strdup("ANIICON");
-	case 23: return strdup("HTML");
-	case 24: return strdup("MANIFEST");
-	default: return r_str_newf("UNKNOWN (%d)", type);
+		case 1: typeName = "CURSOR";
+			break;
+		case 2: typeName = "BITMAP";
+			break;
+		case 3: typeName = "ICON";
+			break;
+		case 4: typeName = "MENU";
+			break;
+		case 5: typeName = "DIALOG";
+			break;
+		case 6: typeName = "STRING";
+			break;
+		case 7: typeName = "FONTDIR";
+			break;
+		case 8: typeName = "FONT";
+			break;
+		case 9: typeName = "ACCELERATOR";
+			break;
+		case 10: typeName = "RCDATA";
+			break;
+		case 11: typeName = "MESSAGETABLE";
+			break;
+		case 12: typeName = "GROUP_CURSOR";
+			break;
+		case 14: typeName = "GROUP_ICON";
+			break;
+		case 16: typeName = "VERSION";
+			break;
+		case 17: typeName = "DLGINCLUDE";
+			break;
+		case 19: typeName = "PLUGPLAY";
+			break;
+		case 20: typeName = "VXD";
+			break;
+		case 21: typeName = "ANICURSOR";
+			break;
+		case 22: typeName = "ANIICON";
+			break;
+		case 23: typeName = "HTML";
+			break;
+		case 24: typeName = "MANIFEST";
+			break;
+		default: return r_str_newf ("UNKNOWN (%d)", type);
+
+		return strdup (typeName);
 	}
 }
 

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2190,52 +2190,72 @@ static char* _resource_lang_str(int id) {
 static char* _resource_type_str(int type) {
 	char * typeName;
 	switch (type) {
-		case 1: typeName = "CURSOR";
-			break;
-		case 2: typeName = "BITMAP";
-			break;
-		case 3: typeName = "ICON";
-			break;
-		case 4: typeName = "MENU";
-			break;
-		case 5: typeName = "DIALOG";
-			break;
-		case 6: typeName = "STRING";
-			break;
-		case 7: typeName = "FONTDIR";
-			break;
-		case 8: typeName = "FONT";
-			break;
-		case 9: typeName = "ACCELERATOR";
-			break;
-		case 10: typeName = "RCDATA";
-			break;
-		case 11: typeName = "MESSAGETABLE";
-			break;
-		case 12: typeName = "GROUP_CURSOR";
-			break;
-		case 14: typeName = "GROUP_ICON";
-			break;
-		case 16: typeName = "VERSION";
-			break;
-		case 17: typeName = "DLGINCLUDE";
-			break;
-		case 19: typeName = "PLUGPLAY";
-			break;
-		case 20: typeName = "VXD";
-			break;
-		case 21: typeName = "ANICURSOR";
-			break;
-		case 22: typeName = "ANIICON";
-			break;
-		case 23: typeName = "HTML";
-			break;
-		case 24: typeName = "MANIFEST";
-			break;
-		default: return r_str_newf ("UNKNOWN (%d)", type);
-
-		return strdup (typeName);
+	case 1:
+		typeName = "CURSOR";
+		break;
+	case 2:
+		typeName = "BITMAP";
+		break;
+	case 3:
+		typeName = "ICON";
+		break;
+	case 4:
+		typeName = "MENU";
+		break;
+	case 5:
+		typeName = "DIALOG";
+		break;
+	case 6:
+		typeName = "STRING";
+		break;
+	case 7:
+		typeName = "FONTDIR";
+		break;
+	case 8:
+		typeName = "FONT";
+		break;
+	case 9:
+		typeName = "ACCELERATOR";
+		break;
+	case 10:
+		typeName = "RCDATA";
+		break;
+	case 11:
+		typeName = "MESSAGETABLE";
+		break;
+	case 12:
+		typeName = "GROUP_CURSOR";
+		break;
+	case 14:
+		typeName = "GROUP_ICON";
+		break;
+	case 16:
+		typeName = "VERSION";
+		break;
+	case 17:
+		typeName = "DLGINCLUDE";
+		break;
+	case 19:
+		typeName = "PLUGPLAY";
+		break;
+	case 20:
+		typeName = "VXD";
+		break;
+	case 21:
+		typeName = "ANICURSOR";
+		break;
+	case 22:
+		typeName = "ANIICON";
+		break;
+	case 23:
+		typeName = "HTML";
+		break;
+	case 24:
+		typeName = "MANIFEST";
+		break;
+	default: return r_str_newf ("UNKNOWN (%d)",type);
 	}
+	return strdup (typeName);
 }
 
 static void _parse_resource_directory(struct PE_(r_bin_pe_obj_t) *bin, Pe_image_resource_directory *dir, ut64 offDir, int type, int id, SdbHash *dirs) {

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2189,28 +2189,28 @@ static char* _resource_lang_str(int id) {
 
 static char* _resource_type_str(int type) {
 	switch (type) {
-	case 1: return "CURSOR";
-	case 2: return "BITMAP";
-	case 3: return "ICON";
-	case 4: return "MENU";
-	case 5: return "DIALOG";
-	case 6: return "STRING";
-	case 7: return "FONTDIR";
-	case 8: return "FONT";
-	case 9: return "ACCELERATOR";
-	case 10: return "RCDATA";
-	case 11: return "MESSAGETABLE";
-	case 12: return "GROUP_CURSOR";
-	case 14: return "GROUP_ICON";
-	case 16: return "VERSION";
-	case 17: return "DLGINCLUDE";
-	case 19: return "PLUGPLAY";
-	case 20: return "VXD";
-	case 21: return "ANICURSOR";
-	case 22: return "ANIICON";
-	case 23: return "HTML";
-	case 24: return "MANIFEST";
-	default: return "UNKNOWN";
+	case 1: return strdup("CURSOR");
+	case 2: return strdup("BITMAP");
+	case 3: return strdup("ICON");
+	case 4: return strdup("MENU");
+	case 5: return strdup("DIALOG");
+	case 6: return strdup("STRING");
+	case 7: return strdup("FONTDIR");
+	case 8: return strdup("FONT");
+	case 9: return strdup("ACCELERATOR");
+	case 10: return strdup("RCDATA");
+	case 11: return strdup("MESSAGETABLE");
+	case 12: return strdup("GROUP_CURSOR");
+	case 14: return strdup("GROUP_ICON");
+	case 16: return strdup("VERSION");
+	case 17: return strdup("DLGINCLUDE");
+	case 19: return strdup("PLUGPLAY");
+	case 20: return strdup("VXD");
+	case 21: return strdup("ANICURSOR");
+	case 22: return strdup("ANIICON");
+	case 23: return strdup("HTML");
+	case 24: return strdup("MANIFEST");
+	default: return r_str_newf("UNKNOWN (%d)", type);
 	}
 }
 


### PR DESCRIPTION
Changed the `return "UNKNOWN"` to `"UNKNOWN (%d)", type`.
Now, whenever the resource type is UNKNOWN, there will still be the type in parentheses.