### PR TITLE
Fix #11223 -aeim.fd use sdb instead of flagspace as database

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3711,10 +3711,11 @@ static void cmd_esil_mem(RCore *core, const char *input) {
 	}
 
 	if (!*input) {
-		RFlagItem *fi = r_flag_get (core->flags, "aeim.fd");
+		char *fi = sdb_get(core->sdb, "aeim.fd", 0);
 		if (fi) {
 			// Close the fd associated with the aeim stack
-			(void)r_io_fd_close (core->io, fi->offset);
+			ut64 fd = sdb_atoi (fi);
+			(void)r_io_fd_close (core->io, fd);
 		}
 	}
 	addr = r_config_get_i (core->config, "esil.stack.addr");
@@ -3753,7 +3754,7 @@ static void cmd_esil_mem(RCore *core, const char *input) {
 		}
 		r_flag_unset_name (core->flags, name);
 		r_flag_unset_name (core->flags, "aeim.stack");
-		r_flag_unset_name (core->flags, "aeim.fd");
+		sdb_unset(core->sdb, "aeim.fd", 0);
 		// eprintf ("Deinitialized %s\n", name);
 		return;
 	}
@@ -3769,8 +3770,10 @@ static void cmd_esil_mem(RCore *core, const char *input) {
 	}
 	r_io_map_set_name (stack_map, name);
 	// r_flag_set (core->flags, name, addr, size);	//why is this here?
-	r_flag_set (core->flags, "aeim.stack", addr, size);
-	r_flag_set (core->flags, "aeim.fd", esil->stack_fd, 1);
+	char val[128], *v;
+	v = sdb_itoa (esil->stack_fd, val, 10);
+	sdb_set(core->sdb, "aeim.fd", v, 0);
+
 	r_config_set_i (core->config, "io.va", true);
 	if (patt && *patt) {
 		switch (*patt) {


### PR DESCRIPTION

Seems to do it
```
[0x0001ece0]> k
aeim.fd=7
[0x0001ece0]> aeim-
[0x0001ece0]> k
[0x0001ece0]> om=
00  0xe0000000 |----------------------------------------------------------------------------------------------------#| 0xe0100000 rw- 11 cortex
01  0x50000000 |------------------------------------#----------------------------------------------------------------| 0x50080000 rw- 10 gpio
02  0x40000000 |----------------------------#------------------------------------------------------------------------| 0x40080000 rw- 9 io
03  0x20007560 |--------------#--------------------------------------------------------------------------------------| 0x20008000 rw- 8 stack_dummy
04  0x20000000 |--------------#--------------------------------------------------------------------------------------| 0x20002000 rwx 6 softdevice_ram
05  0x10001000 |-------#---------------------------------------------------------------------------------------------| 0x10001100 r-- 5 uicr
06  0x10000000 |-------#---------------------------------------------------------------------------------------------| 0x10000100 r-- 4 ficr
07  0x0003b000 |#----------------------------------------------------------------------------------------------------| 0x00040000 r-x 3 boot
08* 0x00018000 |#----------------------------------------------------------------------------------------------------| 0x0003b000 r-x 3 app
09  0x00001000 |#----------------------------------------------------------------------------------------------------| 0x00018000 r-x 3 softdevice
10  0x00000000 |#----------------------------------------------------------------------------------------------------| 0x00001000 r-x 3 mbr
11* 0x00000000 |#----------------------------------------------------------------------------------------------------| 0x00040000 --- 3 flash
```