### PR TITLE
linux_heap_glibc: refactor

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -1186,8 +1186,8 @@ int main(int argc, char **argv, char **envp) {
 #if __linux__ && __GNU_LIBRARY__ && __GLIBC__ && __GLIBC_MINOR__ && __x86_64__
 						ut64 bitness = r_config_get_i (r.config, "asm.bits");
 						if (bitness == 32) {
-							eprintf ("glibc.fc_offset = 0x00158\n");
-							r_config_set_i (r.config, "dbg.glibc.fc_offset", 0x00158);
+							eprintf ("glibc.fc_offset = 0x00148\n");
+							r_config_set_i (r.config, "dbg.glibc.fc_offset", 0x00148);
 						}
 #endif
 					}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2371,10 +2371,10 @@ R_API int r_core_config_init(RCore *core) {
 #endif
 #if __x86_64__
 	SETI ("dbg.glibc.ma_offset", 0x000000, "Main_arena offset from his symbol");
-	SETI ("dbg.glibc.fc_offset", 0x00250, "First chunk offset from brk_start");
+	SETI ("dbg.glibc.fc_offset", 0x00240, "First chunk offset from brk_start");
 #else
 	SETI ("dbg.glibc.ma_offset", 0x1bb000, "Main_arena offset from his symbol");
-	SETI ("dbg.glibc.fc_offset", 0x158, "First chunk offset from brk_start");
+	SETI ("dbg.glibc.fc_offset", 0x148, "First chunk offset from brk_start");
 #endif
 	SETPREF ("dbg.libc.dbglib", "", "Set libc debug library file");
 

--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -36,6 +36,16 @@ R_LIB_VERSION_HEADER(r_heap_glibc);
 #define TCACHE_MAX_BINS 64
 #define TCACHE_FILL_COUNT 7
 
+#define MMAP_ALIGN_32 0x14
+#define MMAP_ALIGN_64 0x18
+#define MMAP_OFFSET 0x8
+
+#define HDR_SZ_32 0x8
+#define HDR_SZ_64 0x10
+#define TC_HDR_SZ 0x10
+#define TC_SZ_32 0x0
+#define TC_SZ_64 0x10
+
 #define largebin_index_32(size)				       \
 (((((ut32)(size)) >>  6) <= 38)?  56 + (((ut32)(size)) >>  6): \
  ((((ut32)(size)) >>  9) <= 20)?  91 + (((ut32)(size)) >>  9): \
@@ -130,12 +140,12 @@ typedef struct r_malloc_state_64 {
 
 typedef struct r_tcache_perthread_struct_32 {
 	ut8 counts[TCACHE_MAX_BINS];
-	unsigned int *entries[TCACHE_MAX_BINS];
+	ut32 entries[TCACHE_MAX_BINS];
 } RHeapTcache_32;
 
 typedef struct r_tcache_perthread_struct_64 {
 	ut8 counts[TCACHE_MAX_BINS];
-	unsigned int *entries[TCACHE_MAX_BINS];
+	ut64 entries[TCACHE_MAX_BINS];
 } RHeapTcache_64;
 
 typedef struct r_malloc_state_tcache_32 {


### PR DESCRIPTION
accept @addr at dmhm & dmhb & dmh & dmhj
fix dmhb x:not_arena infinite loop
fix chunk free/alloc threaded arenas
split r_resolve_main_arena from update_main_arena
add function is_arena
remove unncessari *initial_brk parameter
merge print_heap_segment & print_heap_mmaped & print_mmap_graph & print_heap_graph
dmhj supports tcache in threaded arenas
general use of r_num_get
print status at dmhg
chunk sizes calculated without flags
