### PR TITLE
Vim-like autocompletion in visual offset prompt

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -511,7 +511,7 @@ R_API void r_cons_fill_line() {
 R_API void r_cons_clear_line(int std_err) {
 #if __WINDOWS__
 	if (I.ansicon) {
-		fprintf (std_err? stderr: stdout,"\x1b[0K\r");
+		fprintf (std_err? stderr: stdout,"%s", ANSI_ESC_CLEAR_LINE);
 	} else {
 		char white[1024];
 		memset (&white, ' ', sizeof (white));
@@ -525,7 +525,7 @@ R_API void r_cons_clear_line(int std_err) {
 		fprintf (std_err? stderr: stdout, "\r%s\r", white);
 	}
 #else
-	fprintf (std_err? stderr: stdout,"\x1b[0K\r");
+	fprintf (std_err? stderr: stdout,"%s", ANSI_ESC_CLEAR_LINE);
 #endif
 	fflush (std_err? stderr: stdout);
 }

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -511,7 +511,7 @@ R_API void r_cons_fill_line() {
 R_API void r_cons_clear_line(int std_err) {
 #if __WINDOWS__
 	if (I.ansicon) {
-		fprintf (std_err? stderr: stdout,"%s", ANSI_ESC_CLEAR_LINE);
+		fprintf (std_err? stderr: stdout,"%s", R_CONS_CLEAR_LINE);
 	} else {
 		char white[1024];
 		memset (&white, ' ', sizeof (white));
@@ -525,7 +525,7 @@ R_API void r_cons_clear_line(int std_err) {
 		fprintf (std_err? stderr: stdout, "\r%s\r", white);
 	}
 #else
-	fprintf (std_err? stderr: stdout,"%s", ANSI_ESC_CLEAR_LINE);
+	fprintf (std_err? stderr: stdout,"%s", R_CONS_CLEAR_LINE);
 #endif
 	fflush (std_err? stderr: stdout);
 }

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -452,8 +452,8 @@ static void draw_selection_widget() {
 	}
 	sel_widget->w = R_MIN (sel_widget->w, R_SELWIDGET_MAXW);
 
-	char *background_color = cons->color ? Color_BGBLACK : Color_INVERT; // XXX colors from palette
-	char *selected_color = cons->color ? Color_BGRED : Color_INVERT_RESET; // XXX colors from palette
+	char *background_color = cons->color ? cons->pal.widget_bg : Color_INVERT;
+	char *selected_color = cons->color ? cons->pal.widget_sel : Color_INVERT_RESET;
 	bool scrollbar = sel_widget->options_len > R_SELWIDGET_MAXH;
 	int scrollbar_y = 0, scrollbar_l = 0;
 	if (scrollbar) {
@@ -468,8 +468,10 @@ static void draw_selection_widget() {
 		r_cons_printf ("%s", sel_widget->selection == y + scroll ? selected_color : background_color);
 		r_cons_printf ("%-*.*s", sel_widget->w, sel_widget->w, option);
 		if (scrollbar) {
-			r_cons_printf ("%s", background_color);
+			r_cons_strcat (background_color);
 			r_cons_printf ("%s", R_BETWEEN (scrollbar_y, y, scrollbar_y + scrollbar_l) ? SELWIDGET_SCROLLCHAR : " ");
+		} else {
+			r_cons_memcat (" ", 1);
 		}
 	}
 
@@ -527,7 +529,7 @@ static void selection_widget_select() {
 }
 
 static void selection_widget_update() {
-	if (I.completion.argc == 0 || I.buffer.length == 0 || 
+	if (I.completion.argc == 0 ||
 		(I.completion.argc == 1 && I.buffer.length >= strlen (I.completion.argv[0]))) {
 		selection_widget_erase ();
 		return;
@@ -640,7 +642,7 @@ R_API void r_line_autocomplete() {
 		}
 	}
 
-	if (I.offset_prompt) {
+	if (I.offset_prompt || I.file_prompt) {
 		selection_widget_update ();
 		if (I.sel_widget) {
 			I.sel_widget->complete_common = false;

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -452,8 +452,8 @@ static void draw_selection_widget() {
 	}
 	sel_widget->w = R_MIN (sel_widget->w, R_SELWIDGET_MAXW);
 
-	char *background_color = cons->color ? cons->pal.widget_bg : Color_INVERT;
-	char *selected_color = cons->color ? cons->pal.widget_sel : Color_INVERT_RESET;
+	char *background_color = cons->color ? cons->pal.widget_bg : Color_INVERT_RESET;
+	char *selected_color = cons->color ? cons->pal.widget_sel : Color_INVERT;
 	bool scrollbar = sel_widget->options_len > R_SELWIDGET_MAXH;
 	int scrollbar_y = 0, scrollbar_l = 0;
 	if (scrollbar) {
@@ -467,9 +467,8 @@ static void draw_selection_widget() {
 		char *option = y < sel_widget->options_len ? sel_widget->options[y + scroll] : "";
 		r_cons_printf ("%s", sel_widget->selection == y + scroll ? selected_color : background_color);
 		r_cons_printf ("%-*.*s", sel_widget->w, sel_widget->w, option);
-		if (scrollbar) {
-			r_cons_strcat (background_color);
-			r_cons_printf ("%s", R_BETWEEN (scrollbar_y, y, scrollbar_y + scrollbar_l) ? SELWIDGET_SCROLLCHAR : " ");
+		if (scrollbar && R_BETWEEN (scrollbar_y, y, scrollbar_y + scrollbar_l)) {
+			r_cons_memcat (Color_INVERT" "Color_INVERT_RESET, 10);
 		} else {
 			r_cons_memcat (" ", 1);
 		}
@@ -508,7 +507,7 @@ static void selection_widget_erase() {
 		sel_widget->options_len = 0;
 		sel_widget->selection = -1;
 		draw_selection_widget ();
-		R_FREE(I.sel_widget);
+		R_FREE (I.sel_widget);
 		RCons *cons = r_cons_singleton ();
 		if (cons->event_resize && cons->event_data) {
 			cons->event_resize (cons->event_data);

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -495,7 +495,7 @@ static void selection_widget_down () {
 	}
 }
 
-static void print_rline_task () {
+static void print_rline_task (void *core) {
 	r_cons_clear_line (0);
 	r_cons_printf ("%s%s%s", Color_RESET, I.prompt,  I.buffer.data); 
 	r_cons_flush ();
@@ -511,7 +511,7 @@ static void selection_widget_erase () {
 		RCons *cons = r_cons_singleton ();
 		if (cons->event_resize && cons->event_data) {
 			cons->event_resize (cons->event_data);
-			r_core_task_enqueue_oneshot (cons->event_data, print_rline_task, NULL);
+			cons->cb_task_oneshot (cons->user, print_rline_task, NULL);
 		}
 	}
 }

--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -50,6 +50,8 @@ static struct {
 	{ "func_var", r_offsetof (RConsPrintablePalette, func_var), r_offsetof (RConsPalette, func_var) },
 	{ "func_var_type", r_offsetof (RConsPrintablePalette, func_var_type), r_offsetof (RConsPalette, func_var_type) },
 	{ "func_var_addr", r_offsetof (RConsPrintablePalette, func_var_addr), r_offsetof (RConsPalette, func_var_addr) },
+	{ "widget_bg", r_offsetof (RConsPrintablePalette, widget_bg), r_offsetof (RConsPalette, widget_bg) },
+	{ "widget_sel", r_offsetof (RConsPrintablePalette, widget_sel), r_offsetof (RConsPalette, widget_sel) },
 
 	{ "ai.read", r_offsetof (RConsPrintablePalette, ai_read), r_offsetof (RConsPalette, ai_read) },
 	{ "ai.write", r_offsetof (RConsPrintablePalette, ai_write), r_offsetof (RConsPalette, ai_write) },
@@ -172,6 +174,9 @@ R_API void r_cons_pal_init() {
 	cons->cpal.func_var           = (RColor) RColor_WHITE;
 	cons->cpal.func_var_type      = (RColor) RColor_BLUE;
 	cons->cpal.func_var_addr      = (RColor) RColor_CYAN;
+
+	cons->cpal.widget_bg          = (RColor) RCOLOR (ALPHA_BG, 0x30, 0x30, 0x30, 0x00, 0x00, 0x00);
+	cons->cpal.widget_sel         = (RColor) RColor_BGRED;
 
 	cons->cpal.graph_box          = (RColor) RColor_NULL;
 	cons->cpal.graph_box2         = (RColor) RColor_BLUE;

--- a/libr/cons/rgb.c
+++ b/libr/cons/rgb.c
@@ -204,12 +204,18 @@ static void r_cons_rgb_gen(char *outstr, size_t sz, ut8 attr, ut8 a, ut8 r, ut8 
 	case COLOR_MODE_16: // ansi 16 colors
 		{
 		fgbg -= 8;
-		ut8 k = (r + g + b) / 3;
-		r = (r >= k) ? 1 : 0;
-		g = (g >= k) ? 1 : 0;
-		b = (b >= k) ? 1 : 0;
-		k = (r ? 1 : 0) + (g ? (b ? 6 : 2) : (b ? 4 : 0));
-		written = snprintf (outstr + i, sz - i, "%dm", fgbg + k);
+		if (r == g && g == b) {
+			r = (r > 0x7f) ? 1 : 0;
+			g = (g > 0x7f) ? 1 : 0;
+			b = (b > 0x7f) ? 1 : 0;
+		} else {
+			ut8 k = (r + g + b) / 3;
+			r = (r >= k) ? 1 : 0;
+			g = (g >= k) ? 1 : 0;
+			b = (b >= k) ? 1 : 0;
+		}
+		ut8 c = (r ? 1 : 0) + (g ? (b ? 6 : 2) : (b ? 4 : 0));
+		written = snprintf (outstr + i, sz - i, "%dm", fgbg + c);
 		}
 		break;
 	}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2222,6 +2222,7 @@ R_API void r_core_bind_cons(RCore *core) {
 	core->cons->cb_break = (RConsBreakCallback)r_core_break;
 	core->cons->cb_sleep_begin = (RConsSleepBeginCallback)r_core_sleep_begin;
 	core->cons->cb_sleep_end = (RConsSleepEndCallback)r_core_sleep_end;
+	core->cons->cb_task_oneshot = (RConsQueueTaskOneshot) r_core_task_enqueue_oneshot;
 	core->cons->user = (void*)core;
 }
 

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1407,6 +1407,8 @@ static int autocomplete(RLine *line) {
 				ADDARG("func_var")
 				ADDARG("func_var_type")
 				ADDARG("func_var_addr")
+				ADDARG("widget_bg")
+				ADDARG("widget_sel")
 				ADDARG("ai.read")
 				ADDARG("ai.write")
 				ADDARG("ai.exec")

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -3649,11 +3649,10 @@ static void goto_asmqjmps(RAGraph *g, RCore *core) {
 
 	r_cons_get_size (&rows);
 	r_cons_gotoxy (0, rows);
+	r_cons_clear_line (0);
 	r_cons_printf (Color_RESET);
 	r_cons_printf (h);
 	r_cons_flush ();
-	r_cons_clear_line (0);
-	r_cons_gotoxy (strlen (h) + 1, rows);
 
 	do {
 		char ch = r_cons_readchar ();

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -210,6 +210,8 @@ typedef struct r_cons_palette_t {
 	RColor func_var;
 	RColor func_var_type;
 	RColor func_var_addr;
+	RColor widget_bg;
+	RColor widget_sel;
 
 	/* Graph colors */
 	RColor graph_box;
@@ -278,6 +280,8 @@ typedef struct r_cons_printable_palette_t {
 	char *func_var;
 	char *func_var_type;
 	char *func_var_addr;
+	char *widget_bg;
+	char *widget_sel;
 
 	/* graph colors */
 	char *graph_box;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -377,6 +377,7 @@ typedef int (*RConsClickCallback)(void *core, int x, int y);
 typedef void (*RConsBreakCallback)(void *core);
 typedef void *(*RConsSleepBeginCallback)(void *core);
 typedef void (*RConsSleepEndCallback)(void *core, void *user);
+typedef void (*RConsQueueTaskOneshot)(void *core, void *task, void *user);
 
 typedef struct r_cons_context_t {
 	RConsGrep grep;
@@ -420,6 +421,7 @@ typedef struct r_cons_t {
 	RConsSleepBeginCallback cb_sleep_begin;
 	RConsSleepEndCallback cb_sleep_end;
 	RConsClickCallback cb_click;
+	RConsQueueTaskOneshot cb_task_oneshot;
 
 	void *user; // Used by <RCore*>
 #if __UNIX__ || __CYGWIN__ && !defined(MINGW32)

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -487,6 +487,8 @@ typedef struct r_cons_t {
 
 #define R_CONS_KEY_ESC 0x1b
 
+#define ANSI_ESC_CLEAR_LINE "\r\x1b[0K\r"
+
 #define Color_BLINK        "\x1b[5m"
 #define Color_INVERT       "\x1b[7m"
 #define Color_INVERT_RESET "\x1b[27m"
@@ -795,6 +797,18 @@ R_API const char* r_cons_get_rune(const ut8 ch);
 
 #define R_EDGES_X_INC 4
 
+#define R_SELWIDGET_MAXH 15
+#define R_SELWIDGET_MAXW 30
+
+typedef struct r_selection_widget_t {
+	char **options;
+	int options_len;
+	int selection;
+	int w, h;
+	int scroll;
+	bool complete_common;
+} RSelWidget;
+
 typedef struct r_line_hist_t {
 	char **data;
 	int size;
@@ -827,6 +841,7 @@ struct r_line_t {
 	RLineCompletion completion;
 	RLineBuffer buffer;
 	RLineHistory history;
+	RSelWidget *sel_widget;
 	/* callbacks */
 	RLineHistoryUpCb cb_history_up;
 	RLineHistoryDownCb cb_history_down;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -493,7 +493,7 @@ typedef struct r_cons_t {
 
 #define R_CONS_KEY_ESC 0x1b
 
-#define ANSI_ESC_CLEAR_LINE "\r\x1b[0K\r"
+#define R_CONS_CLEAR_LINE "\x1b[2K\r"
 
 #define Color_BLINK        "\x1b[5m"
 #define Color_INVERT       "\x1b[7m"
@@ -805,8 +805,6 @@ R_API const char* r_cons_get_rune(const ut8 ch);
 
 #define R_SELWIDGET_MAXH 15
 #define R_SELWIDGET_MAXW 30
-
-#define SELWIDGET_SCROLLCHAR "█"
 
 typedef struct r_selection_widget_t {
 	char **options;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -802,6 +802,8 @@ R_API const char* r_cons_get_rune(const ut8 ch);
 #define R_SELWIDGET_MAXH 15
 #define R_SELWIDGET_MAXW 30
 
+#define SELWIDGET_SCROLLCHAR "█"
+
 typedef struct r_selection_widget_t {
 	char **options;
 	int options_len;


### PR DESCRIPTION
This is my attempt to address issue #8476

It is still a proof of concept, since for now it only works in visual offset prompt. But it works everywhere you can call the offset prompt (in visual mode, in panels mode, and in graph mode).

The idea is to make it as general as possible, so it can also be used elsewhere. 

The major change here is not only in the visual representation of autocompletion, but also the fact that this offers autocompletion as-you-type.

Here's a gif of how it looks:
![selection_widget3](https://user-images.githubusercontent.com/3428362/43653088-541d5142-9747-11e8-9a23-1ea5e44742f0.gif)


The keybindings are more or less equal to vim's: up/down arrow keys or Ctrl-n/Ctrl-p to move selection, Enter to select item. Tab to invoke the autocompletion window 

**Feedbacks and code reviews are more than welcome!** I tried to make the code as clean as possible and tried my best to avoid overly hackish things. But I believe it can still be improved.

I'll also move all those functions in a separate file (for now they're just all crammed in dietline.c)