### PR TITLE
travis-extrat-var: correctly escape variables

### DIFF
--- a/travis-extract-var.sh
+++ b/travis-extract-var.sh
@@ -5,7 +5,7 @@ print_var()
     VAR_NAME=$1
     VAR_VALUE=$2
     if [ "${VAR_VALUE}" != "" ] ; then
-	echo "${VAR_NAME}=${VAR_VALUE}"
+	printf "%s=%q\n" "${VAR_NAME}" "${VAR_VALUE}"
     fi
 }
 


### PR DESCRIPTION
* this is a long comment (just for test on travis)