### PR TITLE
Introduce new R_* macros to define direction, null, defaults, etc in function signatures

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -68,11 +68,9 @@ R_API bool r_anal_var_display(RAnal *anal, int delta, char kind, const char *typ
 	return true;
 }
 
-R_API bool r_anal_var_add(RAnal *a, ut64 addr, int scope, int delta, char kind, const char *type, int size,
-		bool isarg, const char *name) {
-	if (!a) {
-		return false;
-	}
+R_API bool r_anal_var_add(RAnal *a, ut64 addr, int scope, int delta, char kind, R_IFNULL("int") const char *type, int size, bool isarg, R_NONNULL const char *name) {
+	r_return_val_if_fail (a, false);
+	r_return_val_if_fail (name, false);
 	if (!kind) {
 		kind = R_ANAL_VAR_KIND_BPV;
 	}

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -13,6 +13,20 @@
 #undef __UNIX__
 #undef __WINDOWS__
 
+#define R_IN /* do not use, implicit */
+#define R_OWN /*own*/
+#define R_OUT /*out*/
+#define R_INOUT /*inout*/
+#define R_NULL /*null*/
+#define R_IFNULL(x) /*ifnull*/
+#ifdef __GNUC__
+#define R_NONNULL __attribute__((__nonnull__))
+#define R_UNUSED __attribute__((__unused__))
+#else
+#define R_NONNULL /*nonnull*/
+#define R_UNUSED /*unused*/
+#endif
+
 #ifdef R_NEW
 #undef R_NEW
 #endif
@@ -199,14 +213,6 @@ extern "C" {
 
 #ifndef __packed
 #define __packed __attribute__((__packed__))
-#endif
-
-#ifndef UNUSED
-#ifdef __GNUC__
-#define UNUSED __attribute__((__unused__))
-#else
-#define UNUSED
-#endif
 #endif
 
 typedef int (*PrintfCallback)(const char *str, ...);

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -14,17 +14,17 @@
 #undef __WINDOWS__
 
 #define R_IN /* do not use, implicit */
-#define R_OWN /*own*/
-#define R_OUT /*out*/
-#define R_INOUT /*inout*/
-#define R_NULL /*null*/
-#define R_IFNULL(x) /*ifnull*/
+#define R_OWN /* pointer ownership is transferred */
+#define R_OUT /* parameter is written, not read */
+#define R_INOUT /* parameter is read and written */
+#define R_NULLABLE /* pointer can be null */
+#define R_IFNULL(x) /* default value for the pointer when null */
 #ifdef __GNUC__
 #define R_NONNULL __attribute__((__nonnull__))
 #define R_UNUSED __attribute__((__unused__))
 #else
-#define R_NONNULL /*nonnull*/
-#define R_UNUSED /*unused*/
+#define R_NONNULL /* nonnull */
+#define R_UNUSED /* unused */
 #endif
 
 #ifdef R_NEW

--- a/libr/include/r_types_base.h
+++ b/libr/include/r_types_base.h
@@ -59,13 +59,11 @@ typedef struct _utX{
 
 #include <stdbool.h>
 
-#define R_ERROR -2
 #define R_FAIL -1
-#define R_FALSE 0
-#define R_TRUE 1
-#define R_TRUFAE 2
+// must be deprecated
 #define R_NOTNULL (void*)(size_t)1
 #define R_EMPTY { 0 }
+#define R_EMPTY2 {{ 0 }}
 
 /* limits */
 #undef UT64_MAX

--- a/libr/include/r_util/r_ctypes.h
+++ b/libr/include/r_util/r_ctypes.h
@@ -37,9 +37,9 @@ R_API int r_type_func_exist(Sdb *TDB, const char *func_name);
 R_API const char *r_type_func_cc(Sdb *TDB, const char *func_name);
 R_API const char *r_type_func_ret(Sdb *TDB, const char *func_name);
 R_API int r_type_func_args_count(Sdb *TDB, R_NONNULL const char *func_name);
-R_API char *r_type_func_args_type(Sdb *TDB, R_NONNULL const char *func_name, int i);
+R_API R_OWN char *r_type_func_args_type(Sdb *TDB, R_NONNULL const char *func_name, int i);
 R_API const char *r_type_func_args_name(Sdb *TDB, R_NONNULL const char *func_name, int i);
-R_API char *r_type_func_guess(Sdb *TDB, char *func_name);
+R_API R_OWN char *r_type_func_guess(Sdb *TDB, R_NONNULL char *func_name);
 
 #ifdef __cplusplus
 }

--- a/libr/include/r_util/r_ctypes.h
+++ b/libr/include/r_util/r_ctypes.h
@@ -36,9 +36,9 @@ R_API char *r_type_format(Sdb *TDB, const char *t);
 R_API int r_type_func_exist(Sdb *TDB, const char *func_name);
 R_API const char *r_type_func_cc(Sdb *TDB, const char *func_name);
 R_API const char *r_type_func_ret(Sdb *TDB, const char *func_name);
-R_API int r_type_func_args_count(Sdb *TDB, const char *func_name);
-R_API char *r_type_func_args_type(Sdb *TDB, const char *func_name, int i);
-R_API char *r_type_func_args_name(Sdb *TDB, const char *func_name, int i);
+R_API int r_type_func_args_count(Sdb *TDB, R_NONNULL const char *func_name);
+R_API char *r_type_func_args_type(Sdb *TDB, R_NONNULL const char *func_name, int i);
+R_API const char *r_type_func_args_name(Sdb *TDB, R_NONNULL const char *func_name, int i);
 R_API char *r_type_func_guess(Sdb *TDB, char *func_name);
 
 #ifdef __cplusplus

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -1,6 +1,6 @@
 /* radare - LGPL - Copyright 2013-2018 - pancake, oddcoder, sivaramaaa */
 
-#include "r_util.h"
+#include <r_util.h>
 
 R_API int r_type_set(Sdb *TDB, ut64 at, const char *field, ut64 val) {
 	const char *kind;
@@ -499,14 +499,13 @@ static R_OWN char *type_func_try_guess(Sdb *TDB, R_NONNULL char *name) {
 // TODO:
 // - symbol names are long and noisy, some of them might not be matched due
 //   to additional information added around name
-R_API char *r_type_func_guess(Sdb *TDB, char *func_name) {
+R_API R_OWN char *r_type_func_guess(Sdb *TDB, R_NONNULL char *func_name) {
 	int offset = 0;
 	char *str = func_name;
 	char *result = NULL;
 	char *first, *last;
-	if (!func_name) {
-		return NULL;
-	}
+	r_return_val_if_fail (TDB, false);
+	r_return_val_if_fail (func_name, false);
 
 	size_t slen = strlen (str);
 	if (slen < MIN_MATCH_LEN) {

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -456,7 +456,7 @@ R_API int r_type_func_args_count(Sdb *TDB, const char *func_name) {
 	return sdb_num_get (TDB, query, 0);
 }
 
-R_API char *r_type_func_args_type(Sdb *TDB, const char *func_name, int i) {
+R_API R_OWN char *r_type_func_args_type(Sdb *TDB, R_NONNULL const char *func_name, int i) {
 	const char *query = sdb_fmt ("func.%s.arg.%d", func_name, i);
 	char *ret = sdb_get (TDB, query, 0);
 	if (ret) {
@@ -470,7 +470,7 @@ R_API char *r_type_func_args_type(Sdb *TDB, const char *func_name, int i) {
 	return NULL;
 }
 
-R_API char *r_type_func_args_name(Sdb *TDB, const char *func_name, int i) {
+R_API const char *r_type_func_args_name(Sdb *TDB, R_NONNULL const char *func_name, int i) {
 	const char *query = sdb_fmt ("func.%s.arg.%d", func_name, i);
 	const char *get = sdb_const_get (TDB, query, 0);
 	if (get) {
@@ -482,7 +482,7 @@ R_API char *r_type_func_args_name(Sdb *TDB, const char *func_name, int i) {
 
 #define MIN_MATCH_LEN 4
 
-static char *type_func_try_guess(Sdb *TDB, char *name) {
+static R_OWN char *type_func_try_guess(Sdb *TDB, R_NONNULL char *name) {
 	const char *res;
 	if (r_str_nlen (name, MIN_MATCH_LEN) < MIN_MATCH_LEN) {
 		return NULL;

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -46,7 +46,7 @@ int gdbr_check_vcont(libgdbr_t *g);
  * remote target's interpreter.
  * \returns 0 on success and -1 on failure
  */
-int gdbr_send_qRcmd(libgdbr_t *g, const char *cmd, void (*cb_printf) (const char *, ...));
+int gdbr_send_qRcmd(libgdbr_t *g, const char *cmd, PrintfCallback cb_printf);
 
 /*!
  * \brief attaches to a process

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -1186,7 +1186,7 @@ void gdbr_invalidate_reg_cache() {
 	reg_cache.valid = false;
 }
 
-int gdbr_send_qRcmd(libgdbr_t *g, const char *cmd, void (*cb_printf) (const char *fmt, ...)) {
+int gdbr_send_qRcmd(libgdbr_t *g, const char *cmd, PrintfCallback cb_printf) {
 	if (!g || !cmd) {
 		return -1;
 	}

--- a/sys/r2api.sh
+++ b/sys/r2api.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+cd $HOME/prg/radare2
+IFS=:
+for a in $PATH ; do
+	if [ -x "$a/radare2" ]; then
+		D=$(dirname `readlink /usr/local/bin/radare2`)
+		cd "$D/../.."
+		if [ -d libr/include ]; then
+			git grep "$1" libr/include | grep -v '#include' | less -p "$1" -R
+			exit 0
+		fi
+	fi
+done
+echo "Cant find r2"


### PR DESCRIPTION
- Helps to identify some bugs at compile time
- Useful for git grep and understand the usage of the functions
- Improve readability
- Fix memleak introduced in previous anal/var pr
- Help to find unnecessary null checks and start to use r_assert
- Deprecate R_TRUFAE R_TRUE R_FALSE and R_ERROR