### PR TITLE
WIP: remove skyline from public API

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -1086,8 +1086,7 @@ int main(int argc, char **argv, char **envp) {
 								(void)r_core_bin_load (&r, filepath, baddr);
 							}
 						} else {
-							r_io_map_new (r.io, iod->fd, perms, 0LL, mapaddr, r_io_desc_size (iod), true);
-							// r_io_map_new (r.io, iod->fd, iod->flags, 0LL, 0LL, r_io_desc_size (iod));
+							r_io_map_new (r.io, iod->fd, perms, 0LL, mapaddr, r_io_desc_size (iod));
 							if (run_anal < 0) {
 								// PoC -- must move -rk functionalitiy into rcore
 								// this may be used with caution (r2 -nn $FILE)
@@ -1115,7 +1114,7 @@ int main(int argc, char **argv, char **envp) {
 						iod = r.io ? r_io_desc_get (r.io, fh->fd) : NULL;
 						if (iod) {
 							perms = iod->flags;
-							r_io_map_new (r.io, iod->fd, perms, 0LL, 0LL, r_io_desc_size (iod), true);
+							r_io_map_new (r.io, iod->fd, perms, 0LL, 0LL, r_io_desc_size (iod));
 						}
 					}
 				}

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -563,7 +563,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 
 	if (plugin && plugin->name) {
 		if (!strncmp (plugin->name, "any", 3)) {
-			r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc), true);
+			r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc));
 			// set use of raw strings
 			//r_config_set (r->config, "bin.rawstr", "true");
 			// r_config_set_i (r->config, "io.va", false);
@@ -575,7 +575,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 
 			//workaround to map correctly malloc:// and raw binaries
 			if (r_io_desc_is_dbg (desc) || (obj && (!obj->sections || !va))) {
-				r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc), true);
+				r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc));
 			}
 
 			RBinInfo *info = obj? obj->info: NULL;
@@ -589,7 +589,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 			}
 		}
 	} else {
-		r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc), true);
+		r_io_map_new (r->io, desc->fd, desc->flags, 0, laddr, r_io_desc_size (desc));
 		if (binfile) {
 			r_core_bin_set_arch_bits (r, binfile->file,
 					r_config_get (r->config, "asm.arch"),

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3801,7 +3801,7 @@ static void cmd_esil_mem(RCore *core, const char *input) {
 	snprintf (uri, sizeof (uri), "malloc://%d", (int)size);
 	esil->stack_fd = r_io_fd_open (core->io, uri, R_IO_RW, 0);
 	if (!(stack_map = r_io_map_add (core->io, esil->stack_fd,
-			R_IO_RW, 0LL, addr, size, true))) {
+			R_IO_RW, 0LL, addr, size))) {
 		r_io_fd_close (core->io, esil->stack_fd);
 		eprintf ("Cannot create map for tha stack, fd %d got closed again\n", esil->stack_fd);
 		esil->stack_fd = 0;

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -676,7 +676,7 @@ static void cmd_open_map(RCore *core, const char *input) {
 				if (!size) {
 					size = r_io_fd_size (core->io, fd);
 				}
-				map = r_io_map_add (core->io, fd, rwx_arg ? rwx : desc->flags, paddr, vaddr, size, true);
+				map = r_io_map_add (core->io, fd, rwx_arg ? rwx : desc->flags, paddr, vaddr, size);
 				r_io_map_set_name (map, name);
 			}
 		} else {
@@ -755,7 +755,7 @@ static void cmd_open_map(RCore *core, const char *input) {
 			RIODesc *desc = r_io_desc_get (core->io, fd);
 			if (desc) {
 				ut64 size = r_io_desc_size (desc);
-				map = r_io_map_add (core->io, fd, desc->flags, 0, 0, size, true);
+				map = r_io_map_add (core->io, fd, desc->flags, 0, 0, size);
 				r_io_map_set_name (map, desc->name);
 			} else {
 				eprintf ("Usage: omm [fd]\n");
@@ -1114,7 +1114,7 @@ static int cmd_open(void *data, const char *input) {
 		if ((file = r_core_file_open (core, ptr, perms, addr))) {
 			fd = file->fd;
 			r_io_map_add (core->io, fd, perms, 0LL, addr,
-					r_io_fd_size (core->io, fd), true);
+					r_io_fd_size (core->io, fd));
 		}
 		r_str_argv_free (argv);
 		if (!silence) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2743,7 +2743,7 @@ reaccept:
 					if (r_core_file_open (core, (const char *)ptr, perm, 0)) {
 						int fd = r_io_fd_get_current (core->io);
 						r_core_bin_load (core, NULL, baddr);
-						r_io_map_add (core->io, fd, perm, 0, 0, r_io_fd_size (core->io, fd), true);
+						r_io_map_add (core->io, fd, perm, 0, 0, r_io_fd_size (core->io, fd));
 						if (core->file) {
 							pipefd = fd;
 						} else {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -646,7 +646,7 @@ static RDisasmState * ds_init(RCore *core) {
 		emustack_min = addr;
 		emustack_max = addr + size;
 		ds->stackFd = r_io_fd_open (core->io, uri, R_IO_RW, 0);
-		RIOMap *map = r_io_map_add (core->io, ds->stackFd, R_IO_RW, 0LL, addr, size, true);
+		RIOMap *map = r_io_map_add (core->io, ds->stackFd, R_IO_RW, 0LL, addr, size);
 		if (!map) {
 			r_io_fd_close (core->io, ds->stackFd);
 			eprintf ("Cannot create map for tha stack, fd %d got closed again\n", ds->stackFd);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -321,7 +321,6 @@ R_API bool r_io_map_is_in_range (RIOMap *map, ut64 from, ut64 to);
 R_API void r_io_map_set_name (RIOMap *map, const char *name);
 R_API void r_io_map_del_name (RIOMap *map);
 R_API RIOMap *r_io_map_add_next_available(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, ut64 load_align);
-R_API void r_io_map_calculate_skyline(RIO *io);
 R_API RList* r_io_map_get_for_fd(RIO *io, int fd);
 R_API bool r_io_map_resize(RIO *io, ut32 id, ut64 newsize);
 
@@ -501,8 +500,6 @@ R_API bool r_io_use_fd (RIO *io, int fd);
 #define r_io_range_free(x)	free(x)
 
 /* io/ioutils.c */
-R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, bool do_skyline);
-R_API bool r_io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch, bool do_skyline);
 R_API bool r_io_create_mem_for_section(RIO *io, RIOSection *sec);
 R_API bool r_io_is_valid_offset (RIO *io, ut64 offset, int hasperm);
 R_API bool r_io_addr_is_mapped(RIO *io, ut64 vaddr);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -306,7 +306,7 @@ R_API bool r_io_map_remap_fd (RIO *io, int fd, ut64 addr);
 R_API bool r_io_map_exists (RIO *io, RIOMap *map);
 R_API bool r_io_map_exists_for_id (RIO *io, ut32 id);
 R_API RIOMap *r_io_map_resolve (RIO *io, ut32 id);
-R_API RIOMap *r_io_map_add (RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
+R_API RIOMap *r_io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
 R_API RIOMap *r_io_map_get (RIO *io, ut64 addr);		//returns the map at vaddr with the highest priority
 R_API RIOMap *r_io_map_get_paddr (RIO *io, ut64 paddr);		//returns the map at paddr with the highest priority
 R_API void r_io_map_reset(RIO* io);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -298,7 +298,7 @@ typedef struct r_io_bind_t {
 } RIOBind;
 
 //map.c
-R_API RIOMap *r_io_map_new (RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
+R_API RIOMap *r_io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
 R_API ut64 r_io_map_next_address(RIO* io, ut64 addr);
 R_API void r_io_map_init (RIO *io);
 R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -3,6 +3,7 @@
 #include <r_io.h>
 #include <sdb.h>
 #include <config.h>
+#include "io_private.h"
 
 R_LIB_VERSION (r_io);
 
@@ -252,7 +253,7 @@ R_API RIODesc* r_io_open(RIO* io, const char* uri, int flags, int mode) {
 	if (!desc) {
 		return NULL;
 	}
-	r_io_map_new (io, desc->fd, desc->flags, 0LL, 0LL, r_io_desc_size (desc), true);
+	r_io_map_new (io, desc->fd, desc->flags, 0LL, 0LL, r_io_desc_size (desc));
 	return desc;
 }
 
@@ -271,12 +272,12 @@ R_API RIODesc* r_io_open_at(RIO* io, const char* uri, int flags, int mode, ut64 
 	// second map
 	if (size && ((UT64_MAX - size + 1) < at)) {
 		// split map into 2 maps if only 1 big map results into interger overflow
-		r_io_map_new (io, desc->fd, desc->flags, UT64_MAX - at + 1, 0LL, size - (UT64_MAX - at) - 1, false);
+		io_map_new (io, desc->fd, desc->flags, UT64_MAX - at + 1, 0LL, size - (UT64_MAX - at) - 1, false);
 		// someone pls take a look at this confusing stuff
 		size = UT64_MAX - at + 1;
 	}
 	// skyline not updated
-	r_io_map_new (io, desc->fd, desc->flags, 0LL, at, size, false);
+	r_io_map_new (io, desc->fd, desc->flags, 0LL, at, size);
 	return desc;
 }
 

--- a/libr/io/io_private.h
+++ b/libr/io/io_private.h
@@ -2,5 +2,6 @@
 #define _IO_PRIVATE_H_
 
 RIOMap *io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
+RIOMap *io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
 
 #endif

--- a/libr/io/io_private.h
+++ b/libr/io/io_private.h
@@ -4,5 +4,7 @@
 RIOMap *io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
 RIOMap *io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
 void io_map_calculate_skyline(RIO *io);
+bool io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, bool do_skyline);
+bool io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch, bool do_skyline);
 
 #endif

--- a/libr/io/io_private.h
+++ b/libr/io/io_private.h
@@ -1,0 +1,6 @@
+#ifndef _IO_PRIVATE_H_
+#define _IO_PRIVATE_H_
+
+RIOMap *io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
+
+#endif

--- a/libr/io/io_private.h
+++ b/libr/io/io_private.h
@@ -3,5 +3,6 @@
 
 RIOMap *io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
 RIOMap *io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline);
+void io_map_calculate_skyline(RIO *io);
 
 #endif

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -50,7 +50,7 @@ static RIODesc *findReusableFile(RIO *io, const char *uri, int flags) {
 
 #endif
 
-R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, bool do_skyline) {
+bool io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, bool do_skyline) {
 	RIODesc *desc = NULL;
 	char *uri = NULL;
 	bool reused = false;
@@ -97,7 +97,7 @@ R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, boo
 	return true;
 }
 
-R_API bool r_io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch, bool do_skyline) {
+bool io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch, bool do_skyline) {
 	RIOMap *map = NULL;
 	int flags = 0;
 	RIODesc *desc;
@@ -131,15 +131,14 @@ R_API bool r_io_create_mem_for_section(RIO *io, RIOSection *sec) {
 	}
 	if (sec->vsize - sec->size > 0) {
 		ut64 at = sec->vaddr + sec->size;
-		if (!r_io_create_mem_map (io, sec, at, false, true)) {
+		if (!io_create_mem_map (io, sec, at, false, true)) {
 			return false;
 		}
 		RIOMap *map = r_io_map_get (io, at);
 		r_io_map_set_name (map, sdb_fmt ("mem.%s", sec->name));
-			
 	}
 	if (sec->size) {
-		if (!r_io_create_file_map (io, sec, sec->size, false, true)) {
+		if (!io_create_file_map (io, sec, sec->size, false, true)) {
 			return false;
 		}
 		RIOMap *map = r_io_map_get (io, sec->vaddr);

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -115,7 +115,7 @@ R_API bool r_io_create_file_map(RIO *io, RIOSection *sec, ut64 size, bool patch,
 		//if the file was not opened with -w desc->flags won't have that bit active
 		flags = flags | desc->flags;
 	}
-	map = r_io_map_add (io, sec->fd, flags, sec->paddr, sec->vaddr, size, do_skyline);
+	map = io_map_add (io, sec->fd, flags, sec->paddr, sec->vaddr, size, do_skyline);
 	if (map) {
 		sec->filemap = map->id;
 		map->name = r_str_newf ("fmap.%s", sec->name);

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -80,7 +80,7 @@ R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, boo
 		return false;
 	}
 	if (do_skyline) {
-		r_io_map_calculate_skyline (io);
+		io_map_calculate_skyline (io);
 	}
 	// this works, because new maps are allways born on the top
 	RIOMap *map = r_io_map_get (io, at);

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -3,6 +3,7 @@
 #include <r_io.h>
 #include <r_util.h>
 #include <r_types.h>
+#include "io_private.h"
 
 // TODO: we may probably take care of this when the binfiles have an associated list of fds
 #define REUSE_NULL_MAPS 1
@@ -64,7 +65,7 @@ R_API bool r_io_create_mem_map(RIO *io, RIOSection *sec, ut64 at, bool null, boo
 		if (desc) {
 			RIOMap *map = r_io_map_get (io, at);
 			if (!map) {
-				r_io_map_new (io, desc->fd, desc->flags, 0LL, at, gap, false);
+				io_map_new (io, desc->fd, desc->flags, 0LL, at, gap, false);
 			}
 			reused = true;
 		}

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -260,7 +260,7 @@ R_API RIOMap* r_io_map_resolve(RIO* io, ut32 id) {
 	return NULL;
 }
 
-R_API RIOMap* r_io_map_add(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline) {
+RIOMap* io_map_add(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size, bool do_skyline) {
 	//check if desc exists
 	RIODesc* desc = r_io_desc_get (io, fd);
 	if (desc) {
@@ -269,6 +269,10 @@ R_API RIOMap* r_io_map_add(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut
 				delta, addr, size, do_skyline);
 	}
 	return NULL;
+}
+
+R_API RIOMap *r_io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size) {
+	return io_map_add (io, fd, flags, delta, addr, size, true);
 }
 
 R_API RIOMap* r_io_map_get_paddr(RIO* io, ut64 paddr) {
@@ -481,7 +485,6 @@ R_API RIOMap* r_io_map_add_next_available(RIO* io, int fd, int flags, ut64 delta
 
 		if (map->fd == fd && ((map->itv.addr <= next_addr && next_addr < to) ||
 						r_itv_contain (map->itv, end_addr))) {
-			//return r_io_map_add(io, fd, flags, delta, map->to, size);
 			next_addr = to + (load_align - (to % load_align)) % load_align;
 			return r_io_map_add_next_available (io, fd, flags, delta, next_addr, size, load_align);
 		}

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -61,7 +61,7 @@ static bool _map_skyline_push(RPVector *map_skyline, ut64 from, ut64 to, RIOMap 
 }
 
 // Store map parts that are not covered by others into io->map_skyline
-R_API void r_io_map_calculate_skyline(RIO *io) {
+void io_map_calculate_skyline(RIO *io) {
 	SdbListIter *iter;
 	RIOMap *map;
 	RPVector events;
@@ -168,7 +168,7 @@ RIOMap* io_map_new(RIO* io, int fd, int flags, ut64 delta, ut64 addr, ut64 size,
 	// new map lives on the top, being top the list's tail
 	ls_append (io->maps, map);
 	if (do_skyline) {
-		r_io_map_calculate_skyline (io);
+		io_map_calculate_skyline (io);
 	}
 	return map;
 }
@@ -187,7 +187,7 @@ R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr) {
 			r_io_map_new (io, map->fd, map->flags, map->delta - addr, 0, size + addr);
 			return true;
 		}
-		r_io_map_calculate_skyline (io);
+		io_map_calculate_skyline (io);
 		return true;
 	}
 	return false;
@@ -307,7 +307,7 @@ R_API RIOMap* r_io_map_get(RIO* io, ut64 addr) {
 R_API void r_io_map_reset(RIO* io) {
 	r_io_map_fini (io);
 	r_io_map_init (io);
-	r_io_map_calculate_skyline (io);
+	io_map_calculate_skyline (io);
 }
 
 R_API bool r_io_map_del(RIO* io, ut32 id) {
@@ -318,7 +318,7 @@ R_API bool r_io_map_del(RIO* io, ut32 id) {
 			if (map->id == id) {
 				ls_delete (io->maps, iter);
 				r_id_pool_kick_id (io->map_ids, id);
-				r_io_map_calculate_skyline (io);
+				io_map_calculate_skyline (io);
 				return true;
 			}
 		}
@@ -345,7 +345,7 @@ R_API bool r_io_map_del_for_fd(RIO* io, int fd) {
 		}
 	}
 	if (ret) {
-		r_io_map_calculate_skyline (io);
+		io_map_calculate_skyline (io);
 	}
 	return ret;
 }
@@ -361,7 +361,7 @@ R_API bool r_io_map_priorize(RIO* io, ut32 id) {
 			if (map->id == id) {
 				ls_split_iter (io->maps, iter);
 				ls_append (io->maps, map);
-				r_io_map_calculate_skyline (io);
+				io_map_calculate_skyline (io);
 				return true;
 			}
 		}
@@ -378,7 +378,7 @@ R_API bool r_io_map_depriorize(RIO* io, ut32 id) {
 			if (map->id == id) {
 				ls_split_iter (io->maps, iter);
 				ls_prepend (io->maps, map);
-				r_io_map_calculate_skyline (io);
+				io_map_calculate_skyline (io);
 				return true;
 			}
 		}
@@ -409,7 +409,7 @@ R_API bool r_io_map_priorize_for_fd(RIO* io, int fd) {
 	ls_join (io->maps, list);
 	ls_free (list);
 	io->maps->free = _map_free;
-	r_io_map_calculate_skyline (io);
+	io_map_calculate_skyline (io);
 	return true;
 }
 
@@ -440,7 +440,7 @@ R_API void r_io_map_cleanup(RIO* io) {
 		}
 	}
 	if (del) {
-		r_io_map_calculate_skyline (io);
+		io_map_calculate_skyline (io);
 	}
 }
 
@@ -538,6 +538,6 @@ R_API bool r_io_map_resize(RIO *io, ut32 id, ut64 newsize) {
 		return true;
 	}
 	map->itv.size = newsize;
-	r_io_map_calculate_skyline (io);
+	io_map_calculate_skyline (io);
 	return true;
 }

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -6,6 +6,7 @@
 #include <r_types.h>
 #include <stdio.h>
 #include <string.h>
+#include "io_private.h"
 
 static void section_free(void *p) {
 	RIOSection *s = (RIOSection *) p;
@@ -642,7 +643,7 @@ R_API bool r_io_section_apply_bin(RIO *io, ut32 bin_id, RIOSectionApplyMethod me
 			_section_apply (io, sec, method);
 		}
 	}
-	r_io_map_calculate_skyline (io);
+	io_map_calculate_skyline (io);
 	return ret;
 }
 
@@ -655,7 +656,7 @@ R_API bool r_io_section_reapply(RIO *io, ut32 id, RIOSectionApplyMethod method) 
 		return false;
 	}
 	bool ret = _section_reapply (io, sec, method);
-	r_io_map_calculate_skyline (io);
+	io_map_calculate_skyline (io);
 	return ret;
 }
 
@@ -672,6 +673,6 @@ R_API bool r_io_section_reapply_bin(RIO *io, ut32 binid, RIOSectionApplyMethod m
 			_section_reapply (io, sec, method);
 		}
 	}
-	r_io_map_calculate_skyline (io);
+	io_map_calculate_skyline (io);
 	return ret;
 }

--- a/libr/io/section.c
+++ b/libr/io/section.c
@@ -401,16 +401,16 @@ static bool _section_apply_for_anal_patch(RIO *io, RIOSection *sec, bool patch) 
 			ut64 at = sec->vaddr + sec->size;
 			// TODO: harden this, handle mapslit
 			// craft the uri for the null-fd
-			if (r_io_create_mem_map (io, sec, at, true, false)) {
+			if (io_create_mem_map (io, sec, at, true, false)) {
 			// we need to create this map for transfering the flags, no real remapping here
-				if (r_io_create_file_map (io, sec, sec->size, patch, false)) {
+				if (io_create_file_map (io, sec, sec->size, patch, false)) {
 					return true;
 				}
 			}
 		}
 	} else {
 		// same as above
-		if (!sec->filemap && r_io_create_file_map (io, sec, sec->vsize, patch, false)) {
+		if (!sec->filemap && io_create_file_map (io, sec, sec->vsize, patch, false)) {
 			return true;
 		}
 	}


### PR DESCRIPTION
cc @MaskRay 

All the "batch" operations which for performance reasons  are done without updating the skyline on every add_map, open_at, etc. were actually inside the `r_io` library. So we should just make them private to the module to avoid confusion to users of r_io. This will also make easier to change implementation details in the future.