### PR TITLE
Fix Segfaults when resize signals occur with running background tasks

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3574,7 +3574,6 @@ R_API int r_core_cmd(RCore *core, const char *cstr, int log) {
 		}
 		rcmd = ptr + 1;
 	}
-	r_th_lock_leave (core->lock);
 	/* run pending analysis commands */
 	run_pending_anal (core);
 	core->cmd_depth++;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2036,6 +2036,7 @@ R_API bool r_core_init(RCore *core) {
 	core->tasks = r_list_newf ((RListFree)r_core_task_free);
 	core->tasks_queue = r_list_new ();
 	core->oneshot_queue = r_list_newf (free);
+	core->oneshots_enqueued = 0;
 	core->tasks_lock = r_th_lock_new (false);
 	core->tasks_running = 0;
 	core->oneshot_running = false;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2035,6 +2035,7 @@ R_API bool r_core_init(RCore *core) {
 	core->task_id_next = 0;
 	core->tasks = r_list_newf ((RListFree)r_core_task_free);
 	core->tasks_queue = r_list_new ();
+	core->oneshot_queue = r_list_newf (free);
 	core->tasks_lock = r_th_lock_new (false);
 	core->tasks_running = 0;
 	core->main_task = r_core_task_new (core, false, NULL, NULL, NULL);
@@ -2241,6 +2242,7 @@ R_API RCore *r_core_fini(RCore *c) {
 	r_list_free (c->scriptstack);
 	r_list_free (c->tasks);
 	r_list_free (c->tasks_queue);
+	r_list_free (c->oneshot_queue);
 	r_th_lock_free (c->tasks_lock);
 	c->rcmd = r_cmd_free (c->rcmd);
 	r_list_free (c->cmd_descriptors);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2038,6 +2038,7 @@ R_API bool r_core_init(RCore *core) {
 	core->oneshot_queue = r_list_newf (free);
 	core->tasks_lock = r_th_lock_new (false);
 	core->tasks_running = 0;
+	core->oneshot_running = false;
 	core->main_task = r_core_task_new (core, false, NULL, NULL, NULL);
 	r_list_append (core->tasks, core->main_task);
 	core->current_task = NULL;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3075,6 +3075,10 @@ static void visual_refresh(RCore *core) {
 	}
 }
 
+static void visual_refresh_oneshot(RCore *core) {
+	r_core_task_enqueue_oneshot (core, (RCoreTaskOneShot) visual_refresh, core);
+}
+
 R_API int r_core_visual(RCore *core, const char *input) {
 	const char *cmdprompt, *teefile;
 	ut64 scrseek;
@@ -3165,8 +3169,9 @@ dodo:
 		if (wheel) {
 			r_cons_enable_mouse (true);
 		}
+		core->cons->event_resize = NULL; // avoid running old event with new data
 		core->cons->event_data = core;
-		core->cons->event_resize = (RConsEvent) visual_refresh;
+		core->cons->event_resize = (RConsEvent) visual_refresh_oneshot;
 		flags = core->print->flags;
 		color = r_config_get_i (core->config, "scr.color");
 		if (color) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -230,6 +230,7 @@ typedef struct r_core_t {
 	int task_id_next;
 	RList *tasks;
 	RList *tasks_queue;
+	RList *oneshot_queue;
 	RCoreTask *current_task;
 	RCoreTask *main_task;
 	RThreadLock *tasks_lock;
@@ -735,6 +736,8 @@ typedef struct r_core_task_t {
 	RCoreTaskCallback cb;
 } RCoreTask;
 
+typedef void (*RCoreTaskOneShot)(void *);
+
 R_API RCoreTask *r_core_task_get(RCore *core, int id);
 R_API void r_core_task_print(RCore *core, RCoreTask *task, int mode);
 R_API void r_core_task_list(RCore *core, int mode);
@@ -742,6 +745,7 @@ R_API const char *r_core_task_status(RCoreTask *task);
 R_API RCoreTask *r_core_task_new(RCore *core, bool create_cons, const char *cmd, RCoreTaskCallback cb, void *user);
 R_API void r_core_task_free(RCoreTask *task);
 R_API void r_core_task_enqueue(RCore *core, RCoreTask *task);
+R_API void r_core_task_enqueue_oneshot(RCore *core, RCoreTaskOneShot func, void *user);
 R_API int r_core_task_run_sync(RCore *core, RCoreTask *task);
 R_API void r_core_task_sync_begin(RCore *core);
 R_API void r_core_task_sync_end(RCore *core);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -231,6 +231,7 @@ typedef struct r_core_t {
 	RList *tasks;
 	RList *tasks_queue;
 	RList *oneshot_queue;
+	int oneshots_enqueued;
 	RCoreTask *current_task;
 	RCoreTask *main_task;
 	RThreadLock *tasks_lock;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -235,6 +235,7 @@ typedef struct r_core_t {
 	RCoreTask *main_task;
 	RThreadLock *tasks_lock;
 	int tasks_running;
+	bool oneshot_running;
 	int cmd_depth;
 	int max_cmd_depth;
 	ut8 switch_file_view;

--- a/libr/include/r_util/r_signal.h
+++ b/libr/include/r_util/r_signal.h
@@ -11,6 +11,10 @@ R_API int r_signal_from_string (const char *str);
 /* Return NULL if signal with `code` not found. */
 R_API const char* r_signal_to_string (int code);
 
+#if HAVE_PTHREAD
+R_API void r_signal_sigmask(int how, const sigset_t *newmask, sigset_t *oldmask);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/libr/util/signal.c
+++ b/libr/util/signal.c
@@ -66,3 +66,9 @@ R_API const char* r_signal_to_string (int code) {
 	}
 	return NULL;
 }
+
+#if HAVE_PTHREAD
+R_API void r_signal_sigmask(int how, const sigset_t *newmask, sigset_t *oldmask) {
+	pthread_sigmask (how, newmask, oldmask);
+}
+#endif

--- a/libr/util/thread.c
+++ b/libr/util/thread.c
@@ -21,9 +21,8 @@ static void *_r_th_launcher(void *_th) {
 		r_th_lock_wait (th->lock);
 	}
 #endif
+	r_th_lock_enter (th->lock);
 	do {
-		// CID 1378280:  API usage errors  (LOCK)
-		// "r_th_lock_leave" unlocks "th->lock->lock" while it is unlocked.
 		r_th_lock_leave (th->lock);
 		th->running = true;
 		ret = th->fun (th);


### PR DESCRIPTION
The idea is to enqueue mini-tasks (so-called oneshots) for the stuff that should be done on a signal. These oneshots are much lighter than real tasks, because they are not run in an own thread, but they also cannot be scheduled, they simply run until they are done.

I had to block signals around locking core->tasks_lock to prevent deadlocks when a signal handler is called while it is still locked.