### PR TITLE
Intial work on type propgation

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -39,30 +39,7 @@ static void r_anal_emul_restore(RCore *core, RConfigHold *hc) {
 	r_config_hold_free (hc);
 }
 
-static void type_match_var(RAnal *anal , Sdb *trace, ut64 addr,const char *type, int idx) {
-	RAnalVar *v;
-	const char *sp_name = r_reg_get_name (anal->reg, R_REG_NAME_SP);
-	const char *bp_name = r_reg_get_name (anal->reg, R_REG_NAME_BP);
-	ut64 sp = r_reg_getv (anal->reg, sp_name);
-	ut64 bp = r_reg_getv (anal->reg, bp_name);
-	char *key = sdb_fmt ("%d.mem.read", idx);
-	int i, array_size = sdb_array_size (trace, key);
-
-	for (i = 0; i < array_size; i++) {
-		if (bp_name) {
-			int bp_idx = sdb_array_get_num (trace, key, i, 0) - bp;
-			if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_BPV, 1, bp_idx))) {
-				r_anal_var_retype (anal, addr, 1, bp_idx, R_ANAL_VAR_KIND_BPV, type, -1, v->isarg, v->name);
-				r_anal_var_free (v);
-			}
-		}
-		int sp_idx = sdb_array_get_num (trace, key, i, 0) - sp;
-		if ((v = r_anal_var_get (anal, addr, R_ANAL_VAR_KIND_SPV, 1, sp_idx))) {
-			r_anal_var_retype (anal, addr, 1, sp_idx, R_ANAL_VAR_KIND_SPV, type, -1, v->isarg, v->name);
-			r_anal_var_free (v);
-		}
-	}
-}
+#define SDB_CONTAINS(i,s) sdb_array_contains (trace, sdb_fmt ("%d.reg.write", i), s, 0)
 
 static bool type_pos_hit(RAnal *anal, Sdb *trace, bool in_stack, int idx, int size, const char *place) {
 	if (in_stack) {
@@ -71,27 +48,93 @@ static bool type_pos_hit(RAnal *anal, Sdb *trace, bool in_stack, int idx, int si
 		ut64 write_addr = sdb_num_get (trace, sdb_fmt ("%d.mem.write", idx), 0);
 		return (write_addr == sp + size);
 	} else {
-		return sdb_array_contains (trace, sdb_fmt ("%d.reg.write", idx), place, 0);
+		return SDB_CONTAINS (idx, place);
 	}
 }
 
-static void type_match(RCore *core, ut64 addr, char *name, int prev_idx) {
+static void var_rename (RAnal *anal, RAnalVar *v, const char *name, ut64 addr) {
+	if (!name || !v) {
+		return;
+	}
+	bool is_default = strncmp (v->name, "local_", 6)? false: true;
+	if (*name == '*') {
+		name++;
+	}
+	// longer name tends to be meaningful like "src" instead of "s1"
+	if (!is_default && (strlen (v->name) > strlen (name))) {
+		return;
+	}
+	RAnalFunction *fcn = r_anal_get_fcn_in (anal, addr, 0);
+	RAnalVar *v1 = r_anal_var_get_byname (anal, fcn, name);
+	if (v1) {
+		r_anal_var_free (v1);
+		return;
+	}
+	r_anal_var_rename (anal, fcn->addr, 1, v->kind, v->name, name);
+}
+
+static void var_retype (RAnal *anal, RAnalVar *var, const char *vname, char *type, ut64 addr) {
+	if (!type || !var) {
+		return;
+	}
+	if (!strncmp (type, "int", 3)) {
+		return;
+	}
+	char *vtype = NULL;
+	char *ntype = type;
+	if (!strncmp (type, "const ", 6)) {
+		// Droping const from type
+		//TODO: Infering const type
+		ntype = type + 6;
+	}
+	if (vname && *vname == '*') {
+		if (!strcmp (type, "void") && strcmp (var->type, "int")) {
+			ntype = var->type;
+		} else {
+			//type *ptr => type *
+			vtype = r_str_newf ("%s %c", ntype, '*');
+		}
+	}
+	if (vtype && *vtype) {
+		ntype = vtype;
+	}
+	r_anal_var_retype (anal, addr, 1, -1, var->kind, ntype, -1, var->isarg, var->name);
+	free (vtype);
+}
+
+static const char *get_regname (RAnal *anal, Sdb *trace, int idx) {
+	const char *query = sdb_fmt ("%d.reg.read", idx);
+	const char *res = sdb_const_get (trace, query, 0);
+	if (!res) {
+		return NULL;
+	}
+	char *tmp = strchr (res, ',');
+	if (tmp) {
+		res = tmp + 1;
+	}
+	RRegItem *ri = r_reg_get (anal->reg, res, -1);
+	if (ri && (ri->size == 32) && (anal->bits == 64)) {
+		res = r_reg_32_to_64 (anal->reg, res);
+	}
+	return res;
+}
+
+static ut64 get_addr (Sdb *trace, const char *regname, int idx) {
+	if (!regname) {
+		return UT64_MAX;
+	}
+	const char *query = sdb_fmt ("%d.reg.read.%s", idx, regname);
+	return r_num_math (NULL, sdb_const_get (trace, query, 0));
+}
+
+static void type_match(RCore *core, ut64 addr, char *fcn_name, const char* cc, int prev_idx) {
 	Sdb *trace = core->anal->esil->db_trace;
 	Sdb *TDB = core->anal->sdb_types;
 	RAnal *anal = core->anal;
-	char *fcn_name;
 	int idx = sdb_num_get (trace, "idx", 0);
 	bool stack_rev = false, in_stack = false;
 
-	if (r_type_func_exist (TDB, name)) {
-		fcn_name = strdup (name);
-	} else if (!(fcn_name = r_type_func_guess (TDB, name))) {
-		//eprintf ("can't find function prototype for %s\n", name);
-		return;
-	}
-	const char* cc = r_anal_cc_func (anal, fcn_name);
-	if (!cc || !r_anal_cc_exist (anal, cc)) {
-		//eprintf ("can't find %s calling convention %s\n", fcn_name, cc);
+	if (!fcn_name || !cc) {
 		return;
 	}
 	int i, j, size = 0, max = r_type_func_args_count (TDB, fcn_name);
@@ -102,7 +145,6 @@ static void type_match(RCore *core, ut64 addr, char *name, int prev_idx) {
 		stack_rev = true;
 	}
 	if (!strncmp (place, "stack", 5)) {
-		// type_match_reg
 		in_stack = true;
 	}
 	for (i = 0; i < max; i++) {
@@ -112,72 +154,68 @@ static void type_match(RCore *core, ut64 addr, char *name, int prev_idx) {
 		if (!in_stack) {
 			place = r_anal_cc_arg (anal, cc, arg_num + 1);
 		}
+		const char *regname = NULL;
+		ut64 xaddr = UT64_MAX;
+		bool cmt_set = false;
+		bool res = false;
+		// Backtrace instruction from source sink to prev source sink
 		for (j = idx; j >= prev_idx; j--) {
-			if (type_pos_hit (anal, trace, in_stack, j, size, place)) {
-				ut64 instr_addr = sdb_num_get (trace, sdb_fmt ("%d.addr", j), 0);
-				r_meta_set_string (anal, R_META_TYPE_COMMENT, instr_addr,
-						sdb_fmt ("%s%s%s", type, r_str_endswith (type, "*") ? "" : " ", name));
-				if (strncmp (type, "int", 3)) {
-					// change type only if not int
-					type_match_var (anal, trace, addr, type , j);
-				}
+			ut64 instr_addr = sdb_num_get (trace, sdb_fmt ("%d.addr", j), 0);
+			RAnalOp *op = r_core_anal_op (core, instr_addr, R_ANAL_OP_MASK_BASIC);
+			if (op && op->type == R_ANAL_OP_TYPE_CALL) {
+				r_anal_op_fini (op);
 				break;
 			}
+			RAnalVar *var = op ? op->var: NULL;
+			// Match type from function param to instr
+			if (type_pos_hit (anal, trace, in_stack, j, size, place)) {
+				if (!cmt_set) {
+					r_meta_set_string (anal, R_META_TYPE_COMMENT, instr_addr,
+							sdb_fmt ("%s%s%s", type, r_str_endswith (type, "*") ? "" : " ", name));
+					cmt_set = true;
+				}
+				if (var) {
+					var_retype (anal, var, name, type, addr);
+					var_rename (anal, var, name, addr);
+					res = true;
+				} else {
+					regname = get_regname (anal, trace, j);
+					xaddr = get_addr (trace, regname, j);
+				}
+			}
+			// Type propagate by following source reg
+			if (!res && regname && SDB_CONTAINS (j, regname)) {
+				if (var) {
+					var_retype (anal, var, name, type, addr);
+					var_rename (anal, var, name, addr);
+					res = true;
+				} else {
+					if (op && op->type == R_ANAL_OP_TYPE_MOV) {
+						regname = get_regname (anal, trace, j);
+					}
+				}
+			} else if (var && res && (xaddr != UT64_MAX)) { // Type progation using value
+				const char *reg = get_regname (anal, trace, j);
+				ut64 ptr = get_addr (trace, reg, j);
+				if (ptr == xaddr) {
+					var_retype (anal, var, name, type, addr);
+				}
+			}
+			r_anal_op_free (op);
 		}
-		size += r_type_get_bitsize (TDB, type) / 8;
+		size += anal->bits / 8;
+		free (type);
 	}
 	r_cons_break_pop ();
-	free (fcn_name);
-}
-
-// Emulates previous N instr
-static void emulate_prev_N_instr(RCore *core, ut64 at, ut64 curpc) {
-	int i, inslen, bsize = R_MIN (64, core->blocksize);
-	RAnalOp aop;
-	const int mininstrsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
-	const int minopcode = R_MAX (1, mininstrsz);
-	const char *pc = r_reg_get_name (core->dbg->reg, R_REG_NAME_PC);
-	RRegItem *r = r_reg_get (core->dbg->reg, pc, -1);
-
-	ut8 *arr = malloc (bsize);
-	if (!arr) {
-		eprintf ("Cannot allocate %d byte(s)\n", bsize);
-		free (arr);
-		return;
-	}
-	r_reg_set_value (core->dbg->reg, r, curpc);
-	for (i = 0; curpc < at; curpc++, i++) {
-		if (i >= (bsize - 32)) {
-			i = 0;
-		}
-		if (!i) {
-			r_io_read_at (core->io, curpc, arr, bsize);
-		}
-		inslen = r_anal_op (core->anal, &aop, curpc, arr + i, bsize - i, R_ANAL_OP_MASK_BASIC);
-		int incr = inslen - 1;
-		if (incr < 0) {
-			incr = minopcode;
-		}
-		i += incr;
-		curpc += incr;
-		if ((inslen > 0) || (inslen < 50)) {
-			if (r_anal_op_nonlinear (aop.type)) {   // skip the instr
-				r_reg_set_value (core->dbg->reg, r, curpc + 1);
-			} else {                       // step instr
-				r_core_esil_step (core, UT64_MAX, NULL, NULL);
-			}
-		}
-		r_anal_op_fini (&aop);
-
-	}
-	free (arr);
 }
 
 R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 	RAnalBlock *bb;
 	RListIter *it;
 	RAnalOp aop = {0};
-	ut64 prevpc;
+	RAnal *anal = core->anal;
+	Sdb *TDB = anal->sdb_types;
+	bool resolved = false;
 
 	if (!core|| !fcn) {
 		return;
@@ -186,9 +224,9 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 		return;
 	}
 	int ret, bsize = R_MAX (64, core->blocksize);
-	const int mininstrsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
+	const int mininstrsz = r_anal_archinfo (anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
 	const int minopcode = R_MAX (1, mininstrsz);
-	int cur_idx , prev_idx = core->anal->esil->trace_idx;
+	int cur_idx , prev_idx = anal->esil->trace_idx;
 	RConfigHold *hc = r_config_hold_new (core->config);
 	if (!hc) {
 		return;
@@ -202,15 +240,15 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 		free (buf);
 		return;
 	}
+	char *fcn_name = NULL;
+	char *ret_type = NULL;
+	const char *ret_reg = NULL;
+	const char *pc = r_reg_get_name (core->dbg->reg, R_REG_NAME_PC);
+	RRegItem *r = r_reg_get (core->dbg->reg, pc, -1);
 	r_list_foreach (fcn->bbs, it, bb) {
 		ut64 addr = bb->addr;
-		int i = 0, curpos, idx = 0;
-		int *previnstr = calloc (MAXINSTR + 1, sizeof (int));
-		if (!previnstr) {
-			eprintf ("Cannot allocate %d byte(s)\n", MAXINSTR + 1);
-			free (buf);
-			return;
-		}
+		int i = 0;
+		r_reg_set_value (core->dbg->reg, r, addr);
 		r_cons_break_push (NULL, NULL);
 		while (1) {
 			if (r_cons_is_breaked ()) {
@@ -222,45 +260,67 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 			if (!i) {
 				r_io_read_at (core->io, addr, buf, bsize);
 			}
-			ret = r_anal_op (core->anal, &aop, addr, buf + i, bsize - i, R_ANAL_OP_MASK_BASIC);
+			ret = r_anal_op (anal, &aop, addr, buf + i, bsize - i, R_ANAL_OP_MASK_BASIC);
 			if (ret <= 0) {
 				i += minopcode;
 				addr += minopcode;
 				r_anal_op_fini (&aop);
 				continue;
 			}
-			int loop_count = sdb_num_get (core->anal->esil->db_trace, sdb_fmt ("0x%"PFMT64x".count", addr), 0);
+			int loop_count = sdb_num_get (anal->esil->db_trace, sdb_fmt ("0x%"PFMT64x".count", addr), 0);
 			if (loop_count > LOOP_MAX || aop.type == R_ANAL_OP_TYPE_RET
 					|| addr >= bb->addr + bb->size || addr < bb->addr) {
+				r_anal_op_fini (&aop);
 				break;
 			}
-			sdb_num_set (core->anal->esil->db_trace, sdb_fmt ("0x%"PFMT64x".count", addr), loop_count + 1, 0);
-			curpos = idx++ % (MAXINSTR + 1);
-			previnstr[curpos] = ret; // This array holds prev n instr size + cur instr size
-			if (aop.type == R_ANAL_OP_TYPE_CALL) {
-				int nbytes = 0;
-				int nb_opcodes = MAXINSTR;
-				SUMARRAY (previnstr, nb_opcodes, nbytes);
-				prevpc = addr - (nbytes - previnstr[curpos]);
-				emulate_prev_N_instr (core, addr, prevpc);
-				RAnalFunction *fcn_call = r_anal_get_fcn_in (core->anal, aop.jump, -1);
-				if (fcn_call) {
-					cur_idx = sdb_num_get (core->anal->esil->db_trace, "idx", 0);
-					type_match (core, addr, fcn_call->name, prev_idx);
-					prev_idx = cur_idx;
-				}
-				memset (previnstr, 0, sizeof (previnstr) * sizeof (*previnstr)); // clearing the buffer
+			sdb_num_set (anal->esil->db_trace, sdb_fmt ("0x%"PFMT64x".count", addr), loop_count + 1, 0);
+			if (r_anal_op_nonlinear (aop.type)) {   // skip the instr
+				r_reg_set_value (core->dbg->reg, r, addr + ret);
+			} else {
+				r_core_esil_step (core, UT64_MAX, NULL, NULL);
 			}
+			Sdb *trace = anal->esil->db_trace;
+			cur_idx = sdb_num_get (trace, "idx", 0);
+			if (aop.type == R_ANAL_OP_TYPE_CALL) {
+				RAnalFunction *fcn_call = r_anal_get_fcn_in (anal, aop.jump, -1);
+				if (fcn_call) {
+					if (r_type_func_exist (TDB, fcn_call->name)) {
+						fcn_name = strdup (fcn_call->name);
+					} else if (!(fcn_name = r_type_func_guess (TDB, fcn_call->name))) {
+						goto beach;
+					}
+					const char* cc = r_anal_cc_func (anal, fcn_name);
+					if (cc && r_anal_cc_exist (anal, cc)) {
+						type_match (core, addr, fcn_name, cc, prev_idx);
+						prev_idx = cur_idx;
+						ret_type = (char *) r_type_func_ret (TDB, fcn_name);
+						ret_reg = r_anal_cc_ret (anal, cc);
+						resolved = false;
+					}
+					free (fcn_name);
+				}
+			}
+			// Forward propgation of function return type
+			if (!resolved && ret_type && ret_reg) {
+				const char *reg = get_regname (anal, trace, cur_idx);
+				if (reg && !strcmp (reg, ret_reg) && aop.var) {
+					var_retype (anal, aop.var, aop.var->name, ret_type, addr);
+					resolved = true;
+				}
+				if (SDB_CONTAINS (cur_idx, ret_reg)) {
+					resolved = true;
+				}
+			}
+beach:
 			i += ret;
 			addr += ret;
 			r_anal_op_fini (&aop);
 
 		}
-		r_cons_break_pop();
 	}
 out_function:
 	free (buf);
 	r_cons_break_pop();
 	r_anal_emul_restore (core, hc);
-	sdb_reset (core->anal->esil->db_trace);
+	sdb_reset (anal->esil->db_trace);
 }

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1362,9 +1362,9 @@ static ut32 tmp_get_realsize (RAnalFunction *f) {
 
 static void ds_show_functions_argvar(RDisasmState *ds, RAnalVar *var, const char *base, bool is_var, char sign) {
 	int delta = sign == '+' ? var->delta : -var->delta;
-	const char *arg_or_var = is_var ? "var" : "arg";
-	r_cons_printf ("%s %s %s @ %s%c0x%x", arg_or_var, var->type, var->name,
-		base, sign, delta);
+	const char *pfx = is_var ? "var" : "arg";
+	r_cons_printf ("%s %s%s%s @ %s%c0x%x", pfx, var->type, r_str_endswith (var->type, "*") ? "" : " ",
+			var->name, base, sign, delta);
 }
 
 static void printVarSummary(RDisasmState *ds, RList *list) {


### PR DESCRIPTION
#### C source code : 
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

void main() {
	int length, length2;
	char *final;
	char *s1 = "Hello";
	char *s2 = "World";

	length = strlen (s1);
	length2 = strlen (s2);
        if (length == length2) {
           ...
        }
	....
}
```
#### r2 output
```
/ (fcn) sym.main 157
|   sym.main ();
|           ; var size_t local_20h @ rbp-0x20
|           ; var size_t size @ rbp-0x1c
|           ; var char *src @ rbp-0x18
|           ; var char *s2 @ rbp-0x10
|           ; var char *dest @ rbp-0x8

|           0x000007aa      55             push rbp
|           0x000007ab      4889e5         mov rbp, rsp
|           0x000007ae      4883ec20       sub rsp, 0x20
|           0x000007b2      488d051b0100.  lea rax, str.Hello          ; 0x8d4 ; "Hello"
|           0x000007b9      488945e8       mov qword [src], rax
|           0x000007bd      488d05160100.  lea rax, str.r2_folks       ; 0x8da ; " r2-folks"
|           0x000007c4      488945f0       mov qword [s2], rax
|           0x000007c8      488b45e8       mov rax, qword [src]
|           0x000007cc      4889c7         mov rdi, rax   
```
* Tested with ELF -  x86 arch for both  32 bit and 64 bit binaries

* Yet has to test for various architecture and lot's of improvement has to be done, which will be dealt in subsequent PR's 

* Added test to r2r [#1369](https://github.com/radare/radare2-regressions/pull/1369)