### PR TITLE
Do not crash if a string with a size of R_NUMCALC_STRSZ is passed

### DIFF
--- a/libr/util/calc.c
+++ b/libr/util/calc.c
@@ -230,7 +230,7 @@ static int cin_get(RNum *num, RNumCalc *nc, char *c) {
 
 static int cin_get_num(RNum *num, RNumCalc *nc, RNumCalcValue *n) {
 	double d;
-	char str[R_NUMCALC_STRSZ]; // TODO: move into the heap?
+	char str[R_NUMCALC_STRSZ + 1]; // TODO: move into the heap?
 	int i = 0;
 	char c;
 	str[0] = 0;


### PR DESCRIPTION
Since str is a fixed array of R_NUMCALC_STRSZ, str[i] will crash
with ASAN if i == R_NUMCALC_STRSZ, as it happen with the loop
and 'i++'

Fix another issue reported on https://github.com/radare/radare2/issues/11407