### PR TITLE
Rename and retype arguments as argc and argv in main function

### DIFF
--- a/libr/anal/d/types.sdb.txt
+++ b/libr/anal/d/types.sdb.txt
@@ -157,6 +157,13 @@ func.malloc.args=1
 func.malloc.arg.0=size_t,size
 func.malloc.ret= void *
 
+main=func
+func.main.args=3
+func.main.arg.0=int,argc
+func.main.arg.1=char **,argv
+func.main.arg.2=char **,envp
+func.main.ret=int
+
 xmalloc=func
 func.xmalloc.args=1
 func.xmalloc.arg.0=size_t,size

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1662,7 +1662,10 @@ beach:
 		r_list_join (args, sp_vars);
 		r_list_join (args, regs);
 		r_list_foreach (args, iter, var) {
-			if ((var->kind == 'r') && get_link_var (ds->core->anal, f->addr, var)) {
+			// Avoids printing register based var if it's counter part
+			// local var is present
+			if ((var->kind == 'r') && get_link_var (ds->core->anal, f->addr, var) &&
+					!strncmp (var->name, "arg_", 4)) {
 				continue;
 			}
 			ds_begin_json_line (ds);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1584,12 +1584,19 @@ static void ds_show_functions(RDisasmState *ds) {
 		char spaces[32];
 		RAnalVar *var;
 		RListIter *iter;
+		char *fname = fcn_name;
 		RList *args = r_anal_var_list (core->anal, f, 'b');
 		RList *regs = r_anal_var_list (core->anal, f, 'r');
 		RList *sp_vars = r_anal_var_list (core->anal, f, 's');
 		r_list_sort (args, (RListComparator)var_comparator);
 		r_list_sort (regs, (RListComparator)var_comparator);
 		r_list_sort (sp_vars, (RListComparator)var_comparator);
+		if (fname) {
+			char *p = strchr(fname, '.');
+			if (p) {
+				fname = p + 1;
+			}
+		}
 		if (call) {
 			ds_begin_json_line (ds);
 			r_cons_print (COLOR (ds, color_fline));
@@ -1597,6 +1604,10 @@ static void ds_show_functions(RDisasmState *ds) {
 			r_cons_printf ("%s %s %s%s (",
 				COLOR_RESET (ds), COLOR (ds, color_fname),
 				fcn_name, COLOR_RESET (ds));
+			if (fname && !strcmp (fname, "main")) {
+				r_cons_printf ("int argc, char **argv, char **envp");
+				goto beach;
+			}
 			bool comma = true;
 			bool arg_bp = false;
 			int tmp_len;
@@ -1632,6 +1643,7 @@ static void ds_show_functions(RDisasmState *ds) {
 						var->name, iter->n ? ", " : "");
 				}
 			}
+beach:
 			r_cons_printf (");");
 			ds_newline (ds);
 		}


### PR DESCRIPTION
Fixes #10850 

```
/ (fcn) main 646
|   main (int argc, char **argv, char **envp);
|           ; var int local_8h @ rsp+0x8
|           ; var int local_10h @ rsp+0x10
|           ; var int local_28h @ rsp+0x28
|           ; var int local_30h @ rsp+0x30
|           ; arg int argc @ rdi
|           ; arg char **argv @ rsi
|           ; DATA XREF from entry0 (0x561d)
|           0x00003d40      4157           push r15                    ; [14] -r-x section size 72505 named .text
|           0x00003d42      4156           push r14
|           0x00003d44      4155           push r13
|           0x00003d46      4154           push r12
|           0x00003d48      55             push rbp
|           0x00003d49      53             push rbx
|           0x00003d4a      89fd           mov ebp, edi                ; argc
|           0x00003d4c      4889f3         mov rbx, rsi                ; argv
|           0x00003d4f      4883ec58       sub rsp, 0x58               ; 'X'
|           0x00003d53      488b3e         mov rdi, qword [rsi]        ; const char *s
```