### PR TITLE
asm parse fixes.

### DIFF
--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -326,12 +326,22 @@ static int filter(RParse *p, RFlag *f, char *data, char *str, int len, bool big_
 								}
 								memmove (ptr_left, ptr_esc, copied_len);
 #if 1
+#if __APPLE__
 								sprintf (ptr_left + copied_len, "%s%s",
 										ansi_found && ptr_right - ptr_end + 1 >= 4 ? "\x1b[0m" : "",
 										ptr_right + 1);
-
+#else
+								strcpy (ptr_left + copied_len,
+										ansi_found && ptr_right - ptr_end + 1 >= 4 ? "\x1b[0m" : "");
+								strcat (ptr_left + copied_len,
+										ptr_right + 1);
+#endif
+#else
+#if __APPLE__
+								sprintf (ptr_left + copied_len, "%s", ptr_right + 1);
 #else
 								strcpy (ptr_left + copied_len, ptr_right + 1);
+#endif
 #endif
 							}
 							break;


### PR DESCRIPTION
on Darwin and with debug symbols, feat_grep test crashes.
on OpenBSD in non debug mode, feat_grep crashes so
we make the last chunk copy consistent.