### PR TITLE
Quick improvement for graph.offset (mainly for Cutter)

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6140,9 +6140,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			r_core_anal_graph (core, r_num_math (core->num, input + 2), R_CORE_ANAL_JSON);
 			break;
 		case 'J': // "agfJ"
-			if (!o_graph_offset) {
-					r_config_set_i (core->config, "asm.offset", false);
-			}
+			r_config_set_i (core->config, "asm.offset", o_graph_offset);
 			r_core_anal_graph (core, r_num_math (core->num, input + 2),
 				R_CORE_ANAL_JSON | R_CORE_ANAL_JSON_FORMAT_DISASM);
 			r_config_restore (hc);


### PR DESCRIPTION
Make `graph.offset` independent on `asm.offset` in the `agJ` (`agfJ`) command.
If `graph.offset` is set to true or false - show offset in graph regardless of the value in `asm.offset`. This will give the users of Cutter (which uses `agJ`) more flexibility.