### PR TITLE
Fixed nasty segfault in vasm.c

### DIFF
--- a/libr/core/vasm.c
+++ b/libr/core/vasm.c
@@ -2,10 +2,12 @@
 
 #include <r_core.h>
 
+#define R_VISUAL_ASM_BUFSIZE 1024
+
 typedef struct {
 	RCore *core;
-	char blockbuf[1024];
-	char codebuf[1024];
+	char blockbuf[R_VISUAL_ASM_BUFSIZE];
+	char codebuf[R_VISUAL_ASM_BUFSIZE];
 	int oplen;
 	ut8 buf[128];
 	RAsmCode *acode;
@@ -40,7 +42,7 @@ static int readline_callback(void *_a, const char *str) {
 		if (a->acode) {
 			xlen = strlen (a->acode->buf_hex);
 			strcpy (a->codebuf, a->blockbuf);
-			memcpy (a->codebuf, a->acode->buf_hex, xlen);
+			memcpy (a->codebuf, a->acode->buf_hex, R_MIN (xlen, R_VISUAL_ASM_BUFSIZE - 1));
 		}
 		{
 			int rows = 0;

--- a/libr/core/vasm.c
+++ b/libr/core/vasm.c
@@ -40,9 +40,12 @@ static int readline_callback(void *_a, const char *str) {
 			r_cons_print ("\n\n");
 		}
 		if (a->acode) {
-			xlen = strlen (a->acode->buf_hex);
+			xlen = R_MIN (strlen (a->acode->buf_hex), R_VISUAL_ASM_BUFSIZE - 2);
 			strcpy (a->codebuf, a->blockbuf);
-			memcpy (a->codebuf, a->acode->buf_hex, R_MIN (xlen, R_VISUAL_ASM_BUFSIZE - 1));
+			memcpy (a->codebuf, a->acode->buf_hex, xlen);
+			if (xlen >= strlen (a->blockbuf)) {
+				a->codebuf[xlen] = '\0';
+			}
 		}
 		{
 			int rows = 0;


### PR DESCRIPTION
Thanks to @Maijin that reported it!

This fixes the following segfault:

To reproduce: If you go to visual assemble and type:
`jmp $$; jmp $$; jmp $$; ...`
at the 1100th character typed or so you'll get a buffer overflow and a segfault