### PR TITLE
Replace sort_attrs (insertion sort) with a single insertion

### DIFF
--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -93,18 +93,6 @@ static const char **attr_at(RConsCanvas *c, int loc) {
 	return NULL;
 }
 
-static void sort_attrs(RConsCanvas *c) {
-	int i, j;
-	RConsCanvasAttr value;
-	for (i = 1; i < c->attrslen; i++) {
-		value = c->attrs[i];
-		for (j = i - 1; j >= 0 && c->attrs[j].loc > value.loc; j--) {
-			c->attrs[j + 1] = c->attrs[j];
-		}
-		c->attrs[j + 1] = value;
-	}
-}
-
 static void stamp_attr(RConsCanvas *c, int loc, int length) {
 	if (!c->color) {
 		return;
@@ -126,10 +114,12 @@ static void stamp_attr(RConsCanvas *c, int loc, int length) {
 		}
 		*s = c->attr;
 	} else {
-		c->attrs[c->attrslen].loc = loc;
-		c->attrs[c->attrslen].a = c->attr;
+		for (i = c->attrslen; i > 0 && loc < c->attrs[i].loc; i--) {
+			c->attrs[i] = c->attrs[i - 1];
+		}
+		c->attrs[i].loc = loc;
+		c->attrs[i].a = c->attr;
 		c->attrslen++;
-		sort_attrs (c);
 	}
 
 	for (i = 1; i < length; i++) {


### PR DESCRIPTION
Inserting an element into a sorted array does not need full insertion sort.

Fixes #11164 
