### PR TITLE
several inline documentation enhancements

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1496,8 +1496,7 @@ R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 		if (strcmp (help[i + 1], "") == 0 && strcmp (help[i + 2], "") == 0) {
 			// no need to indent the sections lines
 			r_cons_printf ("%s%s%s\n", pal_help_color, help[i], pal_reset);
-		}
-		else {
+		} else {
 			// these are the normal lines
 			int padding = max_length - (strlen (help[i]) + strlen (help[i + 1]));
 			r_cons_printf ("| %s%s%s%*s  %s%s%s\n",

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1487,13 +1487,13 @@ R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 	}
 
 	for (i = 0; help[i]; i += 3) {
-		if (strncmp(help[i], usage_str, sizeof(usage_str) - 2) == 0) {
+		if (strncmp (help[i], usage_str, strlen (usage_str)) == 0) {
 			// Lines matching Usage: should always be the first in inline doc
 			r_cons_printf ("%s%s %s  %s%s\n", pal_args_color,
 							help[i], help[i + 1], help[i + 2], pal_reset);
 			continue;
 		}
-		if ( strcmp(help[i + 1], "") == 0 && strcmp(help[i + 2], "") == 0 ) {
+		if (strcmp (help[i + 1], "") == 0 && strcmp (help[i + 2], "") == 0) {
 			// no need to indent the sections lines
 			r_cons_printf ("%s%s%s\n", pal_help_color, help[i], pal_reset);
 		}

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1476,6 +1476,7 @@ R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 			*pal_help_color = use_color ? cons->pal.help : "",
 			*pal_reset = use_color ? cons->pal.reset : "";
 	int i, max_length = 0;
+	const char *usage_str = "Usage:";
 
 	for (i = 0; help[i]; i += 3) {
 		int len0 = strlen (help[i]);
@@ -1486,19 +1487,24 @@ R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 	}
 
 	for (i = 0; help[i]; i += 3) {
-		if (i) {
+		if (strncmp(help[i], usage_str, sizeof(usage_str) - 2) == 0) {
+			// Lines matching Usage: should always be the first in inline doc
+			r_cons_printf ("%s%s %s  %s%s\n", pal_args_color,
+							help[i], help[i + 1], help[i + 2], pal_reset);
+			continue;
+		}
+		if ( strcmp(help[i + 1], "") == 0 && strcmp(help[i + 2], "") == 0 ) {
+			// no need to indent the sections lines
+			r_cons_printf ("%s%s%s\n", pal_help_color, help[i], pal_reset);
+		}
+		else {
+			// these are the normal lines
 			int padding = max_length - (strlen (help[i]) + strlen (help[i + 1]));
 			r_cons_printf ("| %s%s%s%*s  %s%s%s\n",
 					help[i],
 					pal_args_color, help[i + 1],
 					padding, "",
 					pal_help_color, help[i + 2], pal_reset);
-		} else {
-			// no need to indent the first line
-			r_cons_printf ("|%s%s %s%s%s\n",
-					pal_help_color,
-					help[i], help[i + 1], help[i + 2],
-					pal_reset);
 		}
 	}
 }

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -229,6 +229,13 @@ static const char *help_msg_greater_sign[] = {
 	NULL
 };
 
+static const char *help_msg_intro[] = {
+	"Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...", "", "",
+	"Append '?' to any char command to get detailed help", "", "",
+	"Prefix with number to repeat command N times (f.ex: 3x)", "", "",
+	NULL
+};
+
 static void cmd_help_exclamation(RCore *core) {
 	r_core_cmd_help (core, help_msg_exclamation);
 	r_core_cmd_help (core, help_msg_env);
@@ -996,9 +1003,7 @@ static int cmd_help(void *data, const char *input) {
 	case '\0': // "?"
 	default:
 		// TODO #7967 help refactor
-		r_cons_printf ("Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...\n"
-				"Append '?' to any char command to get detailed help\n"
-				"Prefix with number to repeat command N times (f.ex: 3x)\n");
+		r_core_cmd_help (core, help_msg_intro);
 		r_core_cmd_help (core, help_msg_root);
 		break;
 	}


### PR DESCRIPTION
- avoid the ugly lack of space between the command and its description in the usage lines.
- avoid the confusing sections (cf. 'i?')
- prettier general help (cf. '?') -> use r_core_cmd_help instead of
r_cons_printf (#7967)

with help and advices from jeisonwi <3