### PR TITLE
refactor and fix something about section vaddr in PE

### DIFF
--- a/libr/bin/format/mdmp/mdmp_pe.c
+++ b/libr/bin/format/mdmp/mdmp_pe.c
@@ -149,7 +149,7 @@ RList *PE_(r_bin_mdmp_pe_get_sections)(struct PE_(r_bin_mdmp_pe_bin) *pe_bin) {
 	if (!(ret = r_list_new ())) {
 		return NULL;
 	}
-	if (!(sections = PE_(r_bin_pe_get_sections) (pe_bin->bin))){
+	if (!pe_bin->bin || !(sections = pe_bin->bin->sections)){
 		r_list_free (ret);
 		return NULL;
 	}
@@ -201,7 +201,6 @@ RList *PE_(r_bin_mdmp_pe_get_sections)(struct PE_(r_bin_mdmp_pe_bin) *pe_bin) {
 		}
 		r_list_append (ret, ptr);
 	}
-	free (sections);
 	return ret;
 }
 

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -323,10 +323,10 @@ static PE_DWord bin_pe_rva_to_paddr(RBinPEObj* bin, PE_DWord rva) {
 	PE_DWord section_base;
 	int i, section_size;
 	for (i = 0; i < bin->num_sections; i++) {
-		section_base = bin->section_header[i].VirtualAddress;
-		section_size = bin->section_header[i].Misc.VirtualSize;
+		section_base = bin->sections[i].vaddr;
+		section_size = bin->sections[i].vsize;
 		if (rva >= section_base && rva < section_base + section_size) {
-			return bin->section_header[i].PointerToRawData + (rva - section_base);
+			return bin->sections[i].paddr + (rva - section_base);
 		}
 	}
 	return rva;
@@ -3365,7 +3365,11 @@ static struct r_bin_pe_section_t* PE_(r_bin_pe_get_sections)(struct PE_(r_bin_pe
 		}
 		sections[j].vaddr = shdr[i].VirtualAddress;
 		sections[j].size = shdr[i].SizeOfRawData;
-		sections[j].vsize = shdr[i].Misc.VirtualSize;
+		if (shdr[i].Misc.VirtualSize) {
+			sections[j].vsize = shdr[i].Misc.VirtualSize;
+		} else {
+			sections[j].vsize = shdr[i].SizeOfRawData;
+		}
 		if (bin->optional_header) {
 			ut32 sa = bin->optional_header->SectionAlignment;
 			if (sa) {

--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -100,6 +100,9 @@ struct PE_(r_bin_pe_obj_t) {
 	PE_(image_metadata_header) * metadata_header;
 	PE_(image_metadata_stream) * *streams;
 
+	/* store the section information for future use */
+	struct r_bin_pe_section_t *sections;
+
 	// these values define the real offset into the untouched binary
 	ut64 nt_header_offset;
 	ut64 section_header_offset;
@@ -138,7 +141,6 @@ char* PE_(r_bin_pe_get_os)(struct PE_(r_bin_pe_obj_t)* bin);
 char* PE_(r_bin_pe_get_class)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(r_bin_pe_get_bits)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(r_bin_pe_get_section_alignment)(struct PE_(r_bin_pe_obj_t)* bin);
-struct r_bin_pe_section_t* PE_(r_bin_pe_get_sections)(struct PE_(r_bin_pe_obj_t)* bin);
 char* PE_(r_bin_pe_get_subsystem)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(r_bin_pe_is_dll)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(r_bin_pe_is_big_endian)(struct PE_(r_bin_pe_obj_t)* bin);

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -157,7 +157,7 @@ static RList* sections(RBinFile *bf) {
 	if (!(ret = r_list_newf ((RListFree)free))) {
 		return NULL;
 	}
-	if (!(sections = PE_(r_bin_pe_get_sections) (bin))){
+	if (!bin || !(sections = bin->sections)){
 		r_list_free (ret);
 		return NULL;
 	}
@@ -215,7 +215,6 @@ static RList* sections(RBinFile *bf) {
 		}
 		r_list_append (ret, ptr);
 	}
-	free (sections);
 	return ret;
 }
 


### PR DESCRIPTION
This lets `rabin2 -i` show the import things in some PE files in which vsize is zero in their section headers.

I think the PE section code is a mess. The PE_(r_bin_pe_get_sections) function overrides bin->num_sections which originally means the number of sections in the section header, but I still don't know how to rewrite it as other code uses bin->num_sections.