### PR TITLE
Make axj outputting the same data as ax

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -215,7 +215,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 	RList *list = r_anal_ref_list_new();
 	listxrefs (anal->dict_refs, UT64_MAX, list);
 	if (rad == 'j') {
-		anal->cb_printf ("{");
+		anal->cb_printf ("[");
 	}
 	r_list_foreach (list, iter, ref) {
 		int t = ref->type ? ref->type: ' ';
@@ -251,7 +251,16 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 				} else {
 					anal->cb_printf (",");
 				}
-				anal->cb_printf ("\"%"PFMT64d"\":%"PFMT64d, ref->at, ref->addr);
+
+				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
+				r_str_replace_char (name, ' ', 0);
+				anal->cb_printf ("{\"name\":\"%s\",", name? name: "");
+				free (name);
+				anal->cb_printf ("\"at\":%"PFMT64d",\"type\":\"%s\",\"address\":%"PFMT64d, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
+				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
+				r_str_replace_char (name, ' ', 0);
+				anal->cb_printf (",\"xref\":\"%s\"}", (name && *name) ? name : "");
+				free (name);
 			}
 			break;
 		default:
@@ -259,7 +268,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 		}
 	}
 	if (rad == 'j') {
-		anal->cb_printf ("}\n");
+		anal->cb_printf ("]\n");
 	}
 	r_list_free (list);
 }

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -226,12 +226,12 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 		case '\0':
 			{
 				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
-				r_str_replace_char (name, ' ', 0);
+				r_str_replace_ch (name, ' ', 0, true);
 				anal->cb_printf ("%40s", r_str_get2 (name));
 				free (name);
 				anal->cb_printf (" 0x%"PFMT64x" -> %9s -> 0x%"PFMT64x, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
-				r_str_replace_char (name, ' ', 0);
+				r_str_replace_ch (name, ' ', 0, true);
 				anal->cb_printf (" %s\n", r_str_get2 (name));
 				free (name);
 			}
@@ -248,14 +248,13 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 				}
 
 				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
-				r_str_replace_char (name, ' ', 0);
+				r_str_replace_ch (name, ' ', 0, true);
 				anal->cb_printf ("{\"name\":\"%s\",", r_str_get2 (name));
 				free (name);
 				anal->cb_printf ("\"from\":%"PFMT64d",\"type\":\"%s\",\"addr\":%"PFMT64d, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
-				r_str_replace_char (name, ' ', 0);
+				r_str_replace_ch (name, ' ', 0, true);
 				anal->cb_printf (",\"xref\":\"%s\"}", r_str_get2 (name));
-				r_str_get
 				free (name);
 			}
 			break;

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -221,23 +221,18 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 		int t = ref->type ? ref->type: ' ';
 		switch (rad) {
 		case '*':
-			anal->cb_printf ("ax%c 0x%"PFMT64x" 0x%"PFMT64x"\n",
-				t, ref->addr, ref->at);
+			anal->cb_printf ("ax%c 0x%"PFMT64x" 0x%"PFMT64x"\n", t, ref->addr, ref->at);
 			break;
 		case '\0':
 			{
 				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
 				r_str_replace_char (name, ' ', 0);
-				anal->cb_printf ("%40s", name? name: "");
+				anal->cb_printf ("%40s", r_str_get2 (name));
 				free (name);
 				anal->cb_printf (" 0x%"PFMT64x" -> %9s -> 0x%"PFMT64x, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
 				r_str_replace_char (name, ' ', 0);
-				if (name && *name) {
-					anal->cb_printf (" %s\n", name);
-				} else {
-					anal->cb_printf ("\n");
-				}
+				anal->cb_printf (" %s\n", r_str_get2 (name));
 				free (name);
 			}
 			break;
@@ -254,12 +249,13 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 
 				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
 				r_str_replace_char (name, ' ', 0);
-				anal->cb_printf ("{\"name\":\"%s\",", name? name: "");
+				anal->cb_printf ("{\"name\":\"%s\",", r_str_get2 (name));
 				free (name);
-				anal->cb_printf ("\"at\":%"PFMT64d",\"type\":\"%s\",\"address\":%"PFMT64d, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
+				anal->cb_printf ("\"from\":%"PFMT64d",\"type\":\"%s\",\"addr\":%"PFMT64d, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
 				r_str_replace_char (name, ' ', 0);
-				anal->cb_printf (",\"xref\":\"%s\"}", (name && *name) ? name : "");
+				anal->cb_printf (",\"xref\":\"%s\"}", r_str_get2 (name));
+				r_str_get
 				free (name);
 			}
 			break;

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -231,7 +231,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 					anal->cb_printf ("%40s", name);
 					free (name);
 				} else {
-					anal->cb_printf ("%40s", "(null)");
+					anal->cb_printf ("%40s", "noname");
 				}
 				anal->cb_printf (" 0x%"PFMT64x" -> %9s -> 0x%"PFMT64x, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -226,14 +226,22 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 		case '\0':
 			{
 				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
-				r_str_replace_ch (name, ' ', 0, true);
-				anal->cb_printf ("%40s", r_str_get2 (name));
-				free (name);
+				if (name) {
+					r_str_replace_ch (name, ' ', 0, true);
+					anal->cb_printf ("%40s", name);
+					free (name);
+				} else {
+					anal->cb_printf ("%40s", "(null)");
+				}
 				anal->cb_printf (" 0x%"PFMT64x" -> %9s -> 0x%"PFMT64x, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
-				r_str_replace_ch (name, ' ', 0, true);
-				anal->cb_printf (" %s\n", r_str_get2 (name));
-				free (name);
+				if (name) {
+					r_str_replace_ch (name, ' ', 0, true);
+					anal->cb_printf (" %s\n", name);
+					free (name);
+				} else {
+					anal->cb_printf ("\n");
+				}
 			}
 			break;
 		case 'q':
@@ -248,14 +256,22 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 				}
 
 				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
-				r_str_replace_ch (name, ' ', 0, true);
-				anal->cb_printf ("{\"name\":\"%s\",", r_str_get2 (name));
-				free (name);
+				if (name) {
+					r_str_replace_ch (name, ' ', 0, true);
+					anal->cb_printf ("{\"name\":\"%s\",", name);
+					free (name);
+				} else {
+					anal->cb_printf ("{\"name\":\"\",");
+				}
 				anal->cb_printf ("\"from\":%"PFMT64d",\"type\":\"%s\",\"addr\":%"PFMT64d, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
-				r_str_replace_ch (name, ' ', 0, true);
-				anal->cb_printf (",\"xref\":\"%s\"}", r_str_get2 (name));
-				free (name);
+				if (name) {
+					r_str_replace_ch (name, ' ', 0, true);
+					anal->cb_printf (",\"xref\":\"%s\"}", name);
+					free (name);
+				} else {
+					anal->cb_printf (",\"xref\":\"\"}");
+				}
 			}
 			break;
 		default:

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -254,24 +254,21 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 				} else {
 					anal->cb_printf (",");
 				}
-
+				anal->cb_printf ("{");
 				char *name = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
 				if (name) {
 					r_str_replace_ch (name, ' ', 0, true);
-					anal->cb_printf ("{\"name\":\"%s\",", name);
+					anal->cb_printf ("\"name\":\"%s\",", name);
 					free (name);
-				} else {
-					anal->cb_printf ("{\"name\":\"\",");
 				}
 				anal->cb_printf ("\"from\":%"PFMT64d",\"type\":\"%s\",\"addr\":%"PFMT64d, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);
 				if (name) {
 					r_str_replace_ch (name, ' ', 0, true);
-					anal->cb_printf (",\"xref\":\"%s\"}", name);
+					anal->cb_printf (",\"refname\":\"%s\"", name);
 					free (name);
-				} else {
-					anal->cb_printf (",\"xref\":\"\"}");
 				}
+				anal->cb_printf ("}");
 			}
 			break;
 		default:

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -231,7 +231,7 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad) {
 					anal->cb_printf ("%40s", name);
 					free (name);
 				} else {
-					anal->cb_printf ("%40s", "noname");
+					anal->cb_printf ("%40s", "?");
 				}
 				anal->cb_printf (" 0x%"PFMT64x" -> %9s -> 0x%"PFMT64x, ref->at, r_anal_xrefs_type_tostring (t), ref->addr);
 				name = anal->coreb.getNameDelta (anal->coreb.core, ref->addr);

--- a/libr/util/asn1.c
+++ b/libr/util/asn1.c
@@ -25,7 +25,7 @@ static ut32 asn1_ber_indefinite (const ut8 *buffer, ut32 length) {
 	return (next - buffer) + 2;
 }
 
-RASN1Object *asn1_parse_header (const ut8 *buffer, ut32 length) {
+static RASN1Object *asn1_parse_header (const ut8 *buffer, ut32 length) {
 	ut8 head, length8, byte;
 	ut64 length64;
 	if (!buffer || length < 2) {

--- a/libr/util/x509.h
+++ b/libr/util/x509.h
@@ -20,7 +20,7 @@ R_API bool r_x509_parse_tbscertificate(RX509TBSCertificate *tbsc, RASN1Object * 
 R_API void r_x509_free_tbscertificate(RX509TBSCertificate * tbsc);
 
 R_API RX509CRLEntry *r_x509_parse_crlentry(RASN1Object *object);
-void r_x509_name_dump(RX509Name* name, const char* pad, RStrBuf *sb);
+R_API void r_x509_name_dump(RX509Name* name, const char* pad, RStrBuf *sb);
 
 #endif /* R_X509_INTERNAL_H */
 


### PR DESCRIPTION
`ax` output
```
                           segment.LOAD0 0x8048000 ->      CODE -> 0x8048047 segment.PHDR+19
                       section..dynstr+8 0x8048278 ->      CODE -> 0x80482ee section..gnu.version_r+10
                      section..dynstr+11 0x804827b ->      CODE -> 0x80482f1 section..gnu.version_r+13
                      section..dynstr+21 0x8048285 ->      CODE -> 0x80482f6 section..gnu.version_r+18
                      section..dynstr+50 0x80482a2 ->      CODE -> 0x8048308 section..rel.dyn+4
                      section..dynstr+70 0x80482b6 ->      CODE -> 0x804832c section..rel.plt+32
                         section..init+6 0x8048342 ->      CALL -> 0x80483f4 fcn.080483f4
                        section..init+11 0x8048347 ->      CALL -> 0x8048450 sym.frame_dummy
                        section..init+16 0x804834c ->      CALL -> 0x8048620 sym.__do_global_ctors_aux
                          section..plt+6 0x804835a ->      CODE -> 0x8049ffc section..got.plt+8
               sym.imp.__libc_start_main 0x8048364 ->      CODE -> 0x804a000 reloc.__libc_start_main
            sym.imp.__libc_start_main+11 0x804836f ->      CODE -> 0x8048354 section..plt
                           sym.imp.scanf 0x8048374 ->      CODE -> 0x804a004 reloc.scanf
                        sym.imp.scanf+11 0x804837f ->      CODE -> 0x8048354 section..plt
                          sym.imp.strlen 0x8048384 ->      CODE -> 0x804a008 reloc.strlen
                       sym.imp.strlen+11 0x804838f ->      CODE -> 0x8048354 section..plt
                          sym.imp.printf 0x8048394 ->      CODE -> 0x804a00c reloc.printf

```
`axj` output
```
[{
    "name": "segment.LOAD0",
    "at": 134512640,
    "type": "CODE",
    "address": 134512711,
    "xref": "segment.PHDR+19"
}, {
    "name": "section..dynstr+8",
    "at": 134513272,
    "type": "CODE",
    "address": 134513390,
    "xref": "section..gnu.version_r+10"
}, {
    "name": "section..dynstr+11",
    "at": 134513275,
    "type": "CODE",
    "address": 134513393,
    "xref": "section..gnu.version_r+13"
}, {
    "name": "section..dynstr+21",
    "at": 134513285,
    "type": "CODE",
    "address": 134513398,
    "xref": "section..gnu.version_r+18"
}, {
    "name": "section..dynstr+50",
    "at": 134513314,
    "type": "CODE",
    "address": 134513416,
    "xref": "section..rel.dyn+4"
}, {
    "name": "section..dynstr+70",
    "at": 134513334,
    "type": "CODE",
    "address": 134513452,
    "xref": "section..rel.plt+32"
}, {
```