### PR TITLE
Restyling graph backedges + bring back 't' and 'f' hints

### DIFF
--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -106,6 +106,7 @@ static bool apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 
 R_API void r_cons_canvas_line_diagonal (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style) {
 	if (x == x2 || y == y2) {
+		style->dot_style = DOT_STYLE_NORMAL;
 		r_cons_canvas_line_square (c, x, y +1, x2, y2, style);
 		return;
 	}

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -10,8 +10,8 @@
 #define DOTTED_LINE_HORIZ "┄"
 #define DOTTED_LINE_VERT "┊"
 
-#define DASHED_LINE_VERT "┋"
-#define DASHED_LINE_HORIZ "┅"
+#define DASHED_LINE_VERT "╵"
+#define DASHED_LINE_HORIZ "╴"
 
 enum {
 	APEX_DOT = 0,

--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -10,8 +10,8 @@
 #define DOTTED_LINE_HORIZ "┄"
 #define DOTTED_LINE_VERT "┊"
 
-#define UTF8LINE_VERT() (dotted ? DOTTED_LINE_VERT : RUNECODESTR_LINE_VERT)
-#define UTF8LINE_HORIZ() (dotted ? DOTTED_LINE_HORIZ : RUNECODESTR_LINE_HORIZ)
+#define DASHED_LINE_VERT "┋"
+#define DASHED_LINE_HORIZ "┅"
 
 enum {
 	APEX_DOT = 0,
@@ -25,21 +25,40 @@ enum {
 	NRM_NRM
 };
 
+static char* utf8_line_vert (int dot_style) {
+	if (r_cons_singleton ()->dotted_lines) {
+		switch (dot_style) {
+		case DOT_STYLE_NORMAL:      return RUNECODESTR_LINE_VERT;
+		case DOT_STYLE_CONDITIONAL: return DOTTED_LINE_VERT;
+		case DOT_STYLE_BACKEDGE:    return DASHED_LINE_VERT;
+		}
+	}
+	return RUNECODESTR_LINE_VERT;
+}
+
+static char* utf8_line_horiz (int dot_style) {
+	if (r_cons_singleton ()->dotted_lines) {
+		switch (dot_style) {
+		case DOT_STYLE_NORMAL:      return RUNECODESTR_LINE_HORIZ;
+		case DOT_STYLE_CONDITIONAL: return DOTTED_LINE_HORIZ;
+		case DOT_STYLE_BACKEDGE:    return DASHED_LINE_HORIZ;
+		}
+	}
+	return RUNECODESTR_LINE_HORIZ;
+}
+
 static bool apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 		RCanvasLineStyle *style, int isvert) {
 	RCons *cons = r_cons_singleton ();
-	bool dotted = false;
 	switch (style->color) {
 	case LINE_UNCJMP:
 		c->attr = cons->pal.graph_trufae;
 		break;
 	case LINE_TRUE:
 		c->attr = cons->pal.graph_true;
-		dotted = true;
 		break;
 	case LINE_FALSE:
 		c->attr = cons->pal.graph_false;
-		dotted = true;
 		break;
 	case LINE_NONE:
 	default:
@@ -48,9 +67,6 @@ static bool apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 	}
 	if (!c->color) {
 		c->attr = Color_RESET;
-	}
-	if (!r_cons_singleton ()->dotted_lines) {
-		dotted = false;
 	}
 	switch (style->symbol) {
 	case LINE_UNCJMP:
@@ -74,19 +90,18 @@ static bool apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 		break;
 	case LINE_NOSYM_VERT:
 		if (G (x, y)) {
-			W (useUtf8 ? UTF8LINE_VERT () : "|");
+			W (useUtf8 ? utf8_line_vert (style->dot_style) : "|");
 		}
 		break;
 	case LINE_NOSYM_HORIZ:
 		if (G (x, y)) {
-			W (useUtf8 ? UTF8LINE_HORIZ () : "-");
+			W (useUtf8 ? utf8_line_horiz (style->dot_style) : "-");
 		}
 		break;
 	case LINE_NONE:
 	default:
 		break;
 	}
-	return dotted;
 }
 
 R_API void r_cons_canvas_line_diagonal (RConsCanvas *c, int x, int y, int x2, int y2, RCanvasLineStyle *style) {
@@ -154,7 +169,7 @@ loop:
 	c->attr = Color_RESET;
 }
 
-static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int style, bool dotted) {
+static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int style, int dot_style) {
 	const char *l_corner = "?", *r_corner = "?";
 	int i;
 
@@ -227,7 +242,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		break;
 	case NRM_DOT:
 		if (useUtf8) {
-			l_corner = UTF8LINE_HORIZ ();
+			l_corner = utf8_line_horiz (dot_style);
 			if (useUtf8Curvy) {
 				r_corner = RUNECODESTR_CURVE_CORNER_TR;
 			} else {
@@ -240,7 +255,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		break;
 	case NRM_APEX:
 		if (useUtf8) {
-			l_corner = UTF8LINE_HORIZ ();
+			l_corner = utf8_line_horiz (dot_style);
 			if (useUtf8Curvy) {
 				r_corner = RUNECODESTR_CURVE_CORNER_BR;
 			} else {
@@ -258,7 +273,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 			} else {
 				l_corner = RUNECODESTR_CORNER_TL;
 			}
-			r_corner = UTF8LINE_HORIZ ();
+			r_corner = utf8_line_horiz (dot_style);
 		} else {
 			l_corner = ".";
 			r_corner = "-";
@@ -271,7 +286,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 			} else {
 				l_corner = RUNECODESTR_CORNER_BL;
 			}
-			r_corner = UTF8LINE_HORIZ ();
+			r_corner = utf8_line_horiz (dot_style);
 		} else {
 			l_corner = "`";
 			r_corner = "-";
@@ -280,7 +295,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 	case NRM_NRM:
 	default:
 		if (useUtf8) {
-			l_corner = r_corner = UTF8LINE_HORIZ ();
+			l_corner = r_corner = utf8_line_horiz (dot_style);
 		} else {
 			l_corner = r_corner = "-";
 		}
@@ -291,7 +306,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 		W (l_corner);
 	}
 
-	const char *hline = useUtf8 ? UTF8LINE_HORIZ () : "-";
+	const char *hline = useUtf8 ? utf8_line_horiz (dot_style) : "-";
 	r_cons_break_push (NULL, NULL);
 	for (i = x + 1; i < x + width - 1; i++) {
 		if (r_cons_is_breaked ()) {
@@ -308,7 +323,7 @@ static void draw_horizontal_line (RConsCanvas *c, int x, int y, int width, int s
 	}
 }
 
-static void draw_vertical_line (RConsCanvas *c, int x, int y, int height, bool dotted) {
+static void draw_vertical_line (RConsCanvas *c, int x, int y, int height, int dot_style) {
 	int i;
 	/* do not render offscreen vertical lines */
 	if (x + c->sx < 0) {
@@ -317,7 +332,7 @@ static void draw_vertical_line (RConsCanvas *c, int x, int y, int height, bool d
 	if (x + c->sx > c->w) {
 		return;
 	}
-	const char *vline = useUtf8 ? UTF8LINE_VERT () : "|";
+	const char *vline = useUtf8 ? utf8_line_vert (dot_style) : "|";
 	r_cons_break_push (NULL, NULL);
 	for (i = y; i < y + height; i++) {
 		if (r_cons_is_breaked ()) {
@@ -335,7 +350,7 @@ R_API void r_cons_canvas_line_square (RConsCanvas *c, int x, int y, int x2, int 
 	int diff_x = R_ABS (x - x2);
 	int diff_y = R_ABS (y - y2);
 
-	bool dotted = apply_line_style (c, x, y, x2, y2, style, 1);
+	apply_line_style (c, x, y, x2, y2, style, 1);
 
 	// --
 	// TODO: find if there's any collision in this line
@@ -343,18 +358,18 @@ R_API void r_cons_canvas_line_square (RConsCanvas *c, int x, int y, int x2, int 
 		int hl = diff_y / 2 - 1;
 		int hl2 = diff_y - hl;
 		int w = diff_x == 0 ? 0 : diff_x + 1;
-		int style = min_x == x ? APEX_DOT : DOT_APEX;
-		draw_vertical_line (c, x, y + 1, hl, dotted);
-		draw_vertical_line (c, x2, y + hl + 1, hl2, dotted);
-		draw_horizontal_line (c, min_x, y + hl + 1, w, style, dotted);
+		int apex_style = min_x == x ? APEX_DOT : DOT_APEX;
+		draw_vertical_line (c, x, y + 1, hl, style->dot_style);
+		draw_vertical_line (c, x2, y + hl + 1, hl2, style->dot_style);
+		draw_horizontal_line (c, min_x, y + hl + 1, w, apex_style, style->dot_style);
 	} else  {
 		if (y2 == y) {
-			draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT, dotted);
+			draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT, style->dot_style);
 		} else {
 			if (x != x2) {
-				draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX, dotted);
+				draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX, style->dot_style);
 			}
-			draw_vertical_line (c, x2, y2, diff_y, dotted);
+			draw_vertical_line (c, x2, y2, diff_y, style->dot_style);
 		}
 	}
 	c->attr = Color_RESET;
@@ -370,44 +385,44 @@ R_API void r_cons_canvas_line_square_defined (RConsCanvas *c, int x, int y, int 
 	int diff_y = R_ABS (y - y2);
 	int min_y = R_MIN (y, y2);
 
-	bool dotted = apply_line_style (c, x, y, x2, y2, style, isvert);
+	apply_line_style (c, x, y, x2, y2, style, isvert);
 
 	if (isvert) {
 		if (x2 == x) {
-			draw_vertical_line (c, x, y + 1, diff_y + 1, dotted);
+			draw_vertical_line (c, x, y + 1, diff_y + 1, style->dot_style);
 		} else if (y2 - y > 1) {
 			int h1 = 1 + bendpoint;
 			int h2 = diff_y - h1;
 			int w = diff_x == 0 ? 0 : diff_x + 1;
-			int style = min_x == x ? APEX_DOT : DOT_APEX;
-			draw_vertical_line (c, x, y + 1, h1, dotted);
-			draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style, dotted);
-			draw_vertical_line (c, x2, y + h1 + 1 + 1, h2, dotted);
+			int apex_style = min_x == x ? APEX_DOT : DOT_APEX;
+			draw_vertical_line (c, x, y + 1, h1, style->dot_style);
+			draw_horizontal_line (c, min_x, y + bendpoint + 2, w, apex_style, style->dot_style);
+			draw_vertical_line (c, x2, y + h1 + 1 + 1, h2, style->dot_style);
 		} else {
 			//TODO: currently copy-pasted
 			if (y2 == y) {
-				draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT, dotted);
+				draw_horizontal_line (c, min_x, y, diff_x + 1, DOT_DOT, style->dot_style);
 			} else {
 				if (x != x2) {
-					draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX, dotted);
+					draw_horizontal_line (c, min_x, y, diff_x + 1, REV_APEX_APEX, style->dot_style);
 				}
-				draw_vertical_line (c, x2, y2, diff_y-2, dotted);
+				draw_vertical_line (c, x2, y2, diff_y-2, style->dot_style);
 			}
 		}
 	} else {
 		if (y2 == y) {
-			draw_horizontal_line (c, min_x + 1, y, diff_x, NRM_NRM, dotted);
+			draw_horizontal_line (c, min_x + 1, y, diff_x, NRM_NRM, style->dot_style);
 		} else if (x2 - x > 1) {
 			int w1 = 1 + bendpoint;
 			int w2 = diff_x - w1;
 			//int h = diff_x;// == 0 ? 0 : diff_x + 1;
 			//int style = min_x == x ? APEX_DOT : DOT_APEX;
 			//draw_vertical_line (c, x, y + 1, h1);
-			draw_horizontal_line (c, x + 1, y, w1 + 1, y2 > y ? NRM_DOT : NRM_APEX, dotted);
+			draw_horizontal_line (c, x + 1, y, w1 + 1, y2 > y ? NRM_DOT : NRM_APEX, style->dot_style);
 			//draw_horizontal_line (c, min_x, y + bendpoint + 2, w, style);
-			draw_vertical_line (c, x + 1 + w1, min_y + 1, diff_y - 1, dotted);
+			draw_vertical_line (c, x + 1 + w1, min_y + 1, diff_y - 1, style->dot_style);
 			//draw_vertical_line (c, x2, y + h1 + 1 + 1, h2);
-			draw_horizontal_line (c, x + 1 + w1, y2, w2, y2 < y ? DOT_NRM : REV_APEX_NRM, dotted);
+			draw_horizontal_line (c, x + 1 + w1, y2, w2, y2 < y ? DOT_NRM : REV_APEX_NRM, style->dot_style);
 		}
 	}
 	c->attr = Color_RESET;
@@ -429,24 +444,24 @@ R_API void r_cons_canvas_line_back_edge (RConsCanvas *c, int x, int y, int x2, i
 	int w1 = diff_x1 == 0 ? 0 : diff_x1 + 1;
 	int w2 = diff_x2 == 0 ? 0 : diff_x2 + 1;
 
-	bool dotted = apply_line_style (c, x, y, x2, y2, style, isvert);
+	apply_line_style (c, x, y, x2, y2, style, isvert);
 
 	if (isvert) {
-		draw_vertical_line (c, x, y + 1, ybendpoint1 + 1, dotted);
-		draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX, dotted);
-		draw_vertical_line (c, xbendpoint, y2 - ybendpoint2 + 1, diff_y - 1, dotted);
-		draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, DOT_DOT, dotted);
-		draw_vertical_line (c, x2, y2 - ybendpoint2 + 1, ybendpoint2 + 1, dotted);
+		draw_vertical_line (c, x, y + 1, ybendpoint1 + 1, style->dot_style);
+		draw_horizontal_line (c, min_x1, y + ybendpoint1 + 2, w1, REV_APEX_APEX, style->dot_style);
+		draw_vertical_line (c, xbendpoint, y2 - ybendpoint2 + 1, diff_y - 1, style->dot_style);
+		draw_horizontal_line (c, min_x2, y2 - ybendpoint2, w2, DOT_DOT, style->dot_style);
+		draw_vertical_line (c, x2, y2 - ybendpoint2 + 1, ybendpoint2 + 1, style->dot_style);
 	} else {
 		int miny1 = R_MIN (y, xbendpoint);
 		int miny2 = R_MIN (y2, xbendpoint);
 		int diff_y1 = R_ABS (y - xbendpoint);
 		int diff_y2 = R_ABS (y2 - xbendpoint);
 
-		draw_horizontal_line (c, x + 1, y, 1 + ybendpoint1 + 1, xbendpoint > y ? NRM_DOT : NRM_APEX, dotted);
-		draw_vertical_line (c, x + 1 + ybendpoint1 + 1, miny1 + 1, diff_y1 - 1, dotted);
-		draw_horizontal_line (c, x2 - ybendpoint2, xbendpoint, (x + 1 + ybendpoint1 + 1) - (x2 - ybendpoint2) + 1, xbendpoint > y ? REV_APEX_APEX : DOT_DOT, dotted);
-		draw_vertical_line (c, x2 - ybendpoint2, miny2 + 1, diff_y2 - 1, dotted);
-		draw_horizontal_line (c, x2 - ybendpoint2, y2, ybendpoint2 + 1, xbendpoint > y ? DOT_NRM : REV_APEX_NRM, dotted);
+		draw_horizontal_line (c, x + 1, y, 1 + ybendpoint1 + 1, xbendpoint > y ? NRM_DOT : NRM_APEX, style->dot_style);
+		draw_vertical_line (c, x + 1 + ybendpoint1 + 1, miny1 + 1, diff_y1 - 1, style->dot_style);
+		draw_horizontal_line (c, x2 - ybendpoint2, xbendpoint, (x + 1 + ybendpoint1 + 1) - (x2 - ybendpoint2) + 1, xbendpoint > y ? REV_APEX_APEX : DOT_DOT, style->dot_style);
+		draw_vertical_line (c, x2 - ybendpoint2, miny2 + 1, diff_y2 - 1, style->dot_style);
+		draw_horizontal_line (c, x2 - ybendpoint2, y2, ybendpoint2 + 1, xbendpoint > y ? DOT_NRM : REV_APEX_NRM, style->dot_style);
 	}
 }

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2854,6 +2854,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("graph.gv.graph", "", "Graphviz global style attributes. (bgcolor=white)");
 	SETPREF ("graph.gv.current", "false", "Highlight the current node in graphviz graph.");
 	SETPREF ("graph.nodejmps", "true", "Enables shortcuts for every node.");
+	SETPREF ("graph.hints", "true", "Show true (t) and false (f) hints for conditional edges in graph");
 	SETCB ("graph.dotted", "true", &cb_dotted, "Dotted lines for conditional jumps in graph");
 
 	/* hud */

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2705,7 +2705,7 @@ static void agraph_print_edges(RAGraph *g) {
 	}
 	int out_nth, in_nth, bendpoint;
 	RListIter *itn, *itm, *ito;
-	RCanvasLineStyle style = {0};
+	RCanvasLineStyle style = {};
 	const RList *nodes = r_graph_get_nodes (g->graph);
 	RGraphNode *ga;
 	RANode *a;
@@ -2784,15 +2784,18 @@ static void agraph_print_edges(RAGraph *g) {
 				}
 			}
 
+			style.dot_style = DOT_STYLE_NORMAL;
 			if (many || parent_many) {
 				style.color = LINE_UNCJMP;
 			} else {
 				switch (out_nth) {
 				case 0:
 					style.color = LINE_TRUE;
+					style.dot_style = DOT_STYLE_CONDITIONAL;
 					break;
 				case 1:
 					style.color = LINE_FALSE;
+					style.dot_style = DOT_STYLE_CONDITIONAL;
 					break;
 				case -1:
 					style.color = LINE_UNCJMP;
@@ -2814,6 +2817,10 @@ static void agraph_print_edges(RAGraph *g) {
 				bx = b->is_dummy ? b->x : (b->x + b_x_inc);
 				ay = a->y + a->h;
 				by = b->y - 1;
+
+				if (ay > by) {
+					style.dot_style = DOT_STYLE_BACKEDGE;
+				}
 
 				if (many && !g->is_callgraph) {
 					int t = R_EDGES_X_INC + 2 * (neighbours->length + 1);
@@ -2860,6 +2867,11 @@ static void agraph_print_edges(RAGraph *g) {
 				ay = a->is_dummy ? a->y : a->y + R_EDGES_X_INC + out_nth;
 				bx = b->x - 1;
 				by = b->is_dummy ? b->y : b->y + R_EDGES_X_INC + out_nth;
+
+				if (ax > bx) {
+					style.dot_style = DOT_STYLE_BACKEDGE;
+				}
+
 				if (a->w < a->layer_width) {
 					r_cons_canvas_line_square_defined (g->can, ax, ay, a->x + a->layer_width, ay, &style, 0, false);
 					ax = a->x + a->layer_width;

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -2818,9 +2818,8 @@ static void agraph_print_edges(RAGraph *g) {
 				b_x_inc = R_EDGES_X_INC + 2 * (in_nth + 1);
 
 				bx = b->is_dummy ? b->x : (b->x + b_x_inc);
-				ay = a->y + a->h + 1;
+				ay = a->y + a->h;
 				by = b->y - 1;
-
 
 				if (many && !g->is_callgraph) {
 					int t = R_EDGES_X_INC + 2 * (neighbours->length + 1);
@@ -2828,7 +2827,7 @@ static void agraph_print_edges(RAGraph *g) {
 					bendpoint = bx < ax ? neighbours->length - out_nth :  out_nth;
 				} else {
 					ax = a->is_dummy ? a->x : (a->x + a_x_inc);
-					bendpoint = tm->edgectr - 1;
+					bendpoint = tm->edgectr;
 				}
 
 				if (!a->is_dummy && itn == neighbours->head && out_nth == 0 && bx > ax) {
@@ -2836,7 +2835,7 @@ static void agraph_print_edges(RAGraph *g) {
 				}
 				if (a->h < a->layer_height) {
 					r_cons_canvas_line (g->can, ax, ay, ax, ay + a->layer_height - a->h, &style);
-					ay = a->y + a->layer_height + 1;
+					ay = a->y + a->layer_height;
 					style.symbol = LINE_NOSYM_VERT;
 				}
 				if (by >= ay) {
@@ -3228,18 +3227,18 @@ static int agraph_print(RAGraph *g, int is_interactive, RCore *core, RAnalFuncti
 		r_config_set_i (core->config, "asm.bytes", asm_bytes);
 		r_config_set_i (core->config, "asm.cmt.right", asm_cmt_right);
 	}
+	if (g->title && *g->title) {
+		g->can->sy ++;
+	}
 	if (preEdges) {
 		agraph_print_edges (g);
 	}
-	if (g->title && *g->title) {
-		g->can->sy ++;
-		agraph_print_nodes (g);
-		g->can->sy --;
-	} else {
-		agraph_print_nodes (g);
-	}
+	agraph_print_nodes (g);
 	if (!preEdges) {
 		agraph_print_edges (g);
+	}
+	if (g->title && *g->title) {
+		g->can->sy --;
 	}
 	/* print the graph title */
 	(void) G (-g->can->sx, -g->can->sy);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -587,9 +587,14 @@ enum {
 	LINE_NOSYM_HORIZ
 };
 
+#define DOT_STYLE_NORMAL 0
+#define DOT_STYLE_CONDITIONAL 1
+#define DOT_STYLE_BACKEDGE 2
+
 typedef struct r_cons_canvas_line_style_t {
 	int color;
 	int symbol;
+	int dot_style;
 } RCanvasLineStyle;
 
 // UTF-8 symbols indexes

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -930,6 +930,7 @@ typedef struct r_ascii_graph_t {
 	bool is_interactive;
 	int zoom;
 	int movspeed;
+	bool hints;
 
 	RANode *update_seek_on;
 	bool need_reload_nodes;


### PR DESCRIPTION
1. Bring back `t` and `f` hints in graph. Governed by variable `graph.hints`. Defaults to True.
  Added command `#` to toggle hints while in graph view.

2. Use a different style for backedges. 
  I tried using braille characters, but the result was not good (braille points are a 2x4 table, unfortunately all even numbers, lines were decentered and the visual effect was worse than normal hyphens (`-`)).
  So I ended up using **dashed** lines for backedges. I think it is the most clear way to differentiate them from both normal edges and conditional edges. Take a look in this screens:

![image](https://user-images.githubusercontent.com/3428362/43345976-ced5658a-91ef-11e8-9b9d-c479f1b0e2dd.png)

On a different terminal with different font, a conditional backedge:

![image](https://user-images.githubusercontent.com/3428362/43346167-7364f048-91f0-11e8-94e6-f293e77210c1.png)

