### PR TITLE
Add 'aang' to recover function names from stripped golang binaries

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -415,6 +415,66 @@ R_API void r_core_anal_autoname_all_fcns(RCore *core) {
 	}
 }
 
+/* reads .gopclntab section in go binaries to recover function names
+   and adds them as sym.go.* flags */
+R_API void r_core_anal_autoname_all_golang_fcns(RCore *core) {
+	RList* section_list = r_bin_get_sections (core->bin);
+	RListIter *iter;
+	RBinSection *section;
+	ut64 gopclntab = 0;
+	r_list_foreach (section_list, iter, section) {
+		if (strstr (section->name, ".gopclntab")) {
+			gopclntab = section->vaddr;
+			break;
+		}
+	}
+	if (!gopclntab) {
+		r_cons_print ("[x] Could not find .gopclntab section\n");
+		return;
+	}
+	int ptr_size = core->anal->bits / 8;
+	ut64 offset = gopclntab + 2*ptr_size;
+	ut64 size_offset = gopclntab + 3*ptr_size ;
+	unsigned char temp_size[4] = {0};
+	if (!r_io_nread_at (core->io, size_offset, temp_size, 4)) {
+		return;
+	}
+	ut32 size = r_read_le32 (temp_size);
+	int num_syms = 0;
+	r_cons_print ("[x] Reading .gopclntab...\n");
+	while (offset < gopclntab + size) {
+		unsigned char temp_delta[4] = {0};
+		unsigned char temp_func_addr[4] = {0};
+		unsigned char temp_func_name[4] = {0};
+		if (!r_io_nread_at (core->io, offset + ptr_size, temp_delta, 4)) {
+			break;
+		}
+		ut32 delta = r_read_le32 (temp_delta);
+		ut64 func_offset = gopclntab + delta;
+		if (!r_io_nread_at (core->io, func_offset, temp_func_addr, 4) ||
+		    !r_io_nread_at (core->io, func_offset + ptr_size, temp_func_name, 4)) {
+			break;
+		}
+		ut32 func_addr = r_read_le32 (temp_func_addr);
+		ut32 func_name_offset = r_read_le32 (temp_func_name);
+		ut8 func_name[64] = {0};
+		r_io_read_at (core->io, gopclntab + func_name_offset, func_name, 64);
+		if (func_name[0] == 0xff) {
+			break;
+		}
+		r_name_filter ((char *)func_name, 0);
+		r_cons_printf ("[x] Found symbol %s at 0x%x\n", func_name, func_addr);
+		r_flag_set (core->flags, sdb_fmt ("sym.go.%s", func_name), func_addr, 1);
+		offset += 2*ptr_size;
+		num_syms++;
+	}
+	if (num_syms) {
+		r_cons_printf ("\n[x] Found %d symbols and saved them at sym.go.*\n", num_syms);
+	} else {
+		r_cons_print ("[x] Found no symbols.\n");
+	}
+}
+
 /* suggest a name for the function at the address 'addr'.
  * If dump is true, every strings associated with the function is printed */
 R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -429,13 +429,13 @@ R_API void r_core_anal_autoname_all_golang_fcns(RCore *core) {
 		}
 	}
 	if (!gopclntab) {
-		r_cons_print ("[x] Could not find .gopclntab section\n");
+		eprint ("[x] Could not find .gopclntab section");
 		return;
 	}
 	int ptr_size = core->anal->bits / 8;
-	ut64 offset = gopclntab + 2*ptr_size;
-	ut64 size_offset = gopclntab + 3*ptr_size ;
-	unsigned char temp_size[4] = {0};
+	ut64 offset = gopclntab + 2 * ptr_size;
+	ut64 size_offset = gopclntab + 3 * ptr_size ;
+	ut8 temp_size[4] = {0};
 	if (!r_io_nread_at (core->io, size_offset, temp_size, 4)) {
 		return;
 	}
@@ -443,9 +443,9 @@ R_API void r_core_anal_autoname_all_golang_fcns(RCore *core) {
 	int num_syms = 0;
 	r_cons_print ("[x] Reading .gopclntab...\n");
 	while (offset < gopclntab + size) {
-		unsigned char temp_delta[4] = {0};
-		unsigned char temp_func_addr[4] = {0};
-		unsigned char temp_func_name[4] = {0};
+		ut8 temp_delta[4] = {0};
+		ut8 temp_func_addr[4] = {0};
+		ut8 temp_func_name[4] = {0};
 		if (!r_io_nread_at (core->io, offset + ptr_size, temp_delta, 4)) {
 			break;
 		}
@@ -458,14 +458,14 @@ R_API void r_core_anal_autoname_all_golang_fcns(RCore *core) {
 		ut32 func_addr = r_read_le32 (temp_func_addr);
 		ut32 func_name_offset = r_read_le32 (temp_func_name);
 		ut8 func_name[64] = {0};
-		r_io_read_at (core->io, gopclntab + func_name_offset, func_name, 64);
+		r_io_read_at (core->io, gopclntab + func_name_offset, func_name, 63);
 		if (func_name[0] == 0xff) {
 			break;
 		}
 		r_name_filter ((char *)func_name, 0);
 		r_cons_printf ("[x] Found symbol %s at 0x%x\n", func_name, func_addr);
 		r_flag_set (core->flags, sdb_fmt ("sym.go.%s", func_name), func_addr, 1);
-		offset += 2*ptr_size;
+		offset += 2 * ptr_size;
 		num_syms++;
 	}
 	if (num_syms) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -46,6 +46,7 @@ static const char *help_msg_aa[] = {
 	"aaf", " ", "analyze all functions (e anal.hasnext=1;afr @@c:isq)",
 	"aai", "[j]", "show info of all analysis parameters",
 	"aan", "", "autoname functions that either start with fcn.* or sym.func.*",
+	"aang", "", "find function and symbol names from golang binaries",
 	"aap", "", "find and analyze function preludes",
 	"aar", "[?] [len]", "analyze len bytes of instructions for references",
 	"aas", " [len]", "analyze symbols (af @@= `isq~[0]`)",
@@ -7032,8 +7033,14 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		r_core_cmd0 (core, "af @@ entry*");
 		break;
 	case 'n': // "aan"
-		r_core_anal_autoname_all_fcns (core);
-		break; //aan
+		switch (input[1]) {
+		case 'g': // "aang"
+			r_core_anal_autoname_all_golang_fcns (core);
+			break;
+		default: // "aan"
+			r_core_anal_autoname_all_fcns (core);
+		}
+		break;
 	case 'p': // "aap"
 		if (*input == '?') {
 			// TODO: accept parameters for ranges

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4791,7 +4791,7 @@ static int cmd_print(void *data, const char *input) {
 				}
 			}
 			break;
-		case 'z': // psz
+		case 'z': // "psz"
 			if (l > 0) {
 				char *s = malloc (core->blocksize + 1);
 				int i, j;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -495,6 +495,7 @@ R_API int r_core_anal_bb_seek(RCore *core, ut64 addr);
 R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth);
 R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump);
 R_API void r_core_anal_autoname_all_fcns(RCore *core);
+R_API void r_core_anal_autoname_all_golang_fcns(RCore *core);
 R_API int r_core_anal_fcn_list(RCore *core, const char *input, const char *rad);
 R_API char *r_core_anal_fcn_name(RCore *core, RAnalFunction *fcn);
 R_API int r_core_anal_fcn_list_size(RCore *core);


### PR DESCRIPTION
Comments on the api usage are welcome, not sure if there is a better way than doing r_io_nread_at and then r_read_le32