### PR TITLE
fix type confusion

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1755,7 +1755,7 @@ static char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, int depth) {
 			r_io_read_at (core->io, value, buf, sizeof (buf));
 			r_asm_set_pc (core->assembler, value);
 			r_asm_disassemble (core->assembler, &op, buf, sizeof (buf));
-			r_strbuf_appendf (s, " '%s'", op.buf_asm.ptr? op.buf_asm.ptr : op.buf_asm.buf);
+			r_strbuf_appendf (s, " '%s'", r_asm_op_get_asm (&op));
 			/* get library name */
 			{ // NOTE: dup for mapname?
 				RDebugMap *map;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1755,7 +1755,7 @@ static char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, int depth) {
 			r_io_read_at (core->io, value, buf, sizeof (buf));
 			r_asm_set_pc (core->assembler, value);
 			r_asm_disassemble (core->assembler, &op, buf, sizeof (buf));
-			r_strbuf_appendf (s, " '%s'", op.buf_asm);
+			r_strbuf_appendf (s, " '%s'", op.buf_asm.ptr? op.buf_asm.ptr : op.buf_asm.buf);
 			/* get library name */
 			{ // NOTE: dup for mapname?
 				RDebugMap *map;


### PR DESCRIPTION
fix type confusion in r_core_anal_hasrefs_to_depth (libr/core/core.c)

The newest version of radare2 will crash with command "v!" on my laptop, which leads me to a type confusion in vfprintf parameters. Since I have tried to fixed it locally, I just submit my commit as well.

I have viewed the guideline but this is a minor change and I don't think it deserves a new branch anyway