### PR TITLE
Make wc- invalidate all (fully or partially) overlapping cache

### DIFF
--- a/libr/include/r_list.h
+++ b/libr/include/r_list.h
@@ -55,6 +55,8 @@ typedef struct r_oflist_t {
 #define r_list_foreach_prev(list, it, pos)\
 	if (list)\
 		for (it = list->tail; it && (pos = it->data, 1); it = it->p)
+#define r_list_foreach_prev_safe(list, it, tmp, pos) \
+	for (it = list->tail; it && (pos = it->data, tmp = it->p, 1); it = tmp)
 #ifndef _R_LIST_C_
 #define r_list_push(x, y) r_list_append (x, y)
 #define r_list_iterator(x) (x)? (x)->head: NULL


### PR DESCRIPTION
Fix the handling of [to] in wc- [from] [to]