### PR TITLE
Add "save to file" to ag*w commands + colorize comments like ";arg1"

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -703,7 +703,7 @@ R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_s
 					r_anal_var_link (anal, op->addr, op->var);
 				}
 				r_anal_var_access (anal, fcn->addr, 'r', 1, delta, 0, op->addr);
-				r_meta_set_string (anal, R_META_TYPE_COMMENT, op->addr, vname);
+				r_meta_set_string (anal, R_META_TYPE_VARTYPE, op->addr, vname);
 				free (vname);
 			}
 			if (op->dst && opdreg && !strcmp (opdreg, regname)) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2295,29 +2295,30 @@ static char *getViewerPath() {
 	return NULL;
 }
 
-R_API char* r_core_graph_cmd(RCore *core, char *r2_cmd) {
+R_API char* r_core_graph_cmd(RCore *core, char *r2_cmd, char *save_path) {
 	char *cmd = NULL;
-	char *xdotPath = r_file_path ("xdot");
 	const char *ext = r_config_get (core->config, "graph.extension");
-	if (r_file_exists (xdotPath)) {
-		cmd = r_str_newf ("%s > a.dot;!xdot a.dot", r2_cmd);
-	} else {
-		char *dotPath = r_file_path ("dot");
-		if (r_file_exists (dotPath)) {
-			R_FREE (dotPath);
+	char *dotPath = r_file_path ("dot");
+	if (!r_file_exists (dotPath)) {
+		free (dotPath);
+		dotPath = r_file_path ("xdot");
+	}
+	if (r_file_exists (dotPath)) {
+		if (save_path && *save_path) {
+			cmd = r_str_newf ("%s > a.dot;!%s -T%s -o%s a.dot;", r2_cmd, dotPath, ext, save_path);
+		} else {
 			char *viewer = getViewerPath();
 			if (viewer) {
-				cmd = r_str_newf ("%s > a.dot;!dot -T%s -oa.%s a.dot;!%s a.%s", r2_cmd, ext, ext, viewer, ext);
+				cmd = r_str_newf ("%s > a.dot;!%s -T%s -oa.%s a.dot;!%s a.%s", r2_cmd, dotPath, ext, ext, viewer, ext);
 				free (viewer);
 			} else {
 				eprintf ("Cannot find a valid picture viewer");
 			}
-		} else {
-			cmd = r_str_new ("agf");
 		}
-		free (dotPath);
+	} else {
+		cmd = r_str_new ("agf");
 	}
-	free (xdotPath);
+	free (dotPath);
 	return cmd;
 }
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2812,7 +2812,7 @@ R_API int r_core_config_init(RCore *core) {
 	/* graph */
 	SETPREF ("graph.comments", "true", "Show disasm comments in graph");
 	SETPREF ("graph.cmtright", "false", "Show comments at right");
-	SETCB ("graph.extension", "gif", &cb_graphformat, "Graph extension when using 'w' format (png, jpg, pdf, ps, svg, json)");
+	SETCB ("graph.gv.format", "gif", &cb_graphformat, "Graph image extension when using 'w' format (png, jpg, pdf, ps, svg, json)");
 	SETPREF ("graph.refs", "false", "Graph references in callgraphs (.agc*;aggi)");
 	SETI ("graph.edges", 2, "0=no edges, 1=simple edges, 2=avoid collisions");
 	SETI ("graph.layout", 0, "Graph layout (0=vertical, 1=horizontal)");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2295,35 +2295,6 @@ static char *getViewerPath() {
 	return NULL;
 }
 
-R_API char* r_core_graph_cmd(RCore *core, char *r2_cmd, char *save_path) {
-	char *cmd = NULL;
-	const char *ext = r_config_get (core->config, "graph.extension");
-	char *dotPath = r_file_path ("dot");
-	if (!r_file_exists (dotPath)) {
-		free (dotPath);
-		dotPath = r_file_path ("xdot");
-	}
-	if (r_file_exists (dotPath)) {
-		if (save_path && *save_path) {
-			cmd = r_str_newf ("%s > a.dot;!%s -T%s -o%s a.dot;", r2_cmd, dotPath, ext, save_path);
-		} else {
-			char *viewer = getViewerPath();
-			if (viewer) {
-				cmd = r_str_newf ("%s > a.dot;!%s -T%s -oa.%s a.dot;!%s a.%s", r2_cmd, dotPath, ext, ext, viewer, ext);
-				free (viewer);
-			} else {
-				eprintf ("Cannot find a valid picture viewer");
-			}
-		}
-	} else {
-		cmd = r_str_new ("agf");
-	}
-	free (dotPath);
-	return cmd;
-}
-
-
-
 #define SLURP_LIMIT (10*1024*1024)
 R_API int r_core_config_init(RCore *core) {
 	int i;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2271,30 +2271,6 @@ static int cb_dbgsnap(void *user, void *data) {
 	return true;
 }
 
-static char *getViewerPath() {
-	int i;
-	const char *viewers[] = {
-#if __WINDOWS__
-		"explorer",
-#else
-		"open",
-		"geeqie",
-		"gqview",
-		"eog",
-		"xdg-open",
-#endif
-		NULL
-	};
-	for (i = 0; viewers[i]; i++) {
-		char *viewerPath = r_file_path (viewers[i]);
-		if (viewerPath && strcmp (viewerPath, viewers[i])) {
-			return viewerPath;
-		}
-		free (viewerPath);
-	}
-	return NULL;
-}
-
 #define SLURP_LIMIT (10*1024*1024)
 R_API int r_core_config_init(RCore *core) {
 	int i;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5760,7 +5760,7 @@ static char *getViewerPath() {
 	return NULL;
 }
 
-static char* r_core_graph_cmd(RCore *core, char *r2_cmd, const char *save_path) {
+static char* graph_cmd(RCore *core, char *r2_cmd, const char *save_path) {
 	char *cmd = NULL;
 	const char *ext = r_config_get (core->config, "graph.extension");
 	char *dotPath = r_file_path ("dot");
@@ -5970,7 +5970,7 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		if (r_config_get_i (core->config, "graph.web")) {
 			r_core_cmd0 (core, "=H /graph/");
 		} else {
-			char *cmd = r_core_graph_cmd (core, "aggd", input + 1);
+			char *cmd = graph_cmd (core, "aggd", input + 1);
 			if (cmd && *cmd) {
 				if (*(input + 1)) {
 					r_cons_printf ("Saving to file %s ...\n", input + 1);
@@ -6051,7 +6051,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 				r_core_cmd0 (core, "=H /graph/");
 			} else {
 				char *cmdargs = r_str_newf ("agfd @ 0x%"PFMT64x, core->offset);
-				char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
+				char *cmd = graph_cmd (core, cmdargs, input + 2);
 				if (cmd && *cmd) {
 					if (*(input + 2)) {
 						r_cons_printf ("Saving to file %s ...\n", input + 2);
@@ -6354,7 +6354,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			}
 		case 'w': {
 			char *cmdargs = r_str_newf ("agdd 0x%"PFMT64x, core->offset);
-			char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
+			char *cmd = graph_cmd (core, cmdargs, input + 2);
 			if (cmd && *cmd) {
 				r_core_cmd0 (core, cmd);
 			}
@@ -6372,7 +6372,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			r_core_cmd0 (core, "=H /graph/");
 		} else {
 			char *cmdargs = r_str_newf ("agfd @ 0x%"PFMT64x, core->offset);
-			char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
+			char *cmd = graph_cmd (core, cmdargs, input + 2);
 			if (cmd && *cmd) {
 				if (*(input + 1)) {
 					r_cons_printf ("Saving to file %s ...\n", input + 2);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -386,11 +386,11 @@ static const char *help_msg_afvs[] = {
 static const char *help_msg_ag[] = {
 	"Usage:", "ag<graphtype><format> [addr]", "",
 	"Graph commands:", "", "",
-	"agc", "[format] [fcn addr]", "Function callgraph",
-	"agf", "[format] [fcn addr]", "Basic blocks function graph",
-	"agx", "[format] [addr]", "Cross references graph",
-	"agr", "[format] [fcn addr]", "References graph",
-	"aga", "[format] [fcn addr]", "Data references graph",
+	"agc", "[format] [@ fcn addr]", "Function callgraph",
+	"agf", "[format] [@ fcn addr]", "Basic blocks function graph",
+	"agx", "[format] [@ addr]", "Cross references graph",
+	"agr", "[format] [@ fcn addr]", "References graph",
+	"aga", "[format] [@ fcn addr]", "Data references graph",
 	"agd", "[format] [fcn addr]", "Diff graph",
 	"agi", "[format]", "Imports graph",
 	"agC", "[format]", "Global callgraph",
@@ -410,7 +410,7 @@ static const char *help_msg_ag[] = {
 	"g", "", "Graph Modelling Language (gml)",
 	"k", "", "SDB key-value",
 	"*", "", "r2 commands",
-	"w", "", "Web/image (see graph.extension and graph.web)",
+	"w", "[path]", "Web/image display or save to path (see graph.extension and graph.web)",
 	NULL
 };
 
@@ -5925,6 +5925,10 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		} else {
 			char *cmd = r_core_graph_cmd (core, "aggd", input + 1);
 			if (cmd && *cmd) {
+				if (*(input + 1)) {
+					r_cons_printf ("Saving to file %s ...\n", input + 1);
+					r_cons_flush ();
+				}
 				r_core_cmd0 (core, cmd);
 			}
 			free (cmd);
@@ -6008,6 +6012,10 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 				char *cmdargs = r_str_newf ("agfd @ 0x%"PFMT64x, core->offset);
 				char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
 				if (cmd && *cmd) {
+					if (*(input + 1)) {
+						r_cons_printf ("Saving to file %s ...\n", input + 2);
+						r_cons_flush ();
+					}
 					r_core_cmd0 (core, cmd);
 				}
 				free (cmd);
@@ -6315,7 +6323,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 			}
 		case 'w': {
-			char *cmdargs = r_str_newf ("agdd @ 0x%"PFMT64x, core->offset);
+			char *cmdargs = r_str_newf ("agdd 0x%"PFMT64x, core->offset);
 			char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
 			if (cmd && *cmd) {
 				r_core_cmd0 (core, cmd);
@@ -6334,8 +6342,12 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			r_core_cmd0 (core, "=H /graph/");
 		} else {
 			char *cmdargs = r_str_newf ("agfd @ 0x%"PFMT64x, core->offset);
-			char *cmd = r_core_graph_cmd (core, cmdargs, input + 1);
+			char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
 			if (cmd && *cmd) {
+				if (*(input + 1)) {
+					r_cons_printf ("Saving to file %s ...\n", input + 2);
+					r_cons_flush ();
+				}
 				r_core_cmd0 (core, cmd);
 			}
 			free (cmd);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -386,16 +386,16 @@ static const char *help_msg_afvs[] = {
 static const char *help_msg_ag[] = {
 	"Usage:", "ag<graphtype><format> [addr]", "",
 	"Graph commands:", "", "",
-	"aga", "[format] [@ fcn addr]", "Data references graph",
+	"aga", "[format]", "Data references graph",
 	"agA", "[format]", "Global data references graph",
-	"agc", "[format] [@ fcn addr]", "Function callgraph",
+	"agc", "[format]", "Function callgraph",
 	"agC", "[format]", "Global callgraph",
 	"agd", "[format] [fcn addr]", "Diff graph",
-	"agf", "[format] [@ fcn addr]", "Basic blocks function graph",
+	"agf", "[format]", "Basic blocks function graph",
 	"agi", "[format]", "Imports graph",
-	"agr", "[format] [@ fcn addr]", "References graph",
+	"agr", "[format]", "References graph",
 	"agR", "[format]", "Global references graph",
-	"agx", "[format] [@ addr]", "Cross references graph",
+	"agx", "[format]", "Cross references graph",
 	"agg", "[format]", "Custom graph",
 	"ag-", "", "Clear the custom graph",
 	"agn", "[?] title body", "Add a node to the custom graph",
@@ -5743,19 +5743,23 @@ static void agraph_print_node(RANode *n, void *user) {
 static char *getViewerPath() {
 	int i;
 	const char *viewers[] = {
+#if __WINDOWS__
+		"explorer",
+#else
 		"open",
 		"geeqie",
 		"gqview",
 		"eog",
 		"xdg-open",
+#endif
 		NULL
 	};
 	for (i = 0; viewers[i]; i++) {
-		char *dotPath = r_file_path (viewers[i]);
-		if (dotPath && strcmp (dotPath, viewers[i])) {
-			return dotPath;
+		char *viewerPath = r_file_path (viewers[i]);
+		if (viewerPath && strcmp (viewerPath, viewers[i])) {
+			return viewerPath;
 		}
-		free (dotPath);
+		free (viewerPath);
 	}
 	return NULL;
 }

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5923,7 +5923,7 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 		if (r_config_get_i (core->config, "graph.web")) {
 			r_core_cmd0 (core, "=H /graph/");
 		} else {
-			char *cmd = r_core_graph_cmd (core, "aggd");
+			char *cmd = r_core_graph_cmd (core, "aggd", input + 1);
 			if (cmd && *cmd) {
 				r_core_cmd0 (core, cmd);
 			}
@@ -6005,8 +6005,8 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			if (r_config_get_i (core->config, "graph.web")) {
 				r_core_cmd0 (core, "=H /graph/");
 			} else {
-				char *cmdargs = r_str_newf ("agfd %"PFMT64u, r_num_math (core->num, input + 2));
-				char *cmd = r_core_graph_cmd (core, cmdargs);
+				char *cmdargs = r_str_newf ("agfd @ 0x%"PFMT64x, core->offset);
+				char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
 				if (cmd && *cmd) {
 					r_core_cmd0 (core, cmd);
 				}
@@ -6315,9 +6315,8 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			break;
 			}
 		case 'w': {
-			char *cmdargs = r_str_newf ("agdd %"PFMT64u,
-				input[2] ? r_num_math (core->num, input + 2) : core->offset);
-			char *cmd = r_core_graph_cmd (core, cmdargs);
+			char *cmdargs = r_str_newf ("agdd @ 0x%"PFMT64x, core->offset);
+			char *cmd = r_core_graph_cmd (core, cmdargs, input + 2);
 			if (cmd && *cmd) {
 				r_core_cmd0 (core, cmd);
 			}
@@ -6334,8 +6333,8 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 		if (r_config_get_i (core->config, "graph.web")) {
 			r_core_cmd0 (core, "=H /graph/");
 		} else {
-			char *cmdargs = r_str_newf ("agfd %"PFMT64u, r_num_math (core->num, input + 1));
-			char *cmd = r_core_graph_cmd (core, cmdargs);
+			char *cmdargs = r_str_newf ("agfd @ 0x%"PFMT64x, core->offset);
+			char *cmd = r_core_graph_cmd (core, cmdargs, input + 1);
 			if (cmd && *cmd) {
 				r_core_cmd0 (core, cmd);
 			}

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -368,7 +368,7 @@ static void set_offset_hint(RCore *core, RAnalOp op, const char *type, ut64 ladd
 			r_anal_hint_set_offset (core->anal, at, res);
 		}
 	} else if (cmt && r_anal_op_ismemref (op.type)) {
-			r_meta_set_string (core->anal, R_META_TYPE_COMMENT, at, cmt);
+			r_meta_set_string (core->anal, R_META_TYPE_VARTYPE, at, cmt);
 	}
 }
 

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1824,7 +1824,21 @@ static char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, int depth) {
 }
 
 R_API char *r_core_anal_get_comments(RCore *core, ut64 addr) {
-	return core? r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr): NULL;
+	if (core) {
+		char *type = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, addr);
+		char *cmt = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
+		if (type && cmt) {
+			char *ret = r_str_newf ("%s %s", type, cmt);
+			free (type);
+			free (cmt);
+			return ret;
+		} else if (type) {
+			return type;
+		} else if (cmt) {
+			return cmt;
+		}
+	}
+	return NULL;
 }
 
 R_API const char *r_core_anal_optype_colorfor(RCore *core, ut64 addr, bool verbose) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -283,7 +283,7 @@ R_API void r_core_wait(RCore *core);
 R_API RCore *r_core_ncast(ut64 p);
 R_API RCore *r_core_cast(void *p);
 R_API int r_core_config_init(RCore *core);
-R_API char* r_core_graph_cmd(RCore *core, char *r2_cmd);
+R_API char* r_core_graph_cmd(RCore *core, char *r2_cmd, char *save_path);
 R_API int r_core_prompt(RCore *core, int sync);
 R_API int r_core_prompt_exec(RCore *core);
 R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -283,7 +283,6 @@ R_API void r_core_wait(RCore *core);
 R_API RCore *r_core_ncast(ut64 p);
 R_API RCore *r_core_cast(void *p);
 R_API int r_core_config_init(RCore *core);
-R_API char* r_core_graph_cmd(RCore *core, char *r2_cmd, char *save_path);
 R_API int r_core_prompt(RCore *core, int sync);
 R_API int r_core_prompt_exec(RCore *core);
 R_API int r_core_lines_initcache (RCore *core, ut64 start_addr, ut64 end_addr);


### PR DESCRIPTION
This should close #10857 

Command syntax for ag* commands slightly changes:

1. No more [fcn addr] argument; this was useless, now it only uses core->offset. If you want to draw graph of a function with an offset different from the current one, just do `agfv @ other_offset`. The only exception is `agd` command, because you must provide the offset of the function to diff against.

2. Now the `w` (image) format provides an argument, which is the file path to save the image to. If no path is provided, the image is displayed immediately (like before). Slight refactoring of r_core_graph_cmd().

3. Updated ag? help accordingly to this changes. Sent a pr https://github.com/radare/radare2book/pull/139 to r2book too.

4. Comments like ";arg1" will be of the same color of the declaration of arguments, for consistency. I added this pr because it is really just a one line change that I forgot in my last colourize arguments pr.