### PR TITLE
Add type propgation for args from caller to callee function

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -73,6 +73,7 @@ R_API RAnalVar *get_link_var(RAnal *anal, ut64 faddr, RAnalVar *var) {
 	char *var_def = sdb_get (anal->sdb_fcns, inst_key, 0);
 
 	if (!var_def) {
+		free (inst_key);
 		return NULL;
 	}
 	struct VarUsedType vut;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -674,10 +674,8 @@ static void type_cmd(RCore *core, const char *input) {
 		r_core_cmd0 (core, "aei");
 		r_core_cmd0 (core, "aeim");
 		r_reg_arena_push (core->anal->reg);
-		RList *fcns = r_list_clone (core->anal->fcns);
-		// Reversing list so that we get function in top-bottom call order
-		r_list_reverse (fcns);
-		r_list_foreach (fcns, it, fcn) {
+		// Iterating Reverse so that we get function in top-bottom call order
+		r_list_foreach_prev (core->anal->fcns, it, fcn) {
 			int ret = r_core_seek (core, fcn->addr, true);
 			if (!ret) {
 				continue;
@@ -688,7 +686,6 @@ static void type_cmd(RCore *core, const char *input) {
 				break;
 			}
 		}
-		r_list_free (fcns);
 		r_core_cmd0 (core, "aeim-");
 		r_core_cmd0 (core, "aei-");
 		r_core_seek (core, seek, true);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -674,7 +674,10 @@ static void type_cmd(RCore *core, const char *input) {
 		r_core_cmd0 (core, "aei");
 		r_core_cmd0 (core, "aeim");
 		r_reg_arena_push (core->anal->reg);
-		r_list_foreach (core->anal->fcns, it, fcn) {
+		RList *fcns = r_list_clone (core->anal->fcns);
+		// Reversing list so that we get function in top-bottom call order
+		r_list_reverse (fcns);
+		r_list_foreach (fcns, it, fcn) {
 			int ret = r_core_seek (core, fcn->addr, true);
 			if (!ret) {
 				continue;
@@ -685,6 +688,7 @@ static void type_cmd(RCore *core, const char *input) {
 				break;
 			}
 		}
+		r_list_free (fcns);
 		r_core_cmd0 (core, "aeim-");
 		r_core_cmd0 (core, "aei-");
 		r_core_seek (core, seek, true);


### PR DESCRIPTION
![arg_down_1](https://user-images.githubusercontent.com/18589720/42292200-80436bb4-7fee-11e8-8af3-9c0d6078d442.png)


As u could see from above pic that there is no type information available for argument **`s1`** in function **`funcarg`** , but we infer that by propgating type from **`main`**

Also added few test in r2r [#1387](https://github.com/radare/radare2-regressions/pull/1387)