### PR TITLE
Ensure we use correct platform path sep (fixes #11063)

### DIFF
--- a/shlr/tcc/tccpp.c
+++ b/shlr/tcc/tccpp.c
@@ -1587,7 +1587,7 @@ include_trynext:
 			int filepath_len;
 			char *e = file->filename + strlen (file->filename);
 			while (e > file->filename) {
-				if (*e == '/') {
+				if (*e == R_SYS_DIR[0]) {
 					break;
 				}
 				e--;


### PR DESCRIPTION
R_SYS_DIR is either "\" or "/" if on Windows or non-Windows respectively. We replace a hard-coded path separator with R_SYS_DIR[0] to ensure compatibility with all platforms.

This doesn't take into account that Windows supports both path separators but we'll cross that bridge when we get to it.