### PR TITLE
r2pm: install r2pm in bindir instead of $PREFIX/bin

### DIFF
--- a/binr/r2pm/meson.build
+++ b/binr/r2pm/meson.build
@@ -1,1 +1,1 @@
-install_data('r2pm', install_dir: './bin')
+install_data('r2pm', install_dir: get_option('bindir'))


### PR DESCRIPTION
On Exherbo (and probably other distributions) `/usr/x86_64-pc-linux-gnu/bin/` is where binaries are stored, not `/usr/bin/`