### PR TITLE
Dotted lines for conditional jumps in graph

### DIFF
--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -4,6 +4,7 @@
 
 #define useUtf8 (r_cons_singleton ()->use_utf8)
 #define useUtf8Curvy (r_cons_singleton ()->use_utf8_curvy)
+#define dotted (r_cons_singleton ()->dotted_lines)
 
 #define W(y) r_cons_canvas_write (c, y)
 #define G(x, y) r_cons_canvas_gotoxy (c, x, y)

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -215,7 +215,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		break;
 	case NRM_DOT:
 		if (useUtf8) {
-			l_corner = RUNECODESTR_LINE_HORIZ;
+			l_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
 			if (useUtf8Curvy) {
 				r_corner = RUNECODESTR_CURVE_CORNER_TR;
 			} else {
@@ -228,7 +228,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		break;
 	case NRM_APEX:
 		if (useUtf8) {
-			l_corner = RUNECODESTR_LINE_HORIZ;
+			l_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
 			if (useUtf8Curvy) {
 				r_corner = RUNECODESTR_CURVE_CORNER_BR;
 			} else {
@@ -246,7 +246,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 			} else {
 				l_corner = RUNECODESTR_CORNER_TL;
 			}
-			r_corner = RUNECODESTR_LINE_HORIZ;
+			r_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
 		} else {
 			l_corner = ".";
 			r_corner = "-";
@@ -259,7 +259,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 			} else {
 				l_corner = RUNECODESTR_CORNER_BL;
 			}
-			r_corner = RUNECODESTR_LINE_HORIZ;
+			r_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
 		} else {
 			l_corner = "`";
 			r_corner = "-";
@@ -268,7 +268,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 	case NRM_NRM:
 	default:
 		if (useUtf8) {
-			l_corner = r_corner = RUNECODESTR_LINE_HORIZ;
+			l_corner = r_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
 		} else {
 			l_corner = r_corner = "-";
 		}

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -6,7 +6,12 @@
 
 #define useUtf8 (r_cons_singleton ()->use_utf8)
 #define useUtf8Curvy (r_cons_singleton ()->use_utf8_curvy)
-#define dotted (r_cons_singleton ()->dotted_lines)
+
+#define DOTTED_LINE_HORIZ "┄"
+#define DOTTED_LINE_VERT "┊"
+
+#define UTF8LINE_VERT() (dotted ? DOTTED_LINE_VERT : RUNECODESTR_LINE_VERT)
+#define UTF8LINE_HORIZ() (dotted ? DOTTED_LINE_HORIZ : RUNECODESTR_LINE_HORIZ)
 
 enum {
 	APEX_DOT = 0,
@@ -20,18 +25,21 @@ enum {
 	NRM_NRM
 };
 
-static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
+static bool apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 		RCanvasLineStyle *style, int isvert) {
 	RCons *cons = r_cons_singleton ();
+	bool dotted = false;
 	switch (style->color) {
 	case LINE_UNCJMP:
 		c->attr = cons->pal.graph_trufae;
 		break;
 	case LINE_TRUE:
 		c->attr = cons->pal.graph_true;
+		dotted = true;
 		break;
 	case LINE_FALSE:
 		c->attr = cons->pal.graph_false;
+		dotted = true;
 		break;
 	case LINE_NONE:
 	default:
@@ -40,6 +48,9 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 	}
 	if (!c->color) {
 		c->attr = Color_RESET;
+	}
+	if (!r_cons_singleton ()->dotted_lines) {
+		dotted = false;
 	}
 	switch (style->symbol) {
 	case LINE_UNCJMP:
@@ -63,18 +74,19 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 		break;
 	case LINE_NOSYM_VERT:
 		if (G (x, y)) {
-			W (useUtf8 ? (dotted ? "┊" : RUNECODESTR_LINE_VERT) : "|");
+			W (useUtf8 ? UTF8LINE_VERT () : "|");
 		}
 		break;
 	case LINE_NOSYM_HORIZ:
 		if (G (x, y)) {
-			W (useUtf8 ? (dotted ? "┄" : RUNECODESTR_LINE_HORIZ) : "-");
+			W (useUtf8 ? UTF8LINE_HORIZ () : "-");
 		}
 		break;
 	case LINE_NONE:
 	default:
 		break;
 	}
+	return dotted;
 }
 
 R_API void r_cons_canvas_line_diagonal (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style) {
@@ -142,7 +154,7 @@ loop:
 	c->attr = Color_RESET;
 }
 
-static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int style) {
+static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int style, bool dotted) {
 	const char *l_corner = "?", *r_corner = "?";
 	int i;
 
@@ -215,7 +227,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		break;
 	case NRM_DOT:
 		if (useUtf8) {
-			l_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
+			l_corner = UTF8LINE_HORIZ ();
 			if (useUtf8Curvy) {
 				r_corner = RUNECODESTR_CURVE_CORNER_TR;
 			} else {
@@ -228,7 +240,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		break;
 	case NRM_APEX:
 		if (useUtf8) {
-			l_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
+			l_corner = UTF8LINE_HORIZ ();
 			if (useUtf8Curvy) {
 				r_corner = RUNECODESTR_CURVE_CORNER_BR;
 			} else {
@@ -246,7 +258,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 			} else {
 				l_corner = RUNECODESTR_CORNER_TL;
 			}
-			r_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
+			r_corner = UTF8LINE_HORIZ ();
 		} else {
 			l_corner = ".";
 			r_corner = "-";
@@ -259,7 +271,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 			} else {
 				l_corner = RUNECODESTR_CORNER_BL;
 			}
-			r_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
+			r_corner = UTF8LINE_HORIZ ();
 		} else {
 			l_corner = "`";
 			r_corner = "-";
@@ -268,7 +280,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 	case NRM_NRM:
 	default:
 		if (useUtf8) {
-			l_corner = r_corner = dotted ? "┄" : RUNECODESTR_LINE_HORIZ;
+			l_corner = r_corner = UTF8LINE_HORIZ ();
 		} else {
 			l_corner = r_corner = "-";
 		}
@@ -279,7 +291,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		W (l_corner);
 	}
 
-	const char *hline = useUtf8 ? (dotted ? "┄" : RUNECODESTR_LINE_HORIZ) : "-";
+	const char *hline = useUtf8 ? UTF8LINE_HORIZ () : "-";
 	r_cons_break_push (NULL, NULL);
 	for (i = x + 1; i < x + width - 1; i++) {
 		if (r_cons_is_breaked ()) {
@@ -296,7 +308,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 	}
 }
 
-static void draw_vertical_line (RConsCanvas *c, int x, int y, int height) {
+static void draw_vertical_line (RConsCanvas *c, int x, int y, int height, bool dotted) {
 	int i;
 	/* do not render offscreen vertical lines */
 	if (x + c->sx < 0) {
@@ -305,7 +317,7 @@ static void draw_vertical_line (RConsCanvas *c, int x, int y, int height) {
 	if (x + c->sx > c->w) {
 		return;
 	}
-	const char *vline = useUtf8 ? (dotted ? "┊" : RUNECODESTR_LINE_VERT) : "|";
+	const char *vline = useUtf8 ? UTF8LINE_VERT () : "|";
 	r_cons_break_push (NULL, NULL);
 	for (i = y; i < y + height; i++) {
 		if (r_cons_is_breaked ()) {
@@ -323,7 +335,7 @@ R_API void r_cons_canvas_line_square (RConsCanvas *c, int x, int y, int x2, int 
 	int diff_x = R_ABS (x - x2);
 	int diff_y = R_ABS (y - y2);
 
-	apply_line_style (c, x, y, x2, y2, style, 1);
+	bool dotted = apply_line_style (c, x, y, x2, y2, style, 1);
 
 	// --
 	// TODO: find if there's any collision in this line
@@ -332,17 +344,17 @@ R_API void r_cons_canvas_line_square (RConsCanvas *c, int x, int y, int x2, int 
 		int hl2 = diff_y - hl;
 		int w = diff_x == 0 ? 0 : diff_x + 1;
 		int style = min_x == x ? APEX_DOT : DOT_APEX;
-		draw_vertical_line (c, x, y + 1, hl);
-		draw_vertical_line (c, x2, y + hl + 1, hl2);
-		draw_horizontal_line (c, min_x, y + hl + 1, w, style);
+		draw_vertical_line (c, x, y + 1, hl, dotted);
+		draw_vertical_line (c, x2, y + hl + 1, hl2, dotted);
+		draw_horizontal_line (c, min_x, y + hl + 1, w, style, dotted);
 	} else  {
 		if (y2 == y) {
-			draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT);
+			draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT, dotted);
 		} else {
 			if (x != x2) {
-				draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX);
+				draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX, dotted);
 			}
-			draw_vertical_line (c, x2, y2, diff_y);
+			draw_vertical_line (c, x2, y2, diff_y, dotted);
 		}
 	}
 	c->attr = Color_RESET;
@@ -358,44 +370,44 @@ R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int 
 	int diff_y = R_ABS (y - y2);
 	int min_y = R_MIN (y, y2);
 
-	apply_line_style (c, x, y, x2, y2, style, isvert);
+	bool dotted = apply_line_style (c, x, y, x2, y2, style, isvert);
 
 	if (isvert) {
 		if (x2 == x) {
-			draw_vertical_line (c, x, y + 1, diff_y + 1);
+			draw_vertical_line (c, x, y + 1, diff_y + 1, dotted);
 		} else if (y2 - y > 1) {
 			int h1 = 1 + bendpoint;
 			int h2 = diff_y - h1;
 			int w = diff_x == 0 ? 0 : diff_x + 1;
 			int style = min_x == x ? APEX_DOT : DOT_APEX;
-			draw_vertical_line (c, x, y + 1, h1);
-			draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style);
-			draw_vertical_line (c, x2, y + h1 + 1 + 1, h2);
+			draw_vertical_line (c, x, y + 1, h1, dotted);
+			draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style, dotted);
+			draw_vertical_line (c, x2, y + h1 + 1 + 1, h2, dotted);
 		} else {
 			//TODO: currently copy-pasted
 			if (y2 == y) {
-				draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT);
+				draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT, dotted);
 			} else {
 				if (x != x2) {
-					draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX);
+					draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX, dotted);
 				}
-				draw_vertical_line (c, x2, y2, diff_y-2);
+				draw_vertical_line (c, x2, y2, diff_y-2, dotted);
 			}
 		}
 	} else {
 		if (y2 == y) {
-			draw_horizontal_line (c, min_x + 1, y, diff_x, NRM_NRM);
+			draw_horizontal_line (c, min_x + 1, y, diff_x, NRM_NRM, dotted);
 		} else if (x2 - x > 1) {
 			int w1 = 1 + bendpoint;
 			int w2 = diff_x - w1;
 			//int h = diff_x;// == 0 ? 0 : diff_x + 1;
 			//int style = min_x == x ? APEX_DOT : DOT_APEX;
 			//draw_vertical_line (c, x, y + 1, h1);
-			draw_horizontal_line (c, x + 1, y, w1 + 1, y2 > y ? NRM_DOT : NRM_APEX);
+			draw_horizontal_line (c, x + 1, y, w1 + 1, y2 > y ? NRM_DOT : NRM_APEX, dotted);
 			//draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style);
-			draw_vertical_line (c, x + 1 + w1, min_y + 1, diff_y - 1);
+			draw_vertical_line (c, x + 1 + w1, min_y + 1, diff_y - 1, dotted);
 			//draw_vertical_line (c, x2, y + h1 + 1 + 1, h2);
-			draw_horizontal_line (c, x + 1 + w1, y2, w2, y2 < y ? DOT_NRM : REV_APEX_NRM);
+			draw_horizontal_line (c, x + 1 + w1, y2, w2, y2 < y ? DOT_NRM : REV_APEX_NRM, dotted);
 		}
 	}
 	c->attr = Color_RESET;
@@ -417,24 +429,24 @@ R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, i
 	int w1 = diff_x1 == 0 ? 0 : diff_x1 + 1;
 	int w2 = diff_x2 == 0 ? 0 : diff_x2 + 1;
 
-	apply_line_style (c, x, y, x2, y2, style, isvert);
+	bool dotted = apply_line_style (c, x, y, x2, y2, style, isvert);
 
 	if (isvert) {
-		draw_vertical_line (c, x, y + 1, ybendpoint1 + 1);
-		draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX);
-		draw_vertical_line (c, xbendpoint, y2 - ybendpoint2 + 1, diff_y - 1);
-		draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, DOT_DOT);
-		draw_vertical_line (c, x2, y2 - ybendpoint2 + 1, ybendpoint2 + 1);
+		draw_vertical_line (c, x, y + 1, ybendpoint1 + 1, dotted);
+		draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX, dotted);
+		draw_vertical_line (c, xbendpoint, y2 - ybendpoint2 + 1, diff_y - 1, dotted);
+		draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, DOT_DOT, dotted);
+		draw_vertical_line (c, x2, y2 - ybendpoint2 + 1, ybendpoint2 + 1, dotted);
 	} else {
 		int miny1 = R_MIN (y, xbendpoint);
 		int miny2 = R_MIN (y2, xbendpoint);
 		int diff_y1 = R_ABS (y - xbendpoint);
 		int diff_y2 = R_ABS (y2 - xbendpoint);
 
-		draw_horizontal_line (c, x + 1, y, 1 + ybendpoint1 + 1, xbendpoint > y ? NRM_DOT : NRM_APEX);
-		draw_vertical_line (c, x + 1 + ybendpoint1 + 1, miny1 + 1, diff_y1 - 1);
-		draw_horizontal_line (c, x2 - ybendpoint2, xbendpoint, (x + 1 + ybendpoint1 + 1) - (x2 - ybendpoint2) + 1, xbendpoint > y ? REV_APEX_APEX : DOT_DOT);
-		draw_vertical_line (c, x2 - ybendpoint2, miny2 + 1, diff_y2 - 1);
-		draw_horizontal_line (c, x2 - ybendpoint2, y2, ybendpoint2 + 1, xbendpoint > y ? DOT_NRM : REV_APEX_NRM);
+		draw_horizontal_line (c, x + 1, y, 1 + ybendpoint1 + 1, xbendpoint > y ? NRM_DOT : NRM_APEX, dotted);
+		draw_vertical_line (c, x + 1 + ybendpoint1 + 1, miny1 + 1, diff_y1 - 1, dotted);
+		draw_horizontal_line (c, x2 - ybendpoint2, xbendpoint, (x + 1 + ybendpoint1 + 1) - (x2 - ybendpoint2) + 1, xbendpoint > y ? REV_APEX_APEX : DOT_DOT, dotted);
+		draw_vertical_line (c, x2 - ybendpoint2, miny2 + 1, diff_y2 - 1, dotted);
+		draw_horizontal_line (c, x2 - ybendpoint2, y2, ybendpoint2 + 1, xbendpoint > y ? DOT_NRM : REV_APEX_NRM, dotted);
 	}
 }

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -6,6 +6,7 @@
 
 #define useUtf8 (r_cons_singleton ()->use_utf8)
 #define useUtf8Curvy (r_cons_singleton ()->use_utf8_curvy)
+#define dotted (r_cons_singleton ()->dotted_lines)
 
 enum {
 	APEX_DOT = 0,
@@ -62,12 +63,12 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 		break;
 	case LINE_NOSYM_VERT:
 		if (G (x, y)) {
-			W (useUtf8 ? RUNECODESTR_LINE_VERT : "|");
+			W (useUtf8 ? (dotted ? "┊" : RUNECODESTR_LINE_VERT) : "|");
 		}
 		break;
 	case LINE_NOSYM_HORIZ:
 		if (G (x, y)) {
-			W (useUtf8 ? RUNECODESTR_LINE_HORIZ : "-");
+			W (useUtf8 ? (dotted ? "┄" : RUNECODESTR_LINE_HORIZ) : "-");
 		}
 		break;
 	case LINE_NONE:
@@ -278,7 +279,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		W (l_corner);
 	}
 
-	const char *hline = useUtf8? RUNECODESTR_LINE_HORIZ : "-";
+	const char *hline = useUtf8 ? (dotted ? "┄" : RUNECODESTR_LINE_HORIZ) : "-";
 	r_cons_break_push (NULL, NULL);
 	for (i = x + 1; i < x + width - 1; i++) {
 		if (r_cons_is_breaked ()) {
@@ -304,7 +305,7 @@ static void draw_vertical_line (RConsCanvas *c, int x, int y, int height) {
 	if (x + c->sx > c->w) {
 		return;
 	}
-	const char *vline = useUtf8? RUNECODESTR_LINE_VERT : "|";
+	const char *vline = useUtf8 ? (dotted ? "┊" : RUNECODESTR_LINE_VERT) : "|";
 	r_cons_break_push (NULL, NULL);
 	for (i = y; i < y + height; i++) {
 		if (r_cons_is_breaked ()) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1903,6 +1903,13 @@ static int cb_utf8_curvy(void *user, void *data) {
 	return true;
 }
 
+static int cb_dotted(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	core->cons->dotted_lines = node->i_value;
+	return true;
+}
+
 static int cb_zoombyte(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -2846,6 +2853,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("graph.gv.graph", "", "Graphviz global style attributes. (bgcolor=white)");
 	SETPREF ("graph.gv.current", "false", "Highlight the current node in graphviz graph.");
 	SETPREF ("graph.nodejmps", "true", "Enables shortcuts for every node.");
+	SETCB ("graph.dotted", "false", &cb_dotted, "Dotted lines for conditional jumps in graph");
 
 	/* hud */
 	SETPREF ("hud.path", "", "Set a custom path for the HUD file");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2853,7 +2853,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("graph.gv.graph", "", "Graphviz global style attributes. (bgcolor=white)");
 	SETPREF ("graph.gv.current", "false", "Highlight the current node in graphviz graph.");
 	SETPREF ("graph.nodejmps", "true", "Enables shortcuts for every node.");
-	SETCB ("graph.dotted", "false", &cb_dotted, "Dotted lines for conditional jumps in graph");
+	SETCB ("graph.dotted", "true", &cb_dotted, "Dotted lines for conditional jumps in graph");
 
 	/* hud */
 	SETPREF ("hud.path", "", "Set a custom path for the HUD file");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -449,7 +449,7 @@ typedef struct r_cons_t {
 	bool flush;
 	bool use_utf8; // use utf8 features
 	bool use_utf8_curvy; // use utf8 curved corners
-	bool dotted_lines; 
+	bool dotted_lines;
 	int linesleep;
 	int pagesize;
 	char *break_word;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -449,6 +449,7 @@ typedef struct r_cons_t {
 	bool flush;
 	bool use_utf8; // use utf8 features
 	bool use_utf8_curvy; // use utf8 curved corners
+	bool dotted_lines; 
 	int linesleep;
 	int pagesize;
 	char *break_word;


### PR DESCRIPTION
Closes #204 

Added new config var: `graph.dotted`, default to False. 

Fixed a bunch of bugs utf8 related in canvas too.

![2018-07-24-192635_1066x784_scrot](https://user-images.githubusercontent.com/3428362/43156032-50d43c7e-8f79-11e8-8e30-309d1e939411.png)
