### PR TITLE
Wasm analisys

### DIFF
--- a/libr/anal/p/anal_wasm.c
+++ b/libr/anal/p/anal_wasm.c
@@ -8,7 +8,7 @@
 #include "../../bin/format/wasm/wasm.h"
 
 #define WASM_STACK_SIZE 128
-#define END_SIZE 1
+#define WASM_END_SIZE (1)
 
 static struct wasm_stack_t {
 	ut64 loop;
@@ -35,6 +35,9 @@ static ut64 find_if_else(ut64 addr, const ut8 *data, int len, bool is_loop) {
 		int ret = wasm_dis (&wop, data, len);
 		switch (wop.op) {
 		/* Calls here are using index instead of address */
+		case WASM_OP_BLOCK:
+			count++;
+			break;
 		case WASM_OP_LOOP:
 			count++;
 			break;
@@ -86,7 +89,7 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 		/* Calls here are using index instead of address */
 		case WASM_OP_LOOP:
 			//op->type = R_ANAL_OP_TYPE_CJMP;
-			addr2 = find_if_else (addr + 1, data + op->size, len - op->size, true);
+			addr2 = find_if_else (addr + op->size, data + op->size, len - op->size, true);
 			if (addr2 != UT64_MAX) {
 				wasm_stack[wasm_stack_ptr].loop = addr;
 				wasm_stack[wasm_stack_ptr].end = addr2;
@@ -95,27 +98,43 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 			}
 			//op->fail = addr + op->size;
 			break;
+		case WASM_OP_BLOCK:
+			addr2 = find_if_else (addr + op->size, data + op->size, len - op->size, true);
+			if (addr2 != UT64_MAX) {
+				wasm_stack[wasm_stack_ptr].loop = addr;
+				wasm_stack[wasm_stack_ptr].end = addr2;
+				wasm_stack_ptr++;
+				addr2 = UT64_MAX;
+			}
+			break;
 		case WASM_OP_IF:
 			op->type = R_ANAL_OP_TYPE_CJMP;
-			op->jump = find_if_else (addr + 1, data + op->size, len - op->size, false);
+			op->jump = find_if_else (addr + op->size, data + op->size, len - op->size, false);
 			op->fail = addr + op->size;
 			break;
 		case WASM_OP_ELSE:
 			op->type = R_ANAL_OP_TYPE_JMP;
-			op->jump = find_if_else (addr + 1, data + op->size, len - op->size, false);
+			op->jump = find_if_else (addr + op->size, data + op->size, len - op->size, false);
 			break;
 		case WASM_OP_END:
 			if (addr != UT64_MAX) {
 				for (i = 0; i < wasm_stack_ptr; ++i) {
 					if (wasm_stack[i].end == addr) {
-						op->type = R_ANAL_OP_TYPE_JMP;
+						op->type = R_ANAL_OP_TYPE_CJMP;
 						op->jump = wasm_stack[i].loop;
+						op->fail = addr + op->size;
 						break;
 					}
 				}
 			}
 			if (op_old == WASM_OP_CALL || op_old == WASM_OP_CALLINDIRECT || op_old == WASM_OP_RETURN) {
 				op->eob = true;
+				for (i = wasm_stack_ptr - 1; i > 0; --i) {
+					if (addr > wasm_stack[i].loop && addr < wasm_stack[i].end) {
+						op->eob = false;
+						break;
+					}
+				}
 			}
 			break;
 		case WASM_OP_GETLOCAL:
@@ -161,9 +180,6 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 		case WASM_OP_F64GE:
 			op->type = R_ANAL_OP_TYPE_CMP;
 			break;
-		case WASM_OP_BLOCK:
-			//wasm_stack_ptr++;
-			break;
 		case WASM_OP_NOP:
 			op->type = R_ANAL_OP_TYPE_NOP;
 			break;
@@ -178,10 +194,16 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 			break;
 		case WASM_OP_BR:
 			if (addr != UT64_MAX) {
-				for (i = 0; i < wasm_stack_ptr; ++i) {
-					if (wasm_stack[i].loop < addr && wasm_stack[i].end > addr) {
-						op->type = R_ANAL_OP_TYPE_JMP;
-						op->jump = wasm_stack[i].end + END_SIZE;
+				int scope = data[1];
+				for (i = wasm_stack_ptr - 1; i > 0; --i) {
+					if (addr > wasm_stack[i].loop && addr < wasm_stack[i].end) {
+						if (scope > 1) {
+							scope--;
+						} else {
+							op->type = R_ANAL_OP_TYPE_JMP;
+							op->jump = wasm_stack[i].end + WASM_END_SIZE;
+							break;
+						}
 					}
 				}
 			}
@@ -196,7 +218,7 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 			break;
 		case WASM_OP_RETURN:
 			op->type = R_ANAL_OP_TYPE_CRET;
-			if (find_if_else (addr + 1, data + op->size, len - op->size, false) == (addr + 1)) {
+			if (find_if_else (addr + op->size, data + op->size, len - op->size, false) == (addr + 1)) {
 				op->type = R_ANAL_OP_TYPE_RET;
 			}
 		default:
@@ -205,6 +227,10 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 		op_old = wop.op;
 	}
 	return op->size;
+}
+
+static int archinfo(RAnal *a, int q) {
+	return 1;
 }
 
 static int wasm_pre_anal(RAnal *a, struct r_anal_state_type_t *state, ut64 addr) {
@@ -223,6 +249,7 @@ RAnalPlugin r_anal_plugin_wasm = {
 	.license = "LGPL3",
 	.arch = "wasm",
 	.bits = 64,
+	.archinfo = archinfo,
 	.pre_anal_fn_cb = wasm_pre_anal,
 	.op = &wasm_op,
 	.esil = false,

--- a/libr/anal/p/anal_wasm.c
+++ b/libr/anal/p/anal_wasm.c
@@ -9,49 +9,175 @@
 
 ut64 cf_stack [128] = { 0 };
 int cf_stack_ptr = 0;
+WasmOpCodes op_old = 0;
 
-static ut64 get_cf_offset(RAnal *anal, const ut8 *data)
-{
+static ut64 get_cf_offset(RAnal *anal, const ut8 *data) {
 	char flgname[64] = {0};
-	st32 n;
-	read_i32_leb128 (data, data + 1, &n);
-	sprintf(flgname, "fcn.%d", n);
+	snprintf(flgname, sizeof (flgname), "sym.fnc.%d", data[1]);
 	RFlagItem *fi = anal->flb.get (anal->flb.f, flgname);
-	if (fi) return fi->offset;
-	return (ut64)-1;
+	if (fi) {
+		return fi->offset;
+	}
+	return UT64_MAX;
+}
+
+static ut64 find_if_else(ut64 addr, const ut8 *data, int len) {
+	WasmOp wop = {0};
+	st32 count = 0;
+	ut32 offset = addr;
+	while (len > 0) {
+		wasm_dis (&wop, data, len);
+		switch (wop.op) {
+		/* Calls here are using index instead of address */
+		case WASM_OP_IF:
+			count++;
+			break;
+		case WASM_OP_ELSE:
+			if (!count) {
+				return offset + 2;
+			}
+			break;
+		case WASM_OP_END:
+			if (!count) {
+				return offset;
+			} else {
+				count--;
+			}
+			break;
+		default:
+			break;
+		}
+		offset++;
+		data++;
+		len--;
+	}
+	return UT64_MAX;
 }
 
 static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
 	WasmOp wop = {0};
-
 	memset (op, '\0', sizeof (RAnalOp));
 	int ret = wasm_dis (&wop, data, len);
+	op->jump = UT64_MAX;
+	op->fail = UT64_MAX;
+	op->ptr = op->val = UT64_MAX;
 	op->size = ret;
 	op->addr = addr;
+	op->sign = true;
 	op->type = R_ANAL_OP_TYPE_UNK;
 	op->id = wop.op;
-	switch (wop.op) {
-	/* Calls here are using index instead of address */
-	case WASM_OP_BLOCK:
-		cf_stack_ptr++;
-		break;
-	case WASM_OP_CALL:
-	case WASM_OP_CALLINDIRECT:
-		op->type = R_ANAL_OP_TYPE_CALL;
-		op->jump = get_cf_offset (anal, data);
-		break;
-	case WASM_OP_BR:
-		op->type = R_ANAL_OP_TYPE_JMP;
-		op->jump = get_cf_offset (anal, data);
-		break;
-	case WASM_OP_BRIF:
-		op->type = R_ANAL_OP_TYPE_CJMP;
-		op->jump = get_cf_offset (anal, data);
-		break;
-	default:
-		break;
+
+	if (!strncmp(wop.txt, "invalid", 7)) {
+		op->type = R_ANAL_OP_TYPE_ILL;
+		return -1;
+	} else {
+		switch (wop.op) {
+		/* Calls here are using index instead of address */
+		case WASM_OP_LOOP:
+			op->type = R_ANAL_OP_TYPE_CJMP;
+			op->jump = find_if_else (addr + 1, data + op->size, len - op->size);
+			op->fail = addr + op->size;
+			break;
+		case WASM_OP_IF:
+			op->type = R_ANAL_OP_TYPE_CJMP;
+			op->jump = find_if_else (addr + 1, data + op->size, len - op->size);
+			op->fail = addr + op->size;
+			break;
+		case WASM_OP_ELSE:
+			op->type = R_ANAL_OP_TYPE_JMP;
+			op->jump = find_if_else (addr + 1, data + op->size, len - op->size);
+			break;
+		case WASM_OP_END:
+			if (op_old == WASM_OP_CALL || op_old == WASM_OP_CALLINDIRECT || op_old == WASM_OP_RETURN) {
+				op->eob = true;
+			}
+			break;
+		case WASM_OP_GETLOCAL:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			break;
+		case WASM_OP_SETLOCAL:
+		case WASM_OP_TEELOCAL:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			break;
+		case WASM_OP_I32EQZ:
+		case WASM_OP_I32EQ:
+		case WASM_OP_I32NE:
+		case WASM_OP_I32LTS:
+		case WASM_OP_I32LTU:
+		case WASM_OP_I32GTS:
+		case WASM_OP_I32GTU:
+		case WASM_OP_I32LES:
+		case WASM_OP_I32LEU:
+		case WASM_OP_I32GES:
+		case WASM_OP_I32GEU:
+		case WASM_OP_I64EQZ:
+		case WASM_OP_I64EQ:
+		case WASM_OP_I64NE:
+		case WASM_OP_I64LTS:
+		case WASM_OP_I64LTU:
+		case WASM_OP_I64GTS:
+		case WASM_OP_I64GTU:
+		case WASM_OP_I64LES:
+		case WASM_OP_I64LEU:
+		case WASM_OP_I64GES:
+		case WASM_OP_I64GEU:
+		case WASM_OP_F32EQ:
+		case WASM_OP_F32NE:
+		case WASM_OP_F32LT:
+		case WASM_OP_F32GT:
+		case WASM_OP_F32LE:
+		case WASM_OP_F32GE:
+		case WASM_OP_F64EQ:
+		case WASM_OP_F64NE:
+		case WASM_OP_F64LT:
+		case WASM_OP_F64GT:
+		case WASM_OP_F64LE:
+		case WASM_OP_F64GE:
+			op->type = R_ANAL_OP_TYPE_CMP;
+			break;
+		case WASM_OP_BLOCK:
+			cf_stack_ptr++;
+			break;
+		case WASM_OP_CALL:
+		case WASM_OP_CALLINDIRECT:
+			op->type = R_ANAL_OP_TYPE_CALL;
+			op->jump = get_cf_offset (anal, data);
+			op->fail = addr + op->size;
+			if (op->jump != UT64_MAX) {
+				op->ptr = op->jump;
+			}
+			break;
+		case WASM_OP_BR:
+			op->type = R_ANAL_OP_TYPE_JMP;
+			op->jump = get_cf_offset (anal, data);
+			op->fail = addr + op->size;
+			if (op->jump != UT64_MAX) {
+				op->ptr = op->jump;
+			}
+			break;
+		case WASM_OP_BRIF:
+			op->type = R_ANAL_OP_TYPE_CJMP;
+			op->jump = get_cf_offset (anal, data);
+			op->fail = addr + op->size;
+			if (op->jump != UT64_MAX) {
+				op->ptr = op->jump;
+			}
+			break;
+		case WASM_OP_RETURN:
+			op->type = R_ANAL_OP_TYPE_CRET;
+			if (find_if_else (addr + 1, data + op->size, len - op->size) == (addr + 1)) {
+				op->type = R_ANAL_OP_TYPE_RET;
+			}
+		default:
+			break;
+		}
+		op_old = wop.op;
 	}
 	return op->size;
+}
+
+static int archinfo(RAnal *a, int q) {
+	return 1;
 }
 
 RAnalPlugin r_anal_plugin_wasm = {
@@ -60,6 +186,7 @@ RAnalPlugin r_anal_plugin_wasm = {
 	.license = "LGPL3",
 	.arch = "wasm",
 	.bits = 64,
+	.archinfo = archinfo,
 	.op = &wasm_op,
 	.esil = false,
 };

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -843,67 +843,67 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 		ptr->offset = b->cur;
 		switch (ptr->id) {
 		case R_BIN_WASM_SECTION_CUSTOM:
-			eprintf("custom section: 0x%x, ", (ut32)b->cur);
+			// eprintf("custom section: 0x%x, ", (ut32)b->cur);
 			if (!(consume_u32_r (b, max, &ptr->name_len))) {
 				goto beach;
 			}
 			if (consume_str_r (b, max, ptr->name_len, ptr->name) < ptr->name_len) {
 				goto beach;
 			}
-			eprintf("name: %s\n", ptr->name);
+			// eprintf("name: %s\n", ptr->name);
 			break;
 		case R_BIN_WASM_SECTION_TYPE:
-			eprintf("section type: 0x%x, ", (ut32)b->cur);
+			// eprintf("section type: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "type");
 			ptr->name_len = 4;
 			break;
 		case R_BIN_WASM_SECTION_IMPORT:
-			eprintf("section import: 0x%x, ", (ut32)b->cur);
+			// eprintf("section import: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "import");
 			ptr->name_len = 6;
 			break;
 		case R_BIN_WASM_SECTION_FUNCTION:
-			eprintf("section function: 0x%x, ", (ut32)b->cur);
+			// eprintf("section function: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "function");
 			ptr->name_len = 8;
 			break;
 		case R_BIN_WASM_SECTION_TABLE:
-			eprintf("section table: 0x%x, ", (ut32)b->cur);
+			// eprintf("section table: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "table");
 			ptr->name_len = 5;
 			break;
 		case R_BIN_WASM_SECTION_MEMORY:
-			eprintf("section memory: 0x%x, ", (ut32)b->cur);
+			// eprintf("section memory: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "memory");
 			ptr->name_len = 6;
 			break;
 		case R_BIN_WASM_SECTION_GLOBAL:
-			eprintf("section global: 0x%x, ", (ut32)b->cur);
+			// eprintf("section global: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "global");
 			ptr->name_len = 6;
 			break;
 		case R_BIN_WASM_SECTION_EXPORT:
-			eprintf("section export: 0x%x, ", (ut32)b->cur);
+			// eprintf("section export: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "export");
 			ptr->name_len = 6;
 			break;
 		case R_BIN_WASM_SECTION_START:
-			eprintf("section start: 0x%x\n", (ut32)b->cur);
+			// eprintf("section start: 0x%x\n", (ut32)b->cur);
 			strcpy (ptr->name, "start");
 			ptr->name_len = 5;
 			break;
 		case R_BIN_WASM_SECTION_ELEMENT:
-			eprintf("section element: 0x%x, ", (ut32)b->cur);
+			// eprintf("section element: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "element");
 			ptr->name_len = 7;
 			break;
 		case R_BIN_WASM_SECTION_CODE:
-			eprintf("section code: 0x%x, ", (ut32)b->cur);
+			// eprintf("section code: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "code");
 			ptr->name_len = 4;
 			break;
 		case R_BIN_WASM_SECTION_DATA:
-			eprintf("section data: 0x%x, ", (ut32)b->cur);
+			// eprintf("section data: 0x%x, ", (ut32)b->cur);
 			strcpy (ptr->name, "data");
 			ptr->name_len = 4;
 			break;
@@ -917,7 +917,7 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 			if (!(consume_u32_r (b, max, &ptr->count))) {
 				goto beach;
 			}
-			eprintf("count %d\n", ptr->count);
+			// eprintf("count %d\n", ptr->count);
 		}
 		ptr->payload_data = b->cur;
 		ptr->payload_len = ptr->size - (ptr->payload_data - ptr->offset);

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -58,9 +58,22 @@ static RList *entries(RBinFile *bf) {
 	if (!(ret = r_list_newf ((RListFree)free))) {
 		return NULL;
 	}
-	if (!(addr = (ut64) r_bin_wasm_get_entrypoint (bin))) {
-		r_list_free (ret);
-		return NULL;
+
+	addr = (ut64) r_bin_wasm_get_entrypoint (bin);
+	if (!addr) {
+		RList *ret, *codes;
+		if ((codes = r_bin_wasm_get_codes (bin))) {
+			RListIter *iter;
+			RBinWasmCodeEntry *func;
+			r_list_foreach (codes, iter, func) {
+				addr = func->code;
+				break;
+			}
+		}
+		if (!addr) {
+			r_list_free (ret);
+			return NULL;
+		}
 	}
 	if ((ptr = R_NEW0 (RBinAddr))) {
 		ptr->paddr = addr;


### PR DESCRIPTION
Before the patch
```
$ r2 bins/wasm/expr-if.wasm
[0x00000000]> s sym.fnc.0
[0x00000032]> aa
[0x00000032]> pdf
/ (fcn) sym.fnc.0 28
|   sym.fnc.0 ();
|           0x00000032      2000           get_local 0
|           0x00000034      4100           i32.const 0
|           0x00000036      46             i32.eq
|           0x00000037      047f           if (result i32)
|           0x00000039      4101           i32.const 1
|           0x0000003b      05             else
|           0x0000003c      4102           i32.const 2
|           0x0000003e      0b             end
|           0x0000003f      0b             end
|           0x00000040      06             invalid
|           0x00000041      00             trap
|           ;-- fnc.1:
|           0x00000042      4100           i32.const 0
|           0x00000044      1000           call 0
|           0x00000046      0b             end
|           0x00000047      06             invalid
|           0x00000048      00             trap
|           ;-- fnc.2:
|           0x00000049      4101           i32.const 1
|           0x0000004b      1000           call 0
|           ;-- section_end.code:
\           0x0000004d      0b             end

```

After the patch:
```
$ r2 bins/wasm/expr-if.wasm
[0x00000032]> aa
[0x00000032]> pdf
|           ;-- fnc.0:
|           ;-- eip:
/ (fcn) entry0 14
|   entry0 ();
|           ; CALL XREF from sym.fnc.1 (0x44)
|           ; CALL XREF from sym.fnc.2 (0x4b)
|           0x00000032      2000           get_local 0
|           0x00000034      4100           i32.const 0
|           0x00000036      46             i32.eq
|       ,=< 0x00000037      047f           if (result i32)
|       |   0x00000039      4101           i32.const 1
|      ,==< 0x0000003b      05             else
|      |`-> 0x0000003c      4102           i32.const 2
|      |    ; CODE XREF from entry0 (0x3b)
|      `--> 0x0000003e      0b             end
\           0x0000003f      0b             end
```