### PR TITLE
Add user defined field in RBreakpointItem

### DIFF
--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -60,6 +60,7 @@ typedef struct r_bp_item_t {
 	char *data;
 	char *cond; /* used for conditional breakpoints */
 	char *expr; /* to be used for named breakpoints (see r_debug_bp_update) */
+	void *user; /* user defined data associated with the breakpoint */
 } RBreakpointItem;
 
 struct r_bp_t;


### PR DESCRIPTION
This PR adds a `void*` field named `user` in `RBreakpointItem` struct in order for the user implementing a plugin to associate its own data to the breakpoint.

The use case I have is for `r2vmi` debugger plugin, i need to associate a `vmi_event_t` struct with each `breakpoint`.
My current implementation is to use a `GHashTable`, [associating a breakpoint virtual address](https://github.com/Wenzel/r2vmi/blob/master/io_vmi.h#L22) to the `vmi_event_t`, but i would rather directly the breakpoint struct if possible:
https://github.com/Wenzel/r2vmi/blob/master/debug_vmi.c#L543

What do you think ?
Thanks.