### PR TITLE
cmd_debug: remove dco command help

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -115,7 +115,6 @@ static const char *help_msg_dc[] = {
 #endif
 	"dcf", "", "Continue until fork (TODO)",
 	"dck", " <signal> <pid>", "Continue sending signal to process",
-	"dco", " <num>", "Step over <num> instructions",
 	"dcp", "", "Continue until program code (mapped io section)",
 	"dcr", "", "Continue until ret (uses step over)",
 	"dcs", "[?] <num>", "Continue until syscall",


### PR DESCRIPTION
I couldn't find any implementation of the `dco` command, I stopped searching at commit 34d41b897f8d8c3e69ba7cfe7216ad160d98ecc5 (2012).