### PR TITLE
util: try to guess function name only when it contains "dll_"

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -631,6 +631,14 @@ typedef struct {
 	ut8 numaux;
 } SymbolRecord;
 
+static void copy_symbol_name(char *dst, const char *src, size_t len) {
+	if (src && *src == '_') {
+		src++;
+	}
+
+	strncpy (dst, src, len);
+}
+
 static struct r_bin_pe_export_t* parse_symbol_table(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_pe_export_t* exports, int sz) {
 	ut64 sym_tbl_off, num = 0;
 	const int srsz = COFF_SYMBOL_SIZE; // symbol record size
@@ -695,14 +703,14 @@ static struct r_bin_pe_export_t* parse_symbol_table(struct PE_(r_bin_pe_obj_t)* 
 					memcpy (shortname, &sr->shortname, 8);
 					shortname[8] = 0;
 					if (*shortname) {
-						strncpy ((char*) exp[symctr].name, shortname, PE_NAME_LENGTH - 1);
+						copy_symbol_name ((char*) exp[symctr].name, shortname, PE_NAME_LENGTH - 1);
 					} else {
 						char* longname, name[128];
 						ut32* idx = (ut32*) (buf + i + 4);
 						if (r_buf_read_at (bin->b, sym_tbl_off + *idx + shsz, (ut8*) name, 128)) { // == 128) {
 							longname = name;
 							name[sizeof(name) - 1] = 0;
-							strncpy ((char*) exp[symctr].name, longname, PE_NAME_LENGTH - 1);
+							copy_symbol_name ((char*) exp[symctr].name, longname, PE_NAME_LENGTH - 1);
 						} else {
 							sprintf ((char*) exp[symctr].name, "unk_%d", symctr);
 						}

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -631,14 +631,6 @@ typedef struct {
 	ut8 numaux;
 } SymbolRecord;
 
-static void copy_symbol_name(char *dst, const char *src, size_t len) {
-	if (src && *src == '_') {
-		src++;
-	}
-
-	strncpy (dst, src, len);
-}
-
 static struct r_bin_pe_export_t* parse_symbol_table(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_pe_export_t* exports, int sz) {
 	ut64 sym_tbl_off, num = 0;
 	const int srsz = COFF_SYMBOL_SIZE; // symbol record size
@@ -703,14 +695,14 @@ static struct r_bin_pe_export_t* parse_symbol_table(struct PE_(r_bin_pe_obj_t)* 
 					memcpy (shortname, &sr->shortname, 8);
 					shortname[8] = 0;
 					if (*shortname) {
-						copy_symbol_name ((char*) exp[symctr].name, shortname, PE_NAME_LENGTH - 1);
+						strncpy ((char*) exp[symctr].name, shortname, PE_NAME_LENGTH - 1);
 					} else {
 						char* longname, name[128];
 						ut32* idx = (ut32*) (buf + i + 4);
 						if (r_buf_read_at (bin->b, sym_tbl_off + *idx + shsz, (ut8*) name, 128)) { // == 128) {
 							longname = name;
 							name[sizeof(name) - 1] = 0;
-							copy_symbol_name ((char*) exp[symctr].name, longname, PE_NAME_LENGTH - 1);
+							strncpy ((char*) exp[symctr].name, longname, PE_NAME_LENGTH - 1);
 						} else {
 							sprintf ((char*) exp[symctr].name, "unk_%d", symctr);
 						}

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -511,8 +511,7 @@ R_API char *r_type_func_guess(Sdb *TDB, char *func_name) {
 	}
 
 	if (slen > 4) { // were name-matching so ignore autonamed
-		if ((str[0] == 'f' && str[1] == 'c' && str[2] == 'n' && str[3] == '.') ||
-		    (str[0] == 'l' && str[1] == 'o' && str[2] == 'c' && str[3] == '.')) {
+		if (!strncmp (str, "fcn.", 4) || !strncmp (str, "loc.", 4) || !strncmp (str, "sub.", 4)) {
 			return NULL;
 		}
 	}

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -511,7 +511,7 @@ R_API char *r_type_func_guess(Sdb *TDB, char *func_name) {
 	}
 
 	if (slen > 4) { // were name-matching so ignore autonamed
-		if (!strncmp (str, "fcn.", 4) || !strncmp (str, "loc.", 4) || !strncmp (str, "sub.", 4)) {
+		if (!strncmp (str, "fcn.", 4) || !strncmp (str, "loc.", 4)) {
 			return NULL;
 		}
 	}
@@ -531,6 +531,14 @@ R_API char *r_type_func_guess(Sdb *TDB, char *func_name) {
 	// some names are in format module.dll_function_number, try to remove those
 	// also try module.dll_function and function_number
 	if ((first = strchr (str, '_'))) {
+		// check if the prefix is actually "dll_" otherwise don't try to
+		// interpret the name
+		const char *dll = "dll";
+		char *dll_ptr = first - strlen (dll);
+		if (dll_ptr >= str && strncmp (dll_ptr, dll, strlen (dll))) {
+			goto out;
+		}
+
 		last = (char *)r_str_lchr (first, '_');
 		if (!last) {
 			goto out;

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -527,6 +527,11 @@ R_API char *r_type_func_guess(Sdb *TDB, char *func_name) {
 	if ((result = type_func_try_guess (TDB, str))) {
 		return result;
 	}
+
+	if (*str == '_' && (result = type_func_try_guess (TDB, str + 1))) {
+		return result;
+	}
+
 	str = strdup (str);
 	// some names are in format module.dll_function_number, try to remove those
 	// also try module.dll_function and function_number

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -535,7 +535,7 @@ R_API char *r_type_func_guess(Sdb *TDB, char *func_name) {
 		// interpret the name
 		const char *dll = "dll";
 		char *dll_ptr = first - strlen (dll);
-		if (dll_ptr >= str && strncmp (dll_ptr, dll, strlen (dll))) {
+		if (dll_ptr < str || strncmp (dll_ptr, dll, strlen (dll))) {
 			goto out;
 		}
 


### PR DESCRIPTION
Before this patch, a function automatically renamed to "sub.strlen_123"
was identified as a call to strlen, thus the strlen signature was added
as a comment next to a call to that function. This patch prevents that
behaviour.