### PR TITLE
fix segfault in get_src_regname

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -123,6 +123,9 @@ static void var_retype(RAnal *anal, RAnalVar *var, const char *vname, char *type
 static void get_src_regname(RCore *core, ut64 addr, char *regname, int size) {
 	RAnal *anal = core->anal;
 	RAnalOp *op = r_core_anal_op (core, addr, R_ANAL_OP_MASK_ESIL);
+	if (!op) {
+		return;
+	}
 	char *op_esil = strdup (r_strbuf_get (&op->esil));
 	char *tmp = strchr (op_esil, ',');
 	if (tmp) {


### PR DESCRIPTION
when calling get_src_regname on an invalid or unaligned address, r_core_anal_op returns a null pointer, which must be checked in get_src_regname.