### PR TITLE
Remove extra tabs when there's no offsets

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2474,7 +2474,7 @@ static void ds_print_offset(RDisasmState *ds) {
 					ds->show_offseg, seggrn, ds->show_offdec, delta, label);
 		}
 	}
-	if (ds->atabsoff > 0) {
+	if (ds->atabsoff > 0 && ds->show_offset) {
 		if (ds->_tabsoff != ds->atabsoff) {
 			char *b = ds->_tabsbuf;
 			// TODO optimize to avoid down resizing


### PR DESCRIPTION
There's no logic in keeping `asm.tabs.off` whenever there's no offset (`asm.offset = false`).
This is a little UI fix, will look better on Cutter as well.