### PR TITLE
Several themes related changes [r2con]

### DIFF
--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -51,7 +51,7 @@ static const char *help_msg_ec[] = {
 };
 
 static const char *help_msg_eco[] = {
-	"Usage: eco [theme]", "", "load theme (cf. Path and dir.prefix)",
+	"Usage: eco[jc] [theme]", "", "load theme (cf. Path and dir.prefix)",
 	"eco", "", "list available themes",
 	"ecoj", "", "list available themes in JSON",
 	"ecoc", "", "display current theme name",

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -30,22 +30,32 @@ static const char *help_msg_e[] = {
 
 static const char *help_msg_ec[] = {
 	"Usage ec[s?] [key][[=| ]fg] [bg]", "", "",
-	"ec", "", "list all color keys",
+	"ec", " [key]", "list all/key color keys",
 	"ec*", "", "same as above, but using r2 commands",
 	"ecd", "", "set default palette",
 	"ecr", "", "set random palette (see also scr.randpal)",
 	"ecs", "", "show a colorful palette",
 	"ecj", "", "show palette in JSON",
 	"ecc", " [prefix]", "show palette in CSS",
-	"eco", " dark|white", "load white color scheme template",
+	"eco", " [theme]", "load theme if provided (list available themes if not)",
 	"ecp", "", "load previous color theme",
 	"ecn", "", "load next color theme",
-	"ecH", "[?]", "highlight word or instruction",
+	"ecH", " [?]", "highlight word or instruction",
 	"ec", " prompt red", "change color of prompt",
 	"ec", " prompt red blue", "change color and background of prompt",
-	"", " ", "",
+	"Vars:", "", "",
 	"colors:", "", "rgb:000, red, green, blue, #ff0000, ...",
 	"e scr.color", "=0", "use more colors (0: no color 1: ansi 16, 2: 256, 3: 16M)",
+	"$DATADIR/radare2/cons", "", R_JOIN_2_PATHS ("~", R2_HOME_THEMES) " ./",
+	NULL
+};
+
+static const char *help_msg_eco[] = {
+	"Usage: eco [theme]", "", "load theme (cf. Path and dir.prefix)",
+	"eco", "", "list available themes",
+	"ecoj", "", "list available themes in JSON",
+	"ecoc", "", "display current theme name",
+	"Path:", "", "",
 	"$DATADIR/radare2/cons", "", R_JOIN_2_PATHS ("~", R2_HOME_THEMES) " ./",
 	NULL
 };
@@ -341,13 +351,22 @@ static int cmd_eval(void *data, const char *input) {
 				if (failed) {
 					eprintf ("Something went wrong\n");
 				}
+			} else if (input[2] == 'c') {
+				eprintf("%s\n", r_core_get_theme());
 			} else if (input[2] == '?') {
-				eprintf ("Usage: eco [themename]  ;load theme from "
-					R_JOIN_3_PATHS ("%s", R2_THEMES, "") " (see dir.prefix)\n",
-					r_sys_prefix (NULL));
-
+				r_core_cmd_help (core, help_msg_eco);
+				break;
 			} else {
-				nextpal (core, 'l');
+				RList *themes_list = r_core_list_themes (core);
+				RListIter *th_iter;
+				const char *th;
+				r_list_foreach (themes_list, th_iter, th) {
+					if (strcmp (curtheme, th) == 0) {
+					  eprintf ("-> %s\n", th);
+					} else {
+						eprintf ("   %s\n", th);
+					}
+				}
 			}
 			break;
 		case 's': r_cons_pal_show (); break; // "ecs"

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -361,7 +361,7 @@ static int cmd_eval(void *data, const char *input) {
 				RListIter *th_iter;
 				const char *th;
 				r_list_foreach (themes_list, th_iter, th) {
-					if (strcmp (curtheme, th) == 0) {
+					if (!strcmp (curtheme, th)) {
 						eprintf ("-> %s\n", th);
 					} else {
 						eprintf ("   %s\n", th);

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -352,7 +352,7 @@ static int cmd_eval(void *data, const char *input) {
 					eprintf ("Something went wrong\n");
 				}
 			} else if (input[2] == 'c') {
-				eprintf("%s\n", r_core_get_theme());
+				eprintf("%s\n", r_core_get_theme ());
 			} else if (input[2] == '?') {
 				r_core_cmd_help (core, help_msg_eco);
 				break;
@@ -362,7 +362,7 @@ static int cmd_eval(void *data, const char *input) {
 				const char *th;
 				r_list_foreach (themes_list, th_iter, th) {
 					if (strcmp (curtheme, th) == 0) {
-					  eprintf ("-> %s\n", th);
+						eprintf ("-> %s\n", th);
 					} else {
 						eprintf ("   %s\n", th);
 					}


### PR DESCRIPTION
- Adding a command ('ecoc') to print current color theme (c->current).
- Documenting the available themes JSON listing.
- defining a specific 'eco?' for themes related commands.
- Adding a cute little arrow to point current theme when listing themes.
- Replacing nextpal() with r_core_list_themes(), for the list, so the
code is less confusing (it's still used elsewhere ('ecp', 'ecn'), didn't remove it)
- Correcting several typos in eval docs