### PR TITLE
Fix superfluous seek on error while -escr.interactive=0

### DIFF
--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -473,8 +473,10 @@ static int cmd_seek(void *data, const char *input) {
 	case ' ': // "s "
 	{
 		ut64 addr = r_num_math (core->num, input + 1);
-		if (core->num->nc.errors && r_cons_singleton ()->is_interactive) {
-			eprintf ("Cannot seek to unknown address '%s'\n", core->num->nc.calc_buf);
+		if (core->num->nc.errors) {
+			if (r_cons_singleton ()->is_interactive) {
+				eprintf ("Cannot seek to unknown address '%s'\n", core->num->nc.calc_buf);
+			}
 			break;
 		}
 		if (!silent) {


### PR DESCRIPTION

Same error as described in https://github.com/radare/radare2/pull/11160 but appears only when -escr.interactive=0

Shouldn't actually seek on error

```
$ r2 -escr.interactive=0 /bin/ls 
[0x00005430]> s ]
[0x00000000]> 
```

I will add r2-regression tests for this cmd_seek bug when this pull will be merged .