### PR TITLE
fix command interpret when scr.html is on

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -922,7 +922,12 @@ static int cmd_interpret(void *data, const char *input) {
 		if (filter) {
 			*filter = 0;
 		}
+
+		int tmp_html = r_cons_singleton ()->is_html;
+		r_cons_singleton ()->is_html = 0;
 		ptr = str = r_core_cmd_str (core, inp);
+		r_cons_singleton ()->is_html = tmp_html;
+
 		if (filter) {
 			*filter = '~';
 		}


### PR DESCRIPTION
It is generally a bad idea to execute HTML source code. To reproduce:
- open any binary
- enter the following commands:
```
e scr.html=1
.dr*32
```
This will execute the HTML resulting from `dr*32`, as shell commands (due to the `&nbsp;`).
The fix is to save and restore the is_html setting of the context.