### PR TITLE
restore baddr after debug ends when oo'ing

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -106,6 +106,8 @@ R_API int r_core_bin_set_env(RCore *r, RBinFile *binfile) {
 		ut16 bits = info->bits;
 		ut64 baseaddr = r_bin_get_baddr (r->bin);
 		r_config_set_i (r->config, "bin.baddr", baseaddr);
+		char *orig_baddr_str = r_str_newf ("%"PFMT64u, baseaddr);
+		sdb_add (r->sdb, "orig_baddr", orig_baddr_str, 0);
 		r_config_set (r->config, "asm.arch", arch);
 		r_config_set_i (r->config, "asm.bits", bits);
 		r_config_set (r->config, "anal.arch", arch);

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1486,6 +1486,11 @@ static int cmd_open(void *data, const char *input) {
 						r_core_cmd0 (core, "ob-*");
 						r_io_close_all (core->io);
 						r_config_set (core->config, "cfg.debug", "false");
+						char *orig_baddr_str = sdb_get(core->sdb, "orig_baddr", 0);
+						ut64 orig_baddr = r_num_math (NULL, orig_baddr_str);
+						r_bin_set_baddr (core->bin, orig_baddr);
+						r_config_set_i (core->config, "bin.baddr", orig_baddr);
+						r_core_bin_rebase (core, orig_baddr);
 						r_core_cmdf (core, "o %s", file);
 						free (file);
 					} else {


### PR DESCRIPTION
In a PIE binary, if you debug it, the baddr is changed and never restored back to the original baddr when it ends the debug.