### PR TITLE
Fix 10811

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -284,8 +284,8 @@ R_API int r_bp_list(RBreakpoint *bp, int rad) {
 				" %d %c%c%c %s %s %s cmd=\"%s\" cond=\"%s\" " \
 				"name=\"%s\" module=\"%s\"\n",
 				b->addr, b->addr + b->size, b->size,
-				(b->rwx & R_BP_PROT_READ) ? 'r' : '-',
-				(b->rwx & R_BP_PROT_WRITE) ? 'w' : '-',
+				((b->rwx & R_BP_PROT_READ) | (b->rwx & R_BP_PROT_ACCESS)) ? 'r' : '-',
+				((b->rwx & R_BP_PROT_WRITE)| (b->rwx & R_BP_PROT_ACCESS)) ? 'w' : '-',
 				(b->rwx & R_BP_PROT_EXEC) ? 'x' : '-',
 				b->hw ? "hw": "sw",
 				b->trace ? "trace" : "break",

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3405,30 +3405,26 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			int sl = r_str_word_set0 (str);
 			addr = r_num_math (core->num, DB_ARG(0));
 			if (watch) {
-			                if (sl == 2) {
-                                           if (strcmp (DB_ARG(1), "r") == 0){
-                                             rw = R_BP_PROT_READ;
-                                           }
-                                           else{
-                                             if (strcmp (DB_ARG(1), "w") == 0){
-                                               rw = R_BP_PROT_WRITE;
-                                             }
-					     else{
-					       if (strcmp (DB_ARG(1), "rw") == 0){
-						 rw = R_BP_PROT_ACCESS;
-					       }
-					       else{
-						 eprintf ("Usage: dbw <addr> <rw> # Add watchpoint\n");
-						 free (str);
-						 break;
-					       }
-					     }
-					   }
-					} else {
-						eprintf ("Usage: dbw <addr> <rw> # Add watchpoint\n");
+				if (sl == 2) {
+					if (strcmp (DB_ARG(1), "r") == 0){
+						rw = R_BP_PROT_READ;
+					}
+					else if (strcmp (DB_ARG(1), "w") == 0){
+						rw = R_BP_PROT_WRITE;
+					}
+					else if (strcmp (DB_ARG(1), "rw") == 0){
+						rw = R_BP_PROT_ACCESS;
+					}
+					else{
+						eprintf ("Usage: dbw <addr> <r/w/rw> # Add watchpoint\n");
 						free (str);
 						break;
 					}
+				} else {
+					eprintf ("Usage: dbw <addr> <r/w/rw> # Add watchpoint\n");
+					free (str);
+					break;
+				}
 			}
 			if (validAddress (core, addr)) {
 				bpi = r_debug_bp_add (core->dbg, addr, hwbp, watch, rw, NULL, 0);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -96,6 +96,11 @@ static const char *help_msg_dbt[] = {
 	NULL
 };
 
+static const char *help_msg_dbw[] = {
+	"Usage: dbw", "<addr> <r/w/rw>"," # Add watchpoint",
+	NULL
+};
+
 static const char *help_msg_dc[] = {
 	"Usage: dc", "", "Execution continuation commands",
 	"dc", "", "Continue execution of all children",
@@ -3406,22 +3411,22 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			addr = r_num_math (core->num, DB_ARG(0));
 			if (watch) {
 				if (sl == 2) {
-					if (strcmp (DB_ARG(1), "r") == 0){
+					if (!strcmp (DB_ARG(1), "r")){
 						rw = R_BP_PROT_READ;
 					}
-					else if (strcmp (DB_ARG(1), "w") == 0){
+					else if (!strcmp (DB_ARG(1), "w")){
 						rw = R_BP_PROT_WRITE;
 					}
-					else if (strcmp (DB_ARG(1), "rw") == 0){
+					else if (!strcmp (DB_ARG(1), "rw")){
 						rw = R_BP_PROT_ACCESS;
 					}
 					else{
-						eprintf ("Usage: dbw <addr> <r/w/rw> # Add watchpoint\n");
+						r_core_cmd_help (core, help_msg_dbw);
 						free (str);
 						break;
 					}
 				} else {
-					eprintf ("Usage: dbw <addr> <r/w/rw> # Add watchpoint\n");
+					r_core_cmd_help (core, help_msg_dbw);
 					free (str);
 					break;
 				}

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -976,17 +976,43 @@ static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set
 	if (!b) {
 		return false;
 	}
-
 	bpsize = b->size;
-	// TODO handle rwx and conditions
-	if (set)
-		ret = b->hw?
-			gdbr_set_hwbp (desc, b->addr, "", bpsize):
-			gdbr_set_bp (desc, b->addr, "", bpsize);
-	else
-		ret = b->hw?
-			gdbr_remove_hwbp (desc, b->addr, bpsize):
-			gdbr_remove_bp (desc, b->addr, bpsize);
+        // TODO handle conditions
+	switch (b->rwx){
+	case R_BP_PROT_EXEC : {
+		if (set)
+			ret = b->hw?
+					gdbr_set_hwbp (desc, b->addr, "", bpsize):
+					gdbr_set_bp (desc, b->addr, "", bpsize);
+		else
+			ret = b->hw?
+					gdbr_remove_hwbp (desc, b->addr, bpsize):
+					gdbr_remove_bp (desc, b->addr, bpsize);
+		break;
+	}
+	// TODO handle size (area of watch in upper layer and then bpsize. For the moment watches are set on exact on byte
+	case R_BP_PROT_WRITE : {
+		if (set)
+			gdbr_set_hww (desc, b->addr, "", 1);
+		else
+			gdbr_remove_hwbp (desc, b->addr, 1);
+		break;
+	}
+	case R_BP_PROT_READ : {
+		if (set)
+			gdbr_set_hwr (desc, b->addr, "", 1);
+		else
+			gdbr_remove_hwr (desc, b->addr, 1);
+		break;
+	}
+	case R_BP_PROT_ACCESS : {
+		if (set)
+			gdbr_set_hwa (desc, b->addr, "", 1);
+		else
+			gdbr_remove_hwa (desc, b->addr, 1);            
+		break;
+	}
+	}
 	return !ret;
 }
 

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -62,8 +62,7 @@ typedef struct r_bp_item_t {
 	char *expr; /* to be used for named breakpoints (see r_debug_bp_update) */
 } RBreakpointItem;
 
-struct r_bp_t;
-typedef int (*RBreakpointCallback)(struct r_bp_t *bp, RBreakpointItem *b, bool set);
+typedef int (*RBreakpointCallback)(void *bp, RBreakpointItem *b, bool set);
 
 typedef struct r_bp_t {
 	void *user;
@@ -89,6 +88,7 @@ enum {
 	R_BP_PROT_EXEC = 1,
 	R_BP_PROT_WRITE = 2,
 	R_BP_PROT_READ = 4,
+	R_BP_PROT_ACCESS = 8,
 };
 
 typedef struct r_bp_trace_t {

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -101,9 +101,14 @@ int test_command(libgdbr_t *g, const char *command);
  */
 int gdbr_set_bp(libgdbr_t *g, ut64 address, const char *conditions, int sizebp);
 int gdbr_set_hwbp(libgdbr_t *g, ut64 address, const char *conditions, int sizebp);
+int gdbr_set_hww(libgdbr_t *g, ut64 address, const char *conditions, int sizebp);
+int gdbr_set_hwr(libgdbr_t *g, ut64 address, const char *conditions, int sizebp);
+int gdbr_set_hwa(libgdbr_t *g, ut64 address, const char *conditions, int sizebp);
 int gdbr_remove_bp(libgdbr_t *g, ut64 address, int sizebp);
 int gdbr_remove_hwbp(libgdbr_t *g, ut64 address, int sizebp);
-
+int gdbr_remove_hww(libgdbr_t *g, ut64 address, int sizebp);
+int gdbr_remove_hwr(libgdbr_t *g, ut64 address, int sizebp);
+int gdbr_remove_hwa(libgdbr_t *g, ut64 address, int sizebp);
 /*!
  * File read from remote target (only one file open at a time for now)
  */

--- a/shlr/gdb/include/gdbclient/core.h
+++ b/shlr/gdb/include/gdbclient/core.h
@@ -28,11 +28,17 @@
 #define CMD_RBP				"z0"
 #define CMD_HBP				"Z1"
 #define CMD_RHBP			"z1"
+#define CMD_HWW				"Z2"
+#define CMD_RHWW			"z2"
+#define CMD_HWR				"Z3"
+#define CMD_RHWR			"z3"
+#define CMD_HWA				"Z4"
+#define CMD_RHWA			"z4"
 #define CMD_QRCMD			"qRcmd,"
-#define CMD_C					"vCont"
-#define CMD_C_CONT		"c"
+#define CMD_C				"vCont"
+#define CMD_C_CONT			"c"
 #define CMD_C_CONT_SIG		"C"
-#define CMD_C_STEP		"s"
+#define CMD_C_STEP			"s"
 
 enum Breakpoint {
 	BREAKPOINT,

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -981,10 +981,16 @@ int set_bp(libgdbr_t *g, ut64 address, const char *conditions, enum Breakpoint t
 			"%s,%"PFMT64x ",%d", CMD_HBP, address, sizebp);
 		break;
 	case WRITE_WATCHPOINT:
+		ret = snprintf (tmp, sizeof (tmp) - 1,
+			"%s,%"PFMT64x ",%d", CMD_HWW, address, sizebp);
 		break;
 	case READ_WATCHPOINT:
+		ret = snprintf (tmp, sizeof (tmp) - 1,
+			"%s,%"PFMT64x ",%d", CMD_HWR, address, sizebp);
 		break;
 	case ACCESS_WATCHPOINT:
+		ret = snprintf (tmp, sizeof (tmp) - 1,
+			"%s,%"PFMT64x ",%d", CMD_HWA, address, sizebp);
 		break;
 	default:
 		break;
@@ -1012,6 +1018,18 @@ int gdbr_set_hwbp(libgdbr_t *g, ut64 address, const char *conditions, int sizebp
 	return set_bp (g, address, conditions, HARDWARE_BREAKPOINT, sizebp);
 }
 
+int gdbr_set_hww(libgdbr_t *g, ut64 address, const char *conditions, int sizebp) {
+	return set_bp (g, address, conditions, WRITE_WATCHPOINT, sizebp);
+}
+
+int gdbr_set_hwr(libgdbr_t *g, ut64 address, const char *conditions, int sizebp) {
+	return set_bp (g, address, conditions, READ_WATCHPOINT, sizebp);
+}
+
+int gdbr_set_hwa(libgdbr_t *g, ut64 address, const char *conditions, int sizebp) {
+	return set_bp (g, address, conditions, ACCESS_WATCHPOINT, sizebp);
+}
+
 int gdbr_remove_bp(libgdbr_t *g, ut64 address, int sizebp) {
 	return remove_bp (g, address, BREAKPOINT, sizebp);
 }
@@ -1019,6 +1037,19 @@ int gdbr_remove_bp(libgdbr_t *g, ut64 address, int sizebp) {
 int gdbr_remove_hwbp(libgdbr_t *g, ut64 address, int sizebp) {
 	return remove_bp (g, address, HARDWARE_BREAKPOINT, sizebp);
 }
+
+int gdbr_remove_hww(libgdbr_t *g, ut64 address, int sizebp) {
+	return remove_bp (g, address, WRITE_WATCHPOINT, sizebp);
+}
+
+int gdbr_remove_hwr(libgdbr_t *g, ut64 address, int sizebp) {
+	return remove_bp (g, address, READ_WATCHPOINT, sizebp);
+}
+
+int gdbr_remove_hwa(libgdbr_t *g, ut64 address, int sizebp) {
+	return remove_bp (g, address, ACCESS_WATCHPOINT, sizebp);
+}
+
 
 int remove_bp(libgdbr_t *g, ut64 address, enum Breakpoint type, int sizebp) {
 	char tmp[255] = {0};
@@ -1034,10 +1065,13 @@ int remove_bp(libgdbr_t *g, ut64 address, enum Breakpoint type, int sizebp) {
 		ret = snprintf (tmp, sizeof (tmp) - 1, "%s,%"PFMT64x ",%d", CMD_RHBP, address, sizebp);
 		break;
 	case WRITE_WATCHPOINT:
+		ret = snprintf (tmp, sizeof (tmp) - 1, "%s,%"PFMT64x ",%d", CMD_RHWW, address, sizebp);
 		break;
 	case READ_WATCHPOINT:
+		ret = snprintf (tmp, sizeof (tmp) - 1, "%s,%"PFMT64x ",%d", CMD_RHWR, address, sizebp);
 		break;
 	case ACCESS_WATCHPOINT:
+		ret = snprintf (tmp, sizeof (tmp) - 1, "%s,%"PFMT64x ",%d", CMD_RHWA, address, sizebp);
 		break;
 	default:
 		break;


### PR DESCRIPTION
add support for watches using a debugger connected to gdbclient (formerly they behaved as break on execute instead of a real watch).

Known limitations:
- regression not pass but at least same result as with current master:
[166]  SUCCESS
[1]    FIXED
[13]   BROKEN
[0]    FATAL
[0]    FAILED
[180]  TOTAL

- removing watch on access does not work yet (issues a "z1" instead of "z4" command).
- the area to be watched is set hard to 1 byte within libr/debug/p/debug_gdb.c. Needs to be enhanced to get a user set value. 