### PR TITLE
Fix: color ascii escapes in json output

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -479,7 +479,7 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 			if (!d->subtype) {  /* temporary legacy workaround */
 				esc_bslash = false;
 			}
-			str = r_str_escape_latin1 (d->str, false, esc_bslash);
+			str = r_str_escape_latin1 (d->str, false, esc_bslash, false);
 		}
 	} else {
 		str = r_str_escape (d->str);

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -629,7 +629,7 @@ static int cmd_meta_others(RCore *core, const char *input) {
 			case 0:  /* temporary legacy workaround */
 				esc_bslash = false;
 			default:
-				esc_str = r_str_escape_latin1 (mi.str, false, esc_bslash);
+				esc_str = r_str_escape_latin1 (mi.str, false, esc_bslash, false);
 			}
 			if (esc_str) {
 				r_cons_printf ("\"%s\"\n", esc_str);

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -133,7 +133,7 @@ R_API int r_str_re_replace(const char *str, const char *reg, const char *sub);
 R_API int r_str_unescape(char *buf);
 R_API char *r_str_escape(const char *buf);
 R_API char *r_str_escape_dot(const char *buf);
-R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot, bool esc_bslash);
+R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot, bool esc_bslash, bool colors);
 R_API char *r_str_escape_utf8(const char *buf, bool show_asciidot, bool esc_bslash);
 R_API char *r_str_escape_utf16le(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash);
 R_API char *r_str_escape_utf32le(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash);


### PR DESCRIPTION
Color in comments created some problems in cutter:

![photo_2018-08-02_12-25-23](https://user-images.githubusercontent.com/3428362/43583281-545b45bc-965f-11e8-93b4-59a3f8091eab.jpg)

Reported by @fcasal (thanks!)

This does not fix _100%_ of the cases, but _99%_ of them. (e.g. some ascii escapes will still be seen if a user sets a special vartype comment with `Ct` containing UTF8 chars in it, but that's pretty rare, and required more major changes, if needed I'll do it in another pr)