### PR TITLE
Fix #10690 + fix delete_dup_edges 

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3365,10 +3365,10 @@ static char *ds_esc_str(RDisasmState *ds, const char *str, int len, const char *
 }
 
 static void ds_print_str(RDisasmState *ds, const char *str, int len, ut64 refaddr) {
-	const char *prefix;
-	if (!r_bin_string_filter (ds->core->bin, str, refaddr)) {
+	if (ds->core->flags->realnames || !r_bin_string_filter (ds->core->bin, str, refaddr)) {
 		return;
 	}
+	const char *prefix;
 	char *escstr = ds_esc_str (ds, str, len, &prefix);
 	if (escstr) {
 		bool inv = ds->show_color && !ds->show_emu_strinv;

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2126,16 +2126,17 @@ static void get_bbupdate(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 }
 
 static void delete_dup_edges (RAGraph *g) {
-	RListIter *iter, *in_iter, *in_iter2;
+	RListIter *it, *in_it, *in_it2, *in_it2_tmp;
 	RGraphNode *n, *a, *b;
-	r_list_foreach (g->graph->nodes, iter, n) {
-		r_list_foreach (n->out_nodes, in_iter, a) {
-			r_list_foreach (n->out_nodes, in_iter2, b) {
-				if (in_iter == in_iter2) {
-					continue;
-				}
+	r_list_foreach (g->graph->nodes, it, n) {
+		r_list_foreach (n->out_nodes, in_it, a) {
+			for (in_it2 = in_it->n; in_it2 && (b = in_it2->data, in_it2_tmp = in_it2->n, 1); in_it2 = in_it2_tmp) {
 				if (a->idx == b->idx) {
-					r_graph_del_edge (g->graph, n, b);
+					r_list_delete (n->out_nodes, in_it2);
+					r_list_delete_data (n->all_neighbours, b);
+					r_list_delete_data (b->in_nodes, n);
+					r_list_delete_data (b->all_neighbours, n);
+					g->graph->n_edges--;
 				}
 			}
 		}


### PR DESCRIPTION
Closes #10690 

Before:
![image](https://user-images.githubusercontent.com/3428362/42707681-58eb664a-86db-11e8-9f90-e9a34e80d487.png)


After:
![image](https://user-images.githubusercontent.com/3428362/42707594-01108a40-86db-11e8-8719-8ed5ce7b38d2.png)


Also, there were some errors in the delete_dup_edges function I introduced in my last pr:

1. ASAN gave a use after free, which was fixed by using r_list_foreach_safe and a bit of iterator pointer juggling

2. It made more than half of useless checks. Now it takes at least half the time (however I didn't measure how much it impacted overall performance)