### PR TITLE
Add type propagation via format string parsing

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -79,6 +79,7 @@ R_API RAnal *r_anal_new() {
 	anal->sdb_meta = sdb_ns (anal->sdb, "meta", 1);
 	anal->sdb_hints = sdb_ns (anal->sdb, "hints", 1);
 	anal->sdb_types = sdb_ns (anal->sdb, "types", 1);
+	anal->sdb_fmts = sdb_ns (anal->sdb, "spec", 1);
 	anal->sdb_cc = sdb_ns (anal->sdb, "cc", 1);
 	anal->sdb_zigns = sdb_ns (anal->sdb, "zigns", 1);
 	anal->zign_path = strdup ("");

--- a/libr/anal/d/Makefile
+++ b/libr/anal/d/Makefile
@@ -12,6 +12,7 @@ F+= types-x86-macos-64
 F+= types-arm-ios-16
 F+= types-arm-ios-32
 F+= types-arm-ios-64
+F+= spec
 F+= cc-x86-64
 F+= cc-x86-32
 F+= cc-mips-32

--- a/libr/anal/d/meson.build
+++ b/libr/anal/d/meson.build
@@ -11,6 +11,7 @@ sdb_files = [
   'types-arm-ios-16',
   'types-arm-ios-32',
   'types-arm-ios-64',
+  'spec',
   'cc-x86-64',
   'cc-x86-32',
   'cc-mips-32',

--- a/libr/anal/d/spec.sdb.txt
+++ b/libr/anal/d/spec.sdb.txt
@@ -1,0 +1,15 @@
+gcc=spec
+spec.gcc.c=char
+spec.gcc.d=int
+spec.gcc.f=float
+spec.gcc.g=double
+spec.gcc.ld=long int
+spec.gcc.li=long int
+spec.gcc.lf=double
+spec.gcc.lu=unsigned long int
+spec.gcc.llu=unsigned long long int
+spec.gcc.lli=long long int
+spec.gcc.lld=long long int
+spec.gcc.p=void *
+spec.gcc.s=const char *
+spec.gcc.u=unsigned int

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -823,6 +823,11 @@ static int bin_info(RCore *r, int mode) {
 	}
 	r_core_anal_type_init (r);
 	r_core_anal_cc_init (r);
+	const char *dir_prefix = r_config_get (r->config, "dir.prefix");
+	char *spath = sdb_fmt ("%s/"R2_SDB_FCNSIGN"/spec.sdb", dir_prefix);
+	if (r_file_exists (spath)) {
+		sdb_concat_by_path (r->anal->sdb_fmts, spath);
+	}
 	return true;
 }
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2378,6 +2378,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("anal.hasnext", "false", "Continue analysis after each function");
 	SETPREF ("anal.esil", "false", "Use the new ESIL code analysis");
 	SETCB ("anal.strings", "false", &cb_analstrings, "Identify and register strings during analysis (aar only)");
+	SETPREF ("anal.spec", "gcc",  "Set profile for specifying format chars used in type analysis");
 	SETCB ("anal.vars", "true", &cb_analvars, "Analyze local variables and arguments");
 	SETPREF ("anal.vinfun", "true",  "Search values in functions (aav) (false by default to only find on non-code)");
 	SETPREF ("anal.vinfunrange", "false",  "Search values outside function ranges (requires anal.vinfun=false)\n");

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -653,6 +653,7 @@ typedef struct r_anal_t {
 	RAnalRange *limit;
 	RList *plugins;
 	Sdb *sdb_types;
+	Sdb *sdb_fmts;
 	Sdb *sdb_meta; // TODO: Future r_meta api
 	Sdb *sdb_zigns;
 


### PR DESCRIPTION
```c
printf ("fmt : %s , %u , %d", ...)
```

We now parse format string to infer types like `const char *`, `unsigned int` , this would be helpful when we don't have any function signature to infer type from .

Fixes #10574 

Added test in r2r [#1402](https://github.com/radare/radare2-regressions/pull/1402)