### PR TITLE
r2pm OCD fixes, search list aligned with column

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -241,14 +241,23 @@ R2PM_List() {
 }
 
 R2PM_Search() {
+
+	#helper for pretty printing tabbed lists
+	if ! type "column" > /dev/null; then
+		cols() { cat ; }
+	else
+		cols() { column -s $'\t' -t; }
+	fi
+
 	for a in "${R2PM_DBDIR}" "${R2PM_USRDIR}"/db2/*/db ; do
 		[ -d "$a" ] || continue
 (
 		cd "${a}"
 		if [ -n "$1" ]; then
-			grep R2PM_DESC * /dev/null | sed -e "s,:R2PM_DESC,    `printf ' \t'`," -e 's,",,g' | grep -i "$1"
+			grep R2PM_DESC * /dev/null | sed -e "s,:R2PM_DESC,    `printf ' \t'`," -e 's,",,g' | \
+				grep -i "$1" | cols
 		else
-			grep R2PM_DESC * /dev/null | sed -e "s,:R2PM_DESC,    `printf ' \t'`," -e 's,",,g'
+			grep R2PM_DESC * /dev/null | sed -e "s,:R2PM_DESC,    `printf ' \t'`," -e 's,",,g' | cols
 		fi
 )
 	done


### PR DESCRIPTION
align package names across all packages.

 linux, freebsd and mac should all have column. otherwise ignored.