### PR TITLE
Fix #11145. Additional error handling

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -472,11 +472,16 @@ static ut64 num_callback(RNum *userptr, const char *str, int *ok) {
 				if (q) {
 					if (r_str_replace_char (o, ']', 0)>0) {
 						n = r_num_math (core->num, o);
+						if (core->num->nc.errors) {
+							return 0;
+						}
 						r_num_calc_index (core->num, q);
 					}
 				}
 				free (o);
 			}
+		} else {
+			return 0;
 		}
 		// pop state
 		if (ok) *ok = 1;


### PR DESCRIPTION
Added some error handling to fix that.

```
r2 /bin/ls
[0x00005430]> aa
[x] Analyze all flags starting with sym. and entry0 (aa)
[0x00005430]> s=
0x54f0
[0x00005430]> ss main
[0x00003bb0]> s=
0x54f0
[0x00003bb0]> s [
[0x10102464c457f]> s=
0x54f0 > 0x3bb0
```

More info here https://github.com/radare/radare2/issues/11145