### PR TITLE
Fixed snapcraft.yaml to work on build.snapcraft.io

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -55,7 +55,8 @@ parts:
     plugin: meson
     meson-parameters: [--prefix=/usr]
     override-build: |
-      sudo -H pip3 install --system meson
+      pip3 install --system meson
       snapcraftctl build
     build-packages:
       - python3-pip
+      - python3-setuptools


### PR DESCRIPTION
Now the snapcraft.yaml file can be used to build automatically
on build.snapcraft.io. If you want to build in your own VM or container,
use `sudo snapcraft` instead.