### PR TITLE
Improve jmptbl edges, second try

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2828,7 +2828,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("graph.extension", "gif", &cb_graphformat, "Graph extension when using 'w' format (png, jpg, pdf, ps, svg, json)");
 	SETPREF ("graph.refs", "false", "Graph references in callgraphs (.agc*;aggi)");
 	SETI ("graph.edges", 2, "0=no edges, 1=simple edges, 2=avoid collisions");
-	SETPREF ("graph.altedgepos", "false", "Switch to alternative (very experimental) positioning of edges");
 	SETI ("graph.layout", 0, "Graph layout (0=vertical, 1=horizontal)");
 	SETI ("graph.linemode", 1, "Graph edges (0=diagonal, 1=square)");
 	SETPREF ("graph.font", "Courier", "Font for dot graphs");

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2647,6 +2647,9 @@ static int first_x_cmp (RGraphNode *ga, RGraphNode *gb) {
        if (b->y < a->y) {
 	       return -1;
        }
+       if (b->y > a->y) {
+		return 1;
+       }
        if (a->x < b->x) {
                return 1;
        } else if (a->x > b->x) {

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2726,7 +2726,7 @@ static void agraph_print_edges(RAGraph *g) {
 
 		bool many = r_list_length (neighbours) > 2;
 
-		if (many) {
+		if (many && !g->is_callgraph) {
 			ga->out_nodes->sorted = false;
 			r_list_sort (neighbours, first_x_cmp);
 		}
@@ -2775,7 +2775,7 @@ static void agraph_print_edges(RAGraph *g) {
 				ay = a->y + a->h;
 				by = b->y - 1;
 
-				if (many) {
+				if (many && !g->is_callgraph) {
 					int t = R_EDGES_X_INC + 2 * (neighbours->length + 1);
 					ax = a->is_dummy ? a->x : (a->x + a->w/2 + (t/2 - a_x_inc));
 					bendpoint = bx < ax ? neighbours->length - out_nth :  out_nth;
@@ -2786,7 +2786,7 @@ static void agraph_print_edges(RAGraph *g) {
 
 				if (!a->is_dummy && itn == neighbours->head && out_nth == 0 && bx > ax) {
 					a_x_inc += 4;
-					ax += many ? 0 : 4;
+					ax += (many && !g->is_callgraph) ? 0 : 4;
 				}
 				if (a->h < a->layer_height) {
 					r_cons_canvas_line (g->can, ax, ay, ax, ay + a->layer_height - a->h, &style);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -906,7 +906,6 @@ typedef struct r_ascii_graph_t {
 	bool is_tiny;
 	bool is_dis;
 	int edgemode;
-	bool altedgepos;
 	int mode;
 	bool is_callgraph;
 	bool is_interactive;

--- a/libr/util/graph.c
+++ b/libr/util/graph.c
@@ -182,11 +182,13 @@ R_API void r_graph_add_edge (RGraph *t, RGraphNode *from, RGraphNode *to) {
 
 R_API void r_graph_add_edge_at (RGraph *t, RGraphNode *from, RGraphNode *to, int nth) {
 	if (from && to) {
-		r_list_insert (from->out_nodes, nth, to);
-		r_list_append (from->all_neighbours, to);
-		r_list_append (to->in_nodes, from);
-		r_list_append (to->all_neighbours, from);
-		t->n_edges++;
+		if (!r_list_contains (from->out_nodes, to)) {
+			r_list_insert (from->out_nodes, nth, to);
+			r_list_append (from->all_neighbours, to);
+			r_list_append (to->in_nodes, from);
+			r_list_append (to->all_neighbours, from);
+			t->n_edges++;
+		}
 	}
 }
 


### PR DESCRIPTION
So, this is my second try at improving jump tables edges. Here are the main changes:

1. If a node has more than 2 edges, than those edges are centered in the middle of the node

2. If a node has more than 2 edges, those edges are sorted based on the x coordinate of their destination. This way they won't overlap when "bending". You can test this by moving the switch block with H and L and see how the bendpoints change accordingly.

3. Edges with the same origin and destination are merged, so that we have only one edge for multiple cases in one node, resulting in much more clear screen when there is a jumptable.

4. Killed the graph.altedgepos variable that I introduced in my last pr.

This is before:
![2018-07-08-024345_1920x1080_scrot](https://user-images.githubusercontent.com/3428362/42415732-cef7561e-8258-11e8-9107-8322b8138651.png)


This is after:
![2018-07-08-024254_1920x1080_scrot](https://user-images.githubusercontent.com/3428362/42415733-d43ee63c-8258-11e8-9283-7ebbc9fb4c41.png)


I tried to test it a lot, there are still a few minor things to fix but this should clear up all the major messes.