### PR TITLE
Fix r2 -c '?btw 1 1 1' /bin/ls

### DIFF
--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -769,7 +769,7 @@ R_API int r_num_str_split(char *str) {
 
 R_API RList *r_num_str_split_list(char *str) {
 	int i, count = r_num_str_split (str);
-	RList *list = r_list_newf (free);
+	RList *list = r_list_new ();
 	for (i = 0; i < count; i++) {
 		r_list_append (list, str);
 		str += strlen (str) + 1;


### PR DESCRIPTION
There is no reason for the list returned by r_num_str_split_list
to have a link with a variable called 'free', and this cause crash with
ASAN, as seen on https://github.com/radare/radare2/issues/11407