### PR TITLE
Remove RIOAccessLog

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -213,23 +213,6 @@ typedef struct r_io_desc_cache_t {
 	ut8 cdata[R_IO_DESC_CACHE_SIZE];
 } RIODescCache;
 
-typedef struct r_io_access_log_element_t {
-	ut64 vaddr;
-	ut64 paddr;
-	int buf_idx;
-	int expect_len;
-	int len;
-	int fd;
-	int mapid;
-	int flags;
-} RIOAccessLogElement;
-
-typedef struct r_io_access_log_t {
-	bool allocation_failed;
-	ut8 *buf;
-	RList *log;
-} RIOAccessLog;
-
 struct r_io_bind_t;
 
 typedef bool (*RIODescUse) (RIO *io, int fd);
@@ -239,7 +222,6 @@ typedef RIODesc *(*RIOOpen) (RIO *io, const char *uri, int flags, int mode);
 typedef RIODesc *(*RIOOpenAt) (RIO *io, const  char *uri, int flags, int mode, ut64 at);
 typedef bool (*RIOClose) (RIO *io, int fd);
 typedef bool (*RIOReadAt) (RIO *io, ut64 addr, ut8 *buf, int len);
-typedef RIOAccessLog *(*RIOAlReadAt) (RIO *io, ut64 addr, ut8 *buf, int len);
 typedef bool (*RIOWriteAt) (RIO *io, ut64 addr, const ut8 *buf, int len);
 typedef char *(*RIOSystem) (RIO *io, const char* cmd);
 typedef int (*RIOFdOpen) (RIO *io, const char *uri, int flags, int mode);
@@ -254,9 +236,6 @@ typedef bool (*RIOFdIsDbg) (RIO *io, int fd);
 typedef const char *(*RIOFdGetName) (RIO *io, int fd);
 typedef RList *(*RIOFdGetMap) (RIO *io, int fd);
 typedef bool (*RIOFdRemap) (RIO *io, int fd, ut64 addr);
-typedef void (*RIOAlSort) (RIOAccessLog *log);
-typedef void (*RIOAlFree) (RIOAccessLog *log);
-typedef ut8 *(*RIOAlGetFbufByflags) (RIOAccessLog *log, int flags, ut64 *addr, int *len);
 typedef bool (*RIOIsValidOff) (RIO *io, ut64 addr, int hasperm);
 typedef bool (*RIOAddrIsMapped) (RIO *io, ut64 addr);
 typedef SdbList *(*RIOSectionVgetSecsAt) (RIO *io, ut64 vaddr);
@@ -273,7 +252,6 @@ typedef struct r_io_bind_t {
 	RIOOpenAt open_at;
 	RIOClose close;
 	RIOReadAt read_at;
-	RIOAlReadAt al_read_at;	//needed for esil
 	RIOWriteAt write_at;
 	RIOSystem system;
 	RIOFdOpen fd_open;
@@ -288,9 +266,6 @@ typedef struct r_io_bind_t {
 	RIOFdGetName fd_get_name;
 	RIOFdGetMap fd_get_map;
 	RIOFdRemap fd_remap;
-	RIOAlSort al_sort;	//needed for esil
-	RIOAlFree al_free;	//needed for esil
-	RIOAlGetFbufByflags al_buf_byflags;	//needed for esil
 	RIOIsValidOff is_valid_offset;
 	RIOAddrIsMapped addr_is_mapped;
 	RIOSectionVgetSecsAt sections_vget;
@@ -340,12 +315,9 @@ R_API int r_io_close_all (RIO *io);
 R_API int r_io_pread_at (RIO *io, ut64 paddr, ut8 *buf, int len);
 R_API int r_io_pwrite_at (RIO *io, ut64 paddr, const ut8 *buf, int len);
 R_API bool r_io_vread_at_mapped(RIO* io, ut64 vaddr, ut8* buf, int len);
-R_API RIOAccessLog *r_io_al_vread_at (RIO *io, ut64 vaddr, ut8 *buf, int len);
-R_API RIOAccessLog *r_io_al_vwrite_at (RIO *io, ut64 vaddr, const ut8 *buf, int len);
 R_API bool r_io_read_at (RIO *io, ut64 addr, ut8 *buf, int len);
 R_API bool r_io_read_at_mapped(RIO *io, ut64 addr, ut8 *buf, int len);
 R_API int r_io_nread_at (RIO *io, ut64 addr, ut8 *buf, int len);
-R_API RIOAccessLog *r_io_al_read_at (RIO *io, ut64 addr, ut8 *buf, int len);
 R_API void r_io_alprint(RList *ls);
 R_API bool r_io_write_at (RIO *io, ut64 addr, const ut8 *buf, int len);
 R_API bool r_io_read (RIO *io, ut8 *buf, int len);
@@ -509,12 +481,6 @@ R_API bool r_io_is_valid_offset (RIO *io, ut64 offset, int hasperm);
 R_API bool r_io_addr_is_mapped(RIO *io, ut64 vaddr);
 R_API bool r_io_read_i (RIO* io, ut64 addr, ut64 *val, int size, bool endian);
 R_API bool r_io_write_i (RIO* io, ut64 addr, ut64 *val, int size, bool endian);
-R_API RIOAccessLog *r_io_accesslog_new (void);
-R_API void r_io_accesslog_free (RIOAccessLog *log);
-R_API void r_io_accesslog_sort (RIOAccessLog *log);
-R_API void r_io_accesslog_sqash_ignore_gaps (RIOAccessLog *log);
-R_API void r_io_accesslog_sqash_byflags (RIOAccessLog *log, int flags);
-R_API ut8 *r_io_accesslog_getf_buf_byflags (RIOAccessLog *log, int flags, ut64 *addr, int *len);
 
 extern RIOPlugin r_io_plugin_procpid;
 extern RIOPlugin r_io_plugin_malloc;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -14,46 +14,6 @@ static int fd_write_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOM
 	return r_io_fd_write_at (io, fd, addr, buf, len);
 }
 
-static int al_fd_read_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
-	RIOAccessLog *log = (RIOAccessLog *)user;
-	RIOAccessLogElement *ale = R_NEW0 (RIOAccessLogElement);
-	int rlen = r_io_fd_read_at (io, fd, addr, buf, len);
-	if (ale) {
-		ale->expect_len = len;
-		ale->len = rlen;
-		ale->buf_idx = (int)(size_t)(buf - log->buf);
-		ale->flags = map->flags;
-		ale->fd = fd;
-		ale->mapid = map->id;
-		ale->paddr = addr;
-		ale->vaddr = map->itv.addr + (addr - map->delta);
-		r_list_append (log->log, ale);
-	} else {
-		log->allocation_failed = true;
-	}
-	return rlen;
-}
-
-static int al_fd_write_at_wrap (RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user) {
-	RIOAccessLog *log = (RIOAccessLog *)user;
-	RIOAccessLogElement *ale = R_NEW0 (RIOAccessLogElement);
-	int rlen = r_io_fd_write_at (io, fd, addr, buf, len);
-	if (ale) {
-		ale->expect_len = len;
-		ale->len = rlen;
-		ale->buf_idx = (int)(size_t)(buf - log->buf);
-		ale->flags = map->flags;
-		ale->fd = fd;
-		ale->mapid = map->id;
-		ale->paddr = addr;
-		ale->vaddr = map->itv.addr + (addr - map->delta);
-		r_list_append (log->log, ale);
-	} else {
-		log->allocation_failed = true;
-	}
-	return rlen;
-}
-
 typedef int (*cbOnIterMap)(RIO *io, int fd, ut64 addr, ut8 *buf, int len, RIOMap *map, void *user);
 
 // If prefix_mode is true, returns the number of bytes of operated prefix; returns < 0 on error.
@@ -132,46 +92,6 @@ static st64 on_map_skyline(RIO *io, ut64 vaddr, ut8 *buf, int len, int match_flg
 		}
 	}
 	return prefix_mode ? addr - vaddr : ret;
-}
-
-// Precondition: len > 0
-// Non-stop IO
-// Returns true iff all reads/writes on overlapped maps are complete.
-static bool onIterMap(SdbListIter *iter, RIO *io, ut64 vaddr, ut8 *buf,
-		int len, int match_flg, cbOnIterMap op, void *user) {
-	// vendaddr may be 0 to denote 2**64
-	ut64 vendaddr = vaddr + len, len1;
-	int t;
-	bool ret = true;
-	for (; iter; iter = iter->p) {
-		RIOMap *map = (RIOMap *)iter->data;
-		ut64 to = r_itv_end (map->itv);
-		if (r_itv_overlap2 (map->itv, vaddr, len)) {
-			if ((map->flags & match_flg) == match_flg || io->p_cache) {
-				t = vaddr < map->itv.addr
-						? op (io, map->fd, map->delta, buf + map->itv.addr - vaddr,
-								len1 = R_MIN (vendaddr - map->itv.addr, map->itv.size), map, user)
-						: op (io, map->fd, map->delta + vaddr - map->itv.addr, buf,
-								len1 = R_MIN (to - vaddr, len), map, user);
-				if (t != len1) {
-					ret = false;
-				}
-			}
-			if (vaddr < map->itv.addr) {
-				t = onIterMap (iter->p, io, vaddr, buf, map->itv.addr - vaddr, match_flg, op, user);
-				if (!t) {
-					ret = false;
-				}
-			}
-			if (to - 1 < vendaddr - 1) {
-				t = onIterMap (iter->p, io, to, buf + to - vaddr, vendaddr - to, match_flg, op, user);
-				if (!t) {
-					ret = false;
-				}
-			}
-		}
-	}
-	return ret;
 }
 
 R_API RIO* r_io_new() {
@@ -396,37 +316,6 @@ static bool r_io_vwrite_at(RIO* io, ut64 vaddr, const ut8* buf, int len) {
 	return on_map_skyline (io, vaddr, (ut8*)buf, len, R_IO_WRITE, fd_write_at_wrap, false);
 }
 
-R_API RIOAccessLog *r_io_al_vread_at(RIO* io, ut64 vaddr, ut8* buf, int len) {
-	RIOAccessLog *log;
-	if (!io || !buf || (len < 1)) {
-		return NULL;
-	}
-	r_io_map_cleanup (io);
-	if (!io->maps || !(log = r_io_accesslog_new ())) {
-		return NULL;
-	}
-	if (io->ff) {
-		memset (buf, io->Oxff, len);
-	}
-	log->buf = buf;
-	onIterMap (io->maps->tail, io, vaddr, buf, len, R_IO_READ, al_fd_read_at_wrap, log);
-	return log;
-}
-
-R_API RIOAccessLog *r_io_al_vwrite_at(RIO* io, ut64 vaddr, const ut8* buf, int len) {
-	RIOAccessLog *log;
-	if (!io || !buf || (len < 1)) {
-		return NULL;
-	}
-	r_io_map_cleanup (io);
-	if (!io->maps || !(log = r_io_accesslog_new ())) {
-		return NULL;
-	}
-	log->buf = (ut8*)buf;
-	(void)onIterMap (io->maps->tail, io, vaddr, (ut8*)buf, len, R_IO_WRITE, al_fd_write_at_wrap, log);
-	return log;
-}
-
 // Deprecated, use either r_io_read_at_mapped or r_io_nread_at instead.
 // For virtual mode, returns true if all reads on mapped regions are successful
 // and complete.
@@ -501,40 +390,6 @@ R_API int r_io_nread_at(RIO *io, ut64 addr, ut8 *buf, int len) {
 		(void)r_io_cache_read (io, addr, buf, len);
 	}
 	return ret;
-}
-
-R_API RIOAccessLog *r_io_al_read_at(RIO* io, ut64 addr, ut8* buf, int len) {
-	RIOAccessLog *log;
-	RIOAccessLogElement *ale = NULL;
-	int rlen;
-	if (!io || !buf || (len < 1)) {
-		return NULL;
-	}
-	if (io->va) {
-		return r_io_al_vread_at (io, addr, buf, len);
-	}
-	if (!(log = r_io_accesslog_new ())) {
-		return NULL;
-	}
-	log->buf = buf;
-	if (io->ff) {
-		memset (buf, io->Oxff, len);
-	}
-	rlen = r_io_pread_at (io, addr, buf, len);
-	if (io->cached & R_IO_READ) {
-		(void)r_io_cache_read (io, addr, buf, len);
-	}
-	if (!(ale = R_NEW0 (RIOAccessLogElement))) {
-		log->allocation_failed = true;
-	} else {
-		ale->paddr = ale->vaddr = addr;
-		ale->len = rlen;
-		ale->expect_len = len;
-		ale->flags = io->desc ? io->desc->flags : 0;
-		ale->fd = io->desc ? io->desc->fd : 0;		//xxx
-		r_list_append (log->log, ale);
-	}
-	return log;
 }
 
 R_API bool r_io_write_at(RIO* io, ut64 addr, const ut8* buf, int len) {
@@ -696,7 +551,6 @@ R_API int r_io_bind(RIO* io, RIOBind* bnd) {
 	bnd->open_at = r_io_open_at;
 	bnd->close = r_io_fd_close;
 	bnd->read_at = r_io_read_at;
-	bnd->al_read_at = r_io_al_read_at;
 	bnd->write_at = r_io_write_at;
 	bnd->system = r_io_system;
 	bnd->fd_open = r_io_fd_open;
@@ -711,9 +565,6 @@ R_API int r_io_bind(RIO* io, RIOBind* bnd) {
 	bnd->fd_get_name = r_io_fd_get_name;
 	bnd->fd_get_map = r_io_map_get_for_fd;
 	bnd->fd_remap = r_io_map_remap_fd;
-	bnd->al_sort = r_io_accesslog_sort;
-	bnd->al_free = r_io_accesslog_free;
-	bnd->al_buf_byflags = r_io_accesslog_getf_buf_byflags;
 	bnd->is_valid_offset = r_io_is_valid_offset;
 	bnd->addr_is_mapped = r_io_addr_is_mapped;
 	bnd->sections_vget = r_io_sections_vget;

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -7,12 +7,6 @@
 // TODO: we may probably take care of this when the binfiles have an associated list of fds
 #define REUSE_NULL_MAPS 1
 
-static int __access_log_e_cmp (const void *a, const void *b) {
-	RIOAccessLogElement *A = (RIOAccessLogElement *)a;
-	RIOAccessLogElement *B = (RIOAccessLogElement *)b;
-	return (A->buf_idx > B->buf_idx);
-}
-
 typedef struct {
 	const char *uri;
 	int flags;
@@ -209,105 +203,4 @@ R_API bool r_io_write_i(RIO* io, ut64 addr, ut64 *val, int size, bool endian) {
 		return false;
 	}
 	return true;
-}
-
-R_API RIOAccessLog *r_io_accesslog_new() {
-	RIOAccessLog *log = R_NEW0 (RIOAccessLog);
-	if (!log) {
-		return NULL;
-	}
-	if (!(log->log = r_list_newf (free))) {
-		free (log);
-		return NULL;
-	}
-	return log;
-}
-
-R_API void r_io_accesslog_free(RIOAccessLog *log) {
-	if (log) {
-		r_list_free (log->log);
-	}
-	free (log);
-}
-
-R_API void r_io_accesslog_sort(RIOAccessLog *log) {
-	if (!log || !log->log) {
-		return;
-	}
-	r_list_sort (log->log, __access_log_e_cmp);
-}
-
-R_API void r_io_accesslog_sqash_ignore_gaps(RIOAccessLog *log) {
-	RListIter *iter, *ator;
-	RIOAccessLogElement *ale, *ela;
-	if (!log || !log->log || !log->log->length) {
-		return;
-	}
-	if (!log->log->sorted) {
-		r_list_sort (log->log, __access_log_e_cmp);
-	}
-	r_list_foreach_safe (log->log, iter, ator, ale) {
-		if (iter->p) {
-			ela = (RIOAccessLogElement *)iter->p->data;
-			if ((ale->len == ale->expect_len) && (ela->len == ela->expect_len)) {
-				if (ela->mapid != ale->mapid) {
-					ela->mapid = 0;			//what to do with fd?
-				}
-				ela->flags &= ale->flags;
-				ela->len += (ale->buf_idx - ela->buf_idx) + ale->len;
-				r_list_delete (log->log, iter);
-			}
-		}
-	}
-}
-
-R_API void r_io_accesslog_sqash_byflags(RIOAccessLog *log, int flags) {
-	RListIter *iter, *ator;
-	RIOAccessLogElement *ale, *ela;
-	if (!log || !log->log || !log->log->length) {
-		return;
-	}
-	if (!log->log->sorted) {
-		r_list_sort (log->log, __access_log_e_cmp);
-	}
-	r_list_foreach_safe (log->log, iter, ator, ale) {
-		if (iter->p) {
-			ela = (RIOAccessLogElement *)iter->p->data;
-			if (((ale->flags & flags) == (ela->flags & flags)) &&
-				((ale->flags & flags) == flags) &&
-				(ale->len == ale->expect_len) &&	//only sqash on succes
-				(ela->len == ela->expect_len) &&
-				((ela->buf_idx + ela->len) == ale->buf_idx)) {
-				if (ela->mapid != ale->mapid) {
-					ela->mapid = 0;			//what to do with fd?
-				}
-				ela->flags &= (ale->flags & flags);
-				ela->len += ale->len;
-				r_list_delete (log->log, iter);
-			}
-		}
-	}
-}
-
-//gets first buffer that matches with the flags and frees the element
-R_API ut8 *r_io_accesslog_getf_buf_byflags(RIOAccessLog *log, int flags, ut64 *addr, int *len) {
-	RListIter *iter;
-	RIOAccessLogElement *ale;
-	ut8 *ret;
-	if (!log || !log->log || !log->log->length) {
-		return NULL;
-	}
-	if (!log->log->sorted) {
-		r_list_sort (log->log, __access_log_e_cmp);
-	}
-	r_list_foreach (log->log, iter, ale) {
-		if (((ale->flags & flags) == flags) && (ale->len == ale->expect_len)) {
-			ret = &log->buf[ale->buf_idx];
-			*len = ale->len;
-			*addr = ale->vaddr;		//what about pa?
-			r_list_delete (log->log, iter);
-			return ret;
-		}
-	}
-	return NULL;
 }


### PR DESCRIPTION
There were introduced in siol but it is apparent that nobody uses the
API in the year. They make up a significant unused part of IO that distract readers enough and would hamper further IO cleanups.

Their introduction was probably an instance of XY problem. They were supposed to facilitate analysis, esil and debugging io but how they could benefit the features is never clearly justified.
Usually, you not only need raw bytes but also metadata attached to them.
You would have to add a layer on top of RIOAccessLog anyway, render them not so useful.

These stuff are still in git histories. They can be revived anytime when their values are clearly testified.
