### PR TITLE
Fix #11464, reinstate Ct functionality

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -489,6 +489,10 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 			}
 			str = r_str_escape_latin1 (d->str, false, esc_bslash, false);
 		}
+	} else if (d->type == 't') {
+		str = (char *) malloc(strlen(d->str) + 1);
+		strcpy(str, d->str);
+		r_str_sanitize(str);
 	} else {
 		str = r_str_escape (d->str);
 	}
@@ -502,6 +506,8 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 		} else if (d->type == 'f') {
 			pstr = str;
 		} else if (d->type == 's') {
+			pstr = str;
+		} else if (d->type == 't') {
 			pstr = str;
 		} else if (d->type != 'C') {
 			r_name_filter (str, 0);
@@ -643,9 +649,9 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 			case 't': /* vartype */
 				if (rad) {
 					a->cb_printf ("%s %s @ 0x%08"PFMT64x"\n",
-						r_meta_type_to_string (d->type), pstr, d->from);
+						r_meta_type_to_string (d->type), str, d->from);
 				} else {
-					a->cb_printf ("0x%08"PFMT64x" %s\n", d->from, pstr);
+					a->cb_printf ("0x%08"PFMT64x" %s\n", d->from, str);
 				}
 				break;
 			default:

--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -505,7 +505,7 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 			pstr = str;
 		} else if (d->type == 't') {
 			// Sanitize (don't escape) Ct comments so we can see "char *", etc.
-			str = r_str_ndup(d->str, strlen(d->str));
+			str = strdup (d->str);
 			r_str_sanitize(str);
 			pstr = str;
 		} else if (d->type != 'C') {

--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -489,10 +489,6 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 			}
 			str = r_str_escape_latin1 (d->str, false, esc_bslash, false);
 		}
-	} else if (d->type == 't') {
-		str = (char *) malloc(strlen(d->str) + 1);
-		strcpy(str, d->str);
-		r_str_sanitize(str);
 	} else {
 		str = r_str_escape (d->str);
 	}
@@ -508,6 +504,9 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 		} else if (d->type == 's') {
 			pstr = str;
 		} else if (d->type == 't') {
+			// Sanitize (don't escape) Ct comments so we can see "char *", etc.
+			str = r_str_ndup(d->str, strlen(d->str));
+			r_str_sanitize(str);
 			pstr = str;
 		} else if (d->type != 'C') {
 			r_name_filter (str, 0);
@@ -649,9 +648,9 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 			case 't': /* vartype */
 				if (rad) {
 					a->cb_printf ("%s %s @ 0x%08"PFMT64x"\n",
-						r_meta_type_to_string (d->type), str, d->from);
+						r_meta_type_to_string (d->type), pstr, d->from);
 				} else {
-					a->cb_printf ("0x%08"PFMT64x" %s\n", d->from, str);
+					a->cb_printf ("0x%08"PFMT64x" %s\n", d->from, pstr);
 				}
 				break;
 			default:

--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -640,6 +640,14 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, bool show_full) {
 					}
 				}
 				break;
+			case 't': /* vartype */
+				if (rad) {
+					a->cb_printf ("%s %s @ 0x%08"PFMT64x"\n",
+						r_meta_type_to_string (d->type), pstr, d->from);
+				} else {
+					a->cb_printf ("0x%08"PFMT64x" %s\n", d->from, pstr);
+				}
+				break;
 			default:
 				if (rad) {
 					a->cb_printf ("%s %d 0x%08"PFMT64x" # %s\n",

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -426,6 +426,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 				strcat (text, " ");
 				strcat (text, nc);
 				r_meta_set_string (core->anal, R_META_TYPE_COMMENT, addr, text);
+				free (comment);
 				free (text);
 			} else {
 				r_sys_perror ("malloc");
@@ -551,6 +552,7 @@ static int cmd_meta_vartype_comment(RCore *core, const char *input) {
 				strcat (text, " ");
 				strcat (text, nc);
 				r_meta_set_string (core->anal, R_META_TYPE_VARTYPE, addr, text);
+				free (comment);
 				free (text);
 			} else {
 				r_sys_perror ("malloc");

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -522,13 +522,13 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 static int cmd_meta_vartype_comment(RCore *core, const char *input) {
 	ut64 addr = core->offset;
 	switch (input[1]) {
-	case '?':
+	case '?': // "Ct?"
 		r_cons_println ("See C?");
 		break;
 	case 0: // "Ct"
 		r_meta_list (core->anal, R_META_TYPE_VARTYPE, 0);
 		break;
-	case ' ':
+	case ' ': // "Ct <vartype comment> @ addr"
 		{
 		const char* newcomment = r_str_trim_ro (input + 2);
 		char *text, *comment = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, addr);
@@ -549,6 +549,17 @@ static int cmd_meta_vartype_comment(RCore *core, const char *input) {
 			r_meta_set_string (core->anal, R_META_TYPE_VARTYPE, addr, nc);
 		}
 		free (nc);
+		}
+		break;
+	case '.': // "Ct. @ addr"
+		{
+		ut64 at = input[2]? r_num_math (core->num, input + 2): addr;
+		char *comment = r_meta_get_string (
+				core->anal, R_META_TYPE_VARTYPE, at);
+		if (comment) {
+			r_cons_println (comment);
+			free (comment);
+		}
 		}
 		break;
 	case '-': // "Ct-"

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -519,7 +519,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 	return true;
 }
 
-static int cmd_meta_type_comment(RCore *core, const char *input) {
+static int cmd_meta_vartype_comment(RCore *core, const char *input) {
 	ut64 addr = core->offset;
 	switch (input[1]) {
 	case '?':
@@ -994,7 +994,7 @@ static int cmd_meta(void *data, const char *input) {
 		cmd_meta_comment (core, input);
 		break;
 	case 't': // "Ct" type analysis commnets
-		cmd_meta_type_comment (core, input);
+		cmd_meta_vartype_comment (core, input);
 		break;
 	case 'r': // "Cr" run command
 	case 'h': // "Ch" comment

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -519,6 +519,204 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 	return true;
 }
 
+static int cmd_meta_type_comment(RCore *core, const char *input) {
+	ut64 addr = core->offset;
+	switch (input[1]) {
+	case '?':
+		r_core_cmd_help (core, help_msg_CC);
+		break;
+	case ',': // "CC,"
+		if (input[2]=='?') {
+			eprintf ("Usage: CC, [file]\n");
+		} else if (input[2] == ' ') {
+			const char *fn = input+2;
+			char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
+			while (*fn== ' ')fn++;
+			if (comment && *comment) {
+				// append filename in current comment
+				char *nc = r_str_newf ("%s ,(%s)", comment, fn);
+				r_meta_set_string (core->anal, R_META_TYPE_COMMENT, addr, nc);
+				free (nc);
+			} else {
+				char *comment = r_str_newf (",(%s)", fn);
+				r_meta_set_string (core->anal, R_META_TYPE_COMMENT, addr, comment);
+				free (comment);
+			}
+		} else {
+			char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
+			if (comment && *comment) {
+				char *cmtfile = r_str_between (comment, ",(", ")");
+				if (cmtfile && *cmtfile) {
+					char *getcommapath(RCore *core);
+					char *cwd = getcommapath (core);
+					r_cons_printf ("%s"R_SYS_DIR"%s\n", cwd, cmtfile);
+					free (cwd);
+				}
+				free (cmtfile);
+			}
+			free (comment);
+		}
+		break;
+	case '.':
+		  {
+			  ut64 at = input[2]? r_num_math (core->num, input + 2): addr;
+			  char *comment = r_meta_get_string (
+					  core->anal, R_META_TYPE_COMMENT, at);
+			  if (comment) {
+				  r_cons_println (comment);
+				  free (comment);
+			  }
+		  }
+		break;
+	case 0: // "CC"
+		r_meta_list (core->anal, R_META_TYPE_COMMENT, 0);
+		break;
+	case 'f': // "CCf"
+		switch (input[2]) {
+		case 'j': // "CCfj"
+			r_meta_list_at (core->anal, R_META_TYPE_COMMENT, 'j', core->offset);
+			break;
+		default:
+			r_meta_list_at (core->anal, R_META_TYPE_COMMENT, 'f', core->offset);
+			break;
+		}
+		break;
+	case 'j': // "CCj"
+		r_meta_list (core->anal, R_META_TYPE_COMMENT, 'j');
+		break;
+	case '!':
+		{
+			char *out, *comment = r_meta_get_string (
+					core->anal, R_META_TYPE_COMMENT, addr);
+			out = r_core_editor (core, NULL, comment);
+			if (out) {
+				//r_meta_add (core->anal->meta, R_META_TYPE_COMMENT, addr, 0, out);
+				r_core_cmdf (core, "CC-@0x%08"PFMT64x, addr);
+				//r_meta_del (core->anal->meta, input[0], addr, addr+1);
+				r_meta_set_string (core->anal,
+						R_META_TYPE_COMMENT, addr, out);
+				free (out);
+			}
+			free (comment);
+		}
+		break;
+	case '+':
+	case ' ':
+		{
+		const char* newcomment = r_str_trim_ro (input + 2);
+		char *text, *comment = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, addr);
+		char *nc = strdup (newcomment);
+		r_str_unescape (nc);
+		if (comment) {
+			text = malloc (strlen (comment)+ strlen (newcomment)+2);
+			if (text) {
+				strcpy (text, comment);
+				strcat (text, " ");
+				strcat (text, nc);
+				r_meta_set_string (core->anal, R_META_TYPE_VARTYPE, addr, text);
+				free (text);
+			} else {
+				r_sys_perror ("malloc");
+			}
+		} else {
+			r_meta_set_string (core->anal, R_META_TYPE_VARTYPE, addr, nc);
+		}
+		free (nc);
+		}
+		break;
+	case '*':
+		r_meta_list (core->anal, R_META_TYPE_COMMENT, 1);
+		break;
+	case '-': // "CC-"
+		r_meta_del (core->anal, R_META_TYPE_COMMENT, core->offset, 1);
+		break;
+	case 'u':
+		//
+		{
+		char *newcomment;
+		const char *arg = input + 2;
+		while (*arg && *arg == ' ') arg++;
+		if (!strncmp (arg, "base64:", 7)) {
+			char *s = (char *)sdb_decode (arg + 7, NULL);
+			if (s) {
+				newcomment = s;
+			} else {
+				newcomment = NULL;
+			}
+		} else {
+			newcomment = strdup (arg);
+		}
+		if (newcomment) {
+			char *comment = r_meta_get_string (
+					core->anal, R_META_TYPE_COMMENT, addr);
+			if (!comment || (comment && !strstr (comment, newcomment))) {
+				r_meta_set_string (core->anal, R_META_TYPE_COMMENT,
+						addr, newcomment);
+			}
+			free (comment);
+			free (newcomment);
+		}
+		}
+		break;
+	case 'a':
+		{
+		char *s, *p;
+		s = strchr (input, ' ');
+		if (s) {
+			s = strdup (s + 1);
+		} else {
+			eprintf ("Usage\n");
+			return false;
+		}
+		p = strchr (s, ' ');
+		if (p) {
+			*p++ = 0;
+		}
+		ut64 addr;
+		if (input[2]=='-') {
+			if (input[3]) {
+				addr = r_num_math (core->num, input+3);
+				r_meta_del (core->anal,
+						R_META_TYPE_COMMENT,
+						addr, 1);
+			} else eprintf ("Usage: CCa-[address]\n");
+			free (s);
+			return true;
+		}
+		addr = r_num_math (core->num, s);
+		// Comment at
+		if (p) {
+			if (input[2]=='+') {
+				char *comment = r_meta_get_string (
+						core->anal, R_META_TYPE_COMMENT,
+						addr);
+				if (comment) {
+					char* text = r_str_newf ("%s\n%s", comment, p);
+					r_meta_add (core->anal,
+							R_META_TYPE_COMMENT,
+							addr, addr+1, text);
+					free (text);
+				} else {
+					r_meta_add (core->anal,
+							R_META_TYPE_COMMENT,
+							addr, addr+1, p);
+				}
+			} else {
+				r_meta_add (core->anal,
+						R_META_TYPE_COMMENT,
+						addr, addr + 1, p);
+			}
+		} else {
+			eprintf ("Usage: CCa [address] [comment]\n");
+		}
+		free (s);
+		return true;
+		}
+	}
+
+	return true;
+}
+
 static int cmd_meta_others(RCore *core, const char *input) {
 	int n, type = input[0], subtype;
 	char *t = 0, *p, *p2, name[256];
@@ -950,6 +1148,9 @@ static int cmd_meta(void *data, const char *input) {
 	case 'C': // "CC"
 		cmd_meta_comment (core, input);
 		break;
+	case 't': // "Ct" type analysis commnets
+		cmd_meta_type_comment (core, input);
+		break;
 	case 'r': // "Cr" run command
 	case 'h': // "Ch" comment
 	case 's': // "Cs" string
@@ -957,7 +1158,6 @@ static int cmd_meta(void *data, const char *input) {
 	case 'd': // "Cd" data
 	case 'm': // "Cm" magic
 	case 'f': // "Cf" formatted
-	case 't': // "Ct" type analysis commnets
 		cmd_meta_others (core, input);
 		break;
 	case '-': // "C-"

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -18,11 +18,12 @@ static const char *help_msg_C[] = {
 	"CL", "[-][*] [file:line] [addr]", "show or add 'code line' information (bininfo)",
 	"CS", "[-][space]", "manage meta-spaces to filter comments, etc..",
 	"CC", "[?] [-] [comment-text] [@addr]", "add/remove comment",
-	"Ct", "[?] [-] [comment-text] [@addr]", "add/remove type analysis comment",
 	"CC.", "[addr]", "show comment in current address",
 	"CC!", " [@addr]", "edit comment with $EDITOR",
 	"CCa", "[-at]|[at] [text] [@addr]", "add/remove comment at given address",
 	"CCu", " [comment-text] [@addr]", "add unique comment",
+	"Ct", "[?] [-] [comment-text] [@addr]", "add/remove type analysis comment",
+	"Ct.", "[@addr]", "show comment at current or specified address",
 	"Cv", "[bsr][?]", "add comments to args",
 	"Cs", "[?] [-] [size] [@addr]", "add string",
 	"Cz", "[@addr]", "add string (see Cs?)",
@@ -48,6 +49,15 @@ static const char *help_msg_CC[] = {
 	"CC-", " @ cmt_addr", "remove comment at given address",
 	"CCu", " good boy @ addr", "add good boy comment at given address",
 	"CCu", " base64:AA== @ addr", "add comment in base64",
+	NULL
+};
+
+static const char *help_msg_Ct[] = {
+	"Usage: Ct", "[.|-] [@ addr]", " # Manage comments for variable types",
+	"Ct", "", "list all variable type comments",
+	"Ct", " comment-text [@ addr]", "place comment at current or specified address",
+	"Ct.", " [@ addr]", "show comment at current or specified address",
+	"Ct-", " [@ addr]", "remove comment at current or specified address",
 	NULL
 };
 
@@ -523,7 +533,7 @@ static int cmd_meta_vartype_comment(RCore *core, const char *input) {
 	ut64 addr = core->offset;
 	switch (input[1]) {
 	case '?': // "Ct?"
-		r_cons_println ("See C?");
+		r_core_cmd_help (core, help_msg_Ct);
 		break;
 	case 0: // "Ct"
 		r_meta_list (core->anal, R_META_TYPE_VARTYPE, 0);
@@ -566,7 +576,7 @@ static int cmd_meta_vartype_comment(RCore *core, const char *input) {
 		r_meta_del (core->anal, R_META_TYPE_VARTYPE, core->offset, 1);
 		break;
 	default:
-		r_cons_println("Usage: See C?");
+		r_core_cmd_help (core, help_msg_Ct);
 		break;
 	}
 


### PR DESCRIPTION
This is a fix for the `Ct` command functionality causing https://github.com/radare/radare2/pull/11465.  It ensures the proper behavior in the CLI (it's supposed to be more like `CC` than the ones handled by `cmd_meta_others`.)  It also fixes the `Ct` output lines in the `rc` project files from the `Ps` command, since they seemed to be wildly outdated or otherwise incorrect (it was `Ct size @ addr # comment` whereas the correct syntax, according to the help, is `Ct[?] [-] [comment-text] [@addr]`, identical to `CC`.)