### PR TITLE
A simple detection and auto-renaming of stack canary

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -443,6 +443,18 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 						ret_reg = r_anal_cc_ret (anal, cc);
 						resolved = false;
 					}
+					if (!strcmp (fcn_name, "__stack_chk_fail")) {
+						const char *query = sdb_fmt ("%d.addr", cur_idx - 1);
+						ut64 mov_addr = sdb_num_get (trace, query, 0);
+						RAnalOp *mop = r_core_anal_op (core, mov_addr, R_ANAL_OP_MASK_BASIC);
+						if (mop && mop->var) {
+							ut32 type = mop->type & R_ANAL_OP_TYPE_MASK;
+							if (type == R_ANAL_OP_TYPE_MOV) {
+								var_rename (anal, mop->var, "canary", addr);
+							}
+						}
+						r_anal_op_free (mop);
+					}
 					free (fcn_name);
 				}
 			} else if (!resolved && ret_type && ret_reg) {


### PR DESCRIPTION
Fixes #10925 

```
|           ; var int canary @ rbp-0x8
|           0x0000081a      55             push rbp
|           0x0000081b      4889e5         mov rbp, rsp
|           0x0000081e      4883ec30       sub rsp, 0x30               ; '0'
|           0x00000822      64488b042528.  mov rax, qword fs:[0x28]    ; [0x28:8]=0x1a60 ; '('
|           0x0000082b      488945f8       mov qword [canary], rax
....
|       `-> 0x000008da      90             nop
|           0x000008db      488b45f8       mov rax, qword [canary]
|           0x000008df      644833042528.  xor rax, qword fs:[0x28]
|       ,=< 0x000008e8      7405           je 0x8ef
|       |   0x000008ea      e8e1fdffff     call sym.imp.__stack_chk_fail ; void __stack_chk_fail(void)
|       |   ; CODE XREF from main (0x8e8)
|       `-> 0x000008ef      c9             leave
\           0x000008f0      c3             ret

```

Updated a test in r2r [#1417](https://github.com/radare/radare2-regressions/pull/1417)