### PR TITLE
Fix uninitialized local causing rtc failures

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2348,9 +2348,10 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 	bool use_color = r_config_get_i (core->config, "scr.color");
 	int len = 0;
 	int i;
-	int l = 0;
+	int l;
 	RCoreAnalStatsItem total = {0};
 	for (i = 0; i < ((to-from)/piece); i++) {
+		l = 0;
 		ut64 at = from + (piece * i);
 		ut64 ate = at + piece;
 		ut64 p = (at - from) / piece;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2350,7 +2350,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 	int i;
 	RCoreAnalStatsItem total = {0};
 	for (i = 0; i < ((to-from)/piece); i++) {
-		int l = 0;
+		bool insert_separator = false;
 		ut64 at = from + (piece * i);
 		ut64 ate = at + piece;
 		ut64 p = (at - from) / piece;
@@ -2363,14 +2363,13 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 					|| (as->block[p].symbols)
 					|| (as->block[p].rwx)
 					|| (as->block[p].strings)) {
-					r_cons_printf ("\"offset\":%"PFMT64d ",", at), l++;
-					r_cons_printf ("\"size\":%"PFMT64d ",", piece), l++;
+					r_cons_printf ("\"offset\":%"PFMT64d ",", at);
+					r_cons_printf ("\"size\":%"PFMT64d ",", piece);
 				}
-				l = 0;
 #define PRINT_VALUE(name, cond, v) { \
 				if (cond) { \
-					r_cons_printf ("%s\"" name "\":%d", l? ",": "", (v)); \
-					l++; \
+					r_cons_printf ("%s\"" name "\":%d", insert_separator? ",": "", (v)); \
+					insert_separator = true; \
 				}}
 #define PRINT_VALUE2(name, v) PRINT_VALUE(name, v, v)
 				PRINT_VALUE2 ("flags", as->block[p].flags);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2348,7 +2348,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 	bool use_color = r_config_get_i (core->config, "scr.color");
 	int len = 0;
 	int i;
-	int l;
+	int l = 0;
 	RCoreAnalStatsItem total = {0};
 	for (i = 0; i < ((to-from)/piece); i++) {
 		ut64 at = from + (piece * i);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2348,10 +2348,9 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 	bool use_color = r_config_get_i (core->config, "scr.color");
 	int len = 0;
 	int i;
-	int l;
 	RCoreAnalStatsItem total = {0};
 	for (i = 0; i < ((to-from)/piece); i++) {
-		l = 0;
+		int l = 0;
 		ut64 at = from + (piece * i);
 		ut64 ate = at + piece;
 		ut64 p = (at - from) / piece;


### PR DESCRIPTION
```
"The variable 'l' is being used without being initialized."

#  Call Site
00 r_core!failwithmessage+0x234
01 r_core!_RTC_UninitUse+0xa4
02 r_core!cmd_print_blocks+0x4f2 [c:\sources\cutter\radare2\libr\core\cmd_print.c @ 2366] 
03 r_core!cmd_print+0x976 [c:\sources\cutter\radare2\libr\core\cmd_print.c @ 3847] 
04 r_core!r_cmd_call+0x249 [c:\sources\cutter\radare2\libr\core\cmd_api.c @ 237] 
05 r_core!r_core_cmd_subst_i+0x3037 [c:\sources\cutter\radare2\libr\core\cmd.c @ 2904] 
06 r_core!r_core_cmd_subst+0x4df [c:\sources\cutter\radare2\libr\core\cmd.c @ 1933] 
07 r_core!r_core_cmd+0x42e [c:\sources\cutter\radare2\libr\core\cmd.c @ 3608] 
08 r_core!r_core_cmd_str+0x5e [c:\sources\cutter\radare2\libr\core\cmd.c @ 3857] 
09 cutter!CutterCore::cmdj+0x73 [c:\sources\cutter\src\cutter.cpp @ 188] 
```