### PR TITLE
x86_cs MOV family: set val to 2nd operand if imm and if 1st operand is reg

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1981,6 +1981,10 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 			}
 			break;
 		case X86_OP_REG:
+			if (INSOP(1).type == X86_OP_IMM) {
+				op->val = INSOP(1).imm;
+			}
+			break;
 		default:
 			break;
 		}

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2947,11 +2947,11 @@ R_API wchar_t* r_str_mb_to_wc(const char *buf) {
 R_API char *r_str_from_ut64(ut64 val) {
 	int i = 0;
 	char *v = (char *)&val;
-	char *str = (char *)calloc(1, 65);
+	char *str = (char *)calloc(1, 9);
 	if (!str) {
 		return NULL;
 	}
-	while (i < 64 && *v && *v >= '!' && *v <= '~') {
+	while (i < 8 && *v && *v >= '!' && *v <= '~') {
 		str[i++] = *v++;
 	}
 	return str;


### PR DESCRIPTION
Fixes the non-detection issue in #10473.