### PR TITLE
Fix #10465 - Avoid string on low addresses (workaround) for corrupted dwarfs

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -1361,7 +1361,11 @@ static const ut8 *r_bin_dwarf_parse_comp_unit(Sdb *s, const ut8 *obuf,
 					&cu->hdr, debug_str, debug_str_len);
 			if (cu->dies[cu->length].attr_values[i].name == DW_AT_comp_dir) {
 				const char *name = cu->dies[cu->length].attr_values[i].encoding.str_struct.string;
-				sdb_set (s, "DW_AT_comp_dir", name, 0);
+				if (name > 1024) { // solve some null derefs
+					sdb_set (s, "DW_AT_comp_dir", name, 0);
+				} else {
+					eprintf ("Invalid string pointer at %p\n", name);
+				}
 			}
 			cu->dies[cu->length].length++;
 		}


### PR DESCRIPTION
… dwarf