### PR TITLE
Fix minor memleak in cb_pager()

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2396,12 +2396,12 @@ R_API RCore *r_core_fini(RCore *c) {
 	R_FREE (c->cmdlog);
 	r_th_lock_free (c->lock);
 	R_FREE (c->lastsearch);
-	free (c->cons->pager);
-	free (c->panels_tmpcfg);
-	free (c->cmdqueue);
-	free (c->lastcmd);
+	R_FREE (c->cons->pager);
+	R_FREE (c->panels_tmpcfg);
+	R_FREE (c->cmdqueue);
+	R_FREE (c->lastcmd);
 	r_list_free (c->visual.tabs);
-	free (c->block);
+	R_FREE (c->block);
 	r_core_autocomplete_free (c->autocomplete);
 
 	r_list_free (c->undos);
@@ -2443,7 +2443,7 @@ R_API RCore *r_core_fini(RCore *c) {
 	sdb_free (c->sdb);
 	r_core_log_free (c->log);
 	r_parse_free (c->parser);
-	free (c->times);
+	R_FREE (c->times);
 	return NULL;
 }
 

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2396,7 +2396,7 @@ R_API RCore *r_core_fini(RCore *c) {
 	R_FREE (c->cmdlog);
 	r_th_lock_free (c->lock);
 	R_FREE (c->lastsearch);
-	c->cons->pager = NULL;
+	free (c->cons->pager);
 	free (c->panels_tmpcfg);
 	free (c->cmdqueue);
 	free (c->lastcmd);


### PR DESCRIPTION
The heap space allocated by `core->cons->pager` within `cb_pager()` is not
properly released, resulting in ASAN complaining about the memory leak.

**Reproduction:**

```
$ r2 -A /bin/ls
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Constructing a function name for fcn.* and sym.func.* functions (aan)
[x] Type matching analysis for all functions (afta)
[x] Use -AA or aaaa to perform additional experimental analysis.
 -- Use radare2! Lemons included!
[0x00005850]> q

=================================================================
==19512==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f5232675538 in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x77538)
    #1 0x7f52320bb3e7 in cb_pager /home/pageflt/gitroot/pageflt/radare2/libr/core/cconfig.c:1651
    #2 0x7f523145d707 in r_config_set_cb /home/pageflt/gitroot/pageflt/radare2/libr/config/config.c:385
    #3 0x7f52320c49ea in r_core_config_init /home/pageflt/gitroot/pageflt/radare2/libr/core/cconfig.c:2903
    #4 0x7f5231f5ac56 in r_core_init /home/pageflt/gitroot/pageflt/radare2/libr/core/core.c:2344
    #5 0x563a3d3ec3a2 in main /home/pageflt/gitroot/pageflt/radare2/binr/radare2/radare2.c:529
    #6 0x7f522c1b9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 1 byte(s) leaked in 1 allocation(s).
```

**Environment:**

```
$ r2 -v
radare2 3.0.0-git 19531 @ linux-x86-64 git.2.9.0-156-gcb1be2727
commit: cb1be27272cd071823b75a88e91b2512d4f7a5f3 build: 2018-09-20__10:58:57
$ lsb_release -d
Description:	Ubuntu 18.04.1 LTS
```
