### PR TITLE
Revert RVector and RPVector refactoring

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -614,12 +614,12 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int protection, const char 
 			append_bound (list, core->io, search_itv, m->itv.addr, m->itv.size);
 		}
 	} else if (!strcmp (mode, "io.maps")) { // Non-overlapping RIOMap parts not overriden by others (skyline)
-		const RPVector *skyline = &core->io->map_skyline;
+		const RVector *skyline = &core->io->map_skyline;
 		ut64 begin = UT64_MAX;
 		ut64 end = UT64_MAX;
-		size_t i;
-		for (i = 0; i < r_pvector_len (skyline); i++) {
-			const RIOMapSkyline *part = r_pvector_at (skyline, i);
+		int i;
+		for (i = 0; i < skyline->len; i++) {
+			const RIOMapSkyline *part = skyline->a[i];
 			ut64 from = part->itv.addr;
 			ut64 to = part->itv.addr + part->itv.size;
 			// eprintf ("--------- %llx %llx    (%llx %llx)\n", from, to, begin, end);

--- a/libr/include/r_binheap.h
+++ b/libr/include/r_binheap.h
@@ -7,17 +7,17 @@ extern "C" {
 #endif
 
 typedef struct r_binheap_t {
-	RPVector a;
-	RPVectorComparator cmp;
+	RVector a;
+	RVectorComparator cmp;
 } RBinHeap;
 
-R_API void r_binheap_clear(RBinHeap *h);
-#define r_binheap_empty(h) (r_pvector_empty (&(h)->a))
-R_API void r_binheap_init(RBinHeap *h, RPVectorComparator cmp);
-R_API RBinHeap *r_binheap_new(RPVectorComparator cmp);
+R_API void r_binheap_clear(RBinHeap *h, void (*elem_free)(void *));
+#define r_binheap_empty(h) (!(h)->a.len)
+R_API void r_binheap_init(RBinHeap *h, RVectorComparator cmp);
+R_API RBinHeap *r_binheap_new(RVectorComparator cmp);
 R_API bool r_binheap_push(RBinHeap *h, void *x);
 R_API void *r_binheap_pop(RBinHeap *h);
-#define r_binheap_top(h) (r_pvector_at(&((h)->a), 0))
+#define r_binheap_top(h) ((h)->a.a[0])
 
 #ifdef __cplusplus
 }

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -77,7 +77,7 @@ typedef struct r_io_t {
 	RIDPool *sec_ids;
 	RIDPool *map_ids;
 	SdbList *maps; //from tail backwards maps with higher priority are found
-	RPVector map_skyline; // map parts that are not covered by others
+	RVector map_skyline; // map parts that are not covered by others
 	SdbList *sections;
 	RIDStorage *files;
 	RCache *buffer;

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -7,169 +7,80 @@ extern "C" {
 #endif
 
 /*
-  RVector can contain arbitrarily sized elements.
-  RPVector uses RVector internally and always contains void *s.
+  Insert functions returns NULL if reallocation happens and fails,
+  returns the address of newly inserted element if succeeded.
 
-  Hint: remove/pop functions do not reduce the capacity.
-        Call r_(p)vector_shrink explicitly if desired.
-*/
+  Delete functions returns the deleted element.
+  Callers should destruct it if necessary.
 
-typedef int (*RPVectorComparator)(const void *a, const void *b);
-typedef void (*RVectorFree)(void *e, void *user);
-typedef void (*RPVectorFree)(void *e);
+  Usage:
+  int i;
+  void **it;
+
+  // heap allocated RVector
+  RVector *v = r_vector_new ();
+  if (!v) goto err_new;
+  if (!r_vector_push (v, a)) goto err_push;
+  if (!r_vector_insert (v, 0, b)) goto err_insert;
+  for (i = 0; i < v->len; i++) {
+    (void)v->a[i]; // Public members a and len are encouraged to access
+  }
+  r_vector_foreach (v, it) {
+    (void)*it;
+  }
+  // pass function pointer `elem_free`
+  r_vector_free (v, NULL);
+
+  // stack allocated RVector
+  RVector v = {0};
+  // r_vector_init (&v); // v.a = NULL; v.len = v.capacity = 0;
+  r_vector_push (&v, (void *)1);
+  assert (v.len == 1 && v.capacity == 10);
+  // for stack allocated RVector, use r_vector_clear instead of r_vector_free
+  r_vector_clear (&v, NULL);
+ */
 
 typedef struct r_vector_t {
-	void *a;
-	size_t len;
-	size_t capacity;
-	size_t elem_size;
+	void **a;
+	int len;
+	int capacity;
 } RVector;
 
-typedef struct r_pvector_t {
-	RVector v;
-	RPVectorFree free;
-} RPVector;
+typedef int (*RVectorComparator)(const void *a, const void *b);
+typedef void (*RVectorFree)(void *e);
 
-
-// RVector
-
-R_API void r_vector_init(RVector *vec, size_t elem_size);
-
-R_API RVector *r_vector_new(size_t elem_size);
-
-// clears the vector and calls elem_free on every element.
-R_API void r_vector_clear(RVector *vec, RVectorFree elem_free, void *user);
-
-// frees the vector and calls elem_free on every element.
-R_API void r_vector_free(RVector *vec, RVectorFree elem_free, void *user);
-
-// the returned vector will have the same capacity as vec.
+R_API void r_vector_clear(RVector *vec, void (*elem_free)(void *));
 R_API RVector *r_vector_clone(RVector *vec);
+R_API void **r_vector_contains(RVector *vec, void *x);
+R_API void *r_vector_delete_at(RVector *vec, int n);
+R_API bool r_vector_empty(RVector *vec);
+R_API void r_vector_fini(RVector *vec);
+R_API void r_vector_free(RVector *vec, RVectorFree elem_free);
+R_API void r_vector_init(RVector *vec);
+R_API void **r_vector_insert(RVector *vec, int n, void *x);
+R_API void **r_vector_insert_range(RVector *vec, int n, void **first, void **last);
+R_API RVector *r_vector_new(void);
+R_API void *r_vector_pop(RVector *vec);
+R_API void *r_vector_pop_front(RVector *vec);
+R_API void **r_vector_push(RVector *vec, void *x);
+R_API void **r_vector_push_front(RVector *vec, void *x);
+R_API void **r_vector_reserve(RVector *vec, int capacity);
+/* shrink capacity to len, NB. delete operations do not shrink space */
+R_API void **r_vector_shrink(RVector *vec);
+R_API void r_vector_sort(RVector *vec, RVectorComparator cmp);
 
-static inline bool r_vector_empty(RVector *vec)							{ return vec->len == 0; }
+#define r_vector_find(vec, it, cmp_eq) \
+	for (it = (vec)->a; it != (vec)->a + (vec)->len && !(cmp_eq (*it, x)); it++);
 
-// returns a pointer to the offset inside the array where the element of the index lies.
-R_API void *r_vector_index_ptr(RVector *vec, size_t index);
+#define r_vector_foreach(vec, it) \
+	for (it = (vec)->a; it != (vec)->a + (vec)->len; it++)
 
-// helper function to assign an element of size vec->elem_size from elem to p.
-// elem is a pointer to the actual data to assign!
-R_API void r_vector_assign(RVector *vec, void *p, void *elem);
-
-// assign the value of size vec->elem_size at elem to vec at the given index.
-// elem is a pointer to the actual data to assign!
-R_API void *r_vector_assign_at(RVector *vec, size_t index, void *elem);
-
-// remove the element at the given index and write the content to into.
-// It is the caller's responsibility to free potential resources associated with the element.
-R_API void r_vector_remove_at(RVector *vec, size_t index, void *into);
-
-// insert the value of size vec->elem_size at x at the given index.
-// x is a pointer to the actual data to assign!
-R_API void *r_vector_insert(RVector *vec, size_t index, void *x);
-
-// insert count values of size vec->elem_size into vec starting at the given index.
-R_API void *r_vector_insert_range(RVector *vec, size_t index, void *first, size_t count);
-
-// like r_vector_remove_at for the last element
-R_API void r_vector_pop(RVector *vec, void *into);
-
-// like r_vector_remove_at for the first element
-R_API void r_vector_pop_front(RVector *vec, void *into);
-
-// like r_vector_insert for the end of vec
-R_API void *r_vector_push(RVector *vec, void *x);
-
-// like r_vector_insert for the beginning of vec
-R_API void *r_vector_push_front(RVector *vec, void *x);
-
-// make sure the capacity is at least capacity.
-R_API void *r_vector_reserve(RVector *vec, size_t capacity);
-
-// shrink capacity to len.
-R_API void *r_vector_shrink(RVector *vec);
-
-
-// RPVector
-
-// initialize vec and set vec->free to free
-R_API void r_pvector_init(RPVector *vec, RPVectorFree free);
-
-// allocate a new RPVector and set vec->free to free
-R_API RPVector *r_pvector_new(RPVectorFree free);
-
-// clear the vector and call vec->free on every element.
-R_API void r_pvector_clear(RPVector *vec);
-
-// free the vector and call vec->free on every element.
-R_API void r_pvector_free(RPVector *vec);
-
-static inline size_t r_pvector_len(const RPVector *vec)					{ return vec->v.len; }
-
-static inline void *r_pvector_at(const RPVector *vec, size_t index)		{ return ((void **)vec->v.a)[index]; }
-
-static inline void r_pvector_set(RPVector *vec, size_t index, void *e)	{ ((void **)vec->v.a)[index] = e; }
-
-static inline bool r_pvector_empty(RPVector *vec)						{ return r_pvector_len (vec) == 0; }
-
-// returns the respective pointer inside the vector if x is found or NULL otherwise.
-R_API void **r_pvector_contains(RPVector *vec, void *x);
-
-// removes and returns the pointer at the given index. Does not call free.
-R_API void *r_pvector_remove_at(RPVector *vec, size_t index);
-
-// like r_vector_insert, but the pointer x is the actual data to be inserted.
-static inline void **r_pvector_insert(RPVector *vec, size_t index, void *x) { return (void **)r_vector_insert (&vec->v, index, &x); }
-
-// like r_vector_insert_range.
-static inline void **r_pvector_insert_range(RPVector *vec, size_t index, void **first, size_t count) { return r_vector_insert_range (&vec->v, index, first, count); }
-
-// like r_vector_pop, but returns the pointer directly.
-R_API void *r_pvector_pop(RPVector *vec);
-
-// like r_vector_pop_front, but returns the pointer directly.
-R_API void *r_pvector_pop_front(RPVector *vec);
-
-// like r_vector_push, but the pointer x is the actual data to be inserted.
-static inline void **r_pvector_push(RPVector *vec, void *x) { return (void **)r_vector_push (&vec->v, &x); }
-
-// like r_vector_push_front, but the pointer x is the actual data to be inserted.
-static inline void **r_pvector_push_front(RPVector *vec, void *x) { return (void **)r_vector_push_front (&vec->v, &x); }
-
-// sort vec using quick sort.
-R_API void r_pvector_sort(RPVector *vec, RPVectorComparator cmp);
-
-static inline void **r_pvector_reserve(RPVector *vec, size_t capacity)	{ return (void **)r_vector_reserve (&vec->v, capacity); }
-
-static inline void **r_pvector_shrink(RPVector *vec)					{ return (void **)r_vector_shrink (&vec->v); }
-
-/*
- * example:
- *
- * RVector *v = ...;
- * void **it;
- * r_pvector_foreach (v, it) {
- *     void *p = *it;
- *     // Do something with p
- * }
- */
-#define r_pvector_foreach(vec, it) \
-	for (it = (void **)(vec)->v.a; it != (void **)(vec)->v.a + (vec)->v.len; it++)
-
-/*
- * example:
- *
- * RPVector *v = ...; // contains {(void*)0, (void*)2, (void*)4, (void*)6, (void*)8};
- * size_t l;
- * #define CMP(x, y) x - y
- * r_pvector_lower_bound (v, (void *)3, l, CMP);
- * // l == 2
- */
-#define r_pvector_lower_bound(vec, x, i, cmp) \
+#define r_vector_lower_bound(vec, x, i, cmp) \
 	do { \
-		int h = (vec)->v.len, m; \
+		int h = (vec)->len, m; \
 		for (i = 0; i < h; ) { \
 			m = i + ((h - i) >> 1); \
-			if ((cmp (x, ((void **)(vec)->v.a)[m])) > 0) { \
+			if ((cmp (x, (vec)->a[m])) > 0) { \
 				i = m + 1; \
 			} else { \
 				h = m; \
@@ -177,13 +88,12 @@ static inline void **r_pvector_shrink(RPVector *vec)					{ return (void **)r_vec
 		} \
 	} while (0) \
 
-// see r_pvector_lower_bound
-#define r_pvector_upper_bound(vec, x, i, cmp) \
+#define r_vector_upper_bound(vec, x, i, cmp) \
 	do { \
-		int h = (vec)->v.len, m; \
+		int h = (vec)->len, m; \
 		for (i = 0; i < h; ) { \
 			m = i + ((h - i) >> 1); \
-			if (!((cmp (x, ((void **)(vec)->v.a)[m])) < 0)) { \
+			if (!((cmp (x, (vec)->a[m])) < 0)) { \
 				i = m + 1; \
 			} else { \
 				h = m; \

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -59,30 +59,30 @@ typedef int (*cbOnIterMap)(RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap
 // If prefix_mode is true, returns the number of bytes of operated prefix; returns < 0 on error.
 // If prefix_mode is false, operates in non-stop mode and returns true iff all IO operations on overlapped maps are complete.
 static st64 on_map_skyline(RIO *io, ut64 vaddr, ut8 *buf, int len, int match_flg, cbOnIterMap op, bool prefix_mode) {
-	const RPVector *skyline = &io->map_skyline;
+	const RVector *skyline = &io->map_skyline;
 	ut64 addr = vaddr;
-	size_t i;
+	int i;
 	bool ret = true, wrap = !prefix_mode && vaddr + len < vaddr;
 #define CMP(addr, part) (addr < r_itv_end (((RIOMapSkyline *)part)->itv) - 1 ? -1 : \
 			addr > r_itv_end (((RIOMapSkyline *)part)->itv) - 1 ? 1 : 0)
 	// Let i be the first skyline part whose right endpoint > addr
 	if (!len) {
-		i = r_pvector_len (skyline);
+		i = skyline->len;
 	} else {
-		r_pvector_lower_bound (skyline, addr, i, CMP);
-		if (i == r_pvector_len (skyline) && wrap) {
+		r_vector_lower_bound (skyline, addr, i, CMP);
+		if (i == skyline->len && wrap) {
 			wrap = false;
 			i = 0;
 			addr = 0;
 		}
 	}
 #undef CMP
-	while (i < r_pvector_len (skyline)) {
-		const RIOMapSkyline *part = r_pvector_at (skyline, i);
+	while (i < skyline->len) {
+		const RIOMapSkyline *part = skyline->a[i];
 		// Right endpoint <= addr
 		if (r_itv_end (part->itv) - 1 < addr) {
 			i++;
-			if (wrap && i == r_pvector_len (skyline)) {
+			if (wrap && i == skyline->len) {
 				wrap = false;
 				i = 0;
 				addr = 0;
@@ -208,7 +208,6 @@ R_API RIO* r_io_init(RIO* io) {
 	}
 	io->addrbytes = 1;
 	r_io_desc_init (io);
-	r_pvector_init (&io->map_skyline, free);
 	r_io_map_init (io);
 	r_io_section_init (io);
 	r_io_cache_init (io);

--- a/libr/util/binheap.c
+++ b/libr/util/binheap.c
@@ -1,57 +1,55 @@
 #include "r_binheap.h"
 
-static inline void _heap_down(RBinHeap *h, size_t i, void *x) {
-	size_t j;
-	for (; j = i * 2 + 1, j < h->a.v.len; i = j) {
-		if (j + 1 < h->a.v.len && h->cmp (r_pvector_at (&h->a, j+1), r_pvector_at (&h->a, j))) {
+static inline void _heap_down(RBinHeap *h, int i, void *x) {
+	int j;
+	for (; j = i * 2 + 1, j < h->a.len; i = j) {
+		if (j + 1 < h->a.len && h->cmp (h->a.a[j+1], h->a.a[j])) {
 			j++;
 		}
-		if (!(h->cmp (r_pvector_at (&h->a, j+1), x))) {
+		if (!(h->cmp (h->a.a[j], x))) {
 			break;
 		}
-		r_pvector_set (&h->a, i, r_pvector_at (&h->a, j));
+		h->a.a[i] = h->a.a[j];
 	}
-	r_pvector_set (&h->a, i, x);
+	h->a.a[i] = x;
 }
 
-static inline void _heap_up(RBinHeap *h, size_t i, void *x) {
-	size_t j;
-	for (; i && (j = (i-1) >> 1, h->cmp (x, r_pvector_at (&h->a, j))); i = j) {
-		r_pvector_set (&h->a, i, r_pvector_at (&h->a, j));
+static inline void _heap_up(RBinHeap *h, int i, void *x) {
+	int j;
+	for (; i && (j = (i-1) >> 1, h->cmp (x, h->a.a[j])); i = j) {
+		h->a.a[i] = h->a.a[j];
 	}
-	r_pvector_set (&h->a, i, x);
+	h->a.a[i] = x;
 }
 
-R_API void r_binheap_clear(RBinHeap *h) {
-  r_pvector_clear (&h->a);
+R_API void r_binheap_clear(RBinHeap *h, void (*elem_free)(void *)) {
+  r_vector_clear (&h->a, elem_free);
 }
 
-R_API void r_binheap_init(RBinHeap *h, RPVectorComparator cmp) {
-	r_pvector_init (&h->a, NULL);
+R_API void r_binheap_init(RBinHeap *h, RVectorComparator cmp) {
+	r_vector_init (&h->a);
 	h->cmp = cmp;
 }
 
-R_API RBinHeap *r_binheap_new(RPVectorComparator cmp) {
+R_API RBinHeap *r_binheap_new(RVectorComparator cmp) {
 	RBinHeap *h = R_NEW (RBinHeap);
-	if (!h) {
-		return NULL;
+	if (h) {
+		h->cmp = cmp;
 	}
-	r_pvector_init (&h->a, NULL);
-	h->cmp = cmp;
 	return h;
 }
 
 R_API void *r_binheap_pop(RBinHeap *h) {
-	void *ret = r_pvector_at (&h->a, 0);
-	h->a.v.len--;
-	_heap_down (h, 0, r_pvector_at (&h->a, h->a.v.len));
+	void *ret = h->a.a[0];
+	h->a.len--;
+	_heap_down (h, 0, h->a.a[h->a.len]);
 	return ret;
 }
 
 R_API bool r_binheap_push(RBinHeap *h, void *x) {
-	if (!r_pvector_push (&h->a, NULL)) {
+	if (!r_vector_push (&h->a, NULL)) {
 		return false;
 	}
-	_heap_up (h, h->a.v.len - 1, x);
+	_heap_up (h, h->a.len - 1, x);
 	return true;
 }

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -16,237 +16,155 @@
 	: vec->capacity + (vec->capacity >> 1))
 
 #define RESIZE_OR_RETURN_NULL(next_capacity) do { \
-		size_t new_capacity = next_capacity; \
-		void **new_a = realloc (vec->a, vec->elem_size * new_capacity); \
+		int new_capacity = next_capacity; \
+		void **new_a = realloc (vec->a, sizeof(void *) * new_capacity); \
 		if (!new_a) { \
 			return NULL; \
 		} \
 		vec->a = new_a; \
 		vec->capacity = new_capacity; \
 	} while (0)
-		
-		
 
-R_API void r_vector_init(RVector *vec, size_t elem_size) {
-	vec->a = NULL;
-	vec->capacity = vec->len = 0;
-	vec->elem_size = elem_size;
-}
-
-R_API RVector *r_vector_new(size_t elem_size) {
-	RVector *vec = R_NEW (RVector);
-	if (!vec) {
-		return NULL;
-	}
-	r_vector_init (vec, elem_size);
-	return vec;
-}
-
-static void vector_free_elems(RVector *vec, RVectorFree elem_free, void *user) {
+R_API void r_vector_clear(RVector *vec, void (*elem_free)(void *)) {
 	if (elem_free) {
 		while (vec->len > 0) {
-			elem_free (r_vector_index_ptr (vec, --vec->len), user);
+			elem_free (vec->a[--vec->len]);
 		}
 	} else {
 		vec->len = 0;
 	}
-}
-
-R_API void r_vector_clear(RVector *vec, RVectorFree elem_free, void *user) {
-	vector_free_elems (vec, elem_free, user);
 	R_FREE (vec->a);
 	vec->capacity = 0;
 }
 
-R_API void r_vector_free(RVector *vec, RVectorFree elem_free, void *user) {
-	vector_free_elems (vec, elem_free, user);
-	free (vec->a);
-	free (vec);
-}
-
-static bool vector_clone(RVector *dst, RVector *src) {
-	dst->capacity = src->capacity;
-	dst->len = src->len;
-	dst->elem_size = src->elem_size;
-	if (!dst->len) {
-		dst->a = NULL;
-	} else {
-		dst->a = malloc (src->elem_size * src->capacity);
-		if (!dst->a) {
-			return false;
-		}
-		memcpy (dst->a, src->a, src->elem_size * src->len);
-	}
-	return true;
-}
-
 R_API RVector *r_vector_clone(RVector *vec) {
 	RVector *ret = R_NEW (RVector);
-	if (!ret) {
-		return NULL;
-	}
-	if (!vector_clone (ret, vec)) {
-		free (ret);
-		return NULL;
+	if (ret) {
+		ret->capacity = vec->capacity;
+		ret->len = vec->len;
+		if (!vec->len) {
+			ret->a = NULL;
+		} else {
+			ret->a = malloc (sizeof (void *) * vec->len);
+			if (!ret->a) {
+				R_FREE (ret);
+			} else {
+				memcpy (ret->a, vec->a, sizeof (void *) * vec->len);
+			}
+		}
 	}
 	return ret;
 }
 
-
-
-R_API void *r_vector_index_ptr(RVector *vec, size_t index) {
-	return (char *)vec->a + vec->elem_size * index;
-}
-
-R_API void r_vector_assign(RVector *vec, void *p, void *elem) {
-	memcpy (p, elem, vec->elem_size);
-}
-
-R_API void *r_vector_assign_at(RVector *vec, size_t index, void *elem) {
-	void *p = r_vector_index_ptr (vec, index);
-	r_vector_assign (vec, p, elem);
-	return p;
-}
-
-R_API void r_vector_remove_at(RVector *vec, size_t index, void *into) {
-	void *p = r_vector_index_ptr (vec, index);
-	if (into) {
-		r_vector_assign (vec, into, p);
+R_API void **r_vector_contains(RVector *vec, void *x) {
+	int i;
+	for (i = 0; i < vec->len; i++) {
+		if (vec->a[i] == x) {
+			return &vec->a[i];
+		}
 	}
+	return NULL;
+}
+
+R_API void *r_vector_delete_at(RVector *vec, int n) {
+	void *ret = vec->a[n];
 	vec->len--;
-	if (index < vec->len) {
-		memmove (p, (char *)p + vec->elem_size, vec->elem_size * (vec->len - index));
+	for (; n < vec->len; n++) {
+		vec->a[n] = vec->a[n+1];
 	}
+	return ret;
 }
 
+R_API bool r_vector_empty(RVector *vec) {
+	return vec->len == 0;
+}
 
+R_API void r_vector_free(RVector *vec, RVectorFree elem_free) {
+	if (elem_free) {
+		while (vec->len > 0) {
+			elem_free (vec->a[--vec->len]);
+		}
+	} else {
+		vec->len = 0;
+	}
+	free (vec->a);
+	free (vec);
+}
 
-R_API void *r_vector_insert(RVector *vec, size_t index, void *x) {
+R_API void r_vector_init(RVector *vec) {
+	vec->a = NULL;
+	vec->capacity = vec->len = 0;
+}
+
+R_API void **r_vector_insert(RVector *vec, int n, void *x) {
 	if (vec->len >= vec->capacity) {
 		RESIZE_OR_RETURN_NULL (NEXT_VECTOR_CAPACITY);
 	}
-	void *p = r_vector_index_ptr (vec, index);
-	if (index < vec->len) {
-		memmove ((char *)p + vec->elem_size, p, vec->elem_size * (vec->len - index));
+	int i;
+	for (i = vec->len++; i > n; i--) {
+		vec->a[i] = vec->a[i-1];
 	}
-	vec->len++;
-	r_vector_assign (vec, p, x);
-	return p;
+	vec->a[n] = x;
+	return &vec->a[n];
 }
 
-R_API void *r_vector_insert_range(RVector *vec, size_t index, void *first, size_t count) {
-	if (vec->len + count > vec->capacity) {
-		RESIZE_OR_RETURN_NULL (R_MAX (NEXT_VECTOR_CAPACITY, vec->len + count));
+R_API void **r_vector_insert_range(RVector *vec, int n, void **first, void **last) {
+	if (last - first + vec->len > vec->capacity) {
+		RESIZE_OR_RETURN_NULL (R_MAX (NEXT_VECTOR_CAPACITY, last - first + vec->len));
 	}
-	size_t sz = count * vec->elem_size;
-	void *p = r_vector_index_ptr (vec, index);
-	if (index < vec->len) {
-		memmove ((char *)p + sz, p, vec->elem_size * (vec->len - index));
+	int i;
+	for (i = vec->len; i > n; ) {
+		i--;
+		vec->a[last - first + i] = vec->a[i];
 	}
-	vec->len += count;
-	memcpy (p, first, sz);
-	return p;
+	vec->len += last - first;
+	i = n;
+	while (first != last) {
+		vec->a[i++] = *first++;
+	}
+	return &vec->a[n];
 }
 
-R_API void r_vector_pop(RVector *vec, void *into) {
-	if (into) {
-		r_vector_assign (vec, into, r_vector_index_ptr (vec, vec->len - 1));
-	}
-	vec->len--;
+R_API RVector *r_vector_new(void) {
+	return R_NEW0 (RVector);
 }
 
-R_API void r_vector_pop_front(RVector *vec, void *into) {
-	return r_vector_remove_at (vec, 0, into);
+R_API void *r_vector_pop(RVector *vec) {
+	return vec->a[--vec->len];
 }
 
-R_API void *r_vector_push(RVector *vec, void *x) {
+R_API void *r_vector_pop_front(RVector *vec) {
+	return r_vector_delete_at (vec, 0);
+}
+
+R_API void **r_vector_push(RVector *vec, void *x) {
 	if (vec->len >= vec->capacity) {
 		RESIZE_OR_RETURN_NULL (NEXT_VECTOR_CAPACITY);
 	}
-	return r_vector_assign_at (vec, vec->len++, x);
+	vec->a[vec->len] = x;
+	return &vec->a[vec->len++];
 }
 
-R_API void *r_vector_push_front(RVector *vec, void *x) {
+R_API void **r_vector_push_front(RVector *vec, void *x) {
 	return r_vector_insert (vec, 0, x);
 }
 
-R_API void *r_vector_reserve(RVector *vec, size_t capacity) {
+R_API void **r_vector_reserve(RVector *vec, int capacity) {
 	if (vec->capacity < capacity) {
 		RESIZE_OR_RETURN_NULL (capacity);
 	}
 	return vec->a;
 }
 
-R_API void *r_vector_shrink(RVector *vec) {
+R_API void **r_vector_shrink(RVector *vec) {
 	if (vec->len < vec->capacity) {
 		RESIZE_OR_RETURN_NULL (vec->len);
 	}
 	return vec->a;
 }
 
-
-
-
-
-static void pvector_free_elem(void *e, void *user) {
-	void *p = *((void **)e);
-	RPVectorFree elem_free = (RPVectorFree)user;
-	elem_free (p);
-}
-
-
-R_API void r_pvector_init(RPVector *vec, RPVectorFree free) {
-	r_vector_init (&vec->v, sizeof (void *));
-	vec->free = free;
-}
-
-R_API RPVector *r_pvector_new(RPVectorFree free) {
-	RPVector *v = R_NEW (RPVector);
-	if (!v) {
-		return NULL;
-	}
-	r_pvector_init (v, free);
-	return v;
-}
-
-R_API void r_pvector_clear(RPVector *vec) {
-	r_vector_clear (&vec->v, vec->free ? pvector_free_elem : NULL, vec->free);
-}
-
-R_API void r_pvector_free(RPVector *vec) {
-	r_vector_free (&vec->v, vec->free ? pvector_free_elem : NULL, vec->free);
-}
-
-R_API void **r_pvector_contains(RPVector *vec, void *x) {
-	size_t i;
-	for (i = 0; i < vec->v.len; i++) {
-		if (((void **)vec->v.a)[i] == x) {
-			return &((void **)vec->v.a)[i];
-		}
-	}
-	return NULL;
-}
-
-R_API void *r_pvector_remove_at(RPVector *vec, size_t index) {
-	void *r = r_pvector_at (vec, index);
-	r_vector_remove_at (&vec->v, index, NULL);
-	return r;
-}
-
-R_API void *r_pvector_pop(RPVector *vec) {
-	void *r = r_pvector_at (vec, vec->v.len - 1);
-	r_vector_pop (&vec->v, NULL);
-	return r;
-}
-
-R_API void *r_pvector_pop_front(RPVector *vec) {
-	void *r = r_pvector_at (vec, 0);
-	r_vector_pop_front (&vec->v, NULL);
-	return r;
-}
-
 // CLRS Quicksort. It is slow, but simple.
-static void quick_sort(void **a, size_t n, RPVectorComparator cmp) {
+static void quick_sort(void **a, int n, RVectorComparator cmp) {
 	if (n <= 1) return;
 	int i = rand() % n, j = 0;
 	void *t, *pivot = a[i];
@@ -264,6 +182,103 @@ static void quick_sort(void **a, size_t n, RPVectorComparator cmp) {
 	quick_sort (a + j + 1, n - j - 1, cmp);
 }
 
-R_API void r_pvector_sort(RPVector *vec, RPVectorComparator cmp) {
-	quick_sort (vec->v.a, vec->v.len, cmp);
+R_API void r_vector_sort(RVector *vec, RVectorComparator cmp) {
+	quick_sort (vec->a, vec->len, cmp);
 }
+
+#if TEST
+#include <assert.h>
+#include <stddef.h>
+
+int my_cmp(const void *a, const void *b) {
+	return strcmp (a, b) < 0;
+}
+
+// TODO: move into t/vector.c
+int main () {
+	ptrdiff_t i;
+	void **it;
+	RVector *v = r_vector_new ();
+	assert (*r_vector_push (v, (void *)1337) == (void *)1337);
+	for (i = 0; i < 10; i++) {
+		r_vector_push (v, (void *)i);
+		assert (v->len == i + 2);
+	}
+	assert (r_vector_pop_front (v) == (void *)1337);
+	assert (r_vector_contains (v, (void *)9));
+
+	assert (r_vector_delete_at (v, 9) == (void *)9);
+	assert (!r_vector_contains (v, (void *)9));
+
+	i = 0;
+	r_vector_foreach (v, it) {
+		assert (*it == (void *)i++);
+	}
+
+	r_vector_shrink (v);
+	assert (v->len == 9);
+	RVector *v1 = r_vector_clone (v);
+	r_vector_clear (v, NULL);
+	assert (v->capacity == 0 && v->len == 0);
+	assert (v1->len == 9);
+
+	r_vector_free (v, NULL);
+	r_vector_free (v1, NULL);
+
+	RVector s;
+	r_vector_init (&s);
+	r_vector_reserve (&s, 10);
+	r_vector_clear (&s, NULL);
+
+	r_vector_reserve (&s, 10);
+	r_vector_push (&s, (void *)-1);
+	assert (s.len == 1 && s.capacity == 10);
+	for (i = 0; i < 20; i++) {
+		r_vector_push (&s, (void *)i);
+	}
+	r_vector_reserve (&s, 10);
+	r_vector_clear (&s, NULL);
+
+	{
+		void *a[] = {(void*)0, (void*)2, (void*)4, (void*)6, (void*)8};
+		RVector s = {0};
+		int l;
+		r_vector_insert_range (&s, 0, a + 2, a + 5);
+		r_vector_insert_range (&s, 0, a, a + 2);
+
+#define CMP(x, y) x < y
+		r_vector_lower_bound (&s, (void *)4, l, CMP);
+		assert (s.a[l] == (void *)4);
+		r_vector_lower_bound (&s, (void *)5, l, CMP);
+		assert (s.a[l] == (void *)6);
+		r_vector_lower_bound (&s, (void *)6, l, CMP);
+		assert (s.a[l] == (void *)6);
+		r_vector_lower_bound (&s, (void *)9, l, CMP);
+		assert (l == s.len);
+
+		r_vector_upper_bound (&s, (void *)4, l, CMP);
+		assert (s.a[l] == (void *)6);
+		r_vector_upper_bound (&s, (void *)5, l, CMP);
+		assert (s.a[l] == (void *)6);
+		r_vector_upper_bound (&s, (void *)6, l, CMP);
+		assert (s.a[l] == (void *)8);
+#undef CMP
+
+		r_vector_clear (&s, NULL);
+
+		r_vector_push (&s, strdup ("Charmander"));
+		r_vector_push (&s, strdup ("Squirtle"));
+		r_vector_push (&s, strdup ("Bulbasaur"));
+		r_vector_push (&s, strdup ("Meowth"));
+		r_vector_push (&s, strdup ("Caterpie"));
+		r_vector_sort (&s, my_cmp);
+
+		r_vector_lower_bound (&s, "Meow", l, strcmp);
+		assert (!strcmp (s.a[l], "Meowth"));
+
+		r_vector_clear (&s, free);
+	}
+
+	return 0;
+}
+#endif


### PR DESCRIPTION
This reverts commit 72fd9773844d416197ec0fa99df5fbf338a2e749.

Revert "Fix void * arithmetic in vector.c"

This reverts commit cb3ac67ca2e45ddc7177afcb9f1bf8039eed369b.

Revert "Document r_vector"

This reverts commit 4028065542b25008af24fea0b9063ab112bd466d.

Revert "Remove r_pvector_clone() bc it's dangerous and currently unused"

This reverts commit 3c1bd9937abdddf1ed70087f324ba81d481d71b8.

Revert "Fix pvector usage in r_core_get_boundaries_prot"

This reverts commit 8beae0bb91116f8f69fea3afbb5488f6073b19ab.

Revert "Add RPVector struct"

This reverts commit 7577c674ef8049ad9336148d4c063001b78bc187.

Revert "Fix r_vector_clone"

This reverts commit de90215650b9a4c0a9de9750b8b5cf51b17e146a.

Revert "Move vector ptr/assign functions to header, Fix r_vector_insert"

This reverts commit 95cb69cf28673d3d39bb0cf714107db78d58dbf2.

Revert "Fix pvector usage in _map_skyline_push"

This reverts commit 182ab836ef0c147fb8a70c6d59b88f323f0fe7cc.

Revert "Fix r_vector_push"

This reverts commit 0965f2ef133ce598ac3f93c071b55173145e0d4e.

Revert "Move vector tests to r2r, Fix r_pvector_upper_bound name"

This reverts commit ac9fff3c03bced4c546dca71000b955762d15c27.

Revert "Implement flat RVector and pvector"

This reverts commit d5c1fcfd74a1de542ce842fd5b3e54139296278e.