### PR TITLE
Fix #10719 line graph not correctly

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2125,6 +2125,23 @@ static void get_bbupdate(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 	core->anal->stackptr = saved_stackptr;
 }
 
+static void delete_dup_edges (RAGraph *g) {
+	RListIter *iter, *in_iter, *in_iter2;
+	RGraphNode *n, *a, *b;
+	r_list_foreach (g->graph->nodes, iter, n) {
+		r_list_foreach (n->out_nodes, in_iter, a) {
+			r_list_foreach (n->out_nodes, in_iter2, b) {
+				if (in_iter == in_iter2) {
+					continue;
+				}
+				if (a->idx == b->idx) {
+					r_graph_del_edge (g->graph, n, b);
+				}
+			}
+		}
+	}
+}
+
 /* build the RGraph inside the RAGraph g, starting from the Basic Blocks */
 static int get_bbnodes(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 	RAnalBlock *bb;
@@ -2207,6 +2224,7 @@ static int get_bbnodes(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 		}
 	}
 
+	delete_dup_edges (g);
 	ret = true;
 
 cleanup:

--- a/libr/util/graph.c
+++ b/libr/util/graph.c
@@ -182,13 +182,11 @@ R_API void r_graph_add_edge (RGraph *t, RGraphNode *from, RGraphNode *to) {
 
 R_API void r_graph_add_edge_at (RGraph *t, RGraphNode *from, RGraphNode *to, int nth) {
 	if (from && to) {
-		if (!r_list_contains (from->out_nodes, to)) {
-			r_list_insert (from->out_nodes, nth, to);
-			r_list_append (from->all_neighbours, to);
-			r_list_append (to->in_nodes, from);
-			r_list_append (to->all_neighbours, from);
-			t->n_edges++;
-		}
+		r_list_insert (from->out_nodes, nth, to);
+		r_list_append (from->all_neighbours, to);
+		r_list_append (to->in_nodes, from);
+		r_list_append (to->all_neighbours, from);
+		t->n_edges++;
 	}
 }
 


### PR DESCRIPTION
Closes #10719 
Basically the fix was letting r2 set up duplicate edges AT FIRST, 
then deleting them after r2 set up backedges.

Not allowing dup edges was interfering with backedges or edges drawing in general, in particular cases (where there was a backedge from a direct neighbour).