### PR TITLE
Fix Invalid JSON when using izzj with no file opened

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -374,6 +374,9 @@ static bool bin_raw_strings(RCore *r, int mode, int va) {
 	}
 	if (!r->file) {
 		eprintf ("Core file not open\n");
+		if (IS_MODE_JSON (mode)) {
+			r_cons_print ("[]");
+		}
 		return false;
 	}
 	if (!bf) {


### PR DESCRIPTION
Prints `{"strings":}` otherwise.