### PR TITLE
Colorize pxr + use color palette for visual types menu

### DIFF
--- a/libr/cons/d/bold
+++ b/libr/cons/d/bold
@@ -60,3 +60,9 @@ ec linehl rgb:008
 ec func_var yellow . bold
 ec func_var_type blue . bold
 ec func_var_addr cyan . bold
+
+ec ai.read white . bold
+ec ai.write white . bold
+ec ai.exec red . bold
+ec ai.seq green . bold
+ec ai.ascii yellow . bold

--- a/libr/cons/d/consonance
+++ b/libr/cons/d/consonance
@@ -51,3 +51,9 @@ ec graph.traced rgb:090
 ec func_var rgb:fcc
 ec func_var_type rgb:f2a
 ec func_var_addr white
+
+ec ai.read rgb:fcc
+ec ai.write rgb:f2a
+ec ai.exec rgb:f2a
+ec ai.seq rgb:f0f
+ec ai.ascii rgb:fff

--- a/libr/cons/d/cutter
+++ b/libr/cons/d/cutter
@@ -46,3 +46,9 @@ ec graph.traced rgb:e33
 ec func_var rgb:d38
 ec func_var_type blue
 ec func_var_addr rgb:bbb
+
+ec ai.read rgb:18d
+ec ai.write rgb:28d
+ec ai.exec rgb:b80
+ec ai.seq rgb:d38
+ec ai.ascii black

--- a/libr/cons/d/dark
+++ b/libr/cons/d/dark
@@ -47,3 +47,9 @@ ec graph.traced rgb:bbb
 ec func_var rgb:99a
 ec func_var_type rgb:636
 ec func_var_addr rgb:366
+
+ec ai.read rgb:266
+ec ai.write rgb:366
+ec ai.exec rgb:368
+ec ai.seq rgb:d38
+ec ai.ascii rgb:99a

--- a/libr/cons/d/darkda
+++ b/libr/cons/d/darkda
@@ -48,3 +48,9 @@ ec graph.current rgb:fff
 ec func_var rgb:99a
 ec func_var_type rgb:df077e
 ec func_var_addr rgb:ababab
+
+ec ai.read rgb:be077e
+ec ai.write rgb:df077e
+ec ai.exec rgb:9dd600
+ec ai.seq rgb:9dd600
+ec ai.ascii rgb:d25032

--- a/libr/cons/d/defragger
+++ b/libr/cons/d/defragger
@@ -58,3 +58,9 @@ ec gui.border rgb:5fd700
 ec func_var rgb:64604f
 ec func_var_type rgb:00afd7
 ec func_var_addr rgb:afafaf
+
+ec ai.read rgb:a55f00
+ec ai.write rgb:d75f00
+ec ai.exec rgb:ff5f87
+ec ai.seq rgb:9dd600
+ec ai.ascii rgb:d25032

--- a/libr/cons/d/focus
+++ b/libr/cons/d/focus
@@ -48,3 +48,9 @@ ec graph.traced red
 ec func_var cyan
 ec func_var_type rgb:f3f
 ec func_var_addr white
+
+ec ai.read rgb:8f0
+ec ai.write rgb:6f0
+ec ai.exec rgb:f3f
+ec ai.seq white
+ec ai.ascii yellow

--- a/libr/cons/d/lima
+++ b/libr/cons/d/lima
@@ -52,3 +52,9 @@ ec graph.traced rgb:090
 ec func_var yellow
 ec func_var_type green
 ec func_var_addr yellow
+
+ec ai.read rgb:8e2
+ec ai.write rgb:9e2
+ec ai.exec rgb:af2
+ec ai.seq rgb:ef0
+ec ai.ascii rgb:ef0

--- a/libr/cons/d/matrix
+++ b/libr/cons/d/matrix
@@ -48,3 +48,9 @@ ec graph.traced rgb:060
 ec func_var rgb:060
 ec func_var_type rgb:383
 ec func_var_addr rgb:060
+
+ec ai.read rgb:0a1
+ec ai.write rgb:1a1
+ec ai.exec rgb:383
+ec ai.seq rgb:3f3
+ec ai.ascii rgb:3f3

--- a/libr/cons/d/monokai
+++ b/libr/cons/d/monokai
@@ -36,6 +36,7 @@ ec linehl rgb:008
 ec ai.read rgb:66d
 ec ai.write rgb:d66
 ec ai.exec rgb:6d6
+ec ai.ascii rgb:a398e5
 ec graph.box rgb:66d9ef
 ec graph.box2 rgb:ef8d1a
 ec graph.box3 rgb:66d9ef

--- a/libr/cons/d/ogray
+++ b/libr/cons/d/ogray
@@ -50,3 +50,9 @@ ec linehl rgb:111
 ec func_var rgb:f72
 ec func_var_type rgb:777
 ec func_var_addr rgb:555
+
+ec ai.read rgb:eee
+ec ai.write rgb:ddd
+ec ai.exec rgb:fff
+ec ai.seq rgb:f72
+ec ai.ascii rgb:f72

--- a/libr/cons/d/pink
+++ b/libr/cons/d/pink
@@ -45,14 +45,15 @@ ec graph.box4 rgb:f5d
 ec gui.cflow rgb:f5d
 ec gui.dataoffset rgb:f5d
 ec gui.background black
-##  ai.read
-##  ai.write
-##  ai.exec
-##  ai.seq
-##  ai.ascii
 ##  gui.alt_background
 ##  gui.border
 
 ec func_var rgb:72d
 ec func_var_type blue
 ec func_var_addr rgb:72d
+
+ec ai.read rgb:f6e
+ec ai.write rgb:f5d
+ec ai.exec rgb:75a
+ec ai.seq rgb:72d
+ec ai.ascii rgb:72d

--- a/libr/cons/d/rasta
+++ b/libr/cons/d/rasta
@@ -52,3 +52,9 @@ ec graph.traced yellow
 ec func_var green
 ec func_var_type red
 ec func_var_addr yellow
+
+ec ai.read green
+ec ai.write green
+ec ai.exec yellow
+ec ai.seq red
+ec ai.ascii red

--- a/libr/cons/d/sepia
+++ b/libr/cons/d/sepia
@@ -49,3 +49,9 @@ ec graph.box4 rgb:ca6
 ec func_var rgb:fd9
 ec func_var_type rgb:850
 ec func_var_addr rgb:960
+
+ec ai.read rgb:cb7
+ec ai.write rgb:ca6
+ec ai.exec rgb:db7
+ec ai.seq rgb:960
+ec ai.ascii rgb:fec

--- a/libr/cons/d/smyck
+++ b/libr/cons/d/smyck
@@ -37,6 +37,8 @@ ec linehl rgb:004
 ec ai.read rgb:66d
 ec ai.write rgb:d66
 ec ai.exec rgb:6d6
+ec ai.seq rgb:fd6
+ec ai.ascii white
 ec graph.box rgb:9df
 ec graph.box2 rgb:9df
 ec graph.box3 rgb:9df

--- a/libr/cons/d/solarized
+++ b/libr/cons/d/solarized
@@ -48,5 +48,11 @@ ec func_var rgb:28d
 ec func_var_type rgb:cc8
 ec func_var_addr rgb:9aa
 
+ec ai.read rgb:39e
+ec ai.write rgb:577
+ec ai.exec rgb:ab4
+ec ai.seq rgb:899
+ec ai.ascii rgb:899
+
 # background of the terminal must be 134 o 033
 # xterm -fn 10x20 -bg rgb:00/30/30 -fg rgb:e0/e0/e0 -e "r2 -c 'eco solarized' /bin/ls"

--- a/libr/cons/d/tango
+++ b/libr/cons/d/tango
@@ -65,3 +65,9 @@ ec graph.box4 rgb:950
 ec func_var rgb:370
 ec func_var_type rgb:a41
 ec func_var_addr rgb:aaa
+
+ec ai.read rgb:a81
+ec ai.write rgb:a41
+ec ai.exec rgb:c50
+ec ai.seq rgb:ca0
+ec ai.ascii rgb:ca0

--- a/libr/cons/d/twilight
+++ b/libr/cons/d/twilight
@@ -51,3 +51,9 @@ ec graph.box4 rgb:b97
 ec func_var rgb:c64
 ec func_var_type rgb:aa6
 ec func_var_addr rgb:788
+
+ec ai.read rgb:db7
+ec ai.write rgb:ca6
+ec ai.exec rgb:ffd
+ec ai.seq rgb:bb7
+ec ai.ascii rgb:bb7

--- a/libr/cons/d/white
+++ b/libr/cons/d/white
@@ -46,3 +46,9 @@ ec graph.traced red
 ec func_var magenta
 ec func_var_type blue
 ec func_var_addr magenta
+
+ec ai.read magenta
+ec ai.write magenta
+ec ai.exec blue
+ec ai.seq black
+ec ai.ascii black

--- a/libr/cons/d/zenburn
+++ b/libr/cons/d/zenburn
@@ -51,3 +51,9 @@ ec graph.traced red
 ec func_var rgb:7a7
 ec func_var_type rgb:eec
 ec func_var_addr rgb:aaa
+
+ec ai.read rgb:f87
+ec ai.write rgb:c88
+ec ai.exec rgb:cd9
+ec ai.seq rgb:ddc
+ec ai.ascii rgb:ddc

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -481,6 +481,7 @@ static int sdbforcb (void *p, const char *k, const char *v) {
 	const char *pre = " ";
 	RCoreVisualTypes *vt = (RCoreVisualTypes*)p;
 	bool use_color = vt->core->print->flags & R_PRINT_FLAGS_COLOR;
+	char *color_sel = vt->core->cons->pal.prompt;
 	if (vt->optword) {
 		if (!strcmp (vt->type, "struct")) {
 			char *s = r_str_newf ("struct.%s.", vt->optword);
@@ -494,7 +495,7 @@ static int sdbforcb (void *p, const char *k, const char *v) {
 					pre = ">";
 				}
 				if (use_color && *pre=='>')
-					r_cons_printf (Color_YELLOW" %s %s  %s\n"
+					r_cons_printf ("%s %s %s  %s\n", color_sel,
 						Color_RESET, pre, k+strlen (s), v);
 				else
 					r_cons_printf (" %s %s  %s\n",
@@ -515,7 +516,7 @@ static int sdbforcb (void *p, const char *k, const char *v) {
 						pre = ">";
 					}
 					if (use_color && *pre=='>') {
-						r_cons_printf (Color_YELLOW" %s %s  %s\n"
+						r_cons_printf ("%s %s %s  %s\n", color_sel,
 							Color_RESET, pre, k, v);
 					} else {
 						r_cons_printf (" %s %s  %s\n",
@@ -537,8 +538,8 @@ static int sdbforcb (void *p, const char *k, const char *v) {
 				pre = ">";
 			}
 			if (use_color && *pre=='>') {
-				r_cons_printf (Color_YELLOW" %s pf %3s   %s\n"
-					Color_RESET,pre, fmt, k);
+				r_cons_printf ("%s %s pf %3s   %s\n"Color_RESET,
+					color_sel, pre, fmt, k);
 			} else {
 				r_cons_printf (" %s pf %3s   %s\n",
 					pre, fmt, k);
@@ -553,7 +554,7 @@ static int sdbforcb (void *p, const char *k, const char *v) {
 				pre = ">";
 			}
 			if (use_color && *pre == '>') {
-				r_cons_printf (Color_YELLOW" %s %s\n"Color_RESET,
+				r_cons_printf ("%s %s %s\n"Color_RESET, color_sel,
 					(vt->t_idx == vt->t_ctr)?
 					">":" ", k);
 			} else {
@@ -597,14 +598,17 @@ R_API int r_core_visual_types(RCore *core) {
 	for (;;) {
 		r_cons_clear00 ();
 		for (i = 0; opts[i]; i++) {
-			const char *fmt = use_color
-				? (h_opt == i)
-					? Color_BGREEN"[%s] "Color_RESET
-					: Color_GREEN" %s  "Color_RESET
-				: (h_opt == i)
-					? "[%s] "
-					: " %s  ";
-			r_cons_printf (fmt, opts[i]);
+			if (use_color) {
+				if (h_opt == i) {
+					r_cons_printf ("%s[%s]%s ", core->cons->pal.call, 
+						opts[i], Color_RESET);
+				} else {
+					r_cons_printf ("%s%s%s  ", core->cons->pal.other, 
+						opts[i], Color_RESET);
+				}
+			} else {
+				r_cons_printf (h_opt == i ? "[%s] " : " %s  ", opts[i]);
+			}
 		}
 		r_cons_newline ();
 		if (optword) {


### PR DESCRIPTION
Closes https://github.com/radare/radare2/issues/10047 and closes https://github.com/radare/radare2/issues/9966

The problem with the coloring in pxr was not the code, but the missing of ai.* colors in most colorschemes. I added them manually, trying my best to respect each scheme's own style. If you find any any inconsistencies, report them!

pxr example:

![image](https://user-images.githubusercontent.com/3428362/43050377-eb22f0ae-8e07-11e8-89ac-1f93ea728277.png)


Visual types:
![image](https://user-images.githubusercontent.com/3428362/43050380-fa0fdcc6-8e07-11e8-82be-235b8f1f0765.png)
