### PR TITLE
Optimize sdb_array_add_num: always use SDB_NUM_BASE and don't check for decimal

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -377,7 +377,8 @@ static int meta_add(RAnal *a, int type, int subtype, ut64 from, ut64 to, const c
 		int idx = sdb_array_indexof (DB, key, value, 0);
 		sdb_array_delete (DB, key, idx, 0);
 	}
-	snprintf (val, sizeof (val)-1, "%c", type);
+	val[0] = type;
+	val[1] = '\0';
 	sdb_array_add (DB, key, val, 0);
 	meta_inrange_add (a, from, to - from);
 	return true;

--- a/shlr/sdb/src/array.c
+++ b/shlr/sdb/src/array.c
@@ -210,15 +210,9 @@ SDB_API int sdb_array_set_num(Sdb *s, const char *key, int idx, ut64 val,
 }
 
 SDB_API int sdb_array_add_num(Sdb *s, const char *key, ut64 val, ut32 cas) {
-	char valstr10[SDB_NUM_BUFSZ], valstr16[SDB_NUM_BUFSZ];
-	char *v10 = sdb_itoa (val, valstr10, 10);
-	char *v16 = sdb_itoa (val, valstr16, 16);
-	// TODO: optimize
-	// TODO: check cas vs mycas
-	if (sdb_array_contains (s, key, v10, NULL)) {
-		return 0;
-	}
-	return sdb_array_add (s, key, v16, cas); // TODO: v10 or v16
+	char buf[SDB_NUM_BUFSZ];
+	char *v = sdb_itoa (val, buf, SDB_NUM_BASE);
+	return sdb_array_add (s, key, v, cas);
 }
 
 // XXX: index should be supressed here? if its a set we shouldnt change the index
@@ -226,7 +220,7 @@ SDB_API int sdb_array_add(Sdb *s, const char *key, const char *val, ut32 cas) {
 	if (sdb_array_contains (s, key, val, NULL)) {
 		return 0;
 	}
-	return sdb_array_set (s, key, -1, val, cas);
+	return sdb_array_insert (s, key, -1, val, cas);
 }
 
 SDB_API int sdb_array_add_sorted(Sdb *s, const char *key, const char *val, ut32 cas) {


### PR DESCRIPTION
https://github.com/radare/sdb/pull/156/files

```
# t1 is an empty project

# Before

% time (repeat 10 ~/Dev/Bin/radare2/release/binr/radare2/radare2 -p t1 -c '' -Q a.out)
( repeat 10; do; ~/Dev/Bin/radare2/release/binr/radare2/radare2 -p t1 -c '' -)  1.21s user 0.05s system 98% cpu 1.277 total

# After

% time (repeat 10 ~/Dev/Bin/radare2/release/binr/radare2/radare2 -p t1 -c '' -Q a.out)
( repeat 10; do; ~/Dev/Bin/radare2/release/binr/radare2/radare2 -p t1 -c '' -)  0.62s user 0.08s system 96% cpu 0.729 total
```

sdb can be optimized a lot and become more readable if you use some coverage tool (with radare2-regressions tests) and remove redundant code (it might be risky to remove the check here).