### PR TITLE
Remove uses of `REPEAT`

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -892,6 +892,18 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		const char *r0 = REG64(0);
 		const char *r1 = REG64(1);
 		int size = REGSIZE64(1);
+#if 0
+		r_strbuf_setf (&op->esil,
+			"0,%s,=,"                        // dst = 0
+			"%d,"                            // initial counter = size
+			"DUP,"                           // counter: size -> 0 (repeat here)
+				"DUP,1,SWAP,-,8,*,"          // counter to bits in source
+					"DUP,0xff,<<,%s,&,>>,"   // src byte moved to LSB
+				"SWAP,%d,-,8,*,"             // invert counter, calc dst bit
+				"SWAP,<<,%s,|=,"             // shift left to there and insert
+			"4,REPEAT",                      // goto 5th instruction
+			r0, size, r1, size, r0);
+#endif
 		if (size == 8) {
 			r_strbuf_setf (&op->esil,
 				"56,0xff,%s,&,<<,%s,=,"

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -914,6 +914,18 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		}
 		break;
 	}
+	case ARM64_INS_REV32:
+	{
+		const char *r0 = REG64(0);
+		const char *r1 = REG64(1);
+		r_strbuf_setf (&op->esil,
+			"24,0x000000ff000000ff,%s,&,<<,%s,=,"
+			"16,0x000000ff000000ff,8,%s,>>,&,<<,%s,|=,"
+			"8,0x000000ff000000ff,16,%s,>>,&,<<,%s,|=,"
+			"0x000000ff000000ff,24,%s,>>,&,%s,|=,",
+			r1, r0, r1, r0, r1, r0, r1, r0);
+		break;
+	}
 	case ARM64_INS_REV16:
 	{
 		const char *r0 = REG64(0);

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -892,16 +892,26 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		const char *r0 = REG64(0);
 		const char *r1 = REG64(1);
 		int size = REGSIZE64(1);
-		r_strbuf_setf (&op->esil,
-			"0,%s,=,"                        // dst = 0
-			"%d,"                            // initial counter = size
-			"DUP,"                           // counter: size -> 0 (repeat here)
-				"DUP,1,SWAP,-,8,*,"          // counter to bits in source
-					"DUP,0xff,<<,%s,&,>>,"   // src byte moved to LSB
-				"SWAP,%d,-,8,*,"             // invert counter, calc dst bit
-				"SWAP,<<,%s,|=,"             // shift left to there and insert
-			"4,REPEAT",                      // goto 5th instruction
-			r0, size, r1, size, r0);
+		if (size == 8) {
+			r_strbuf_setf (&op->esil,
+				"56,0xff,%s,&,<<,%s,=,"
+				"48,0xff,8,%s,>>,&,<<,%s,|=,"
+				"40,0xff,16,%s,>>,&,<<,%s,|=,"
+				"32,0xff,24,%s,>>,&,<<,%s,|=,"
+				"24,0xff,32,%s,>>,&,<<,%s,|=,"
+				"16,0xff,40,%s,>>,&,<<,%s,|=,"
+				"8,0xff,48,%s,>>,&,<<,%s,|=,"
+				"0xff,56,%s,>>,&,%s,|=,",
+				r1, r0, r1, r0, r1, r0, r1, r0,
+				r1, r0, r1, r0, r1, r0, r1, r0);
+		} else {
+			r_strbuf_setf (&op->esil,
+				"24,0xff,%s,&,<<,%s,=,"
+				"16,0xff,8,%s,>>,&,<<,%s,|=,"
+				"8,0xff,16,%s,>>,&,<<,%s,|=,"
+				"0xff,24,%s,>>,&,%s,|=,",
+				r1, r0, r1, r0, r1, r0, r1, r0);
+		}
 		break;
 	}
 	case ARM64_INS_REV16:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -783,29 +783,10 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 	case X86_INS_SAR:
 		// TODO: Set CF. See case X86_INS_SHL for more details.
 		{
-			ut64 val = 0;
-			switch (gop.insn->detail->x86.operands[0].size) {
-			case 1:
-				val = 0x80;
-				break;
-			case 2:
-				val = 0x8000;
-				break;
-			case 4:
-				val = 0x80000000;
-				break;
-			case 8:
-				val = 0x8000000000000000;
-				break;
-			default:
-				val = 0x80;
-			}
 			src = getarg (&gop, 1, 0, NULL, SRC_AR);
-			dst = getarg (&gop, 0, 0, NULL, DST_AR);
-			esilprintf (op, "%s,1,%s,>>,0x%"PFMT64x",%s,&,|,%s,=,1,%s,&,cf,=,1,REPEAT", src, dst, val, dst, dst, dst);
-			/*src = getarg (&gop, 1, 0, NULL, SRC_AR);
-			dst = getarg (&gop, 0, 1, ">>>>", DST_AR);
-			esilprintf (op, "%s,%s,$z,zf,=,$p,pf,=,$s,sf,=", src, dst);*/
+			dst_r = getarg (&gop, 0, 0, NULL, DST_R_AR);
+			dst_w = getarg (&gop, 0, 1, NULL, DST_W_AR);
+			esilprintf (op, "0,cf,=,1,%s,-,1,<<,%s,&,?{,1,cf,=,},%s,%s,>>>>,%s,$z,zf,=,$p,pf,=,$s,sf,=", src, dst_r, src, dst_r, dst_w);
 		}
 		break;
 	case X86_INS_SARX:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -783,6 +783,28 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 	case X86_INS_SAR:
 		// TODO: Set CF. See case X86_INS_SHL for more details.
 		{
+#if 0
+			ut64 val = 0;
+			switch (gop.insn->detail->x86.operands[0].size) {
+			case 1:
+				val = 0x80;
+				break;
+			case 2:
+				val = 0x8000;
+				break;
+			case 4:
+				val = 0x80000000;
+				break;
+			case 8:
+				val = 0x8000000000000000;
+				break;
+			default:
+				val = 0x80;
+			}
+			src = getarg (&gop, 1, 0, NULL, SRC_AR);
+			dst = getarg (&gop, 0, 0, NULL, DST_AR);
+			esilprintf (op, "%s,1,%s,>>,0x%"PFMT64x",%s,&,|,%s,=,1,%s,&,cf,=,1,REPEAT", src, dst, val, dst, dst, dst);
+#endif
 			src = getarg (&gop, 1, 0, NULL, SRC_AR);
 			dst_r = getarg (&gop, 0, 0, NULL, DST_R_AR);
 			dst_w = getarg (&gop, 0, 1, NULL, DST_W_AR);


### PR DESCRIPTION
The only two uses of the `REPEAT` ESIL instruction were for ARM64 `REV` and x86 `SAR`, so I rewrote the ESIL for those two instructions without `REPEAT`. This was one of the things that required using capstone in radeco (radareorg/radeco-lib#188).

I also added ESIL for ARM64 `REV32` while I was at it.