### PR TITLE
fix arm ldr esil write back.

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2030,9 +2030,17 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 						if (disp < 0) {
 							r_strbuf_appendf (&op->esil, "%d,%s,-,0xffffffff,&,[4],0x%x,&,%s,=",
 								-disp, MEMBASE(1), mask, REG(0));
+							if (insn->detail->arm.writeback) {
+								r_strbuf_appendf (&op->esil, ",%d,%s,+,%s,=",
+									-disp, MEMBASE(1), MEMBASE(1));
+							}
 						} else {
 							r_strbuf_appendf (&op->esil, "%d,%s,+,0xffffffff,&,[4],0x%x,&,%s,=",
 								disp, MEMBASE(1), mask, REG(0));
+							if (insn->detail->arm.writeback) {
+								r_strbuf_appendf (&op->esil, ",%d,%s,+,%s,=",
+									disp, MEMBASE(1), MEMBASE(1));
+							}
 						}
 					}
 				}


### PR DESCRIPTION
writeback('!' in ldr) for ldr instruction was not implemented.
i added writeback for ldr with imm.
for example ldr ip, [r3, 4]! should do 
ip  = r3 + 4
r3 += 4
probably should also add this not only for imm.

test:
`r2 -a arm -b 32 -c 'wx 04c0b3e51111111122222222' -qc 'dr r3=4;ar r3,ip;aes;ar r3,ip' -`
