### PR TITLE
Fix color ascii escapes in json output, again

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -472,7 +472,7 @@ static void ds_comment(RDisasmState *ds, bool align, const char *format, ...) {
 	} else {
 		char buffer[4096];
 		vsnprintf (buffer, sizeof(buffer), format, ap);
-		char *escstr = r_str_escape_latin1 (buffer, false, true, false);
+		char *escstr = r_str_escape_latin1 (buffer, false, true, true);
 		if (escstr) {
 			r_cons_printf ("%s", escstr);
 			free (escstr);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1259,7 +1259,7 @@ R_API char *r_str_escape_dot(const char *buf) {
 }
 
 R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot, bool esc_bslash, bool colors) {
-	return r_str_escape_ (buf, false, false, !colors, show_asciidot, esc_bslash);
+	return r_str_escape_ (buf, false, colors, !colors, show_asciidot, esc_bslash);
 }
 
 static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool show_asciidot, bool esc_bslash) {


### PR DESCRIPTION
So I don't know how I managed to miss it but I didn't push my last commit in the previous pr https://github.com/radare/radare2/pull/10898 and there were still ascii escapes in the json output :(

Also it wasn't working with asm.cmt.right=0, now it is fixed there too