### PR TITLE
Add tasks_running to RCore to reduce tasks overhead

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2027,6 +2027,7 @@ R_API bool r_core_init(RCore *core) {
 	core->tasks = r_list_newf ((RListFree)r_core_task_free);
 	core->tasks_queue = r_list_new ();
 	core->tasks_lock = r_th_lock_new (false);
+	core->tasks_running = 0;
 	core->main_task = r_core_task_new (core, false, NULL, NULL, NULL);
 	r_list_append (core->tasks, core->main_task);
 	core->current_task = NULL;

--- a/libr/core/task.c
+++ b/libr/core/task.c
@@ -8,23 +8,23 @@ R_API void r_core_task_print (RCore *core, RCoreTask *task, int mode) {
 		r_cons_printf ("{\"id\":%d,\"state\":\"", task->id);
 		switch (task->state) {
 			case R_CORE_TASK_STATE_BEFORE_START:
-				r_cons_print("before_start");
+				r_cons_print ("before_start");
 				break;
 			case R_CORE_TASK_STATE_RUNNING:
-				r_cons_print("running");
+				r_cons_print ("running");
 				break;
 			case R_CORE_TASK_STATE_SLEEPING:
-				r_cons_print("sleeping");
+				r_cons_print ("sleeping");
 				break;
 			case R_CORE_TASK_STATE_DONE:
-				r_cons_print("done");
+				r_cons_print ("done");
 				break;
 		}
-		r_cons_print("\",\"cmd\":");
+		r_cons_print ("\",\"cmd\":");
 		if (task->cmd) {
-			r_cons_printf("\"%s\"}", task->cmd);
+			r_cons_printf ("\"%s\"}", task->cmd);
 		} else {
-			r_cons_printf("null}");
+			r_cons_printf ("null}");
 		}
 		break;
 	default: {
@@ -47,6 +47,7 @@ R_API void r_core_task_list(RCore *core, int mode) {
 	if (mode == 'j') {
 		r_cons_printf ("[");
 	}
+	r_th_lock_enter (core->tasks_lock);
 	r_list_foreach (core->tasks, iter, task) {
 		r_core_task_print (core, task, mode);
 		if (mode == 'j' && iter->n) {
@@ -55,7 +56,10 @@ R_API void r_core_task_list(RCore *core, int mode) {
 	}
 	if (mode == 'j') {
 		r_cons_printf ("]\n");
+	} else {
+		r_cons_printf ("--\ntotal running: %d\n", core->tasks_running);
 	}
+	r_th_lock_leave (core->tasks_lock);
 }
 
 static void task_join(RCoreTask *task) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -233,6 +233,7 @@ typedef struct r_core_t {
 	RCoreTask *current_task;
 	RCoreTask *main_task;
 	RThreadLock *tasks_lock;
+	int tasks_running;
 	int cmd_depth;
 	int max_cmd_depth;
 	ut8 switch_file_view;


### PR DESCRIPTION
for #10506 

Reducing the overhead in `task_wakeup()` is not that easy unfortunately, but that one is only called once when starting a task or leaving sleep mode, so it is far less critical than in `r_core_task_schedule()`.