### PR TITLE
 Make yanking more compliant with bash conventions 

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -78,7 +78,7 @@ static void kill_word() {
 	I.buffer.length = strlen (I.buffer.data);
 }
 
-static void yank() {
+static void paste() {
 	if (I.clipboard) {
 		char *cursor = I.buffer.data + I.buffer.index;
 		int dist = (I.buffer.data + I.buffer.length) - cursor;
@@ -825,7 +825,7 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 		case 24:// ^X -- do nothing but store in prev = *buf
 			break;
 		case 25:// ^Y - paste
-			yank ();
+			paste ();
 			break;
 		case 14:// ^n
 			if (gcomp) {
@@ -1190,7 +1190,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		case 24:// ^X -- do nothing but store in prev = *buf
 			break;
 		case 25:// ^Y - paste
-			yank ();
+			paste ();
 			break;
 		case 14:// ^n
 			if (gcomp) {

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -57,6 +57,22 @@ static void backward_kill_word() {
 	}
 }
 
+static void kill_word() {
+	int i;
+	for (i = I.buffer.index + 1; i < I.buffer.length && is_word_break_char (I.buffer.data[i]); i++) {
+		/* Move the cursor index forward until we hit a non-word-break-character */
+	}
+	for (; i < I.buffer.length && !is_word_break_char (I.buffer.data[i]); i++) {
+		/* Move the cursor index forward we hit a word-break-character */
+	}
+	if (I.buffer.index >= I.buffer.length) {
+		I.buffer.length = I.buffer.index;
+	}
+	memmove (I.buffer.data + I.buffer.index, I.buffer.data + i,
+			I.buffer.length - i + 1);
+	I.buffer.length = strlen (I.buffer.data);
+}
+
 static void unix_word_rubout() {
 	int i;
 	if (I.buffer.index > 0) {
@@ -1220,6 +1236,10 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 				if (i < 0) {
 					I.buffer.index = 0;
 				}
+				break;
+			case 'D':
+			case 'd':
+				kill_word ();
 				break;
 			case 'F':
 			case 'f':

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -50,15 +50,9 @@ static void backward_kill_word() {
 		if (I.buffer.index > I.buffer.length) {
 			I.buffer.length = I.buffer.index;
 		}
-
 		len = I.buffer.index - i + 1;
 		free (I.clipboard);
-		I.clipboard = malloc (len + 1);
-		if (I.clipboard != NULL) {
-			strncpy (I.clipboard, I.buffer.data + i, len);
-			I.clipboard[len - 1] = '\0';
-		}
-
+		I.clipboard = r_str_ndup(I.buffer.data + i, len);
 		memmove (I.buffer.data + i, I.buffer.data + I.buffer.index,
 				I.buffer.length - I.buffer.index + 1);
 		I.buffer.length = strlen (I.buffer.data);
@@ -77,15 +71,9 @@ static void kill_word() {
 	if (I.buffer.index >= I.buffer.length) {
 		I.buffer.length = I.buffer.index;
 	}
-
 	len = i - I.buffer.index + 1;
 	free (I.clipboard);
-	I.clipboard = malloc (len + 1);
-	if (I.clipboard != NULL) {
-		strncpy (I.clipboard, I.buffer.data + I.buffer.index, len);
-		I.clipboard[len - 1] = '\0';
-	}
-
+	I.clipboard = r_str_ndup(I.buffer.data + I.buffer.index, len);
 	memmove (I.buffer.data + I.buffer.index, I.buffer.data + i, len);
 	I.buffer.length = strlen (I.buffer.data);
 }
@@ -93,7 +81,7 @@ static void kill_word() {
 static void yank() {
 	int len, dist;
 	char *cursor;
-	if (I.clipboard != NULL) {
+	if (I.clipboard) {
 		cursor = I.buffer.data + I.buffer.index;
 		dist = (I.buffer.data + I.buffer.length) - cursor;
 		len = strlen (I.clipboard);
@@ -839,7 +827,7 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 		case 24:// ^X -- do nothing but store in prev = *buf
 			break;
 		case 25:// ^Y - paste
-			yank();
+			yank ();
 			break;
 		case 14:// ^n
 			if (gcomp) {
@@ -1204,7 +1192,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		case 24:// ^X -- do nothing but store in prev = *buf
 			break;
 		case 25:// ^Y - paste
-			yank();
+			yank ();
 			break;
 		case 14:// ^n
 			if (gcomp) {

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -34,7 +34,7 @@ static inline bool is_word_break_char(char ch) {
 
 /* https://www.gnu.org/software/bash/manual/html_node/Commands-For-Killing.html */
 static void backward_kill_word() {
-	int i;
+	int i, len;
 	if (I.buffer.index > 0) {
 		for (i = I.buffer.index - 1; i > 0 && is_word_break_char (I.buffer.data[i]); i--) {
 			/* Move the cursor index back until we hit a non-word-break-character */
@@ -50,6 +50,15 @@ static void backward_kill_word() {
 		if (I.buffer.index > I.buffer.length) {
 			I.buffer.length = I.buffer.index;
 		}
+
+		len = I.buffer.index - i + 1;
+		free (I.clipboard);
+		I.clipboard = malloc (len + 1);
+		if (I.clipboard != NULL) {
+			strncpy (I.clipboard, I.buffer.data + i, len);
+			I.clipboard[len - 1] = '\0';
+		}
+
 		memmove (I.buffer.data + i, I.buffer.data + I.buffer.index,
 				I.buffer.length - I.buffer.index + 1);
 		I.buffer.length = strlen (I.buffer.data);
@@ -58,7 +67,7 @@ static void backward_kill_word() {
 }
 
 static void kill_word() {
-	int i;
+	int i, len;
 	for (i = I.buffer.index + 1; i < I.buffer.length && is_word_break_char (I.buffer.data[i]); i++) {
 		/* Move the cursor index forward until we hit a non-word-break-character */
 	}
@@ -68,9 +77,31 @@ static void kill_word() {
 	if (I.buffer.index >= I.buffer.length) {
 		I.buffer.length = I.buffer.index;
 	}
-	memmove (I.buffer.data + I.buffer.index, I.buffer.data + i,
-			I.buffer.length - i + 1);
+
+	len = i - I.buffer.index + 1;
+	free (I.clipboard);
+	I.clipboard = malloc (len + 1);
+	if (I.clipboard != NULL) {
+		strncpy (I.clipboard, I.buffer.data + I.buffer.index, len);
+		I.clipboard[len - 1] = '\0';
+	}
+
+	memmove (I.buffer.data + I.buffer.index, I.buffer.data + i, len);
 	I.buffer.length = strlen (I.buffer.data);
+}
+
+static void yank() {
+	int len, dist;
+	char *cursor;
+	if (I.clipboard != NULL) {
+		cursor = I.buffer.data + I.buffer.index;
+		dist = (I.buffer.data + I.buffer.length) - cursor;
+		len = strlen (I.clipboard);
+		I.buffer.length += len;
+		memmove (cursor + len, cursor, dist);
+		memcpy (cursor, I.clipboard, len);
+		I.buffer.index += len;
+	}
 }
 
 static void unix_word_rubout() {
@@ -808,16 +839,7 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 		case 24:// ^X -- do nothing but store in prev = *buf
 			break;
 		case 25:// ^Y - paste
-			if (I.clipboard != NULL) {
-				I.buffer.length += strlen (I.clipboard);
-				// TODO: support endless strings
-				if (I.buffer.length < R_LINE_BUFSIZE) {
-					I.buffer.index = I.buffer.length;
-					strcat (I.buffer.data, I.clipboard);
-				} else {
-					I.buffer.length -= strlen (I.clipboard);
-				}
-			}
+			yank();
 			break;
 		case 14:// ^n
 			if (gcomp) {
@@ -1182,16 +1204,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		case 24:// ^X -- do nothing but store in prev = *buf
 			break;
 		case 25:// ^Y - paste
-			if (I.clipboard != NULL) {
-				I.buffer.length += strlen (I.clipboard);
-				// TODO: support endless strings
-				if (I.buffer.length < R_LINE_BUFSIZE) {
-					I.buffer.index = I.buffer.length;
-					strcat (I.buffer.data, I.clipboard);
-				} else {
-					I.buffer.length -= strlen (I.clipboard);
-				}
-			}
+			yank();
 			break;
 		case 14:// ^n
 			if (gcomp) {

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -52,7 +52,7 @@ static void backward_kill_word() {
 		}
 		len = I.buffer.index - i + 1;
 		free (I.clipboard);
-		I.clipboard = r_str_ndup(I.buffer.data + i, len);
+		I.clipboard = r_str_ndup (I.buffer.data + i, len);
 		memmove (I.buffer.data + i, I.buffer.data + I.buffer.index,
 				I.buffer.length - I.buffer.index + 1);
 		I.buffer.length = strlen (I.buffer.data);
@@ -73,18 +73,16 @@ static void kill_word() {
 	}
 	len = i - I.buffer.index + 1;
 	free (I.clipboard);
-	I.clipboard = r_str_ndup(I.buffer.data + I.buffer.index, len);
+	I.clipboard = r_str_ndup (I.buffer.data + I.buffer.index, len);
 	memmove (I.buffer.data + I.buffer.index, I.buffer.data + i, len);
 	I.buffer.length = strlen (I.buffer.data);
 }
 
 static void yank() {
-	int len, dist;
-	char *cursor;
 	if (I.clipboard) {
-		cursor = I.buffer.data + I.buffer.index;
-		dist = (I.buffer.data + I.buffer.length) - cursor;
-		len = strlen (I.clipboard);
+		char *cursor = I.buffer.data + I.buffer.index;
+		int dist = (I.buffer.data + I.buffer.length) - cursor;
+		int len = strlen (I.clipboard);
 		I.buffer.length += len;
 		memmove (cursor + len, cursor, dist);
 		memcpy (cursor, I.clipboard, len);


### PR DESCRIPTION
In my comment on #10656 I mentioned that `kill_word` should move the killed region into the kill ring (emacs terminology, it's called "clipboard" in the code). I implemented this behavior for both `kill_word` and `kill_backwards_word`, as well as making the actual yanking more compliant (yanks to the current index, rather than to the end of the line).

Expect more tomorrow, as I'm planning to do more work to make Dietline more compliant with the readline conventions.