### PR TITLE
Few fixes for type propagation

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -91,7 +91,7 @@ static void var_retype (RAnal *anal, RAnalVar *var, const char *vname, char *typ
 		return;
 	}
 	char *vtype = NULL;
-	char *ntype = type;
+	char *ntype = r_str_trim (type);
 	if (!strncmp (type, "const ", 6)) {
 		// Droping const from type
 		//TODO: Infering const type

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -56,7 +56,11 @@ static void var_rename (RAnal *anal, RAnalVar *v, const char *name, ut64 addr) {
 	if (!name || !v) {
 		return;
 	}
-	bool is_default = strncmp (v->name, "local_", 6)? false: true;
+	if (!*name || !strcmp (name , "...")) {
+		return;
+	}
+	bool is_default = (!strncmp (v->name, "local_", 6)
+			|| !strncmp (v->name, "arg_", 4))? true: false;
 	if (*name == '*') {
 		name++;
 	}
@@ -77,7 +81,13 @@ static void var_retype (RAnal *anal, RAnalVar *var, const char *vname, char *typ
 	if (!type || !var) {
 		return;
 	}
+	if (!*type) {
+		return;
+	}
 	if (!strncmp (type, "int", 3)) {
+		return;
+	}
+	if (strncmp (var->type, "void", 4) && strncmp (var->type, "int", 3)) {
 		return;
 	}
 	char *vtype = NULL;
@@ -88,12 +98,8 @@ static void var_retype (RAnal *anal, RAnalVar *var, const char *vname, char *typ
 		ntype = type + 6;
 	}
 	if (vname && *vname == '*') {
-		if (!strcmp (type, "void") && strcmp (var->type, "int")) {
-			ntype = var->type;
-		} else {
-			//type *ptr => type *
-			vtype = r_str_newf ("%s %c", ntype, '*');
-		}
+		//type *ptr => type *
+		vtype = r_str_newf ("%s %c", ntype, '*');
 	}
 	if (vtype && *vtype) {
 		ntype = vtype;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6765,8 +6765,8 @@ static int cmd_anal_all(RCore *core, const char *input) {
 					rowlog_done (core);
 				}
 				if (input[1] == 'a') { // "aaaa"
-					bool ioCache = r_config_get_i (core->config, "io.pcache");
-					r_config_set_i (core->config, "io.pcache", 1);
+					bool ioCache = r_config_get_i (core->config, "io.cache");
+					r_config_set_i (core->config, "io.cache", 1);
 					if (sdb_count (core->anal->sdb_zigns) > 0) {
 						rowlog (core, "Check for zignature from zigns folder (z/)");
 						r_core_cmd0 (core, "z/");
@@ -6777,7 +6777,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 					if (!ioCache) {
 						r_core_cmd0 (core, "wc-*");
 					}
-					r_config_set_i (core->config, "io.pcache", ioCache);
+					r_config_set_i (core->config, "io.cache", ioCache);
 				}
 				r_core_cmd0 (core, "s-");
 				if (dh_orig) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4180,11 +4180,14 @@ static void ds_print_calls_hints(RDisasmState *ds) {
 	} else {
 		for (i = 0; i < arg_max; i++) {
 			char *type = r_type_func_args_type (TDB, name, i);
+			char *tname = r_type_func_args_name (TDB, name, i);
 			if (type && *type) {
 				r_cons_printf ("%s%s%s%s%s", i == 0 ? "": " ", type,
 						type[strlen (type) -1] == '*' ? "": " ",
-						r_type_func_args_name (TDB, name, i),
-						i == arg_max - 1 ? ")": ",");
+						tname, i == arg_max - 1 ? ")": ",");
+			} else if (tname && !strcmp (tname, "...")) {
+				r_cons_printf ("%s%s%s", i == 0 ? "": " ",
+						tname, i == arg_max - 1 ? ")": ",");
 			}
 			free (type);
 		}

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -518,6 +518,9 @@ R_API char *r_type_func_guess(Sdb *TDB, char *func_name) {
 	}
 	slen -= offset;
 	str += offset;
+	if (!strncmp (str, "__isoc99_", 9)) {
+		str += 9;
+	}
 	if ((result = type_func_try_guess (TDB, str))) {
 		return result;
 	}


### PR DESCRIPTION
* Fixed few warnings caused due to `"..."` name with null type params in function  like `fscanf` etc .

* Changed `io.pcache` to `io.cache` only for afta, because some type where not infered due to this !