### PR TITLE
glibc tcache parsing checked by a config flag, no more preprocessor

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -1151,6 +1151,13 @@ int main(int argc, char **argv, char **envp) {
 					RBinObject *obj = r_bin_get_object (r.bin);
 					if (obj && obj->info) {
 						eprintf ("asm.bits %d\n", obj->info->bits);
+#if __linux__ && __GNU_LIBRARY__ && __GLIBC__ && __GLIBC_MINOR__ && __x86_64__
+						ut64 bitness = r_config_get_i (r.config, "asm.bits");
+						if (bitness == 32) {
+							eprintf ("glibc.fc_offset = 0x00158\n");
+							r_config_set_i (r.config, "dbg.glibc.fc_offset", 0x00158);
+						}
+#endif
 					}
 				}
 			}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2384,6 +2384,18 @@ R_API int r_core_config_init(RCore *core) {
 #else
 	SETCB("dbg.malloc", "jemalloc", &cb_malloc, "Choose malloc structure parser");
 #endif
+#if __GLIBC_MINOR__ > 25
+	SETPREF ("dbg.glibc.tcache", "true", "Set glib tcache parsing");
+#else
+	SETPREF ("dbg.glibc.tcache", "false", "Set glib tcache parsing");
+#endif
+#if R_SYS_BITS == R_SYS_BITS_64
+	SETI ("dbg.glibc.ma_offset", 0x000000, "Main_arena offset from his symbol");
+	SETI ("dbg.glibc.fc_offset", 0x00250, "First chunk offset from brk_start");
+#else
+	SETI ("dbg.glibc.ma_offset", 0x1bb000, "Main_arena offset from his symbol");
+	SETI ("dbg.glibc.fc_offset", 0x18, "First chunk offset from brk_start");
+#endif
 
 	SETPREF ("esil.prestep", "true", "Step before esil evaluation in `de` commands");
 	SETPREF ("esil.fillstack", "", "Initialize ESIL stack with (random, debrujn, sequence, zeros, ...)");

--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -32,51 +32,9 @@ R_LIB_VERSION_HEADER(r_heap_glibc);
 #define BITSPERMAP (1U << BINMAPSHIFT)
 #define BINMAPSIZE (NBINS / BITSPERMAP)
 #define MAX(a,b) (((a)>(b))?(a):(b))
-
-#if __GLIBC_MINOR__ > 25
-#define MALLOC_ALIGNMENT 16
-#else
-#define MALLOC_ALIGNMENT MAX (2 * SZ,  __alignof__ (long double))
-#endif
-
-#define MALLOC_ALIGN_MASK (MALLOC_ALIGNMENT - 1)
 #define NPAD -6
-
-
-#if __GLIBC_MINOR__ > 25
-#define MallocState GH(RHeap_MallocState_tcache)
-#define SIZE_SZ (sizeof (size_t))
-#define MIN_CHUNK_SIZE SZ*4
-#define MINSIZE  \
-  (unsigned long)(((MIN_CHUNK_SIZE+MALLOC_ALIGN_MASK) & ~MALLOC_ALIGN_MASK))
-#define request2size(req)                                         \
-  (((req) + SIZE_SZ + MALLOC_ALIGN_MASK < MINSIZE)  ?             \
-   MINSIZE :                                                      \
-   ((req) + SIZE_SZ + MALLOC_ALIGN_MASK) & ~MALLOC_ALIGN_MASK)
-
-# define TCACHE_MAX_BINS        	64
-# define MAX_TCACHE_SIZE        	tidx2usize (TCACHE_MAX_BINS-1)
-/* Only used to pre-fill the tunables.  */
-# define tidx2usize(idx)        (((size_t) idx) * MALLOC_ALIGNMENT + MINSIZE - SIZE_SZ)
-
-/* When "x" is from chunksize().  */
-# define csize2tidx(x) (((x) - MINSIZE + MALLOC_ALIGNMENT - 1) / MALLOC_ALIGNMENT)
-/* When "x" is a user-provided size.  */
-# define usize2tidx(x) csize2tidx (request2size (x))
-
-/* With rounding and alignment, the bins are...
-   idx 0   bytes 0..24 (64-bit) or 0..12 (32-bit)
-   idx 1   bytes 25..40 or 13..20
-   idx 2   bytes 41..56 or 21..28
-   etc.  */
- 
-/* This is another arbitrary limit, which tunables can change.  Each
-tcache bin will hold at most this number of chunks.  */
-# define TCACHE_FILL_COUNT 7
-
-#else
-#define MallocState GH(RHeap_MallocState)
-#endif
+#define TCACHE_MAX_BINS 64
+#define TCACHE_FILL_COUNT 7
 
 #define largebin_index_32(size)				       \
 (((((ut32)(size)) >>  6) <= 38)?  56 + (((ut32)(size)) >>  6): \
@@ -142,39 +100,34 @@ typedef RHeapChunk32 *mfastbinptr32;
 typedef RHeapChunk32 *mchunkptr32;
 */
 
-typedef struct r_malloc_state_32 { 
-	int mutex; 				/* serialized access */ 
-	int flags; 				/* flags */
-	ut32 fastbinsY[NFASTBINS];		/* array of fastchunks */
-	ut32 top; 				/* top chunk's base addr */ 
-	ut32 last_remainder;			/* remainder top chunk's addr */
-	ut32 bins[NBINS * 2 - 2];   		/* array of remainder free chunks */
-	unsigned int binmap[BINMAPSIZE]; 	/* bitmap of bins */
+typedef struct r_malloc_state_32 {
+	int mutex;                              /* serialized access */
+	int flags;                              /* flags */
+	ut32 fastbinsY[NFASTBINS];              /* array of fastchunks */
+	ut32 top;                               /* top chunk's base addr */
+	ut32 last_remainder;                    /* remainder top chunk's addr */
+	ut32 bins[NBINS * 2 - 2];               /* array of remainder free chunks */
+	unsigned int binmap[BINMAPSIZE];        /* bitmap of bins */
+	ut32 next;                              /* double linked list of chunks */
+	ut32 next_free;                         /* double linked list of free chunks */
+	ut32 system_mem;                        /* current allocated memory of current arena */
+	ut32 max_system_mem;                    /* maximum system memory */
+} RHeap_MallocState_32;
 
-	ut32 next; 				/* double linked list of chunks */
-	ut32 next_free; 			/* double linked list of free chunks */
+typedef struct r_malloc_state_64 {
+	int mutex;                              /* serialized access */
+	int flags;                              /* flags */
+	ut64 fastbinsY[NFASTBINS];              /* array of fastchunks */
+	ut64 top;                               /* top chunk's base addr */
+	ut64 last_remainder;                    /* remainder top chunk's addr */
+	ut64 bins[NBINS * 2 - 2];               /* array of remainder free chunks */
+	unsigned int binmap[BINMAPSIZE];        /* bitmap of bins */
+	ut64 next;                              /* double linked list of chunks */
+	ut64 next_free;                         /* double linked list of free chunks */
+	ut64 system_mem;                        /* current allocated memory of current arena */
+	ut64 max_system_mem;                    /* maximum system memory */
+} RHeap_MallocState_64;
 
-	ut32 system_mem; 			/* current allocated memory of current arena */
-	ut32 max_system_mem;  			/* maximum system memory */
-} RHeap_MallocState_32; 
-
-typedef struct r_malloc_state_64 { 
-	int mutex; 				/* serialized access */ 
-	int flags; 				/* flags */
-	ut64 fastbinsY[NFASTBINS];		/* array of fastchunks */
-	ut64 top; 				/* top chunk's base addr */ 
-	ut64 last_remainder;			/* remainder top chunk's addr */
-	ut64 bins[NBINS * 2 - 2];   		/* array of remainder free chunks */
-	unsigned int binmap[BINMAPSIZE]; 	/* bitmap of bins */
-
-	ut64 next; 				/* double linked list of chunks */
-	ut64 next_free; 			/* double linked list of free chunks */
-
-	ut64 system_mem; 			/* current allocated memory of current arena */
-	ut64 max_system_mem;  			/* maximum system memory */
-} RHeap_MallocState_64; 
-
-#if __GLIBC_MINOR__ > 25
 typedef struct r_tcache_perthread_struct_32 {
 	ut8 counts[TCACHE_MAX_BINS];
 	unsigned int *entries[TCACHE_MAX_BINS];
@@ -186,46 +139,66 @@ typedef struct r_tcache_perthread_struct_64 {
 } RHeapTcache_64;
 
 typedef struct r_malloc_state_tcache_32 {
-	int mutex; 				/* serialized access */
-	int flags; 				/* flags */
-
+	int mutex;                              /* serialized access */
+	int flags;                              /* flags */
 	int have_fast_chunks;                   /* have fast chunks */
-
-	ut32 fastbinsY[NFASTBINS + 1];		/* array of fastchunks */
-	ut32 top; 				/* top chunk's base addr */
-	ut32 last_remainder;			/* remainder top chunk's addr */
-	ut32 bins[NBINS * 2 - 2];   		/* array of remainder free chunks */
-	unsigned int binmap[BINMAPSIZE]; 	/* bitmap of bins */
-
-	ut32 next; 				/* double linked list of chunks */
-	ut32 next_free; 			/* double linked list of free chunks */
+	ut32 fastbinsY[NFASTBINS + 1];          /* array of fastchunks */
+	ut32 top;                               /* top chunk's base addr */
+	ut32 last_remainder;                    /* remainder top chunk's addr */
+	ut32 bins[NBINS * 2 - 2];               /* array of remainder free chunks */
+	unsigned int binmap[BINMAPSIZE];        /* bitmap of bins */
+	ut32 next;                              /* double linked list of chunks */
+	ut32 next_free;                         /* double linked list of free chunks */
 	unsigned int attached_threads;          /* threads attached */
-
-	ut32 system_mem;	 		/* current allocated memory of current arena */
-	ut32 max_system_mem;  			/* maximum system memory */
+	ut32 system_mem;                        /* current allocated memory of current arena */
+	ut32 max_system_mem;                    /* maximum system memory */
 } RHeap_MallocState_tcache_32;
 
-
 typedef struct r_malloc_state_tcache_64 {
-	int mutex; 				/* serialized access */
-	int flags; 				/* flags */
-
+	int mutex;                              /* serialized access */
+	int flags;                              /* flags */
 	int have_fast_chunks;                   /* have fast chunks */
+	ut64 fastbinsY[NFASTBINS];              /* array of fastchunks */
+	ut64 top;                               /* top chunk's base addr */
+	ut64 last_remainder;                    /* remainder top chunk's addr */
+	ut64 bins[NBINS * 2 - 2];               /* array of remainder free chunks */
+	unsigned int binmap[BINMAPSIZE];        /* bitmap of bins */
+	ut64 next;                              /* double linked list of chunks */
+	ut64 next_free;                         /* double linked list of free chunks */
+	unsigned int attached_threads;          /* threads attached */
+	ut64 system_mem;                        /* current allocated memory of current arena */
+	ut64 max_system_mem;                    /* maximum system memory */
+} RHeap_MallocState_tcache_64;
 
-	ut64 fastbinsY[NFASTBINS];		/* array of fastchunks */
-	ut64 top; 				/* top chunk's base addr */
-	ut64 last_remainder;			/* remainder top chunk's addr */
-	ut64 bins[NBINS * 2 - 2];   		/* array of remainder free chunks */
-	unsigned int binmap[BINMAPSIZE]; 	/* bitmap of bins */
+typedef struct r_malloc_state {
+	int mutex;                              /* serialized access */
+	int flags;                              /* flags */
+	unsigned int binmap[BINMAPSIZE];        /* bitmap of bins */
 
-	ut64 next; 				/* double linked list of chunks */
-	ut64 next_free; 			/* double linked list of free chunks */
+	/*tcache*/
+	int have_fast_chunks;                   /* have fast chunks */
 	unsigned int attached_threads;          /* threads attached */
 
-	ut64 system_mem;	 		/* current allocated memory of current arena */
-	ut64 max_system_mem;  			/* maximum system memory */
-} RHeap_MallocState_tcache_64;
-#endif
+	/*32 bits members*/
+	ut32 fastbinsY_32[NFASTBINS + 1];       /* array of fastchunks */
+	ut32 top_32;                            /* top chunk's base addr */
+	ut32 last_remainder_32;                 /* remainder top chunk's addr */
+	ut32 bins_32[NBINS * 2 - 2];            /* array of remainder free chunks */
+	ut32 next_32;                           /* double linked list of chunks */
+	ut32 next_free_32;                      /* double linked list of free chunks */
+	ut32 system_mem_32;                     /* current allocated memory of current arena */
+	ut32 max_system_mem_32;                 /* maximum system memory */
+
+	/*64 bits members */
+	ut64 fastbinsY_64[NFASTBINS];           /* array of fastchunks */
+	ut64 top_64;                            /* top chunk's base addr */
+	ut64 last_remainder_64;                 /* remainder top chunk's addr */
+	ut64 bins_64[NBINS * 2 - 2];            /* array of remainder free chunks */
+	ut64 next_64;                           /* double linked list of chunks */
+	ut64 next_free_64;                      /* double linked list of free chunks */
+	ut64 system_mem_64;                     /* current allocated memory of current arena */
+	ut64 max_system_mem_64;                 /* maximum system memory */
+} MallocState;
 
 typedef struct r_heap_info_32 {
 	ut32 ar_ptr;			/* Arena for this heap. */
@@ -235,7 +208,7 @@ typedef struct r_heap_info_32 {
 
 	/* Make sure the following data is properly aligned, particularly
 	that sizeof (heap_info) + 2 * SZ is a multiple of
-	MALLOC_ALIGNMENT. */	
+	MALLOC_ALIGNMENT. */
 	/* char pad[NPAD * SZ & MALLOC_ALIGN_MASK]; */
 } RHeapInfo_32;
 
@@ -255,4 +228,3 @@ typedef struct r_heap_info_64 {
 }
 #endif
 #endif
-


### PR DESCRIPTION
the tcache parsing is controlled by glibc.tcache

Created some more options : 

 dbg.glibc.fc_offset: First chunk offset from brk_start
 dbg.glibc.ma_offset: Main_arena offset from his symbol
 dbg.glibc.tcache: Set glib tcache parsing

Now its possible to relocate offsets to main_arena and first chunk if needed
This flags only affects if tcache parsing is enabled