### PR TITLE
Move global `tmp` to function-scope

### DIFF
--- a/libr/asm/arch/hexagon/hexagon.c
+++ b/libr/asm/arch/hexagon/hexagon.c
@@ -56,10 +56,9 @@ char* hex_get_cntl_reg(int opreg){
 	}
 }
 
-char tmp[5] = { 0 };
-
 char* hex_get_sys_reg(int opreg)
 {
+	static char tmp[5];
 	switch (opreg) {
 		case HEX_REG_SGP0:
 			return "SGP0";


### PR DESCRIPTION
The name is so common that it can interpose or be interposed by other modules.


224:ut32 constant_extender = 1;

is also bad. Please fix it