### PR TITLE
Fix #11480 Fix crash when asm.decoff is enabled

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -5832,7 +5832,7 @@ R_API void r_print_offset_sg(RPrint *p, ut64 off, int invert, int offseg, int se
 				if (offdec) {
 					snprintf (space, sizeof (space), "%"PFMT64d, off);
 					white = r_str_pad (' ', 10 - strlen (space));
-					r_cons_printf ("%s%s%s%s", k, white, space, off, reset);
+					r_cons_printf ("%s%s%s%s", k, white, space, reset);
 				} else {
 					r_cons_printf ("%s0x%08"PFMT64x "%s", k, off, reset);
 				}


### PR DESCRIPTION
This fixes a crash when running `pd` when `asm.decoff` is enabled.
The `off` argument in the sprintf statement should be removed as it is redundant and doesn't match the format string.