### PR TITLE
Fix format string for dsb

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1940,7 +1940,7 @@ line = NULL;
 	if (!strncmp (input, "dsb", 3)) {
 		RAnalBlock *bb = r_anal_bb_from_offset (core->anal, core->offset);
 		if (bb) {
-			line = s = r_core_cmd_strf (core, "pD %"PFMT64d" @ 0x%08"PFMT64x, bb->size, bb->addr);
+			line = s = r_core_cmd_strf (core, "pD %i @ 0x%08"PFMT64x, bb->size, bb->addr);
 		}
 	} else if (!strncmp (input, "dsf", 3) || !strncmp (input, "dsr", 3)) {
 		RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, R_ANAL_FCN_TYPE_NULL);


### PR DESCRIPTION
Since bb->size is a int, we should use %i, not %lld, as this cause
a error with linters (lgtm.com in this case).