### PR TITLE
Fix a small memory leak in extract_rarg()

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -702,7 +702,7 @@ R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_s
 				!strcmp (opdreg, regname);
 			if ((op->src[0] && opsreg && !strcmp (opsreg, regname)) || cond) {
 				const char *vname = NULL;
-				const char *type = "int";
+				const char *type = NULL;
 				char *name = NULL;
 				int delta = 0;
 				RRegItem *ri = r_reg_get (anal->reg, regname, -1);
@@ -725,6 +725,7 @@ R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_s
 				r_anal_var_access (anal, fcn->addr, R_ANAL_VAR_KIND_REG, 1, delta, 0, op->addr);
 				r_meta_set_string (anal, R_META_TYPE_VARTYPE, op->addr, vname);
 				free (name);
+				free (type);
 			}
 			if (op->dst && opdreg && !strcmp (opdreg, regname)) {
 				reg_set [i] = 1;


### PR DESCRIPTION
This PR addresses the following issue:

- **Fix a small memory leak in extract_rarg()**

ASAN reports a memory leak within extract_rarg() because `type` is not
properly freed upon being allocated within `r_type_func_args_type()`.
It's safe to set `type` to NULL: it's only passed to r_anal_var_add(),
which already initializes it to its default value ("int").

Reproduction:

ASAN build (`ASAN="address leak"`) on `Ubuntu 18.04.1 LTS`, running
`radare2 3.0.0-git 19469 @ linux-x86-64 git.2.9.0-109-g4014e938d`:

```
$ r2 -A /bin/ls
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Constructing a function name for fcn.* and sym.func.* functions (aan)
[x] Type matching analysis for all functions (afta)
[x] Use -AA or aaaa to perform additional experimental analysis.
 -- I did it for the pwnz.
[0x00005850]> q

=================================================================
==6647==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 35 byte(s) in 3 object(s) allocated from:
    #0 0x7fcd8a7b4538 in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x77538)
    #1 0x7fcd84a73c9b in sdb_get_len /home/pageflt/gitroot/pageflt/radare2/shlr/sdb/src/sdb.c:276
    #2 0x7fcd84a73cd4 in sdb_get /home/pageflt/gitroot/pageflt/radare2/shlr/sdb/src/sdb.c:280
    #3 0x7fcd84a1d620 in r_type_func_args_type /home/pageflt/gitroot/pageflt/radare2/libr/util/ctype.c:461
    #4 0x7fcd8802e545 in extract_rarg /home/pageflt/gitroot/pageflt/radare2/libr/anal/var.c:713
    #5 0x7fcd8a29b2d4 in r_core_recover_vars /home/pageflt/gitroot/pageflt/radare2/libr/core/canal.c:2659
    #6 0x7fcd8a29f68d in r_core_anal_all /home/pageflt/gitroot/pageflt/radare2/libr/core/canal.c:3253
    #7 0x7fcd8a14c235 in cmd_anal_all /home/pageflt/gitroot/pageflt/radare2/libr/core/cmd_anal.c:7024
    #8 0x7fcd8a14eaaf in cmd_anal /home/pageflt/gitroot/pageflt/radare2/libr/core/cmd_anal.c:7442
    #9 0x7fcd8a2804c2 in r_cmd_call /home/pageflt/gitroot/pageflt/radare2/libr/core/cmd_api.c:239
    #10 0x7fcd8a1db85e in r_core_cmd_subst_i /home/pageflt/gitroot/pageflt/radare2/libr/core/cmd.c:2949
    #11 0x7fcd8a1d445f in r_core_cmd_subst /home/pageflt/gitroot/pageflt/radare2/libr/core/cmd.c:1955
    #12 0x7fcd8a1e0cd8 in r_core_cmd /home/pageflt/gitroot/pageflt/radare2/libr/core/cmd.c:3668
    #13 0x7fcd8a1e19f5 in r_core_cmd0 /home/pageflt/gitroot/pageflt/radare2/libr/core/cmd.c:3834
    #14 0x55d152a67103 in main /home/pageflt/gitroot/pageflt/radare2/binr/radare2/radare2.c:1352
    #15 0x7fcd84304b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 35 byte(s) leaked in 3 allocation(s).
```
