### PR TITLE
Fix r_hex_str_is_valid to handle space like r_hex_str2bin

### DIFF
--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -485,14 +485,16 @@ R_API st64 r_hex_bin_truncate (ut64 in, int n) {
 // Check if str contains only hexademical characters and return length of bytes
 R_API int r_hex_str_is_valid(const char* str) {
 	int i;
+	int len = 0;
 	if (!strncmp (str, "0x", 2)) {
 		str += 2;
 	}
-	for (i = 0; str[i] != '\0' && str[i] != ' '; i++) {
-		if (IS_HEXCHAR (str[i])) {
+	for (i = 0; str[i] != '\0'; i++) {
+		if (IS_HEXCHAR (str[i]))
+			len++;
+		if (IS_HEXCHAR (str[i]) || IS_WHITESPACE(str[i]))
 			continue;
-		}
 		return -1; //if we're here, then str isnt valid
 	}
-	return i;
+	return len;
 }


### PR DESCRIPTION
r_hex_str_is_valid is called only once from r_reg_arena_set_bytes,
to find the size of the hexadecimal string. However, it stop
at the first space, while the method used for the conversion
r_hex_str2bin is skipping space and continue to convert.

So with a long enough string passed to drw and arw, it is possible
to crash r2, as reported in https://github.com/radare/radare2/issues/11407