### PR TITLE
Info headers (r2con)

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2197,8 +2197,8 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 		r_flag_space_set (r->flags, print_segments ? "segments" : "sections");
 	}
 	if (IS_MODE_NORMAL (mode)) {
-		r_cons_printf ("Nm Paddr       Size Vaddr      Memsz Perms %s Name\n",
-                   chksum ? "Checksum         " : "");
+		r_cons_printf ("Nm Paddr       Size Vaddr      Memsz Perms %sName\n",
+                   chksum ? "Checksum          " : "");
 	}
 	r_list_foreach (sections, iter, section) {
 		char perms[] = "----";

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2186,7 +2186,9 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 	} else if (IS_MODE_RAD (mode) && !at) {
 		r_cons_printf ("fs %ss\n", type);
 	} else if (IS_MODE_NORMAL (mode) && !at && !printHere) {
-		r_cons_printf ("[%s]\n", print_segments ? "Segments" : "Sections");
+		r_cons_printf ("[%s]\n"
+                   "Nm Paddr       Size Vaddr      Memsz Perms Name\n",
+                   print_segments ? "Segments" : "Sections");
 	} else if (IS_MODE_NORMAL (mode) && printHere) {
 		r_cons_printf ("Current section\n");
 	} else if (IS_MODE_SET (mode)) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2192,10 +2192,12 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 		r_cons_printf ("fs %ss\n", type);
 	} else if (IS_MODE_NORMAL (mode) && !at && !printHere) {
 		r_cons_printf ("[%s]\n"
-                   "Nm Paddr       Size Vaddr      Memsz Perms Name\n",
-                   print_segments ? "Segments" : "Sections");
+                   "Nm Paddr       Size Vaddr      Memsz Perms%s Name\n",
+                   print_segments ? "Segments" : "Sections",
+								   chksum ? chksum : "");
 	} else if (IS_MODE_NORMAL (mode) && printHere) {
-		r_cons_printf ("Current section\n");
+		r_cons_printf ("Current section\n"
+                   "Nm Paddr       Size Vaddr      Memsz Perms Name\n");
 	} else if (IS_MODE_SET (mode)) {
 		fd = r_core_file_cur_fd (r);
 		r_flag_space_set (r->flags, print_segments ? "segments" : "sections");

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -181,8 +181,7 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 	}
 	if (IS_MODE_NORMAL (mode)) {
 		r_cons_printf ("[Strings]\n");
-		r_cons_printf ("Num Vaddr      Paddr      Len Size "
-                   "Section  Type  String\n");
+		r_cons_printf ("Num Vaddr      Paddr      Len Size Section  Type  String\n");
 	}
 	RBinString b64 = {0};
 	r_list_foreach (list, iter, string) {
@@ -1658,7 +1657,7 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 		r_cons_println ("fs imports");
 	} else if (IS_MODE_NORMAL (mode)) {
 		r_cons_println ("[Imports]");
-		r_cons_println (" Num Vaddr       Bind      Type Name");
+		r_cons_println ("Num  Vaddr       Bind      Type Name");
 	}
 	r_list_foreach (imports, iter, import) {
 		if (name && strcmp (import->name, name)) {
@@ -1873,18 +1872,17 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 		if (IS_MODE_RAD (mode)) {
 			r_cons_printf ("fs exports\n");
 		} else if (IS_MODE_NORMAL (mode)) {
-			r_cons_printf (printHere ? "" : "[Exports]\n"
-			                                "Num Paddr      Vaddr      Bind"
-																			"     Type Size Name\n");
+			r_cons_printf (printHere ? "" : "[Exports]\n");
 		}
 	} else if (!at && !exponly) {
 		if (IS_MODE_RAD (mode)) {
 			r_cons_printf ("fs symbols\n");
 		} else if (IS_MODE_NORMAL (mode)) {
-			r_cons_printf (printHere ? "" : "[Symbols]\n"
-			                                "Num Paddr      Vaddr      Bind"
-																			"     Type Size Name\n");
+			r_cons_printf (printHere ? "" : "[Symbols]\n");
 		}
+	}
+	if (IS_MODE_NORMAL (mode)) {
+		r_cons_printf ("Num Paddr      Vaddr      Bind     Type Size Name\n");
 	}
 
 	r_list_foreach (symbols, iter, symbol) {
@@ -2191,16 +2189,16 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 	} else if (IS_MODE_RAD (mode) && !at) {
 		r_cons_printf ("fs %ss\n", type);
 	} else if (IS_MODE_NORMAL (mode) && !at && !printHere) {
-		r_cons_printf ("[%s]\n"
-                   "Nm Paddr       Size Vaddr      Memsz Perms%s Name\n",
-                   print_segments ? "Segments" : "Sections",
-                   chksum ? chksum : "");
+		r_cons_printf ("[%s]\n", print_segments ? "Segments" : "Sections");
 	} else if (IS_MODE_NORMAL (mode) && printHere) {
-		r_cons_printf ("Current section\n"
-                   "Nm Paddr       Size Vaddr      Memsz Perms Name\n");
+		r_cons_printf ("Current section\n");
 	} else if (IS_MODE_SET (mode)) {
 		fd = r_core_file_cur_fd (r);
 		r_flag_space_set (r->flags, print_segments ? "segments" : "sections");
+	}
+	if (IS_MODE_NORMAL (mode)) {
+		r_cons_printf ("Nm Paddr       Size Vaddr      Memsz Perms %s Name\n",
+                   chksum ? "Checksum         " : "");
 	}
 	r_list_foreach (sections, iter, section) {
 		char perms[] = "----";

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -179,6 +179,11 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 		r_flag_space_set (r->flags, "strings");
 		r_cons_break_push (NULL, NULL);
 	}
+	if (IS_MODE_NORMAL (mode)) {
+		r_cons_printf ("[Strings]\n");
+		r_cons_printf ("Num Vaddr      Paddr      Len Size "
+                   "Section  Type  String\n");
+	}
 	RBinString b64 = {0};
 	r_list_foreach (list, iter, string) {
 		const char *section_name, *type_string;
@@ -325,7 +330,7 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 			r_cons_printf ("%03u 0x%08"PFMT64x" 0x%08"
 				PFMT64x" %3u %3u "
 				"(%s) %5s %s",
-				string->ordinal, paddr, vaddr, 
+				string->ordinal, paddr, vaddr,
 				string->length, string->size,
 				section_name, type_string, str);
 #endif
@@ -2172,7 +2177,7 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 	if (!dup_chk_ht) {
 		return false;
 	}
-	
+
 	if (chksum && *chksum == '.') {
 		printHere = true;
 	}
@@ -3388,7 +3393,7 @@ R_API int r_core_bin_info(RCore *core, int action, int mode, int va, RCoreBinFil
 	if (filter && filter->name) {
 		name = filter->name;
 	}
-	
+
 	// use our internal values for va
 	va = va ? VA_TRUE : VA_FALSE;
 #if 0

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1658,6 +1658,7 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 		r_cons_println ("fs imports");
 	} else if (IS_MODE_NORMAL (mode)) {
 		r_cons_println ("[Imports]");
+		r_cons_println (" Num Vaddr       Bind      Type Name");
 	}
 	r_list_foreach (imports, iter, import) {
 		if (name && strcmp (import->name, name)) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2194,7 +2194,7 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 		r_cons_printf ("[%s]\n"
                    "Nm Paddr       Size Vaddr      Memsz Perms%s Name\n",
                    print_segments ? "Segments" : "Sections",
-								   chksum ? chksum : "");
+                   chksum ? chksum : "");
 	} else if (IS_MODE_NORMAL (mode) && printHere) {
 		r_cons_printf ("Current section\n"
                    "Nm Paddr       Size Vaddr      Memsz Perms Name\n");

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1873,13 +1873,17 @@ static int bin_symbols_internal(RCore *r, int mode, ut64 laddr, int va, ut64 at,
 		if (IS_MODE_RAD (mode)) {
 			r_cons_printf ("fs exports\n");
 		} else if (IS_MODE_NORMAL (mode)) {
-			r_cons_printf (printHere ? "" : "[Exports]\n");
+			r_cons_printf (printHere ? "" : "[Exports]\n"
+			                                "Num Paddr      Vaddr      Bind"
+																			"     Type Size Name\n");
 		}
 	} else if (!at && !exponly) {
 		if (IS_MODE_RAD (mode)) {
 			r_cons_printf ("fs symbols\n");
 		} else if (IS_MODE_NORMAL (mode)) {
-			r_cons_printf (printHere ? "" : "[Symbols]\n");
+			r_cons_printf (printHere ? "" : "[Symbols]\n"
+			                                "Num Paddr      Vaddr      Bind"
+																			"     Type Size Name\n");
 		}
 	}
 


### PR DESCRIPTION
Added column headers when viewing strings, sections, imports, exports or symbols in a binary, which makes it easier to understand information given from the i command.

Also added a [Strings] message when printing strings with iz to improve consistency with other i commands.