### PR TITLE
Do not hardcode 9 for SIGKILL

### DIFF
--- a/binr/r2agent/r2agent.c
+++ b/binr/r2agent/r2agent.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
 				// TODO: show page here?
 				int pid = atoi (rs->path + 11);
 				if (pid > 0) {
-					kill (pid, 9);
+					kill (pid, SIGKILL);
 				}
 			} else if (!strncmp (rs->path, "/file/open/", 11)) {
 				int pid;

--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -375,7 +375,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 	}
 	if (!task) {
 		if (pid > 0 && !strncmp (file, "smach://", 8)) {
-			kill (pid, 9);
+			kill (pid, SIGKILL);
 			eprintf ("Child killed\n");
 		}
 #if 0
@@ -384,7 +384,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 		 * what was this intended to check anyway ? */
 		if (pid > 0 && io->referer && !strncmp (io->referer, "dbg://", 6)) {
 			eprintf ("Child killed\n");
-			kill (pid, 9);
+			kill (pid, SIGKILL);
 		}
 #endif
 		switch (errno) {

--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -200,7 +200,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 			return NULL;
 		}
 		/* do nothing here */
-		kill (getpid (), 9);
+		kill (getpid (), SIGKILL);
 #endif
 	} else if (!strncmp (cmd, "call ", 5)) {
 		size_t cbptr = 0;

--- a/libr/socket/proc.c
+++ b/libr/socket/proc.c
@@ -71,7 +71,7 @@ error:
 R_API int r_socket_proc_close(struct r_socket_proc_t *sp) {
 #if __UNIX__
 	/* this is wrong */
-	kill (sp->pid, 9);
+	kill (sp->pid, SIGKILL);
 	waitpid (sp->pid, NULL, 0); //WNOHANG);
 	close (sp->fd0[0]);
 	close (sp->fd0[1]);


### PR DESCRIPTION
Changes 9 with SIGKILL as 'kill' operand.