### PR TITLE
Fold switch cases pointing to the same instruction

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -443,7 +443,7 @@ static void queue_case(RAnal *anal, ut64 switch_addr, ut64 case_addr, ut64 id, u
 	// 	id, case_addr);
 	anal->cmdtail = r_str_appendf (anal->cmdtail,
 		"f case.%d.0x%"PFMT64x " 1 @ 0x%08"PFMT64x "\n",
-		id, case_addr, case_addr);
+		id, switch_addr, case_addr);
 }
 
 static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut64 ip, ut64 jmptbl_loc, ut64 jmptbl_off, ut64 sz, ut64 jmptbl_size, ut64 default_case, int ret0) {

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -442,8 +442,8 @@ static void queue_case(RAnal *anal, ut64 switch_addr, ut64 case_addr, ut64 id, u
 	// 	"CCu case %d: @ 0x%"PFMT64x "\n",
 	// 	id, case_addr);
 	anal->cmdtail = r_str_appendf (anal->cmdtail,
-		"f case.%d.0x%"PFMT64x " 1 @ 0x%08"PFMT64x "\n",
-		id, switch_addr, case_addr);
+		"f case.0x%"PFMT64x ".%d 1 @ 0x%08"PFMT64x "\n",
+		switch_addr, id, case_addr);
 }
 
 static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut64 ip, ut64 jmptbl_loc, ut64 jmptbl_off, ut64 sz, ut64 jmptbl_size, ut64 default_case, int ret0) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1860,7 +1860,7 @@ static void ds_show_flags(RDisasmState *ds) {
 			continue;
 		}
 		if (!strncmp (flag->name, "case.", 5)) {
-			sscanf (flag->name + 5, "%d.%63s", &case_current, addr);
+			sscanf (flag->name + 5, "%63[^.].%d", addr, &case_current);
 			ut64 saddr = r_num_math (core->num, addr);
 			if (case_start == -1) {
 				switch_addr = saddr;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1866,7 +1866,9 @@ static void ds_show_flags(RDisasmState *ds) {
 				switch_addr = saddr;
 				case_prev = case_current;
 				case_start = case_current;
-				continue;
+				if (iter != uniqlist->tail) {
+					continue;
+				}
 			}
 			if (case_current == case_prev + 1 && switch_addr == saddr) {
 				case_prev = case_current;
@@ -1899,7 +1901,9 @@ static void ds_show_flags(RDisasmState *ds) {
 		}
 		if (ds->asm_demangle && flag->realname) {
 			if (!strncmp (flag->name, "case.", 5)) {
-				if (case_prev != case_start) {
+				if (!strncmp (flag->name + 5, "default", 7)) {
+					r_cons_printf ("%s:", flag->name);
+				} else if (case_prev != case_start) {
 					r_cons_printf ("cases %d...%d (%s):", case_start, case_prev, addr);
 					if (iter != uniqlist->head) {
 						iter = iter->p;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1860,7 +1860,7 @@ static void ds_show_flags(RDisasmState *ds) {
 			continue;
 		}
 		if (!strncmp (flag->name, "case.", 5)) {
-			sscanf (flag->name + 5, "%d.%s", &case_current, addr);
+			sscanf (flag->name + 5, "%d.%63s", &case_current, addr);
 			ut64 saddr = r_num_math (core->num, addr);
 			if (case_start == -1) {
 				switch_addr = saddr;


### PR DESCRIPTION
Closes #10474 

It confronts the address of the switch instruction, so it should work even if multiple switches point to the same instruction.

Before:
![photo_2018-06-25_22-05-05](https://user-images.githubusercontent.com/3428362/41872985-e43f75c2-78c3-11e8-8512-0120f9cc6c95.jpg)


After:
![2018-06-25-215835_796x145_scrot](https://user-images.githubusercontent.com/3428362/41873071-2bc36660-78c4-11e8-8b6e-bcbd7aa59d48.png)

