### PR TITLE
Fix #10895 - tcc infinite loop

### DIFF
--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -792,7 +792,7 @@ static int cmd_type(void *data, const char *input) {
 			// TODO #7967 help refactor: move to detail
 			r_core_cmd_help (core, help_msg_td);
 			r_cons_printf ("Note: The td command should be put between double quotes\n"
-				"Example: \" td struct foo {int bar;int cow};\""
+				"Example: \"td struct foo {int bar;int cow;};\""
 				"\nt");
 
 		} else if (input[1] == ' ') {

--- a/libr/parse/code.c
+++ b/libr/parse/code.c
@@ -93,7 +93,10 @@ R_API char *r_parse_c_string(RAnal *anal, const char *code) {
 	if (!T) return NULL;
 	tcc_set_callback (T, &appendstring, &str);
 	sdb_foreach (anal->sdb_types, typeload, NULL);
-	tcc_compile_string (T, code);
+	if (tcc_compile_string (T, code) != 0) {
+		free (str);
+		str = NULL;
+	}
 	tcc_delete (T);
 	return str;
 }

--- a/shlr/tcc/tcc.h
+++ b/shlr/tcc/tcc.h
@@ -846,6 +846,11 @@ ST_DATA int tcc_ext;
 /* XXX: get rid of this ASAP */
 ST_DATA struct TCCState *tcc_state;
 
+static inline int tcc_nerr() {
+	return tcc_state->nb_errors;
+}
+
+
 #ifdef MEM_DEBUG
 ST_DATA int mem_cur_size;
 ST_DATA int mem_max_size;


### PR DESCRIPTION
I dived into ./shlr/tcc sources and now I believe that removing of *longjmp* (in this commit https://github.com/radare/radare2/commit/a3c9088c79cb21a56c5b79b64d2323fad73879eb) wasn't good idea.
Maybe there is no choice for MSVC support.

This PR fixes #10895 and few other errors, but *longjmp* absence breaks all error handling for tcc related functions. To fix the errors we need to revise all parser functions and handle ALL errors for *skip*/*expect*/tcc_error more gracefully.

Maybe I overcomplicate things. If you think so, and this commit is good enough plz accept PR.