### PR TITLE
WIP: Remove hardcoded list of scripts

### DIFF
--- a/sys/shellcheck.sh
+++ b/sys/shellcheck.sh
@@ -21,7 +21,7 @@ SHCHK="shellcheck --format=${FMT}"
 
 if ! [ -f "./sys/scripts.list" ] ;then
 	echo "Find all shellscripts, caching in sys/scripts.list"
-	find .  -not -iwholename '*.git*' -print0  | xargs -0 file | grep "POSIX shell script" | cut -d: -f1  > sys/scripts.list
+	find . \! -path '/.git' -print0  | xargs -0 file | grep "POSIX shell script" | cut -d: -f1  > sys/scripts.list
 fi
 
 checkshellscript "./sys/scripts.list" "$SHCHK"

--- a/sys/shellcheck.sh
+++ b/sys/shellcheck.sh
@@ -12,17 +12,8 @@ checkshellscript() {
 		
 }
 
-FMT=gcc
-#if [ -n "${SHELLCHECK_XML}" ]; then
-#	FMT=checkstyle
-#fi
+echo "Find all shellscripts, caching $SCRIPTS"
+SCRIPTS=$(find . \! -path '/.git' -print0  | xargs -0 file | grep "POSIX shell script" | cut -d: -f1)
 
-SHCHK="shellcheck --format=${FMT}"
-
-if ! [ -f "./sys/scripts.list" ] ;then
-	echo "Find all shellscripts, caching in sys/scripts.list"
-	find . \! -path '/.git' -print0  | xargs -0 file | grep "POSIX shell script" | cut -d: -f1  > sys/scripts.list
-fi
-
-checkshellscript "./sys/scripts.list" "$SHCHK"
-#checkshellscript "./sys/scripts.list" "checkbashisms"
+checkshellscript "./sys/scripts.list" "shellcheck --format=gcc"
+checkshellscript "./sys/scripts.list" "checkbashisms"

--- a/sys/shellcheck.sh
+++ b/sys/shellcheck.sh
@@ -1,113 +1,28 @@
 #!/bin/sh
-fileslist=(
-./autogen.sh
-./binr/rax2/test-rax2.sh
-./binr/r2pm/r2pm
-./configure
-./configure.hook
-./configure-plugins
-./doc/dexdump.sh
-./doc/repo
-./env.sh
-./libr/asm/t/lops.sh
-./libr/asm/t/test.arm
-./libr/asm/t/test.cmp
-./libr/asm/t/test.new
-./libr/asm/t/test.nz
-./libr/depgraph.pl
-./libr/egg/t/t-exit1.sh
-./libr/egg/t/t-fun2.sh
-./libr/egg/t/t-fun3.sh
-./libr/egg/t/t-fun4.sh
-./libr/egg/t/t-fun5.sh
-./libr/egg/t/t-fun6.sh
-./libr/egg/t/t-fun.sh
-./libr/egg/t/t-hello.sh
-./libr/egg/t/t-loop2.sh
-./libr/egg/t/t-loop.sh
-./libr/egg/t/t-looptail.sh
-./libr/egg/t/t-nest2.sh
-./libr/egg/t/t-nest3.sh
-./libr/egg/t/t-nest.sh
-./libr/egg/t/t-strlen.sh
-./libr/fs/p/makeplugin.sh
-./libr/stripsyms.sh
-./libr/symgraph.pl
-./libr/syscall/d/gen.sh
-./libr/syscall/d/par.sh
-./media/Radare2.iosapp/Radare2
-./mk/rapi-list
-./sys/afl.sh
-./sys/android-target.sh
-./sys/android-build.sh
-./sys/android-shell.sh
-./sys/asan.sh
-./sys/bokken.sh
-./sys/build-harden.sh
-./sys/build.sh
-./sys/cherrypull.sh
-./sys/clang-analyzer.sh
-./sys/clone-r2-bindings.sh
-./sys/dist-all.sh
-./sys/dist-bin.sh
-./sys/dist.sh
-./sys/duktape.sh
-./sys/emscripten.sh
-./sys/extras.sh
-./sys/farm/bins.sh
-./sys/farm/check.sh
-./sys/farm/daemon.sh
-./sys/farm/html.sh
-./sys/farm/prepare.sh
-./sys/farm/push.sh
-./sys/farm/run.sh
-./sys/farm.sh
-./sys/find-regression.sh
-./sys/gtkaml.sh
-./sys/gtk.sh
-./sys/indent.sh
-./sys/install-rev.sh
-./sys/install.sh
-./sys/ios-cydia.sh
-./sys/ios-sdk-gcc
-./sys/ios-simulator.sh
-./sys/ios-static.sh
-./sys/jam.sh
-./sys/ldconfig.sh
-./sys/locdiff
-./sys/maemo.sh
-./sys/mingw32-deps.sh
-./sys/mingw32-python-deps.sh
-./sys/mingw32-python.sh
-./sys/mingw32.sh
-./sys/mingw64-deps.sh
-./sys/mingw64.sh
-./sys/ndk-gcc
-./sys/osx-pkg.sh
-./sys/osx-pkg-uninstall.sh
-./sys/osx-pkg-uninstall.tool
-./sys/purge.sh
-./sys/python-bindist.sh
-./sys/python-dist.sh
-./sys/python-r2pipe.sh
-./sys/python.sh
-./sys/rebuild.sh
-./sys/shellcheck.sh
-./sys/static.sh
-./sys/sync.sh
-./sys/tiny.sh
-./sys/update.sh
-./sys/user.sh
-./sys/vala.sh
-)
+
+
+checkshellscript() {
+	filelist="$1"
+	checkfun="$2"
+
+	while read -r file 
+	do
+		$checkfun "$file"	
+	done < "$filelist"
+		
+}
 
 FMT=gcc
-if [ -n "${SHELLCHECK_XML}" ]; then
-	FMT=checkstyle
-fi
+#if [ -n "${SHELLCHECK_XML}" ]; then
+#	FMT=checkstyle
+#fi
+
 SHCHK="shellcheck --format=${FMT}"
 
-for i in "${fileslist[@]}"
-do
-	${SHCHK} $i
-done
+if ! [ -f "./sys/scripts.list" ] ;then
+	echo "Find all shellscripts, caching in sys/scripts.list"
+	find .  -not -iwholename '*.git*' -print0  | xargs -0 file | grep "POSIX shell script" | cut -d: -f1  > sys/scripts.list
+fi
+
+checkshellscript "./sys/scripts.list" "$SHCHK"
+#checkshellscript "./sys/scripts.list" "checkbashisms"


### PR DESCRIPTION
shellcheck.sh update

removed hardcoded list of scripts
disabled shellcheck xml format

The plan is to have the list of scripts generated (on first use) instead of trying to maintain list.
Added simple checkbashisms example and  do we really need the xml report  from checkscript? 


