### PR TITLE
Some improvements on malloc calls

### DIFF
--- a/libr/anal/data.c
+++ b/libr/anal/data.c
@@ -96,8 +96,7 @@ R_API char *r_anal_data_to_string(RAnalData *d, RConsPrintablePalette *pal) {
 
 	if (!d) return NULL;
 
-	line = malloc (mallocsz);
-	if (!line) {
+	if (!(line = malloc (mallocsz))) {
 		eprintf ("Cannot allocate %d byte(s)\n", mallocsz);
 		return NULL;
 	}
@@ -214,15 +213,13 @@ R_API RAnalData *r_anal_data_new_string(ut64 addr, const char *p, int len, int t
 	if (type == R_ANAL_DATA_TYPE_WIDE_STRING) {
 		/* TODO: add support for wide strings */
 	} else {
-		ad->str = malloc (len + 1);
-		if (!ad->str) {
+		if (!(ad->str = malloc (len + 1))) {
 			r_anal_data_free (ad);
 			return NULL;
 		}
 		memcpy (ad->str, p, len);
 		ad->str[len] = 0;
-		ad->buf = malloc (len + 1);
-		if (!ad->buf) {
+		if (!(ad->buf = malloc (len + 1))) {
 			r_anal_data_free (ad);
 			eprintf ("Cannot allocate %d byte(s)\n", len + 1);
 			return NULL;

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -676,7 +676,10 @@ static int node_match_functions(const RAnal *anal, const RFlirtNode *root_node) 
 		}
 
 		int func_size = r_anal_fcn_size (func);
-		func_buf = malloc (func_size);
+		if (!(func_buf = malloc (func_size))) {
+			ret = false;
+			goto exit;
+		}
 		if (!anal->iob.read_at (anal->iob.io, func->addr, func_buf, func_size)) {
 			eprintf ("Couldn't read function\n");
 			ret = false;
@@ -1342,8 +1345,7 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 		}
 	}
 
-	name = malloc (header->library_name_len + 1);
-	if (!name) {
+	if (!(name = malloc (header->library_name_len + 1))) {
 		goto exit;
 	}
 
@@ -1361,7 +1363,9 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 #endif
 
 	size = r_buf_size (flirt_buf) - flirt_buf->cur;
-	buf = malloc (size);
+	if (!(buf = malloc (size))) {
+		goto exit;
+	}
 	if (r_buf_read_at (flirt_buf, flirt_buf->cur, buf, size) != size) {
 		goto exit;
 	}

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -410,7 +410,7 @@ static int handle_bb_cf_linear_sweep (RAnal *anal, RAnalState *state) {
 			result = R_ANAL_RET_ERROR;
 			break;
 		case R_ANAL_OP_TYPE_JMP:
-			if (paddr64 = malloc (sizeof(ut64))) {
+			if ((paddr64 = malloc (sizeof(ut64)))) {
 				*paddr64 = bb->jump;
 				IFDBG eprintf (" - Handling a jmp @ 0x%04"PFMT64x", adding for future visit\n", addr);
 				r_list_append (nodes->cfg_node_addrs, paddr64);
@@ -418,12 +418,12 @@ static int handle_bb_cf_linear_sweep (RAnal *anal, RAnalState *state) {
 			result = R_ANAL_RET_END;
 			break;
 		case R_ANAL_OP_TYPE_CJMP:
-			if (paddr64 = malloc (sizeof(ut64))) {
+			if ((paddr64 = malloc (sizeof(ut64)))) {
 				*paddr64 = bb->jump;
 				IFDBG eprintf (" - Handling a bb->jump @ 0x%04"PFMT64x", adding 0x%04"PFMT64x" for future visit\n", addr, *paddr64);
 				r_list_append (nodes->cfg_node_addrs, paddr64);
 			}
-			if (paddr64 = malloc (sizeof(ut64))) {
+			if ((paddr64 = malloc (sizeof(ut64)))) {
 				*paddr64 = bb->fail;
 				IFDBG eprintf (" - Handling a bb->fail @ 0x%04"PFMT64x", adding 0x%04"PFMT64x" for future visit\n", addr, *paddr64);
 				r_list_append (nodes->cfg_node_addrs, paddr64);
@@ -439,7 +439,7 @@ static int handle_bb_cf_linear_sweep (RAnal *anal, RAnalState *state) {
 				r_list_foreach (bb->switch_op->cases, iter, caseop) {
 					ut64 * paddr64;
 					if (caseop) {
-						if (paddr64 = malloc (sizeof(ut64))) {
+						if ((paddr64 = malloc (sizeof(ut64)))) {
 							*paddr64 = caseop->jump;
 							IFDBG eprintf ("Adding 0x%04"PFMT64x" for future visit\n", *paddr64);
 							r_list_append (nodes->cfg_node_addrs, paddr64);

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -47,7 +47,7 @@ typedef struct r_anal_ex_java_lin_sweep {
 ut64 METHOD_START = 0;
 
 // XXX - TODO add code in the java_op that is aware of when it is in a
-// switch statement, like in the shlr/java/code.c so that this does not 
+// switch statement, like in the shlr/java/code.c so that this does not
 // report bad blocks.  currently is should be easy to ignore these blocks,
 // in output for the pdj
 
@@ -410,19 +410,20 @@ static int handle_bb_cf_linear_sweep (RAnal *anal, RAnalState *state) {
 			result = R_ANAL_RET_ERROR;
 			break;
 		case R_ANAL_OP_TYPE_JMP:
-			paddr64 = malloc (sizeof(ut64));
-			*paddr64 = bb->jump;
-			IFDBG eprintf (" - Handling a jmp @ 0x%04"PFMT64x", adding for future visit\n", addr);
-			r_list_append (nodes->cfg_node_addrs, paddr64);
+			if (paddr64 = malloc (sizeof(ut64))) {
+				*paddr64 = bb->jump;
+				IFDBG eprintf (" - Handling a jmp @ 0x%04"PFMT64x", adding for future visit\n", addr);
+				r_list_append (nodes->cfg_node_addrs, paddr64);
+			}
 			result = R_ANAL_RET_END;
 			break;
 		case R_ANAL_OP_TYPE_CJMP:
-			paddr64 = malloc (sizeof(ut64));
-			*paddr64 = bb->jump;
-			IFDBG eprintf (" - Handling a bb->jump @ 0x%04"PFMT64x", adding 0x%04"PFMT64x" for future visit\n", addr, *paddr64);
-			r_list_append (nodes->cfg_node_addrs, paddr64);
-			paddr64 = malloc (sizeof(ut64));
-			if (paddr64) {
+			if (paddr64 = malloc (sizeof(ut64))) {
+				*paddr64 = bb->jump;
+				IFDBG eprintf (" - Handling a bb->jump @ 0x%04"PFMT64x", adding 0x%04"PFMT64x" for future visit\n", addr, *paddr64);
+				r_list_append (nodes->cfg_node_addrs, paddr64);
+			}
+			if (paddr64 = malloc (sizeof(ut64))) {
 				*paddr64 = bb->fail;
 				IFDBG eprintf (" - Handling a bb->fail @ 0x%04"PFMT64x", adding 0x%04"PFMT64x" for future visit\n", addr, *paddr64);
 				r_list_append (nodes->cfg_node_addrs, paddr64);
@@ -438,10 +439,11 @@ static int handle_bb_cf_linear_sweep (RAnal *anal, RAnalState *state) {
 				r_list_foreach (bb->switch_op->cases, iter, caseop) {
 					ut64 * paddr64;
 					if (caseop) {
-						paddr64 = malloc (sizeof(ut64));
-						*paddr64 = caseop->jump;
-						IFDBG eprintf ("Adding 0x%04"PFMT64x" for future visit\n", *paddr64);
-						r_list_append (nodes->cfg_node_addrs, paddr64);
+						if (paddr64 = malloc (sizeof(ut64))) {
+							*paddr64 = caseop->jump;
+							IFDBG eprintf ("Adding 0x%04"PFMT64x" for future visit\n", *paddr64);
+							r_list_append (nodes->cfg_node_addrs, paddr64);
+						}
 					}
 				}
 			}
@@ -563,7 +565,7 @@ static int analyze_method(RAnal *anal, RAnalFunction *fcn, RAnalState *state) {
 	java_new_method (fcn->addr);
 	state->current_fcn = fcn;
 	// Not a resource leak.  Basic blocks should be stored in the state->fcn
-	// TODO: ? RList *bbs = 
+	// TODO: ? RList *bbs =
 	r_anal_ex_perform_analysis (anal, state, fcn->addr);
 	return state->anal_ret_val;
 }
@@ -585,8 +587,7 @@ static int java_analyze_fns_from_buffer( RAnal *anal, ut64 start, ut64 end, int 
 		end = start + buf_len;
 	}
 
-	buffer = malloc (buf_len);
-	if (!buffer) {
+	if (!(buffer = malloc (buf_len))) {
 		return R_ANAL_RET_ERROR;
 	}
 
@@ -736,7 +737,7 @@ static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 		java_switch_op (anal, op, addr, data, len);
 		// IN_SWITCH_OP = 1;
 	}
-	/* TODO: 
+	/* TODO:
 	// not sure how to handle the states for IN_SWITCH_OP, SWITCH_OP_CASES,
 	// and NUM_CASES_SEEN, because these are dependent on whether or not we
 	// are in a switch, and given the non-reentrant state of opcode analysis
@@ -789,7 +790,7 @@ static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 static RAnalOp * java_op_from_buffer(RAnal *anal, RAnalState *state, ut64 addr) {
 
 	RAnalOp *op = r_anal_op_new ();
-	//  get opcode size 
+	//  get opcode size
 	if (!op) return 0;
 	memset (op, '\0', sizeof (RAnalOp));
 	java_op (anal, op, addr, state->buffer, state->len - (addr - state->start) );

--- a/libr/asm/arch/arm/armass.c
+++ b/libr/asm/arch/arm/armass.c
@@ -204,7 +204,7 @@ static st8 iflag(char *input) {
 	st8 res = 0;
 	ut8 i;
 	r_str_case (input, false);
-	
+
 	for (i = 0; i < strlen(input); i++) {
 		switch (input[i]) {
 		case 'a':
@@ -227,7 +227,7 @@ static ut64 cqcheck(char **input) {
 	ut64 res = 0;
 	int i;
 	ut8 offset = 0;
-	
+
 	const char *conds[] = {
 		"eq", "ne", "cs", "cc", "mi", "pl", "vs", "vc",
 		"hi", "ls", "ge", "lt", "gt", "le", "al", "nv", 0
@@ -251,7 +251,7 @@ static ut64 cqcheck(char **input) {
 		*input += 2;
 		offset += 2;
 	}
-	
+
 	if (**input == '\0') {
 		return res;
 	}
@@ -261,7 +261,7 @@ static ut64 cqcheck(char **input) {
 
 static ut64 opmask(char *input, char *opcode, ut64 allowed_mask) {
 	ut64 res = 0;
-	
+
 	r_str_case (input, false);
 	if (strlen (opcode) > strlen (input)) {
 		return 0;
@@ -270,7 +270,7 @@ static ut64 opmask(char *input, char *opcode, ut64 allowed_mask) {
 		input += strlen (opcode);
 		res |= M_BIT;
 		res |= cqcheck (&input);
-		
+
 		if ((*input == 's') && (S_BIT & allowed_mask)) {
 			res |= S_BIT;
 			input++;
@@ -469,7 +469,7 @@ static ut64 getnumbang(const char *str) {
 	free (temp);
 	return res; // err propagates
 }
-	
+
 static ut32 getimmed8(const char *str) {
 	ut32 num = getnum (str);
 	if (err) {
@@ -644,13 +644,11 @@ static st32 getlistmask(char *input) {
 	char *temp = NULL;
 	char *temp2 = NULL;
 	char *otemp = NULL;
-	temp2 = malloc (strlen (input) + 1);
-	if (!temp2) {
+	if (!(temp2 = malloc (strlen (input) + 1))) {
 		res = -1;
 		goto end;
 	}
-	temp = (char *)malloc (strlen (input) + 1);
-	if (!temp) {
+	if (!(temp = (char *)malloc (strlen (input) + 1))) {
 		res = -1;
 		goto end;
 	}
@@ -707,7 +705,7 @@ static st32 getregmemstart(const char *input) {
 	input++;
 	return getreg (input);
 }
-	
+
 static st32 getregmemstartend(const char *input) {
 	st32 res;
 	if (!input || (strlen (input) < 2) || (*input != '[') || !r_str_endswith (input, "]")) {
@@ -722,7 +720,7 @@ static st32 getregmemstartend(const char *input) {
 	free (temp);
 	return res;
 }
-	
+
 static st32 getregmemend(const char *input) {
 	st32 res;
 	if (!input || !*input || !r_str_endswith (input, "]")) {
@@ -737,10 +735,10 @@ static st32 getregmemend(const char *input) {
 	free (temp);
 	return res;
 }
-	
+
 static st32 getreglist(const char *input) {
 	st32 res;
-	
+
 	if (!input || (strlen (input) < 2) || (*input != '{') || !r_str_endswith (input, "}")) {
 		return -1;
 	}
@@ -823,7 +821,7 @@ static int getcoproc(const char *str) {
 
 static int getcoprocreg(const char *str) {
 	char *ep;
-	
+
 	if (!str || !*str) {
 		return -1;
 	}
@@ -847,8 +845,8 @@ static ut8 interpret_msrbank (char *str, ut8 *spsr) {
 		*spsr = 1;
 	} else {
 		*spsr = 0;
-	}		
-	
+	}
+
 	if (r_str_startswith (str, "apsr_")) {
 		if (!(strcmp (str+5, "g"))) {
 			return 0x4;
@@ -876,7 +874,7 @@ static ut8 interpret_msrbank (char *str, ut8 *spsr) {
 	}
 	return 0;
 }
-		
+
 static ut32 thumb_getshift(const char *str) {
 	// only immediate shifts are ever used by thumb-2. Bit positions are different from ARM.
 	const char *shifts[] = {
@@ -890,16 +888,16 @@ static ut32 thumb_getshift(const char *str) {
 	err = false;
 	ut32 argn;
 	ut32 i;
-	
+
 	r_str_case (type,true);
-	
+
 	if (!strcmp (type, shifts[5])) {
 		// handle RRX alias case
-		res |= 3 << 12;	
+		res |= 3 << 12;
 		free (type);
 		return res;
 	}
-	
+
 	space = strchr (type, ' ');
 	if (!space) {
 		free (type);
@@ -908,7 +906,7 @@ static ut32 thumb_getshift(const char *str) {
 	}
 	*space = 0;
 	arg = strdup (++space);
-	
+
 	for (i = 0; shifts[i]; i++) {
 		if (!strcmp (type, shifts[i])) {
 			shift = true;
@@ -922,7 +920,7 @@ static ut32 thumb_getshift(const char *str) {
 		return 0;
 	}
 	res |= i << 12;
-		
+
 	argn = getnum (arg);
 	if (err || argn > 32) {
 		err = true;
@@ -957,8 +955,8 @@ void collect_list(char *input[]) {
 	if (input[0] == NULL) {
 		return;
 	}
-	char *temp  = malloc (500);
-	if (!temp) {
+	char *temp;
+	if (!(temp = malloc (500))) {
 		return;
 	}
 	temp[0] = 0;
@@ -1012,7 +1010,7 @@ static ut64 thumb_selector(char *args[]) {
 			res |= 2 << (i*4);
 			continue;
 		}
-		err = false;   	
+		err = false;
 		thumb_getshift (args[i]);
 		if (!err) {
 			res |= 3 << (i*4);
@@ -1073,7 +1071,7 @@ static ut64 thumb_selector(char *args[]) {
 	err = false;
 	return res;
 }
-		
+
 static ut32 getshift(const char *str) {
 	char type[128];
 	char arg[128];
@@ -1297,7 +1295,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((reg1 > 15) || (reg2 > 15)) {
 				return -1;
 			}
-			
+
 			if (reg2 == 13) {
 				if ((reg1 < 8) && (num < 1024) && (num % 4 == 0) && (!(m & DOTW_BIT)) && (!(m & W_BIT))) {
 					ao->o = 0x00a8;
@@ -1390,7 +1388,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((reg1 > 15) || (reg2 > 15) || (reg3 > 15)) {
 				return -1;
 			}
-				
+
 			if (reg2 == 13) {
 				if ((reg1 == reg3) && (!(m & DOTW_BIT)) && (shift == 0)) {
 					ao->o = 0x6844;
@@ -1683,7 +1681,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		default:
 			return -1;
 		}
-	} else 
+	} else
 	if (( m = opmask (ao->op, "blx", 0) )) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -1886,7 +1884,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		default:
 			return -1;
 		}
-	} else 	
+	} else
 	if (( m = opmask (ao->op, "clrex", 0) )) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -2188,7 +2186,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_OTHER: {
 			ut16 cond;
 			ut16 i;
-			
+
 			const char *conds[] = {
 				"eq", "ne", "cs", "cc", "mi", "pl", "vs", "vc",
 				"hi", "ls", "ge", "lt", "gt", "le", "al", "nv", 0
@@ -2241,7 +2239,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				imm = -imm;
 			} else {
 				ao->o |= 1 << 31;
-			}				
+			}
 			if ((proc > 15) || (reg1 > 15) || (reg2 > 15) || (imm > 1024) || (imm % 4 != 0)) {
 				return -1;
 			}
@@ -2271,7 +2269,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				imm = -imm;
 			} else {
 				ao->o |= 1 << 31;
-			}				
+			}
 			if ((proc > 15) || (reg1 > 15) || (reg2 > 15) || (imm > 1024) || (imm % 4 != 0)) {
 				return -1;
 			}
@@ -2298,7 +2296,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				imm = -imm;
 			} else {
 				ao->o |= 1 << 31;
-			}				
+			}
 			if ((proc > 15) || (reg1 > 15) || (reg2 > 15) || (imm > 1024) || (imm % 4 != 0)) {
 				return -1;
 			}
@@ -2326,7 +2324,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 					list ^= 1 << (reg1);
 				}
 				ao->o |= (list & 0xff) << 8;
-					
+
 				return 2;
 			}
 			if (list & 0x2000) {
@@ -2338,7 +2336,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				// ldmia is the default!
 				ao->o = 0xb0e80000;
 			}
-				
+
 			ao->o |= reg1 << 24;
 			ao->o |= (list & 0xff) << 8;
 			ao->o |= (list & 0xff00) >> 8;
@@ -2358,13 +2356,13 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if (list & 0x2000) {
 				return -1;
 			}
-			
+
 			if ((m & DB_BIT) || (m & EA_BIT)) {
 				ao->o = 0x10e90000;
 			} else {
 				ao->o = 0x90e80000;
 			}
-				
+
 			ao->o |= reg1 << 24;
 			ao->o |= (list & 0xff) << 8;
 			ao->o |= (list & 0xff00) >> 8;
@@ -2569,7 +2567,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				return mem_32bit_2reg (ao, m);
 			} else {
 				return -1;
-			}			
+			}
 		        }
 			break;
 		case THUMB_REG_BRACKREGBRACK_CONST: {
@@ -2581,10 +2579,10 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			}
 			if (ldrsel == 0) {
 				ao->o = 0x50f80009;
-			} else 
+			} else
 			if (ldrsel == B_BIT) {
 				ao->o = 0x10f80009;
-			} else 
+			} else
 			if (ldrsel == H_BIT) {
 				ao->o = 0x30f80009;
 			} else {
@@ -2611,10 +2609,10 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			}
 			if (ldrsel == 0) {
 				ao->o = 0x50f8000d;
-			} else 
+			} else
 			if (ldrsel == B_BIT) {
 				ao->o = 0x10f8000d;
-			} else 
+			} else
 			if (ldrsel == H_BIT) {
 				ao->o = 0x30f8000d;
 			} else {
@@ -2774,7 +2772,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_BRACKREGBRACK: {
 			ut8 reg1 = getreg (ao->a[0]);
 			ut8 reg2 = getregmemstartend (ao->a[1]);
-			
+
 			if (ldrsel == B_BIT) {
 				ao->o = 0xd0e84f0f;
 				ao->o |= reg1 << 4;
@@ -2790,7 +2788,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if (ldrsel == 0) {
 				ao->a[1][strlen (ao->a[1]) - 1] = '\0';
 				ao->a[2] = "0]";
-			} else 
+			} else
 				return -1;
 		        }
 			// intentional fallthrough
@@ -2832,7 +2830,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if (num > 32) {
 				return -1;
 			}
-			ao->o = 0x0000;			
+			ao->o = 0x0000;
 			if (std_16bit_2reg (ao, m)) {
 				ao->o |= (num & 0x03) << 14;
 				ao->o |= num >> 2;
@@ -2865,7 +2863,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		default:
 			return -1;
 		}
-	} else		
+	} else
 	if ((m = opmask (ao->op, "lsr", S_BIT))) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -3016,7 +3014,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if (reg1 > 15) {
 				return -1;
 			}
-			
+
 			if ((m & W_BIT) || (m & T_BIT)) {
 				ut32 wnum = getnum (ao->a[1]);
 				if (wnum > 65535) {
@@ -3030,18 +3028,18 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				ao->o |= getthzeroimmed16 (wnum);
 				return 4;
 			}
-			
+
 			if (err) {
 				return -1;
 			}
-			
+
 			if ((num < 256) && (reg1 < 8) && (!(m & DOTW_BIT))) {
 				ao->o = 0x0020;
 				ao->o |= reg1;
 				ao->o |= num << 8;
 				return 2;
 			}
-				
+
 			ao->o = 0x4ff00000;
 			ao->o |= reg1;
 			ao->o |= getthimmed12 (ao->a[1]);
@@ -3054,7 +3052,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG: {
 			ut32 reg1 = getreg (ao->a[0]);
 			ut32 reg2 = getreg (ao->a[1]);
-			
+
 			if ((reg1 > 15) || (reg2 > 15)) {
 				return -1;
 			}
@@ -3066,14 +3064,14 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				ao->o |= reg2 << 11;
 				return 2;
 			}
-			
+
 			if ((reg1 < 8) && (reg2 < 8) && (!(m & DOTW_BIT))) {
 				ao->o = 0;
 				ao->o |= reg1 << 8;
 				ao->o |= reg2 << 11;
 				return 2;
 			}
-			
+
 			ao->o = 0x4fea0000;
 			ao->o |= reg1;
 			ao->o |= reg2 << 8;
@@ -3086,7 +3084,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		default:
 			return -1;
 		}
-	} else 
+	} else
 	if ((m = opmask (ao->op, "mrc", TWO_BIT))) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -3175,14 +3173,14 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				ao->o |= reg1;
 				return 4;
 			}
-			
+
 			return -1;
 		        }
 			break;
 		default:
 			return -1;
 		}
-	} else 
+	} else
 	if ((m = opmask (ao->op, "msr", 0))) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -3195,7 +3193,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((bank == 0) || (reg1 > 15)) {
 				return -1;
 			}
-			
+
 			ao->o = 0x80f30080;
 			ao->o |= reg1 << 24;
 			ao->o |= bank;
@@ -3240,7 +3238,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			ut8 reg1 = getreg (ao->a[0]);
 			err = false;
 			ut32 num = getthimmed12 (ao->a[1]);
-			
+
 			if ((reg1 > 15) || err) {
 				return -1;
 			}
@@ -3266,7 +3264,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((reg1 > 15) || (reg2 > 15)) {
 				return -1;
 			}
-			
+
 			ao->o = 0xc043;
 			if ((shift == 0) && (std_16bit_2reg (ao, m))) {
 				return 2;
@@ -3344,7 +3342,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		default:
 			return -1;
 		}
-	} else 
+	} else
 	if ((m = opmask (ao->op, "orr", S_BIT))) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -3391,7 +3389,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		default:
 			return -1;
 		}
-	} else 
+	} else
 	if ((m = opmask (ao->op, "pkh", BT_BIT | TB_BIT))) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -3419,7 +3417,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG_REG_SHIFT: {
 			ut32 shift = thumb_getshift (ao->a[3]);
 
-			if (((m & TB_BIT) && ((shift & 0x00003000) != 0x00002000)) || ((m & BT_BIT) && ((shift & 0x00003000) != 0)) || ((m & (TB_BIT | BT_BIT)) == 0)) {	
+			if (((m & TB_BIT) && ((shift & 0x00003000) != 0x00002000)) || ((m & BT_BIT) && ((shift & 0x00003000) != 0)) || ((m & (TB_BIT | BT_BIT)) == 0)) {
 				return -1;
 			}
 
@@ -3749,7 +3747,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if (std_16bit_2reg (ao, m)) {
 				return 2;
 			}
-			
+
 			if (m & SIXTEEN_BIT) {
 				ao->o = 0x90fa90f0;
 			} else
@@ -3781,7 +3779,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if (reg1 > 15) {
 				return -1;
 			}
-			
+
 			if ((m & DB_BIT) || (m & EA_BIT)) {
 				ao->o = 0x10e800c0;
 			} else {
@@ -3843,11 +3841,11 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG: {
 			ut8 reg1 = getreg (ao->a[0]);
 			ut8 reg2 = getreg (ao->a[1]);
-			
+
 			if ((reg1 > 15) || (reg2 > 15)) {
 				return -1;
 			}
-			
+
 			ao->o = 0x4fea3000;
 			ao->o |= reg1;
 			ao->o |= reg2 << 8;
@@ -3987,7 +3985,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				return -1;
 			}
 			ao->o |= num;
-			
+
 			return std_32bit_2reg (ao, m, false);
 		        }
 			break;
@@ -4169,7 +4167,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_CONST: {
 			err = false;
 			ut32 num = getnum (ao->a[0]);
-			
+
 			if (err || (num > 15)) {
 				return -1;
 			}
@@ -4191,7 +4189,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			ut8 reg2 = getreg (ao->a[1]);
 			ut8 reg3 = getreg (ao->a[2]);
 			ut8 reg4 = getreg (ao->a[3]);
-			
+
 			if ((reg1 > 15) || (reg2 > 15) || (reg3 > 15) || (reg4 > 15) || (m & DOTN_BIT)) {
 				return -1;
 			}
@@ -4487,7 +4485,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				ao->o = 0x0de800c0;
 			} else {
 				ao->o = 0x8de900c0;
-			}				
+			}
 			ao->o |= num << 8;
 			ao->o |= w << 29;
 			return 4;
@@ -4592,7 +4590,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((coproc > 15) || (coreg > 15) || (reg > 15) || (num > 4092) || (num < -4092) || (num % 4 != 0)) {
 				return -1;
 			}
-		
+
 			ao->o = 0x00ed0000;
 			if (m & L_BIT) {
 				ao->o |= 1 << 30;
@@ -4604,7 +4602,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				num = -num;
 			} else {
 				ao->o |= 1 << 31;
-			}				
+			}
 			ao->o |= coproc;
 			ao->o |= coreg << 4;
 			ao->o |= reg << 24;
@@ -4621,7 +4619,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((coproc > 15) || (coreg > 15) || (reg > 15) || (num > 4092) || (num < -4092) || (num % 4 != 0)) {
 				return -1;
 			}
-		
+
 			ao->o = 0x20ec0000;
 			if (m & L_BIT) {
 				ao->o |= 1 << 30;
@@ -4650,7 +4648,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((coproc > 15) || (coreg > 15) || (reg > 15) || (num > 4092) || (num < -4092) || (num % 4 != 0)) {
 				return -1;
 			}
-		
+
 			ao->o = 0x20ed0000;
 			if (m & L_BIT) {
 				ao->o |= 1 << 30;
@@ -4700,7 +4698,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((m & (FD_BIT | DB_BIT | IA_BIT | EA_BIT)) == 0) {
 				return -1;
 			}
-			
+
 			if (m & (FD_BIT | DB_BIT)) {
 				ao->o = 0x00e90000;
 			} else {
@@ -4720,7 +4718,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		default:
 			return -1;
 		}
-	} else 
+	} else
 	if ((m = opmask (ao->op, "str", B_BIT | T_BIT | D_BIT | H_BIT))) {
 		ut64 argt = thumb_selector (ao->a);
 		ut32 strsel = m & (B_BIT | H_BIT | D_BIT);
@@ -4753,7 +4751,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				ao->o |= num << 8;
 				return mem_32bit_2reg (ao, m);
 			}
-			
+
 			if ((strsel == 0) && (reg2 == 13) && (num >= 0) && (num < 1024) && ((num % 4) == 0) && (reg1 < 8) & (!(m & DOTW_BIT))) {
 				ao->o = 0x0090;
 				ao->o |= reg1;
@@ -4785,7 +4783,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 					return 2;
 				}
 			}
-			
+
 			if ((num > 4095) || (num < -255)) {
 				return -1;
 			}
@@ -4831,10 +4829,10 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 
 			if (strsel == 0) {
 				ao->o = 0x40f80009;
-			} else 
+			} else
 			if (strsel == B_BIT) {
 				ao->o = 0x00f80009;
-			} else 
+			} else
 			if (strsel == H_BIT) {
 				ao->o = 0x20f80009;
 			} else {
@@ -4861,10 +4859,10 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 
 			if (strsel == 0) {
 				ao->o = 0x40f8000d;
-			} else 
+			} else
 			if (strsel == B_BIT) {
 				ao->o = 0x00f8000d;
-			} else 
+			} else
 			if (strsel == H_BIT) {
 				ao->o = 0x20f8000d;
 			} else {
@@ -4911,23 +4909,23 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			ut8 reg2 = getregmemstart (ao->a[1]);
 			ut8 reg3 = getreg (ao->a[2]);
 			ut32 shift = getshiftmemend (ao->a[3]) >> 2;
-			
+
 			if (((shift & 0xffffcfff) != 0) || (reg1 > 15) || (reg2 > 15) || (reg3 > 15)) {
 				return -1;
 			}
 
 			if (strsel == 0) {
 				ao->o = 0x40f80000;
-			} else 
+			} else
 			if (strsel == B_BIT) {
 				ao->o = 0x00f80000;
-			} else 
+			} else
 			if (strsel == H_BIT) {
 				ao->o = 0x20f80000;
 			} else {
 				return -1;
 			}
-			
+
 			ao->o |= reg1 << 4;
 			ao->o |= reg2 << 24;
 			ao->o |= reg3 << 8;
@@ -5024,7 +5022,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			ut8 reg1 = getreg (ao->a[0]);
 			ut8 reg2 = getreg (ao->a[1]);
 			ut8 reg3 = getregmemstartend (ao->a[2]);
-			
+
 			if ((strsel == D_BIT) || (reg1 > 15) || (reg2 > 15) || (reg3 > 15)) {
 				return -1;
 			}
@@ -5084,7 +5082,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		        }
 			break;
 		}
-	} else 
+	} else
 	if ((m = opmask (ao->op, "sub", S_BIT | W_BIT))) {
 		ut64 argt = thumb_selector (ao->a);
 		switch (argt) {
@@ -5114,7 +5112,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				}
 				err = false;
 				ut32 thnum = getthimmed12 (ao->a[2]);
-				
+
 				if (!err && (!(m & W_BIT))) {
 					ao->o = 0xadf10000;
 					ao->o |= thnum;
@@ -5153,7 +5151,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 
 			err = false;
 			ut32 thnum = getthimmed12 (ao->a[2]);
-			
+
 			if (!err && (!(m & W_BIT))) {
 				ao->o = 0xa0f10000;
 				ao->o |= thnum;
@@ -5209,7 +5207,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				ao->o |= (reg3 >> 2);
 				return 2;
 			}
-			
+
 			ao->o = 0xa0eb0000;
 			return std_32bit_3reg (ao, m, true);
 		        }
@@ -5260,7 +5258,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			}
 
 			ut64 sufsel = m & (B_BIT | H_BIT | SIXTEEN_BIT);
-			
+
 			if (sufsel == B_BIT) {
 				ao->o = 0x40fa80f0;
 			} else
@@ -5350,7 +5348,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			ut8 reg1 = getregmemstart (ao->a[0]);
 			ut8 reg2 = getreg (ao->a[1]);
 			ut32 shift = getshiftmemend (ao->a[2]);
-			
+
 			if ((reg1 > 15) || (reg2 > 15) || (shift != 0x00004000) || (sufsel != H_BIT)) {
 				return -1;
 			}
@@ -5416,7 +5414,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			break;
 		case THUMB_REG_REG: {
 			ao->o = 0x0042;
-			
+
 			if (std_16bit_2reg (ao, m)) {
 				return 2;
 			}
@@ -5481,7 +5479,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			ut8 reg2 = getreg (ao->a[1]);
 			ut32 lsb = getnum (ao->a[2]);
 			ut32 widthm1 = getnum (ao->a[3]) - 1;
-			
+
 			if ((reg1 > 15) || (reg2 > 15) || (lsb > 31) || ((31 - lsb) <= widthm1)) {
 				return -1;
 			}
@@ -5526,13 +5524,13 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG_REG: {
 			if (sufsel == EIGHT_BIT) {
 				ao->o = 0x80fa60f0;
-			} else 
+			} else
 			if (sufsel == SIXTEEN_BIT) {
 				ao->o = 0x90fa60f0;
 			} else {
 				return -1;
 			}
-				
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5549,9 +5547,9 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			// intentional fallthrough
 		case THUMB_REG_REG_REG: {
 			ao->o = 0xa0fa60f0;
-			
+
 			return std_32bit_3reg (ao, m, false);
-			
+
 		        }
 			break;
 		default:
@@ -5567,7 +5565,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			// intentional fallthrough
 		case THUMB_REG_REG_REG: {
 			ao->o = 0xe0fa60f0;
-			
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5586,13 +5584,13 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG_REG: {
 			if (sufsel == EIGHT_BIT) {
 				ao->o = 0xc0fa60f0;
-			} else 
+			} else
 			if (sufsel == SIXTEEN_BIT) {
 				ao->o = 0xd0fa60f0;
 			} else {
 				return -1;
 			}
-				
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5612,7 +5610,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((reg1 > 15) || (reg2 > 15) || (reg3 > 15) || (reg4 > 15)) {
 				return -1;
 			}
-			
+
 			ao->o = 0xe0fb6000;
 			ao->o |= reg1 << 4;
 			ao->o |= reg2;
@@ -5637,7 +5635,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((reg1 > 15) || (reg2 > 15) || (reg3 > 15) || (reg4 > 15)) {
 				return -1;
 			}
-			
+
 			ao->o = 0xe0fb0000;
 			ao->o |= reg1 << 4;
 			ao->o |= reg2;
@@ -5662,7 +5660,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((reg1 > 15) || (reg2 > 15) || (reg3 > 15) || (reg4 > 15)) {
 				return -1;
 			}
-			
+
 			ao->o = 0xa0fb0000;
 			ao->o |= reg1 << 4;
 			ao->o |= reg2;
@@ -5686,13 +5684,13 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG_REG: {
 			if (sufsel == EIGHT_BIT) {
 				ao->o = 0x80fa50f0;
-			} else 
+			} else
 			if (sufsel == SIXTEEN_BIT) {
 				ao->o = 0x90fa50f0;
 			} else {
 				return -1;
 			}
-				
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5709,7 +5707,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			// intentional fallthrough
 		case THUMB_REG_REG_REG: {
 			ao->o = 0xa0fa50f0;
-			
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5726,7 +5724,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			// intentional fallthrough
 		case THUMB_REG_REG_REG: {
 			ao->o = 0xe0fa50f0;
-			
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5745,13 +5743,13 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG_REG: {
 			if (sufsel == EIGHT_BIT) {
 				ao->o = 0xc0fa50f0;
-			} else 
+			} else
 			if (sufsel == SIXTEEN_BIT) {
 				ao->o = 0xd0fa50f0;
 			} else {
 				return -1;
 			}
-				
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5768,7 +5766,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			// intentional fallthrough
 		case THUMB_REG_REG_REG: {
 			ao->o = 0x70fb00f0;
-			
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5788,7 +5786,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			if ((reg1 > 15) || (reg2 > 15) || (reg3 > 15) || (reg4 > 15)) {
 				return -1;
 			}
-			
+
 			ao->o = 0x70fb0000;
 			ao->o |= reg1;
 			ao->o |= reg2 << 24;
@@ -5857,7 +5855,7 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 			// intentional fallthrough
 		case THUMB_REG_REG_REG: {
 			ao->o = 0xe0fa40f0;
-			
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;
@@ -5876,13 +5874,13 @@ static int thumb_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 		case THUMB_REG_REG_REG: {
 			if (sufsel == EIGHT_BIT) {
 				ao->o = 0xc0fa40f0;
-			} else 
+			} else
 			if (sufsel == SIXTEEN_BIT) {
 				ao->o = 0xd0fa40f0;
 			} else {
 				return -1;
 			}
-				
+
 			return std_32bit_3reg (ao, m, false);
 		        }
 			break;

--- a/libr/asm/arch/xap/dis.c
+++ b/libr/asm/arch/xap/dis.c
@@ -396,7 +396,7 @@ static int decode_known(struct state *s, struct directive *d) {
 		if (d->d_operand < 0) {
 			d->d_operand *= -1;
 			sign = "-";
-		}	
+		}
 	} else {
 		d->d_operand = s->s_prefix_val | in->in_operand;
 		if (d->d_operand & 0x80) {
@@ -464,8 +464,8 @@ static int read_bin(struct state *s, struct directive *d) {
 
 static inline struct directive *next_inst(struct state *s) {
 	int rd;
-	struct directive *d = malloc (sizeof (*d));
-	if (!d) {
+	struct directive *d;
+	if (!(d = malloc (sizeof (*d)))) {
 		perror ("malloc()");
 		return NULL;
 	}

--- a/libr/asm/p/asm_arm_gnu.c
+++ b/libr/asm/p/asm_arm_gnu.c
@@ -107,8 +107,7 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 		return false;
 	}
 	va_start (ap, format);
-	tmp = malloc (strlen (format) + strlen (buf_global) + 2);
-	if (!tmp) {
+	if (!(tmp = malloc (strlen (format) + strlen (buf_global) + 2))) {
 		va_end (ap);
 		return false;
 	}

--- a/libr/asm/p/asm_cris_gnu.c
+++ b/libr/asm/p/asm_cris_gnu.c
@@ -55,8 +55,9 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	va_start (ap, format);
 		flen = strlen (format);
 		glen = strlen (buf_global);
-		tmp = malloc (flen + glen + 2);
-		if (!tmp) return 0;
+		if (!(tmp = malloc (flen + glen + 2))) {
+			return 0;
+		}
 		memcpy (tmp, buf_global, glen);
 		memcpy (tmp+glen, format, flen);
 		tmp[flen+glen] = 0;

--- a/libr/asm/p/asm_hppa_gnu.c
+++ b/libr/asm/p/asm_hppa_gnu.c
@@ -58,8 +58,7 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	va_start (ap, format);
 	flen = strlen (format);
 	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (tmp) {
+	if ((tmp = malloc (flen + glen + 2))) {
 		memcpy (tmp, buf_global, glen);
 		memcpy (tmp + glen, format, flen);
 		tmp[flen + glen] = 0;

--- a/libr/asm/p/asm_lanai_gnu.c
+++ b/libr/asm/p/asm_lanai_gnu.c
@@ -49,8 +49,7 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	va_start (ap, format);
 	flen = strlen (format);
 	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) {
+	if (!(tmp = malloc (flen + glen + 2))) {
 		va_end (ap);
 		return 0;
 	}

--- a/libr/asm/p/asm_mips_gnu.c
+++ b/libr/asm/p/asm_mips_gnu.c
@@ -45,8 +45,7 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	if (!buf_global || !format)
 		return false;
 	va_start (ap, format);
- 	tmp = malloc (strlen (format)+strlen (buf_global)+2);
-	if (!tmp) {
+ 	if (!(tmp = malloc (strlen (format)+strlen (buf_global)+2))) {
 		va_end (ap);
 		return false;
 	}

--- a/libr/asm/p/asm_nios2.c
+++ b/libr/asm/p/asm_nios2.c
@@ -48,8 +48,9 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	va_start (ap, format);
 	flen = strlen (format);
 	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) return 0;
+	if (!(tmp = malloc (flen + glen + 2))) {
+		return 0;
+	}
 	memcpy (tmp, buf_global, glen);
 	memcpy (tmp+glen, format, flen);
 	tmp[flen+glen] = 0;

--- a/libr/asm/p/asm_ppc_gnu.c
+++ b/libr/asm/p/asm_ppc_gnu.c
@@ -46,8 +46,9 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	va_start (ap, format);
 	flen = strlen (format);
 	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) return 0;
+	if (!(tmp = malloc (flen + glen + 2))) {
+		return 0;
+	}
 	memcpy (tmp, buf_global, glen);
 	memcpy (tmp+glen, format, flen);
 	tmp[flen+glen] = 0;

--- a/libr/asm/p/asm_sh.c
+++ b/libr/asm/p/asm_sh.c
@@ -44,9 +44,9 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	int ret;
 	if (!buf_global)
 		return 0;
-	tmp = malloc (strlen (format)+strlen (buf_global)+2);
-	if (!tmp)
+	if (!(tmp = malloc (strlen (format)+strlen (buf_global)+2))) {
 		return 0;
+	}
 	va_start (ap, format);
 	sprintf (tmp, "%s%s", buf_global, format);
 	ret = vsprintf (buf_global, tmp, ap);

--- a/libr/asm/p/asm_tricore.c
+++ b/libr/asm/p/asm_tricore.c
@@ -52,9 +52,9 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	}
 	flen = strlen (format);
 	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) return 0;
-
+	if (!(tmp = malloc (flen + glen + 2))) {
+		return 0;
+	}
 	if (strchr (buf_global, '%')) {
 		char *buf_local = strdup (buf_global);
 		if (!buf_local) {

--- a/libr/asm/p/asm_vax.c
+++ b/libr/asm/p/asm_vax.c
@@ -55,8 +55,9 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	va_start (ap, format);
 	flen = strlen (format);
 	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) return 0;
+	if (!(tmp = malloc (flen + glen + 2))) {
+		return 0;
+	}
 	memcpy (tmp, buf_global, glen);
 	memcpy (tmp+glen, format, flen);
 	tmp[flen+glen] = 0;

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4370,7 +4370,9 @@ static int parseOperand(RAsm *a, const char *str, Operand *op, bool isrepop) {
 				// scale with the offset (scale + offset) otherwise the scale
 				// will be the sum of the two. This splits the numbers
 				char *tmp;
-				tmp = malloc (strlen (str + pos) + 1);
+				if (!(tmp = malloc (strlen (str + pos) + 1))) {
+					return nextpos;
+				}
 				strcpy (tmp, str + pos);
 				strtok (tmp, "+-");
 				st64 read = getnum (a, tmp);

--- a/libr/asm/p/asm_xtensa.c
+++ b/libr/asm/p/asm_xtensa.c
@@ -50,8 +50,8 @@ static int buf_fprintf(void *stream, const char *format, ...) {
 	va_start (ap, format);
 	int flen = strlen (format);
 	int glen = strlen (buf_global);
-	char *tmp = malloc (flen + glen + 2);
-	if (!tmp) {
+	char *tmp;
+	if (!(tmp = malloc (flen + glen + 2))) {
 		return 0;
 	}
 	memcpy (tmp, buf_global, glen);

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -74,9 +74,8 @@ R_API RBinXtrData *r_bin_xtrdata_new(RBuffer *buf, ut64 offset, ut64 size,
 	data->metadata = metadata;
 	data->loaded = 0;
 	// TODO: USE RBuffer *buf inside RBinXtrData*
-	data->buffer = malloc (size + 1);
-	// data->laddr = 0; /// XXX
-	if (!data->buffer) {
+	if (!(data->buffer = malloc (size + 1))) {
+		// data->laddr = 0; /// XXX
 		free (data);
 		return NULL;
 	}
@@ -327,7 +326,7 @@ R_API int r_bin_reload(RBin *bin, int fd, ut64 baseaddr) {
 			res = false;
 			goto error;
 		}
-		// OMG NOES we want to use io, not this shit. 
+		// OMG NOES we want to use io, not this shit.
 		buf_bytes = calloc (1, sz + 1);
 		if (!buf_bytes) {
 			iob->fd_close (iob->io, tfd);

--- a/libr/bin/dbginfo.c
+++ b/libr/bin/dbginfo.c
@@ -76,7 +76,10 @@ R_API char *r_bin_addr2text(RBin *bin, ut64 addr, int origin) {
 		if (!out) {
 			return r_str_newf ("%s:%d", file, line);
 		}
-		out2 = malloc ((strlen (file) + 64 + strlen (out)) * sizeof (char));
+		if (!(out2 = malloc ((strlen (file) + 64 + strlen (out)) * sizeof (char)))) {
+			free(out);
+			return NULL;
+		}
 		if (origin > 1) {
 			file_nopath = NULL;
 		} else {

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -291,7 +291,9 @@ R_API char *r_bin_demangle_objc(RBinFile *binfile, const char *sym) {
 		} else {
 			if (nargs) {
 				const char *arg = "int";
-				args = malloc (((strlen (arg) + 4) * nargs) + 1);
+				if (!(args = malloc (((strlen (arg) + 4) * nargs) + 1))) {
+					return NULL;
+				}
 				args[0] = 0;
 				for (i = 0;i < nargs; i++) {
 					strcat (args, arg);
@@ -339,7 +341,7 @@ R_API char *r_bin_demangle_rust(RBinFile *binfile, const char *sym, ut64 vaddr) 
 	char *str, *out, *in;
 
 	str = r_bin_demangle_cxx (binfile, sym, vaddr);
-	
+
 	if (!str) {
 		return str;
 	}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1393,7 +1393,7 @@ static ut64 get_import_addr(ELFOBJ *bin, int sym) {
 									 : r_read_le64 (buf);
 
 						if (!plt_sym_addr) {
-							//XXX HACK ALERT!!!! full relro?? try to fix it 
+							//XXX HACK ALERT!!!! full relro?? try to fix it
 							//will there always be .plt.got, what would happen if is .got.plt?
 							RBinElfSection *s = get_section_by_name (bin, ".plt.got");
  							if (Elf_(r_bin_elf_has_relro)(bin) < R_ELF_PART_RELRO || !s) {
@@ -1403,7 +1403,7 @@ static ut64 get_import_addr(ELFOBJ *bin, int sym) {
 							of = of + got_addr - got_offset;
 							while (plt_addr + 2 + 4 < s->offset + s->size) {
 								/*we try to locate the plt entry that correspond with the relocation
-								  since got does not point back to .plt. In this case it has the following 
+								  since got does not point back to .plt. In this case it has the following
 								  form
 
 								  ff253a152000   JMP QWORD [RIP + 0x20153A]
@@ -1412,7 +1412,7 @@ static ut64 get_import_addr(ELFOBJ *bin, int sym) {
 								  ff25ec9f0408   JMP DWORD [reloc.puts_236]
 
 								  plt_addr + 2 to remove jmp opcode and get the imm reading 4
-								  and if RIP (plt_addr + 6) + imm == rel->offset 
+								  and if RIP (plt_addr + 6) + imm == rel->offset
 								  return plt_addr, that will be our sym addr
 
 								  perhaps this hack doesn't work on 32 bits
@@ -1861,8 +1861,7 @@ char *Elf_(r_bin_elf_intrp)(ELFOBJ *bin) {
 			if (sz < 1) {
 				return NULL;
 			}
-			str = malloc (sz + 1);
-			if (!str) {
+			if (!(str = malloc (sz + 1))) {
 				return NULL;
 			}
 			if (r_buf_read_at (bin->b, addr, (ut8*)str, sz) < 1) {
@@ -2266,8 +2265,8 @@ ut8 *Elf_(r_bin_elf_grab_regstate)(ELFOBJ *bin, int *len) {
 					regdelta = reginf[X86_64].regdelta;
 					break;
 			}
-			ut8 *buf = malloc (regsize);
-			if (r_buf_read_at (bin->b, bin->phdr[i].p_offset + offset + regdelta, buf, regsize) != regsize) {
+			ut8 *buf;
+			if ((buf = malloc (regsize)) && r_buf_read_at (bin->b, bin->phdr[i].p_offset + offset + regdelta, buf, regsize) != regsize) {
 				free (buf);
 				bprintf ("Cannot read register state from CORE file\n");
 				return NULL;
@@ -3056,7 +3055,7 @@ static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type
 					tsize = 16;
 				} else if (type == R_BIN_ELF_SYMBOLS) {
 					tsize = sym[k].st_size;
-					toffset = (ut64)sym[k].st_value; 
+					toffset = (ut64)sym[k].st_value;
 					is_sht_null = sym[k].st_shndx == SHT_NULL;
 				} else {
 					continue;

--- a/libr/bin/format/elf/elf_write.c
+++ b/libr/bin/format/elf/elf_write.c
@@ -44,9 +44,9 @@ ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const cha
 		eprintf ("Cannot find section\n");
 		return 0;
 	}
- 
+
 	eprintf ("delta: %"PFMT64d"\n", delta);
-	
+
 	/* rewrite rel's (imports) */
 	for (i = 0, shdrp = shdr; i < ehdr->e_shnum; i++, shdrp++) {
 		if (!strcmp(&strtab[shdrp->sh_name], ".got")) {
@@ -61,8 +61,7 @@ ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const cha
 	for (i = 0, shdrp = shdr; i < ehdr->e_shnum; i++, shdrp++) {
 		if (!strcmp (&strtab[shdrp->sh_name], ".rel.plt")) {
 			Elf_(Rel) *rel, *relp;
-			rel = (Elf_(Rel) *)malloc (1+shdrp->sh_size);
-			if (!rel) {
+			if (!(rel = (Elf_(Rel) *)malloc (1+shdrp->sh_size))) {
 				perror ("malloc");
 				return 0;
 			}
@@ -83,8 +82,7 @@ ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const cha
 			break;
 		} else if (!strcmp (&strtab[shdrp->sh_name], ".rela.plt")) {
 			Elf_(Rela) *rel, *relp;
-			rel = (Elf_(Rela) *)malloc (shdrp->sh_size + 1);
-			if (!rel) {
+			if (!(rel = (Elf_(Rela) *)malloc (shdrp->sh_size + 1))) {
 				perror("malloc");
 				return 0;
 			}
@@ -126,12 +124,12 @@ ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const cha
 
 	/* rewrite program headers */
 	for (i = 0, phdrp = phdr; i < ehdr->e_phnum; i++, phdrp++) {
-#if 0 
+#if 0
 		if (phdrp->p_offset < rsz_offset && phdrp->p_offset + phdrp->p_filesz > rsz_offset) {
 			phdrp->p_filesz += delta;
 			phdrp->p_memsz += delta;
 		}
-#endif 
+#endif
 		if (phdrp->p_offset >= rsz_offset + rsz_osize) {
 			phdrp->p_offset += delta;
 			if (phdrp->p_vaddr) phdrp->p_vaddr += delta;
@@ -161,7 +159,10 @@ ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const cha
 	/* XXX Check when delta is negative */
 	rest_size = bin->size - (rsz_offset + rsz_osize);
 
-	buf = (ut8 *)malloc (1+bin->size);
+	if (!(buf = (ut8 *) malloc (1 + bin->size))) {
+		perror ("malloc (buf)");
+		return 0;
+	}
 	r_buf_read_at (bin->b, 0, (ut8*)buf, bin->size);
 	r_buf_set_bytes (bin->b, (ut8*)buf, (int)(rsz_offset+rsz_size+rest_size));
 

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -1073,8 +1073,8 @@ static int init_items(struct MACH0_(obj_t)* bin) {
 					dy.name = r_read_ble32 (&sdy[8], bin->big_endian);
 
 					int len = dy.cmdsize;
-					char *buf = malloc (len+1);
-					if (buf) {
+					char *buf;
+					if (buf = malloc (len+1)) {
 						// wtf @ off + 0xc ?
 						r_buf_read_at (bin->b, off + 0xc, (ut8*)buf, len);
 						buf[len] = 0;

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -1074,7 +1074,7 @@ static int init_items(struct MACH0_(obj_t)* bin) {
 
 					int len = dy.cmdsize;
 					char *buf;
-					if (buf = malloc (len+1)) {
+					if ((buf = malloc (len+1))) {
 						// wtf @ off + 0xc ?
 						r_buf_read_at (bin->b, off + 0xc, (ut8*)buf, len);
 						buf[len] = 0;

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -288,7 +288,9 @@ static void get_ivar_list_t(mach0_ut p, RBinFile *bf, RBinClass *klass) {
 				left = strlen (name) + 1;
 			} else {
 				int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
-				name = malloc (name_len + 1);
+				if (!(name = malloc (name_len + 1))) {
+					goto error;
+				}
 				len = r_buf_read_at (bf->buf, r, (ut8 *)name, name_len);
 				if (len < 1) {
 					eprintf ("Error reading\n");
@@ -575,7 +577,9 @@ static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinCl
 				left = strlen (name) + 1;
 			} else {
 				int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
-				name = malloc (name_len + 1);
+				if (!(name = malloc (name_len + 1))) {
+					goto error;
+				}
 				len = r_buf_read_at (bf->buf, r, (ut8 *)name, name_len);
 				name[name_len] = 0;
 				if (len < 1) {
@@ -598,8 +602,7 @@ static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinCl
 				left = strlen (rtype) + 1;
 			} else {
 				left = 1;
-				rtype = malloc (left + 1);
-				if (!rtype) {
+				if (!(rtype = malloc (left + 1))) {
 					goto error;
 				}
 				if (r_buf_read_at (bf->buf, r, (ut8 *)rtype, left) != left) {
@@ -758,8 +761,7 @@ static void get_protocol_list_t(mach0_ut p, RBinFile *bf, RBinClass *klass) {
 				left = strlen (name) + 1;
 			} else {
 				int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
-				name = malloc (name_len + 1);
-				if (!name) {
+				if (!(name = malloc (name_len + 1))) {
 					return;
 				}
 				if (r_buf_read_at (bf->buf, r, (ut8 *)name, name_len) != name_len) {
@@ -896,8 +898,8 @@ static void get_class_ro_t(mach0_ut p, RBinFile *bf, ut32 *is_meta_class, RBinCl
 			left = strlen (klass->name) + 1;
 		} else {
 			int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
-			char *name = malloc (name_len + 1);
-			if (name) {
+			char *name;
+			if (name = malloc (name_len + 1)) {
 				int rc = r_buf_read_at (bf->buf, r, (ut8 *)name, name_len);
 				if (rc != name_len) {
 					rc = 0;

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -899,7 +899,7 @@ static void get_class_ro_t(mach0_ut p, RBinFile *bf, ut32 *is_meta_class, RBinCl
 		} else {
 			int name_len = R_MIN (MAX_CLASS_NAME_LEN, left);
 			char *name;
-			if (name = malloc (name_len + 1)) {
+			if ((name = malloc (name_len + 1))) {
 				int rc = r_buf_read_at (bf->buf, r, (ut8 *)name, name_len);
 				if (rc != name_len) {
 					rc = 0;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -671,7 +671,10 @@ static struct r_bin_pe_export_t* parse_symbol_table(struct PE_(r_bin_pe_obj_t)* 
 		exp = (struct r_bin_pe_export_t*) (((const ut8*) exports) + osz);
 	} else {
 		sz = exports_sz;
-		exports = malloc (sz);
+		if (!(exports = malloc (sz))) {
+			free(buf);
+			return NULL;
+		}
 		exp = exports;
 	}
 

--- a/libr/bin/mangling/microsoft_demangle.c
+++ b/libr/bin/mangling/microsoft_demangle.c
@@ -248,8 +248,9 @@ int get_namespace_and_name(	char *buf, STypeCodeStr *type_code_str,
 	names_l = r_list_new();
 
 #define SET_OPERATOR_CODE(str) { \
-	str_info = (SStrInfo *) malloc (sizeof(SStrInfo)); \
-	if (!str_info) break; \
+	if (!(str_info = (SStrInfo *) malloc (sizeof(SStrInfo)))) { \
+		break; \
+	} \
 	str_info->len = strlen (str); \
 	str_info->str_ptr = str; \
 	r_list_append (names_l, str_info); \
@@ -298,8 +299,9 @@ int get_namespace_and_name(	char *buf, STypeCodeStr *type_code_str,
 		case '$':
 		{
 			int i = 0;
-			str_info = (SStrInfo *) malloc (sizeof(SStrInfo));
-			if (!str_info) break;
+			if (!(str_info = (SStrInfo *) malloc (sizeof(SStrInfo)))) {
+				break;
+			}
 			i = get_template (buf + 1, str_info);
 			if (!i) {
 				R_FREE (str_info);
@@ -384,7 +386,9 @@ int get_namespace_and_name(	char *buf, STypeCodeStr *type_code_str,
 		// check is it teamplate???
 		if ((*tmp == '?') && (*(tmp + 1) == '$')) {
 			int i = 0;
-			str_info = (SStrInfo *) malloc (sizeof(SStrInfo));
+			if (!(str_info = (SStrInfo *) malloc (sizeof(SStrInfo)))) {
+				goto get_namespace_and_name_err;
+			}
 			i = get_template (tmp + 2, str_info);
 			if (!i) {
 				R_FREE (str_info);
@@ -407,13 +411,17 @@ int get_namespace_and_name(	char *buf, STypeCodeStr *type_code_str,
 			}
 			len = 1;
 		} else {
-			tmp = (char *) malloc (len + 1);
+			if (!(tmp = (char *) malloc (len + 1))) {
+				goto get_namespace_and_name_err;
+			}
 			memset (tmp, 0, len + 1);
 			memcpy (tmp, prev_pos, len);
 			r_list_append (abbr_names, tmp);
 		}
 
-		str_info = (SStrInfo *) malloc (sizeof (SStrInfo));
+		if (!(str_info = (SStrInfo *) malloc (sizeof (SStrInfo)))) {
+			goto get_namespace_and_name_err;
+		}
 		str_info->str_ptr = tmp;
 		str_info->len = strlen (tmp);
 
@@ -642,13 +650,17 @@ char* get_num(SStateInfo *state)
 {
 	char *ptr = 0;
 	if (*state->buff_for_parsing >= '0' && *state->buff_for_parsing <= '8') {
-		ptr = (char *) malloc (2);
+		if (!(ptr = (char *) malloc (2))) {
+			return NULL;
+		}
 		ptr[0] = *state->buff_for_parsing + 1;
 		ptr[1] = '\0';
 		state->buff_for_parsing++;
 		state->amount_of_read_chars++;
 	} else if (*state->buff_for_parsing == '9') {
-		ptr = (char *) malloc (3);
+		if (!(ptr = (char *) malloc (3))) {
+			return NULL;
+		}
 		ptr[0] = '1';
 		ptr[1] = '0';
 		ptr[2] = '\0';
@@ -667,7 +679,9 @@ char* get_num(SStateInfo *state)
 		if (*state->buff_for_parsing != '@')
 			return ptr;
 
-		ptr = (char *)malloc (16);
+		if (!(ptr = (char *)malloc (16))) {
+			return NULL;
+		}
 		sprintf (ptr, "%u", ret);
 		state->buff_for_parsing++;
 		state->amount_of_read_chars++;
@@ -1327,7 +1341,9 @@ static EDemanglerErr parse_microsoft_mangled_name(char *sym, char **demangled_na
 				r_list_append (abbr_types, strdup (tmp));
 			}
 
-			str_arg = (SStrInfo *) malloc (sizeof(SStrInfo));
+			if (!(str_arg = (SStrInfo *) malloc (sizeof(SStrInfo)))) {
+				goto parse_microsoft_mangled_name_err;
+			}
 			str_arg->str_ptr = strdup (tmp);
 			str_arg->len = strlen (tmp);
 

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -111,7 +111,9 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->file = bf->file? strdup (bf->file): NULL;
 	ret->type = strdup ("ART");
 
-	ret->bclass = malloc (5);
+	if (!(ret->bclass = malloc (5))) {
+		return NULL;
+	}
 	memcpy (ret->bclass, &ao->art.version, 4);
 	ret->bclass[3] = 0;
 

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -453,9 +453,9 @@ static void dex_parse_debug_item(RBinFile *binfile, RBinDexObj *bin,
 			// Emit what was previously there, if anything
 			// emitLocalCbIfLive
 			if (debug_locals[register_num].live) {
-				struct dex_debug_local_t *local = malloc (
-					sizeof (struct dex_debug_local_t));
-				if (!local) {
+				struct dex_debug_local_t *local;
+				if (!(local = malloc (
+					sizeof (struct dex_debug_local_t)))) {
 					keep = false;
 					break;
 				}
@@ -496,9 +496,9 @@ static void dex_parse_debug_item(RBinFile *binfile, RBinDexObj *bin,
 			// Emit what was previously there, if anything
 			// emitLocalCbIfLive
 			if (debug_locals[register_num].live) {
-				struct dex_debug_local_t *local = malloc (
-					sizeof (struct dex_debug_local_t));
-				if (!local) {
+				struct dex_debug_local_t *local;
+				if (!(local = malloc (
+					sizeof (struct dex_debug_local_t)))) {
 					keep = false;
 					break;
 				}
@@ -531,9 +531,9 @@ static void dex_parse_debug_item(RBinFile *binfile, RBinDexObj *bin,
 				return;
 			}
 			if (debug_locals[register_num].live) {
-				struct dex_debug_local_t *local = malloc (
-					sizeof (struct dex_debug_local_t));
-				if (!local) {
+				struct dex_debug_local_t *local;
+				if (!(local = malloc (
+					sizeof (struct dex_debug_local_t)))) {
 					keep = false;
 					break;
 				}
@@ -580,9 +580,8 @@ static void dex_parse_debug_item(RBinFile *binfile, RBinDexObj *bin,
 			int adjusted_opcode = opcode - 10;
 			address += (adjusted_opcode / 15);
 			line += -4 + (adjusted_opcode % 15);
-			struct dex_debug_position_t *position =
-				malloc (sizeof (struct dex_debug_position_t));
-			if (!position) {
+			struct dex_debug_position_t *position;
+			if (!(position = malloc (sizeof (struct dex_debug_position_t)))) {
 				keep = false;
 				break;
 			}
@@ -856,8 +855,7 @@ static RList *strings(RBinFile *bf) {
 		len = dex_read_uleb128 (buf, sizeof (buf));
 
 		if (len > 5 && len < R_BIN_SIZEOF_STRINGS) {
-			ptr->string = malloc (len + 1);
-			if (!ptr->string) {
+			if (!(ptr->string = malloc (len + 1))) {
 				goto out_error;
 			}
 			off = bin->strings[i] + dex_uleb128_len (buf, sizeof (buf));
@@ -1522,9 +1520,10 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 
 		p = r_buf_get_at (binfile->buf, c->class_data_offset, NULL);
 		p_end = p + binfile->buf->length - c->class_data_offset;
-		//XXX check for NULL!!
-		c->class_data = (struct dex_class_data_item_t *)malloc (
-			sizeof (struct dex_class_data_item_t));
+		if (!(c->class_data = (struct dex_class_data_item_t *)malloc (
+			sizeof (struct dex_class_data_item_t)))) {
+			return;
+		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->static_fields_size);
 		p = r_uleb128 (p, p_end - p, &c->class_data->instance_fields_size);
 		p = r_uleb128 (p, p_end - p, &c->class_data->direct_methods_size);

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -162,8 +162,8 @@ static RBinAddr* binsym(RBinFile *bf, int sym) {
 		ret->vaddr = Elf_(r_bin_elf_p2v) (obj, addr);
 		if (is_arm && addr & 1) {
 			ret->bits = 16;
-			ret->vaddr--; 
-			ret->paddr--; 
+			ret->vaddr--;
+			ret->paddr--;
 		}
 	}
 	return ret;
@@ -898,8 +898,8 @@ static void _patch_reloc (ut16 e_machine, RIOBind *iob, RBinElfReloc *rel, ut64 
 }
 
 static bool ht_insert_intu64(SdbHash* ht, int key, ut64 value) {
-	ut64 *mvalue = malloc (sizeof (ut64));
-	if (!mvalue) {
+	ut64 *mvalue;
+	if (!(mvalue = malloc (sizeof (ut64)))) {
 		return false;
 	}
 	*mvalue = value;

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -87,7 +87,10 @@ static RList* sections(RBinFile *bf){
 	r_buf_read_at (bf->buf, 0x148, &bank, 1);
 	bank = gb_get_rombanks(bank);
 #ifdef _MSC_VER
-	RBinSection **rombank = (RBinSection**) malloc (sizeof (RBinSection*) * bank);
+	RBinSection **rombank;
+	if (!(rombank = (RBinSection**) malloc (sizeof (RBinSection*) * bank))) {
+		return NULL;
+	}
 #else
 	RBinSection *rombank[bank];
 #endif
@@ -207,7 +210,10 @@ static RBinInfo* info(RBinFile *bf) {
 	r_buf_read_at (bf->buf, 0x104, rom_header, 76);
 	ret->file = calloc (1, 17);
 	strncpy (ret->file, (const char*)&rom_header[48], 16);
-	ret->type = malloc (128);
+	if (!(ret->type = malloc (128))) {
+		free(ret);
+		return NULL;
+	}
 	ret->type[0] = 0;
 	gb_get_gbtype (ret->type, rom_header[66], rom_header[63]);
 	gb_add_cardtype (ret->type, rom_header[67]); // XXX

--- a/libr/bin/p/bin_xbe.c
+++ b/libr/bin/p/bin_xbe.c
@@ -22,8 +22,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = malloc (sizeof (r_bin_plugin_xbe));
-	if (!bf->o->bin_obj) {
+	if (!(bf->o->bin_obj = malloc (sizeof (r_bin_plugin_xbe)))) {
 		return false;
 	}
 	obj = bf->o->bin_obj;

--- a/libr/bin/pdb/dbi.c
+++ b/libr/bin/pdb/dbi.c
@@ -138,8 +138,9 @@ void parse_dbi_stream(void *parsed_pdb_stream, R_STREAM_FILE *stream_file)
 	stream_file_seek (stream_file, pos, 0);
 
 	size = dbi_stream->dbi_header.module_size;
-	dbiexhdr_data = (char *) malloc(size);
-	if (!dbiexhdr_data) return;
+	if (!(dbiexhdr_data = (char *) malloc(size))) {
+		return;
+	}
 	stream_file_read (stream_file, size, dbiexhdr_data);
 
 	dbi_stream->dbiexhdrs = r_list_new();

--- a/libr/bin/pdb/fpo.c
+++ b/libr/bin/pdb/fpo.c
@@ -39,7 +39,9 @@ void parse_fpo_stream(void *stream, R_STREAM_FILE *stream_file)
 	SFPOStream *fpo_stream = 0;
 
 	stream_file_get_size(stream_file, &data_size);
-	data = (char *) malloc(data_size);
+	if (!(data = (char *) malloc(data_size))) {
+		return;
+	}
 	stream_file_get_data(stream_file, data);
 
 	fpo_stream = (SFPOStream *) stream;
@@ -47,7 +49,9 @@ void parse_fpo_stream(void *stream, R_STREAM_FILE *stream_file)
 	curr_read_bytes = 0;
 	ptmp = data;
 	while (read_bytes < data_size) {
-		fpo_data = (SFPO_DATA *) malloc(sizeof(SFPO_DATA));
+		if (!(fpo_data = (SFPO_DATA *) malloc(sizeof(SFPO_DATA)))) {
+			break;
+		}
 		curr_read_bytes = parse_fpo_data(ptmp, data_size, &read_bytes, fpo_data);
 		ptmp += curr_read_bytes;
 
@@ -102,8 +106,9 @@ void parse_fpo_new_stream(void *stream, R_STREAM_FILE *stream_file)
 	SFPONewStream *fpo_stream = 0;
 
 	stream_file_get_size (stream_file, &data_size);
-	data = (char *) malloc (data_size);
-	if (!data) return;
+	if (!(data = (char *) malloc (data_size))) {
+		return;
+	}
 	stream_file_get_data (stream_file, data);
 
 	fpo_stream = (SFPONewStream *) stream;
@@ -111,10 +116,8 @@ void parse_fpo_new_stream(void *stream, R_STREAM_FILE *stream_file)
 	curr_read_bytes = 0;
 	ptmp = data;
 	while (read_bytes < data_size) {
-		fpo_data = (SFPO_DATA_V2 *) malloc (sizeof(SFPO_DATA_V2));
-		if (!fpo_data) {
-			free (data);
-			return;
+		if (!(fpo_data = (SFPO_DATA_V2 *) malloc (sizeof(SFPO_DATA_V2)))) {
+			break;
 		}
 		curr_read_bytes = parse_fpo_data_v2 (ptmp, data_size, &read_bytes, fpo_data);
 		ptmp += curr_read_bytes;

--- a/libr/bin/pdb/omap.c
+++ b/libr/bin/pdb/omap.c
@@ -19,8 +19,9 @@ void parse_omap_stream(void *stream, R_STREAM_FILE *stream_file) {
 	SOmapStream *omap_stream = 0;
 
 	stream_file_get_size (stream_file, &data_size);
-	data = (char *) malloc (data_size);
-	if (!data) return;
+	if (!(data = (char *) malloc (data_size))) {
+		return;
+	}
 	stream_file_get_data (stream_file, data);
 
 	omap_stream = (SOmapStream *) stream;
@@ -28,8 +29,9 @@ void parse_omap_stream(void *stream, R_STREAM_FILE *stream_file) {
 	omap_stream->omap_entries = r_list_new();
 	ptmp = data;
 	while (read_bytes < data_size) {
-		omap_entry = (SOmapEntry *) malloc (sizeof(SOmapEntry));
-		if (!omap_entry) break;
+		if (!(omap_entry = (SOmapEntry *) malloc (sizeof(SOmapEntry)))) {
+			break;
+		}
 		curr_read_bytes = parse_omap_entry (ptmp, data_size, &read_bytes, omap_entry);
 		if (!curr_read_bytes) {
 			free (omap_entry);
@@ -97,8 +99,7 @@ int omap_remap(void *stream, int address) {
 	len = r_list_length (omap_stream->omap_entries);
 
 	if (omap_stream->froms == 0) {
-		omap_stream->froms = (unsigned int *) malloc (4 * len);
-		if (!omap_stream->froms) {
+		if (!(omap_stream->froms = (unsigned int *) malloc (4 * len))) {
 			return -1;
 		}
 		it = r_list_iterator (omap_stream->omap_entries);

--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -270,8 +270,7 @@ static void free_info_stream(void *stream) {
 			stream_parse_func->parse_stream = (parse_func);			\
 			stream_parse_func->free = (free_func);				\
 			if (stream_size) {						\
-				stream_parse_func->stream = malloc (stream_size);	\
-				if (!stream_parse_func->stream) {			\
+				if (!(stream_parse_func->stream = malloc (stream_size))) 	 { \
 					R_FREE (stream_parse_func);			\
 					return;						\
 				}							\
@@ -687,8 +686,7 @@ static int build_format_flags(R_PDB *pdb, char *type, int pos, char *res_field, 
 		case eStructState:
 			res_field[pos] = '?';
 			tmp = strtok (NULL, " ");
-			name = (char *) malloc (strlen (tmp) + strlen (*name_field) + 1 + 2);
-			if (!name) {
+			if (!(name = (char *) malloc (strlen (tmp) + strlen (*name_field) + 1 + 2))) {
 				return 0;
 			}
 			r_name_filter (tmp, -1);
@@ -743,8 +741,7 @@ static int build_format_flags(R_PDB *pdb, char *type, int pos, char *res_field, 
 			}
 			res_field[pos] = 'E';
 			tmp = strtok (NULL, " ");
-			name = (char *) malloc (strlen (tmp) + strlen (*name_field) + 1 + 2);
-			if (!name) {
+			if (!(name = (char *) malloc (strlen (tmp) + strlen (*name_field) + 1 + 2))) {
 				return 0;
 			}
 			strcpy (name, tmp);
@@ -759,8 +756,7 @@ static int build_format_flags(R_PDB *pdb, char *type, int pos, char *res_field, 
 		case eBitfieldState:
 			res_field[pos] = 'B';
 			tmp = strtok (NULL, " ");
-			name = (char *) malloc (strlen (tmp) + strlen (*name_field) + 1 + 2);
-			if (!name) {
+			if (!(name = (char *) malloc (strlen (tmp) + strlen (*name_field) + 1 + 2))) {
 				return 0;
 			}
 			strcpy (name, tmp);
@@ -798,15 +794,13 @@ void build_command_field(ELeafType lt, char **command_field) {
 	switch (lt) {
 	case eLF_STRUCTURE:
 	case eLF_UNION:
-		*command_field = (char *) malloc (strlen ("pf.") + 1);
-		if (!(*command_field)) {
+		if (!(*command_field = (char *) malloc (strlen ("pf.") + 1))) {
 			break;
 		}
 		strcpy (*command_field, "pf.");
 		break;
 	case eLF_ENUM:
-		*command_field = (char *) malloc (strlen ("\"td enum ") + 1);
-		if (!(*command_field)) {
+		if (!(*command_field = (char *) malloc (strlen ("\"td enum ") + 1))) {
 			break;
 		}
 		strcpy (*command_field, "\"td enum ");
@@ -831,8 +825,7 @@ int build_flags_format_and_members_field(R_PDB *pdb, ELeafType lt, char *name, c
 	switch (lt) {
 	case eLF_STRUCTURE:
 	case eLF_UNION:
-		members_field[i] = (char *) malloc (sizeof(char) * strlen (name) + 1);
-		if (!members_field[i]) {
+		if (!(members_field[i] = (char *) malloc (sizeof(char) * strlen (name) + 1))) {
 			return 0;
 		}
 		strcpy (members_field[i], name);
@@ -869,11 +862,15 @@ int alloc_format_flag_and_member_fields(RList *ptmp, char **flags_format_field, 
 	if (!*members_amount) {
 		return 0;
 	}
-	*flags_format_field = (char *) malloc (*members_amount + 1);
+	if (!(*flags_format_field = (char *) malloc (*members_amount + 1))) {
+		return 0;
+	}
 	memset (*flags_format_field, 0, *members_amount + 1);
 
 	size = sizeof *members_name_field * (*members_amount);
-	*members_name_field = (char **) malloc (size);
+	if (!(*members_name_field = (char **) malloc (size))) {
+		return 0;
+	}
 	for (i = 0; i < *members_amount; i++) {
 		(*members_name_field)[i] = 0;
 	}

--- a/libr/bin/pdb/pdb_downloader.c
+++ b/libr/bin/pdb/pdb_downloader.c
@@ -51,8 +51,7 @@ static int download(struct SPDBDownloader *pd) {
 	}
 	// dbg_file len is > 0
 	archive_name_len = strlen (opt->dbg_file);
-	archive_name = malloc (archive_name_len + 1);
-	if (!archive_name) {
+	if (!(archive_name = malloc (archive_name_len + 1))) {
 		return 0;
 	}
 	memcpy (archive_name, opt->dbg_file, archive_name_len + 1);

--- a/libr/bin/pdb/stream_pe.c
+++ b/libr/bin/pdb/stream_pe.c
@@ -13,8 +13,7 @@ void parse_pe_stream(void *stream, R_STREAM_FILE *stream_file)
 	int sctn_header_size =0;
 
 	stream_file_get_size (stream_file, &data_size);
-	data = (char *) malloc (data_size);
-	if (!data) {
+	if (!(data = (char *) malloc (data_size))) {
 		return;
 	}
 	stream_file_get_data (stream_file, data);
@@ -23,8 +22,7 @@ void parse_pe_stream(void *stream, R_STREAM_FILE *stream_file)
 	ptmp = data;
 	pe_stream->sections_hdrs = r_list_new ();
 	while (read_bytes < data_size) {
-		sctn_header = (SIMAGE_SECTION_HEADER *) malloc (sctn_header_size);
-		if (!sctn_header) {
+		if (!(sctn_header = (SIMAGE_SECTION_HEADER *) malloc (sctn_header_size))) {
 			break;
 		}
 		memcpy (sctn_header, ptmp, sctn_header_size);

--- a/libr/bin/pdb/tpi.c
+++ b/libr/bin/pdb/tpi.c
@@ -1012,8 +1012,7 @@ static void get_array_print_type(void *type, char **name) {
 	name_len = strlen ("array: ");
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1))) {
 		if (need_to_free) {
 			R_FREE (tmp_name);
 		}
@@ -1050,8 +1049,7 @@ static void get_pointer_print_type(void *type, char **name) {
 	if (tmp_name) {
 		name_len += strlen (tmp_name);
 	}
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1))) {
 	// 	free (tmp_name);
 		return;
 	}
@@ -1087,8 +1085,7 @@ static void get_modifier_print_type(void *type, char **name) {
 	if (tmp_name) {
 		name_len += strlen (tmp_name);
 	}
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1))) {
 		if (need_to_free) {
 			free (tmp_name);
 		}
@@ -1106,8 +1103,9 @@ static void get_modifier_print_type(void *type, char **name) {
 
 static void get_procedure_print_type(void *type, char **name) {
 	const int name_len = strlen ("proc ");
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, "proc ");
 }
@@ -1134,8 +1132,7 @@ static void get_bitfield_print_type(void *type, char **name) {
 	if (tmp_name)
 		name_len += strlen (tmp_name);
 	name_len += 4;
-	*name = (char *) malloc (name_len + 1 + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1 + 1))) {
 		if (need_to_free) free (tmp_name);
 		return;
 	}
@@ -1156,8 +1153,9 @@ static void get_fieldlist_print_type(void *type, char **name) {
 	int name_len = 0;
 
 	name_len = strlen ("fieldlist ");
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, "fieldlist ");
 }
@@ -1182,8 +1180,7 @@ static void get_enum_print_type(void *type, char **name) {
 	name_len = strlen ("enum ");
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1))) {
 		if (need_to_free) free (tmp_name);
 		return;
 	}
@@ -1213,8 +1210,9 @@ static void get_class_struct_print_type(void *type, char **name) {
 	name_len = strlen(tmp1);
 	if (tmp_name)
 		name_len += strlen(tmp_name);
-	*name = (char *) malloc(name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc(name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy(*name, tmp1);
 	if (tmp_name)
@@ -1231,8 +1229,9 @@ static void get_arglist_print_type(void *type, char **name) {
 	int name_len = 0;
 
 	name_len = strlen ("arg_list");
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, "arg_list");
 //	STypeInfo *ti = (STypeInfo *) type;
@@ -1266,8 +1265,9 @@ static void get_mfunction_print_type(void *type, char **name) {
 	int name_len = 0;
 
 	name_len = strlen("mfunction ");
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, "mfunction ");
 }
@@ -1286,8 +1286,9 @@ static void get_union_print_type(void *type, char **name) {
 	name_len = strlen (tmp1);
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, tmp1);
 	if (tmp_name)
@@ -1303,8 +1304,9 @@ static void get_vtshape_print_type(void *type, char **name) {
 	int name_len = 0;
 
 	name_len = strlen ("vtshape");
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, "vthape");
 }
@@ -1320,8 +1322,9 @@ static void get_enumerate_print_type(void *type, char **name) {
 	name_len = strlen (tmp1);
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, tmp1);
 	if (tmp_name)
@@ -1359,8 +1362,7 @@ static void get_nesttype_print_type(void *type, char **name) {
 	name_len = strlen ("nesttype ");
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1))) {
 		if (need_to_free) free (tmp_name);
 		return;
 	}
@@ -1384,8 +1386,9 @@ static void get_method_print_type(void *type, char **name) {
 	name_len = strlen (tmp1);
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) return;
+	if (!(*name = (char *) malloc (name_len + 1))) {
+		return;
+	}
 	// name[name_len] = '\0';
 	strcpy (*name, tmp1);
 	if (tmp_name)
@@ -1415,8 +1418,7 @@ static void get_member_print_type(void *type, char **name) {
 	name_len = strlen ("(member) ");
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1))) {
 		if (need_to_free) R_FREE (tmp_name);
 		return;
 	}
@@ -1450,8 +1452,7 @@ static void get_onemethod_print_type(void *type, char **name) {
 	name_len = strlen ("onemethod ");
 	if (tmp_name)
 		name_len += strlen (tmp_name);
-	*name = (char *) malloc (name_len + 1);
-	if (!(*name)) {
+	if (!(*name = (char *) malloc (name_len + 1))) {
 		if (need_to_free) free (tmp_name);
 		return;
 	}
@@ -1468,8 +1469,9 @@ static void get_onemethod_print_type(void *type, char **name) {
 void init_scstring(SCString *cstr, unsigned int size, char *name)
 {
 	cstr->size = size;
-	cstr->name = (char *) malloc (size);
-	if (!cstr->name) return;
+	if (!(cstr->name = (char *) malloc (size))) {
+		return;
+	}
 	strcpy (cstr->name, name);
 }
 
@@ -1507,8 +1509,10 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 	READ2(*read_bytes, len, val->value_or_type, leaf_data, ut16);
 
 	if (val->value_or_type < eLF_CHAR) {
-		SCString *sctr = (SCString *) malloc (sizeof (SCString));
-		if (!sctr) return 0;
+		SCString *sctr;
+		if (!(sctr = (SCString *) malloc (sizeof (SCString)))) {
+			return 0;
+		}
 		parse_sctring (sctr, leaf_data, read_bytes, len);
 		val->name_or_val = sctr;
 	} else {
@@ -1518,8 +1522,9 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 		    SVal_LF_UQUADWORD lf_uqword;
 		    READ8(*read_bytes, len, lf_uqword.value, leaf_data, st64);
 		    parse_sctring(&lf_uqword.name, leaf_data, read_bytes, len);
-		    val->name_or_val = malloc(sizeof(SVal_LF_UQUADWORD));
-		    if (!val->name_or_val) break;
+		    if (!(val->name_or_val = malloc(sizeof(SVal_LF_UQUADWORD)))) {
+			break;
+		    }
 		    memcpy(val->name_or_val, &lf_uqword, sizeof(SVal_LF_UQUADWORD));
 		    break;
 		}
@@ -1528,8 +1533,9 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 			SVal_LF_QUADWORD lf_qword;
 			READ8(*read_bytes, len, lf_qword.value, leaf_data, st64);
 			parse_sctring (&lf_qword.name, leaf_data, read_bytes, len);
-			val->name_or_val = malloc (sizeof (SVal_LF_QUADWORD));
-			if (!val->name_or_val) break;
+			if (!(val->name_or_val = malloc (sizeof (SVal_LF_QUADWORD)))) {
+				break;
+			}
 			memcpy (val->name_or_val, &lf_qword, sizeof (SVal_LF_QUADWORD));
 			break;
 		}
@@ -1538,8 +1544,9 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 			SVal_LF_CHAR lf_char;
 			READ2(*read_bytes, len, lf_char.value, leaf_data, st16);
 			parse_sctring (&lf_char.name, leaf_data, read_bytes, len);
-			val->name_or_val = malloc (sizeof (SVal_LF_CHAR));
-			if (!val->name_or_val) break;
+			if (!(val->name_or_val = malloc (sizeof (SVal_LF_CHAR)))) {
+				break;
+			}
 			memcpy (val->name_or_val, &lf_char, sizeof (SVal_LF_CHAR));
 			break;
 		}
@@ -1552,8 +1559,9 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 			// reading long value
 			READ4(*read_bytes, len, lf_long.value, leaf_data, st32);
 			parse_sctring (&lf_long.name, leaf_data, read_bytes, len);
-			val->name_or_val = malloc (sizeof (SVal_LF_LONG));
-			if (!val->name_or_val) break;
+			if (!(val->name_or_val = malloc (sizeof (SVal_LF_LONG)))) {
+				break;
+			}
 			memcpy (val->name_or_val, &lf_long, sizeof (SVal_LF_LONG));
 			break;
 		}
@@ -1566,8 +1574,9 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 			// reading ulong value
 			READ4(*read_bytes, len, lf_ulong.value, leaf_data, ut32);
 			parse_sctring (&lf_ulong.name, leaf_data, read_bytes, len);
-			val->name_or_val = malloc (sizeof (SVal_LF_ULONG));
-			if (!val->name_or_val) break;
+			if (!(val->name_or_val = malloc (sizeof (SVal_LF_ULONG)))) {
+				break;
+			}
 			memcpy(val->name_or_val, &lf_ulong, sizeof (SVal_LF_ULONG));
 			break;
 		}
@@ -1576,8 +1585,9 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 			SVal_LF_SHORT lf_short;
 			READ2(*read_bytes, len, lf_short.value, leaf_data, st16);
 			parse_sctring (&lf_short.name, leaf_data, read_bytes, len);
-			val->name_or_val = malloc (sizeof (SVal_LF_SHORT));
-			if (!val->name_or_val) break;
+			if (!(val->name_or_val = malloc (sizeof (SVal_LF_SHORT)))) {
+				break;
+			}
 			memcpy (val->name_or_val, &lf_short, sizeof (SVal_LF_SHORT));
 			break;
 		}
@@ -1586,8 +1596,9 @@ static int parse_sval(SVal *val, unsigned char *leaf_data, unsigned int *read_by
 			SVal_LF_USHORT lf_ushort;
 			READ2(*read_bytes, len, lf_ushort.value, leaf_data, ut16);
 			parse_sctring (&lf_ushort.name, leaf_data, read_bytes, len);
-			val->name_or_val = malloc (sizeof(SVal_LF_USHORT));
-			if (!val->name_or_val) break;
+			if (!(val->name_or_val = malloc (sizeof(SVal_LF_USHORT)))) {
+				break;
+			}
 			memcpy(val->name_or_val, &lf_ushort, sizeof (SVal_LF_USHORT));
 			break;
 		}
@@ -2080,8 +2091,9 @@ static int parse_lf_arglist(SLF_ARGLIST *lf_arglist, unsigned char *leaf_data, u
 
 	READ4(*read_bytes, len, lf_arglist->count, leaf_data, ut32);
 
-	lf_arglist->arg_type = (unsigned int *) malloc (lf_arglist->count * 4);
-	if (!lf_arglist->arg_type) return 0;
+	if (!(lf_arglist->arg_type = (unsigned int *) malloc (lf_arglist->count * 4))) {
+		return 0;
+	}
 	memcpy (lf_arglist->arg_type, leaf_data, lf_arglist->count * 4);
 	leaf_data += (lf_arglist->count * 4);
 	*read_bytes += (lf_arglist->count * 4);
@@ -2173,8 +2185,9 @@ static int parse_lf_vtshape(SLF_VTSHAPE *lf_vtshape, unsigned char *leaf_data, u
 	READ2(*read_bytes, len, lf_vtshape->count, leaf_data, ut16);
 
 	size = (4 * lf_vtshape->count + (lf_vtshape->count % 2) * 4) / 8;
-	lf_vtshape->vt_descriptors = (char *) malloc (size);
-	if (!lf_vtshape->vt_descriptors) return 0;
+	if (!(lf_vtshape->vt_descriptors = (char *) malloc (size))) {
+		return 0;
+	}
 	memcpy (lf_vtshape->vt_descriptors, leaf_data, size);
 	leaf_data += size;
 	*read_bytes += size;
@@ -2186,8 +2199,11 @@ static int parse_lf_vtshape(SLF_VTSHAPE *lf_vtshape, unsigned char *leaf_data, u
 }
 
 #define PARSE_LF(lf_type, lf_func) { \
-	lf_type *lf = (lf_type *) malloc(sizeof(lf_type)); \
-	if (!lf) { free (leaf_data); return 0; }\
+	lf_type *lf; \
+	if (!(lf = (lf_type *) malloc(sizeof(lf_type)))) { \
+		free (leaf_data); \
+		return 0; \
+	} \
 	parse_##lf_func(lf, leaf_data + 2, &read_bytes, type->length); \
 	type->type_data.type_info = (void *) lf; \
 	init_stype_info(&type->type_data); \
@@ -2201,8 +2217,9 @@ static int parse_tpi_stypes(R_STREAM_FILE *stream, SType *type) {
 	stream_file_read(stream, 2, (char *)&type->length);
 	if (type->length<1)
 		return 0;
-	leaf_data = (unsigned char *) malloc(type->length);
-	if (!leaf_data) return 0;
+	if (!(leaf_data = (unsigned char *) malloc(type->length))) {
+		return 0;
+	}
 	stream_file_read (stream, type->length, (char *)leaf_data);
 	type->type_data.leaf_type = *(unsigned short *)leaf_data;
 	read_bytes += 2;
@@ -2227,8 +2244,8 @@ static int parse_tpi_stypes(R_STREAM_FILE *stream, SType *type) {
 	case eLF_POINTER:
 //		printf("eLF_POINTER\n");
 	{
-		SLF_POINTER *lf = (SLF_POINTER *) malloc(sizeof(SLF_POINTER)); \
-		if (!lf) { \
+		SLF_POINTER *lf; \
+		if (!(lf = (SLF_POINTER *) malloc(sizeof(SLF_POINTER)))) { \
 			free (leaf_data); \
 			return 0; \
 		} \
@@ -2294,8 +2311,9 @@ int parse_tpi_stream(void *parsed_pdb_stream, R_STREAM_FILE *stream) {
 	base_idx = tpi_stream->header.ti_min;
 
 	for (i = tpi_stream->header.ti_min; i < tpi_stream->header.ti_max; i++) {
-		type = (SType *) malloc (sizeof (SType));
-		if (!type) return 0;
+		if (!(type = (SType *) malloc (sizeof (SType)))) {
+			return 0;
+		}
 		type->tpi_idx = i;
 		type->type_data.type_info = 0;
 		type->type_data.leaf_type = eLF_MAX;

--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -178,8 +178,7 @@ static RBreakpointItem *r_bp_add(RBreakpoint *bp, const ut8 *obytes, ut64 addr, 
 			return NULL;
 		}
 		if (obytes) {
-			b->obytes = malloc (size);
-			if (!b->obytes) {
+			if (!(b->obytes = malloc (size))) {
 				free (b->bbytes);
 				return NULL;
 			}

--- a/libr/bp/bp_traptrace.c
+++ b/libr/bp/bp_traptrace.c
@@ -75,17 +75,15 @@ R_API int r_bp_traptrace_add(RBreakpoint *bp, ut64 from, ut64 to) {
 	len = to-from;
 	if (len >= ST32_MAX)
 		return false;
-	buf = (ut8*) malloc ((int)len);
-	if (!buf)
+	if (!(buf = (ut8*) malloc ((int)len))) {
 		return false;
-	trap = (ut8*) malloc ((int)len+4);
-	if (!trap) {
+	}
+	if (!(trap = (ut8*) malloc ((int)len+4))) {
 		free (buf);
 		return false;
 	}
 	bitlen = (len>>4)+1;
-	bits = malloc (bitlen);
-	if (!bits) {
+	if (!(bits = malloc (bitlen))) {
 		free (buf);
 		free (trap);
 		return false;

--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -511,7 +511,7 @@ R_API int r_cons_canvas_resize(RConsCanvas *c, int w, int h) {
 			newline = malloc ((w + 1));
 		}
 		if (!newline) {
-			r_con_canvas_free(c);
+			r_cons_canvas_free(c);
 			return false;
 		}
 		c->blen[i] = w;

--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -221,20 +221,19 @@ R_API RConsCanvas *r_cons_canvas_new(int w, int h) {
 	c->color = 0;
 	c->sx = 0;
 	c->sy = 0;
-	c->b = malloc (sizeof *c->b * h);
-	if (!c->b) {
+	if (!(c->b = malloc (sizeof *c->b * h))) {
 		goto beach;
 	}
-	c->blen = malloc (sizeof *c->blen * h);
-	if (!c->blen) {
+	if (!(c->blen = malloc (sizeof *c->blen * h))) {
 		goto beach;
 	}
-	c->bsize = malloc (sizeof *c->bsize * h);
-	if (!c->bsize) {
+	if (!(c->bsize = malloc (sizeof *c->bsize * h))) {
 		goto beach;
 	}
 	for (i = 0; i < h; i++) {
-		c->b[i] = malloc (w + 1);
+		if (!(c->b[i] = malloc (w + 1))) {
+			goto beach;
+		}
 		c->blen[i] = w;
 		c->bsize[i] = w + 1;
 		if (!c->b[i]) {
@@ -306,7 +305,7 @@ static int expand_line (RConsCanvas *c, int real_len, int utf8_len) {
 	if (padding) {
 		if (padding > 0 && c->blen[c->y] + padding > c->bsize[c->y]) {
 			int newsize = R_MAX (c->bsize[c->y] * 1.5, c->blen[c->y] + padding);
-			char * newline = realloc (c->b[c->y], sizeof (*c->b[c->y])*(newsize)); 
+			char * newline = realloc (c->b[c->y], sizeof (*c->b[c->y])*(newsize));
 			if (!newline) {
 				return false;
 			}
@@ -316,8 +315,8 @@ static int expand_line (RConsCanvas *c, int real_len, int utf8_len) {
 		}
 		int size = R_MAX (c->blen[c->y] - c->x - utf8_len, 0);
 		char *start = c->b[c->y] + c->x + utf8_len;
-		char *tmp = malloc (size);
-		if (!tmp) {
+		char *tmp;
+		if (!(tmp = malloc (size))) {
 			return false;
 		}
 		memcpy (tmp, start, size);
@@ -367,7 +366,7 @@ R_API void r_cons_canvas_write(RConsCanvas *c, const char *s) {
 		}
 
 		int real_len = r_str_nlen (s_part, slen);
-		int utf8_len = utf8len_fixed (s_part, slen); 
+		int utf8_len = utf8len_fixed (s_part, slen);
 
 		if (!expand_line (c, real_len, utf8_len)) {
 			break;
@@ -511,6 +510,10 @@ R_API int r_cons_canvas_resize(RConsCanvas *c, int w, int h) {
 		} else {
 			newline = malloc ((w + 1));
 		}
+		if (!newline) {
+			r_con_canvas_free(c);
+			return false;
+		}
 		c->blen[i] = w;
 		c->bsize[i] = w + 1;
 		if (!newline) {
@@ -561,8 +564,7 @@ R_API void r_cons_canvas_box(RConsCanvas *c, int x, int y, int w, int h, const c
 	if (!c->color) {
 		c->attr = Color_RESET;
 	}
-	row = malloc (w + 1);
-	if (!row) {
+	if (!(row = malloc (w + 1))) {
 		return;
 	}
 	row[0] = roundcorners? '.': tl_corner[0];
@@ -607,8 +609,8 @@ R_API void r_cons_canvas_fill(RConsCanvas *c, int x, int y, int w, int h, char c
 	if (w < 0) {
 		return;
 	}
-	char *row = malloc (w + 1);
-	if (!row) {
+	char *row;
+	if (!(row = malloc (w + 1))) {
 		return;
 	}
 	memset (row, ch, w);

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -69,8 +69,7 @@ static RConsStack *cons_stack_dump(bool recreate) {
 	}
 
 	if (recreate && I.context->buffer_sz > 0) {
-		I.context->buffer = malloc (I.context->buffer_sz);
-		if (!I.context->buffer) {
+		if (!(I.context->buffer = malloc (I.context->buffer_sz))) {
 			I.context->buffer = data->buf;
 			free (data);
 			return NULL;
@@ -1235,8 +1234,8 @@ R_API void r_cons_set_cup(int enable) {
 }
 
 R_API void r_cons_column(int c) {
-	char *b = malloc (I.context->buffer_len + 1);
-	if (!b) {
+	char *b;
+	if (!(b = malloc (I.context->buffer_len + 1))) {
 		return;
 	}
 	memcpy (b, I.context->buffer, I.context->buffer_len);
@@ -1296,8 +1295,7 @@ R_API void r_cons_highlight(const char *word) {
 		} else {
 			I.highlight = strdup (word);
 		}
-		rword = malloc (word_len + linv[0] + linv[1] + 1);
-		if (!rword) {
+		if (!(rword = malloc (word_len + linv[0] + linv[1] + 1))) {
 			free (cpos);
 			free (clean);
 			return;

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -519,15 +519,15 @@ R_API int r_cons_grepbuf(char *buf, int len) {
 	}
 	if (!cons->context->buffer) {
 		cons->context->buffer_len = len + 20;
-		cons->context->buffer = malloc (cons->context->buffer_len);
+		if (!(cons->context->buffer = malloc (cons->context->buffer_len))) {
+			return 0;
+		}
 		cons->context->buffer[0] = 0;
 	}
-	out = tbuf = calloc (1, len);
-	if (!out) {
+	if (!(out = tbuf = calloc (1, len))) {
 		return 0;
 	}
-	tline = malloc (len);
-	if (!tline) {
+	if (!(tline = malloc (len))) {
 		free (out);
 		return 0;
 	}

--- a/libr/cons/less.c
+++ b/libr/cons/less.c
@@ -73,8 +73,7 @@ static int *splitlines (char *s, int *lines_count) {
 	if (lines_size * sizeof (int) < lines_size) {
 		return NULL;
 	}
-	lines = malloc (lines_size * sizeof (int));
-	if (!lines) {
+	if (!(lines = malloc (lines_size * sizeof (int)))) {
 		return NULL;
 	}
 	lines[row++] = 0;

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -357,8 +357,8 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 		r_anal_emul_restore (core, hc);
 		return;
 	}
-	ut8 *buf = malloc (bsize);
-	if (!buf) {
+	ut8 *buf;
+	if (!(buf = malloc (bsize))) {
 		free (buf);
 		r_anal_emul_restore (core, hc);
 		return;

--- a/libr/core/asm.c
+++ b/libr/core/asm.c
@@ -429,8 +429,7 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		return NULL;
 	}
 
-	buf = (ut8 *)malloc (len);
-	if (!buf) {
+	if (!(buf = (ut8 *)malloc (len))) {
 		r_list_free (hits);
 		return NULL;
 	} else if (!hits) {
@@ -479,7 +478,10 @@ static RList * r_core_asm_back_disassemble_all(RCore *core, ut64 addr, ut64 len,
 	RCoreAsmHit dummy_value;
 	RCoreAsmHit *hit = NULL;
 	RAsmOp op;
-	ut8 *buf = (ut8 *)malloc (len + extra_padding);
+	ut8 *buf;
+	if (!(buf = (ut8 *)malloc (len + extra_padding))) {
+		return NULL;
+	}
 	int current_instr_len = 0;
 	ut64 current_instr_addr = addr,
 		 current_buf_pos = len - 1,

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -129,7 +129,7 @@ static char *is_string_at(RCore *core, ut64 addr, int *olen) {
 		}
 		return (char*) str;
 	}
-	
+
 	ut64 *cstr = (ut64*)str;
 	ut64 lowptr = cstr[0];
 	if (lowptr >> 32) { // must be pa mode only
@@ -142,7 +142,7 @@ static char *is_string_at(RCore *core, ut64 addr, int *olen) {
 		if (ptr >> 32) { // must be pa mode only
 			ptr &= UT32_MAX;
 		}
-		if (ptr) {	
+		if (ptr) {
 			r_io_read_at (core->io, ptr, rstr, sizeof (rstr));
 			rstr[127] = 0;
 			ret = is_string (rstr, 128, &len);
@@ -1109,7 +1109,10 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 			sdb_num_set (DB, key, bbi->size, 0); // bb.<addr>.size=<num>
 		} else if (is_json) {
 			RDebugTracepoint *t = r_debug_trace_get (core->dbg, bbi->addr);
-			ut8 *buf = malloc (bbi->size);
+			ut8 *buf;
+			if (!(buf = malloc (bbi->size))) {
+				return 0;
+			}
 			if (count > 1) {
 				r_cons_printf (",");
 			}
@@ -1364,8 +1367,7 @@ R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head) {
 
 	if (ret == R_ANAL_RET_NEW) { /* New bb */
 		// XXX: use static buffer size of 512 or so
-		buf = malloc (core->anal->opt.bb_max_size);
-		if (!buf) {
+		if (!(buf = malloc (core->anal->opt.bb_max_size))) {
 			goto error;
 		}
 		do {
@@ -2834,8 +2836,8 @@ static bool opiscall(RCore *core, RAnalOp *aop, ut64 addr, const ut8* buf, int l
 // TODO(maskray) RAddrInterval API
 #define OPSZ 8
 R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode) {
-	ut8 *buf = (ut8 *)malloc (core->blocksize);
-	if (!buf) {
+	ut8 *buf;
+	if (!(buf = (ut8 *)malloc (core->blocksize))) {
 		return -1;
 	}
 	int ptrdepth = r_config_get_i (core->config, "anal.ptrdepth");
@@ -3018,7 +3020,7 @@ static void found_xref(RCore *core, ut64 at, ut64 xref_to, RAnalRefType type, in
 		// Add to SDB
 		if (xref_to) {
 			r_anal_xrefs_set (core->anal, at, xref_to, type);
-		}	
+		}
 	} else if (rad == 'j') {
 		// Output JSON
 		if (count > 0) {
@@ -3073,17 +3075,15 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 		eprintf ("Error: block size too small\n");
 		return -1;
 	}
-	buf = malloc (bsz);
-	if (!buf) {
+	if (!(buf = malloc (bsz))) {
 		eprintf ("Error: cannot allocate a block\n");
 		return -1;
 	}
-	block = malloc (bsz);
-	if (!block) {
+	if (!(block = malloc (bsz))) {
 		eprintf ("Error: cannot allocate a temp block\n");
 		free (buf);
 		return -1;
-	}	
+	}
 	if (rad == 'j') {
 		r_cons_printf ("{");
 	}
@@ -3252,8 +3252,7 @@ R_API int r_core_anal_data (RCore *core, ut64 addr, int count, int depth, int wo
 	int i, j;
 
 	count = R_MIN (count, len);
-	buf = malloc (len + 1);
-	if (!buf) {
+	if (!(buf = malloc (len + 1))) {
 		return false;
 	}
 	memset (buf, 0xff, len);
@@ -3328,9 +3327,8 @@ R_API RCoreAnalStats* r_core_anal_get_stats(RCore *core, ut64 from, ut64 to, ut6
 	}
 	blocks = (to - from) / step;
 	as_size = (1 + blocks) * sizeof (RCoreAnalStatsItem);
-	as->block = malloc (as_size);
-	if (!as->block) {
-		free (as);
+	if (!(as->block = malloc (as_size))) {
+		free(as);
 		return NULL;
 	}
 	memset (as->block, 0, as_size);
@@ -3825,8 +3823,7 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 		return;
 	}
 
-	buf = malloc (size + 2);
-	if (!buf) {
+	if (!(buf = malloc (size + 2))) {
 		perror ("malloc");
 		return;
 	}
@@ -3853,8 +3850,7 @@ static void getpcfromstack(RCore *core, RAnalEsil *esil) {
 		goto err_anal_op;
 	}
 	tmp_esil_str_len = strlen (esilstr) + strlen (spname) + maxaddrlen;
-	tmp_esil_str = (char*) malloc (tmp_esil_str_len);
-	if (!tmp_esil_str) {
+	if (!(tmp_esil_str = (char*) malloc (tmp_esil_str_len))) {
 		goto err_anal_op;
 	}
 	tmp_esil_str[tmp_esil_str_len - 1] = '\0';
@@ -3962,8 +3958,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 	if (iend < 0) {
 		return;
 	}
-	buf = malloc (iend + 2);
-	if (!buf) {
+	if (!(buf = malloc (iend + 2))) {
 		perror ("malloc");
 		return;
 	}

--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -60,8 +60,8 @@ static void print_format_values(RCore *core, const char *fmt, bool onstack, ut64
 	int width = (core->anal->bits == 64)? 8: 4;
 	int bsize = R_MIN (64, core->blocksize);
 
-	ut8 *buf = malloc (bsize);
-	if (!buf) {
+	ut8 *buf;
+	if (!(buf = malloc (bsize))) {
 		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		free (buf);
 		return;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -320,7 +320,7 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 			r_cons_printf ("%03u 0x%08"PFMT64x" 0x%08"
 				PFMT64x" %3u %3u "
 				"(%s) %5s %s",
-				string->ordinal, paddr, vaddr, 
+				string->ordinal, paddr, vaddr,
 				string->length, string->size,
 				section_name, type_string, str);
 #endif
@@ -2117,7 +2117,7 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 	if (!dup_chk_ht) {
 		return false;
 	}
-	
+
 	if (chksum && *chksum == '.') {
 		printHere = true;
 	}
@@ -2243,8 +2243,8 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 		} else if (IS_MODE_SIMPLE (mode)) {
 			char *hashstr = NULL;
 			if (chksum) {
-				ut8 *data = malloc (section->size);
-				if (!data) {
+				ut8 *data;
+				if (!(data = malloc (section->size))) {
 					goto out;
 				}
 				ut32 datalen = section->size;
@@ -2263,8 +2263,8 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 		} else if (IS_MODE_JSON (mode)) {
 			char *hashstr = NULL;
 			if (chksum) {
-				ut8 *data = malloc (section->size);
-				if (!data) {
+				ut8 *data;
+				if (!(data = malloc (section->size))) {
 					goto out;
 				}
 				ut32 datalen = section->size;
@@ -2343,8 +2343,8 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 		} else {
 			char *hashstr = NULL, str[128];
 			if (chksum) {
-				ut8 *data = malloc (section->size);
-				if (!data) {
+				ut8 *data;
+				if (!(data = malloc (section->size))) {
 					goto out;
 				}
 				ut32 datalen = section->size;
@@ -3356,7 +3356,7 @@ R_API int r_core_bin_info(RCore *core, int action, int mode, int va, RCoreBinFil
 	if (filter && filter->name) {
 		name = filter->name;
 	}
-	
+
 	// use our internal values for va
 	va = va ? VA_TRUE : VA_FALSE;
 #if 0

--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -78,8 +78,7 @@ R_API bool r_core_dump(RCore *core, const char *file, ut64 addr, ut64 size, int 
 	/* some io backends seems to be buggy in those cases */
 	if (bs > 4096)
 		bs = 4096;
-	buf = malloc (bs);
-	if (!buf) {
+	if (!(buf = malloc (bs))) {
 		eprintf ("Cannot alloc %d byte(s)\n", bs);
 		fclose (fd);
 		return false;
@@ -110,8 +109,7 @@ R_API int r_core_write_op(RCore *core, const char *arg, char op) {
 	ut8 *buf;
 
 	// XXX we can work with config.block instead of dupping it
-	buf = (ut8 *)malloc (core->blocksize);
-	if (!buf) {
+	if (!(buf = (ut8 *)malloc (core->blocksize))) {
 		goto beach;
 	}
 	memcpy (buf, core->block, core->blocksize);
@@ -121,9 +119,9 @@ R_API int r_core_write_op(RCore *core, const char *arg, char op) {
 		if (arg) {  // parse arg for key
 			// r_hex_str2bin() is guaranteed to output maximum half the
 			// input size, or 1 byte if there is just a single nibble.
-			str = (char *)malloc (strlen (arg) / 2 + 1);
-			if (!str)
+			if (!(str = (char *)malloc (strlen (arg) / 2 + 1))) {
 				goto beach;
+			}
 			len = r_hex_str2bin (arg, (ut8 *)str);
 			// Output is invalid if there was just a single nibble,
 			// but in that case, len is negative (-1).

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -433,8 +433,7 @@ static int cmd_alias(void *data, const char *input) {
 		return 0;
 	}
 	i = strlen (input);
-	buf = malloc (i + 2);
-	if (!buf) {
+	if (!(buf = malloc (i + 2))) {
 		return 0;
 	}
 	*buf = '$'; // prefix aliases with a dash
@@ -490,8 +489,7 @@ static int cmd_alias(void *data, const char *input) {
 		if (v) {
 			if (q) {
 				char *out, *args = q + 1;
-				out = malloc (strlen (v) + strlen (args) + 2);
-				if (out) { //XXX slow
+				if ((out = malloc (strlen (v) + strlen (args) + 2))) { //XXX slow
 					strcpy (out, v);
 					strcat (out, " ");
 					strcat (out, args);
@@ -2610,8 +2608,7 @@ repeat_arroba:
 			case 'f': // "@f:" // slurp file in block
 				f = r_file_slurp (ptr + 2, &sz);
 				if (f) {
-					buf = malloc (sz);
-					if (buf) {
+					if ((buf = malloc (sz))) {
 						free (core->block);
 						core->block = buf;
 						core->blocksize = sz;
@@ -2671,8 +2668,7 @@ repeat_arroba:
 				break;
 			case 'x': // "@x:" // hexpairs
 				if (ptr[1] == ':') {
-					buf = malloc (strlen (ptr + 2) + 1);
-					if (buf) {
+					if ((buf = malloc (strlen (ptr + 2) + 1))) {
 						len = r_hex_str2bin (ptr + 2, buf);
 						r_core_block_size (core, R_ABS(len));
 						memcpy (core->block, buf, core->blocksize);
@@ -3033,7 +3029,7 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 			r_list_foreach (obj->sections, it, sec){
 				ut64 addr = sec->vaddr;
 				ut64 size = sec->vsize;
-				// TODO: 
+				// TODO:
 				//if (R_BIN_SCN_EXECUTABLE & sec->srwx) {
 				//	continue;
 				//}
@@ -3554,8 +3550,7 @@ R_API int r_core_cmd(RCore *core, const char *cstr, int log) {
 		core->lastcmd = strdup (cstr);
 	}
 
-	ocmd = cmd = malloc (strlen (cstr) + 4096);
-	if (!ocmd) {
+	if (!(ocmd = cmd = malloc (strlen (cstr) + 4096))) {
 		goto beach;
 	}
 	r_str_cpy (cmd, cstr);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4793,11 +4793,12 @@ static void _anal_calls(RCore *core, ut64 addr, ut64 addr_end) {
 		return;
 	}
 	ut8 *buf, *block0, *block1;
+	buf = block0 = block1 = NULL;
 	if (!(buf = malloc (bsz))) {
 		return;
 	}
-	*block0 = calloc (1, bsz);
-	if (!(*block1 = malloc (bsz))) {
+	block0 = calloc (1, bsz);
+	if (!(block1 = malloc (bsz))) {
 		return;
 	}
 	if (!buf || !block0 || !block1) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3915,8 +3915,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 		buf_sz = maxopsize;
 	}
 	addr_end = addr + buf_sz;
-	buf = malloc (buf_sz);
-	if (!buf) {
+	if (!(buf = malloc (buf_sz))) {
 		return false;
 	}
 	(void)r_io_read_at (core->io, addr, (ut8 *)buf, buf_sz);
@@ -4068,8 +4067,7 @@ static void cmd_aespc(RCore *core, ut64 addr, int off) {
 			return;
 		}
 	}
-	buf = malloc (bsize);
-	if (!buf) {
+	if (!(buf = malloc (bsize))) {
 		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		free (buf);
 		return;
@@ -4794,9 +4792,14 @@ static void _anal_calls(RCore *core, ut64 addr, ut64 addr_end) {
 	if (addr_end - addr > UT32_MAX) {
 		return;
 	}
-	ut8 *buf = malloc (bsz);
-	ut8 *block0 = calloc (1, bsz);
-	ut8 *block1 = malloc (bsz);
+	ut8 *buf, *block0, *block1;
+	if (!(buf = malloc (bsz))) {
+		return;
+	}
+	*block0 = calloc (1, bsz);
+	if (!(*block1 = malloc (bsz))) {
+		return;
+	}
 	if (!buf || !block0 || !block1) {
 		eprintf ("Error: cannot allocate buf or block\n");
 		free (buf);
@@ -5878,8 +5881,8 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		r_agraph_foreach (core->graph, agraph_print_node, NULL);
 		r_agraph_foreach_edge (core->graph, agraph_print_edge, NULL);
 		break;
-	case 'J': 
-	case 'j': 
+	case 'J':
+	case 'j':
 		r_cons_printf ("{\"nodes\":[");
 		r_agraph_print_json (core->graph);
 		r_cons_printf ("]}\n");
@@ -6301,7 +6304,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 	case 'v': // "agv" alias for "agfv"
 		r_core_cmdf (core, "agfv%s", input + 1);
 		break;
-	case 'w':// "agw" 
+	case 'w':// "agw"
 		if (r_config_get_i (core->config, "graph.web")) {
 			r_core_cmd0 (core, "=H /graph/");
 		} else {
@@ -7019,8 +7022,8 @@ static int cmd_anal(void *data, const char *input) {
 		break;
 	case '8':
 		{
-			ut8 *buf = malloc (strlen (input) + 1);
-			if (buf) {
+			ut8 *buf;
+			if ((buf = malloc (strlen (input) + 1))) {
 				int len = r_hex_str2bin (input + 1, buf);
 				if (len > 0) {
 					core_anal_bytes (core, buf, len, 0, input[1]);

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -254,8 +254,7 @@ R_API int r_cmd_call_long(RCmd *cmd, const char *input) {
 			int lcmd = strlen (c->cmd_short);
 			int linp = strlen (input+c->cmd_len);
 			/// SLOW malloc on most situations. use stack
-			inp = malloc (lcmd+linp+2); // TODO: use static buffer with R_CMD_MAXLEN
-			if (!inp) {
+			if (!(inp = malloc (lcmd+linp+2))) { // TODO: use static buffer with R_CMD_MAXLEN
 				return -1;
 			}
 			memcpy (inp, c->cmd_short, lcmd);
@@ -347,13 +346,17 @@ R_API int r_cmd_macro_add(RCmdMacro *mac, const char *oname) {
 		*ptr = ' ';
 	}
 	if (!macro) {
-		macro = (struct r_cmd_macro_item_t *)malloc (
-			sizeof (struct r_cmd_macro_item_t));
+		if (!(macro = (struct r_cmd_macro_item_t *)malloc (
+			sizeof (struct r_cmd_macro_item_t)))) {
+			return -1;
+		}
 		macro->name = strdup (name);
 	}
 
 	macro->codelen = (pbody[0])? strlen (pbody)+2 : 4096;
-	macro->code = (char *)malloc (macro->codelen);
+	if (!(macro->code = (char *)malloc (macro->codelen))) {
+		return -1;
+	}
 	*macro->code = '\0';
 	macro->nargs = 0;
 	if (!args)

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -67,8 +67,7 @@ R_API int r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd)
 	cmpw->size = size;
 	snprintf (cmpw->cmd, sizeof (cmpw->cmd), "%s", cmd);
 	cmpw->odata = NULL;
-	cmpw->ndata = malloc (size);
-	if (!cmpw->ndata) {
+	if (!(cmpw->ndata = malloc (size))) {
 		free (cmpw);
 		return false;
 	}
@@ -124,8 +123,7 @@ R_API int r_core_cmpwatch_update(RCore *core, ut64 addr) {
 	r_list_foreach (core->watchers, iter, w) {
 		free (w->odata);
 		w->odata = w->ndata;
-		w->ndata = malloc (w->size);
-		if (!w->ndata) {
+		if (!(w->ndata = malloc (w->size))) {
 			return false;
 		}
 		r_io_read_at (core->io, w->addr, w->ndata, w->size);
@@ -204,12 +202,10 @@ static int radare_compare_unified(RCore *core, ut64 of, ut64 od, int len) {
 	if (len < 1) {
 		return false;
 	}
-	f = malloc (len);
-	if (!f) {
+	if (!(f = malloc (len))) {
 		return false;
 	}
-	d = malloc (len);
-	if (!d) {
+	if (!(d = malloc (len))) {
 		free (f);
 		return false;
 	}
@@ -548,8 +544,7 @@ static int cmd_cmp(void *data, const char *input) {
 		free (filled);
 		break;
 	case 'X':
-		buf = malloc (core->blocksize);
-		if (buf) {
+		if ((buf = malloc (core->blocksize))) {
 			if (!r_io_read_at (core->io, r_num_math (core->num,
 					    input + 1), buf, core->blocksize)) {
 				eprintf ("Cannot read hexdump\n");
@@ -570,8 +565,7 @@ static int cmd_cmp(void *data, const char *input) {
 			eprintf ("Cannot open file '%s'\n", input + 2);
 			return false;
 		}
-		buf = (ut8 *) malloc (core->blocksize);
-		if (buf) {
+		if ((buf = (ut8 *) malloc (core->blocksize))) {
 			if (fread (buf, 1, core->blocksize, fd) < 1) {
 				eprintf ("Cannot read file %s\n", input + 2);
 			} else {
@@ -657,8 +651,8 @@ static int cmd_cmp(void *data, const char *input) {
 				}
 			}
 			int col = core->cons->columns > 123;
-			ut8 *b = malloc (core->blocksize);
-			if (b != NULL) {
+			ut8 *b;
+			if ((b = malloc (core->blocksize))) {
 				memset (b, 0xff, core->blocksize);
 				r_io_read_at (core->io, addr, b, core->blocksize);
 				r_print_hexdiff (core->print, core->offset, block,

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1150,8 +1150,8 @@ static int __r_debug_snap_diff(RCore *core, int idx) {
 	core->print->flags |= R_PRINT_FLAGS_DIFFOUT;
 	r_list_foreach (dbg->snaps, iter, snap) {
 		if (count == idx) {
-			ut8 *b = malloc (snap->size);
-			if (!b) {
+			ut8 *b;
+			if (!(b = malloc (snap->size))) {
 				eprintf ("Cannot allocate snapshot\n");
 				continue;
 			}
@@ -1301,9 +1301,9 @@ static int dump_maps(RCore *core, int perm, const char *filename) {
 			do_dump = true;
 		}
 		if (do_dump) {
-			ut8 *buf = malloc (map->size);
+			ut8 *buf;
+			if (!(buf = malloc (map->size))) {
 			//TODO: use mmap here. we need a portable implementation
-			if (!buf) {
 				eprintf ("Cannot allocate 0x%08"PFMT64x" bytes\n", map->size);
 				free (buf);
 				/// XXX: TODO: read by blocks!!1
@@ -3449,7 +3449,9 @@ static RTreeNode *add_trace_tree_child (Sdb *db, RTree *t, RTreeNode *cur, ut64 
 	snprintf (dbkey, TN_KEY_LEN, TN_KEY_FMT, addr);
 	t_node = (struct trace_node *)(size_t)sdb_num_get (db, dbkey, NULL);
 	if (!t_node) {
-		t_node = (struct trace_node *)malloc (sizeof (*t_node));
+		if (!(t_node = (struct trace_node *)malloc (sizeof (*t_node)))) {
+			return NULL;
+		}
 		t_node->addr = addr;
 		t_node->refs = 1;
 		sdb_num_set (db, dbkey, (ut64)(size_t)t_node, 0);

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -408,8 +408,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 		char *nc = strdup (newcomment);
 		r_str_unescape (nc);
 		if (comment) {
-			text = malloc (strlen (comment)+ strlen (newcomment)+2);
-			if (text) {
+			if ((text = malloc (strlen (comment)+ strlen (newcomment)+2))) {
 				strcpy (text, comment);
 				strcat (text, " ");
 				strcat (text, nc);

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -826,9 +826,8 @@ static bool reopen_in_malloc_cb(void *user, void *data, ut32 id) {
 		return false;
 	}
 
-	ut8 *buf = malloc (size);
-// if malloc fails, we can just abort the loop by returning false
-	if (!buf) {
+	ut8 *buf;
+	if (!(buf = malloc (size))) {
 		free (uri);
 		return false;
 	}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -764,8 +764,8 @@ static void cmd_pDj(RCore *core, const char *arg) {
 		bsize = -bsize;
 	}
 	r_cons_print ("[");
-	ut8 *buf = malloc (bsize);
-	if (buf) {
+	ut8 *buf;
+	if ((buf = malloc (bsize))) {
 		r_io_read_at (core->io, core->offset, buf, bsize);
 		r_core_print_disasm_json (core, core->offset, buf, bsize, 0);
 		free (buf);
@@ -1505,7 +1505,10 @@ static int printzoomcallback(void *user, int mode, ut64 addr, ut8 *bufz, ut64 si
 R_API void r_core_print_cmp(RCore *core, ut64 from, ut64 to) {
 	long int delta = 0;
 	int col = core->cons->columns > 123;
-	ut8 *b = malloc (core->blocksize);
+	ut8 *b;
+	if (!(b = malloc (core->blocksize))) {
+		return;
+	}
 	ut64 addr = core->offset;
 	memset (b, 0xff, core->blocksize);
 	delta = addr - from;
@@ -2491,8 +2494,7 @@ static ut8 *analBars(RCore *core, int type, int nblocks, int blocksize, int skip
 		eprintf ("Error: failed to malloc memory");
 		return NULL;
 	}
-	p = malloc (blocksize);
-	if (!p) {
+	if (!(p = malloc (blocksize))) {
 		R_FREE (ptr);
 		eprintf ("Error: failed to malloc memory");
 		return NULL;
@@ -2686,8 +2688,7 @@ static void cmd_print_bars(RCore *core, const char *input) {
 				eprintf ("Error: failed to malloc memory");
 				goto beach;
 			}
-			p = malloc (blocksize);
-			if (!p) {
+			if (!(p = malloc (blocksize))) {
 				R_FREE (ptr);
 				eprintf ("Error: failed to malloc memory");
 				goto beach;
@@ -2755,8 +2756,7 @@ static void cmd_print_bars(RCore *core, const char *input) {
 			eprintf ("Error: failed to malloc memory");
 			goto beach;
 		}
-		p = malloc (blocksize);
-		if (!p) {
+		if (!(p = malloc (blocksize))) {
 			R_FREE (ptr);
 			eprintf ("Error: failed to malloc memory");
 			goto beach;
@@ -2782,8 +2782,7 @@ static void cmd_print_bars(RCore *core, const char *input) {
 			eprintf ("Error: failed to malloc memory");
 			goto beach;
 		}
-		p = malloc (blocksize);
-		if (!p) {
+		if (!(p = malloc (blocksize))) {
 			R_FREE (ptr);
 			eprintf ("Error: failed to malloc memory");
 			goto beach;
@@ -3387,8 +3386,8 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 				}
 // const char *cmd = (type_print == 'D')? "pDj": "pIj";
 // r_core_cmdf (core, "%s %d @ 0x%"PFMT64x, cmd, b->size, b->addr);
-				ut8 *buf = malloc (b->size);
-				if (buf) {
+				ut8 *buf;
+				if ((buf = malloc (b->size))) {
 					r_io_read_at (core->io, b->addr, buf, b->size);
 					r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
 					free (buf);
@@ -3415,8 +3414,8 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 			const char *cmd = (type_print == 'D')? "pDj": "pIj";
 			r_core_cmdf (core, "%s %d @ 0x%"PFMT64x, cmd, b->size, b->addr);
 #endif
-			ut8 *buf = malloc (b->size);
-			if (buf) {
+			ut8 *buf;
+			if ((buf = malloc (b->size))) {
 				r_io_read_at (core->io, b->addr, buf, b->size);
 				r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
 				free (buf);
@@ -3445,8 +3444,8 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 				const char *cmd = (type_print == 'D')? "pDj": "pIj";
 				r_core_cmdf (core, "%s %d @0x%"PFMT64x, cmd, b->size, b->addr);
 #endif
-				ut8 *buf = malloc (b->size);
-				if (buf) {
+				ut8 *buf;
+				if ((buf = malloc (b->size))) {
 					r_io_read_at (core->io, b->addr, buf, b->size);
 					r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
 					free (buf);
@@ -3628,7 +3627,10 @@ R_API void r_print_code(RPrint *p, ut64 addr, ut8 *buf, int len, char lang) {
 		}
 	} break;
 	case 'J': { // "pcJ"
-		char *out = malloc (len * 3);
+		char *out;
+		if (!(out = malloc (len * 3))) {
+			break;
+		}
 		p->cb_printf ("var buffer = new Buffer(\"");
 		out[0] = 0;
 		r_base64_encode (out, buf, len);
@@ -3868,7 +3870,10 @@ static int cmd_print(void *data, const char *input) {
 					0
 				};
 				const char *str;
-				char *hex_arg = malloc (strlen (arg));
+				char *hex_arg;
+				if (!(hex_arg = malloc (strlen (arg)))) {
+					break;
+				}
 
 				bufsz = r_hex_str2bin (arg, (ut8 *) hex_arg);
 				ret = r_anal_op (core->anal, &aop, core->offset,
@@ -3927,7 +3932,10 @@ static int cmd_print(void *data, const char *input) {
 		} else if (l != 0) {
 			int from, to;
 			const int size = len * 8;
-			char *spc, *buf = malloc (size + 1);
+			char *spc, *buf;
+			if (!(buf = malloc (size + 1))) {
+				break;
+			}
 			spc = strchr (input, ' ');
 			if (spc) {
 				len = r_num_math (core->num, spc + 1);
@@ -3978,8 +3986,7 @@ static int cmd_print(void *data, const char *input) {
 				len = core->blocksize;
 			}
 			size = len * 8;
-			buf = malloc (size + 1);
-			if (buf) {
+			if ((buf = malloc (size + 1))) {
 				r_str_bits (buf, core->block, size, NULL);
 				r_cons_println (buf);
 				free (buf);
@@ -4190,8 +4197,8 @@ static int cmd_print(void *data, const char *input) {
 			} else {
 				RAnalBlock *b = r_anal_bb_from_offset (core->anal, core->offset);
 				if (b) {
-					ut8 *block = malloc (b->size + 1);
-					if (block) {
+					ut8 *block;
+					if ((block = malloc (b->size + 1))) {
 						r_io_read_at (core->io, b->addr, block, b->size);
 
 						if (input[2] == 'j') {
@@ -4278,8 +4285,8 @@ static int cmd_print(void *data, const char *input) {
 					prev_result = true;
 					r_list_foreach (f->bbs, locs_it, b) {
 
-						ut8 *buf = malloc (b->size);
-						if (buf) {
+						ut8 *buf;
+						if ((buf = malloc (b->size))) {
 							if (first) {
 								first = false;
 							} else if (!first && prev_result) {
@@ -4408,11 +4415,10 @@ static int cmd_print(void *data, const char *input) {
 			ut64 start;
 
 			if (bw_disassemble) {
-				block1 = malloc (core->blocksize);
 				if (l < 0) {
 					l = -l;
 				}
-				if (block1) {
+				if ((block1 = malloc (core->blocksize))) {
 					if (*input == 'D') { // pD
 						free (block1);
 						if (!(block1 = malloc (l))) {
@@ -4458,8 +4464,7 @@ static int cmd_print(void *data, const char *input) {
 						eprintf ("Block size too big\n");
 						return 1;
 					}
-					block1 = malloc (addrbytes * l);
-					if (block1) {
+					if ((block1 = malloc (addrbytes * l))) {
 						if (addrbytes * l > core->blocksize) {
 							r_io_read_at (core->io, addr, block1, addrbytes * l); // core->blocksize);
 						} else {
@@ -4472,8 +4477,7 @@ static int cmd_print(void *data, const char *input) {
 					}
 				} else {
 					int bs1 = l * 16;
-					block1 = malloc (R_MAX (bs, bs1));
-					if (block1) {
+					if ((block1 = malloc (R_MAX (bs, bs1)))) {
 						memcpy (block1, block, bs);
 						if (bs1 > bs) {
 							r_io_read_at (core->io, addr + bs / addrbytes, block1 + (bs - bs % addrbytes),
@@ -4538,12 +4542,12 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'i': // "psi"
 			if (l > 0) {
-				ut8 *buf = malloc (1024);
-				int delta = 512;
-				ut8 *p, *e, *b;
-				if (!buf) {
+				ut8 *buf;
+				if (!(buf = malloc (1024))) {
 					return 0;
 				}
+				int delta = 512;
+				ut8 *p, *e, *b;
 				if (core->offset < delta) {
 					delta = core->offset;
 				}
@@ -4577,9 +4581,9 @@ static int cmd_print(void *data, const char *input) {
 		case 'b': // "psb"
 			if (l > 0) {
 				int quiet = input[2] == 'q'; // "psbq"
-				char *s = malloc (core->blocksize + 1);
+				char *s;
 				int i, j, hasnl = 0;
-				if (s) {
+				if ((s = malloc (core->blocksize + 1))) {
 					memset (s, 0, core->blocksize);
 					if (!quiet) {
 						r_print_offset (core->print, core->offset, 0, 0, 0, 0, NULL);
@@ -4615,9 +4619,9 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'z': // psz
 			if (l > 0) {
-				char *s = malloc (core->blocksize + 1);
+				char *s;
 				int i, j;
-				if (s) {
+				if ((s = malloc (core->blocksize + 1))) {
 					memset (s, 0, core->blocksize);
 					// TODO: filter more chars?
 					for (i = j = 0; i < core->blocksize; i++) {
@@ -5424,8 +5428,8 @@ static int cmd_print(void *data, const char *input) {
 	case '6': // "p6"
 		if (l) {
 			int malen = (core->blocksize * 4) + 1;
-			ut8 *buf = malloc (malen);
-			if (!buf) {
+			ut8 *buf;
+			if (!(buf = malloc (malen))) {
 				break;
 			}
 			memset (buf, 0, malen);

--- a/libr/core/cmd_section.c
+++ b/libr/core/cmd_section.c
@@ -21,7 +21,7 @@ static const char *help_msg_S[] = {
 	"Sj","","list sections in JSON (alias for iSj)",
 	"Sl"," [file]","load contents of file into current section (see dml)",
 	"Sr"," [name]","rename section on current seek",
-	"SR", "[?]", "Remap sections with different mode of operation", 
+	"SR", "[?]", "Remap sections with different mode of operation",
 	NULL
 };
 
@@ -37,7 +37,7 @@ static const char *help_msg_Sr[] = {
 
 static const char* help_msg_SR[] = {
 	"Usage:","SR[b|s][a|p|e] [id]","",
-	"SRb", "[a|p|e] binid", "Remap sections of binid for Analysis, Patch or Emulation", 
+	"SRb", "[a|p|e] binid", "Remap sections of binid for Analysis, Patch or Emulation",
 	"SRs","[a|p|e] secid","Remap section with sectid for Analysis, Patch or Emulation",
 	NULL
 };
@@ -187,7 +187,10 @@ static bool dumpSectionsToDisk(RCore *core) {
 	RIOSection *s;
 
 	ls_foreach (core->io->sections, iter, s) {
-		ut8 *buf = malloc (s->size);
+		ut8 *buf;
+		if (!(buf = malloc (s->size))) {
+			return false;
+		}
 		r_io_read_at (core->io, s->paddr, buf, s->size);
 		snprintf (file, sizeof (file),
 			"0x%08"PFMT64x"-0x%08"PFMT64x"-%s.dmp",
@@ -219,11 +222,13 @@ static bool dumpSectionToDisk(RCore *core, char *file) {
 	}
 	ls_foreach (core->io->sections, iter, s) {
 		if (o >= s->paddr && o < s->paddr + s->size) {
-			ut8 *buf = malloc (s->size);
+			ut8 *buf;
+			if (!(buf = malloc (s->size))) {
+				return false;
+			}
 			r_io_read_at (core->io, s->paddr, buf, s->size);
 			if (!file) {
-				heapfile = (char *)malloc (len);
-				if (!heapfile) {
+				if (!(heapfile = (char *)malloc (len))) {
 					free (buf);
 					return false;
 				}
@@ -338,7 +343,7 @@ static int cmd_section(void *data, const char *input) {
 // TODO: add command to resize current section
 		break;
 	case 'R' : // "SR"
-		return cmd_section_reapply (core, input + 1);	
+		return cmd_section_reapply (core, input + 1);
 	case 'f': // "Sf"
 		if (input[1] == ' ') {
 			ut64 n = r_num_math (core->num, input + 1);
@@ -458,7 +463,7 @@ static int cmd_section(void *data, const char *input) {
 			return false;
 		}
 		if (core->io->va || core->io->debug) {
-			s = r_io_section_vget (core->io, core->offset); 
+			s = r_io_section_vget (core->io, core->offset);
 			o = s ? core->offset - s->vaddr + s->paddr : core->offset;
 		}
 		ls_foreach (core->io->sections, iter, s) {
@@ -564,7 +569,7 @@ static int cmd_section(void *data, const char *input) {
 			SdbListIter *iter, *iter2;
 			RIOSection *s;
 			if (core->io->va || core->io->debug) {
-				s = r_io_section_vget (core->io, o); 
+				s = r_io_section_vget (core->io, o);
 				o = s ? o - s->vaddr + s->paddr : o;
 			}
 			ls_foreach_safe (core->io->sections, iter, iter2, s) {
@@ -580,7 +585,7 @@ static int cmd_section(void *data, const char *input) {
 			SdbListIter *iter;
 			RIOSection *s;
 			if (core->io->va || core->io->debug) {
-				s = r_io_section_vget (core->io, o); 
+				s = r_io_section_vget (core->io, o);
 				o = s ? o - s->vaddr + s->paddr : o;
 			}
 			if (input[1] == 'j') { // "S.j"

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -215,8 +215,7 @@ R_API int r_core_lines_initcache(RCore *core, ut64 start_addr, ut64 end_addr) {
 
 	line_count = start_addr? 0: 1;
 	core->print->lines_cache[0] = start_addr? 0: baddr;
-	buf = malloc (bsz);
-	if (!buf) {
+	if (!(buf = malloc (bsz))) {
 		return -1;
 	}
 	r_cons_break_push (NULL, NULL);
@@ -553,8 +552,8 @@ static int cmd_seek(void *data, const char *input) {
 					if (!name) {
 						name = strdup ("");
 					}
-					ut64 *val = malloc (sizeof (ut64));
-					if (!val) {
+					ut64 *val;
+					if (!(val = malloc (sizeof (ut64)))) {
 						free (name);
 						break;
 					}

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -451,8 +451,8 @@ static void link_struct_offset(RCore *core, RAnalFunction *fcn) {
 	int i, ret, bsize = R_MAX (64, core->blocksize);
 	const int mininstrsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
 	const int minopcode = R_MAX (1, mininstrsz);
-	ut8 *buf = malloc (bsize);
-	if (!buf) {
+	ut8 *buf;
+	if (!(buf = malloc (bsize))) {
 		free (buf);
 		r_anal_esil_free (esil);
 		return;
@@ -1044,9 +1044,9 @@ static int cmd_type(void *data, const char *input) {
 				if (!type)
 					break;
 				int tmp_len = strlen (name) + strlen (type);
-				char *tmp = malloc (tmp_len + 1);
+				char *tmp;
 				r_type_del (TDB, name);
-				if (tmp) {
+				if ((tmp = malloc (tmp_len + 1))) {
 					snprintf (tmp, tmp_len + 1, "%s.%s.", type, name);
 					SdbList *l = sdb_foreach_list (TDB, true);
 					ls_foreach (l, iter, kv) {

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -183,7 +183,10 @@ static void cmd_write_fail() {
 }
 
 R_API int cmd_write_hexpair(RCore* core, const char* pairs) {
-	ut8 *buf = malloc (strlen (pairs) + 1);
+	ut8 *buf;
+	if (!(buf = malloc (strlen (pairs) + 1))) {
+		return -1;
+	}
 	int len = r_hex_str2bin (pairs, buf);
 	if (len != 0) {
 		if (len < 0) {
@@ -231,7 +234,10 @@ static bool encrypt_or_decrypt_block(RCore *core, const char *algo, const char *
 		}
 		if (r_crypto_set_key (cry, binkey, keylen, 0, direction)) {
 			if (iv) {
-				ut8 *biniv = malloc (strlen (iv) + 1);
+				ut8 *biniv;
+				if (!(biniv = malloc (strlen (iv) + 1))) {
+					return false;
+				}
 				int ivlen = r_hex_str2bin (iv, biniv);
 				if (ivlen < 1) {
 					ivlen = strlen(iv);
@@ -412,7 +418,7 @@ static void cmd_write_op (RCore *core, const char *input) {
 								len -= res;
 								addr += res;
 							}
-						} 
+						}
 					}
 					free (buf);
 				} else {
@@ -790,8 +796,7 @@ static int cmd_write(void *data, const char *input) {
 		if (!fail) {
 			switch (input[1]) {
 			case 'd': // "w6d"
-				buf = malloc (str_len);
-				if (!buf) {
+				if (!(buf = malloc (str_len))) {
 					eprintf ("Error: failed to malloc memory");
 					break;
 				}
@@ -802,8 +807,8 @@ static int cmd_write(void *data, const char *input) {
 				}
 				break;
 			case 'e': { // "w6e"
-				ut8 *bin_buf = malloc (str_len);
-				if (!bin_buf) {
+				ut8 *bin_buf;
+				if (!(bin_buf = malloc (str_len))) {
 					eprintf ("Error: failed to malloc memory");
 					break;
 				}
@@ -1040,8 +1045,7 @@ static int cmd_write(void *data, const char *input) {
 		off = r_num_math (core->num, input+1);
 		len = (int)off;
 		if (len > 0) {
-			buf = malloc (len);
-			if (buf != NULL) {
+			if ((buf = malloc (len))) {
 				r_num_irand ();
 				for (i=0; i<len; i++)
 					buf[i] = r_num_rand (256);
@@ -1467,8 +1471,8 @@ static int cmd_write(void *data, const char *input) {
 		break;
 	case 'b': { // "wb"
 		int len = strlen (input);
-		ut8 *buf = malloc (len+1);
-		if (buf) {
+		ut8 *buf;
+		if ((buf = malloc (len+1))) {
 			len = r_hex_str2bin (input+1, buf);
 			if (len > 0) {
 				r_mem_copyloop (core->block, buf, core->blocksize, len);
@@ -1523,7 +1527,10 @@ static int cmd_write(void *data, const char *input) {
 				*arg = 0;
 				ut64 addr = r_num_math (core->num, input+2);
 				ut64 len = r_num_math (core->num, arg+1);
-				ut8 *data = malloc (len);
+				ut8 *data;
+				if (!(data = malloc (len))) {
+					return -1;
+				}
 				r_io_read_at (core->io, addr, data, len);
 				r_io_write_at (core->io, core->offset, data, len);
 				free (data);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -87,8 +87,8 @@ static bool addFcnBytes(RCore *core, RAnalFunction *fcn, const char *name) {
 	int fcnlen = r_anal_fcn_realsize (fcn);
 	int len = R_MIN (core->io->addrbytes * fcnlen, maxsz);
 
-	ut8 *buf = malloc (len);
-	if (!buf) {
+	ut8 *buf;
+	if (!(buf = malloc (len))) {
 		return false;
 	}
 
@@ -197,8 +197,12 @@ static bool addBytesZign(RCore *core, const char *name, int type, const char *ar
 
 	hexbytes = r_str_word_get0 (args0, 0);
 	blen = strlen (hexbytes) + 4;
-	bytes = malloc (blen);
-	mask = malloc (blen);
+	if (!(bytes = malloc (blen))) {
+		goto out;
+	}
+	if (!(mask = malloc (blen))) {
+		goto out;
+	}
 
 	size = r_hex_str2binmask (hexbytes, bytes, mask);
 	if (size <= 0) {
@@ -559,7 +563,10 @@ static int fcnMatchCB(RSignItem *it, RAnalFunction *fcn, void *user) {
 }
 
 static bool searchRange(RCore *core, ut64 from, ut64 to, bool rad, struct ctxSearchCB *ctx) {
-	ut8 *buf = malloc (core->blocksize);
+	ut8 *buf;
+	if (!(buf = malloc (core->blocksize))) {
+		return false;
+	}
 	ut64 at;
 	int rlen;
 	bool retval = true;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4888,7 +4888,7 @@ toro:
 		if (nbuf) {
 			free (nbuf);
 		}
-		if ((buf = nbuf = malloc (len))) {
+		if (!(buf = nbuf = malloc (len))) {
 			goto toro;
 		}
 		if (ds->tries > 0) {

--- a/libr/core/hack.c
+++ b/libr/core/hack.c
@@ -175,8 +175,8 @@ R_API bool r_core_hack_x86(RCore *core, const char *op, const RAnalOp *analop) {
 	int i, size = analop->size;
 	if (!strcmp (op, "nop")) {
 		if (size * 2 + 1 < size) return false;
-		char *str = malloc (size * 2 + 1);
-		if (!str) {
+		char *str;
+		if (!(str = malloc (size * 2 + 1))) {
 			return false;
 		}
 		for (i = 0; i < size; i++)

--- a/libr/core/p/core_anal.c
+++ b/libr/core/p/core_anal.c
@@ -97,8 +97,8 @@ static int bbAdd(Sdb *db, ut64 from, ut64 to, ut64 jump, ut64 fail) {
 
 void addTarget(RCore *core, RStack *stack, Sdb *db, ut64 addr) {
 	if (!sdb_num_get (db, Fhandled(addr), NULL)) {
-		ut64* value = (ut64*) malloc (1 * sizeof(ut64));
-		if (!value) {
+		ut64* value;
+		if (!(value = (ut64*) malloc (1 * sizeof(ut64)))) {
 			eprintf ("Failed to allocate memory for address stack\n");
 			return;
 		}

--- a/libr/core/p/core_java.c
+++ b/libr/core/p/core_java.c
@@ -710,7 +710,9 @@ static char * r_cmd_replace_name (const char *s_new, ut32 replace_len, const cha
 		ut32 consumed = 0;
 		const char * next = r_cmd_get_next_classname_str (buffer+consumed, s_old);
 		IFDBG r_cons_printf ("Replacing \"%s\" with \"%s\" in: %s\n", s_old, s_new, buffer);
-		result = malloc (num_occurrences*replace_len + buf_len);
+		if (!(result = malloc (num_occurrences*replace_len + buf_len))) {
+			return NULL;
+		}
 		memset (result, 0, num_occurrences*replace_len + buf_len);
 		p_result = result;
 		while (next && consumed < buf_len) {
@@ -758,7 +760,9 @@ static int r_cmd_java_get_class_names_from_input (const char *input, char **clas
 
 		if (p && end && p != end) {
 			*class_name_len = end - p + 1;
-			*class_name = malloc (*class_name_len);
+			if (!(*class_name = malloc (*class_name_len))) {
+				return 0;
+			}
 			snprintf (*class_name, *class_name_len, "%s", p );
 			cmd_sz = *class_name_len - 1 < cmd_sz ? cmd_sz - *class_name_len : 0;
 		}
@@ -771,7 +775,9 @@ static int r_cmd_java_get_class_names_from_input (const char *input, char **clas
 
 			if (p && end && p != end) {
 				*new_class_name_len = end - p + 1;
-				*new_class_name = malloc (*new_class_name_len);
+				if (!(*new_class_name = malloc (*new_class_name_len))) {
+					return 0;
+				}
 				snprintf (*new_class_name, *new_class_name_len, "%s", p );
 				res = true;
 			}
@@ -821,7 +827,9 @@ static int r_cmd_java_handle_replace_classname_value (RCore *core, const char *c
 
 			if (!buffer) continue;
 			len = R_BIN_JAVA_USHORT ( buffer, 1);
-			name = malloc (len+3);
+			if (!(name = malloc (len+3))) {
+				return false;
+			}
 			memcpy (name, buffer+3, len);
 			name[len] = 0;
 
@@ -887,7 +895,9 @@ static int r_cmd_java_handle_reload_bin (RCore *core, const char *cmd) {
 	if (buf_size == 0) {
 		res = r_io_use_fd (core->io, core->file->fd);
 		buf_size = r_io_size (core->io);
-		buf = malloc (buf_size);
+		if (!(buf = malloc (buf_size))) {
+			return false;
+		}
 		memset (buf, 0, buf_size);
 		r_io_read_at (core->io, addr, buf, buf_size);
 	}
@@ -1755,7 +1765,9 @@ static char * r_cmd_java_get_descriptor (RCore *core, RBinJavaObj *bin, ut16 idx
 		fn_len += strlen (class_name);
 		fn_len += strlen (name);
 		fn_len += 2; // dot + null
-		fullname = malloc (fn_len);
+		if (!(fullname = malloc (fn_len))) {
+			return NULL;
+		}
 		snprintf (fullname, fn_len, "%s.%s", class_name, name);
 	}
 	if (fullname) prototype = r_bin_java_unmangle_without_flags (fullname, descriptor);

--- a/libr/core/pseudo.c
+++ b/libr/core/pseudo.c
@@ -42,8 +42,7 @@ static void find_and_change (char* in, int len) {
 			if (ctx.type != TYPE_NONE && ctx.right && ctx.left && ctx.rightlen > 0 && ctx.leftlen > 0) {
 				char* copy = NULL;
 				if (ctx.leftlen > ctx.rightlen) {
-					copy = (char*) malloc (ctx.leftlen);
-					if (copy) {
+					if ((copy = (char*) malloc (ctx.leftlen))) {
 						memcpy (copy, ctx.left, ctx.leftlen);
 						memcpy (ctx.left, ctx.right, ctx.rightlen);
 						memmove (ctx.comment - ctx.leftlen + ctx.rightlen, ctx.comment, ctx.right - ctx.comment);
@@ -51,8 +50,7 @@ static void find_and_change (char* in, int len) {
 					}
 				} else if (ctx.leftlen < ctx.rightlen) {
 					if (ctx.linecount < 1) {
-						copy = (char*) malloc (ctx.rightlen);
-						if (copy) {
+						if ((copy = (char*) malloc (ctx.rightlen))) {
 							memcpy (copy, ctx.right, ctx.rightlen);
 							memcpy (ctx.right + ctx.rightlen - ctx.leftlen, ctx.left, ctx.leftlen);
 							memmove (ctx.comment + ctx.rightlen - ctx.leftlen, ctx.comment, ctx.right - ctx.comment);
@@ -70,8 +68,7 @@ static void find_and_change (char* in, int len) {
 //						}
 					}
 				} else if (ctx.leftlen == ctx.rightlen) {
-					copy = (char*) malloc (ctx.leftlen);
-					if (copy) {
+					if ((copy = (char*) malloc (ctx.leftlen))) {
 						memcpy (copy, ctx.right, ctx.leftlen);
 						memcpy (ctx.right, ctx.left, ctx.leftlen);
 						memcpy (ctx.left, copy, ctx.leftlen);

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -504,7 +504,9 @@ static int r_core_rtr_http_run(RCore *core, int launch, int browse, const char *
 	int newblksz, origblksz = core->blocksize;
 	ut8 *newblk, *origblk = core->block;
 
-	newblk = malloc (core->blocksize);
+	if (!(newblk = malloc (core->blocksize))) {
+		return 0;
+	}
 	memcpy (newblk, core->block, core->blocksize);
 
 	core->block = newblk;
@@ -1654,8 +1656,8 @@ R_API void r_core_rtr_session(RCore *core, const char *input) {
 }
 
 static ut8 *r_rap_packet(ut8 type, ut32 len) {
-	ut8 *buf = malloc (len + 5);
-	if (buf) {
+	ut8 *buf;
+	if ((buf = malloc (len + 5))) {
 		buf[0] = type;
 		r_write_be32 (buf + 1, len);
 	}

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -1084,13 +1084,13 @@ R_API int r_core_visual_classes(RCore *core) {
 			break;
 		case 'J': index += 10; break;
 		case 'j': index++; break;
-		case 'k': 
+		case 'k':
 			if (--index < 0) {
 				index = 0;
 			}
 			break;
-		case 'K': 
-			index -= 10; 
+		case 'K':
+			index -= 10;
 			if (index < 0) {
 				index = 0;
 			}
@@ -3079,7 +3079,9 @@ repeat:
 			n = r_str_nlen_w ((const char *)p + ntotal,
 					plen - ntotal) + 1;
 			if (n < 2) break;
-			name = malloc (n + 10);
+			if (!(name = malloc (n + 10))) {
+				return;
+			}
 			strcpy (name, "str.");
 			for (i = 0, j = 0; i < n; i++, j++) {
 				name[4 + i] = p[j + ntotal];
@@ -3127,8 +3129,7 @@ repeat:
 		} else {
 			n = r_str_nlen_w ((const char*)p, plen) + 1;
 		}
-		name = malloc (n + 10);
-		if (!name) {
+		if (!(name = malloc (n + 10))) {
 			break;
 		}
 		strcpy (name, "str.");

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -77,7 +77,9 @@ static int perform_mapped_file_yank(RCore *core, ut64 offset, ut64 len, const ch
 		ut64 actual_len = len <= yank_file_sz? len: 0;
 		ut8 *buf = NULL;
 		if (actual_len > 0 && res == addr) {
-			buf = malloc (actual_len);
+			if (!(buf = malloc (actual_len))) {
+				return 0;
+			}
 			if (!r_io_read_at (core->io, addr, buf, actual_len)) {
 				actual_len = 0;
 			}
@@ -136,8 +138,7 @@ R_API int r_core_yank(struct r_core_t *core, ut64 addr, int len) {
 	if (len == 0) {
 		len = core->blocksize;
 	}
-	buf = malloc (len);
-	if (!buf) {
+	if (!(buf = malloc (len))) {
 		return false;
 	}
 	if (addr != core->offset) {

--- a/libr/crypto/p/crypto_aes_algo.c
+++ b/libr/crypto/p/crypto_aes_algo.c
@@ -42,7 +42,11 @@ void aes_expkey (const struct aes_state *st, ut32 ***expkey)
 	// memcpy (&expkey, _expkey, 2 * (st->rounds + 1) * Nb);
 	int ROUND_KEY_COUNT = 4 * (1 + st->rounds);
 #ifdef _MSC_VER
-	ut32 *tk = (ut32*)malloc (sizeof (ut32) * st->columns);
+	ut32 *tk;
+	if (!(tk = (ut32*)malloc (sizeof (ut32) * st->columns))) {
+		return;
+	}
+
 #else
 	ut32 tk[st->columns];
 #endif
@@ -208,7 +212,7 @@ void aes_decrypt (struct aes_state *st, ut8 *in, ut8 *result) {
 #else
 	ut32 expkey[2][st->rounds + 1][Nb];
 #endif
-	
+
 	aes_expkey(st, expkey);
 
 	ut32 t0, t1, t2, t3, tt;

--- a/libr/crypto/p/crypto_base64.c
+++ b/libr/crypto/p/crypto_base64.c
@@ -22,8 +22,7 @@ static bool update(RCrypto *cry, const ut8 *buf, int len) {
 	ut8 *obuf = NULL;
 	if (cry->dir == 0) {
 		olen = ((len + 2) / 3 ) * 4;
-		obuf = malloc (olen + 1);
-		if (!obuf) {
+		if (!(obuf = malloc (olen + 1))) {
 			return false;
 		}
 		r_base64_encode ((char *)obuf, (const ut8 *)buf, len);
@@ -32,8 +31,7 @@ static bool update(RCrypto *cry, const ut8 *buf, int len) {
 		if (len > 0) {
 			olen -= (buf[len-1] == '=') ? ((buf[len-2] == '=') ? 2 : 1) : 0;
 		}
-		obuf = malloc (olen + 1);
-		if (!obuf) {
+		if (!(obuf = malloc (olen + 1))) {
 			return false;
 		}
 		olen = r_base64_decode (obuf, (const char *)buf, len);

--- a/libr/crypto/p/crypto_base91.c
+++ b/libr/crypto/p/crypto_base91.c
@@ -24,8 +24,8 @@ static bool update(RCrypto *cry, const ut8 *buf, int len) {
 	if (!cry || !buf || len < 1) {
 		return false;
 	}
-	ut8 *obuf = malloc (olen);
-	if (!obuf) {
+	ut8 *obuf;
+	if (!(obuf = malloc (olen))) {
 		return false;
 	}
 	if (cry->dir == 0) {

--- a/libr/crypto/p/crypto_rc6.c
+++ b/libr/crypto/p/crypto_rc6.c
@@ -30,7 +30,10 @@ static bool rc6_init(struct rc6_state *const state, const ut8 *key, int keylen, 
 	int c = keylen / u;
 	int t = 2 * r + 4;
 #ifdef _MSC_VER
-	ut32 *L = (ut32*) malloc (sizeof (ut32) * c);
+	ut32 *L;
+	if (!(L = (ut32*) malloc (sizeof (ut32) * c))) {
+		return false;
+	}
 #else
 	ut32 L[c];
 #endif
@@ -57,7 +60,7 @@ static bool rc6_init(struct rc6_state *const state, const ut8 *key, int keylen, 
 		k = (k + 1) % t;
 		j = (j + 1) % c;
 	}
-	
+
 	state->key_size = keylen/8;
 #ifdef _MSC_VER
 	free (L);
@@ -189,7 +192,7 @@ static bool update(RCrypto *cry, const ut8 *buf, int len) {
 			rc6_encrypt (&st, buf + BLOCK_SIZE * i, obuf + BLOCK_SIZE * i);
 		}
 	}
-	
+
 	r_crypto_append (cry, obuf, len);
 	free (obuf);
 	return true;
@@ -209,7 +212,7 @@ RCryptoPlugin r_crypto_plugin_rc6 = {
 };
 
 #ifndef CORELIB
-RLibStruct radare_plugin = { 
+RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_CRYPTO,
 	.data = &r_crypto_plugin_rc6,
 	.version = R2_VERSION

--- a/libr/crypto/p/crypto_xor.c
+++ b/libr/crypto/p/crypto_xor.c
@@ -17,7 +17,9 @@ static bool xor_init(struct xor_state *const state, const ut8 *key, int keylen) 
 		return false;
 	}
 	state->key_size = keylen;
-	state->key = malloc (keylen);
+	if (!(state->key = malloc (keylen))) {
+		return false;
+	}
 	memcpy (state->key, key, keylen);
 	return true;
 }
@@ -69,7 +71,7 @@ RCryptoPlugin r_crypto_plugin_xor = {
 };
 
 #ifndef CORELIB
-RLibStruct radare_plugin = { 
+RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_CRYPTO,
 	.data = &r_crypto_plugin_xor,
 	.version = R2_VERSION

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -111,22 +111,22 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 			dbg->pc_at_bp = false;
 		}
 	}
-	
+
 	if (!dbg->pc_at_bp_set) {
 		eprintf ("failed to determine position of pc after breakpoint");
 	}
-	
+
 	if (dbg->pc_at_bp) {
 		pc_off = 0;
 		b = r_bp_get_at (dbg->bp, pc);
 	} else {
 		b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
 	}
-	
+
 	if (!b) {
 		return true;
 	}
-	
+
 	b = r_bp_get_at (dbg->bp, pc - dbg->bpsize);
 	if (!b) { /* we don't. nothing left to do */
 		/* Some targets set pc to breakpoint */
@@ -506,8 +506,7 @@ R_API ut64 r_debug_execute(RDebug *dbg, const ut8 *buf, int len, int restore) {
 		rpc = r_reg_get_value (dbg->reg, ripc);
 		rsp = r_reg_get_value (dbg->reg, risp);
 
-		backup = malloc (len);
-		if (!backup) {
+		if (!(backup = malloc (len))) {
 			free (orig);
 			return 0LL;
 		}
@@ -981,9 +980,8 @@ static ut64 get_prev_instr(RDebug *dbg, ut64 from, ut64 to) {
 	RAnalOp aop = {0};
 	const int mininstrsz = r_anal_archinfo (dbg->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
 	const int minopcode = R_MAX (1, mininstrsz);
-	ut8 *buf = malloc (bsize);
-
-	if (!buf) {
+	ut8 *buf;
+	if (!(buf = malloc (bsize))) {
 		eprintf ("Cannot allocate %d byte(s)\n", bsize);
 		free (buf);
 		return 0;

--- a/libr/debug/p/bfvm.c
+++ b/libr/debug/p/bfvm.c
@@ -41,9 +41,9 @@ R_API int bfvm_init(BfvmCPU *c, ut32 size, int circular) {
 	memset (c, '\0', sizeof (BfvmCPU));
 
 	/* data */
-	c->mem = (ut8 *)malloc (size);
-	if (!c->mem)
+	if (!(c->mem = (ut8 *)malloc (size))) {
 		return 0;
+	}
 	memset (c->mem, '\0', size);
 
 	/* setup */
@@ -54,12 +54,16 @@ R_API int bfvm_init(BfvmCPU *c, ut32 size, int circular) {
 	/* screen */
 	c->screen = BFVM_SCREEN_ADDR;
 	c->screen_size = BFVM_SCREEN_SIZE;
-	c->screen_buf = (ut8*)malloc (c->screen_size);
+	if (!(c->screen_buf = (ut8*)malloc (c->screen_size))) {
+		return -1;
+	}
 	memset (c->screen_buf, '\0', c->screen_size);
 
 	/* input */
 	c->input_size = BFVM_INPUT_SIZE;
-	c->input_buf = (ut8*)malloc (c->input_size);
+	if (!(c->input_buf = (ut8*)malloc (c->input_size))) {
+		return -1;
+	}
 	bfvm_reset (c);
 	return 1;
 }

--- a/libr/debug/p/native/bt/fuzzy-all.c
+++ b/libr/debug/p/native/bt/fuzzy-all.c
@@ -48,7 +48,9 @@ static RList *backtrace_fuzzy(RDebug *dbg, ut64 at) {
 	RList *list;
 
 	stacksize = 1024*512; // 512KB .. should get the size from the regions if possible
-	stack = malloc (stacksize);
+	if (!(stack = malloc (stacksize))) {
+		return NULL;
+	}
 	if (at == UT64_MAX) {
 		RRegItem *ri;
 		RReg *reg = dbg->reg;

--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -672,8 +672,7 @@ static void *get_ntfile_data(linux_map_entry_t *head) {
 	}
 	n_segments = mapping_file.count;
 	n_pag = 1;
-	pp = maps_data = malloc (size);
-	if (!maps_data)	{
+	if (!(pp = maps_data = malloc (size))) {
 		return NULL;
 	}
 	memcpy (maps_data, &n_segments, sizeof (n_segments));
@@ -763,8 +762,7 @@ static bool dump_elf_map_content(RDebug *dbg, RBuffer *dest, linux_map_entry_t *
 			continue;
 		}
 		size = p->end_addr - p->start_addr;
-		map_content = malloc (size);
-		if (!map_content) {
+		if (!(map_content = malloc (size))) {
 			return false;
 		}
 		ret = dbg->iob.read_at (dbg->iob.io, p->start_addr, map_content, size);

--- a/libr/debug/p/native/maps/windows.c
+++ b/libr/debug/p/native/maps/windows.c
@@ -143,8 +143,7 @@ static int set_mod_inf(HANDLE h_proc, RDebugMap *map, RWinModInfo *mod) {
 			mod->sect_count = nt_hdrs->FileHeader.NumberOfSections;
 			sect_hdr = (IMAGE_SECTION_HEADER *)((char *)nt_hdrs + sizeof (IMAGE_NT_HEADERS));
 		}
-		mod->sect_hdr = (IMAGE_SECTION_HEADER *)malloc (sizeof (IMAGE_SECTION_HEADER) * mod->sect_count);
-		if (!mod->sect_hdr) {
+		if (!(mod->sect_hdr = (IMAGE_SECTION_HEADER *)malloc (sizeof (IMAGE_SECTION_HEADER) * mod->sect_count))) {
 			perror ("malloc set_mod_inf()");
 			goto err_set_mod_info;
 		}
@@ -172,7 +171,7 @@ static void proc_mem_img(HANDLE h_proc, RList *map_list, RList *mod_list, RWinMo
 				mod->map = map;
 				set_mod_inf (h_proc, map, mod);
 				break;
-			}	
+			}
 		}
 	}
 	if (mod->map && mod->sect_hdr && mod->sect_count > 0) {
@@ -254,7 +253,7 @@ static RList *w32_dbg_maps(RDebug *dbg) {
 	/* get process modules list */
 	mod_list = w32_dbg_modules (dbg);
 	/* process memory map */
-	while (cur_addr < si.lpMaximumApplicationAddress && 
+	while (cur_addr < si.lpMaximumApplicationAddress &&
 		VirtualQueryEx (h_proc, cur_addr, &mbi, sizeof (mbi)) != 0) {
 		if (mbi.State != MEM_FREE) {
 			switch (mbi.Type) {
@@ -272,6 +271,6 @@ static RList *w32_dbg_maps(RDebug *dbg) {
 	}
 err_w32_dbg_maps:
 	free (mod_inf.sect_hdr);
-	r_list_free (mod_list);		
+	r_list_free (mod_list);
 	return map_list;
 }

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -411,7 +411,7 @@ static int debug_exception_event (DEBUG_EVENT *de) {
 	case EXCEPTION_INT_DIVIDE_BY_ZERO:
 	case EXCEPTION_STACK_OVERFLOW:
 		eprintf ("(%d) Fatal exception (%s) in thread %d\n",
-			(int)de->dwProcessId, 
+			(int)de->dwProcessId,
 			get_w32_excep_name(code),
 			(int)de->dwThreadId);
 		break;
@@ -442,8 +442,7 @@ static char *get_file_name_from_handle (HANDLE handle_file) {
 	if (!handle_file_map) {
 		goto err_get_file_name_from_handle;
 	}
-	filename = malloc ((MAX_PATH + 1) * sizeof (TCHAR));
-	if (!filename) {
+	if (!(filename = malloc ((MAX_PATH + 1) * sizeof (TCHAR)))) {
 		goto err_get_file_name_from_handle;
 	}
 	/* Create a file mapping to get the file name. */
@@ -478,7 +477,7 @@ static char *get_file_name_from_handle (HANDLE handle_file) {
 			}
 		}
 		cur_drive++;
-	} 
+	}
 err_get_file_name_from_handle:
 	if (map) {
 		UnmapViewOfFile (map);
@@ -491,7 +490,7 @@ err_get_file_name_from_handle:
 		free (filename);
 		return filename_;
 
-	}	
+	}
 	return NULL;
 }
 
@@ -1148,8 +1147,7 @@ static void w32_info_user(RDebug *dbg, RDebugInfo *rdi) {
 		r_sys_perror ("w32_info_user/GetTokenInformation");
 		goto err_w32_info_user;
 	}
-	tok_usr = (PTOKEN_USER)malloc (tok_len);
-	if (!tok_usr) {
+	if (!(tok_usr = (PTOKEN_USER)malloc (tok_len))) {
 		perror ("w32_info_user/malloc tok_usr");
 		goto err_w32_info_user;
 	}
@@ -1157,14 +1155,12 @@ static void w32_info_user(RDebug *dbg, RDebugInfo *rdi) {
 		r_sys_perror ("w32_info_user/GetTokenInformation");
 		goto err_w32_info_user;
 	}
-	usr = (LPTSTR)malloc (usr_len);
-	if (!usr) {
+	if (!(usr = (LPTSTR)malloc (usr_len))) {
 		perror ("w32_info_user/malloc usr");
 		goto err_w32_info_user;
 	}
 	*usr = '\0';
-	usr_dom = (LPTSTR)malloc (usr_dom_len);
-	if (!usr_dom) {
+	if (!(usr_dom = (LPTSTR)malloc (usr_dom_len))) {
 		perror ("w32_info_user/malloc usr_dom");
 		goto err_w32_info_user;
 	}
@@ -1174,7 +1170,7 @@ static void w32_info_user(RDebug *dbg, RDebugInfo *rdi) {
 		goto err_w32_info_user;
 	}
 	if (*usr_dom) {
-		rdi->usr = r_str_newf (W32_TCHAR_FSTR"\\"W32_TCHAR_FSTR, usr_dom, usr);		
+		rdi->usr = r_str_newf (W32_TCHAR_FSTR"\\"W32_TCHAR_FSTR, usr_dom, usr);
 	} else {
 		rdi->usr = r_sys_conv_utf16_to_utf8 (usr);
 	}
@@ -1203,8 +1199,7 @@ static void w32_info_exe(RDebug *dbg, RDebugInfo *rdi) {
 		r_sys_perror ("w32_info_exe/OpenProcess");
 		goto err_w32_info_exe;
 	}
-	path = (LPTSTR)malloc (MAX_PATH + 1);
-	if (!path) {
+	if (!(path = (LPTSTR)malloc (MAX_PATH + 1))) {
 		perror ("w32_info_exe/malloc path");
 		goto err_w32_info_exe;
 	}

--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -622,7 +622,7 @@ int xnu_get_vmmap_entries_for_pid (pid_t pid) {
 		if (info.is_submap) {
 			nesting_depth++;
 		} else {
-			address += size; 
+			address += size;
 			n++;
 		}
 	}
@@ -636,7 +636,7 @@ int xnu_get_vmmap_entries_for_pid (pid_t pid) {
 	segment_count * segment_command_sz + thread_count * \
 	sizeof (struct thread_command) + tstate_size * thread_count
 
-static void get_mach_header_sizes(size_t *mach_header_sz, 
+static void get_mach_header_sizes(size_t *mach_header_sz,
 									size_t *segment_command_sz) {
 #if __ppc64__ || __x86_64__
 	*mach_header_sz = sizeof(struct mach_header_64);
@@ -686,11 +686,11 @@ static void xnu_build_corefile_header (vm_offset_t header,
 	mh64 = (struct mach_header_64 *)header;
 	mh64->magic = MH_MAGIC_64;
 	mh64->cputype = xnu_get_cpu_type (pid);
-	mh64->cpusubtype = xnu_get_cpu_subtype (); 
+	mh64->cpusubtype = xnu_get_cpu_subtype ();
 	mh64->filetype = MH_CORE;
 	mh64->ncmds = segment_count + thread_count;
 	mh64->sizeofcmds = command_size;
-	mh64->reserved = 0; // 8-byte alignment 
+	mh64->reserved = 0; // 8-byte alignment
 #elif __i386__ || __ppc__ || __POWERPC__
 	struct mach_header *mh;
 	mh = (struct mach_header *)header;
@@ -745,7 +745,7 @@ static int xnu_write_mem_maps_to_buffer (RBuffer *buffer, RList *mem_maps, int s
 	struct segment_command *sc;
 #endif
 	r_list_foreach_safe (mem_maps, iter, iter2, curr_map) {
-		eprintf ("Writing section from 0x%"PFMT64x" to 0x%"PFMT64x" (%"PFMT64d")\n", 
+		eprintf ("Writing section from 0x%"PFMT64x" to 0x%"PFMT64x" (%"PFMT64d")\n",
 			curr_map->addr, curr_map->addr_end, curr_map->size);
 
 		vm_map_offset_t vmoffset = curr_map->addr;
@@ -832,7 +832,7 @@ cleanup:
 	return error;
 }
 
-static int xnu_get_thread_status (register thread_t thread, int flavor, 
+static int xnu_get_thread_status (register thread_t thread, int flavor,
 	thread_state_t tstate, mach_msg_type_number_t *count) {
 	return thread_get_state (thread, flavor, tstate, count);
 }
@@ -925,7 +925,7 @@ bool xnu_generate_corefile (RDebug *dbg, RBuffer *dest) {
 			(flavors[i].count * sizeof(int));
 	}
 
-	command_size = COMMAND_SIZE (segment_count,segment_command_sz, 
+	command_size = COMMAND_SIZE (segment_count,segment_command_sz,
 		r_list_length (threads_list), tstate_size);
 	header_size = command_size + mach_header_sz; // XXX: Add here the round_page() ?
 	header = (vm_offset_t)calloc (1, header_size);
@@ -986,8 +986,7 @@ RDebugPid *xnu_get_pid (int pid) {
 	uid = uidFromPid (pid);
 
 	/* Allocate space for the arguments. */
-	procargs = (char *)malloc (argmax);
-	if (!procargs) {
+	if (!(procargs = (char *)malloc (argmax))) {
 		eprintf ("getcmdargs(): insufficient memory for procargs %d\n",
 			(int)(size_t)argmax);
 		return NULL;
@@ -1411,7 +1410,7 @@ RList *xnu_dbg_maps(RDebug *dbg, int only_modules) {
 				}
 			}
 		}
-		r_list_append (list, m2);	
+		r_list_append (list, m2);
 	}
 	r_list_sort (list, cmp);
  	r_list_free (modules);

--- a/libr/debug/snap.c
+++ b/libr/debug/snap.c
@@ -232,11 +232,10 @@ R_API RDebugSnapDiff *r_debug_snap_map(RDebug *dbg, RDebugMap *map) {
 		snap->addr_end = map->addr_end;
 		snap->size = map->size;
 		snap->page_num = page_num;
-		snap->data = malloc (map->size);
-		snap->perm = map->perm;
-		if (!snap->data) {
+		if (!(snap->data = malloc (map->size))) {
 			goto error;
 		}
+		snap->perm = map->perm;
 		snap->hashes = R_NEWS0 (ut8 *, page_num);
 		if (!snap->hashes) {
 			free (snap->data);
@@ -351,7 +350,10 @@ R_API RDebugSnapDiff *r_debug_diff_add(RDebug *dbg, RDebugSnap *base) {
 	/* Compare hash of pages. */
 	for (addr = base->addr; addr < base->addr_end; addr += SNAP_PAGE_SIZE) {
 		ut8 *prev_hash, *cur_hash;
-		ut8 *buf = malloc (clust_page);
+		ut8 *buf;
+		if (!(buf = malloc (clust_page))) {
+			return NULL;
+		}
 		/* Copy current memory value to buf and calculate cur_hash from it. */
 		dbg->iob.read_at (dbg->iob.io, addr, buf, clust_page);
 		digest_size = r_hash_calculate (base->hash_ctx, algobit, buf, clust_page);

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -198,8 +198,9 @@ R_API void r_egg_math (REgg *egg) {//, char eq, const char *vs, char type, const
 R_API int r_egg_raw(REgg *egg, const ut8 *b, int len) {
 	char *out;
 	int outlen = len*2; // two hexadecimal digits per byte
-	out = malloc (outlen+1);
-	if (!out) return false;
+	if (!(out = malloc (outlen + 1))) {
+		return false;
+	}
 	r_hex_bin2str (b, len, out);
 	r_buf_append_bytes (egg->buf, (const ut8*)".hex ", 5);
 	r_buf_append_bytes (egg->buf, (const ut8*)out, outlen);
@@ -211,8 +212,9 @@ R_API int r_egg_raw(REgg *egg, const ut8 *b, int len) {
 static int r_egg_raw_prepend(REgg *egg, const ut8 *b, int len) {
 	char *out;
 	int outlen = len*2; // two hexadecimal digits per byte
-	out = malloc (outlen+1);
-	if (!out) return false;
+	if (!(out = malloc (outlen + 1))) {
+		return false;
+	}
 	r_hex_bin2str (b, len, out);
 	r_buf_prepend_bytes (egg->buf, (const ut8*)"\n", 1);
 	r_buf_prepend_bytes (egg->buf, (const ut8*)out, outlen);
@@ -403,8 +405,7 @@ R_API int r_egg_padding (REgg *egg, const char *pad) {
 			return false;
 		}
 
-		buf = malloc (number);
-		if (!buf) {
+		if (!(buf = malloc (number))) {
 			free (o);
 			return false;
 		}

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -124,7 +124,7 @@ R_API void r_egg_lang_init(REgg *egg) {
 	egg->lang.varsize = 'l';
 	/* do call or inline it ? */	// BOOL
 	egg->lang.docall = 1;
-	egg->lang.line = 1;	
+	egg->lang.line = 1;
 	egg->lang.file = "stdin";
 	egg->lang.oc = '\n';
 	egg->lang.mode = NORMAL;
@@ -649,7 +649,10 @@ static void rcc_fun(REgg *egg, const char *str) {
 				} else {
 					egg->lang.mode = INLINE;
 					free (egg->lang.syscallbody);
-					egg->lang.syscallbody = malloc (4096);	// XXX hardcoded size
+					if (!(egg->lang.syscallbody = malloc (4096))) {	// XXX hardcoded size
+						R_FREE(egg->lang.dstvar);
+						return;
+					}
 					egg->lang.dstval = egg->lang.syscallbody;
 					R_FREE (egg->lang.dstvar);
 					egg->lang.ndstval = 0;
@@ -671,7 +674,9 @@ static void rcc_fun(REgg *egg, const char *str) {
 				egg->lang.mode = DATA;
 				egg->lang.ndstval = 0;
 				egg->lang.dstvar = strdup (skipspaces (str));
-				egg->lang.dstval = malloc (4096);
+				if (!(egg->lang.dstval = malloc (4096))) {
+					return;
+				}
 			} else if (strstr (ptr, "naked")) {
 				egg->lang.mode = NAKED;
 				/*
@@ -685,7 +690,9 @@ static void rcc_fun(REgg *egg, const char *str) {
 				egg->lang.mode = INLINE;
 				free (egg->lang.dstvar);
 				egg->lang.dstvar = strdup (skipspaces (str));
-				egg->lang.dstval = malloc (4096);
+				if (!(egg->lang.dstval = malloc (4096))) {
+					return;
+				}
 				egg->lang.ndstval = 0;
 			} else {
 				// naked label

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -506,7 +506,10 @@ R_API RFlagItem *r_flag_set_next(RFlag *f, const char *name, ut64 off, ut32 size
 		return r_flag_set (f, name, off, size);
 	}
 	int i, newNameSize = strlen (name);
-	char *newName = malloc (newNameSize + 16);
+	char *newName;
+	if (!(newName = malloc (newNameSize + 16))) {
+		return NULL;
+	}
 	strcpy (newName, name);
 	for (i = 0; ; i++) {
 		snprintf (newName + newNameSize, 15, ".%d", i);

--- a/libr/fs/fs.c
+++ b/libr/fs/fs.c
@@ -341,15 +341,13 @@ R_API int r_fs_dir_dump(RFS* fs, const char* path, const char* name) {
 		if (!strcmp (file->name, ".") || !strcmp (file->name, "..")) {
 			continue;
 		}
-		str = (char*) malloc (strlen (name) + strlen (file->name) + 2);
-		if (!str) {
+		if (!(str = (char*) malloc (strlen (name) + strlen (file->name) + 2))) {
 			return false;
 		}
 		strcpy (str, name);
 		strcat (str, "/");
 		strcat (str, file->name);
-		npath = malloc (strlen (path) + strlen (file->name) + 2);
-		if (!npath) {
+		if (!(npath = malloc (strlen (path) + strlen (file->name) + 2))) {
 			free (str);
 			return false;
 		}
@@ -397,8 +395,7 @@ static void r_fs_find_off_aux(RFS* fs, const char* name, ut64 offset, RList* lis
 			continue;
 		}
 
-		found = (char*) malloc (strlen (name) + strlen (item->name) + 2);
-		if (!found) {
+		if (!(found = (char*) malloc (strlen (name) + strlen (item->name) + 2))) {
 			break;
 		}
 		strcpy (found, name);
@@ -440,8 +437,7 @@ static void r_fs_find_name_aux(RFS* fs, const char* name, const char* glob, RLis
 	dirs = r_fs_dir (fs, name);
 	r_list_foreach (dirs, iter, item) {
 		if (r_str_glob (item->name, glob)) {
-			found = (char*) malloc (strlen (name) + strlen (item->name) + 2);
-			if (!found) {
+			if (!(found = (char*) malloc (strlen (name) + strlen (item->name) + 2))) {
 				break;
 			}
 			strcpy (found, name);
@@ -453,8 +449,7 @@ static void r_fs_find_name_aux(RFS* fs, const char* name, const char* glob, RLis
 			continue;
 		}
 		if (item->type == R_FS_FILE_TYPE_DIRECTORY) {
-			found = (char*) malloc (strlen (name) + strlen (item->name) + 2);
-			if (!found) {
+			if (!(found = (char*) malloc (strlen (name) + strlen (item->name) + 2))) {
 				break;
 			}
 			strcpy (found, name);

--- a/libr/fs/shell.c
+++ b/libr/fs/shell.c
@@ -191,15 +191,13 @@ R_API int r_fs_shell_prompt(RFSShell* shell, RFS* fs, const char* root) {
 				input++;
 			if (input[0] == '/') {
 				if (root) {
-					s = malloc (strlen (root) + strlen (input) + 2);
-					if (!s) {
+					if (!(s = malloc (strlen (root) + strlen (input) + 2))) {
 						goto beach;
 					}
 					strcpy (s, root);
 				}
 			} else {
-				s = malloc (strlen (path) + strlen (input) + 2);
-				if (!s) {
+				if (!(s = malloc (strlen (path) + strlen (input) + 2))) {
 					goto beach;
 				}
 				strcpy (s, path);

--- a/libr/hash/hash.c
+++ b/libr/hash/hash.c
@@ -348,7 +348,9 @@ R_API char *r_hash_to_string(RHash *ctx, const char *name, const ut8 *data, int 
 		if (digest_size * 2 < digest_size) {
 			digest_hex = NULL;
 		} else {
-			digest_hex = malloc ((digest_size * 2) + 1);
+			if (!(digest_hex = malloc ((digest_size * 2) + 1))) {
+				return NULL;
+			}
 			for (i = 0; i < digest_size; i++) {
 				sprintf (digest_hex + (i * 2), "%02x", ctx->digest[i]);
 			}

--- a/libr/hash/xxhash.c
+++ b/libr/hash/xxhash.c
@@ -125,9 +125,9 @@ struct XXH_state32_t {
 };
 
 void *XXH32_init (ut32 seed) {
-	struct XXH_state32_t *state =
-		(struct XXH_state32_t *) malloc (sizeof (struct XXH_state32_t));
-	if (!state) {
+	struct XXH_state32_t *state;
+	if (!(state =
+		(struct XXH_state32_t *) malloc (sizeof (struct XXH_state32_t)))) {
 		return NULL;
 	}
 	state->seed = seed;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -707,7 +707,7 @@ R_API bool r_io_set_write_mask(RIO* io, const ut8* mask, int len) {
 		io->write_mask_len = 0;
 		return true;
 	}
-	if (io->write_mask = (ut8*) malloc (len)) {
+	if ((io->write_mask = (ut8*) malloc (len))) {
 		memcpy (io->write_mask, mask, len);
 		io->write_mask_len = len;
 		return true;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -219,8 +219,7 @@ R_API RIO* r_io_init(RIO* io) {
 R_API RBuffer *r_io_read_buf(RIO *io, ut64 addr, int len) {
 	RBuffer *b = R_NEW0 (RBuffer);
 	if (!b) return NULL;
-	b->buf = malloc (len);
-	if (!b->buf) {
+	if (!(b->buf = malloc (len))) {
 		free (b);
 		return NULL;
 	}
@@ -708,10 +707,13 @@ R_API bool r_io_set_write_mask(RIO* io, const ut8* mask, int len) {
 		io->write_mask_len = 0;
 		return true;
 	}
-	io->write_mask = (ut8*) malloc (len);
-	memcpy (io->write_mask, mask, len);
-	io->write_mask_len = len;
-	return true;
+	if (io->write_mask = (ut8*) malloc (len)) {
+		memcpy (io->write_mask, mask, len);
+		io->write_mask_len = len;
+		return true;
+	} else {
+		return false;
+	}
 }
 
 R_API int r_io_bind(RIO* io, RIOBind* bnd) {

--- a/libr/io/p/io_bfdbg.c
+++ b/libr/io/p/io_bfdbg.c
@@ -164,7 +164,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			return NULL;
 		}
 		mal->size = rlen;
-		if (mal->buf = malloc (mal->size+1)) {
+		if ((mal->buf = malloc (mal->size+1))) {
 			memcpy (mal->buf, out, rlen);
 			free (out);
 			return r_io_desc_new (io, &r_io_plugin_bfdbg,

--- a/libr/io/p/io_bfdbg.c
+++ b/libr/io/p/io_bfdbg.c
@@ -164,8 +164,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			return NULL;
 		}
 		mal->size = rlen;
-		mal->buf = malloc (mal->size+1);
-		if (mal->buf != NULL) {
+		if (mal->buf = malloc (mal->size+1)) {
 			memcpy (mal->buf, out, rlen);
 			free (out);
 			return r_io_desc_new (io, &r_io_plugin_bfdbg,

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -132,7 +132,11 @@ static int fork_and_ptraceme(RIO *io, int bits, const char *cmd) {
 	}
 	cmd_len += i-1; // Add argc-1 spaces
 
-	char *cmdline = malloc ((cmd_len + 1) * sizeof (char));
+	char *cmdline;
+	if (!(cmdline = malloc ((cmd_len + 1) * sizeof (char)))) {
+		eprintf("Cannot allocate %d byte(s)\n", (cmd_len + 1) * sizeof (char));
+		return -1;
+	}
 	int cmd_i = 0; // Next character to write in cmdline
 	i = 0;
 	while (argv[i]) {

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -208,7 +208,7 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 			}
 			a_count = count + (aligned-(count%aligned));
 
-			if (a_buf = malloc (a_count+aligned)) {
+			if ((a_buf = malloc (a_count+aligned))) {
 				int i;
 				memset (a_buf, 0xff, a_count + aligned);
 				if (lseek (mmo->fd, a_off, SEEK_SET) < 0) {
@@ -261,7 +261,7 @@ static int r_io_def_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) 
 				return -1;
 			}
 			a_count = count + (aligned - (count % aligned));
-			if (a_buf = malloc (a_count + aligned)) {
+			if ((a_buf = malloc (a_count + aligned))) {
 				int i;
 				memset (a_buf, 0xff, a_count+aligned);
 				for (i = 0; i < a_count; i += aligned) {

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -208,8 +208,7 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 			}
 			a_count = count + (aligned-(count%aligned));
 
-			a_buf = malloc (a_count+aligned);
-			if (a_buf) {
+			if (a_buf = malloc (a_count+aligned)) {
 				int i;
 				memset (a_buf, 0xff, a_count + aligned);
 				if (lseek (mmo->fd, a_off, SEEK_SET) < 0) {
@@ -262,8 +261,7 @@ static int r_io_def_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) 
 				return -1;
 			}
 			a_count = count + (aligned - (count % aligned));
-			a_buf = malloc (a_count + aligned);
-			if (a_buf) {
+			if (a_buf = malloc (a_count + aligned)) {
 				int i;
 				memset (a_buf, 0xff, a_count+aligned);
 				for (i = 0; i < a_count; i += aligned) {

--- a/libr/io/p/io_gzip.c
+++ b/libr/io/p/io_gzip.c
@@ -18,7 +18,7 @@ static inline ut32 _io_malloc_sz(RIODesc *desc) {
 	}
 	RIOGzip *mal = (RIOGzip*)desc->data;
 	return mal? mal->size: 0;
-} 
+}
 
 static inline void _io_malloc_set_sz(RIODesc *desc, ut32 sz) {
 	if (!desc) {
@@ -28,7 +28,7 @@ static inline void _io_malloc_set_sz(RIODesc *desc, ut32 sz) {
 	if (mal) {
 		mal->size = sz;
 	}
-} 
+}
 
 static inline ut8* _io_malloc_buf(RIODesc *desc) {
 	if (!desc) {
@@ -90,8 +90,7 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
 	if (_io_malloc_off (fd) > mallocsz) {
 		return false;
 	}
-	new_buf = malloc (count);
-	if (!new_buf) {
+	if (!(new_buf = malloc (count))) {
 		return -1;
 	}
 	memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));

--- a/libr/io/p/io_http.c
+++ b/libr/io/p/io_http.c
@@ -82,20 +82,16 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			RIOMalloc *mal = R_NEW0 (RIOMalloc);
 			if (!mal) return NULL;
 			mal->size = rlen;
-			mal->buf = malloc (mal->size+1);
-			if (!mal->buf) {
+			if (!(mal->buf = malloc (mal->size+1))) {
+				eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname+9, mal->size);
 				free (mal);
 				return NULL;
 			}
-			if (mal->buf != NULL) {
-				mal->fd = getmalfd (mal);
-				memcpy (mal->buf, out, mal->size);
-				free (out);
-				return r_io_desc_new (io, &r_io_plugin_http,
-					pathname, rw, mode, mal);
-			}
-			eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname+9, mal->size);
-			free (mal);
+			mal->fd = getmalfd (mal);
+			memcpy (mal->buf, out, mal->size);
+			free (out);
+			return r_io_desc_new (io, &r_io_plugin_http,
+				pathname, rw, mode, mal);
 		}
 		free (out);
 	}

--- a/libr/io/p/io_malloc.c
+++ b/libr/io/p/io_malloc.c
@@ -18,7 +18,7 @@ static inline ut32 _io_malloc_sz(RIODesc *desc) {
 	}
 	RIOMalloc *mal = (RIOMalloc*)desc->data;
 	return mal? mal->size: 0;
-} 
+}
 
 static inline void _io_malloc_set_sz(RIODesc *desc, ut32 sz) {
 	if (!desc) {
@@ -28,7 +28,7 @@ static inline void _io_malloc_set_sz(RIODesc *desc, ut32 sz) {
 	if (mal) {
 		mal->size = sz;
 	}
-} 
+}
 
 static inline ut8* _io_malloc_buf(RIODesc *desc) {
 	if (!desc) {
@@ -90,8 +90,7 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
 	if (_io_malloc_off (fd) > mallocsz) {
 		return false;
 	}
-	new_buf = malloc (count);
-	if (!new_buf) {
+	if (!(new_buf = malloc (count))) {
 		return -1;
 	}
 	memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));

--- a/libr/io/p/io_r2k_linux.c
+++ b/libr/io/p/io_r2k_linux.c
@@ -425,8 +425,7 @@ int run_old_command(RIO *io, RIODesc *iodesc, const char *buf) {
 			r2k_struct.beid = beid;
 			r2k_struct.pid = (beid == 1) ? pid : 0;
 
-			cmd = (char *) malloc (27);
-			if (!cmd) {
+			if (!(cmd = (char *) malloc (27))) {
 				io->cb_printf ("io_r2k_linux : Malloc failed. Seeking to 0x0\n");
 				io->cb_core_cmd (io->user, "s 0");
 			} else {

--- a/libr/io/p/io_r2web.c
+++ b/libr/io/p/io_r2web.c
@@ -20,8 +20,9 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	if (!fd || !fd->data)
 		return -1;
 	if (count * 3 < count) return -1;
-	hexbuf = malloc (count * 3);
-	if (!hexbuf) return -1;
+	if (!(hexbuf = malloc (count * 3))) {
+		return -1;
+	}
 	hexbuf[0] = 0;
 	r_hex_bin2str (buf, count, hexbuf);
 	url = r_str_newf ("%s/wx%%20%s@%"PFMT64d,
@@ -43,8 +44,10 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		rURL(fd), count, io->off);
 	out = r_socket_http_get (url, &code, &rlen);
 	if (out && rlen>0) {
-		ut8 *tmp = malloc (rlen+1);
-		if (!tmp) goto beach;
+		ut8 *tmp;
+		if (!(tmp = malloc (rlen+1))) {
+			goto beach;
+		}
 		ret = r_hex_str2bin (out, tmp);
 		memcpy (buf, tmp, R_MIN (count, rlen));
 		free (tmp);

--- a/libr/io/p/io_sparse.c
+++ b/libr/io/p/io_sparse.c
@@ -76,8 +76,8 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			return NULL;
 		}
 		if (size > 0) {
-			ut8 *data = malloc (size);
-			if (!data) {
+			ut8 *data;
+			if (!(data = malloc (size))) {
 				eprintf ("Cannot allocate (%s) %d byte(s)\n",
 					pathname+9, size);
 				mal->offset = 0;

--- a/libr/io/p/io_tcp.c
+++ b/libr/io/p/io_tcp.c
@@ -138,22 +138,18 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 				return NULL;
 			}
 			mal->size = rlen;
-			mal->buf = malloc (mal->size + 1);
-			if (!mal->buf) {
+			if (!(mal->buf = malloc (mal->size + 1))) {
+				eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname + 9, mal->size);
 				free (mal);
 				free (out);
 				return NULL;
 			}
-			if (mal->buf != NULL) {
-				mal->fd = getmalfd (mal);
-				memcpy (mal->buf, out, mal->size);
-				free (out);
-				rw = 7;
-				return r_io_desc_new (io, &r_io_plugin_tcp,
-					pathname, rw, mode, mal);
-			}
-			eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname + 9, mal->size);
-			free (mal);
+			mal->fd = getmalfd (mal);
+			memcpy (mal->buf, out, mal->size);
+			free (out);
+			rw = 7;
+			return r_io_desc_new (io, &r_io_plugin_tcp,
+				pathname, rw, mode, mal);
 		}
 		free (out);
 	}

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -141,9 +141,9 @@ static int r_io_zip_slurp_file(RIOZipFileObj *zfo) {
 		}
 		zip_stat_init (&sb);
 		if (zFile && zfo->b && !zip_stat_index (zipArch, zfo->entry, 0, &sb)) {
-			ut8 *buf = malloc (sb.size);
-			memset (buf, 0, sb.size);
-			if (buf) {
+			ut8 *buf;
+			if (buf = malloc (sb.size)) {
+				memset (buf, 0, sb.size);
 				zip_fread (zFile, buf, sb.size);
 				r_buf_set_bytes (zfo->b, buf, sb.size);
 				res = true;
@@ -356,7 +356,7 @@ char * r_io_zip_get_by_file_idx(const char * archivename, const char *idx, ut32 
 }
 
 static RIODesc *r_io_zip_open(RIO *io, const char *file, int rw, int mode) {
-	RIODesc *res = NULL;	
+	RIODesc *res = NULL;
 	char *pikaboo, *tmp;
 	RIOZipFileObj *zfo = NULL;
 	char *zip_uri = NULL, *zip_filename = NULL, *filename_in_zipfile = NULL;
@@ -547,8 +547,7 @@ static int r_io_zip_realloc_buf(RIOZipFileObj *zfo, int count) {
 		if (!buffer) {
 			return false;
 		}
-		buffer->buf = malloc (zfo->b->cur + count );
-		if (!buffer->buf) {
+		if (!(buffer->buf = malloc (zfo->b->cur + count ))) {
 			r_buf_free (buffer);
 			return false;
 		}
@@ -568,8 +567,8 @@ static bool r_io_zip_truncate_buf(RIOZipFileObj *zfo, int size) {
 		return r_io_zip_realloc_buf (zfo, size - zfo->b->length);
 	}
 	if (size > 0) {
-		ut8 *buf = malloc (size);
-		if (!buf) {
+		ut8 *buf;
+		if (!(buf = malloc (size))) {
 			return false;
 		}
 		memcpy (buf, zfo->b->buf, size);

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -142,7 +142,7 @@ static int r_io_zip_slurp_file(RIOZipFileObj *zfo) {
 		zip_stat_init (&sb);
 		if (zFile && zfo->b && !zip_stat_index (zipArch, zfo->entry, 0, &sb)) {
 			ut8 *buf;
-			if (buf = malloc (sb.size)) {
+			if ((buf = malloc (sb.size))) {
 				memset (buf, 0, sb.size);
 				zip_fread (zFile, buf, sb.size);
 				r_buf_set_bytes (zfo->b, buf, sb.size);

--- a/libr/io/p_cache.c
+++ b/libr/io/p_cache.c
@@ -153,7 +153,7 @@ R_API int r_io_desc_cache_read(RIODesc *desc, ut64 paddr, ut8 *buf, int len) {
 	while (amount < len) {
 		sdb_itoa (caddr, k, 10);
 		// get an existing desc-cache, if it exists
-		if (!(cache = (RIODescCache *)(size_t)sdb_num_get (desc->cache, k, NULL))) {	
+		if (!(cache = (RIODescCache *)(size_t)sdb_num_get (desc->cache, k, NULL))) {
 			amount += (R_IO_DESC_CACHE_SIZE - cbaddr);
 			ptr += (R_IO_DESC_CACHE_SIZE - cbaddr);
 			goto beach;
@@ -213,8 +213,7 @@ static int __desc_cache_list_cb(void *user, const char *k, const char *v) {
 				if (!cache) {
 					return false;
 				}
-				cache->data = malloc (R_IO_DESC_CACHE_SIZE - byteaddr);
-				if (!cache->data) {
+				if (!(cache->data = malloc (R_IO_DESC_CACHE_SIZE - byteaddr))) {
 					free (cache);
 					return false;
 				}
@@ -341,7 +340,7 @@ static int __desc_cache_cleanup_cb(void *user, const char *k, const char *v) {
 	}
 	if (size <= (blockaddr + R_IO_DESC_CACHE_SIZE - 1)) {
 		//this looks scary, but it isn't
-		byteaddr = (int)(size - blockaddr) - 1;		
+		byteaddr = (int)(size - blockaddr) - 1;
 		cache->cached &= cleanup_masks[byteaddr];
 	}
 	return true;

--- a/libr/io/undo.c
+++ b/libr/io/undo.c
@@ -204,14 +204,12 @@ R_API void r_io_wundo_new(RIO *io, ut64 off, const ut8 *data, int len) {
 	uw->set = true;
 	uw->off = off;
 	uw->len = len;
-	uw->n = (ut8*) malloc (len);
-	if (!uw->n) {
+	if (!(uw->n = (ut8*) malloc (len))) {
 		free (uw);
 		return;
 	}
 	memcpy (uw->n, data, len);
-	uw->o = (ut8*) malloc (len);
-	if (!uw->o) {
+	if (!(uw->o = (ut8*) malloc (len))) {
 		R_FREE (uw);
 		return;
 	}

--- a/libr/magic/apprentice.c
+++ b/libr/magic/apprentice.c
@@ -516,13 +516,13 @@ static int apprentice_load(RMagic *ms, struct r_magic **magicp, ut32 *nmagicp, c
 	DIR *dir;
 	struct dirent *d;
 	char subfn[MAXPATHLEN];
-#else	
+#else
 	HANDLE hdir;
 	WIN32_FIND_DATAW entry;
 	wchar_t dir[MAX_PATH];
 	wchar_t *wcpath;
 	char *cfname;
-	char subfn[1024];	
+	char subfn[1024];
 #endif
 	ms->flags |= R_MAGIC_CHECK;	/* Enable checks for parsed files */
 
@@ -1373,7 +1373,7 @@ static int check_format(RMagic *ms, struct r_magic *m) {
 
 	if (file_nformats != file_nnames) {
 		return -1;
-	}		
+	}
 
 	if (m->type >= file_nformats) {
 		file_magwarn(ms, "Internal error inconsistency between "
@@ -1763,7 +1763,7 @@ static int apprentice_compile(RMagic *ms, struct r_magic **magicp, ut32 *nmagicp
 
 	dbname = mkdbname(fn, 1);
 
-	if (!dbname) 
+	if (!dbname)
 		goto out;
 
 	if ((fd = r_sandbox_open(dbname, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0644)) == -1) {
@@ -1813,8 +1813,7 @@ static char *mkdbname(const char *fn, int strip) {
 	if (fnlen + extlen + 1 > MAXPATHLEN) {
 		return NULL;
 	}
-	buf = malloc (fnlen + extlen + 1);
-	if (buf) {
+	if ((buf = malloc (fnlen + extlen + 1))) {
 		memcpy (buf, fn, fnlen);
 		memcpy (buf+fnlen, ext, extlen);
 		buf[fnlen+extlen] = 0;

--- a/libr/magic/funcs.c
+++ b/libr/magic/funcs.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Christos Zoulas 2003.
  * All Rights Reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -12,7 +12,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -73,8 +73,7 @@ int file_vprintf(RMagic *ms, const char *fmt, va_list ap) {
 	if (ms->o.buf != NULL) {
 		int obuflen = strlen (ms->o.buf);
 		len = obuflen + buflen+1;
-		newstr = malloc (len+1);
-		if (!newstr) {
+		if (!(newstr = malloc (len+1))) {
 			free (buf);
 			return -1;
 		}
@@ -286,7 +285,7 @@ const char *file_getbuffer(RMagic *ms) {
 #endif
 	for (np = ms->o.pbuf, op = ms->o.buf; *op; op++) {
 		if (isprint ((ut8)*op)) {
-			*np++ = *op;	
+			*np++ = *op;
 		} else {
 			OCTALIFY (np, op);
 		}

--- a/libr/magic/magic.c
+++ b/libr/magic/magic.c
@@ -4,7 +4,7 @@
 /*
  * Copyright (c) Christos Zoulas 2003.
  * All Rights Reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -14,7 +14,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -126,7 +126,7 @@ R_API int r_magic_errno(RMagic* m) {
 
 #include "patchlevel.h"
 
-#ifndef PIPE_BUF 
+#ifndef PIPE_BUF
 /* Get the PIPE_BUF from pathconf */
 #ifdef _PC_PIPE_BUF
 #define PIPE_BUF pathconf(".", _PC_PIPE_BUF)
@@ -270,8 +270,7 @@ R_API RMagic* r_magic_new(int flags) {
 	if (!ms) return NULL;
 	r_magic_setflags (ms, flags);
 	ms->o.buf = ms->o.pbuf = NULL;
-	ms->c.li = malloc ((ms->c.len = 10) * sizeof (*ms->c.li));
-	if (!ms->c.li) {
+	if (!(ms->c.li = malloc ((ms->c.len = 10) * sizeof (*ms->c.li)))) {
 		free (ms);
 		return NULL;
 	}
@@ -326,7 +325,7 @@ R_API const char * r_magic_buffer(RMagic *ms, const void *buf, size_t nb) {
 		return NULL;
 	/*
 	 * The main work is done here!
-	 * We have the file name and/or the data buffer to be identified. 
+	 * We have the file name and/or the data buffer to be identified.
 	 */
 	if (file_buffer (ms, -1, NULL, buf, nb) == -1)
 		return NULL;

--- a/libr/magic/softmagic.c
+++ b/libr/magic/softmagic.c
@@ -312,7 +312,9 @@ static st32 mprint(RMagic *ms, struct r_magic *m) {
 		case -1:
 			return -1;
 		case 1:
-			buf = malloc (2);
+			if (!(buf = malloc (2))) {
+				return -1;
+			}
 			if (snprintf (buf, 2, "%c", (ut8)v)<0) {
 				free (buf);
 				return -1;
@@ -337,7 +339,9 @@ static st32 mprint(RMagic *ms, struct r_magic *m) {
 		case -1:
 			return -1;
 		case 1:
-			buf = malloc (32);
+			if (!(buf = malloc (32))) {
+				return -1;
+			}
 			if (snprintf (buf, 32, "%hu", (unsigned short)v) < 0) {
 				free (buf);
 				return -1;
@@ -363,7 +367,9 @@ static st32 mprint(RMagic *ms, struct r_magic *m) {
 		case -1:
 			return -1;
 		case 1:
-			buf = malloc (32);
+			if (!(buf = malloc (32))) {
+				return -1;
+			}
 			if (snprintf (buf, 32, "%u", (ut32)v) < 0) {
 				free (buf);
 				return -1;
@@ -448,7 +454,9 @@ static st32 mprint(RMagic *ms, struct r_magic *m) {
 		case -1:
 			return -1;
 		case 1:
-			buf = malloc (32);
+			if (!(buf = malloc (32))) {
+				return -1;
+			}
 			if (snprintf (buf, 32, "%g", vf) < 0) {
 				free (buf);
 				return -1;
@@ -473,7 +481,9 @@ static st32 mprint(RMagic *ms, struct r_magic *m) {
 		case -1:
 			return -1;
 		case 1:
-			buf = malloc (32);
+			if (!(buf = malloc (32))) {
+				return -1;
+			}
 			if (snprintf (buf, 32, "%g", vd) < 0) {
 				free (buf);
 				return -1;

--- a/libr/parse/code.c
+++ b/libr/parse/code.c
@@ -11,8 +11,10 @@ static void appendstring(const char *msg, char **s) {
 	if (!s) {
 		printf ("%s\n", msg);
 	} else if (*s) {
-		char *p = malloc (strlen (msg) + strlen (*s) + 1);
-		if (!p) return;
+		char *p;
+		if (!(p = malloc (strlen (msg) + strlen (*s) + 1))) {
+			return;
+		}
 		strcpy (p, *s);
 		free (*s);
 		*s = p;

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -40,7 +40,7 @@ R_API ut8* r_reg_get_bytes(RReg* reg, int type, int* size) {
 	if (size) {
 		*size = sz;
 	}
-	if (buf = malloc (sz)) {
+	if ((buf = malloc (sz))) {
 		memcpy (buf, reg->regset[type].arena->bytes, sz);
 	}
 	return buf;

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -14,8 +14,7 @@ R_API ut8* r_reg_get_bytes(RReg* reg, int type, int* size) {
 		/* serialize ALL register types in a single buffer */
 		// owned buffer is returned
 		osize = sz = 0;
-		buf = malloc (8);
-		if (!buf) {
+		if (!(buf = malloc (8))) {
 			return NULL;
 		}
 		for (i = 0; i < R_REG_TYPE_LAST; i++) {
@@ -41,8 +40,7 @@ R_API ut8* r_reg_get_bytes(RReg* reg, int type, int* size) {
 	if (size) {
 		*size = sz;
 	}
-	buf = malloc (sz);
-	if (buf) {
+	if (buf = malloc (sz)) {
 		memcpy (buf, reg->regset[type].arena->bytes, sz);
 	}
 	return buf;
@@ -255,8 +253,8 @@ R_API ut8* r_reg_arena_peek(RReg* reg) {
 	if (!reg || !regset || !regset->arena || (regset->arena->size < 1)) {
 		return NULL;
 	}
-	ut8* ret = malloc (regset->arena->size);
-	if (!ret) {
+	ut8* ret;
+	if (!(ret = malloc (regset->arena->size))) {
 		return NULL;
 	}
 	memcpy (ret, regset->arena->bytes, regset->arena->size);
@@ -276,8 +274,8 @@ R_API ut8* r_reg_arena_dup(RReg* reg, const ut8* source) {
 	if (!reg || !regset || !regset->arena || (regset->arena->size < 1)) {
 		return NULL;
 	}
-	ut8* ret = malloc (regset->arena->size);
-	if (!ret) {
+	ut8* ret;
+	if (!(ret = malloc (regset->arena->size))) {
 		return NULL;
 	}
 	memcpy (ret, source, regset->arena->size);
@@ -294,8 +292,8 @@ R_API int r_reg_arena_set_bytes(RReg* reg, const char* str) {
 		return -1;
 	}
 	int bin_str_len = (len + 1) / 2; //2 hex chrs for 1 byte
-	ut8* bin_str = malloc (bin_str_len);
-	if (!bin_str) {
+	ut8* bin_str;
+	if (!(bin_str = malloc (bin_str_len))) {
 		eprintf ("Failed to decode hex str.\n");
 		return -1;
 	}

--- a/libr/reg/value.c
+++ b/libr/reg/value.c
@@ -222,7 +222,7 @@ R_API ut64 r_reg_set_bvalue(RReg *reg, RRegItem *item, const char *str) {
 R_API R_HEAP char *r_reg_get_bvalue(RReg *reg, RRegItem *item) {
 	char *out = NULL;
 	if (reg && item && item->flags) {
-		if (out = malloc (strlen (item->flags) + 1)) {
+		if ((out = malloc (strlen (item->flags) + 1))) {
 			ut64 num = r_reg_get_value (reg, item);
 			r_str_bits (out, (ut8 *)&num,
 				strlen (item->flags) * 8, item->flags);

--- a/libr/reg/value.c
+++ b/libr/reg/value.c
@@ -222,8 +222,7 @@ R_API ut64 r_reg_set_bvalue(RReg *reg, RRegItem *item, const char *str) {
 R_API R_HEAP char *r_reg_get_bvalue(RReg *reg, RRegItem *item) {
 	char *out = NULL;
 	if (reg && item && item->flags) {
-		out = malloc (strlen (item->flags) + 1);
-		if (out) {
+		if (out = malloc (strlen (item->flags) + 1)) {
 			ut64 num = r_reg_get_value (reg, item);
 			r_str_bits (out, (ut8 *)&num,
 				strlen (item->flags) * 8, item->flags);

--- a/libr/search/bytepat.c
+++ b/libr/search/bytepat.c
@@ -18,8 +18,9 @@ typedef struct _fnditem {
 
 static fnditem* init_fi() {
 	fnditem* n;
-	n = (fnditem*) malloc (sizeof (fnditem));
-	if (!n) return NULL;
+	if (!(n = (fnditem*) malloc (sizeof (fnditem)))) {
+		return NULL;
+	}
 	n->next = NULL;
 	return n;
 }
@@ -39,10 +40,11 @@ static void fini_fi(fnditem* fi) {
 static void add_fi (fnditem* n, unsigned char* blk, int patlen) {
 	fnditem* p;
 	for (p=n; p->next!=NULL; p=p->next);
-	p->next = (fnditem*) malloc (sizeof (fnditem));
-	p = p->next;
-	memcpy (p->str, blk, patlen);
-	p->next = NULL;
+	if (p->next = (fnditem*) malloc (sizeof (fnditem))) {
+		p = p->next;
+		memcpy (p->str, blk, patlen);
+		p->next = NULL;
+	}
 }
 
 static int is_fi_present(fnditem* n, unsigned char* blk , int patlen) {

--- a/libr/search/bytepat.c
+++ b/libr/search/bytepat.c
@@ -40,7 +40,7 @@ static void fini_fi(fnditem* fi) {
 static void add_fi (fnditem* n, unsigned char* blk, int patlen) {
 	fnditem* p;
 	for (p=n; p->next!=NULL; p=p->next);
-	if (p->next = (fnditem*) malloc (sizeof (fnditem))) {
+	if ((p->next = (fnditem*) malloc (sizeof (fnditem)))) {
 		p = p->next;
 		memcpy (p->str, blk, patlen);
 		p->next = NULL;

--- a/libr/search/keyword.c
+++ b/libr/search/keyword.c
@@ -155,6 +155,7 @@ R_API RSearchKeyword* r_search_keyword_new_hex(const char *kwstr, const char *bm
 R_API RSearchKeyword* r_search_keyword_new_hexmask(const char *kwstr, const char *data) {
 	RSearchKeyword *ks = NULL;
 	ut8 *kw, *bm;
+	kw = bm = NULL;
 	if (kwstr != NULL) {
 		int len = strlen (kwstr);
 		if ((kw = malloc (len + 4)) && (bm = malloc (len + 4))) {

--- a/libr/search/keyword.c
+++ b/libr/search/keyword.c
@@ -20,15 +20,13 @@ R_API RSearchKeyword* r_search_keyword_new(const ut8 *kwbuf, int kwlen, const ut
 	kw->type = R_SEARCH_KEYWORD_TYPE_BINARY;
 	kw->data = (void *) data;
 	kw->keyword_length = kwlen;
-	kw->bin_keyword = malloc (kwlen);
-	if (!kw->bin_keyword) {
+	if (!(kw->bin_keyword = malloc (kwlen))) {
 		r_search_keyword_free (kw);
 		return NULL;
 	}
 	memcpy (kw->bin_keyword, kwbuf, kwlen);
 	if (bmbuf && bmlen > 0 && !ignoreMask (bmbuf, bmlen)) {
-		kw->bin_binmask = malloc (bmlen);
-		if (!kw->bin_binmask) {
+		if (!(kw->bin_binmask = malloc (bmlen))) {
 			r_search_keyword_free (kw);
 			return NULL;
 		}
@@ -56,8 +54,9 @@ R_API RSearchKeyword* r_search_keyword_new_str(const char *kwbuf, const char *bm
 	int bmlen = 0;
 
 	if (bmstr) {
-		bmbuf = malloc (strlen (bmstr)+1);
-		if (!bmbuf) return NULL;
+		if (!(bmbuf = malloc (strlen (bmstr)+1))) {
+			return NULL;
+		}
 		bmlen = r_hex_str2bin (bmstr, bmbuf);
 		if (bmlen < 1) {
 			free (bmbuf);
@@ -82,8 +81,9 @@ R_API RSearchKeyword* r_search_keyword_new_wide(const char *kwbuf, const char *b
 	int bmlen = 0;
 
 	if (bmstr) {
-		bmbuf = malloc (strlen (bmstr)+1);
-		if (!bmbuf) return NULL;
+		if (!(bmbuf = malloc (strlen (bmstr)+1))) {
+			return NULL;
+		}
 		bmlen = r_hex_str2bin (bmstr, bmbuf);
 		if (bmlen < 1) {
 			free(bmbuf);
@@ -92,7 +92,10 @@ R_API RSearchKeyword* r_search_keyword_new_wide(const char *kwbuf, const char *b
 	}
 
 	len = strlen(kwbuf);
-	str = malloc((len+1)*2);
+	if (!(str = malloc ((len + 1) * 2))) {
+		free(bmbuf);
+		return NULL;
+	}
 	for (p2=kwbuf, p=str; *p2; p+=2, p2++) {
 		if (ignore_case)
 			p[0] = tolower((const unsigned char)*p2);
@@ -115,13 +118,13 @@ R_API RSearchKeyword* r_search_keyword_new_hex(const char *kwstr, const char *bm
 	ut8 *kwbuf, *bmbuf;
 	int kwlen, bmlen = 0;
 
-	if (!kwstr)
+	if (!kwstr) {
 		return NULL;
+	}
 
-	kwbuf = malloc (strlen (kwstr)+1);
-	if (!kwbuf)
+	if (!(kwbuf = malloc (strlen (kwstr)+1))) {
 		return NULL;
-
+	}
 	kwlen = r_hex_str2bin (kwstr, kwbuf);
 	if (kwlen < 1) {
 		free (kwbuf);
@@ -130,8 +133,7 @@ R_API RSearchKeyword* r_search_keyword_new_hex(const char *kwstr, const char *bm
 
 	bmbuf = NULL;
 	if (bmstr && *bmstr) {
-		bmbuf = malloc (strlen (bmstr)+1);
-		if (!bmbuf) {
+		if (!(bmbuf = malloc (strlen (bmstr)+1))) {
 			free (kwbuf);
 			return NULL;
 		}
@@ -155,9 +157,7 @@ R_API RSearchKeyword* r_search_keyword_new_hexmask(const char *kwstr, const char
 	ut8 *kw, *bm;
 	if (kwstr != NULL) {
 		int len = strlen (kwstr);
-		kw = malloc (len + 4);
-		bm = malloc (len + 4);
-		if (kw != NULL && bm != NULL) {
+		if ((kw = malloc (len + 4)) && (bm = malloc (len + 4))) {
 			len = r_hex_str2binmask (kwstr, (ut8*)kw, (ut8*)bm);
 			if (len<0)
 				len = -len -1;
@@ -198,8 +198,7 @@ R_API RSearchKeyword *r_search_keyword_new_regexp (const char *str, const char *
 	if (!kw)
 		return NULL;
 
-	kw->bin_keyword = malloc (length+1);
-	if (!kw->bin_keyword) {
+	if (!(kw->bin_keyword = malloc (length+1))) {
 		r_search_keyword_free (kw);
 		return NULL;
 	}

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -155,8 +155,7 @@ R_API int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int le
 			left->len = 0;
 		}
 	} else {
-		left = malloc (sizeof(RSearchLeftover) + (size_t)2 * (longest - 1));
-		if (!left) {
+		if (!(left = malloc (sizeof(RSearchLeftover) + (size_t)2 * (longest - 1)))) {
 			return -1;
 		}
 		s->data = left;
@@ -371,8 +370,7 @@ R_API int r_search_mybinparse_update(RSearch *s, ut64 from, const ut8 *buf, int 
 			left->len = 0;
 		}
 	} else {
-		left = malloc (sizeof(RSearchLeftover) + (size_t)2 * (longest - 1));
-		if (!left) {
+		if (!(left = malloc (sizeof(RSearchLeftover) + (size_t)2 * (longest - 1)))) {
 			return -1;
 		}
 		s->data = left;

--- a/libr/util/astr.c
+++ b/libr/util/astr.c
@@ -29,8 +29,7 @@ R_API RASN1String *r_asn1_concatenate_strings (RASN1String *s0, RASN1String *s1,
 		return NULL;
 	}
 	len = s0->length + s1->length - 1;
-	str = (char*) malloc (len);
-	if (!str) {
+	if (!(str = (char*) malloc (len))) {
 		if (freestr) {
 			r_asn1_free_string (s0);
 			r_asn1_free_string (s1);
@@ -63,8 +62,8 @@ R_API RASN1String *r_asn1_stringify_utctime (const ut8 *buffer, ut32 length) {
 		return NULL;
 	}
 	const int str_sz = 24;
-	char *str = malloc (str_sz);
-	if (!str) {
+	char *str;
+	if (!(str = malloc (str_sz))) {
 		return NULL;
 	}
 	str[0] = buffer[4];
@@ -100,8 +99,8 @@ R_API RASN1String *r_asn1_stringify_time (const ut8 *buffer, ut32 length) {
 		return NULL;
 	}
 	const int str_sz = 24;
-	char *str = malloc (str_sz);
-	if (!str) {
+	char *str;
+	if (!(str = malloc (str_sz))) {
 		return NULL;
 	}
 
@@ -142,8 +141,7 @@ R_API RASN1String *r_asn1_stringify_bits (const ut8 *buffer, ut32 length) {
 		return NULL;
 	}
 	size = 1 + ((length - 1)* 8) - buffer[0];
-	str = (char*) malloc (size);
-	if (!str) {
+	if (!(str = (char*) malloc (size))) {
 		return NULL;
 	}
 	for (i = 1, j = 0; i < length && j < size; ++i) {
@@ -173,8 +171,7 @@ R_API RASN1String *r_asn1_stringify_integer (const ut8 *buffer, ut32 length) {
 		return NULL;
 	}
 	size = 3 * length;
-	str = (char*) malloc (size);
-	if (!str) {
+	if (!(str = (char*) malloc (size))) {
 		return NULL;
 	}
 	memset (str, 0, size);
@@ -198,8 +195,7 @@ R_API RASN1String* r_asn1_stringify_bytes (const ut8 *buffer, ut32 length) {
 	}
 	size = (4 * length);
 	size += (64 - (size % 64));
-	str = (char*) malloc (size);
-	if (!str) {
+	if (!(str = (char*) malloc (size))) {
 		return NULL;
 	}
 	memset (str, 0x20, size);

--- a/libr/util/btree.c
+++ b/libr/util/btree.c
@@ -64,7 +64,7 @@ R_API void btree_traverse(struct btree_node *root, int reverse, void *context, B
 R_API bool btree_del(struct btree_node *proot, void *x, BTREE_CMP(cmp), BTREE_DEL(del)) {
 	struct btree_node *p = btree_search (proot, x, cmp, 1);
 	if (p) {
-		// p->right = 
+		// p->right =
 		btree_remove (p->left, del);
 		p->left = NULL;
 		return true;
@@ -102,7 +102,10 @@ R_API void btree_insert(struct btree_node **T, struct btree_node *p, BTREE_CMP(c
 }
 
 R_API void btree_add(struct btree_node **T, void *e, BTREE_CMP(cmp)) {
-	struct btree_node *p = (struct btree_node*) malloc (sizeof (struct btree_node));
+	struct btree_node *p;
+	if (!(p = (struct btree_node*) malloc (sizeof (struct btree_node)))) {
+		return;
+	}
 	p->data = e;
 	p->hits = 0;
 	p->left = p->right = NULL;

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -378,8 +378,7 @@ R_API char *r_buf_to_string(RBuffer *b) {
 	if (!b) {
 		return strdup ("");
 	}
-	s = malloc (b->length + 1);
-	if (s) {
+	if (s = malloc (b->length + 1)) {
 		memmove (s, b->buf, b->length);
 		s[b->length] = 0;
 	}
@@ -811,7 +810,9 @@ R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len) {
 		}
 		b->empty = 0;
 		free (b->buf);
-		b->buf = (ut8 *) malloc (addr + len);
+		if (!(b->buf = (ut8 *) malloc (addr + len))) {
+			return 0;
+		}
 	}
 	return r_buf_cpy (b, addr, b->buf, buf, len, true);
 }
@@ -868,8 +869,7 @@ R_API char *r_buf_free_to_string(RBuffer *b) {
 		p = r_buf_to_string (b);
 	} else {
 		r_buf_append_bytes (b, (const ut8*)"", 1);
-		p = malloc (b->length + 1);
-		if (!p) {
+		if (!(p = malloc (b->length + 1))) {
 			return NULL;
 		}
 		memmove (p, b->buf, b->length);
@@ -894,8 +894,8 @@ R_API bool r_buf_resize (RBuffer *b, ut64 newsize) {
 		sparse_limits (b->sparse, 0, &last_addr);
 		int buf_len = newsize - last_addr;
 		if (buf_len > 0) {
-			ut8 *buf = malloc (buf_len);
-			if (buf) {
+			ut8 *buf;
+			if (buf = malloc (buf_len)) {
 				memset (buf, b->Oxff, buf_len);
 				sparse_write (b->sparse, last_addr, buf, buf_len);
 				free (buf);

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -378,7 +378,7 @@ R_API char *r_buf_to_string(RBuffer *b) {
 	if (!b) {
 		return strdup ("");
 	}
-	if (s = malloc (b->length + 1)) {
+	if ((s = malloc (b->length + 1))) {
 		memmove (s, b->buf, b->length);
 		s[b->length] = 0;
 	}
@@ -895,7 +895,7 @@ R_API bool r_buf_resize (RBuffer *b, ut64 newsize) {
 		int buf_len = newsize - last_addr;
 		if (buf_len > 0) {
 			ut8 *buf;
-			if (buf = malloc (buf_len)) {
+			if ((buf = malloc (buf_len))) {
 				memset (buf, b->Oxff, buf_len);
 				sparse_write (b->sparse, last_addr, buf, buf_len);
 				free (buf);

--- a/libr/util/cache.c
+++ b/libr/util/cache.c
@@ -45,8 +45,7 @@ R_API const ut8 *r_cache_get(RCache *c, ut64 addr, int *len) {
 
 R_API int r_cache_set(RCache *c, ut64 addr, const ut8 *buf, int len) {
 	if (!c->buf) {
-		c->buf = malloc (len);
-		if (!c->buf) {
+		if (!(c->buf = malloc (len))) {
 			return 0;
 		}
 		memcpy (c->buf, buf, len);
@@ -57,8 +56,7 @@ R_API int r_cache_set(RCache *c, ut64 addr, const ut8 *buf, int len) {
 		int baselen = (c->base - addr);
 		int newlen = baselen + ((len > c->len)? len: c->base);
 		// XXX expensive heap usage. must simplify
-		b = malloc (newlen);
-		if (!b) {
+		if (!(b = malloc (newlen))) {
 			return 0;
 		}
 		memset (b, 0xff, newlen);

--- a/libr/util/chmod.c
+++ b/libr/util/chmod.c
@@ -122,9 +122,11 @@ int parsemode(const char *str) {
 }
 
 char * agetcwd(void) {
-        char *buf = malloc (4096);
-	if (!buf) return NULL;
-        if(!getcwd(buf, 4096))
+        char *buf;
+	if (!(buf = malloc (4096))) {
+		return NULL;
+	}
+	if(!getcwd(buf, 4096))
                 eprintf("getcwd:");
         return buf;
 }

--- a/libr/util/constr.c
+++ b/libr/util/constr.c
@@ -5,7 +5,9 @@
 R_API RConstr* r_constr_new (int size) {
 	RConstr *c = R_NEW (RConstr);
 	c->l = size>0? size: 1024;
-	c->b = malloc (c->l);
+	if (!(c->b = malloc (c->l))) {
+		return NULL;
+	}
 	c->i = *c->b = 0;
 	return c;
 }

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -257,8 +257,7 @@ R_API char *r_stdin_slurp (int *sz) {
 	if ((newfd = dup (0)) < 0) {
 		return NULL;
 	}
-	buf = malloc (BS);
-	if (!buf) {
+	if (!(buf = malloc (BS))) {
 		close (newfd);
 		return NULL;
 	}
@@ -378,8 +377,7 @@ R_API ut8 *r_file_slurp_hexpairs(const char *str, int *usz) {
 	(void) fseek (fd, 0, SEEK_END);
 	sz = ftell (fd);
 	(void) fseek (fd, 0, SEEK_SET);
-	ret = (ut8*)malloc ((sz>>1)+1);
-	if (!ret) {
+	if (!(ret = (ut8*)malloc ((sz>>1)+1))) {
 		fclose (fd);
 		return NULL;
 	}
@@ -418,8 +416,7 @@ R_API char *r_file_slurp_range(const char *str, ut64 off, int sz, int *osz) {
 		fclose (fd);
 		return NULL;
 	}
-	ret = (char *) malloc (sz + 1);
-	if (ret) {
+	if (!(ret = (char *) malloc (sz + 1))) {
 		if (osz) {
 			*osz = (int)(size_t) fread (ret, 1, sz, fd);
 		} else {
@@ -810,7 +807,10 @@ err_r_file_mmap_windows:
 #else
 static RMmap *r_file_mmap_other (RMmap *m) {
 	ut8 empty = m->len == 0;
-	m->buf = malloc ((empty?1024:m->len));
+	if (!(m->buf = malloc ((empty?1024:m->len)))) {
+		free(m);
+		return NULL;
+	}
 	if (!empty && m->buf) {
 		lseek (m->fd, (off_t)0, SEEK_SET);
 		read (m->fd, m->buf, m->len);
@@ -901,7 +901,9 @@ R_API char *r_file_temp (const char *prefix) {
 		prefix = "";
 	}
 	namesz = strlen (prefix) + strlen (path) + 32;
-	name = malloc (namesz);
+	if (!(name = malloc (namesz))) {
+		return NULL;
+	}
 	snprintf (name, namesz, "%s/%s.%"PFMT64x, path, prefix, r_sys_now ());
 	free (path);
 	return name;
@@ -918,8 +920,7 @@ R_API int r_file_mkstemp(const char *prefix, char **oname) {
 	LPTSTR path_ = r_sys_conv_utf8_to_utf16 (path);
 	LPTSTR prefix_ = r_sys_conv_utf8_to_utf16 (prefix);
 
-	name = (LPTSTR)malloc (sizeof (TCHAR) * (MAX_PATH + 1));
-	if (!name) {
+	if (!(name = (LPTSTR)malloc (sizeof (TCHAR) * (MAX_PATH + 1)))) {
 		goto err_r_file_mkstemp;
 	}
 	if (GetTempFileName (path_, prefix_, 0, name)) {

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2016 - pancake */ 
+/* radare - LGPL - Copyright 2007-2016 - pancake */
 #include "r_types.h"
 #include "r_util.h"
 #include <stdio.h>
@@ -268,8 +268,8 @@ R_API char *r_hex_from_js(const char *code) {
 	char * str = r_str_ndup (start + 1, end - start - 1);
 
 	/* assuming base64 input, output will always be shorter */
-	ut8 *b64d = malloc (end - start);
-	if (!b64d) {
+	ut8 *b64d;
+	if (!(b64d = malloc (end - start))) {
 		free (str);
 		return NULL;
 	}
@@ -283,8 +283,8 @@ R_API char *r_hex_from_js(const char *code) {
 
 	// TODO: use r_str_bin2hex
 	int i, len = strlen ((const char *)b64d);
-	char * out = malloc (len * 2 + 1);
-	if (!out) {
+	char *out;
+	if (!(out = malloc (len * 2 + 1))) {
 		free (str);
 		free (b64d);
 		return NULL;
@@ -389,8 +389,9 @@ R_API char *r_hex_bin2strdup(const ut8 *in, int len) {
 	char tmp[5], *out;
 
 	if ((len + 1) * 2 < len) return NULL;
-	out = malloc ((len + 1) * 2);
-	if (!out) return NULL;
+	if (!(out = malloc ((len + 1) * 2))) {
+		return NULL;
+	}
 	for (i = idx = 0; i < len; i++, idx += 2)  {
 		snprintf (tmp, sizeof (tmp), "%02x", in[i]);
 		memcpy (out+idx, tmp, 2);

--- a/libr/util/json_indent.c
+++ b/libr/util/json_indent.c
@@ -167,8 +167,8 @@ R_API char* r_print_json_indent(const char* s, bool color, const char* tab, cons
 		return NULL;
 	}
 
-	char *O = malloc (osz);
-	if (!O) {
+	char *O;
+	if (!(O = malloc (osz))) {
 		return NULL;
 	}
 	OE = O + osz;

--- a/libr/util/mem.c
+++ b/libr/util/mem.c
@@ -40,12 +40,10 @@ R_API void r_mem_copyloop(ut8 *dest, const ut8 *orig, int dsize, int osize) {
 R_API int r_mem_cmp_mask(const ut8 *dest, const ut8 *orig, const ut8 *mask, int len) {
 	int i, ret = -1;
 	ut8 *mdest, *morig;
-	mdest = malloc (len);
-	if (!mdest) {
+	if (!(mdest = malloc (len))) {
 		return ret;
 	}
-	morig = malloc (len);
-	if (!morig) {
+	if (!(morig = malloc (len))) {
 		free (mdest);
 		return ret;
 	}
@@ -281,8 +279,8 @@ R_API int r_mem_protect(void *ptr, int size, const char *prot) {
 }
 
 R_API void *r_mem_dup(void *s, int l) {
-	void *d = malloc (l);
-	if (!d) {
+	void *d;
+	if (!(d = malloc (l))) {
 		return NULL;
 	}
 	memcpy (d, s, l);

--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -83,10 +83,9 @@ bool r_pkcs7_parse_digestalgorithmidentifier (RPKCS7DigestAlgorithmIdentifiers *
 		for (i = 0; i < dai->length; ++i) {
 			// r_x509_parse_algorithmidentifier returns bool,
 			// so i have to allocate before calling the function
-			dai->elements[i] = (RX509AlgorithmIdentifier *) malloc (sizeof (RX509AlgorithmIdentifier));
+			if ((dai->elements[i] = (RX509AlgorithmIdentifier *) malloc (sizeof (RX509AlgorithmIdentifier)))) {
 			//should i handle invalid memory? the function checks the pointer
 			//or it should return if dai->elements[i] == NULL ?
-			if (dai->elements[i]) {
 				//Memset is needed to initialize to 0 the structure and avoid garbage.
 				memset (dai->elements[i], 0, sizeof (RX509AlgorithmIdentifier));
 				r_x509_parse_algorithmidentifier (dai->elements[i], object->list.objects[i]);
@@ -251,7 +250,7 @@ bool r_pkcs7_parse_signeddata (RPKCS7SignedData *sd, RASN1Object *object) {
 	memset (sd, 0, sizeof (RPKCS7SignedData));
 	RASN1Object **elems = object->list.objects;
 	//Following RFC
-	sd->version = (ut32) elems[0]->sector[0]; 
+	sd->version = (ut32) elems[0]->sector[0];
 	r_pkcs7_parse_digestalgorithmidentifier (&sd->digestAlgorithms, elems[1]);
 	r_pkcs7_parse_contentinfo (&sd->contentInfo, elems[2]);
 	//Optional
@@ -602,7 +601,7 @@ char *r_pkcs7_cms_dump (RCMS* container) {
 	if (length <= p) {
 		free (buffer);
 		return NULL;
-	}	
+	}
 	r = snprintf (buffer + p, length - p, "  SignerInfos:\n");
 	p += (ut32) r;
 	if (r < 0 || length <= p) {
@@ -712,7 +711,7 @@ RJSVar *r_pkcs7_cms_json (RCMS* container) {
 
 	var = r_json_number_new (container->signedData.version);
 	R_JSON_FREE_ON_FAIL (r_json_object_add (obj, "Version", var), var);
-	
+
 	if (container->signedData.digestAlgorithms.elements) {
 		array = r_json_array_new (container->signedData.digestAlgorithms.length);
 		for (i = 0; i < container->signedData.digestAlgorithms.length; ++i) {

--- a/libr/util/pool.c
+++ b/libr/util/pool.c
@@ -59,8 +59,7 @@ R_API void *r_mem_pool_alloc(RMemoryPool *pool) {
 			eprintf ("FAIL: Cannot allocate more memory in the pool\n");
 			return NULL;
 		}
-		pool->nodes[pool->npool] = malloc (pool->nodesize * pool->poolsize);
-		if (!pool->nodes[pool->npool]) {
+		if (!(pool->nodes[pool->npool] = malloc (pool->nodesize * pool->poolsize))) {
 			return NULL;
 		}
 		pool->ncount = 0;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -237,8 +237,8 @@ R_API char* r_print_stereogram_bytes(const ut8 *buf, int len) {
 	int rows = len / cols;
 
 	int size = (2 + cols) * rows;
-	char *bump = malloc (size + 1); //(cols+2) * rows);
-	if (!bump) {
+	char *bump;
+	if (!(bump = malloc (size + 1))) { //(cols+2) * rows);
 		return NULL;
 	}
 	for (i = bumpi = 0; bumpi < size && i < len; i++) {
@@ -1106,8 +1106,8 @@ static const char* getchardiff(char *fmt, ut8 a, ut8 b) {
 #define CD(a, b) getchardiff (fmt, a[i + j], b[i + j])
 
 static ut8* M(const ut8 *b, int len) {
-	ut8 *r = malloc (len + 16);
-	if (!r) {
+	ut8 *r;
+	if (!(r = malloc (len + 16))) {
 		return NULL;
 	}
 	memset (r, 0xff, len + 16);
@@ -1922,8 +1922,8 @@ R_API void r_print_hex_from_bin (RPrint *p, char *bin_str) {
 	int i, j, index;
 	RPrint myp = {.cb_printf = libc_printf};
 	const int len = strlen (bin_str);
-	ut64 n, *buf = malloc (sizeof (ut64) * ((len + 63) / 64));
-	if (buf == NULL) {
+	ut64 n, *buf;
+	if (!(buf = malloc (sizeof (ut64) * ((len + 63) / 64)))) {
 		eprintf ("allocation failed\n");
 		return;
 	}

--- a/libr/util/r_json.c
+++ b/libr/util/r_json.c
@@ -130,12 +130,10 @@ R_API bool r_json_object_add (RJSVar* object, const char* name, RJSVar* value) {
 		value->ref--;;
 		return false;
 	}
-	v = (RJSVar**) malloc (len * sizeof (RJSVar*));
-	if (!v) {
+	if (!(v = (RJSVar**) malloc (len * sizeof (RJSVar*)))) {
 		return false;
 	}
-	c = (char**) malloc (len * sizeof (char*));
-	if (!c) {
+	if (!(c = (char**) malloc (len * sizeof (char*)))) {
 		free (v);
 		return false;
 	}
@@ -198,8 +196,8 @@ static char* _r_json_null_str (bool expanded) {
 		return NULL;
 	}
 	const int len = sizeof (R_JSON_NULL);
-	char *c = (char*) malloc (len);
-	if (c) {
+	char *c;
+	if ((c = (char*) malloc (len))) {
 		memcpy (c, R_JSON_NULL, len);
 	}
 	return c;
@@ -217,24 +215,21 @@ R_API char* r_json_var_string (RJSVar* var, bool expanded) {
 		break;
 	case R_JS_NUMBERS:
 		len = snprintf (NULL, 0, "%d", var->number) + 1;
-		c = (char*) malloc (len);
-		if (!c) {
+		if (!(c = (char*) malloc (len))) {
 			break;
 		}
 		snprintf (c, len, "%d", var->number);
 		break;
 	case R_JS_BOOLEAN:
 		len = var->boolean ? sizeof (R_JSON_TRUE) : sizeof (R_JSON_FALSE);
-		c = (char*) malloc (len);
-		if (!c) {
+		if (!(c = (char*) malloc (len))) {
 			break;
 		}
 		snprintf (c, len, "%s", var->boolean ? R_JSON_TRUE : R_JSON_FALSE);
 		break;
 	case R_JS_STRING:
 		len = var->string.l + 2;
-		c = (char*) malloc (len);
-		if (!c) {
+		if (!(c = (char*) malloc (len))) {
 			break;
 		}
 		memcpy (c + 1, var->string.s, var->string.l);
@@ -248,7 +243,10 @@ R_API char* r_json_var_string (RJSVar* var, bool expanded) {
 			char* p, *e;
 			char** t = R_NEWS0 (char*, var->array.l);
 			if (!t) {
-				c = (char*) malloc (sizeof (R_JSON_EMPTY_ARR));
+				if (!(c = (char*) malloc (sizeof (R_JSON_EMPTY_ARR)))) {
+					free(t);
+					return NULL;
+				}
 				memcpy (c, R_JSON_EMPTY_ARR, sizeof (R_JSON_EMPTY_ARR));
 				break;
 			}
@@ -276,7 +274,9 @@ R_API char* r_json_var_string (RJSVar* var, bool expanded) {
 			}
 			free (t);
 		} else {
-			c = (char*) malloc (sizeof (R_JSON_EMPTY_ARR));
+			if (!(c = (char*) malloc (sizeof (R_JSON_EMPTY_ARR)))) {
+				return NULL;
+			}
 			memcpy (c, R_JSON_EMPTY_ARR, sizeof (R_JSON_EMPTY_ARR));
 		}
 		break;
@@ -285,7 +285,10 @@ R_API char* r_json_var_string (RJSVar* var, bool expanded) {
 			char* p, *e;
 			char** t = R_NEWS0 (char*, var->object.l);
 			if (!t) {
-				c = (char*) malloc (sizeof (R_JSON_EMPTY_OBJ));
+				if (!(c = (char*) malloc (sizeof (R_JSON_EMPTY_OBJ)))) {
+					free(t);
+					return NULL;
+				}
 				memcpy (c, R_JSON_EMPTY_OBJ, sizeof (R_JSON_EMPTY_OBJ));
 				break;
 			}
@@ -296,7 +299,10 @@ R_API char* r_json_var_string (RJSVar* var, bool expanded) {
 				fflush (stdout);
 				len += strlen (t[i]) + strlen (var->object.n[i]) + 4;
 			}
-			c = (char*) malloc (len);
+			if (!(c = (char*) malloc (len))) {
+				free(t);
+				return NULL;
+			}
 			p = c + 1;
 			e = p + len;
 			for (i = 0; i < var->object.l; i++) {
@@ -315,7 +321,9 @@ R_API char* r_json_var_string (RJSVar* var, bool expanded) {
 			}
 			free (t);
 		} else {
-			c = (char*) malloc (sizeof (R_JSON_EMPTY_OBJ));
+			if (!(c = (char*) malloc (sizeof (R_JSON_EMPTY_OBJ)))) {
+				return NULL;
+			}
 			memcpy (c, R_JSON_EMPTY_OBJ, sizeof (R_JSON_EMPTY_OBJ));
 		}
 		break;

--- a/libr/util/range.c
+++ b/libr/util/range.c
@@ -49,8 +49,7 @@ R_API int r_range_set_data(RRange *rgs, ut64 addr, const ut8 *buf, int len) {
 	if (!r) {
 		return 0;
 	}
-	r->data = (ut8*)malloc (len);
-	if (!r->data) {
+	if (!(r->data = (ut8*)malloc (len))) {
 		return 0;
 	}
 	r->datalen = len;
@@ -89,8 +88,8 @@ R_API RRange *r_range_new_from_string(const char *string) {
 R_API int r_range_add_from_string(RRange *rgs, const char *string) {
 	ut64 addr, addr2;
 	int i, len = strlen (string) + 1;
-	char *str, *ostr = malloc (len);
-	if (!ostr) {
+	char *str, *ostr;
+	if (!(ostr = malloc (len))) {
 		return 0;
 	}
 	char *p = str = ostr;

--- a/libr/util/regex/regcomp.c
+++ b/libr/util/regex/regcomp.c
@@ -162,8 +162,9 @@ R_API RRegex *r_regex_new (const char *pattern, const char *flags) {
 	memset(&rx, 0, sizeof(RRegex));
 	if (r_regex_comp (&rx, pattern, r_regex_flags (flags)))
 		return NULL;
-	r = malloc (sizeof (RRegex));
-	if (!r) return NULL;
+	if (!(r = malloc (sizeof (RRegex)))) {
+		return NULL;
+	}
 	memcpy (r, &rx, sizeof (RRegex));
 	return r;
 }
@@ -1424,7 +1425,7 @@ doinsert(struct parse *p, sop op, size_t opnd, sopno pos)
 				p->pend[i]++;
 			}
 		}
-	}	
+	}
 
 	memmove((char *)&p->strip[pos+1], (char *)&p->strip[pos],
 						(HERE()-pos-1)*sizeof(sop));

--- a/libr/util/slist.c
+++ b/libr/util/slist.c
@@ -127,7 +127,9 @@ R_API void r_slist_optimize(RSList *s) {
 	if (s->nitems * sizeof (void *) < s->nitems) {
 		s->items = NULL;
 	} else {
-		s->items = malloc (1 + (sizeof (void *) * s->nitems));
+		if (!(s->items = malloc (1 + (sizeof (void *) * s->nitems)))) {
+			return;
+		}
 	}
 //eprintf ("MOD %d (block size)\n", s->mod);
 // store integers as indexes inside the allocated heap

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -279,7 +279,7 @@ R_API void r_str_case(char *str, bool up) {
 			*str = (*str=='x' && oc=='0') ? 'x': toupper ((int)(ut8)*str);
 		}
 	} else {
-		for (; *str; str++) { 
+		for (; *str; str++) {
 			*str = tolower ((int)(ut8)*str);
 		}
 	}
@@ -298,8 +298,7 @@ R_API char *r_str_home(const char *str) {
 	if (str) {
 		length += strlen (R_SYS_DIR) + strlen (str);
 	}
-	dst = (char *)malloc (length);
-	if (!dst) {
+	if (!(dst = (char *)malloc (length))) {
 		goto fail;
 	}
 	strcpy (dst, home);
@@ -500,8 +499,7 @@ R_API char *r_str_word_get0set(char *stra, int stralen, int idx, const char *new
 	}
 	if (!p) {
 		int nslen = strlen (newstr);
-		out = malloc (nslen + 1);
-		if (!out) {
+		if (!(out = malloc (nslen + 1))) {
 			return NULL;
 		}
 		strcpy (out, newstr);
@@ -517,8 +515,7 @@ R_API char *r_str_word_get0set(char *stra, int stralen, int idx, const char *new
 		blen = 0;
 	}
 	nlen = alen + blen + strlen (newstr);
-	out = malloc (nlen + 2);
-	if (!out) {
+	if (!(out = malloc (nlen + 2))) {
 		return NULL;
 	}
 	if (alen > 0) {
@@ -670,8 +667,7 @@ R_API char *r_str_newlen(const char *str, int len) {
 	if (len < 1) {
 		return NULL;
 	}
-	buf = malloc (len + 1);
-	if (!buf) {
+	if (!(buf = malloc (len + 1))) {
 		return NULL;
 	}
 	memcpy (buf, str, len);
@@ -787,8 +783,7 @@ R_API char *r_str_word_get_first(const char *text) {
 	for (;*text && IS_SEPARATOR (*text); text++);
 	/* strdup */
 	len = strlen (text);
-	ret = (char *)malloc (len + 1);
-	if (!ret) {
+	if (!(ret = (char *)malloc (len + 1))) {
 		eprintf ("Cannot allocate %d byte(s).\n", len+1);
 		return NULL;
 	}
@@ -809,8 +804,8 @@ R_API char *r_str_ndup(const char *ptr, int len) {
 	if (len < 0) {
 		return NULL;
 	}
-	char *out = malloc (len + 1);
-	if (!out) {
+	char *out;
+	if (!(out = malloc (len + 1))) {
 		return NULL;
 	}
 	strncpy (out, ptr, len);
@@ -826,8 +821,7 @@ R_API char *r_str_dup(char *ptr, const char *string) {
 		return NULL;
 	}
 	len = strlen (string)+1;
-	ptr = malloc (len+1);
-	if (!ptr) {
+	if (!(ptr = malloc (len+1))) {
 		return NULL;
 	}
 	memcpy (ptr, string, len);
@@ -838,7 +832,7 @@ R_API void r_str_writef(int fd, const char *fmt, ...) {
 	char *buf;
 	va_list ap;
 	va_start (ap, fmt);
-	if ((buf = malloc (4096)) != NULL) {
+	if ((buf = malloc (4096))) {
 		vsnprintf (buf, 4096, fmt, ap);
 		r_str_write (fd, buf);
 		free (buf);
@@ -903,8 +897,8 @@ R_API char *r_str_appendf(char *ptr, const char *fmt, ...) {
 	va_start (ap, fmt);
 	ret = vsnprintf (string, sizeof (string), fmt, ap);
 	if (ret >= sizeof (string)) {
-		char *p = malloc (ret + 2);
-		if (!p) {
+		char *p;
+		if (!(p = malloc (ret + 2))) {
 			va_end (ap);
 			return NULL;
 		}
@@ -1210,8 +1204,7 @@ static char *r_str_escape_(const char *buf, int dot_nl, bool ign_esc_seq, bool s
 	}
 	/* Worst case scenario, we convert every byte to a single-char escape
 	 * (e.g. \n) if show_asciidot, or \xhh if !show_asciidot */
-	new_buf = malloc (1 + strlen (buf) * (show_asciidot ? 2 : 4));
-	if (!new_buf) {
+	if (!(new_buf = malloc (1 + strlen (buf) * (show_asciidot ? 2 : 4)))) {
 		return NULL;
 	}
 	p = buf;
@@ -1287,8 +1280,7 @@ static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool s
 		end = buf + len;
 	}
 	/* Worst case scenario, we convert every byte to \xhh */
-	new_buf = malloc (1 + (len * 4));
-	if (!new_buf) {
+	if (!(new_buf = malloc (1 + (len * 4)))) {
 		return NULL;
 	}
 	p = buf;
@@ -1498,8 +1490,7 @@ R_API int r_str_ansi_filter(char *str, char **out, int **cposs, int len) {
 	if (len < 0) {
 		len = strlen (str);
 	}
-	tmp = malloc (len + 1);
-	if (!tmp) {
+	if (!(tmp = malloc (len + 1))) {
 		return -1;
 	}
 	memcpy (tmp, str, len + 1);
@@ -1553,8 +1544,7 @@ R_API char *r_str_ansi_crop(const char *str, ut32 x, ut32 y, ut32 x2, ut32 y2) {
 		s++;
 	}
 	r_len = str_len + nr_of_lines * strlen (Color_RESET) + 1;
-	r = ret = malloc (r_len);
-	if (!r) {
+	if (!(r = ret = malloc (r_len))) {
 		return NULL;
 	}
 	r_end = r + r_len;
@@ -1743,8 +1733,7 @@ R_API char *r_str_arg_escape(const char *arg) {
 	if (!arg) {
 		return NULL;
 	}
-	str = malloc ((2 * strlen (arg) + 1) * sizeof (char)); // Worse case when every character need to be escaped
-	if (!str) {
+	if (!(str = malloc ((2 * strlen (arg) + 1) * sizeof (char)))) { // Worse case when every character need to be escaped
 		return NULL;
 	}
 	for (src_i = 0; arg[src_i] != '\0'; src_i++) {
@@ -1778,12 +1767,11 @@ R_API char **r_str_argv(const char *cmdline, int *_argc) {
 		return NULL;
 	}
 
-	char **argv = malloc (argv_len * sizeof (char *));
-	if (!argv) {
+	char **argv;
+	if (!(argv = malloc (argv_len * sizeof (char *)))) {
 		return NULL;
 	}
-	args = malloc (128 + strlen (cmdline) * sizeof (char)); // Unescaped args will be shorter, so strlen (cmdline) will be enough
-	if (!args) {
+	if (!(args = malloc (128 + strlen (cmdline) * sizeof (char)))) { // Unescaped args will be shorter, so strlen (cmdline) will be enough
 		free (argv);
 		return NULL;
 	}
@@ -2087,8 +2075,7 @@ R_API char *r_str_uri_encode(const char *s) {
 	if (!s) {
 		return NULL;
 	}
-	od = d = malloc (1 + (strlen (s) * 4));
-	if (!d) {
+	if (!(od = d = malloc (1 + (strlen (s) * 4)))) {
 		return NULL;
 	}
 	for (; *s; s++) {
@@ -2228,8 +2215,7 @@ R_API char *r_str_utf16_encode(const char *s, int len) {
 	if ((len * 7) + 1 < len) {
 		return NULL;
 	}
-	od = d = malloc (1 + (len * 7));
-	if (!d) {
+	if (!(od = d = malloc (1 + (len * 7)))) {
 		return NULL;
 	}
 	for (i = 0; i < len; s++, i++) {
@@ -2410,8 +2396,8 @@ R_API char *r_str_prefix_all(const char *s, const char *pfx) {
 			newlines++;
 		}
 	}
-	char *o = malloc (len + (pfx_len * newlines) + 1);
-	if (!o) {
+	char *o;
+	if (!(o = malloc (len + (pfx_len * newlines) + 1))) {
 		return NULL;
 	}
 	memcpy (o, pfx, pfx_len);
@@ -2655,8 +2641,7 @@ R_API const char *r_str_const_at(char ***consts, const char *ptr) {
 		}
 		*consts = res;
 	} else {
-		*consts = malloc (sizeof (void*) * 2);
-		if (!*consts) {
+		if (!(*consts = malloc (sizeof (void*) * 2))) {
 			return NULL;
 		}
 	}
@@ -3040,7 +3025,7 @@ R_API int r_snprintf(char *string, int len, const char *fmt, ...) {
 // Strips all the lines in str that contain key
 R_API void r_str_stripLine(char *str, const char *key) {
 	size_t i, j, klen, slen, off;
-	const char *ptr; 
+	const char *ptr;
 
 	if (!str || !key) {
 		return;
@@ -3058,7 +3043,7 @@ R_API void r_str_stripLine(char *str, const char *key) {
 			}
 			break;
 		}
-			
+
 		off = (size_t) (ptr - (str + i)) + 1;
 
 		ptr = (char*) r_mem_mem ((ut8*) str + i, off, (ut8*) key, klen);

--- a/libr/util/strbuf.c
+++ b/libr/util/strbuf.c
@@ -29,8 +29,7 @@ R_API bool r_strbuf_set(RStrBuf *sb, const char *s) {
 	if (l >= sizeof (sb->buf)) {
 		char *ptr = sb->ptr;
 		if (!ptr || l+1 > sb->ptrlen) {
-			ptr = malloc (l + 1);
-			if (!ptr) {
+			if (!(ptr = malloc (l + 1))) {
 				return false;
 			}
 			sb->ptrlen = l + 1;
@@ -57,8 +56,8 @@ R_API bool r_strbuf_setf(RStrBuf *sb, const char *fmt, ...) {
 	va_copy (ap2, ap);
 	rc = vsnprintf (string, sizeof (string), fmt, ap);
 	if (rc >= sizeof (string)) {
-		char *p = malloc (rc + 1);
-		if (!p) {
+		char *p;
+		if (!(p = malloc (rc + 1))) {
 			ret = false;
 			goto done;
 		}
@@ -91,8 +90,7 @@ R_API int r_strbuf_append_n(RStrBuf *sb, const char *s, int l) {
 		char *p = sb->ptr;
 		bool allocated = true;
 		if (!sb->ptr) {
-			p = malloc (newlen);
-			if (p && sb->len > 0) {
+			if ((p = malloc (newlen)) && sb->len > 0) {
 				memcpy (p, sb->buf, sb->len);
 			}
 		} else if (sb->len + l + 1 > sb->ptrlen) {
@@ -119,8 +117,8 @@ R_API int r_strbuf_appendf(RStrBuf *sb, const char *fmt, ...) {
 	va_start (ap, fmt);
 	ret = vsnprintf (string, sizeof (string) - 1, fmt, ap);
 	if (ret >= sizeof (string)) {
-		char *p = malloc (ret + 2);
-		if (!p) {
+		char *p;
+		if (!(p = malloc (ret + 2))) {
 			va_end (ap);
 			return false;
 		}

--- a/libr/util/strpool.c
+++ b/libr/util/strpool.c
@@ -9,8 +9,7 @@ R_API RStrpool* r_strpool_new (int sz) {
 		return NULL;
 	}
 	if (sz < 1) sz = 1024;
-	p->str = malloc (sz);
-	if (!p->str) {
+	if (!(p->str = malloc (sz))) {
 		eprintf ("Malloc failed!\n");
 		free (p);
 		return NULL;
@@ -145,8 +144,7 @@ R_API char *r_strpool_slice (RStrpool *p, int index) {
 	}
 	idx = (size_t)(x - p->str);
 	len = p->len - idx;
-	o = malloc (len + 128);
-	if (!o) {
+	if (!(o = malloc (len + 128))) {
 		return NULL;
 	}
 	memcpy (o, x, len);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -11,7 +11,7 @@
 #endif
 #if defined(__FreeBSD__)
 # include <sys/param.h>
-# if __FreeBSD_version >= 1000000 
+# if __FreeBSD_version >= 1000000
 #  define FREEBSD_WITH_BACKTRACE
 # endif
 #endif
@@ -185,7 +185,7 @@ R_API RList *r_sys_dir(const char *path) {
 		}
 		closedir (dir);
 	}
-#endif	
+#endif
 	return list;
 }
 
@@ -396,8 +396,7 @@ R_API char *r_sys_getenv(const char *key) {
 	if (!key) {
 		return NULL;
 	}
-	envbuf = (LPTSTR)malloc (sizeof (TCHAR) * TMP_BUFSIZE);
-	if (!envbuf) {
+	if (!(envbuf = (LPTSTR)malloc (sizeof (TCHAR) * TMP_BUFSIZE))) {
 		goto err_r_sys_get_env;
 	}
 	key_ = r_sys_conv_utf8_to_utf16 (key);
@@ -488,7 +487,7 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 			close (sh_out[1]);
 		}
 		if (sterr) {
-			dup2 (sh_err[1], 2); 
+			dup2 (sh_err[1], 2);
 		} else {
 			close (2);
 		}
@@ -824,7 +823,10 @@ R_API int r_sys_run(const ut8 *buf, int len) {
 	int st, pid;
 #endif
 // TODO: define R_SYS_ALIGN_FORWARD in r_util.h
-	ut8 *ptr, *p = malloc ((sz + len) << 1);
+	ut8 *ptr, *p;
+	if (!(p = malloc ((sz + len) << 1))) {
+		return false;
+	}
 	ptr = p;
 	pdelta = ((size_t)(p)) & (4096 - 1);
 	if (pdelta) {
@@ -870,7 +872,10 @@ R_API int r_sys_run(const ut8 *buf, int len) {
 }
 
 R_API int r_is_heap (void *p) {
-	void *q = malloc (8);
+	void *q;
+	if (!(q = malloc (8))) {
+		return 0;
+	}
 	ut64 mask = UT64_MAX;
 	ut64 addr = (ut64)(size_t)q;
 	addr >>= 16;

--- a/libr/util/thread_sem.c
+++ b/libr/util/thread_sem.c
@@ -35,8 +35,7 @@ R_API RThreadSemaphore *r_th_sem_new(unsigned int initial) {
 		return NULL;
 	}
 #  else
-	sem->sem = malloc (sizeof (sem_t));
-	if (!sem->sem) {
+	if (!(sem->sem = malloc (sizeof (sem_t)))) {
 		free (sem);
 		return NULL;
 	}

--- a/libr/util/ubase64.c
+++ b/libr/util/ubase64.c
@@ -102,8 +102,7 @@ R_API char *r_base64_encode_dyn(const char *str, int len) {
 	if (olen < len) {
 		return NULL;
 	}
-	bout = (char *)malloc (olen);
-	if (!bout) {
+	if (!(bout = (char *)malloc (olen))) {
 		return NULL;
 	}
 	for (in = out = 0; in < len; in += 3, out += 4)

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -84,8 +84,7 @@ R_API char *r_num_units(char *buf, ut64 num) {
 	int tnum;
 	double fnum = num;
 	if (!buf) {
-		buf = malloc (32);
-		if (!buf) {
+		if (!(buf = malloc (32))) {
 			return NULL;
 		}
 	}
@@ -399,7 +398,9 @@ R_API ut64 r_num_math(RNum *num, const char *str) {
 	if (!str) return 0LL;
 
 	len = strlen (str)+1;
-	os = malloc (len+1);
+	if (!(os = malloc (len+1))) {
+		return 0LL;
+	}
 
 	s = os;
 	memcpy (s, str, len);

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -45,8 +45,7 @@ R_API RVector *r_vector_clone(RVector *vec) {
 		if (!vec->len) {
 			ret->a = NULL;
 		} else {
-			ret->a = malloc (sizeof (void *) * vec->len);
-			if (!ret->a) {
+			if (!(ret->a = malloc (sizeof (void *) * vec->len))) {
 				R_FREE (ret);
 			} else {
 				memcpy (ret->a, vec->a, sizeof (void *) * vec->len);

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -105,7 +105,7 @@ R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE out) {
 			NULL,          // use parent's environment
 			NULL,          // use parent's current directory
 			&si,  // STARTUPINFO pointer
-			&pi))) {  // receives PROCESS_INFORMATION 
+			&pi))) {  // receives PROCESS_INFORMATION
 		ret = 1;
 		CloseHandle (pi.hProcess);
 		CloseHandle (pi.hThread);
@@ -124,8 +124,7 @@ char *ReadFromPipe(HANDLE fh) {
 	int strl = 0;
 	int strsz = BUFSIZE+1;
 
-	str = malloc (strsz);
-	if (!str) {
+	if (!(str = malloc (strsz))) {
 		return NULL;
 	}
 	for (;;) {

--- a/libr/util/x509.c
+++ b/libr/util/x509.c
@@ -212,8 +212,7 @@ RX509Certificate * r_x509_parse_certificate (RASN1Object *object) {
 	if (!object) {
 		return NULL;
 	}
-	certificate = (RX509Certificate*) malloc (sizeof (RX509Certificate));
-	if (!certificate) {
+	if (!(certificate = (RX509Certificate*) malloc (sizeof (RX509Certificate)))) {
 		r_asn1_free_object (object);
 		return NULL;
 	}
@@ -268,8 +267,7 @@ RX509CRLEntry *r_x509_parse_crlentry (RASN1Object *object) {
 	if (!object || object->list.length != 2) {
 		return NULL;
 	}
-	entry = (RX509CRLEntry *) malloc (sizeof (RX509CRLEntry));
-	if (!entry) {
+	if (!(entry = (RX509CRLEntry *) malloc (sizeof (RX509CRLEntry)))) {
 		return NULL;
 	}
 	entry->userCertificate = r_asn1_create_binary (object->list.objects[0]->sector, object->list.objects[0]->length);
@@ -283,8 +281,7 @@ RX509CertificateRevocationList* r_x509_parse_crl (RASN1Object *object) {
 	if (!object || object->list.length < 4) {
 		return NULL;
 	}
-	crl = (RX509CertificateRevocationList *) malloc (sizeof (RX509CertificateRevocationList));
-	if (!crl) {
+	if (!(crl = (RX509CertificateRevocationList *) malloc (sizeof (RX509CertificateRevocationList)))) {
 		return NULL;
 	}
 	memset (crl, 0, sizeof (RX509CertificateRevocationList));


### PR DESCRIPTION
Almost all `malloc` calls are checked.
Plus:

rewrite:
```
void* p = malloc(..);
if (!p) {
```
by:
```
if (!(p = malloc(..))) {
```

*Edit*: my clang-format removed some trailing spaces 