### PR TITLE
Fix ARM_INS_CMP ESIL to correctly set carry bit

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1530,7 +1530,7 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 		}
 		break;
 	case ARM_INS_CMP:
-		r_strbuf_appendf (&op->esil, "%s,%s,==,$z,zf,=", ARG(1), ARG(0));
+		r_strbuf_appendf (&op->esil, "%s,%s,==,$z,zf,=,$c31,cf,=", ARG(1), ARG(0));
 		break;
 	case ARM_INS_CMN:
 		r_strbuf_appendf (&op->esil, "%s,%s,!=,$z,zf,=", ARG(1), ARG(0));


### PR DESCRIPTION
This fixes the esil to correctly set the carry flag for ARM Thumb emulation.
This in reference to issue #10577