### PR TITLE
Separate command history for sdb shell "ks"

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -253,6 +253,7 @@ R_API int r_line_set_hist_callback(RLine *line, RLineHistoryUpCb up, RLineHistor
 	line->cb_history_down = down;
 	line->offset_hist_index = 0;
 	line->file_hist_index = 0;
+	line->sdbshell_hist_iter = r_list_head (line->sdbshell_hist);
 	return 1;
 }
 
@@ -376,6 +377,7 @@ R_API void r_line_hist_free() {
 		}
 	}
 	R_FREE (I.history.data);
+	R_FREE (I.sdbshell_hist);
 	I.history.index = 0;
 }
 

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -991,7 +991,6 @@ R_API int sdbshell_history_down(RLine *line) {
 	return true;
 }
 
-
 static int cmd_kuery(void *data, const char *input) {
 	char buf[1024], *out;
 	RCore *core = (RCore*)data;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -971,6 +971,27 @@ static int callback_foreach_kv (void *user, const char *k, const char *v) {
 	return 1;
 }
 
+R_API int sdbshell_history_up(RLine *line) {
+	if (!line->sdbshell_hist_iter || !line->sdbshell_hist_iter->n) {
+		return false;
+	}
+	line->sdbshell_hist_iter = line->sdbshell_hist_iter->n;
+	strncpy (line->buffer.data, line->sdbshell_hist_iter->data, R_LINE_BUFSIZE - 1);
+	line->buffer.index = line->buffer.length = strlen (line->buffer.data);
+	return true;
+}
+
+R_API int sdbshell_history_down(RLine *line) {
+	if (!line->sdbshell_hist_iter || !line->sdbshell_hist_iter->p) {
+		return false;
+	}
+	line->sdbshell_hist_iter = line->sdbshell_hist_iter->p;
+	strncpy (line->buffer.data, line->sdbshell_hist_iter->data, R_LINE_BUFSIZE - 1);
+	line->buffer.index = line->buffer.length = strlen (line->buffer.data);
+	return true;
+}
+
+
 static int cmd_kuery(void *data, const char *input) {
 	char buf[1024], *out;
 	RCore *core = (RCore*)data;
@@ -1010,6 +1031,13 @@ static int cmd_kuery(void *data, const char *input) {
 			free (p);
 		}
 		if (!s) s = core->sdb;
+		RLine *line = core->cons->line;
+		if (!line->sdbshell_hist) {
+			line->sdbshell_hist = r_list_newf (free);
+			r_list_append (line->sdbshell_hist, r_str_new ("\0"));
+		}
+		RList *sdb_hist = line->sdbshell_hist;
+		r_line_set_hist_callback (line, &sdbshell_history_up, &sdbshell_history_down);
 		for (;;) {
 			r_line_set_prompt (p);
 			if (r_cons_fgets (buf, buflen, 0, NULL) < 1) {
@@ -1018,11 +1046,19 @@ static int cmd_kuery(void *data, const char *input) {
 			if (!*buf) {
 				break;
 			}
+
+			if (sdb_hist && r_list_length (sdb_hist) == 1 || 
+				(r_list_length (sdb_hist) > 1 && strcmp (r_list_get_n (sdb_hist, 1), buf))) {
+				r_list_insert (sdb_hist, 1, strdup (buf));
+			}
+			line->sdbshell_hist_iter = sdb_hist->head;
+
 			out = sdb_querys (s, NULL, 0, buf);
 			if (out) {
 				r_cons_println (out);
 			}
 		}
+		r_line_set_hist_callback (core->cons->line, &cmd_history_up, &cmd_history_down);
 		break;
 	case 'o':
 		if (r_sandbox_enable (0)) {

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -840,6 +840,8 @@ struct r_line_t {
 	int offset_hist_index;
 	bool file_prompt;
 	int file_hist_index;
+	RList *sdbshell_hist;
+	RListIter *sdbshell_hist_iter;
 }; /* RLine */
 
 #ifdef R_API


### PR DESCRIPTION
Closes #7649 
Since I couldn't reuse RLineHistory, I added a simple list to RLine to keep last sdbshell commands. 
I also check that a duplicate command is not inserted more than once (like dietline does)