### PR TITLE
Fix Repology image aspect ratio in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | **Infrastructure** |  [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/741/badge)](https://bestpractices.coreinfrastructure.org/projects/741) |
 | **Codecov** | [![codecov](https://codecov.io/gh/radare/radare2/branch/master/graph/badge.svg)](https://codecov.io/gh/radare/radare2)
 <a href="https://repology.org/metapackage/radare2">
-<img src="https://repology.org/badge/vertical-allrepos/radare2.svg" alt="Packaging status" align="right" width="150px" height="700px">
+<img src="https://repology.org/badge/vertical-allrepos/radare2.svg" alt="Packaging status" align="right" width="150px">
 </a>
 
 # Introduction


### PR DESCRIPTION
The Repology image was distorted because its height is specified in HTML but its original height can change over time. By not setting a fixed height, this makes sure it doesn't become distorted as new distributions are added.