### PR TITLE
sys/user.sh: use dirname($0) instead of dirname($PWD/$0)

### DIFF
--- a/sys/user.sh
+++ b/sys/user.sh
@@ -5,7 +5,7 @@ gmake --help >/dev/null 2>&1
 [ $? = 0 ] && MAKE=gmake
 
 # find root
-cd "$(dirname "$PWD/$0")" ; cd ..
+cd "$(dirname "$0")" ; cd ..
 
 # update
 if [ "$1" != "--without-pull" ]; then


### PR DESCRIPTION
1. If `$0` doesn't have a path component, then `dirname` is going to return "`.`" which is the same as `$PWD`. So `dirname($0)` and `dirname($PWD/$0)` are equivalent here.
1. If `$0` is an absolute pathname, then `$PWD/$0` causes breakage. Thus this pr.