### PR TITLE
Add r_core_bind_cons()

### DIFF
--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -715,6 +715,7 @@ static int cmd_cmp(void *data, const char *input) {
 		if (!r_core_file_open (core2, file2, 0, 0LL)) {
 			eprintf ("Cannot open diff file '%s'\n", file2);
 			r_core_free (core2);
+			r_core_bind_cons (core);
 			return false;
 		}
 		// TODO: must replicate on core1 too
@@ -729,6 +730,7 @@ static int cmd_cmp(void *data, const char *input) {
 		/* exchange a segfault with a memleak */
 		core2->config = NULL;
 		r_core_free (core2);
+		r_core_bind_cons (core);
 	}
 	break;
 	case 'u': // "cu"

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -183,7 +183,6 @@ typedef struct r_core_t {
 	RCoreFile *file;
 	RList *files;
 	RNum *num;
-	RNum *old_num;
 	RLib *lib;
 	RCmd *rcmd;
 	RCmdDescriptor root_cmd_descriptor;
@@ -278,6 +277,7 @@ R_API RBin *r_core_get_bin (RCore *core);
 R_API RConfig *r_core_get_config (RCore *core);
 R_API RAsmOp *r_core_disassemble (RCore *core, ut64 addr);
 R_API bool r_core_init(RCore *core);
+R_API void r_core_bind_cons(RCore *core); // to restore pointers in cons
 R_API RCore *r_core_new(void);
 R_API RCore *r_core_free(RCore *core);
 R_API RCore *r_core_fini(RCore *c);


### PR DESCRIPTION
Fixes #10710

This function can be used to explicitly re-connect a core to cons. I also removed the old_num in core, because this is handled by the function as well.