### PR TITLE
Verify input is not in hex before interpreting as float

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -35,7 +35,7 @@ static int format_output(char mode, const char *s) {
 		break;
 	case '0': {
 		int len = strlen (s);
-		if (len > 0 && s[len - 1] == 'f' && mode != '0') {
+		if (len > 0 && s[len - 1] == 'f' && !r_str_startswith (s, "0x")) {
 			R_STATIC_ASSERT (sizeof (float) == 4)
 			float f = (float) num->fvalue;
 			ut8 *p = (ut8 *) &f;

--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -35,7 +35,7 @@ static int format_output(char mode, const char *s) {
 		break;
 	case '0': {
 		int len = strlen (s);
-		if (len > 0 && s[len - 1] == 'f') {
+		if (len > 0 && s[len - 1] == 'f' && mode != '0') {
 			R_STATIC_ASSERT (sizeof (float) == 4)
 			float f = (float) num->fvalue;
 			ut8 *p = (ut8 *) &f;


### PR DESCRIPTION
If the user's input ends in a 'f' character, rax2 will interpreted it as a float. This is problematic when the input is in hexadecimal format because 'f' is within the hexadecimal alphabet. 
```
$ rax2 -ke 0xdeadbeef
Fx4f5eadbf
```
This PR verifies that the input is not in hexadecimal format before converting it to a float. This will produce the expected output.
```
$ rax2 -ke 0xdeadbeef
0xefbeadde
```