### PR TITLE
Join Tasks using Lock

### DIFF
--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -715,6 +715,7 @@ typedef enum {
 typedef struct r_core_task_t {
 	int id;
 	RTaskState state;
+	RThreadLock *running_lock;
 	void *user;
 	RCore *core;
 	RThreadCond *dispatch_cond;


### PR DESCRIPTION
This is better than joining the thread, because pthread_join only allows a thread to be joined by one other thread.