### PR TITLE
MSVC RTTI class name demangling

### DIFF
--- a/libr/anal/rtti.c
+++ b/libr/anal/rtti.c
@@ -2,6 +2,17 @@
 
 #include "r_anal.h"
 
+R_API char *r_anal_rtti_demangle_class_name(RAnal *anal, const char *name) {
+	RVTableContext context;
+	r_anal_vtable_begin (anal, &context);
+	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
+		return r_anal_rtti_msvc_demangle_class_name (name);
+	} else {
+		// TODO: implement class name demangling for itanium
+		return NULL;
+	}
+}
+
 R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode) {
 	bool use_json = mode == 'j';
 	if (use_json) {

--- a/libr/anal/rtti.c
+++ b/libr/anal/rtti.c
@@ -7,10 +7,9 @@ R_API char *r_anal_rtti_demangle_class_name(RAnal *anal, const char *name) {
 	r_anal_vtable_begin (anal, &context);
 	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
 		return r_anal_rtti_msvc_demangle_class_name (name);
-	} else {
-		// TODO: implement class name demangling for itanium
-		return NULL;
 	}
+	// TODO: implement class name demangling for itanium
+	return NULL;
 }
 
 R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode) {

--- a/libr/anal/rtti_msvc.c
+++ b/libr/anal/rtti_msvc.c
@@ -391,11 +391,10 @@ R_API char *r_anal_rtti_msvc_demangle_class_name(const char *name) {
 			*c++ = ':';
 			*c++ = ':';
 			part_len = 0;
-			oc--;
 		} else {
 			part_len++;
-			oc--;
 		}
+		oc--;
 	}
 	memcpy (c, oc + 1, part_len);
 	c[part_len] = '\0';

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -552,6 +552,7 @@ static const char *help_msg_av[] = {
 	"av*", "", "like av, but as r2 commands",
 	"avr", "[j@addr]", "try to parse RTTI at vtable addr (see anal.cpp.abi)",
 	"avra", "[j]", "search for vtables and try to parse RTTI at each of them",
+	"avrD", " [classname]", "demangle a class name from RTTI",
 	NULL
 };
 
@@ -7184,6 +7185,20 @@ static void cmd_anal_rtti(RCore *core, const char *input) {
 	case 'a': // "avra"
 		r_anal_rtti_print_all (core->anal, input[1]);
 		break;
+	case 'D': { // "avrD"
+		char *dup = strdup (input + 1);
+		if (!dup) {
+			break;
+		}
+		char *name = r_str_trim (dup);
+		char *demangled = r_anal_rtti_demangle_class_name (core->anal, dup);
+		free (name);
+		if (demangled) {
+			r_cons_println (demangled);
+			free (demangled);
+		}
+		break;
+	}
 	default :
 		r_core_cmd_help (core, help_msg_av);
 		break;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1684,6 +1684,7 @@ R_API RList *r_anal_vtable_get_methods(RVTableContext *context, RVTableInfo *tab
 R_API void r_anal_list_vtables(RAnal *anal, int rad);
 
 /* rtti */
+R_API char *r_anal_rtti_msvc_demangle_class_name(const char *name);
 R_API void r_anal_rtti_msvc_print_complete_object_locator(RVTableContext *context, ut64 addr, int mode);
 R_API void r_anal_rtti_msvc_print_type_descriptor(RVTableContext *context, ut64 addr, int mode);
 R_API void r_anal_rtti_msvc_print_class_hierarchy_descriptor(RVTableContext *context, ut64 addr, int mode);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1696,6 +1696,7 @@ R_API void r_anal_rtti_itanium_print_si_class_type_info(RVTableContext *context,
 R_API void r_anal_rtti_itanium_print_vmi_class_type_info(RVTableContext *context, ut64 addr, int mode);
 R_API void r_anal_rtti_itanium_print_at_vtable(RVTableContext *context, ut64 addr, int mode);
 
+R_API char *r_anal_rtti_demangle_class_name(RAnal *anal, const char *name);
 R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode);
 R_API void r_anal_rtti_print_all(RAnal *anal, int mode);
 


### PR DESCRIPTION
I am aware that there is already msvc demangling in bin and it would intuitively make sense to reuse that here. However while the class name format in rtti looks very similar to the one used for symbols normally, it is different.
Since msvc mangling is not officially documented and I wasn't able to find any other place where this kind of class name mangling was used by msvc other than rtti, I decided to add it to the rtti code.

Tests: https://github.com/radare/radare2-regressions/pull/1446