### PR TITLE
Added stopaddr dbg info to dij

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4695,6 +4695,7 @@ static int cmd_debug(void *data, const char *input) {
 					P ("\"addr\":%"PFMT64d",", core->dbg->reason.addr);
 					P ("\"inbp\":%s,", r_str_bool (core->dbg->reason.bp_addr));
 					P ("\"baddr\":%"PFMT64d",", r_debug_get_baddr (core->dbg, NULL));
+					P ("\"stopaddr\":%"PFMT64d",", core->dbg->stopaddr);
 					P ("\"pid\":%d,", rdi->pid);
 					P ("\"tid\":%d,", rdi->tid);
 					P ("\"uid\":%d,", rdi->uid);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4645,6 +4645,7 @@ static int cmd_debug(void *data, const char *input) {
 					P ("baddr=0x%"PFMT64x"\n", r_debug_get_baddr (core->dbg, NULL));
 					P ("pid=%d\n", rdi->pid);
 					P ("tid=%d\n", rdi->tid);
+					P ("stopaddr=0x%"PFMT64x"\n", core->dbg->stopaddr);
 					if (rdi->uid != -1) {
 						P ("uid=%d\n", rdi->uid);
 					}

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -75,7 +75,7 @@ int linux_handle_signals (RDebug *dbg) {
 		//ptrace (PTRACE_SETSIGINFO, dbg->pid, 0, &siginfo);
 		dbg->reason.type = R_DEBUG_REASON_SIGNAL;
 		dbg->reason.signum = siginfo.si_signo;
-		//dbg->stopaddr = siginfo.si_addr;
+		dbg->stopaddr = siginfo.si_addr;
 		//dbg->errno = siginfo.si_errno;
 		// siginfo.si_code -> HWBKPT, USER, KERNEL or WHAT
 #warning DO MORE RDEBUGREASON HERE

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -277,6 +277,7 @@ typedef struct r_debug_t {
 	int steps; /* counter of steps done */
 	RDebugReason reason; /* stop reason */
 	RDebugRecoilMode recoil_mode; /* what did the user want to do? */
+	ut64 stopaddr;  /* stop address  */
 
 	/* tracing vars */
 	RDebugTrace *trace;


### PR DESCRIPTION
Added stopaddr dbg info to dij command

```
[0x00400551]> dij
{"type":"segfault","signal":"SIGSEGV","signum":11,"sigpid":10386,"addr":0,"inbp":false,"baddr":4194304,"stopaddr":0,"pid":10386,"tid":10386,"uid":0,"gid":0,"exe":"/home/invictus1306/Documents/r2conf/init_test/mytests/test1","cmdline":"/home/invictus1306/Documents/r2conf/init_test/mytests/test1","cwd":"/home/invictus1306/Documents/r2conf/init_test/mytests","stopreason":2}
```