### PR TITLE
Fix a use-after-free and a memory leak in handling of WASM binaries 

### DIFF
--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -269,10 +269,7 @@ static RBinInfo *info(RBinFile *bf) {
 }
 
 static ut64 size(RBinFile *bf) {
-	if (!bf->o->info) {
-		bf->o->info = info (bf);
-	}
-	if (!bf->o->info) {
+	if (!bf || !bf->buf) {
 		return 0;
 	}
 	return bf->buf->length;

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -72,7 +72,6 @@ static RList *entries(RBinFile *bf) {
 		}
 		if (!addr) {
 			r_list_free (ret);
-			r_list_free (codes);
 			return NULL;
 		}
 	}


### PR DESCRIPTION
This PR addresses the following problems in handling of WASM binaries:

- **Fix issue #11399: use-after-free in symbols():**

Commit 7e083b57f introduced the issue #11399. The list referenced by
`codes` in `entries()`, is the same list that `bf->g_codes` is pointing at.
By freeing it, we introduce a use-after-free in a subsequent call within
`symbols()`, where we try to iterate over the list that `bf->g_codes` is
supposed to be referencing.

- **Fix memleak during loading of WASM binaries:**

A memory leak is reported by ASAN when handling WASM binaries. It is
caused by multiple allocations of `RBinInfo` structure. First, `RBinInfo`
is allocated within a call to `size()` from `r_bin_object_set_items()`. Then
there is another, explicit allocation of a `RBinInfo` structure through
a call to the `info()` callback of the WASM `RBinPlugin`. This causes loss
of reference to the initial structure, and subsequently a leak.

There are no apparent uses of `RBinInfo` structure inbetween these two
points, and the `size()` result is in no way dependent on this structure,
therefore I resolved the memory leak by removing the allocation from
within `size()`.

After addressing these issues, I experience no crashes or ASAN errors
when working with the reproducer of #11399 or other WASM binaries:

```
$ r2 -A samples/11399/r2_uaf_symbols
err: beach sections
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze value pointers (aav)
[x] Value from 0x00000000 to 0x0001c862 (aav)
[x] 0x00000000-0x0001c862 in 0x0-0x1c862 (aav)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Constructing a function name for fcn.* and sym.func.* functions (aan)
[x] Type matching analysis for all functions (afta)
[x] Use -AA or aaaa to perform additional experimental analysis.
 -- Wrong argument
[0x00000000]> q
$
```