### PR TITLE
two fixes for working with heap in 32bits

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1438,10 +1438,9 @@ static void get_hash_debug_file(RCore *core, const char *path, char *hash, int h
 		if (strstr (s->name, ".note.gnu.build-id")) {
 			if (r_buf_read_at (binfile->buf, s->vaddr + 16, buf, 20) == 20) {
 				break;
-			} else {
-				eprintf ("Cannot read from buffer\n");
-				goto out_error;
 			}
+			eprintf ("Cannot read from buffer\n");
+			goto out_error;
 		}
 	}
 	for (i = 0; i < 20; i++) {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1436,11 +1436,7 @@ static void get_hash_debug_file(RCore *core, const char *path, char *hash, int h
 	RBinSection *s;
 	r_list_foreach (sects, iter, s) {
 		if (strstr (s->name, ".note.gnu.build-id")) {
-			err = r_io_read_at (core->io, s->vaddr + 16, (ut8 *) buf, 20);
-			if (!err) {
-				eprintf ("Unable to read from memory\n");
-				goto out_error;
-			}
+			memcpy(buf, binfile->buf->buf + s->vaddr + 16, 20);
 			break;
 		}
 	}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1436,8 +1436,12 @@ static void get_hash_debug_file(RCore *core, const char *path, char *hash, int h
 	RBinSection *s;
 	r_list_foreach (sects, iter, s) {
 		if (strstr (s->name, ".note.gnu.build-id")) {
-			memcpy(buf, binfile->buf->buf + s->vaddr + 16, 20);
-			break;
+			if (r_buf_read_at (binfile->buf, s->vaddr + 16, buf, 20) == 20) {
+				break;
+			} else {
+				eprintf ("Cannot read from buffer\n");
+				goto out_error;
+			}
 		}
 	}
 	for (i = 0; i < 20; i++) {

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -964,9 +964,9 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena, GHT *in
 #if __GLIBC_MINOR__ > 25
 	GHT tcache_fd = GHT_MAX, tcache_tmp = GHT_MAX;
 #if HEAP32
-	*initial_brk = ( (brk_start >> 12) << 12 ) + sizeof(GH(RHeapTcache)) + MALLOC_ALIGNMENT + 0x418;
+	*initial_brk = ( (brk_start >> 12) << 12 ) + sizeof (GH(RHeapTcache)) + MALLOC_ALIGNMENT + 0x418;
 #else
-	*initial_brk = ( (brk_start >> 12) << 12 ) + sizeof(GH(RHeapTcache)) + MALLOC_ALIGNMENT;
+	*initial_brk = ( (brk_start >> 12) << 12 ) + sizeof (GH(RHeapTcache)) + MALLOC_ALIGNMENT;
 #endif
 #else
 	*initial_brk = (brk_start >> 12) << 12;

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -1051,7 +1051,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena, GHT *in
 		(void)r_io_read_at (core->io, brk_start + MALLOC_ALIGNMENT, (ut8 *)tcache, sizeof ( GH(RHeapTcache) ));
 		for (int i=0; i < TCACHE_MAX_BINS; i++){
 			if( tcache->counts[i] > 0 ) {
-				if ( (ut64)tcache->entries[i] - SZ*2 == (ut64)prev_chunk ){
+				if ( (ut64)tcache->entries[i] - SZ * 2 == (ut64)prev_chunk ){
 					is_free = true;
 					break;
 				}
@@ -1059,7 +1059,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena, GHT *in
 					tcache_fd = (ut64)tcache->entries[i];
 					for (int n = 1; n < tcache->counts[i]; n++) {
 						(void)r_io_read_at (core->io, tcache_fd, &tcache_tmp, sizeof ( GHT ) );
-						if ( (ut64)tcache_tmp - SZ*2 == (ut64)prev_chunk ) {
+						if ( (ut64)tcache_tmp - SZ * 2 == (ut64)prev_chunk ) {
 							is_free = true;
 							break;
 						}

--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -191,7 +191,7 @@ typedef struct r_malloc_state_tcache_32 {
 
 	int have_fast_chunks;                   /* have fast chunks */
 
-	ut32 fastbinsY[NFASTBINS];		/* array of fastchunks */
+	ut32 fastbinsY[NFASTBINS + 1];		/* array of fastchunks */
 	ut32 top; 				/* top chunk's base addr */
 	ut32 last_remainder;			/* remainder top chunk's addr */
 	ut32 bins[NBINS * 2 - 2];   		/* array of remainder free chunks */


### PR DESCRIPTION
fix heap dmh for tcache in 32bits (debian9 testing 32bits)
fix hash calculation of libc-dbg file (debian9 32bits)