### PR TITLE
io: API refactoring (regular and _batch versions)

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -1086,8 +1086,7 @@ int main(int argc, char **argv, char **envp) {
 								(void)r_core_bin_load (&r, filepath, baddr);
 							}
 						} else {
-							r_io_map_new (r.io, iod->fd, perms, 0LL, mapaddr, r_io_desc_size (iod), true);
-							// r_io_map_new (r.io, iod->fd, iod->flags, 0LL, 0LL, r_io_desc_size (iod));
+							r_io_map_new (r.io, iod->fd, perms, 0LL, mapaddr, r_io_desc_size (iod));
 							if (run_anal < 0) {
 								// PoC -- must move -rk functionalitiy into rcore
 								// this may be used with caution (r2 -nn $FILE)
@@ -1115,7 +1114,7 @@ int main(int argc, char **argv, char **envp) {
 						iod = r.io ? r_io_desc_get (r.io, fh->fd) : NULL;
 						if (iod) {
 							perms = iod->flags;
-							r_io_map_new (r.io, iod->fd, perms, 0LL, 0LL, r_io_desc_size (iod), true);
+							r_io_map_new (r.io, iod->fd, perms, 0LL, 0LL, r_io_desc_size (iod));
 						}
 					}
 				}

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -563,7 +563,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 
 	if (plugin && plugin->name) {
 		if (!strncmp (plugin->name, "any", 3)) {
-			r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc), true);
+			r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc));
 			// set use of raw strings
 			//r_config_set (r->config, "bin.rawstr", "true");
 			// r_config_set_i (r->config, "io.va", false);
@@ -575,7 +575,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 
 			//workaround to map correctly malloc:// and raw binaries
 			if (r_io_desc_is_dbg (desc) || (obj && (!obj->sections || !va))) {
-				r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc), true);
+				r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc));
 			}
 
 			RBinInfo *info = obj? obj->info: NULL;
@@ -589,7 +589,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 			}
 		}
 	} else {
-		r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc), true);
+		r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc));
 		if (binfile) {
 			r_core_bin_set_arch_bits (r, binfile->file,
 					r_config_get (r->config, "asm.arch"),

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3798,7 +3798,7 @@ static void cmd_esil_mem(RCore *core, const char *input) {
 	snprintf (uri, sizeof (uri), "malloc://%d", (int)size);
 	esil->stack_fd = r_io_fd_open (core->io, uri, R_IO_RW, 0);
 	if (!(stack_map = r_io_map_add (core->io, esil->stack_fd,
-			R_IO_RW, 0LL, addr, size, true))) {
+			R_IO_RW, 0LL, addr, size))) {
 		r_io_fd_close (core->io, esil->stack_fd);
 		eprintf ("Cannot create map for tha stack, fd %d got closed again\n", esil->stack_fd);
 		esil->stack_fd = 0;

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -676,7 +676,7 @@ static void cmd_open_map(RCore *core, const char *input) {
 				if (!size) {
 					size = r_io_fd_size (core->io, fd);
 				}
-				map = r_io_map_add (core->io, fd, rwx_arg ? rwx : desc->flags, paddr, vaddr, size, true);
+				map = r_io_map_add (core->io, fd, rwx_arg ? rwx : desc->flags, paddr, vaddr, size);
 				r_io_map_set_name (map, name);
 			}
 		} else {
@@ -755,7 +755,7 @@ static void cmd_open_map(RCore *core, const char *input) {
 			RIODesc *desc = r_io_desc_get (core->io, fd);
 			if (desc) {
 				ut64 size = r_io_desc_size (desc);
-				map = r_io_map_add (core->io, fd, desc->flags, 0, 0, size, true);
+				map = r_io_map_add (core->io, fd, desc->flags, 0, 0, size);
 				r_io_map_set_name (map, desc->name);
 			} else {
 				eprintf ("Usage: omm [fd]\n");
@@ -1114,7 +1114,7 @@ static int cmd_open(void *data, const char *input) {
 		if ((file = r_core_file_open (core, ptr, perms, addr))) {
 			fd = file->fd;
 			r_io_map_add (core->io, fd, perms, 0LL, addr,
-					r_io_fd_size (core->io, fd), true);
+					r_io_fd_size (core->io, fd));
 		}
 		r_str_argv_free (argv);
 		if (!silence) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2737,7 +2737,7 @@ reaccept:
 					if (r_core_file_open (core, (const char *)ptr, perm, 0)) {
 						int fd = r_io_fd_get_current (core->io);
 						r_core_bin_load (core, NULL, baddr);
-						r_io_map_add (core->io, fd, perm, 0, 0, r_io_fd_size (core->io, fd), true);
+						r_io_map_add (core->io, fd, perm, 0, 0, r_io_fd_size (core->io, fd));
 						if (core->file) {
 							pipefd = fd;
 						} else {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -646,7 +646,7 @@ static RDisasmState * ds_init(RCore *core) {
 		emustack_min = addr;
 		emustack_max = addr + size;
 		ds->stackFd = r_io_fd_open (core->io, uri, R_IO_RW, 0);
-		RIOMap *map = r_io_map_add (core->io, ds->stackFd, R_IO_RW, 0LL, addr, size, true);
+		RIOMap *map = r_io_map_add (core->io, ds->stackFd, R_IO_RW, 0LL, addr, size);
 		if (!map) {
 			r_io_fd_close (core->io, ds->stackFd);
 			eprintf ("Cannot create map for tha stack, fd %d got closed again\n", ds->stackFd);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -298,7 +298,8 @@ typedef struct r_io_bind_t {
 } RIOBind;
 
 //map.c
-R_API RIOMap *r_io_map_new (RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
+R_API RIOMap *r_io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
+R_API RIOMap *r_io_map_new_batch(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
 R_API ut64 r_io_map_next_address(RIO* io, ut64 addr);
 R_API void r_io_map_init (RIO *io);
 R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr);
@@ -306,7 +307,8 @@ R_API bool r_io_map_remap_fd (RIO *io, int fd, ut64 addr);
 R_API bool r_io_map_exists (RIO *io, RIOMap *map);
 R_API bool r_io_map_exists_for_id (RIO *io, ut32 id);
 R_API RIOMap *r_io_map_resolve (RIO *io, ut32 id);
-R_API RIOMap *r_io_map_add (RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
+R_API RIOMap *r_io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
+R_API RIOMap *r_io_map_add_batch(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
 R_API RIOMap *r_io_map_get (RIO *io, ut64 addr);		//returns the map at vaddr with the highest priority
 R_API RIOMap *r_io_map_get_paddr (RIO *io, ut64 paddr);		//returns the map at paddr with the highest priority
 R_API void r_io_map_reset(RIO* io);
@@ -330,7 +332,8 @@ R_API RIO *r_io_new (void);
 R_API RIO *r_io_init (RIO *io);
 R_API RIODesc *r_io_open_nomap (RIO *io, const char *uri, int flags, int mode);		//should return int
 R_API RIODesc *r_io_open (RIO *io, const char *uri, int flags, int mode);
-R_API RIODesc *r_io_open_at (RIO *io, const char *uri, int flags, int mode, ut64 at);
+R_API RIODesc *r_io_open_at(RIO *io, const char *uri, int flags, int mode, ut64 at);
+R_API RIODesc *r_io_open_at_batch(RIO *io, const char *uri, int flags, int mode, ut64 at);
 R_API RList *r_io_open_many (RIO *io, const char *uri, int flags, int mode);
 R_API RIODesc* r_io_open_buffer (RIO *io, RBuffer *b, int flags, int mode);
 R_API bool r_io_close (RIO *io);
@@ -501,8 +504,10 @@ R_API bool r_io_use_fd (RIO *io, int fd);
 #define r_io_range_free(x)	free(x)
 
 /* io/ioutils.c */
-R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, bool do_skyline);
-R_API bool r_io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch, bool do_skyline);
+R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null);
+R_API bool r_io_create_mem_map_batch(RIO *io, RIOSection *sec, ut64 at, bool null);
+R_API bool r_io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch);
+R_API bool r_io_create_file_map_batch(RIO *io, RIOSection *sec, ut64 size, bool patch);
 R_API bool r_io_create_mem_for_section(RIO *io, RIOSection *sec);
 R_API bool r_io_is_valid_offset (RIO *io, ut64 offset, int hasperm);
 R_API bool r_io_addr_is_mapped(RIO *io, ut64 vaddr);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -323,13 +323,13 @@ R_API bool r_io_map_is_in_range (RIOMap *map, ut64 from, ut64 to);
 R_API void r_io_map_set_name (RIOMap *map, const char *name);
 R_API void r_io_map_del_name (RIOMap *map);
 R_API RIOMap *r_io_map_add_next_available(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, ut64 load_align);
-R_API void r_io_map_calculate_skyline(RIO *io);
 R_API RList* r_io_map_get_for_fd(RIO *io, int fd);
 R_API bool r_io_map_resize(RIO *io, ut32 id, ut64 newsize);
 
 //io.c
 R_API RIO *r_io_new (void);
 R_API RIO *r_io_init (RIO *io);
+R_API void r_io_update(RIO *io);
 R_API RIODesc *r_io_open_nomap (RIO *io, const char *uri, int flags, int mode);		//should return int
 R_API RIODesc *r_io_open (RIO *io, const char *uri, int flags, int mode);
 R_API RIODesc *r_io_open_at(RIO *io, const char *uri, int flags, int mode, ut64 at);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -294,12 +294,12 @@ R_API RIODesc *r_io_open_at(RIO *io, const char *uri, int flags, int mode, ut64 
 
 /**
  * It creates a new RIODesc from the specified uri, without updating the
- * internal state of IO. You should call `r_io_map_calculate_skyline` to ensure
+ * internal state of IO. You should call `r_io_update` to ensure
  * updates done with this function are correctly handled by IO.
  *
  * WARNING: Use this function cautiously, when the performance overhead caused
  *          by the update of the internal IO state can be reduced by manually
- *          handling it with `r_io_map_calculate_skyline`.
+ *          handling it with `r_io_update`.
  */
 R_API RIODesc *r_io_open_at_batch(RIO *io, const char *uri, int flags, int mode, ut64 at) {
 	return open_at (io, uri, flags, mode, at, false);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -275,8 +275,7 @@ R_API RIODesc* r_io_open_at(RIO* io, const char* uri, int flags, int mode, ut64 
 		// someone pls take a look at this confusing stuff
 		size = UT64_MAX - at + 1;
 	}
-	// skyline not updated
-	r_io_map_new (io, desc->fd, desc->flags, 0LL, at, size, false);
+	r_io_map_new (io, desc->fd, desc->flags, 0LL, at, size, true);
 	return desc;
 }
 

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -252,12 +252,12 @@ R_API RIODesc* r_io_open(RIO* io, const char* uri, int flags, int mode) {
 	if (!desc) {
 		return NULL;
 	}
-	r_io_map_new (io, desc->fd, desc->flags, 0LL, 0LL, r_io_desc_size (desc), true);
+	r_io_map_new (io, desc->fd, desc->flags, 0LL, 0LL, r_io_desc_size (desc));
 	return desc;
 }
 
 /* opens a file and maps it to an offset specified by the "at"-parameter */
-R_API RIODesc* r_io_open_at(RIO* io, const char* uri, int flags, int mode, ut64 at) {
+static RIODesc* open_at(RIO* io, const char* uri, int flags, int mode, ut64 at, bool do_skyline) {
 	RIODesc* desc;
 	ut64 size;
 	if (!io || !io->maps) {
@@ -271,12 +271,38 @@ R_API RIODesc* r_io_open_at(RIO* io, const char* uri, int flags, int mode, ut64 
 	// second map
 	if (size && ((UT64_MAX - size + 1) < at)) {
 		// split map into 2 maps if only 1 big map results into interger overflow
-		r_io_map_new (io, desc->fd, desc->flags, UT64_MAX - at + 1, 0LL, size - (UT64_MAX - at) - 1, false);
+		r_io_map_new_batch (io, desc->fd, desc->flags, UT64_MAX - at + 1, 0LL, size - (UT64_MAX - at) - 1);
 		// someone pls take a look at this confusing stuff
 		size = UT64_MAX - at + 1;
 	}
-	r_io_map_new (io, desc->fd, desc->flags, 0LL, at, size, true);
+	if (do_skyline) {
+		r_io_map_new (io, desc->fd, desc->flags, 0LL, at, size);
+	} else {
+		r_io_map_new_batch (io, desc->fd, desc->flags, 0LL, at, size);
+	}
 	return desc;
+}
+
+/**
+ * It creates a new RIODesc from the specified uri and it ensures the internal
+ * state is updated and consistent. Use this function unless there are very good
+ * reasons to prefer its _batch version (r_io_open_at_batch)
+ */
+R_API RIODesc *r_io_open_at(RIO *io, const char *uri, int flags, int mode, ut64 at) {
+	return open_at (io, uri, flags, mode, at, true);
+}
+
+/**
+ * It creates a new RIODesc from the specified uri, without updating the
+ * internal state of IO. You should call `r_io_map_calculate_skyline` to ensure
+ * updates done with this function are correctly handled by IO.
+ *
+ * WARNING: Use this function cautiously, when the performance overhead caused
+ *          by the update of the internal IO state can be reduced by manually
+ *          handling it with `r_io_map_calculate_skyline`.
+ */
+R_API RIODesc *r_io_open_at_batch(RIO *io, const char *uri, int flags, int mode, ut64 at) {
+	return open_at (io, uri, flags, mode, at, false);
 }
 
 /* opens many files, without mapping them. This should be discussed */

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -79,7 +79,7 @@ static bool create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, bool do
 		return false;
 	}
 	if (do_skyline) {
-		r_io_map_calculate_skyline (io);
+		r_io_update (io);
 	}
 	// this works, because new maps are allways born on the top
 	RIOMap *map = r_io_map_get (io, at);
@@ -104,7 +104,7 @@ R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null) {
  *
  * WARNING: Use this function cautiously, when the performance overhead caused
  *          by the update of the internal IO state can be reduced by manually
- *          handling it with `r_io_map_calculate_skyline`.
+ *          handling it with `r_io_update`.
  */
 R_API bool r_io_create_mem_map_batch(RIO *io, RIOSection *sec, ut64 at, bool null) {
 	return create_mem_map (io, sec, at, null, false);
@@ -149,7 +149,7 @@ R_API bool r_io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch)
  *
  * WARNING: Use this function cautiously, when the performance overhead caused
  *          by the update of the internal IO state can be reduced by manually
- *          handling it with `r_io_map_calculate_skyline`.
+ *          handling it with `r_io_update`.
  */
 R_API bool r_io_create_file_map_batch(RIO *io, RIOSection *sec, ut64 size, bool patch) {
 	return create_file_map (io, sec, size, patch, false);

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -145,7 +145,7 @@ out:
 	free (deleted);
 }
 
-R_API RIOMap* r_io_map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline) {
+static RIOMap* map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline) {
 	if (!size || !io || !io->maps || !io->map_ids) {
 		return NULL;
 	}
@@ -158,7 +158,7 @@ R_API RIOMap* r_io_map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut
 	map->delta = delta;
 	if ((UT64_MAX - size + 1) < addr) {
 		/// XXX: this is leaking a map!!!
-		r_io_map_new (io, fd, flags, delta - addr, 0LL, size + addr, do_skyline);
+		map_new (io, fd, flags, delta - addr, 0LL, size + addr, do_skyline);
 		size = -(st64)addr;
 	}
 	// RIOMap describes an interval of addresses (map->from; map->to)
@@ -173,6 +173,28 @@ R_API RIOMap* r_io_map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut
 	return map;
 }
 
+/**
+ * It creates a new RIOMap from the specified file descriptor and it ensures the
+ * internal state is updated and consistent. Use this function unless there are
+ * very good reasons to prefer its _batch version (r_io_map_new_batch)
+ */
+R_API RIOMap *r_io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size) {
+	return map_new (io, fd, flags, delta, addr, size, true);
+}
+
+/**
+ * It creates a new RIOMap from the specified file descriptor, without updating
+ * the internal state of IO. You should call `r_io_map_calculate_skyline` to
+ * ensure updates done with this function are correctly handled by IO.
+ *
+ * WARNING: Use this function cautiously, when the performance overhead caused
+ *          by the update of the internal IO state can be reduced by manually
+ *          handling it with `r_io_map_calculate_skyline`.
+ */
+R_API RIOMap *r_io_map_new_batch(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size) {
+	return map_new (io, fd, flags, delta, addr, size, false);
+}
+
 R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr) {
 	RIOMap *map = r_io_map_resolve (io, id);
 	if (map) {
@@ -180,7 +202,7 @@ R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr) {
 		map->itv.addr = addr;
 		if (UT64_MAX - size + 1 < addr) {
 			map->itv.size = -addr;
-			r_io_map_new (io, map->fd, map->flags, map->delta - addr, 0, size + addr, true);
+			r_io_map_new (io, map->fd, map->flags, map->delta - addr, 0, size + addr);
 			return true;
 		}
 		r_io_map_calculate_skyline (io);
@@ -256,15 +278,29 @@ R_API RIOMap* r_io_map_resolve(RIO* io, ut32 id) {
 	return NULL;
 }
 
-R_API RIOMap* r_io_map_add(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline) {
+static RIOMap* map_add(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline) {
 	//check if desc exists
 	RIODesc* desc = r_io_desc_get (io, fd);
 	if (desc) {
 		//a map cannot have higher permissions than the desc belonging to it
-		return r_io_map_new (io, fd, (flags & desc->flags) | (flags & R_IO_EXEC),
+		return map_new (io, fd, (flags & desc->flags) | (flags & R_IO_EXEC),
 				delta, addr, size, do_skyline);
 	}
 	return NULL;
+}
+
+R_API RIOMap *r_io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size) {
+	return map_add (io, fd, flags, delta, addr, size, true);
+}
+
+/**
+ *
+ * WARNING: Use this function cautiously, when the performance overhead caused
+ *          by the update of the internal IO state can be reduced by manually
+ *          handling it with `r_io_map_calculate_skyline`.
+ */
+R_API RIOMap *r_io_map_add_batch(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size) {
+	return map_add (io, fd, flags, delta, addr, size, false);
 }
 
 R_API RIOMap* r_io_map_get_paddr(RIO* io, ut64 paddr) {
@@ -477,13 +513,12 @@ R_API RIOMap* r_io_map_add_next_available(RIO* io, int fd, int flags, ut64 delta
 
 		if (map->fd == fd && ((map->itv.addr <= next_addr && next_addr < to) ||
 						r_itv_contain (map->itv, end_addr))) {
-			//return r_io_map_add(io, fd, flags, delta, map->to, size);
 			next_addr = to + (load_align - (to % load_align)) % load_align;
 			return r_io_map_add_next_available (io, fd, flags, delta, next_addr, size, load_align);
 		}
 		break;
 	}
-	return r_io_map_new (io, fd, flags, delta, next_addr, size, true);
+	return r_io_map_new (io, fd, flags, delta, next_addr, size);
 }
 
 R_API ut64 r_io_map_next_address(RIO* io, ut64 addr) {
@@ -527,7 +562,7 @@ R_API bool r_io_map_resize(RIO *io, ut32 id, ut64 newsize) {
 	ut64 addr = map->itv.addr;
 	if (UT64_MAX - newsize + 1 < addr) {
 		map->itv.size = -addr;
-		r_io_map_new (io, map->fd, map->flags, map->delta - addr, 0, newsize + addr, true);
+		r_io_map_new (io, map->fd, map->flags, map->delta - addr, 0, newsize + addr);
 		return true;
 	}
 	map->itv.size = newsize;

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -400,16 +400,16 @@ static bool _section_apply_for_anal_patch(RIO *io, RIOSection *sec, bool patch) 
 			ut64 at = sec->vaddr + sec->size;
 			// TODO: harden this, handle mapslit
 			// craft the uri for the null-fd
-			if (r_io_create_mem_map (io, sec, at, true, false)) {
-			// we need to create this map for transfering the flags, no real remapping here
-				if (r_io_create_file_map (io, sec, sec->size, patch, false)) {
+			if (r_io_create_mem_map_batch (io, sec, at, true)) {
+				// we need to create this map for transfering the flags, no real remapping here
+				if (r_io_create_file_map_batch (io, sec, sec->size, patch)) {
 					return true;
 				}
 			}
 		}
 	} else {
 		// same as above
-		if (!sec->filemap && r_io_create_file_map (io, sec, sec->vsize, patch, false)) {
+		if (!sec->filemap && r_io_create_file_map_batch (io, sec, sec->vsize, patch)) {
 			return true;
 		}
 	}

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -642,7 +642,7 @@ R_API bool r_io_section_apply_bin(RIO *io, ut32 bin_id, RIOSectionApplyMethod me
 			_section_apply (io, sec, method);
 		}
 	}
-	r_io_map_calculate_skyline (io);
+	r_io_update (io);
 	return ret;
 }
 
@@ -655,7 +655,7 @@ R_API bool r_io_section_reapply(RIO *io, ut32 id, RIOSectionApplyMethod method) 
 		return false;
 	}
 	bool ret = _section_reapply (io, sec, method);
-	r_io_map_calculate_skyline (io);
+	r_io_update (io);
 	return ret;
 }
 
@@ -672,6 +672,6 @@ R_API bool r_io_section_reapply_bin(RIO *io, ut32 binid, RIOSectionApplyMethod m
 			_section_reapply (io, sec, method);
 		}
 	}
-	r_io_map_calculate_skyline (io);
+	r_io_update (io);
 	return ret;
 }


### PR DESCRIPTION
r2r PR: https://github.com/radare/radare2-regressions/pull/1466

This PR does the following things:
- remove `do_skyline` parameter from io APIs by splitting functions in a "regular" version and a "batch" one. The regular version is the one we should always use unless for performance reasons we may want to batch updates to maps/fds and update the io state with a call to `r_io_update` (aka `r_io_map_update_skyline`). This makes it much clearer that the _batch versions are risky and should be used with care.
- fixes a bug in `r_open_at` which wasn't updating the internal state of IO (aka the skyline).