### PR TITLE
Fix arm jump table issue #11099

### DIFF
--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -85,7 +85,6 @@ R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb, ut64 addr, ut8 *buf, ut64 len, 
 		bb->addr = addr;
 	}
 	len -= 16; // XXX: hack to avoid segfault by x86im
-	printf("r_anal_bb\n");
 	while (idx < len) {
 		// TODO: too slow object construction
 		if (!(op = r_anal_op_new ())) {
@@ -120,7 +119,6 @@ R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb, ut64 addr, ut8 *buf, ut64 len, 
 				// TODO: get values from anal backend
 				bb->cond->type = R_ANAL_COND_EQ;
 			} else VERBOSE_ANAL eprintf ("Unknown conditional for block 0x%"PFMT64x"\n", bb->addr);
-			printf("CJMP block %p\n", bb->addr);
 			bb->conditional = 1;
 			bb->fail = op->fail;
 			bb->jump = op->jump;

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -85,6 +85,7 @@ R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb, ut64 addr, ut8 *buf, ut64 len, 
 		bb->addr = addr;
 	}
 	len -= 16; // XXX: hack to avoid segfault by x86im
+	printf("r_anal_bb\n");
 	while (idx < len) {
 		// TODO: too slow object construction
 		if (!(op = r_anal_op_new ())) {
@@ -119,6 +120,7 @@ R_API int r_anal_bb(RAnal *anal, RAnalBlock *bb, ut64 addr, ut8 *buf, ut64 len, 
 				// TODO: get values from anal backend
 				bb->cond->type = R_ANAL_COND_EQ;
 			} else VERBOSE_ANAL eprintf ("Unknown conditional for block 0x%"PFMT64x"\n", bb->addr);
+			printf("CJMP block %p\n", bb->addr);
 			bb->conditional = 1;
 			bb->fail = op->fail;
 			bb->jump = op->jump;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1280,7 +1280,7 @@ repeat:
 					ut64 table_size, default_case;
 					table_size = cmpval + 1;
 					default_case = op.fail; // is this really default case?
-					if (table_size != UT64_MAX && default_case != UT64_MAX && (op.reg || op.ireg)) {
+					if (cmpval != UT64_MAX && default_case != UT64_MAX && (op.reg || op.ireg)) {
 						if (op.ireg) {
 							ret = try_walkthrough_jmptbl (anal, fcn, depth, op.addr, op.ptr, op.ptr, anal->bits >> 3, table_size, default_case, ret);
 						} else { // op.reg

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -465,7 +465,7 @@ static int walkthrough_arm_jmptbl_style(RAnal *anal, RAnalFunction *fcn, int dep
 			default_case, default_case);
 
 	}
-	return 1;
+	return ret;
 }
 
 static int try_walkthrough_jmptbl(RAnal *anal, RAnalFunction *fcn, int depth, ut64 ip, ut64 jmptbl_loc, ut64 jmptbl_off, ut64 sz, ut64 jmptbl_size, ut64 default_case, int ret0) {

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1267,6 +1267,7 @@ repeat:
 		case R_ANAL_OP_TYPE_CJMP:
 		case R_ANAL_OP_TYPE_MCJMP:
 		case R_ANAL_OP_TYPE_RCJMP:
+		case R_ANAL_OP_TYPE_UCJMP:
 			if (anal->opt.cjmpref) {
 				(void) r_anal_xrefs_set (anal, op.addr, op.jump, R_ANAL_REF_TYPE_CODE);
 			}

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2682,9 +2682,10 @@ jmp $$ + 4 + ( [delta] * 2 )
 			op->stackop = R_ANAL_STACK_GET;
 			op->stackptr = 0;
 			op->ptr = -MEMDISP(1);
-		} else if (REGID(0) == ARM_REG_PC && REGBASE(1) == ARM_REG_PC) {
+		} else if (REGBASE(1) == ARM_REG_PC) {
 			op->ptr = (addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1);
-			if (insn->detail->arm.cc != ARM_CC_AL) {
+			op->refptr = 4;
+			if (REGID(0) == ARM_REG_PC && insn->detail->arm.cc != ARM_CC_AL) {
 				//op->type = R_ANAL_OP_TYPE_MCJMP;
 				op->type = R_ANAL_OP_TYPE_UCJMP;
 				op->fail = addr+op->size;
@@ -2692,7 +2693,6 @@ jmp $$ + 4 + ( [delta] * 2 )
 				op->ireg = r_str_get (cs_reg_name(handle, INSOP (1).mem.index));
 				break;
 			}
-			op->refptr = 4;
 		}
 		break;
 	case ARM_INS_BLX:

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2036,7 +2036,11 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 			}
 		}
 		if (REGBASE(0) == ARM_REG_PC) {
-		}
+            op->type = R_ANAL_OP_TYPE_UJMP;
+            if (insn->detail->arm.cc != ARM_CC_AL) {
+                op->type = R_ANAL_OP_TYPE_MCJMP;
+            }
+        }
 		break;
 	case ARM_INS_MRS:
 		op->family = R_ANAL_OP_FAMILY_PRIV;

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2036,11 +2036,11 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 			}
 		}
 		if (REGBASE(0) == ARM_REG_PC) {
-            op->type = R_ANAL_OP_TYPE_UJMP;
-            if (insn->detail->arm.cc != ARM_CC_AL) {
-                op->type = R_ANAL_OP_TYPE_MCJMP;
-            }
-        }
+			op->type = R_ANAL_OP_TYPE_UJMP;
+			if (insn->detail->arm.cc != ARM_CC_AL) {
+				op->type = R_ANAL_OP_TYPE_MCJMP;
+			}
+		}
 		break;
 	case ARM_INS_MRS:
 		op->family = R_ANAL_OP_FAMILY_PRIV;

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1468,7 +1468,8 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case ARM_INS_ADD:
 		op->type = R_ANAL_OP_TYPE_ADD;
 		if (REGID(1) == ARM_REG_PC && insn->detail->arm.cc != ARM_CC_AL) {
-			op->type = R_ANAL_OP_TYPE_RCJMP;
+			//op->type = R_ANAL_OP_TYPE_RCJMP;
+			op->type = R_ANAL_OP_TYPE_UCJMP;
 		}
 		MATH32("+");
 		break;
@@ -2038,7 +2039,8 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 		if (REGBASE(0) == ARM_REG_PC) {
 			op->type = R_ANAL_OP_TYPE_UJMP;
 			if (insn->detail->arm.cc != ARM_CC_AL) {
-				op->type = R_ANAL_OP_TYPE_MCJMP;
+				//op->type = R_ANAL_OP_TYPE_MCJMP;
+				op->type = R_ANAL_OP_TYPE_UCJMP;
 			}
 		}
 		break;
@@ -2568,7 +2570,8 @@ jmp $$ + 4 + ( [delta] * 2 )
 		if (REGID(1) == ARM_REG_PC) {
 			op->ptr = (addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1);
 			if (insn->detail->arm.cc != ARM_CC_AL) {
-				op->type = R_ANAL_OP_TYPE_RCJMP;
+				//op->type = R_ANAL_OP_TYPE_RCJMP;
+				op->type = R_ANAL_OP_TYPE_UCJMP;
 				op->fail = addr+op->size;
 				op->jump = ((addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1)) & UT64_MAX;
 				op->reg = r_str_get (cs_reg_name (handle, INSOP (2).reg));
@@ -2681,7 +2684,8 @@ jmp $$ + 4 + ( [delta] * 2 )
 		} else if (REGBASE(1) == ARM_REG_PC) {
 			op->ptr = (addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1);
 			if (insn->detail->arm.cc != ARM_CC_AL) {
-				op->type = R_ANAL_OP_TYPE_MCJMP;
+				//op->type = R_ANAL_OP_TYPE_MCJMP;
+				op->type = R_ANAL_OP_TYPE_UCJMP;
 				op->fail = addr+op->size;
 				op->jump = ((addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1)) & UT64_MAX;
 				op->ireg = r_str_get (cs_reg_name(handle, INSOP (1).mem.index));

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1467,6 +1467,9 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case ARM_INS_SADD8:
 	case ARM_INS_ADD:
 		op->type = R_ANAL_OP_TYPE_ADD;
+		if (REGID(1) == ARM_REG_PC && insn->detail->arm.cc != ARM_CC_AL) {
+			op->type = R_ANAL_OP_TYPE_RCJMP;
+		}
 		MATH32("+");
 		break;
 	case ARM_INS_SSUB16:
@@ -2033,7 +2036,6 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 			}
 		}
 		if (REGBASE(0) == ARM_REG_PC) {
-			op->type = R_ANAL_OP_TYPE_UJMP;
 		}
 		break;
 	case ARM_INS_MRS:
@@ -2560,8 +2562,15 @@ jmp $$ + 4 + ( [delta] * 2 )
 	case ARM_INS_ADD:
 		op->type = R_ANAL_OP_TYPE_ADD;
 		if (REGID(1) == ARM_REG_PC) {
-			//op->ptr = pc + addr + (thumb ? 4 : 8) + IMM(2);
-			//op->refptr = 4;
+			op->ptr = (addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1);
+			if (insn->detail->arm.cc != ARM_CC_AL) {
+				op->type = R_ANAL_OP_TYPE_RCJMP;
+				op->fail = addr+op->size;
+				op->jump = ((addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1)) & UT64_MAX;
+				op->reg = r_str_get (cs_reg_name (handle, INSOP (2).reg));
+				break;
+			}
+			op->refptr = 4;
 		}
 		break;
 	case ARM_INS_VMOV:
@@ -2666,8 +2675,15 @@ jmp $$ + 4 + ( [delta] * 2 )
 			op->stackptr = 0;
 			op->ptr = -MEMDISP(1);
 		} else if (REGBASE(1) == ARM_REG_PC) {
-			op->refptr = 4;
 			op->ptr = (addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1);
+			if (insn->detail->arm.cc != ARM_CC_AL) {
+				op->type = R_ANAL_OP_TYPE_MCJMP;
+				op->fail = addr+op->size;
+				op->jump = ((addr & ~3LL) + (thumb? 4: 8) + MEMDISP(1)) & UT64_MAX;
+				op->ireg = r_str_get (cs_reg_name(handle, INSOP (1).mem.index));
+				break;
+			}
+			op->refptr = 4;
 		}
 		break;
 	case ARM_INS_BLX:

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -385,7 +385,7 @@ On x86 acording to Wikipedia
 	} RAnalOpPrefix;
 
 // XXX: this definition is plain wrong. use enum or empower bits
-#define R_ANAL_OP_TYPE_MASK 0x8000ffff
+#define R_ANAL_OP_TYPE_MASK 0xf000ffff
 typedef enum {
 	R_ANAL_OP_TYPE_COND  = 0x80000000, // TODO must be moved to prefix?
 	//TODO: MOVE TO PREFIX .. it is used by anal_ex.. must be updated
@@ -400,7 +400,9 @@ typedef enum {
 	R_ANAL_OP_TYPE_IJMP  = R_ANAL_OP_TYPE_IND | R_ANAL_OP_TYPE_UJMP,
 	R_ANAL_OP_TYPE_IRJMP = R_ANAL_OP_TYPE_IND | R_ANAL_OP_TYPE_REG | R_ANAL_OP_TYPE_UJMP,
 	R_ANAL_OP_TYPE_CJMP  = R_ANAL_OP_TYPE_COND | R_ANAL_OP_TYPE_JMP,  /* conditional jump */
+	R_ANAL_OP_TYPE_RCJMP = R_ANAL_OP_TYPE_REG | R_ANAL_OP_TYPE_CJMP,  /* conditional jump register */
 	R_ANAL_OP_TYPE_MJMP  = R_ANAL_OP_TYPE_MEM | R_ANAL_OP_TYPE_JMP,  /* conditional jump */
+	R_ANAL_OP_TYPE_MCJMP  = R_ANAL_OP_TYPE_MEM | R_ANAL_OP_TYPE_CJMP,  /* conditional jump */
 	R_ANAL_OP_TYPE_UCJMP = R_ANAL_OP_TYPE_COND | R_ANAL_OP_TYPE_UJMP, /* conditional unknown jump */
 	R_ANAL_OP_TYPE_CALL  = 3,  /* call to subroutine (branch+link) */
 	R_ANAL_OP_TYPE_UCALL = 4, /* unknown call (register or so) */

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -385,7 +385,7 @@ On x86 acording to Wikipedia
 	} RAnalOpPrefix;
 
 // XXX: this definition is plain wrong. use enum or empower bits
-#define R_ANAL_OP_TYPE_MASK 0xf000ffff
+#define R_ANAL_OP_TYPE_MASK 0x8000ffff
 typedef enum {
 	R_ANAL_OP_TYPE_COND  = 0x80000000, // TODO must be moved to prefix?
 	//TODO: MOVE TO PREFIX .. it is used by anal_ex.. must be updated


### PR DESCRIPTION
This is my attempt to fix arm jump table issue #11099 and fix my problem at https://github.com/radare/radare2/issues/3201#issuecomment-411599449. This below is arm binary uses for testing.
[switch_table.zip](https://github.com/radare/radare2/files/2305747/switch_table.zip)
To reproduce switch_table binary.
```
  % r2 ./callback.elf
 -- Remember to maintain your ~/.radare_history
[0x000103cc]> s sym.input_handler2
[0x000105b0]> af
[0x000105b0]> pdf
```
[ctfzone_mobilebank.zip](https://github.com/radare/radare2/files/2305754/ctfzone_mobilebank.zip)
To reproduce using mobile_bank binary.
```
 % r2 ./mobile_bank.45115ff5f655d94fc26cb5244928b3fc
 -- THIS IS NOT A BUG
[0x0001082c]> s 0x11284 
[0x00011284]> af
[0x00011284]> pdf
```

Now arm switch case is displayed in visual graph.
![image](https://user-images.githubusercontent.com/29397847/44395009-ced14780-a562-11e8-9bff-1ff22738b510.png)
![image](https://user-images.githubusercontent.com/29397847/44395047-e6a8cb80-a562-11e8-960a-f4e7fc307b6b.png)

