### PR TITLE
libr/cons: Do proper signal handling, use pselect

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -485,6 +485,13 @@ int main(int argc, char **argv, char **envp) {
 
 	bool noStderr = false;
 
+#ifdef __UNIX
+	sigset_t sigBlockMask;
+	sigemptyset (&sigBlockMask);
+	sigaddset (&sigBlockMask, SIGWINCH);
+	r_signal_sigmask (SIG_BLOCK, &sigBlockMask, NULL);
+#endif
+
 	r_sys_set_environ (envp);
 
 	if ((tmp = r_sys_getenv ("R_DEBUG"))) {

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -336,7 +336,12 @@ static BOOL __w32_control(DWORD type) {
 	return false;
 }
 #elif __UNIX__ || __CYGWIN__
+volatile sig_atomic_t sigwinchFlag;
 static void resize(int sig) {
+	sigwinchFlag = 1;
+}
+
+void resizeWin(void) {
 	if (I.event_resize) {
 		I.event_resize (I.event_data);
 	}


### PR DESCRIPTION
Fixes async-signal-safety and changing errno within the signal handler
for SIGWINCH, which can cause crashes and maybe security issues.

For async-signal-safety make the signal handler just set a flag, which
is checked for while waiting for input (pselect).