### PR TITLE
Improve syscall search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1759,6 +1759,13 @@ static void do_syscall_search(RCore *core, struct search_parameters *param) {
 	r_cons_break_push (NULL, NULL);
 	const char *a0 = r_reg_get_name (core->anal->reg, R_REG_NAME_SN);
 	char *esp = r_str_newf ("%s,=", a0);
+	char *esp32 = NULL;
+	if (core->anal->bits == 64) {
+		const char *reg = r_reg_64_to_32 (core->anal->reg, a0);
+		if (reg) {
+			esp32 = r_str_newf ("%s,=", reg);
+		}
+	}
 	r_list_foreach (list, iter, map) {
 		ut64 from = map->itv.addr;
 		ut64 to = r_itv_end (map->itv);
@@ -1790,16 +1797,18 @@ static void do_syscall_search(RCore *core, struct search_parameters *param) {
 				const char *es = R_STRBUF_SAFEGET (&aop.esil);
 				if (strstr (es, esp)) {
 					syscallNumber = aop.val;
+				} else if (esp32 && strstr (es, esp32)){
+					syscallNumber = aop.val;
 				}
 			}
 			if ((aop.type == R_ANAL_OP_TYPE_SWI) && ret) { // && (aop.val > 10)) {
+#if USE_EMULATION
 				// This for calculating no of bytes to be subtracted , to get n instr above syscall
 				int nbytes = 0;
 				int nb_opcodes = MAXINSTR;
 				SUMARRAY (previnstr, nb_opcodes, nbytes);
 				curpc = at - (nbytes - previnstr[curpos]);
-#if USE_EMULATION
-				// int off = emulateSyscallPrelude (core, at, curpc);
+				int off = emulateSyscallPrelude (core, at, curpc);
 #else
 				int off = syscallNumber;
 #endif
@@ -1840,6 +1849,7 @@ beach:
 	r_anal_esil_free (esil);
 	r_cons_break_pop ();
 	free (buf);
+	free (esp32);
 	free (esp);
 }
 

--- a/libr/include/r_reg.h
+++ b/libr/include/r_reg.h
@@ -145,6 +145,7 @@ R_API RRegSet *r_reg_regset_get(RReg *r, int type);
 R_API ut64 r_reg_getv(RReg *reg, const char *name);
 R_API ut64 r_reg_setv(RReg *reg, const char *name, ut64 val);
 R_API const char *r_reg_32_to_64(RReg *reg, const char *rreg32);
+R_API const char *r_reg_64_to_32(RReg *reg, const char *rreg64);
 R_API const char *r_reg_get_type(int idx);
 R_API const char *r_reg_get_name(RReg *reg, int kind);
 R_API const char *r_reg_get_role(int role);

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -36,6 +36,33 @@ R_API const char* r_reg_32_to_64(RReg* reg, const char* rreg32) {
 	return NULL;
 }
 
+// Take the 64 bits name of a register, and return the 32 bit name of it.
+// If there is no equivalent 32 bit register return NULL.
+R_API const char* r_reg_64_to_32(RReg* reg, const char* rreg64) {
+	int i, j = -1;
+	RListIter* iter;
+	RRegItem* item;
+	for (i = 0; i < R_REG_TYPE_LAST; ++i) {
+		r_list_foreach (reg->regset[i].regs, iter, item) {
+			if (item->size == 64 && !r_str_casecmp (rreg64, item->name)) {
+				j = item->offset;
+				break;
+			}
+		}
+	}
+	if (j != -1) {
+		for (i = 0; i < R_REG_TYPE_LAST; ++i) {
+			r_list_foreach (reg->regset[i].regs, iter, item) {
+				if (item->offset == j && item->size == 32) {
+					return item->name;
+				}
+			}
+		}
+	}
+	return NULL;
+}
+
+
 R_API const char* r_reg_get_type(int idx) {
 	return (idx >= 0 && idx < R_REG_TYPE_LAST)? types[idx]: NULL;
 }


### PR DESCRIPTION
```
0x01057924      b806000002     mov eax, 0x2000006
0x01057929      0f05           syscall
```
After @radare 's PR, there was bunch syscall missing due to the rax and eax miss-match issue in 64 bits bins, the PR tries to fix that issue!   