### PR TITLE
Change prioritization terminology to add clarification

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -33,7 +33,7 @@ static const char *help_msg_o[] = {
 	"oo","+","reopen current file in read-write",
 	"ood","[r] [args]","reopen in debugger mode (with args)",
 	"oo[bnm]"," [...]","see oo? for help",
-	"op"," [fd]", "prioritize given fd (see also ob)",
+	"op"," [fd]", "select the given fd as current file (see also ob)",
 	"ox", " fd fdx", "exchange the descs of fd and fdx and keep the mapping",
 	NULL
 };


### PR DESCRIPTION
Prioritize seems like a strange choice of wording to use here because there doesn't appear to be any prioritization after the prioritized file. You are either interacting with the prioritized file or none at all. For me personally was confusing while trying to figure out how to interact with the "o" set of menus, what this was actually doing, and understand that prioritize is the action I wanted to take to select the file to interact with. Is there ever a case where this understanding of prioritization isn't true?

If this is a change that is desired, does it make sense to change the terminology globally away from prioritization?