### PR TITLE
now it's way easier to move around multiple panels.

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -1730,6 +1730,12 @@ repeat:
 		// sleep (1);
 		break;
 	}
+	const int keyNum = key - 48;
+	if ('0' <= key && key <= '9' && keyNum < panels->n_panels) {
+		panels->panel[panels->curnode].refresh = true;
+		panels->curnode = keyNum;
+		panels->panel[panels->curnode].refresh = true;
+	}
 	goto repeat;
 exit:
 	core->print->cur = originCursor;


### PR DESCRIPTION
tired of moving around multiple panels you opened or split not-knowingly?

now you can push 0 ~ 9 to move to n-th panel. accidentally opened up more than 10 panels? i don't know, but that's way too many anyway and you can just go to 9th first then tab tab and tab from there :P 