### PR TITLE
cmd.load: Run when binary is loaded

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -886,12 +886,7 @@ int main(int argc, char **argv, char **envp) {
 	}
 
 	if (run_rc) {
-		const char *atstart;
 		radare2_rc (&r);
-		atstart = r_config_get (r.config, "cmd.atstart");
-		if (atstart && *atstart) {
-			r_list_prepend (cmds, (char *)atstart);
-		}
 	}
 
 	if (r_config_get_i (r.config, "zign.autoload")) {

--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -886,7 +886,12 @@ int main(int argc, char **argv, char **envp) {
 	}
 
 	if (run_rc) {
+		const char *atstart;
 		radare2_rc (&r);
+		atstart = r_config_get (r.config, "cmd.atstart");
+		if (atstart && *atstart) {
+			r_list_prepend (cmds, (char *)atstart);
+		}
 	}
 
 	if (r_config_get_i (r.config, "zign.autoload")) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2702,6 +2702,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("cmd.gprompt", "", "Graph visual prompt commands");
 	SETPREF ("cmd.hit", "", "Run when a search hit is found");
 	SETPREF ("cmd.open", "", "Run when file is opened");
+	SETPREF ("cmd.load", "", "Run when binary is loaded");
 	SETCB ("cmd.pdc", "", &cb_cmdpdc, "Select pseudo-decompiler command to run after pdc");
 	SETCB ("cmd.log", "", &cb_cmdlog, "Every time a new T log is added run this command");
 	SETPREF ("cmd.prompt", "", "Prompt commands");
@@ -2711,7 +2712,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("cmd.fcn.rename", "", "Run when a function is renamed");
 	SETPREF ("cmd.visual", "", "Replace current print mode");
 	SETPREF ("cmd.vprompt", "", "Visual prompt commands");
-	SETPREF ("cmd.atstart", "", "Run before initial prompt, for use only in radare2rc");
 
 	SETCB ("cmd.esil.mdev", "", &cb_cmd_esil_mdev, "Command to run when memory device address is accessed");
 	SETCB ("cmd.esil.intr", "", &cb_cmd_esil_intr, "Command to run when an esil interrupt happens");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2711,6 +2711,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("cmd.fcn.rename", "", "Run when a function is renamed");
 	SETPREF ("cmd.visual", "", "Replace current print mode");
 	SETPREF ("cmd.vprompt", "", "Visual prompt commands");
+	SETPREF ("cmd.atstart", "", "Run before initial prompt, for use only in radare2rc");
 
 	SETCB ("cmd.esil.mdev", "", &cb_cmd_esil_mdev, "Command to run when memory device address is accessed");
 	SETCB ("cmd.esil.intr", "", &cb_cmd_esil_intr, "Command to run when an esil interrupt happens");

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -505,6 +505,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 	RBinPlugin *plugin = NULL;
 	RBinObject *obj = NULL;
 	int is_io_load;
+	const char *cmd_load;
 	if (!cf) {
 		return false;
 	}
@@ -559,6 +560,10 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 	plugin = r_bin_file_cur_plugin (binfile);
 	if (plugin && plugin->name) {
 		load_scripts_for (r, plugin->name);
+	}
+	cmd_load = r_config_get (r->config, "cmd.load");
+	if (cmd_load && *cmd_load) {
+		r_core_cmd (r, cmd_load, 0);
 	}
 
 	if (plugin && plugin->name) {


### PR DESCRIPTION
Motivation for this is that I'm trying to run `tk func.__libc_start_main.noreturn=false` in my `~/.radare2rc` but can't because the type sdb files are loaded after `~/.radare2rc` is processed and thus the change above is overwritten.