### PR TITLE
Support for fullwidth characters of the CJK charset (Chinese, Japanese, Korean).

### DIFF
--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -265,7 +265,6 @@ beach: {
        }
 }
 
-
 static int utf8len_fixed(const char *s, int n) {
 	int i = 0, j = 0, fullwidths = 0;
 	while (s[i] && n > 0) {
@@ -361,7 +360,6 @@ R_API void r_cons_canvas_write(RConsCanvas *c, const char *s) {
 		slen = piece_len;
 
 		if (piece_len > left) {
-			/*int utf8_piece_len = utf8len_fixed (s_part, piece_len, c->bsize[c->y] - c->x);*/
 			int utf8_piece_len = utf8len_fixed (s_part, piece_len);
 			if (utf8_piece_len >= c->w - attr_x) {
 				slen = left;
@@ -389,7 +387,6 @@ R_API void r_cons_canvas_write(RConsCanvas *c, const char *s) {
 			c->attr = Color_RESET;
 			stamp_attr (c, c->y*c->w + attr_x, 0);
 			c->y++;
-
 			s++;
 			if (*s == '\0' || c->y  >= c->h) {
 				break;

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -38,6 +38,8 @@ R_API bool r_str_range_in(const char *r, ut64 addr);
 R_API int r_str_len_utf8(const char *s);
 R_API int r_str_len_utf8char(const char *s, int left);
 R_API void r_str_filter_zeroline(char *str, int len);
+R_API int r_str_utf8_codepoint (char* s, int left);
+R_API bool r_str_char_fullwidth (char* s, int left);
 R_API int r_str_write(int fd, const char *b);
 R_API void r_str_ncpy(char *dst, const char *src, int n);
 R_API void r_str_sanitize(char *c);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1509,7 +1509,6 @@ R_API int r_str_ansi_filter(char *str, char **out, int **cposs, int len) {
 	return j;
 }
 
-
 R_API char *r_str_ansi_crop(const char *str, ut32 x, ut32 y, ut32 x2, ut32 y2) {
 	char *r, *r_end, *ret;
 	const char *s, *s_start;


### PR DESCRIPTION
R2 doesn't support fullwidth characters (chars that take up two cells of the terminal), this can be reproduced easily by creating a comment like `CC 逆向工程
` and going to either visual disasm, graph or panels view. 
Sometimes the line right below gets duplicated, or the panels and graph layout break down:
![2018-07-02-190554_479x271_scrot](https://user-images.githubusercontent.com/3428362/42176946-02915682-7e2b-11e8-99da-7224b89dff79.png)

This is because those characters occupy two cells instead of one, thus messing up all layout calculations:
![2018-07-02-190820_212x65_scrot](https://user-images.githubusercontent.com/3428362/42177023-5b29c4f0-7e2b-11e8-970a-741d7a6200c9.png)

This pr is intended to fix those kind of things. Please, test it if you can, as there are a lot of corner cases. I fixed all of the things I could see, but I'm not sure I've got them all.