### PR TITLE
cons/d/xvilka: make nops a bit more visible

### DIFF
--- a/libr/cons/d/xvilka
+++ b/libr/cons/d/xvilka
@@ -12,7 +12,7 @@ ec usrcmt rgb:ff0 rgb:06f
 ec push rgb:0c0
 ec pop rgb:0c0
 ec cmp rgb:060
-ec nop rgb:333
+ec nop rgb:777
 ec b0x00 rgb:444
 ec b0x7f rgb:555
 ec b0xff rgb:666


### PR DESCRIPTION
I don't know if it's only for me, but I already have solarized theme on my terminal, and `xvilka` theme looks really great, apart from the nops which become almost invisible. I guess making them less visible was done on purpose, but I think it still makes sense to see them, even if less compared to other instructions.