### PR TITLE
Revert #10742 "End rabin2 json output with newline"

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -1123,7 +1123,7 @@ int main(int argc, char **argv) {
 		rabin_do_operation (op);
 	}
 	if (isradjson) {
-		r_cons_print ("}\n");
+		r_cons_print ("}");
 	}
 	r_cons_flush ();
 	r_bin_options_free (bo);


### PR DESCRIPTION
Revert #10742 since the reason given is false.