### PR TITLE
__libc_start_main might return

### DIFF
--- a/libr/anal/d/types-linux.sdb.txt
+++ b/libr/anal/d/types-linux.sdb.txt
@@ -40,7 +40,6 @@ func.__libc_start_main.arg.3=func,init
 func.__libc_start_main.arg.4=func,fini
 func.__libc_start_main.arg.5=func,rtld_fini
 func.__libc_start_main.arg.6=void *,stack_end
-func.__libc_start_main.noreturn=true
 func.__libc_start_main.ret=int
 
 __uClibc_main=func


### PR DESCRIPTION
[This hlt instruction on line 128](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/i386/start.S;hb=688903eb3ef01301d239ab753d309d45720610a7#l128) shows that the glibc developers do not assume 100% that `__libc_start_main` will not return, so neither should we.