### PR TITLE
Intial support for register base args 

### DIFF
--- a/libr/anal/cc.c
+++ b/libr/anal/cc.c
@@ -25,6 +25,22 @@ R_API const char *r_anal_cc_arg(RAnal *anal, const char *convention, int n) {
 
 }
 
+R_API int r_anal_cc_max_arg(RAnal *anal, const char *cc) {
+	int ret = 0;
+	const char *query, *res;
+	if (!anal || !cc) {
+		return 0;
+	}
+	do {
+		query = sdb_fmt ("cc.%s.arg%d", cc, ret + 1);
+		res = sdb_const_get (DB, query, 0);
+		if (res) {
+			ret++;
+		}
+	} while (res && ret < 6);
+	return ret;
+}
+
 R_API const char *r_anal_cc_ret(RAnal *anal, const char *convention) {
 	char *query = sdb_fmt ("cc.%s.ret", convention);
 	return sdb_const_get (DB, query, 0);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1003,6 +1003,9 @@ repeat:
 			bb->stackptr = 0;
 			break;
 		}
+		if (anal->opt.vars) {
+			extract_vars(anal, fcn, &op);
+		}
 		if (op.ptr && op.ptr != UT64_MAX && op.ptr != UT32_MAX) {
 			// swapped parameters wtf
 			r_anal_xrefs_set (anal, op.addr, op.ptr, R_ANAL_REF_TYPE_DATA);

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2757,7 +2757,7 @@ static void set_opdir(RAnalOp *op) {
 
 static void op_fillval(RAnalOp *op , csh handle, cs_insn *insn, int bits) {
 	static RRegItem reg;
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		op->src[0] = r_anal_value_new ();
 		ZERO_FILL (reg);

--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -99,7 +99,7 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	static RRegItem reg;
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
 		ZERO_FILL (reg);
 		if (OPERAND(1).type == M68K_OP_MEM) {

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -609,7 +609,7 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnal *anal, RAnalOp *op, csh *handle, cs_insn *insn) {
 	static RRegItem reg;
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (OPERAND(1).type == MIPS_OP_MEM) {
 			ZERO_FILL (reg);

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -564,7 +564,7 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	static RRegItem reg;
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (INSOP(1).type == PPC_OP_MEM) {
 			ZERO_FILL (reg);

--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -74,7 +74,7 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	static RRegItem reg;
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (INSOP(0).type == SPARC_OP_MEM) {
 			ZERO_FILL (reg);

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1678,7 +1678,7 @@ static void op_fillval (RAnal *a, RAnalOp *op, csh *handle, cs_insn *insn){
 	};
 	static RRegItem regs[2];
 
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
 	case R_ANAL_OP_TYPE_CMP:
 	case R_ANAL_OP_TYPE_LEA:

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -561,6 +561,164 @@ static void var_add_structure_fields_to_list(RAnal *a, RAnalVar *av, const char 
 	}
 }
 
+#define VARPREFIX "local"
+#define ARGPREFIX "arg"
+
+//Variable recovery functions
+static char *get_varname(RAnal *a, RAnalFunction *fcn, char type, const char *pfx, int idx) {
+	char *varname = r_str_newf ("%s_%xh", pfx, idx);
+	int i = 2;
+	char v_kind;
+	int v_delta;
+	while (1) {
+		char *name_key = sdb_fmt ("var.0x%"PFMT64x ".%d.%s", fcn->addr, 1, varname);
+		char *name_value = sdb_get (a->sdb_fcns, name_key, 0);
+		if (!name_value) {
+			break;
+		}
+		const char *comma = strchr (name_value, ',');
+		if (comma && *comma) {
+			v_delta = r_num_math (NULL, comma + 1);
+			v_kind = *name_value;
+		}
+		if (v_kind == type && R_ABS (v_delta) == idx) {
+			free (name_value);
+			return varname;
+		}
+		free (varname);
+		free (name_value);
+		varname = r_str_newf ("%s_%xh_%d", pfx, idx, i);
+		i++;
+	}
+	return varname;
+}
+
+static const char *get_regname(RAnal *anal, RAnalValue *value) {
+	const char *name = NULL;
+	if (value && value->reg && value->reg->name) {
+		name = value->reg->name;
+		RRegItem *ri = r_reg_get (anal->reg, value->reg->name, -1);
+		if (ri && (ri->size == 32) && (anal->bits == 64)) {
+			name = r_reg_32_to_64 (anal->reg, value->reg->name);
+		}
+	}
+	return name;
+}
+
+static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg, const char *sign, char type) {
+	char sigstr[16] = {0};
+	st64 ptr;
+	char *addr;
+	if (!anal || !fcn || !op) {
+		return;
+	}
+	snprintf (sigstr, sizeof (sigstr), ",%s,%s", reg, sign);
+	const char *op_esil = r_strbuf_get (&op->esil);
+	if (!op_esil) {
+		return;
+	}
+	char *esil_buf = strdup (op_esil);
+	if (!esil_buf) {
+		return;
+	}
+	char *ptr_end = strstr (esil_buf, sigstr);
+	if (!ptr_end) {
+		free (esil_buf);
+		return;
+	}
+	*ptr_end = 0;
+	addr = ptr_end;
+	while ((addr[0] != '0' || addr[1] != 'x') && addr >= esil_buf + 1 && *addr != ',') {
+		addr--;
+	}
+	if (strncmp (addr, "0x", 2)) {
+		//XXX: This is a workaround for inconsistent esil
+		if ((op->stackop == R_ANAL_STACK_SET) || (op->stackop == R_ANAL_STACK_GET)) {
+			ptr = R_ABS (op->ptr);
+			if (ptr%4) {
+				goto beach;
+			}
+		} else {
+			goto beach;
+		}
+	} else {
+		ptr = (st64) r_num_get (NULL, addr);
+	}
+	int rw = (op->direction == R_ANAL_OP_DIR_WRITE) ? 1 : 0;
+	if (*sign == '+') {
+		const char *pfx = ((ptr < fcn->maxstack) && (type == 's')) ? VARPREFIX : ARGPREFIX;
+		bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;
+		char *varname = get_varname (anal, fcn, type, pfx, R_ABS (ptr));
+		r_anal_var_add (anal, fcn->addr, 1, ptr, type, NULL, anal->bits / 8, isarg, varname);
+		r_anal_var_access (anal, fcn->addr, type, 1, ptr, rw, op->addr);
+		free (varname);
+	} else {
+		char *varname = get_varname (anal, fcn, type, VARPREFIX, R_ABS (ptr));
+		r_anal_var_add (anal, fcn->addr, 1, -ptr, type, NULL, anal->bits / 8, 0, varname);
+		r_anal_var_access (anal, fcn->addr, type, 1, -ptr, rw, op->addr);
+		free (varname);
+	}
+beach:
+	free (esil_buf);
+}
+
+R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count) {
+	const char *opsreg = NULL;
+	const char *opdreg = NULL;
+	int i, delta = 0;
+
+	if (!anal || !op || !fcn) {
+		return;
+	}
+	int max_count = r_anal_cc_max_arg (anal, fcn->cc);
+	if (!max_count || (*count >= max_count)) {
+		return;
+	}
+	if (op->src[0]) {
+		opsreg = get_regname (anal, op->src[0]);
+	}
+	if (op->dst) {
+		opdreg = get_regname (anal, op->dst);
+	}
+	if (opsreg) {
+		RRegItem *ri = r_reg_get (anal->reg, opsreg, -1);
+		if (ri) {
+			delta = ri->index;
+		}
+	}
+	for (i = 0; i < max_count; i++) {
+		const char *regname = r_anal_cc_arg (anal, fcn->cc, i + 1);
+		// reg_set enusres we only extract first-read argument reg
+		if (!reg_set [i] && regname) {
+			if (op->src[0] && opsreg && !strcmp (opsreg, regname)) {
+				char *vname = r_str_newf ("%s%d", "arg", i + 1);
+				r_anal_var_add (anal, fcn->addr, 1, delta, 'r', NULL, anal->bits / 8,
+						1, vname);
+				r_anal_var_access (anal, fcn->addr, 'r', 1, delta, 0, op->addr);
+				r_meta_set_string (anal, R_META_TYPE_COMMENT, op->addr, vname);
+				free (vname);
+				break;
+			}
+			if (op->dst && opdreg &&!strcmp (opdreg, regname)) {
+				reg_set [i] = 1;
+				count++;
+				break;
+			}
+		}
+	}
+}
+
+R_API void extract_vars(RAnal *anal, RAnalFunction *fcn, RAnalOp *op) {
+	if (!anal || !fcn || !op) {
+		return;
+	}
+	const char *BP = anal->reg->name[R_REG_NAME_BP];
+	const char *SP =  anal->reg->name[R_REG_NAME_SP];
+	extract_arg (anal, fcn, op, BP, "+", 'b');
+	extract_arg (anal, fcn, op, BP, "-", 'b');
+	extract_arg (anal, fcn, op, SP, "+", 's');
+}
+
 static RList *var_generate_list(RAnal *a, RAnalFunction *fcn, int kind, bool dynamicVars) {
 	if (!a || !fcn) {
 		return NULL;
@@ -746,7 +904,7 @@ R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int m
 					eprintf ("Register not found");
 					break;
 				}
-				anal->cb_printf ("reg %s %s @ %s\n",
+				anal->cb_printf ("arg %s %s @ %s\n",
 					var->type, var->name, i->name);
 				}
 				break;

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -172,7 +172,7 @@ static void type_match(RCore *core, ut64 addr, char *fcn_name, const char* cc, i
 				r_anal_op_fini (op);
 				break;
 			}
-			RAnalVar *var = op ? op->var: NULL;
+			RAnalVar *var = (op && op->var && op->var->kind != 'r') ? op->var: NULL;
 			// Match type from function param to instr
 			if (type_pos_hit (anal, trace, in_stack, j, size, place)) {
 				if (!cmt_set) {
@@ -309,8 +309,10 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 			// Forward propgation of function return type
 			if (!resolved && ret_type && ret_reg) {
 				const char *reg = get_regname (anal, trace, cur_idx);
-				if (reg && !strcmp (reg, ret_reg) && aop.var) {
-					var_retype (anal, aop.var, aop.var->name, ret_type, addr);
+				//TODO: Type inference for register based arg
+				RAnalVar *var = (aop.var && aop.var && (aop.var->kind != 'r'))? aop.var: NULL;
+				if (reg && !strcmp (reg, ret_reg) && var) {
+					var_retype (anal, aop.var, var->name, ret_type, addr);
 					resolved = true;
 				}
 				if (SDB_CONTAINS (cur_idx, ret_reg)) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2611,11 +2611,169 @@ static RList *recurse(RCore *core, RAnalBlock *from, RAnalBlock *dest) {
 	return NULL;
 }
 
-R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
+#define VARPREFIX "local"
+#define ARGPREFIX "arg"
+
+static char *get_varname(RAnal *a, RAnalFunction *fcn, char type, const char *pfx, int idx) {
+	char *varname = r_str_newf ("%s_%xh", pfx, idx);
+	int i = 2;
+	char v_kind;
+	int v_delta;
+	while (1) {
+		char *name_key = sdb_fmt ("var.0x%"PFMT64x ".%d.%s", fcn->addr, 1, varname);
+		char *name_value = sdb_get (a->sdb_fcns, name_key, 0);
+		if (!name_value) {
+			break;
+		}
+		const char *comma = strchr (name_value, ',');
+		if (comma && *comma) {
+			v_delta = r_num_math (NULL, comma + 1);
+			v_kind = *name_value;
+		}
+		if (v_kind == type && R_ABS (v_delta) == idx) {
+			free (name_value);
+			return varname;
+		}
+		free (varname);
+		free (name_value);
+		varname = r_str_newf ("%s_%xh_%d", pfx, idx, i);
+		i++;
+	}
+	return varname;
+}
+
+static const char *get_regname(RAnal *anal, RAnalValue *value) {
+	const char *name = NULL;
+	if (value && value->reg && value->reg->name) {
+		name = value->reg->name;
+		RRegItem *ri = r_reg_get (anal->reg, value->reg->name, -1);
+		if (ri && (ri->size == 32) && (anal->bits == 64)) {
+			name = r_reg_32_to_64 (anal->reg, value->reg->name);
+		}
+	}
+	return name;
+}
+
+static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg, const char *sign, char type) {
+	char sigstr[16] = {0};
+	st64 ptr;
+	char *addr;
+	if (!anal || !fcn || !op) {
+		return;
+	}
+	snprintf (sigstr, sizeof (sigstr), ",%s,%s", reg, sign);
+	const char *op_esil = r_strbuf_get (&op->esil);
+	if (!op_esil) {
+		return;
+	}
+	char *esil_buf = strdup (op_esil);
+	if (!esil_buf) {
+		return;
+	}
+	char *ptr_end = strstr (esil_buf, sigstr);
+	if (!ptr_end) {
+		free (esil_buf);
+		return;
+	}
+	*ptr_end = 0;
+	addr = ptr_end;
+	while ((addr[0] != '0' || addr[1] != 'x') && addr >= esil_buf + 1 && *addr != ',') {
+		addr--;
+	}
+	if (strncmp (addr, "0x", 2)) {
+		//XXX: This is a workaround for inconsistent esil
+		if ((op->stackop == R_ANAL_STACK_SET) || (op->stackop == R_ANAL_STACK_GET)) {
+			ptr = R_ABS (op->ptr);
+			if (ptr%4) {
+				goto beach;
+			}
+		} else {
+			goto beach;
+		}
+	} else {
+		ptr = (st64) r_num_get (NULL, addr);
+	}
+	int rw = (op->direction == R_ANAL_OP_DIR_WRITE) ? 1 : 0;
+	if (*sign == '+') {
+		int maxstack = r_core_get_stacksz (anal->coreb.core, fcn->addr, op->addr);
+		const char *pfx = ((ptr < maxstack) && (type == 's')) ? VARPREFIX : ARGPREFIX;
+		bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;
+		char *varname = get_varname (anal, fcn, type, pfx, R_ABS (ptr));
+		r_anal_var_add (anal, fcn->addr, 1, ptr, type, NULL, anal->bits / 8, isarg, varname);
+		r_anal_var_access (anal, fcn->addr, type, 1, ptr, rw, op->addr);
+		free (varname);
+	} else {
+		char *varname = get_varname (anal, fcn, type, VARPREFIX, R_ABS (ptr));
+		r_anal_var_add (anal, fcn->addr, 1, -ptr, type, NULL, anal->bits / 8, 0, varname);
+		r_anal_var_access (anal, fcn->addr, type, 1, -ptr, rw, op->addr);
+		free (varname);
+	}
+beach:
+	free (esil_buf);
+}
+
+static void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count) {
+	const char *opsreg = NULL;
+	const char *opdreg = NULL;
+	int i, delta = 0;
+
+	if (!anal || !op || !fcn) {
+		return;
+	}
+	int max_count = r_anal_cc_max_arg (anal, fcn->cc);
+	if (!max_count || (*count >= max_count)) {
+		return;
+	}
+	if (op->src[0]) {
+		opsreg = get_regname (anal, op->src[0]);
+	}
+	if (op->dst) {
+		opdreg = get_regname (anal, op->dst);
+	}
+	if (opsreg) {
+		RRegItem *ri = r_reg_get (anal->reg, opsreg, -1);
+		delta = ri->index;
+	}
+	for (i = 0; i < max_count; i++) {
+		const char *regname = r_anal_cc_arg (anal, fcn->cc, i + 1);
+		// reg_set enusres we only extract first-read argument reg
+		if (!reg_set [i] && regname) {
+			if (op->src[0] && opsreg && !strcmp (opsreg, regname)) {
+				char *vname = r_str_newf ("%s%d", "arg", i + 1);
+				r_anal_var_add (anal, fcn->addr, 1, delta, 'r', NULL, anal->bits / 8,
+						1, vname);
+				r_anal_var_access (anal, fcn->addr, 'r', 1, delta, 0, op->addr);
+				r_meta_set_string (anal, R_META_TYPE_COMMENT, op->addr, vname);
+				free (vname);
+				break;
+			}
+			if (op->dst && opdreg &&!strcmp (opdreg, regname)) {
+				reg_set [i] = 1;
+				count++;
+				break;
+			}
+		}
+	}
+}
+
+static void extract_vars(RAnal *anal, RAnalFunction *fcn, RAnalOp *op) {
+	if (!anal || !fcn || !op) {
+		return;
+	}
+	const char *BP = anal->reg->name[R_REG_NAME_BP];
+	const char *SP =  anal->reg->name[R_REG_NAME_SP];
+	extract_arg (anal, fcn, op, BP, "+", 'b');
+	extract_arg (anal, fcn, op, BP, "-", 'b');
+	extract_arg (anal, fcn, op, SP, "+", 's');
+}
+
+R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn) {
 	ut8 *tbuf, *buf;
 	RListIter *tmp = NULL;
 	RAnalBlock *bb = NULL;
 	RAnalOp *op = NULL;
+	int count = 0;
+	int reg_set[10] = {0};
 	ut64 pos;
 
 	if (!core || !core->anal || !fcn || core->anal->opt.bb_max_size < 1) {
@@ -2643,7 +2801,7 @@ R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
 			bb_size = bb->size;
 		}
 		if (!r_io_read_at (core->io, bb->addr, buf, bb->size)) {
-	//		eprintf ("read error\n");
+			//eprintf ("read error\n");
 			break;
 		}
 		pos = bb->addr;
@@ -2651,12 +2809,13 @@ R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-			op = r_core_anal_op (core, pos, R_ANAL_OP_MASK_ESIL);
+			op = r_core_anal_op (core, pos, R_ANAL_OP_MASK_ALL);
 			if (!op) {
-	//			eprintf ("Cannot get op\n");
+				//eprintf ("Cannot get op\n");
 				break;
 			}
-			r_anal_fcn_fill_args (core->anal, fcn, op);
+			extract_vars (core->anal, fcn, op);
+			extract_rarg (core->anal, op, fcn, reg_set, &count);
 			int opsize = op->size;
 			r_anal_op_free (op);
 			if (opsize < 1) {
@@ -2665,7 +2824,6 @@ R_API void fcn_callconv(RCore *core, RAnalFunction *fcn) {
 			pos += opsize;
 		}
 	}
-
 	free (buf);
 	return;
 }
@@ -3248,6 +3406,7 @@ R_API int r_core_anal_all(RCore *core) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
+			r_core_recover_vars (core, fcni);
 			if (!strncmp (fcni->name, "sym.", 4) || !strncmp (fcni->name, "main", 4)) {
 				fcni->type = R_ANAL_FCN_TYPE_SYM;
 			}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2611,164 +2611,8 @@ static RList *recurse(RCore *core, RAnalBlock *from, RAnalBlock *dest) {
 	return NULL;
 }
 
-#define VARPREFIX "local"
-#define ARGPREFIX "arg"
-
-static char *get_varname(RAnal *a, RAnalFunction *fcn, char type, const char *pfx, int idx) {
-	char *varname = r_str_newf ("%s_%xh", pfx, idx);
-	int i = 2;
-	char v_kind;
-	int v_delta;
-	while (1) {
-		char *name_key = sdb_fmt ("var.0x%"PFMT64x ".%d.%s", fcn->addr, 1, varname);
-		char *name_value = sdb_get (a->sdb_fcns, name_key, 0);
-		if (!name_value) {
-			break;
-		}
-		const char *comma = strchr (name_value, ',');
-		if (comma && *comma) {
-			v_delta = r_num_math (NULL, comma + 1);
-			v_kind = *name_value;
-		}
-		if (v_kind == type && R_ABS (v_delta) == idx) {
-			free (name_value);
-			return varname;
-		}
-		free (varname);
-		free (name_value);
-		varname = r_str_newf ("%s_%xh_%d", pfx, idx, i);
-		i++;
-	}
-	return varname;
-}
-
-static const char *get_regname(RAnal *anal, RAnalValue *value) {
-	const char *name = NULL;
-	if (value && value->reg && value->reg->name) {
-		name = value->reg->name;
-		RRegItem *ri = r_reg_get (anal->reg, value->reg->name, -1);
-		if (ri && (ri->size == 32) && (anal->bits == 64)) {
-			name = r_reg_32_to_64 (anal->reg, value->reg->name);
-		}
-	}
-	return name;
-}
-
-static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg, const char *sign, char type) {
-	char sigstr[16] = {0};
-	st64 ptr;
-	char *addr;
-	if (!anal || !fcn || !op) {
-		return;
-	}
-	snprintf (sigstr, sizeof (sigstr), ",%s,%s", reg, sign);
-	const char *op_esil = r_strbuf_get (&op->esil);
-	if (!op_esil) {
-		return;
-	}
-	char *esil_buf = strdup (op_esil);
-	if (!esil_buf) {
-		return;
-	}
-	char *ptr_end = strstr (esil_buf, sigstr);
-	if (!ptr_end) {
-		free (esil_buf);
-		return;
-	}
-	*ptr_end = 0;
-	addr = ptr_end;
-	while ((addr[0] != '0' || addr[1] != 'x') && addr >= esil_buf + 1 && *addr != ',') {
-		addr--;
-	}
-	if (strncmp (addr, "0x", 2)) {
-		//XXX: This is a workaround for inconsistent esil
-		if ((op->stackop == R_ANAL_STACK_SET) || (op->stackop == R_ANAL_STACK_GET)) {
-			ptr = R_ABS (op->ptr);
-			if (ptr%4) {
-				goto beach;
-			}
-		} else {
-			goto beach;
-		}
-	} else {
-		ptr = (st64) r_num_get (NULL, addr);
-	}
-	int rw = (op->direction == R_ANAL_OP_DIR_WRITE) ? 1 : 0;
-	if (*sign == '+') {
-		int maxstack = r_core_get_stacksz (anal->coreb.core, fcn->addr, op->addr);
-		const char *pfx = ((ptr < maxstack) && (type == 's')) ? VARPREFIX : ARGPREFIX;
-		bool isarg = strcmp(pfx , ARGPREFIX) ? false : true;
-		char *varname = get_varname (anal, fcn, type, pfx, R_ABS (ptr));
-		r_anal_var_add (anal, fcn->addr, 1, ptr, type, NULL, anal->bits / 8, isarg, varname);
-		r_anal_var_access (anal, fcn->addr, type, 1, ptr, rw, op->addr);
-		free (varname);
-	} else {
-		char *varname = get_varname (anal, fcn, type, VARPREFIX, R_ABS (ptr));
-		r_anal_var_add (anal, fcn->addr, 1, -ptr, type, NULL, anal->bits / 8, 0, varname);
-		r_anal_var_access (anal, fcn->addr, type, 1, -ptr, rw, op->addr);
-		free (varname);
-	}
-beach:
-	free (esil_buf);
-}
-
-static void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count) {
-	const char *opsreg = NULL;
-	const char *opdreg = NULL;
-	int i, delta = 0;
-
-	if (!anal || !op || !fcn) {
-		return;
-	}
-	int max_count = r_anal_cc_max_arg (anal, fcn->cc);
-	if (!max_count || (*count >= max_count)) {
-		return;
-	}
-	if (op->src[0]) {
-		opsreg = get_regname (anal, op->src[0]);
-	}
-	if (op->dst) {
-		opdreg = get_regname (anal, op->dst);
-	}
-	if (opsreg) {
-		RRegItem *ri = r_reg_get (anal->reg, opsreg, -1);
-		delta = ri->index;
-	}
-	for (i = 0; i < max_count; i++) {
-		const char *regname = r_anal_cc_arg (anal, fcn->cc, i + 1);
-		// reg_set enusres we only extract first-read argument reg
-		if (!reg_set [i] && regname) {
-			if (op->src[0] && opsreg && !strcmp (opsreg, regname)) {
-				char *vname = r_str_newf ("%s%d", "arg", i + 1);
-				r_anal_var_add (anal, fcn->addr, 1, delta, 'r', NULL, anal->bits / 8,
-						1, vname);
-				r_anal_var_access (anal, fcn->addr, 'r', 1, delta, 0, op->addr);
-				r_meta_set_string (anal, R_META_TYPE_COMMENT, op->addr, vname);
-				free (vname);
-				break;
-			}
-			if (op->dst && opdreg &&!strcmp (opdreg, regname)) {
-				reg_set [i] = 1;
-				count++;
-				break;
-			}
-		}
-	}
-}
-
-static void extract_vars(RAnal *anal, RAnalFunction *fcn, RAnalOp *op) {
-	if (!anal || !fcn || !op) {
-		return;
-	}
-	const char *BP = anal->reg->name[R_REG_NAME_BP];
-	const char *SP =  anal->reg->name[R_REG_NAME_SP];
-	extract_arg (anal, fcn, op, BP, "+", 'b');
-	extract_arg (anal, fcn, op, BP, "-", 'b');
-	extract_arg (anal, fcn, op, SP, "+", 's');
-}
-
-R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn) {
-	ut8 *tbuf, *buf;
+R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn, bool argonly) {
+	ut8 *buf;
 	RListIter *tmp = NULL;
 	RAnalBlock *bb = NULL;
 	RAnalOp *op = NULL;
@@ -2792,13 +2636,7 @@ R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn) {
 			continue;
 		}
 		if (bb->size > bb_size) {
-			tbuf = realloc (buf, bb->size);
-			if (!tbuf) {
-				eprintf ("Cannot realloc bb to %d\n", (int)bb->size);
-				continue;
-			}
-			buf = tbuf;
-			bb_size = bb->size;
+			continue;
 		}
 		if (!r_io_read_at (core->io, bb->addr, buf, bb->size)) {
 			//eprintf ("read error\n");
@@ -2814,8 +2652,10 @@ R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn) {
 				//eprintf ("Cannot get op\n");
 				break;
 			}
-			extract_vars (core->anal, fcn, op);
 			extract_rarg (core->anal, op, fcn, reg_set, &count);
+			if (!argonly) {
+				extract_vars (core->anal, fcn, op);
+			}
 			int opsize = op->size;
 			r_anal_op_free (op);
 			if (opsize < 1) {
@@ -3406,7 +3246,7 @@ R_API int r_core_anal_all(RCore *core) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-			r_core_recover_vars (core, fcni);
+			r_core_recover_vars (core, fcni, true);
 			if (!strncmp (fcni->name, "sym.", 4) || !strncmp (fcni->name, "main", 4)) {
 				fcni->type = R_ANAL_FCN_TYPE_SYM;
 			}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -955,7 +955,7 @@ static int var_cmd(RCore *core, const char *str) {
 		r_anal_var_delete_all (core->anal, fcn->addr, R_ANAL_VAR_KIND_REG);
 		r_anal_var_delete_all (core->anal, fcn->addr, R_ANAL_VAR_KIND_BPV);
 		r_anal_var_delete_all (core->anal, fcn->addr, R_ANAL_VAR_KIND_SPV);
-		r_core_recover_vars (core, fcn);
+		r_core_recover_vars (core, fcn, false);
 		free (p);
 		return true;
 	case 'n':
@@ -2780,7 +2780,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 				if (r_cons_is_breaked ()) {
 					break;
 				}
-				r_core_recover_vars (core, fcni);
+				r_core_recover_vars (core, fcni, true);
 			}
 		}
 		flag_every_function (core);
@@ -6789,6 +6789,17 @@ static int cmd_anal_all(RCore *core, const char *input) {
 				if (r_config_get_i (core->config, "anal.autoname")) {
 					r_core_anal_autoname_all_fcns (core);
 					rowlog_done (core);
+				}
+				if (core->anal->opt.vars) {
+					RAnalFunction *fcni;
+					RListIter *iter;
+					r_list_foreach (core->anal->fcns, iter, fcni) {
+						if (r_cons_is_breaked ()) {
+							break;
+						}
+						//extract only reg based var here
+						r_core_recover_vars (core, fcni, true);
+					}
 				}
 				if (input[1] == 'a') { // "aaaa"
 					bool ioCache = r_config_get_i (core->config, "io.cache");

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -394,7 +394,7 @@ R_API int r_core_get_stacksz (RCore *core, ut64 from, ut64 to) {
 			}
 		}
 		at += op->size;
-		r_anal_op_fini (op);
+		r_anal_op_free (op);
 	}
 	return maxstack;
 }

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1635,8 +1635,9 @@ static void ds_show_functions(RDisasmState *ds) {
 					eprintf("Register not found");
 					break;
 				}
-				r_cons_printf ("reg %s %s @ %s",
-					var->type, var->name, i->name);
+				r_cons_printf ("reg %s%s%s @ %s",
+					var->type, r_str_endswith (var->type, "*") ? "" : " ",
+					var->name, i->name);
 				}
 				break;
 			case 's': {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1635,7 +1635,7 @@ static void ds_show_functions(RDisasmState *ds) {
 					eprintf("Register not found");
 					break;
 				}
-				r_cons_printf ("reg %s%s%s @ %s",
+				r_cons_printf ("arg %s%s%s @ %s",
 					var->type, r_str_endswith (var->type, "*") ? "" : " ",
 					var->name, i->name);
 				}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1455,6 +1455,8 @@ R_API RAnalVar *r_anal_var_get (RAnal *a, ut64 addr, char kind, int scope, int i
 R_API const char *r_anal_var_scope_to_str(RAnal *anal, int scope);
 R_API int r_anal_var_access_add(RAnal *anal, RAnalVar *var, ut64 from, int set);
 R_API int r_anal_var_access_del(RAnal *anal, RAnalVar *var, ut64 from);
+R_API void extract_vars(RAnal *anal, RAnalFunction *fcn, RAnalOp *op);
+R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count);
 R_API RAnalVarAccess *r_anal_var_access_get(RAnal *anal, RAnalVar *var, ut64 from);
 R_API RAnalVar *r_anal_var_get_byname (RAnal *anal, RAnalFunction *fcn, const char* name);
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1352,7 +1352,6 @@ R_API RAnalFunction *r_anal_fcn_find_name(RAnal *anal, const char *name);
 R_API RList *r_anal_fcn_list_new(void);
 R_API int r_anal_fcn_insert(RAnal *anal, RAnalFunction *fcn);
 R_API void r_anal_fcn_free(void *fcn);
-R_API void r_anal_fcn_fill_args (RAnal *anal, RAnalFunction *fcn, RAnalOp *op);
 R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr,
 		ut8 *buf, ut64 len, int reftype);
 R_API int r_anal_fcn_add(RAnal *anal, ut64 addr, ut64 size,
@@ -1510,6 +1509,7 @@ R_API RList *r_anal_var_list_dynamic(RAnal *anal, RAnalFunction *fcn, int kind);
 // calling conventions API
 R_API int r_anal_cc_exist (RAnal *anal, const char *convention);
 R_API const char *r_anal_cc_arg(RAnal *anal, const char *convention, int n);
+R_API int r_anal_cc_max_arg(RAnal *anal, const char *cc);
 R_API const char *r_anal_cc_ret(RAnal *anal, const char *convention);
 R_API const char *r_anal_cc_default(RAnal *anal);
 R_API const char *r_anal_cc_func(RAnal *anal, const char *func_name);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -441,6 +441,8 @@ R_API RList *r_core_get_func_args(RCore *core, const char *func_name);
 R_API void r_core_print_func_args(RCore *core);
 R_API char *resolve_fcn_name(RAnal *anal, const char * func_name);
 
+R_API int r_core_get_stacksz (RCore *core, ut64 from, ut64 to);
+
 /* anal.c */
 R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr, int mask);
 R_API void r_core_anal_esil(RCore *core, const char *str, const char *addr);
@@ -547,7 +549,7 @@ R_API char *r_core_sysenv_begin(RCore *core, const char *cmd);
 R_API void r_core_sysenv_end(RCore *core, const char *cmd);
 R_API void r_core_sysenv_help(const RCore* core);
 
-R_API void fcn_callconv (RCore *core, RAnalFunction *fcn);
+R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn);
 /* bin.c */
 #define R_CORE_BIN_PRINT	0x000 
 #define R_CORE_BIN_RADARE	0x001

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -549,7 +549,7 @@ R_API char *r_core_sysenv_begin(RCore *core, const char *cmd);
 R_API void r_core_sysenv_end(RCore *core, const char *cmd);
 R_API void r_core_sysenv_help(const RCore* core);
 
-R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn);
+R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn, bool argonly);
 /* bin.c */
 #define R_CORE_BIN_PRINT	0x000 
 #define R_CORE_BIN_RADARE	0x001

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -235,7 +235,7 @@ static int parse(RParse *p, const char *data, char *str) {
 }
 
 static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
-	RList *spargs, *bpargs, *regargs;
+	RList *spargs, *bpargs;
 	RAnalVar *var;
 	RListIter *iter;
 	char *oldstr, *newstr;
@@ -275,7 +275,6 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 		}
 	}
 
-	regargs = p->varlist (p->anal, f, 'r');
 	bpargs = p->varlist (p->anal, f, 'b');
 	spargs = p->varlist (p->anal, f, 's');
 	bool ucase = IS_UPPER (*tstr);
@@ -373,12 +372,6 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 			break;
 		}
 		free (oldstr);
-	}
-	r_list_foreach (regargs, iter, var) {
-		RRegItem *r = r_reg_index_get (p->anal->reg, var->delta);
-		if (r && r->name && strstr (tstr, r->name)) {
-			tstr = r_str_replace (tstr, r->name, var->name, 1);
-		}
 	}
 	if (len > strlen (tstr)) {
 		strncpy (str, tstr, strlen (tstr));

--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -325,9 +325,9 @@ static inline void mk_reg_str(const char *regname, int delta, bool sign, bool at
 }
 
 static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
-	RList *regs, *bpargs, *spargs;
-	RAnalVar *reg, *bparg, *sparg;
-	RListIter *regiter, *bpargiter, *spiter;
+	RList *bpargs, *spargs;
+	RAnalVar *bparg, *sparg;
+	RListIter *bpargiter, *spiter;
 	char oldstr[64], newstr[64];
 	char *tstr = strdup (data);
 	if (!tstr) {
@@ -390,7 +390,6 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
                 free (tstr);
 		return false;
         }
-	regs = p->varlist (p->anal, f, 'r');
 	bpargs = p->varlist (p->anal, f, 'b');
 	spargs = p->varlist (p->anal, f, 's');
 	/*iterate over stack pointer arguments/variables*/
@@ -482,13 +481,6 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 		bp[0] = 0;
 	}
 
-	r_list_foreach (regs, regiter, reg) {
-		RRegItem *r = r_reg_index_get (p->anal->reg, reg->delta);
-		if (r && r->name && strstr (tstr, r->name)){
-			tstr = r_str_replace (tstr, r->name, reg->name, 1);
-		}
-	}
-
 	bool ret = true;
 	if (len > strlen (tstr)) {
 		strncpy (str, tstr, strlen (tstr));
@@ -500,7 +492,6 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 	free (tstr);
 	r_list_free (spargs);
 	r_list_free (bpargs);
-	r_list_free (regs);
 	return ret;
 }
 


### PR DESCRIPTION
Fix #10483 

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

/* A simple Hello World program :) */

void funcarg(char *s1 ,char *s2, int c, int d) {
	char *final;
	final = malloc (c + d);
	if (final) {
		strcpy (final, s1);
		strcat (final, s2);
		printf ("%s\n", final);
		free (final);
	}

}
void main (int argc, char *argv) {
	char *s1 = "Hello";
	char *s2 = " r2-folks";
	funcarg (s1, s2, strlen (s1), strlen (s2));
}
```
#### Before 

```
[0x0000081e]> s sym.funcarg 
[0x000007aa]> pdf
/ (fcn) sym.funcarg 116
|   sym.funcarg ();
|           ; var int local_28h @ rbp-0x28
|           ; var int local_24h @ rbp-0x24
|           ; var int local_20h @ rbp-0x20
|           ; var int local_18h @ rbp-0x18
|           ; var int local_8h @ rbp-0x8
|           ; CALL XREF from 0x0000086d (sym.main)
|           0x000007aa      55             push rbp
|           0x000007ab      4889e5         mov rbp, rsp
|           0x000007ae      4883ec30       sub rsp, 0x30               ; '0'
|           0x000007b2      48897de8       mov qword [local_18h], rdi
|           0x000007b6      488975e0       mov qword [local_20h], rsi
|           0x000007ba      8955dc         mov dword [local_24h], edx
|           0x000007bd      894dd8         mov dword [local_28h], ecx

```
#### After (Updated)

```
[0x0000081e]> s sym.funcarg 
[0x000007aa]> pdf
/ (fcn) sym.funcarg 116
|   sym.funcarg (int arg1, int arg2, int arg3, int arg4);
|           ; var int local_28h @ rbp-0x28
|           ; var int local_24h @ rbp-0x24
|           ; var int local_20h @ rbp-0x20
|           ; var int local_18h @ rbp-0x18
|           ; var int local_8h @ rbp-0x8
|           ; arg int arg1 @ rdi
|           ; arg int arg2 @ rsi
|           ; arg int arg3 @ rdx
|           ; arg int arg4 @ rcx
|           ; CALL XREF from 0x0000086d (sym.main)
|           0x000007aa      55             push rbp
|           0x000007ab      4889e5         mov rbp, rsp
|           0x000007ae      4883ec30       sub rsp, 0x30               ; '0'
|           0x000007b2      48897de8       mov qword [local_18h], rdi  ; arg1
|           0x000007b6      488975e0       mov qword [local_20h], rsi  ; arg2
|           0x000007ba      8955dc         mov dword [local_24h], edx  ; arg3
|           0x000007bd      894dd8         mov dword [local_28h], ecx  ; arg4

```

Added test in r2r [#1378](https://github.com/radare/radare2-regressions/pull/1378)

#### Next Plans

Still there are lot to improve : 

* Type propagation for register based arg

* Better naming and handling of register-based arg

* **Note** : Currently the register based argument var name are NOT substituted in disassembly rather it's added as a comment (which IMHO is better instead of replacing all occurrences of registers )