### PR TITLE
Use waitpid with WNOHANG in lang_pipe_run()

### DIFF
--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -120,6 +120,7 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 	child = r_sys_fork ();
 	if (child == -1) {
 		/* error */
+		perror ("pipe run");
 	} else if (!child) {
 		/* children */
 		r_sandbox_system (code, 1);
@@ -177,7 +178,7 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 	if (safe_in != -1) {
 		close (safe_in);
 	}
-	waitpid (child, NULL, 0);
+	waitpid (child, NULL, WNOHANG);
 	return true;
 #else
 #if __WINDOWS__


### PR DESCRIPTION
I am having issues in Cutter, where this waitpid call never returns. Specifying WNOHANG here fixes the issue.
It would makes sense to me since the child process could have already quit when waitpid is called, can't it?