### PR TITLE
Fix uleb128 decoding `pf u`

### DIFF
--- a/libr/util/uleb128.c
+++ b/libr/util/uleb128.c
@@ -39,14 +39,12 @@ R_API const ut8 *r_uleb128(const ut8 *data, int datalen, ut64 *v) {
 R_API const ut8 *r_uleb128_decode(const ut8 *data, int *datalen, ut64 *v) {
 	ut8 c = 0xff;
 	ut64 s = 0, sum = 0, l = 0;
-	if (data && *data) {
-		do {
-			c = *(data++) & 0xff;
-			sum |= ((ut32) (c&0x7f) << s);
-			s += 7;
-			l++;
-		} while (c & 0x80);
-	}
+	do {
+		c = *(data++) & 0xff;
+		sum |= ((ut32) (c&0x7f) << s);
+		s += 7;
+		l++;
+	} while (c & 0x80);
 	if (v) *v = sum;
 	if (datalen) *datalen = l;
 	return data;


### PR DESCRIPTION
What it did before:
```
[0x00000000]> pf [3]u
0x00000000 = [ 0, 0, 0 ]
[0x00000000]> pf [3]ub
0x00000000 = [ 0, 0, 0 ]
0x00000000 = 0x00
[0x00000000]> pf uu
0x00000000 = 0
0x00000000 = 0
^D
```

Now:
```
% ni -C debug
ninja: Entering directory `debug'
[3/55] Generating symbol file 'libr...ha/libr_util.so.2.8.0-git.symbols'.
% ~/Dev/Bin/radare2/debug/binr/radare2/radare2 -
[0x00000000]> pf uu
0x00000000 = 0
0x00000001 = 0
[0x00000000]> pf uuub
0x00000000 = 0
0x00000001 = 0
0x00000002 = 0
0x00000003 = 0x00
[0x00000000]> pf [3]ub
0x00000000 = [ 0, 0, 0 ]
0x00000003 = 0x00
[0x00000000]>
```