### PR TITLE
libr/core/cmd.c: Fix related to unsigned numbers

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2636,7 +2636,7 @@ repeat_arroba:
 			if (ptr[2] == '.') { // "@.."
 				if (ptr[3] == '.') { // "@..."
 					ut64 addr = r_num_tail (core->num, core->offset, ptr + 4);
-					r_core_block_size (core, R_ABS (addr - core->offset));
+					r_core_block_size (core, R_ABS ((st64)addr - (st64)core->offset));
 					goto fuji;
 				} else {
 					addr = r_num_tail (core->num, core->offset, ptr + 3);


### PR DESCRIPTION
Subtraction of unsigned numbers always yields a positive number. Adds
casts to st64 to give the intended result.