### PR TITLE
fix #11275 attempt.

### DIFF
--- a/libr/anal/p/anal_wasm.c
+++ b/libr/anal/p/anal_wasm.c
@@ -93,8 +93,12 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 	op->type = R_ANAL_OP_TYPE_UNK;
 	op->id = wop.op;
 
-	if (!strncmp(wop.txt, "invalid", 7)) {
+	if (!strncmp (wop.txt, "invalid", 7)) {
 		op->type = R_ANAL_OP_TYPE_ILL;
+		return -1;
+	} 
+	if (wasm_stack_ptr >= WASM_STACK_SIZE) {
+		op->type = R_ANAL_OP_TYPE_NULL;
 		return -1;
 	} else {
 		switch (wop.op) {

--- a/libr/asm/op.c
+++ b/libr/asm/op.c
@@ -32,7 +32,7 @@ R_API char *r_asm_op_get_asm(RAsmOp *op) {
 }
 
 R_API ut8 *r_asm_op_get_buf(RAsmOp *op) {
-	return r_strbuf_get (&op->buf);
+	return (ut8*)r_strbuf_get (&op->buf);
 }
 
 R_API int r_asm_op_get_size(RAsmOp *op) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2219,6 +2219,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 	r_cons_printf ("{\"offset\":%"PFMT64d",\"name\":\"%s\",\"size\":%d",
 			fcn->addr, name, r_anal_fcn_size (fcn));
 	r_cons_printf (",\"realsz\":%d", r_anal_fcn_realsize (fcn));
+	r_cons_printf (",\"stackframe\":%d", fcn->maxstack);
 	r_cons_printf (",\"cc\":%d", r_anal_fcn_cc (fcn));
 	r_cons_printf (",\"cost\":%d", r_anal_fcn_cost (core->anal, fcn));
 	r_cons_printf (",\"nbbs\":%d", r_list_length (fcn->bbs));


### PR DESCRIPTION
with the given use case there was an overflow
above the upper end of the stack.