### PR TITLE
Fix 11112 - Rename {srwx,flags,perms} to perm. (-21 LOC)

### DIFF
--- a/binr/Makefile
+++ b/binr/Makefile
@@ -11,7 +11,7 @@ BINS=rax2 rasm2 rabin2 rahash2 radiff2 radare2 rafind2 rarun2 ragg2 r2agent
 LIBR2=$(call libname-version,libr2.$(EXT_SO),${LIBVERSION})
 
 all: preload
-	@for BINARY in $(BINS) ; do $(MAKE) -C $${BINARY} all; done
+	@for BINARY in $(BINS) ; do $(MAKE) -C $${BINARY} all || exit 1; done
 ifeq ($(COMPILER),ios-sdk)
 	$(MAKE) ios-sign
 endif

--- a/binr/preload/libr2.c
+++ b/binr/preload/libr2.c
@@ -16,7 +16,7 @@ static RCoreFile *openself(void) {
 	char *out = r_core_cmd_str (core, "o");
 	if (out) {
 		if (!strstr (out, "self://")) {
-			fd = r_core_file_open (core, "self://", R_IO_RW, 0);
+			fd = r_core_file_open (core, "self://", R_PERM_RW, 0);
 		}
 		free (out);
 	}
@@ -74,7 +74,7 @@ void alloc_console() {
 static void start_r2() {
 	core = r_core_new ();
 	r_core_loadlibs (core, R_CORE_LOADLIBS_ALL, NULL);
-	RCoreFile *fd = r_core_file_open (core, "self://", R_IO_RW, 0);
+	RCoreFile *fd = r_core_file_open (core, "self://", R_PERM_RW, 0);
 	r_core_prompt_loop (core);
 	r_core_file_close (core, fd);
 }

--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -978,7 +978,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (file && *file) {
-		if ((fh = r_core_file_open (&core, file, R_IO_READ, 0))) {
+		if ((fh = r_core_file_open (&core, file, R_PERM_R, 0))) {
 			fd = r_io_fd_get_current (core.io);
 			if (fd == -1) {
 				eprintf ("r_core: Cannot open file '%s'\n", file);

--- a/binr/rafind2/rafind2.c
+++ b/binr/rafind2/rafind2.c
@@ -130,7 +130,7 @@ static int rafind_open_file(char *file) {
 	}
 
 	io = r_io_new ();
-	fd = r_io_open_nomap (io, file, R_IO_READ, 0);
+	fd = r_io_open_nomap (io, file, R_PERM_R, 0);
 	if (!fd) {
 		eprintf ("Cannot open file '%s'\n", file);
 		return 1;

--- a/binr/rahash2/rahash2.c
+++ b/binr/rahash2/rahash2.c
@@ -681,7 +681,7 @@ int main(int argc, char **argv) {
 				ut8 *buf = (ut8 *) r_stdin_slurp (&sz);
 				char *uri = r_str_newf ("malloc://%d", sz);
 				if (sz > 0) {
-					desc = r_io_open_nomap (io, uri, R_IO_READ, 0);
+					desc = r_io_open_nomap (io, uri, R_PERM_R, 0);
 					if (!desc) {
 						eprintf ("rahash2: Cannot open malloc://1024\n");
 						return 1;
@@ -694,7 +694,7 @@ int main(int argc, char **argv) {
 					eprintf ("rahash2: Cannot hash directories\n");
 					return 1;
 				}
-				desc = r_io_open_nomap (io, argv[i], R_IO_READ, 0);
+				desc = r_io_open_nomap (io, argv[i], R_PERM_R, 0);
 				if (!desc) {
 					eprintf ("rahash2: Cannot open '%s'\n", argv[i]);
 					return 1;

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -89,7 +89,7 @@ static void map_cpu_memory (RAnal *anal, int entry, ut32 addr, ut32 size, bool f
 	} else {
 		// allocate memory for address space
 		char *mstr = r_str_newf ("malloc://%d", size);
-		desc = anal->iob.open_at (anal->iob.io, mstr, R_IO_READ | R_IO_WRITE, 0, addr);
+		desc = anal->iob.open_at (anal->iob.io, mstr, R_PERM_RW, 0, addr);
 		r_str_free (mstr);
 		// set 8051 address space as name of mapped memory
 		if (desc && anal->iob.fd_get_name (anal->iob.io, desc->fd)) {

--- a/libr/anal/p/anal_pic.c
+++ b/libr/anal/p/anal_pic.c
@@ -640,14 +640,13 @@ static RIODesc *cpu_memory_map (RIOBind *iob, RIODesc *desc, ut32 addr,
 	if (desc && iob->fd_get_name (iob->io, desc->fd)) {
 		iob->fd_remap (iob->io, desc->fd, addr);
 	} else {
-		desc = iob->open_at (iob->io, mstr, R_IO_READ | R_IO_WRITE, 0, addr);
+		desc = iob->open_at (iob->io, mstr, R_PERM_RW, 0, addr);
 	}
 	free (mstr);
 	return desc;
 }
 
-static bool pic_midrange_reg_write (RReg *reg, const char *regname,
-				    ut32 num) {
+static bool pic_midrange_reg_write (RReg *reg, const char *regname, ut32 num) {
 	if (reg) {
 		RRegItem *item = r_reg_get (reg, regname, R_REG_TYPE_GPR);
 		if (item) {

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -245,7 +245,7 @@ R_API int r_bin_load(RBin *bin, const char *file, ut64 baseaddr, ut64 loadaddr, 
 		iob = &bin->iob;
 	}
 	if (!iob->desc_get (iob->io, fd)) {
-		fd = iob->fd_open (iob->io, file, R_IO_READ, 0644);
+		fd = iob->fd_open (iob->io, file, R_PERM_R, 0644);
 	}
 	bin->rawstr = rawstr;
 	// Use the current RIODesc otherwise r_io_map_select can swap them later on
@@ -269,7 +269,7 @@ R_API int r_bin_load_as(RBin *bin, const char *file, ut64 baseaddr,
 		return false;
 	}
 	if (fd < 0) {
-		fd = iob->fd_open (iob->io, file, R_IO_READ, 0644);
+		fd = iob->fd_open (iob->io, file, R_PERM_R, 0644);
 	}
 	if (fd < 0) {
 		return false;
@@ -320,7 +320,7 @@ R_API int r_bin_reload(RBin *bin, int fd, ut64 baseaddr) {
 		// load the bin-properly.  Many of the plugins require all
 		// content and are not
 		// stream based loaders
-		int tfd = iob->fd_open (iob->io, name, R_IO_READ, 0);
+		int tfd = iob->fd_open (iob->io, name, R_PERM_R, 0);
 		if (tfd < 0) {
 			res = false;
 			goto error;
@@ -403,7 +403,7 @@ R_API bool r_bin_load_io2(RBin *bin, int fd, ut64 baseaddr, ut64 loadaddr, int x
 	file_sz = iob->fd_size (io, fd);
 	// file_sz = UT64_MAX happens when attaching to frida:// and other non-debugger io plugins which results in double opening
 	if (is_debugger && file_sz == UT64_MAX) {
-		tfd = iob->fd_open (io, fname, R_IO_READ, 0644);
+		tfd = iob->fd_open (io, fname, R_PERM_R, 0644);
 		if (tfd >= 1) {
 			file_sz = iob->fd_size (io, tfd);
 		}
@@ -458,7 +458,7 @@ R_API bool r_bin_load_io2(RBin *bin, int fd, ut64 baseaddr, ut64 loadaddr, int x
 					if (is_debugger && sz != file_sz) {
 						R_FREE (buf_bytes);
 						if (tfd < 0) {
-							tfd = iob->fd_open (io, fname, R_IO_READ, 0);
+							tfd = iob->fd_open (io, fname, R_PERM_R, 0);
 						}
 						sz = iob->fd_size (io, tfd);
 						if (sz != UT64_MAX) {
@@ -1540,7 +1540,7 @@ R_API ut64 r_bin_get_vaddr(RBin *bin, ut64 paddr, ut64 vaddr) {
 		if (bin->cur->o->info->bits == 16) {
 			RBinSection *s = r_bin_get_section_at (bin->cur->o, paddr, false);
 			// autodetect thumb
-			if (s && s->srwx & 1 && strstr (s->name, "text")) {
+			if (s && (s->perm & R_PERM_X) && strstr (s->name, "text")) {
 				if (!strcmp (bin->cur->o->info->arch, "arm") && (vaddr & 1)) {
 					vaddr = (vaddr >> 1) << 1;
 				}

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -652,7 +652,7 @@ static void parseCodeDirectory (RBuffer *b, int offset, int datasize) {
 	ut8 *hash = p + cscd.hashOffset;
 	int j = 0;
 	int k = 0;
-	eprintf ("Hashed region: 0x%08"PFMT64x" - 0x%08"PFMT64x"\n", 0, cscd.codeLimit);
+	eprintf ("Hashed region: 0x%08"PFMT64x" - 0x%08"PFMT64x"\n", (ut64)0, (ut64)cscd.codeLimit);
 	for (j = 0; j < cscd.nCodeSlots; j++) {
 		int fof = 4096 * j;
 		int idx = j * hashSize;
@@ -1604,7 +1604,7 @@ struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
 			sectname[16] = 0;
 			r_str_filter (sectname, -1);
 			// hack to support multiple sections with same name
-			sections[i].srwx = prot2perm (seg->initprot);
+			sections[i].perm = prot2perm (seg->initprot);
 			sections[i].last = 0;
 		}
 		sections[i].last = 1;
@@ -1638,7 +1638,7 @@ struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
 		for (j = 0; j < bin->nsegs; j++) {
 			if (sections[i].addr >= bin->segs[j].vmaddr &&
 				sections[i].addr < (bin->segs[j].vmaddr + bin->segs[j].vmsize)) {
-				sections[i].srwx = prot2perm (bin->segs[j].initprot);
+				sections[i].perm = prot2perm (bin->segs[j].initprot);
 				break;
 			}
 		}

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -31,7 +31,7 @@ struct section_t {
 	ut64 vsize;
 	ut32 align;
 	ut32 flags;
-	int srwx;
+	int perm;
 	char name[R_BIN_MACH0_STRING_LENGTH];
 	int last;
 };

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -40,27 +40,27 @@ struct minidump_memory_info *r_bin_mdmp_get_mem_info(struct r_bin_mdmp_obj *obj,
 	return NULL;
 }
 
-ut32 r_bin_mdmp_get_srwx(struct r_bin_mdmp_obj *obj, ut64 vaddr) {
+ut32 r_bin_mdmp_get_perm(struct r_bin_mdmp_obj *obj, ut64 vaddr) {
 	struct minidump_memory_info *mem_info;
 
 	if (!(mem_info = r_bin_mdmp_get_mem_info(obj, vaddr))) {
 		/* if there is no mem info in the dump, assume default permission */
-		return R_BIN_SCN_READABLE;
+		return R_PERM_R;
 	}
 
 	/* FIXME: Have I got these mappings right, I am not sure I have!!! */
 
 	switch (mem_info->protect) {
 	case MINIDUMP_PAGE_READONLY:
-		return R_BIN_SCN_READABLE;
+		return R_PERM_R;
 	case MINIDUMP_PAGE_READWRITE:
-		return R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE;
+		return R_PERM_RW;
 	case MINIDUMP_PAGE_EXECUTE:
-		return R_BIN_SCN_EXECUTABLE;
+		return R_PERM_X;
 	case MINIDUMP_PAGE_EXECUTE_READ:
-		return R_BIN_SCN_EXECUTABLE | R_BIN_SCN_READABLE;
+		return R_PERM_RX;
 	case MINIDUMP_PAGE_EXECUTE_READWRITE:
-		return R_BIN_SCN_EXECUTABLE | R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE;
+		return R_PERM_RWX;
 	case MINIDUMP_PAGE_NOACCESS:
 	case MINIDUMP_PAGE_WRITECOPY:
 	case MINIDUMP_PAGE_EXECUTE_WRITECOPY:

--- a/libr/bin/format/mdmp/mdmp.h
+++ b/libr/bin/format/mdmp/mdmp.h
@@ -58,7 +58,7 @@ struct r_bin_mdmp_obj {
 struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(struct r_buf_t *buf);
 void r_bin_mdmp_free(struct r_bin_mdmp_obj *obj);
 ut64 r_bin_mdmp_get_paddr(struct r_bin_mdmp_obj *obj, ut64 vaddr);
-ut32 r_bin_mdmp_get_srwx(struct r_bin_mdmp_obj *obj, ut64 vaddr);
+ut32 r_bin_mdmp_get_perm(struct r_bin_mdmp_obj *obj, ut64 vaddr);
 struct minidump_memory_info *r_bin_mdmp_get_mem_info(struct r_bin_mdmp_obj *obj, ut64 vaddr);
 
 #endif /* MDMP_H */

--- a/libr/bin/format/mdmp/mdmp_pe.c
+++ b/libr/bin/format/mdmp/mdmp_pe.c
@@ -177,22 +177,22 @@ RList *PE_(r_bin_mdmp_pe_get_sections)(struct PE_(r_bin_mdmp_pe_bin) *pe_bin) {
 		ptr->paddr = sections[i].paddr + pe_bin->paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
 		ptr->add = false;
-		ptr->srwx = 0;
-		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_EXECUTABLE;
+		ptr->perm = 0;
+		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_X;
 		}
-		if (R_BIN_PE_SCN_IS_WRITABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_WRITABLE;
+		if (R_BIN_PE_SCN_IS_WRITABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_W;
 		}
-		if (R_BIN_PE_SCN_IS_READABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_READABLE;
+		if (R_BIN_PE_SCN_IS_READABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_X;
 		}
-		if (R_BIN_PE_SCN_IS_SHAREABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_SHAREABLE;
+		if (R_BIN_PE_SCN_IS_SHAREABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_SHAR;
 		}
 #define X 1
 #define ROW (4 | 2)
-		if (ptr->srwx & ROW && !(ptr->srwx & X) && ptr->size > 0) {
+		if (ptr->perm & ROW && !(ptr->perm & X) && ptr->size > 0) {
 			if (!strcmp (ptr->name, ".rsrc") ||
 				!strcmp (ptr->name, ".data") ||
 				!strcmp (ptr->name, ".rdata")) {

--- a/libr/bin/format/omf/omf.c
+++ b/libr/bin/format/omf/omf.c
@@ -749,8 +749,7 @@ int r_bin_omf_send_sections(RList *list, OMF_segment *section, r_bin_omf_obj *ob
 		new->vsize = data->size;
 		new->paddr = data->paddr;
 		new->vaddr = section->vaddr + data->offset + OMF_BASE_ADDR;
-		new->srwx = R_BIN_SCN_EXECUTABLE | R_BIN_SCN_WRITABLE |
-			R_BIN_SCN_READABLE;
+		new->perm = R_PERM_RWX;
 		new->add = true;
 		r_list_append (list, new);
 		data = data->next;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2568,7 +2568,7 @@ struct r_bin_pe_addr_t* PE_(r_bin_pe_get_entrypoint)(struct PE_(r_bin_pe_obj_t)*
 				"trying to fix it but i do not promise nothing\n");
 		}
 		for (i = 0; i < bin->num_sections; i++) {
-			if (sections[i].flags & PE_IMAGE_SCN_MEM_EXECUTE) {
+			if (sections[i].perm & PE_IMAGE_SCN_MEM_EXECUTE) {
 				entry->paddr = sections[i].paddr;
 				entry->vaddr = sections[i].vaddr + base_addr;
 				paddr = 1;
@@ -2602,7 +2602,7 @@ struct r_bin_pe_addr_t* PE_(r_bin_pe_get_entrypoint)(struct PE_(r_bin_pe_obj_t)*
 		struct r_bin_pe_section_t* sections = bin->sections;
 		for (i = 0; i < bin->num_sections; i++) {
 			//If there is a section with x without w perm is a good candidate to be the entrypoint
-			if (sections[i].flags & PE_IMAGE_SCN_MEM_EXECUTE && !(sections[i].flags & PE_IMAGE_SCN_MEM_WRITE)) {
+			if (sections[i].perm & PE_IMAGE_SCN_MEM_EXECUTE && !(sections[i].perm & PE_IMAGE_SCN_MEM_WRITE)) {
 				entry->paddr = sections[i].paddr;
 				entry->vaddr = sections[i].vaddr + base_addr;
 				break;
@@ -3247,7 +3247,7 @@ void PE_(r_bin_pe_check_sections)(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_
 			}
 			//look for other segment with x that is already mapped and hold entrypoint
 			for (j = 0; !sections[j].last; j++) {
-				if (sections[j].flags & PE_IMAGE_SCN_MEM_EXECUTE) {
+				if (sections[j].perm & PE_IMAGE_SCN_MEM_EXECUTE) {
 					addr_beg = sections[j].paddr;
 					addr_end = addr_beg + sections[j].size;
 					if (addr_beg <= entry->paddr && entry->paddr < addr_end) {
@@ -3270,7 +3270,7 @@ void PE_(r_bin_pe_check_sections)(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_
 				sections[i].paddr = entry->paddr;
 				sections[i].vaddr = entry->vaddr - base_addr;
 				sections[i].size = sections[i].vsize = new_section_size;
-				sections[i].flags = new_perm;
+				sections[i].perm = new_perm;
 			}
 			goto out_function;
 		}
@@ -3306,7 +3306,7 @@ void PE_(r_bin_pe_check_sections)(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_
 	sections[i].paddr = entry->paddr;
 	sections[i].vaddr = entry->vaddr - base_addr;
 	sections[i].size = sections[i].vsize = new_section_size;
-	sections[i].flags = new_perm;
+	sections[i].perm = new_perm;
 	sections[i + 1].last = 1;
 	*sects = sections;
 out_function:
@@ -3387,7 +3387,7 @@ static struct r_bin_pe_section_t* PE_(r_bin_pe_get_sections)(struct PE_(r_bin_pe
 			}
 		}
 		sections[j].paddr = shdr[i].PointerToRawData;
-		sections[j].flags = shdr[i].Characteristics;
+		sections[j].perm = shdr[i].Characteristics;
 		sections[j].last = 0;
 		j++;
 	}

--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -27,7 +27,7 @@ struct r_bin_pe_section_t {
 	ut64 vsize;
 	ut64 vaddr;
 	ut64 paddr;
-	ut64 flags;
+	ut64 perm;
 	int last;
 };
 

--- a/libr/bin/format/pe/pe_write.c
+++ b/libr/bin/format/pe/pe_write.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2010-2017 pancake, nibble */
+/* radare - LGPL - Copyright 2010-2018 pancake, nibble */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -20,27 +20,26 @@ bool PE_(r_bin_pe_section_perms)(struct PE_(r_bin_pe_obj_t) *bin, const char *na
 			ut32 newperms_le;
 
 			/* Apply permission flags */
-			if (perms & R_BIN_SCN_EXECUTABLE) {
+			if (perms & R_PERM_X) {
 				newperms |=  PE_IMAGE_SCN_MEM_EXECUTE;
 			} else {
 				newperms &= ~PE_IMAGE_SCN_MEM_EXECUTE;
 			}
-			if (perms & R_BIN_SCN_WRITABLE) {
+			if (perms & R_PERM_W) {
 				newperms |=  PE_IMAGE_SCN_MEM_WRITE;
 			} else {
 				newperms &= ~PE_IMAGE_SCN_MEM_WRITE;
 			}
-			if (perms & R_BIN_SCN_READABLE) {
+			if (perms & R_PERM_R) {
 				newperms |=  PE_IMAGE_SCN_MEM_READ;
 			} else {
 				newperms &= ~PE_IMAGE_SCN_MEM_READ;
 			}
-			if (perms & R_BIN_SCN_SHAREABLE) {
+			if (perms & R_PERM_SHAR) {
 				newperms |=  PE_IMAGE_SCN_MEM_SHARED;
 			} else {
 				newperms &= ~PE_IMAGE_SCN_MEM_SHARED;
 			}
-
 
 			patchoff = bin->section_header_offset;
 			patchoff += i * sizeof (PE_(image_section_header));

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2015-2017 - pancake */
+/* radare - LGPL - Copyright 2015-2018 - pancake */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -171,7 +171,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = art.image_size; // TODO: align?
 	ptr->paddr = 0;
 	ptr->vaddr = art.image_base;
-	ptr->srwx = R_BIN_SCN_READABLE; // r--
+	ptr->perm = R_PERM_R; // r--
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -183,7 +183,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = art.bitmap_size;
 	ptr->paddr = art.bitmap_offset;
 	ptr->vaddr = art.image_base + art.bitmap_offset;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -195,7 +195,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vaddr = art.oat_file_begin;
 	ptr->size = art.oat_file_end - art.oat_file_begin;
 	ptr->vsize = ptr->size;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -207,7 +207,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vaddr = art.oat_data_begin;
 	ptr->size = art.oat_data_end - art.oat_data_begin;
 	ptr->vsize = ptr->size;
-	ptr->srwx = R_BIN_SCN_READABLE; // r--
+	ptr->perm = R_PERM_R; // r--
 	ptr->add = true;
 	r_list_append (ret, ptr);
 

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -72,7 +72,7 @@ static RList *patch_relocs(RBin *b) {
 	if (!b || !b->iob.io || !b->iob.io->desc) {
 		return NULL;
 	}
-	if (!(b->iob.io->cached & R_IO_WRITE)) {
+	if (!(b->iob.io->cached & R_PERM_W)) {
 		eprintf (
 			"Warning: please run r2 with -e io.cache=true to patch "
 			"relocations\n");

--- a/libr/bin/p/bin_bios.c
+++ b/libr/bin/p/bin_bios.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2013-2017 - pancake */
+/* radare - LGPL - Copyright 2013-2018 - pancake */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -11,14 +11,14 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 		/* hacky check to avoid detecting multidex bins as bios */
 		/* need better fix for this */
 		if (!memcmp (buf, "dex", 3)) {
-			return 0;
+			return false;
 		}
 		/* Check if this a 'jmp' opcode */
 		if ((buf[ep] == 0xea) || (buf[ep] == 0xe9)) {
-			return 1;
+			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
@@ -84,8 +84,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = ptr->size = 0x10000;
 	ptr->paddr = bf->buf->length - ptr->size;
 	ptr->vaddr = 0xf0000;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
-	            R_BIN_SCN_EXECUTABLE;
+	ptr->perm = R_PERM_RWX;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;

--- a/libr/bin/p/bin_bootimg.c
+++ b/libr/bin/p/bin_bootimg.c
@@ -195,7 +195,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = bi->page_size;
 	ptr->paddr = 0;
 	ptr->vaddr = 0;
-	ptr->srwx = R_BIN_SCN_READABLE; // r--
+	ptr->perm = R_PERM_R; // r--
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -207,7 +207,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = ADD_REMAINDER (ptr->size, bi->page_size);
 	ptr->paddr = bi->page_size;
 	ptr->vaddr = bi->kernel_addr;
-	ptr->srwx = R_BIN_SCN_READABLE; // r--
+	ptr->perm = R_PERM_R; // r--
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -221,7 +221,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = ADD_REMAINDER (bi->ramdisk_size, bi->page_size);
 		ptr->paddr = ROUND_DOWN (base, bi->page_size);
 		ptr->vaddr = bi->ramdisk_addr;
-		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+		ptr->perm = R_PERM_RX; // r-x
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
@@ -236,7 +236,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = ADD_REMAINDER (bi->second_size, bi->page_size);
 		ptr->paddr = ROUND_DOWN (base, bi->page_size);
 		ptr->vaddr = bi->second_addr;
-		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+		ptr->perm = R_PERM_RX; // r-x
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -151,15 +151,15 @@ static RList *sections(RBinFile *bf) {
 			ptr->vsize = obj->scn_hdrs[i].s_size;
 			ptr->paddr = obj->scn_hdrs[i].s_scnptr;
 			ptr->add = true;
-			ptr->srwx = 0;
+			ptr->perm = 0;
 			if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_READ) {
-				ptr->srwx |= R_BIN_SCN_READABLE;
+				ptr->perm |= R_PERM_R;
 			}
 			if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_WRITE) {
-				ptr->srwx |= R_BIN_SCN_WRITABLE;
+				ptr->perm |= R_PERM_W;
 			}
 			if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_EXECUTE) {
-				ptr->srwx |= R_BIN_SCN_EXECUTABLE;
+				ptr->perm |= R_PERM_X;
 			}
 			r_list_append (ret, ptr);
 		}

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -1921,7 +1921,7 @@ static RList *sections(RBinFile *bf) {
 		strcpy (ptr->name, "header");
 		ptr->size = ptr->vsize = sizeof (struct dex_header_t);
 		ptr->paddr= ptr->vaddr = 0;
-		ptr->srwx = R_BIN_SCN_READABLE;
+		ptr->perm = R_PERM_R;
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
@@ -1931,7 +1931,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->paddr= ptr->vaddr = sizeof (struct dex_header_t);
 		ptr->size = bin->code_from - ptr->vaddr; // fix size
 		ptr->vsize = ptr->size;
-		ptr->srwx = R_BIN_SCN_READABLE;
+		ptr->perm = R_PERM_R;
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
@@ -1940,7 +1940,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vaddr = ptr->paddr = bin->code_from; //ptr->vaddr = fsym;
 		ptr->size = bin->code_to - ptr->paddr;
 		ptr->vsize = ptr->size;
-		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+		ptr->perm = R_PERM_RX;
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
@@ -1956,7 +1956,7 @@ static RList *sections(RBinFile *bf) {
 			// hacky workaround
 			//ptr->size = ptr->vsize = 1024;
 		}
-		ptr->srwx = R_BIN_SCN_READABLE; //|2;
+		ptr->perm = R_PERM_R; //|2;
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}

--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -114,7 +114,7 @@ static RList *sections(RBinFile *bf) {
 		s->vaddr = dol->text_vaddr[i];
 		s->size = dol->text_size[i];
 		s->vsize = s->size;
-		s->srwx = r_str_rwx ("r-x");
+		s->perm = r_str_rwx ("r-x");
 		s->add = true;
 		r_list_append (ret, s);
 	}
@@ -129,7 +129,7 @@ static RList *sections(RBinFile *bf) {
 		s->vaddr = dol->data_vaddr[i];
 		s->size = dol->data_size[i];
 		s->vsize = s->size;
-		s->srwx = r_str_rwx ("r--");
+		s->perm = r_str_rwx ("r--");
 		s->add = true;
 		r_list_append (ret, s);
 	}
@@ -140,7 +140,7 @@ static RList *sections(RBinFile *bf) {
 	s->vaddr = dol->bss_addr;
 	s->size = dol->bss_size;
 	s->vsize = s->size;
-	s->srwx = r_str_rwx ("rw-");
+	s->perm = r_str_rwx ("rw-");
 	s->add = true;
 	r_list_append (ret, s);
 

--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -300,7 +300,7 @@ static RDyldRebaseInfo *get_rebase_info(RBinFile *bf, RDyldCache *cache) {
 	int i;
 	for (i = 0; i < cache->hdr->mappingCount; ++i) {
 		int perm = prot2perm (cache->maps[i].initProt);
-		if (!(perm & R_BIN_SCN_EXECUTABLE)) {
+		if (!(perm & R_PERM_X)) {
 			start_of_data = cache->maps[i].fileOffset;// + bf->o->boffset;
 			break;
 		}
@@ -1044,7 +1044,7 @@ static void sections_from_bin(RList *ret, RBinFile *bf, RDyldBinImage *bin) {
 		if (!ptr->vaddr) {
 			ptr->vaddr = ptr->paddr;
 		}
-		ptr->srwx = sections[i].srwx;
+		ptr->perm = sections[i].perm;
 		r_list_append (ret, ptr);
 	}
 	free (sections);
@@ -1080,7 +1080,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->paddr = cache->maps[i].fileOffset;// + bf->o->boffset;
 		ptr->vaddr = cache->maps[i].address;
 		ptr->add = true;
-		ptr->srwx = prot2perm (cache->maps[i].initProt);
+		ptr->perm = prot2perm (cache->maps[i].initProt);
 		r_list_append (ret, ptr);
 	}
 

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -196,15 +196,15 @@ static RList* sections(RBinFile *bf) {
 			ptr->paddr = section[i].offset;
 			ptr->vaddr = section[i].rva;
 			ptr->add = !obj->phdr; // Load sections if there is no PHDR
-			ptr->srwx = 0;
+			ptr->perm = 0;
 			if (R_BIN_ELF_SCN_IS_EXECUTABLE (section[i].flags)) {
-				ptr->srwx |= R_BIN_SCN_EXECUTABLE;
+				ptr->perm |= R_PERM_X;
 			}
 			if (R_BIN_ELF_SCN_IS_WRITABLE (section[i].flags)) {
-				ptr->srwx |= R_BIN_SCN_WRITABLE;
+				ptr->perm |= R_PERM_W;
 			}
 			if (R_BIN_ELF_SCN_IS_READABLE (section[i].flags)) {
-				ptr->srwx |= R_BIN_SCN_READABLE;
+				ptr->perm |= R_PERM_R;
 			}
 			r_list_append (ret, ptr);
 		}
@@ -224,7 +224,7 @@ static RList* sections(RBinFile *bf) {
 			ptr->vsize = phdr[i].p_memsz;
 			ptr->paddr = phdr[i].p_offset;
 			ptr->vaddr = phdr[i].p_vaddr;
-			ptr->srwx = phdr[i].p_flags;
+			ptr->perm = phdr[i].p_flags;
 			ptr->is_segment = true;
 			switch (phdr[i].p_type) {
 			case PT_DYNAMIC:
@@ -280,8 +280,7 @@ static RList* sections(RBinFile *bf) {
 			ptr->paddr = 0;
 			ptr->vaddr = 0x10000;
 			ptr->add = true;
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
-				R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RWX;
 			r_list_append (ret, ptr);
 		}
 	}
@@ -301,7 +300,7 @@ static RList* sections(RBinFile *bf) {
 		if (obj->ehdr.e_type == ET_REL) {
 			ptr->add = true;
 		}
-		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE;
+		ptr->perm = R_PERM_RW;
 		ptr->is_segment = true;
 		r_list_append (ret, ptr);
 	}
@@ -980,7 +979,7 @@ static RList* patch_relocs(RBin *b) {
 	n_vaddr = g->vaddr + g->vsize;
 	//reserve at least that space
 	size = bin->reloc_num * 4;
-	if (!b->iob.section_add (io, n_off, n_vaddr, size, size, R_BIN_SCN_READABLE, ".got.r2", 0, io->desc->fd)) {
+	if (!b->iob.section_add (io, n_off, n_vaddr, size, size, R_PERM_R, ".got.r2", 0, io->desc->fd)) {
 		return NULL;
 	}
 	if (!(relcs = Elf_(r_bin_elf_get_relocs) (bin))) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -154,7 +154,7 @@ static RList* sections(RBinFile *bf) {
 			// eprintf ("mapping text to va = 0\n");
 			// ptr->vaddr = ptr->paddr;
 		}
-		ptr->srwx = sections[i].srwx;
+		ptr->perm = sections[i].perm;
 		r_list_append (ret, ptr);
 	}
 	free (sections);

--- a/libr/bin/p/bin_mbn.c
+++ b/libr/bin/p/bin_mbn.c
@@ -132,7 +132,7 @@ static RList* sections(RBinFile *bf) {
 	ptr->vsize = sb.psize;
 	ptr->paddr = sb.paddr + 40;
 	ptr->vaddr = sb.vaddr;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
 	ptr->has_strings = true;
 	r_list_append (ret, ptr);
@@ -145,7 +145,7 @@ static RList* sections(RBinFile *bf) {
 	ptr->vsize = sb.sign_sz;
 	ptr->paddr = sb.sign_va - sb.vaddr;
 	ptr->vaddr = sb.sign_va;
-	ptr->srwx = R_BIN_SCN_READABLE; // r--
+	ptr->perm = R_PERM_R; // r--
 	ptr->has_strings = true;
 	ptr->add = true;
 	r_list_append (ret, ptr);
@@ -159,7 +159,7 @@ static RList* sections(RBinFile *bf) {
 		ptr->vsize = sb.cert_sz;
 		ptr->paddr = sb.cert_va - sb.vaddr;
 		ptr->vaddr = sb.cert_va;
-		ptr->srwx = R_BIN_SCN_READABLE; // r--
+		ptr->perm = R_PERM_R; // r--
 		ptr->has_strings = true;
 		ptr->add = true;
 		r_list_append (ret, ptr);

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -249,7 +249,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->add = true;
 		ptr->has_strings = false;
 
-		ptr->srwx = r_bin_mdmp_get_srwx (obj, ptr->vaddr);
+		ptr->perm = r_bin_mdmp_get_perm (obj, ptr->vaddr);
 
 		r_list_append (ret, ptr);
 	}
@@ -268,7 +268,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->add = true;
 		ptr->has_strings = false;
 
-		ptr->srwx = r_bin_mdmp_get_srwx (obj, ptr->vaddr);
+		ptr->perm = r_bin_mdmp_get_perm (obj, ptr->vaddr);
 
 		r_list_append (ret, ptr);
 
@@ -293,7 +293,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->add = false;
 		ptr->has_strings = false;
 		/* As this is an encompassing section we will set the RWX to 0 */
-		ptr->srwx = 0;
+		ptr->perm = 0;
 
 		r_list_append (ret, ptr);
 
@@ -345,7 +345,7 @@ static RList *mem (RBinFile *bf) {
 		}
 		ptr->addr = module->start_of_memory_range;
 		ptr->size = location? location->data_size: 0;
-		ptr->perms = r_bin_mdmp_get_srwx (obj, ptr->addr);
+		ptr->perms = r_bin_mdmp_get_perm (obj, ptr->addr);
 
 		/* [1] */
 		state = type = a_protect = 0;
@@ -367,7 +367,7 @@ static RList *mem (RBinFile *bf) {
 		}
 		ptr->addr = module64->start_of_memory_range;
 		ptr->size = module64->data_size;
-		ptr->perms = r_bin_mdmp_get_srwx (obj, ptr->addr);
+		ptr->perms = r_bin_mdmp_get_perm (obj, ptr->addr);
 
 		/* [1] */
 		state = type = a_protect = 0;

--- a/libr/bin/p/bin_menuet.c
+++ b/libr/bin/p/bin_menuet.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2016 - pancake */
+/* radare2 - LGPL - Copyright 2016-2018 - pancake */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -132,7 +132,7 @@ static RList* sections(RBinFile *bf) {
 	ptr->vsize = ptr->size + (ptr->size % 4096);
 	ptr->paddr = r_read_ble32 (buf + 12, false);
 	ptr->vaddr = ptr->paddr + baddr (bf);
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -148,7 +148,7 @@ static RList* sections(RBinFile *bf) {
 		ptr->vsize = ptr->size + (ptr->size % 4096);
 		ptr->paddr = r_read_ble32 (buf + 40, false);
 		ptr->vaddr = ptr->paddr + baddr (bf);
-		ptr->srwx = R_BIN_SCN_READABLE; // r--
+		ptr->perm = R_PERM_R; // r--
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}

--- a/libr/bin/p/bin_mz.c
+++ b/libr/bin/p/bin_mz.c
@@ -168,7 +168,7 @@ static RList * sections(RBinFile *bf) {
 		ptr->vsize = segments[i].size;
 		ptr->paddr = segments[i].paddr;
 		ptr->vaddr = segments[i].paddr;
-		ptr->srwx = r_str_rwx ("rwx");
+		ptr->perm = r_str_rwx ("rwx");
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}

--- a/libr/bin/p/bin_nes.c
+++ b/libr/bin/p/bin_nes.c
@@ -101,7 +101,7 @@ static RList* sections(RBinFile *bf) {
 	ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
 	ptr->vaddr = ROM_START_ADDRESS;
 	ptr->vsize = ROM_SIZE;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+	ptr->perm = R_PERM_RX;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;

--- a/libr/bin/p/bin_nin3ds.c
+++ b/libr/bin/p/bin_nin3ds.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - 2016 - a0rtega */
+/* radare - LGPL - 2018 - a0rtega */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -66,7 +66,7 @@ static RList *sections(RBinFile *bf) {
 			sections[i]->vsize = loaded_header.sections[i].size;
 			sections[i]->paddr = loaded_header.sections[i].offset;
 			sections[i]->vaddr = loaded_header.sections[i].address;
-			sections[i]->srwx = r_str_rwx ("rwx");
+			sections[i]->perm = r_str_rwx ("rwx");
 			sections[i]->add = true;
 		}
 	}

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -70,7 +70,7 @@ static RList *sections(RBinFile *bf) {
 	ptr9->vsize = loaded_header.arm9_size;
 	ptr9->paddr = loaded_header.arm9_rom_offset;
 	ptr9->vaddr = loaded_header.arm9_ram_address;
-	ptr9->srwx = r_str_rwx ("rwx");
+	ptr9->perm = r_str_rwx ("rwx");
 	ptr9->add = true;
 	r_list_append (ret, ptr9);
 
@@ -79,7 +79,7 @@ static RList *sections(RBinFile *bf) {
 	ptr7->vsize = loaded_header.arm7_size;
 	ptr7->paddr = loaded_header.arm7_rom_offset;
 	ptr7->vaddr = loaded_header.arm7_ram_address;
-	ptr7->srwx = r_str_rwx ("rwx");
+	ptr7->perm = r_str_rwx ("rwx");
 	ptr7->add = true;
 	r_list_append (ret, ptr7);
 

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -114,7 +114,7 @@ static RList* sections(RBinFile *bf){
 	rombank[0]->size = 0x4000;
 	rombank[0]->vsize = 0x4000;
 	rombank[0]->vaddr = 0;
-	rombank[0]->srwx = r_str_rwx ("rx");
+	rombank[0]->perm = r_str_rwx ("rx");
 	rombank[0]->add = true;
 
 	r_list_append (ret, rombank[0]);
@@ -125,7 +125,7 @@ static RList* sections(RBinFile *bf){
 		rombank[i]->paddr = i*0x4000;
 		rombank[i]->vaddr = i*0x10000-0xc000;			//spaaaaaaaaaaaaaaaace!!!
 		rombank[i]->size = rombank[i]->vsize = 0x4000;
-		rombank[i]->srwx = r_str_rwx ("rx");
+		rombank[i]->perm = r_str_rwx ("rx");
 		rombank[i]->add = true;
 		r_list_append (ret,rombank[i]);
 	}

--- a/libr/bin/p/bin_ningba.c
+++ b/libr/bin/p/bin_ningba.c
@@ -80,7 +80,6 @@ static RList *sections(RBinFile *bf) {
 	RList *ret = NULL;
 	RBinSection *s = R_NEW0 (RBinSection);
 	ut64 sz = r_buf_size (bf->buf);
-
 	if (!(ret = r_list_new ())) {
 		free (s);
 		return NULL;
@@ -90,7 +89,7 @@ static RList *sections(RBinFile *bf) {
 	s->vaddr = 0x8000000;
 	s->size = sz;
 	s->vsize = 0x2000000;
-	s->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+	s->perm = R_PERM_RX;
 	s->add = true;
 
 	r_list_append (ret, s);

--- a/libr/bin/p/bin_nro.c
+++ b/libr/bin/p/bin_nro.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2017 - pancake */
+/* radare2 - LGPL - Copyright 2017-2018 - pancake */
 
 // TODO: Support NRR and MODF
 #include <r_types.h>
@@ -119,7 +119,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = 0x80;
 	ptr->paddr = 0;
 	ptr->vaddr = 0;
-	ptr->srwx = R_BIN_SCN_READABLE;
+	ptr->perm = R_PERM_R;
 	ptr->add = false;
 	r_list_append (ret, ptr);
 
@@ -136,7 +136,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = mod0sz;
 		ptr->paddr = mod0;
 		ptr->vaddr = mod0 + ba;
-		ptr->srwx = R_BIN_SCN_READABLE; // rw-
+		ptr->perm = R_PERM_R; // rw-
 		ptr->add = false;
 		r_list_append (ret, ptr);
 	} else {
@@ -154,7 +154,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = sig0sz;
 		ptr->paddr = sig0;
 		ptr->vaddr = sig0 + ba;
-		ptr->srwx = R_BIN_SCN_READABLE; // r--
+		ptr->perm = R_PERM_R; // r--
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	} else {
@@ -170,7 +170,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->size = ptr->vsize;
 	ptr->paddr = readLE32 (b, NRO_OFF (text_memoffset));
 	ptr->vaddr = ptr->paddr + ba;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -183,7 +183,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->size = ptr->vsize;
 	ptr->paddr = readLE32 (b, NRO_OFF (ro_memoffset));
 	ptr->vaddr = ptr->paddr + ba;
-	ptr->srwx = R_BIN_SCN_READABLE; // r-x
+	ptr->perm = R_PERM_R; // r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -196,7 +196,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->size = ptr->vsize;
 	ptr->paddr = readLE32 (b, NRO_OFF (data_memoffset));
 	ptr->vaddr = ptr->paddr + ba;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE; // rw-
+	ptr->perm = R_PERM_RW;
 	ptr->add = true;
 	eprintf ("Base Address 0x%08"PFMT64x "\n", ba);
 	eprintf ("BSS Size 0x%08"PFMT64x "\n", (ut64)

--- a/libr/bin/p/bin_nso.c
+++ b/libr/bin/p/bin_nso.c
@@ -67,7 +67,7 @@ static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sd
 	RBuffer *newbuf = r_buf_new_empty (total_size);
 	ut64 ba = baddr (bf);
 
-	if (rbin->iob.io && !(rbin->iob.io->cached & R_IO_WRITE)) {
+	if (rbin->iob.io && !(rbin->iob.io->cached & R_PERM_W)) {
 		eprintf ("Please add \'-e io.cache=true\' option to r2 command\n");
 		goto fail;
 	}
@@ -165,7 +165,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = readLE32 (b, NSO_OFF (text_memoffset));
 	ptr->paddr = 0;
 	ptr->vaddr = 0;
-	ptr->srwx = R_BIN_SCN_READABLE;
+	ptr->perm = R_PERM_R;
 	ptr->add = false;
 	r_list_append (ret, ptr);
 
@@ -178,7 +178,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->size = ptr->vsize;
 	ptr->paddr = readLE32 (b, NSO_OFF (text_memoffset));
 	ptr->vaddr = readLE32 (b, NSO_OFF (text_loc)) + ba;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;	// r-x
+	ptr->perm = R_PERM_RX;	// r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -191,7 +191,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->size = ptr->vsize;
 	ptr->paddr = readLE32 (b, NSO_OFF (ro_memoffset));
 	ptr->vaddr = readLE32 (b, NSO_OFF (ro_loc)) + ba;
-	ptr->srwx = R_BIN_SCN_READABLE;	// r--
+	ptr->perm = R_PERM_R;	// r--
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -204,7 +204,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->size = ptr->vsize;
 	ptr->paddr = readLE32 (b, NSO_OFF (data_memoffset));
 	ptr->vaddr = readLE32 (b, NSO_OFF (data_loc)) + ba;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE;	// rw-
+	ptr->perm = R_PERM_RW;
 	ptr->add = true;
 	eprintf ("BSS Size 0x%08"PFMT64x "\n", (ut64)
 		readLE32 (bf->buf, NSO_OFF (bss_size)));
@@ -213,15 +213,11 @@ static RList *sections(RBinFile *bf) {
 }
 
 static RList *symbols(RBinFile *bf) {
-	RBinNXOObj *bin;
 	if (!bf || !bf->o || !bf->o->bin_obj) {
 		return NULL;
 	}
-	bin = (RBinNXOObj*) bf->o->bin_obj;
-	if (!bin) {
-		return NULL;
-	}
-	return bin->methods_list;
+	RBinNXOObj *bin = (RBinNXOObj*) bf->o->bin_obj;
+	return bin? bin->methods_list: NULL;
 }
 
 static RList *imports(RBinFile *bf) {

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -78,7 +78,7 @@ static RList *sections(RBinFile *bf) {
 	ptr->vsize = textsize + (textsize % 4096);
 	ptr->paddr = 8 * 4;
 	ptr->vaddr = ptr->paddr;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
 	// add data segment
@@ -92,7 +92,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = datasize + (datasize % 4096);
 		ptr->paddr = textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE; // rw-
+		ptr->perm = R_PERM_RW;
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
@@ -108,7 +108,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = symssize + (symssize % 4096);
 		ptr->paddr = datasize + textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = R_BIN_SCN_READABLE; // r--
+		ptr->perm = R_PERM_R; // r--
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
@@ -123,7 +123,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = spszsize + (spszsize % 4096);
 		ptr->paddr = symssize + datasize + textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = R_BIN_SCN_READABLE; // r--
+		ptr->perm = R_PERM_R; // r--
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}
@@ -138,7 +138,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = pcszsize + (pcszsize % 4096);
 		ptr->paddr = spszsize + symssize + datasize + textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
-		ptr->srwx = R_BIN_SCN_READABLE; // r--
+		ptr->perm = R_PERM_R; // r--
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -16,7 +16,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 		 */
 		if (!memcmp (buf, "MZ", 2)) {
 			if (!memcmp (buf+idx, "PE", 2) &&
-				!memcmp (buf+idx+0x18, "\x0b\x01", 2)) {
+				!memcmp (buf + idx + 0x18, "\x0b\x01", 2)) {
 				return true;
 			}
 			// TODO: Add one more indicator, to prevent false positives

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -185,28 +185,22 @@ static RList* sections(RBinFile *bf) {
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
 		ptr->add = true;
-		ptr->srwx = 0;
-		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_EXECUTABLE;
+		ptr->perm = 0;
+		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_X;
+			ptr->perm |= R_PERM_R; // implicit
 		}
-		if (R_BIN_PE_SCN_IS_WRITABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_WRITABLE;
+		if (R_BIN_PE_SCN_IS_WRITABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_W;
 		}
-		if (R_BIN_PE_SCN_IS_READABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_READABLE;
-		} else {
-			//fix those sections that could have been fucked up
-			//if the section does have -x- but not -r- add it
-			if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].flags)) {
-				ptr->srwx |= R_BIN_SCN_READABLE;
-			}
+		if (R_BIN_PE_SCN_IS_READABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_R;
 		}
-		if (R_BIN_PE_SCN_IS_SHAREABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_SHAREABLE;
+		// this is causing may tests to fail because rx != srx
+		if (R_BIN_PE_SCN_IS_SHAREABLE (sections[i].perm)) {
+			ptr->perm |= R_PERM_SHAR;
 		}
-#define X 1
-#define ROW (4 | 2)
-		if (ptr->srwx & ROW && !(ptr->srwx & X) && ptr->size > 0) {
+		if ((ptr->perm & R_PERM_RW) && !(ptr->perm & R_PERM_X) && ptr->size > 0) {
 			if (!strcmp (ptr->name, ".rsrc") ||
 			  	!strcmp (ptr->name, ".data") ||
 				!strcmp (ptr->name, ".rdata")) {

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -97,8 +97,7 @@ static RList* sections(RBinFile *bf) {
 	ut64 textsize = UT64_MAX;
 	RList *ret = NULL;
 	RBinSection *ptr = NULL;
-	PebbleAppInfo pai;
-	memset (&pai, 0, sizeof (pai));
+	PebbleAppInfo pai = {{0}};
 	if (!r_buf_read_at (bf->buf, 0, (ut8*)&pai, sizeof(pai))) {
 		eprintf ("Truncated Header\n");
 		return NULL;
@@ -114,7 +113,7 @@ static RList* sections(RBinFile *bf) {
 	strcpy (ptr->name, "relocs");
 	ptr->vsize = ptr->size = pai.num_reloc_entries * sizeof (ut32);
 	ptr->vaddr = ptr->paddr = pai.reloc_list_start;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE;
+	ptr->perm = R_PERM_RW;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 	if (ptr->vaddr < textsize) {
@@ -128,7 +127,7 @@ static RList* sections(RBinFile *bf) {
 	strcpy (ptr->name, "symtab");
 	ptr->vsize = ptr->size = 0;
 	ptr->vaddr = ptr->paddr = pai.sym_table_addr;
-	ptr->srwx = R_BIN_SCN_READABLE;
+	ptr->perm = R_PERM_R;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 	if (ptr->vaddr < textsize) {
@@ -141,8 +140,7 @@ static RList* sections(RBinFile *bf) {
 	strcpy (ptr->name, "text");
 	ptr->vaddr = ptr->paddr = 0x80;
 	ptr->vsize = ptr->size = textsize - ptr->paddr;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE |
-		R_BIN_SCN_EXECUTABLE;
+	ptr->perm = R_PERM_RWX;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -152,7 +150,7 @@ static RList* sections(RBinFile *bf) {
 	strcpy (ptr->name, "header");
 	ptr->vsize = ptr->size = sizeof (PebbleAppInfo);
 	ptr->vaddr = ptr->paddr = 0;
-	ptr->srwx = R_BIN_SCN_READABLE;
+	ptr->perm = R_PERM_R;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 

--- a/libr/bin/p/bin_psxexe.c
+++ b/libr/bin/p/bin_psxexe.c
@@ -70,7 +70,7 @@ static RList* sections(RBinFile* bf) {
 	sect->size = sz - PSXEXE_TEXTSECTION_OFFSET;
 	sect->vaddr = psxheader.t_addr;
 	sect->vsize = psxheader.t_size;
-	sect->srwx = R_BIN_SCN_EXECUTABLE | R_BIN_SCN_READABLE;
+	sect->perm = R_PERM_RX;
 	sect->add = true;
 	sect->has_strings = true;
 

--- a/libr/bin/p/bin_sfc.c
+++ b/libr/bin/p/bin_sfc.c
@@ -90,7 +90,7 @@ static void addrom(RList *ret, const char *name, int i, ut64 paddr, ut64 vaddr, 
 	ptr->paddr = paddr;
 	ptr->vaddr = vaddr;
 	ptr->size = ptr->vsize = size;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+	ptr->perm = R_PERM_RX;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 }

--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -259,7 +259,7 @@ static RList *sections(RBinFile *bf) {
 	strcpy (ptr->name, "vtable");
 	ptr->paddr = ptr->vaddr = 0;
 	ptr->size = ptr->vsize = 0x100;
-	ptr->srwx = R_BIN_SCN_READABLE;
+	ptr->perm = R_PERM_R;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -269,7 +269,7 @@ static RList *sections(RBinFile *bf) {
 	strcpy (ptr->name, "header");
 	ptr->paddr = ptr->vaddr = 0x100;
 	ptr->size = ptr->vsize = sizeof (SMD_Header);
-	ptr->srwx = R_BIN_SCN_READABLE;
+	ptr->perm = R_PERM_R;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 
@@ -285,7 +285,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vaddr += baddr;
 	}
 	ptr->size = ptr->vsize = bf->buf->length - ptr->paddr;
-	ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+	ptr->perm = R_PERM_RX;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;

--- a/libr/bin/p/bin_spc700.c
+++ b/libr/bin/p/bin_spc700.c
@@ -61,7 +61,7 @@ static RList* sections(RBinFile *bf) {
 	ptr->size = RAM_SIZE;
 	ptr->vaddr = 0x0;
 	ptr->vsize = RAM_SIZE;
-	ptr->srwx = R_BIN_SCN_READABLE;
+	ptr->perm = R_PERM_R;
 	ptr->add = true;
 	r_list_append (ret, ptr);
 	return ret;

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -117,19 +117,19 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = sections[i].vsize;
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr;
-		ptr->srwx = 0;
+		ptr->perm = 0;
 		ptr->add = true;
 		if (R_BIN_TE_SCN_IS_EXECUTABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_EXECUTABLE;
+			ptr->perm |= R_PERM_X;
 		}
 		if (R_BIN_TE_SCN_IS_WRITABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_WRITABLE;
+			ptr->perm |= R_PERM_W;
 		}
 		if (R_BIN_TE_SCN_IS_READABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_READABLE;
+			ptr->perm |= R_PERM_R;
 		}
 		if (R_BIN_TE_SCN_IS_SHAREABLE (sections[i].flags)) {
-			ptr->srwx |= R_BIN_SCN_SHAREABLE;
+			ptr->perm |= R_PERM_SHAR;
 		}
 		/* All TE files have _TEXT_RE section, which is 16-bit, because of
 		 * CPU start in this mode */

--- a/libr/bin/p/bin_vsf.c
+++ b/libr/bin/p/bin_vsf.c
@@ -115,7 +115,7 @@ static RList *mem(RBinFile *bf) {
 	}
 	RList *ret;
 	RBinMem *m;
-	if (!(ret = r_list_new())) {
+	if (!(ret = r_list_new ())) {
 		return NULL;
 	}
 	ret->free = free;
@@ -161,7 +161,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xa000;
 			ptr->vsize = 1024 * 8;	// BASIC size (8k)
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 
@@ -176,7 +176,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8;	// KERNAL size (8k)
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 
@@ -194,7 +194,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = 1024 * 28; // (28k)
 			ptr->vaddr = 0x4000;
 			ptr->vsize = 1024 * 28;	// BASIC size (28k)
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 
@@ -210,7 +210,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = 1024 * 4; // (4k)
 			ptr->vaddr = 0xb000;
 			ptr->vsize = 1024 * 4;	// BASIC size (4k)
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 
@@ -225,7 +225,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = 1024 * 4; // (4k)
 			ptr->vaddr = 0xc000;
 			ptr->vsize = 1024 * 4;	// BASIC size (4k)
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 
@@ -240,7 +240,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8;	// KERNAL size (8k)
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 
@@ -261,7 +261,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RWX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 		} else {
@@ -278,7 +278,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RWX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 
@@ -290,7 +290,7 @@ static RList* sections(RBinFile* bf) {
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
-			ptr->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_WRITABLE | R_BIN_SCN_EXECUTABLE;
+			ptr->perm = R_PERM_RWX;
 			ptr->add = true;
 			r_list_append (ret, ptr);
 		}

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -114,7 +114,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->paddr = sec->offset;
 		ptr->add = true;
 		// TODO permissions
-		ptr->srwx = 0;
+		ptr->perm = 0;
 		r_list_append (ret, ptr);
 	}
 	return ret;

--- a/libr/bin/p/bin_xbe.c
+++ b/libr/bin/p/bin_xbe.c
@@ -152,12 +152,12 @@ static RList *sections(RBinFile *bf) {
 		item->vsize = sect[i].vsize;
 		item->add = true;
 
-		item->srwx = R_BIN_SCN_READABLE;
+		item->perm = R_PERM_R;
 		if (sect[i].flags & SECT_FLAG_X) {
-			item->srwx |= R_BIN_SCN_EXECUTABLE;
+			item->perm |= R_PERM_X;
 		}
 		if (sect[i].flags & SECT_FLAG_W) {
-			item->srwx |= R_BIN_SCN_WRITABLE;
+			item->perm |= R_PERM_W;
 		}
 		r_list_append (ret, item);
 	}

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -127,7 +127,7 @@ static RList *sections(RBinFile *bf) {
 	text->vsize = text->size;
 	text->paddr = N64_ROM_START;
 	text->vaddr = baddr (bf);
-	text->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE; // r-x
+	text->perm = R_PERM_RX;
 	text->add = true;
 	r_list_append (ret, text);
 	return ret;

--- a/libr/bp/bp_watch.c
+++ b/libr/bp/bp_watch.c
@@ -8,12 +8,12 @@ static void r_bp_watch_add_hw(RBreakpoint *bp, RBreakpointItem *b) {
 	}
 }
 
-R_API RBreakpointItem* r_bp_watch_add(RBreakpoint *bp, ut64 addr, int size, int hw, int rw) {
+R_API RBreakpointItem* r_bp_watch_add(RBreakpoint *bp, ut64 addr, int size, int hw, int perm) {
 	RBreakpointItem *b;
 	if (addr == UT64_MAX || size < 1) {
 		return NULL;
 	}
-	if (r_bp_get_in (bp, addr, rw)) {
+	if (r_bp_get_in (bp, addr, perm)) {
 		eprintf ("Breakpoint already set at this address.\n");
 		return NULL;
 	}
@@ -21,7 +21,7 @@ R_API RBreakpointItem* r_bp_watch_add(RBreakpoint *bp, ut64 addr, int size, int 
 	b->addr = addr + bp->delta;
 	b->size = size;
 	b->enabled = true;
-	b->rwx = rw;
+	b->perm = perm;
 	b->hw = hw;
 	if (hw) {
 		r_bp_watch_add_hw (bp, b);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -98,8 +98,8 @@ static bool iscodesection(RCore *core, ut64 addr) {
 		return true;
 	}
 	return false;
-	// BSS return (s && s->flags & R_IO_WRITE)? 0: 1;
-	// Cstring return (s && s->flags & R_IO_EXEC)? 1: 0;
+	// BSS return (s && s->flags & R_PERM_W)? 0: 1;
+	// Cstring return (s && s->flags & R_PERM_X)? 1: 0;
 }
 #endif
 
@@ -227,13 +227,13 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 						types |= R_ANAL_ADDR_TYPE_LIBRARY;
 					}
 				}
-				if (map->perm & R_IO_EXEC) {
+				if (map->perm & R_PERM_X) {
 					types |= R_ANAL_ADDR_TYPE_EXEC;
 				}
-				if (map->perm & R_IO_READ) {
+				if (map->perm & R_PERM_R) {
 					types |= R_ANAL_ADDR_TYPE_READ;
 				}
-				if (map->perm & R_IO_WRITE) {
+				if (map->perm & R_PERM_W) {
 					types |= R_ANAL_ADDR_TYPE_WRITE;
 				}
 				// find function
@@ -247,7 +247,7 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 			}
 		}
 	} else {
-		int _rwx = -1;
+		int _perm = -1;
 		RIOSection *ios;
 		SdbListIter *iter;
 		if (core->io) {
@@ -255,7 +255,7 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 			ls_foreach (core->io->sections, iter, ios) {
 				if (addr >= ios->vaddr && addr < (ios->vaddr + ios->vsize)) {
 					// sections overlap, so we want to get the one with lower perms
-					_rwx = (_rwx != -1) ? R_MIN (_rwx, ios->flags) : ios->flags;
+					_perm = (_perm != -1) ? R_MIN (_perm, ios->perm) : ios->perm;
 					// TODO: we should identify which maps come from the program or other
 					//types |= R_ANAL_ADDR_TYPE_PROGRAM;
 					// find function those sections should be created by hand or esil init
@@ -268,14 +268,14 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 				}
 			}
 		}
-		if (_rwx != -1) {
-			if (_rwx & R_IO_EXEC) {
+		if (_perm != -1) {
+			if (_perm & R_PERM_X) {
 				types |= R_ANAL_ADDR_TYPE_EXEC;
 			}
-			if (_rwx & R_IO_READ) {
+			if (_perm & R_PERM_R) {
 				types |= R_ANAL_ADDR_TYPE_READ;
 			}
-			if (_rwx & R_IO_WRITE) {
+			if (_perm & R_PERM_W) {
 				types |= R_ANAL_ADDR_TYPE_WRITE;
 			}
 		}
@@ -527,7 +527,7 @@ static int r_anal_try_get_fcn(RCore *core, RAnalRef *ref, int fcndepth, int refd
 	}
 	r_io_read_at (core->io, ref->addr, buf, bufsz);
 
-	if (sec->flags & R_IO_EXEC &&
+	if (sec->perm & R_PERM_X &&
 	    r_anal_check_fcn (core->anal, buf, bufsz, ref->addr, sec->vaddr,
 			      sec->vaddr + sec->vsize)) {
 		if (core->anal->limit) {
@@ -794,7 +794,7 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 				ut64 addr = fcn->addr + r_anal_fcn_size (fcn);
 				RIOSection *sect = r_io_section_vget (core->io, addr);
 				// only get next if found on an executable section
-				if (!sect || (sect && sect->flags & 1)) {
+				if (!sect || (sect && sect->perm & R_PERM_X)) {
 					for (i = 0; i < nexti; i++) {
 						if (next[i] == addr) {
 							break;
@@ -860,7 +860,7 @@ error:
 		if (fcn && has_next) {
 			ut64 newaddr = fcn->addr + r_anal_fcn_size (fcn);
 			RIOSection *sect = r_io_section_vget (core->io, newaddr);
-			if (!sect || (sect && (sect->flags & 1))) {
+			if (!sect || (sect && (sect->perm & R_PERM_X))) {
 				next = next_append (next, &nexti, newaddr);
 				for (i = 0; i < nexti; i++) {
 					if (!next[i]) {
@@ -3195,7 +3195,7 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 	at = from;
 	while (at < to && !r_cons_is_breaked ()) {
 		int i = 0, ret = bsz;
-		if (!r_io_is_valid_offset (core->io, at, R_IO_EXEC)) {
+		if (!r_io_is_valid_offset (core->io, at, R_PERM_X)) {
 			break;
 		}
 		(void)r_io_read_at (core->io, at, buf, bsz);
@@ -3441,8 +3441,8 @@ R_API RCoreAnalStats* r_core_anal_get_stats(RCore *core, ut64 from, ut64 to, ut6
 	for (at = from; at < to; at += step) {
 		RIOSection *sec = r_io_section_get (core->io, at);
 		piece = (at - from) / step;
-		as->block[piece].rwx = sec ? sec->flags :
-				(core->io->desc ? core->io->desc->flags: 0);
+		as->block[piece].perm = sec ? sec->perm:
+				(core->io->desc ? core->io->desc->perm: 0);
 	}
 	// iter all flags
 	r_list_foreach (core->flags->flags, iter, f) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1529,9 +1529,9 @@ static int cb_io_cache_read(void *user, void *data) {
 	RCore *core = (RCore *)user;
 	RConfigNode *node = (RConfigNode *)data;
 	if (node->i_value) {
-		core->io->cached |= R_IO_READ;
+		core->io->cached |= R_PERM_R;
 	} else {
-		core->io->cached &= ~R_IO_READ;
+		core->io->cached &= ~R_PERM_R;
 	}
 	return true;
 }
@@ -1540,9 +1540,9 @@ static int cb_io_cache_write(void *user, void *data) {
 	RCore *core = (RCore *)user;
 	RConfigNode *node = (RConfigNode *)data;
 	if (node->i_value) {
-		core->io->cached |= R_IO_WRITE;
+		core->io->cached |= R_PERM_W;
 	} else {
-		core->io->cached &= ~R_IO_WRITE;
+		core->io->cached &= ~R_PERM_W;
 	}
 	return true;
 }

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3121,7 +3121,7 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 				ut64 addr = sec->vaddr;
 				ut64 size = sec->vsize;
 				// TODO: 
-				//if (R_BIN_SCN_EXECUTABLE & sec->srwx) {
+				//if (R_BIN_SCN_EXECUTABLE & sec->perm) {
 				//	continue;
 				//}
 				r_core_seek_size (core, addr, size);

--- a/libr/core/cmd_mount.c
+++ b/libr/core/cmd_mount.c
@@ -264,7 +264,7 @@ static int cmd_mount(void *data, const char *_input) {
 		if (file) {
 			r_fs_read (core->fs, file, 0, file->size);
 			char *uri = r_str_newf ("malloc://%d", file->size);
-			RIODesc *fd = r_io_open (core->io, uri, R_IO_READ | R_IO_WRITE, 0);
+			RIODesc *fd = r_io_open (core->io, uri, R_PERM_RW, 0);
 			if (fd) {
 				r_io_desc_write (fd, file->data, file->size);
 			}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2511,7 +2511,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 					|| (as->block[p].functions)
 					|| (as->block[p].comments)
 					|| (as->block[p].symbols)
-					|| (as->block[p].rwx)
+					|| (as->block[p].perm)
 					|| (as->block[p].strings)) {
 					r_cons_printf ("\"offset\":%"PFMT64u ",", at);
 					r_cons_printf ("\"size\":%"PFMT64u ",", piece);
@@ -2528,7 +2528,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 				PRINT_VALUE2 ("comments", as->block[p].comments);
 				PRINT_VALUE2 ("symbols", as->block[p].symbols);
 				PRINT_VALUE2 ("strings", as->block[p].strings);
-				PRINT_VALUE ("rwx", as->block[p].rwx, r_str_rwx_i (as->block[p].rwx));
+				PRINT_VALUE ("perm", as->block[p].perm, r_str_rwx_i (as->block[p].perm));
 #undef PRINT_VALUE
 #undef PRINT_VALUE2
 				r_cons_strcat ("}");
@@ -2560,7 +2560,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 					RIOSection *s = r_io_section_vget (core->io, at);
 					if (use_color) {
 						if (s) {
-							if (s->flags & 1) {
+							if (s->perm & R_PERM_X) {
 								r_cons_print (Color_BGBLUE);
 							} else {
 								r_cons_print (Color_BGGREEN);

--- a/libr/core/cmd_section.c
+++ b/libr/core/cmd_section.c
@@ -87,9 +87,9 @@ static void list_section_visual(RIO *io, ut64 seek, ut64 len, int use_color, int
 			r_num_units (buf, s->size);
 			if (use_color) {
 				color_end = Color_RESET;
-				if (s->flags & 1) { // exec bit
+				if (s->perm & R_PERM_X) { // exec bit
 					color = Color_GREEN;
-				} else if (s->flags & 2) { // write bit
+				} else if (s->perm & R_PERM_W) { // write bit
 					color = Color_RED;
 				} else {
 					color = "";
@@ -118,11 +118,11 @@ static void list_section_visual(RIO *io, ut64 seek, ut64 len, int use_color, int
 			if (io->va) {
 				io->cb_printf ("| %s0x%08"PFMT64x"%s %5s %s  %04s\n",
 						color, s->vaddr + s->vsize, color_end, buf,
-						r_str_rwx_i (s->flags), s->name);
+						r_str_rwx_i (s->perm), s->name);
 			} else {
 				io->cb_printf ("| %s0x%08"PFMT64x"%s %5s %s  %04s\n",
 						color, s->paddr+s->size, color_end, buf,
-						r_str_rwx_i (s->flags), s->name);
+						r_str_rwx_i (s->perm), s->name);
 			}
 
 			i++;
@@ -148,7 +148,7 @@ static void __section_list (RIO *io, ut64 offset, RPrint *print, int rad) {
 			print->cb_printf ("f section.%s %"PFMT64d" 0x%"PFMT64x"\n", n, s->size, s->vaddr);
 			print->cb_printf ("S 0x%08"PFMT64x" 0x%08"PFMT64x" 0x%08"
 				PFMT64x" 0x%08"PFMT64x" %s %s\n", s->paddr,
-				s->vaddr, s->size, s->vsize, n, r_str_rwx_i (s->flags));
+				s->vaddr, s->size, s->vsize, n, r_str_rwx_i (s->perm));
 			free (n);
 		}
 	} else {
@@ -169,7 +169,7 @@ static void __section_list (RIO *io, ut64 offset, RPrint *print, int rad) {
 			}
 			print->cb_printf ("pa=0x%08"PFMT64x" %s va=0x%08"PFMT64x
 				" sz=0x%04"PFMT64x" vsz=0x%04"PFMT64x" %s", s->paddr,
-				r_str_rwx_i (s->flags), s->vaddr, s->size, s->vsize, s->name);
+				r_str_rwx_i (s->perm), s->vaddr, s->size, s->vsize, s->name);
 			if (s->arch && s->bits) {
 				print->cb_printf ("  ; %s %d", r_sys_arch_str (s->arch),
 					s->bits);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2783,9 +2783,9 @@ reaccept:
 					ut64 baddr = r_config_get_i (core->config, "bin.laddr");
 					r_socket_read_block (c, ptr, cmd);
 					ptr[cmd] = 0;
-					ut32 perm = R_IO_READ;
-					if (flg & R_IO_WRITE) {
-						perm |= R_IO_WRITE;
+					ut32 perm = R_PERM_R;
+					if (flg & R_PERM_W) {
+						perm |= R_PERM_W;
 					}
 					if (r_core_file_open (core, (const char *)ptr, perm, 0)) {
 						int fd = r_io_fd_get_current (core->io);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -640,8 +640,8 @@ static RDisasmState * ds_init(RCore *core) {
 		ut64 addr = r_reg_getv (core->anal->reg, "SP") - (size / 2);
 		emustack_min = addr;
 		emustack_max = addr + size;
-		ds->stackFd = r_io_fd_open (core->io, uri, R_IO_RW, 0);
-		RIOMap *map = r_io_map_add (core->io, ds->stackFd, R_IO_RW, 0LL, addr, size);
+		ds->stackFd = r_io_fd_open (core->io, uri, R_PERM_RW, 0);
+		RIOMap *map = r_io_map_add (core->io, ds->stackFd, R_PERM_RW, 0LL, addr, size);
 		if (!map) {
 			r_io_fd_close (core->io, ds->stackFd);
 			eprintf ("Cannot create map for tha stack, fd %d got closed again\n", ds->stackFd);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -535,11 +535,11 @@ static bool store_files_and_maps (RCore *core, RIODesc *desc, ut32 id) {
 	RListIter *iter;
 	RIOMap *map;
 	if (desc) {
-		r_cons_printf ("ofs %s %s\n", desc->uri, r_str_rwx_i (desc->flags));
+		r_cons_printf ("ofs %s %s\n", desc->uri, r_str_rwx_i (desc->perm));
 		if ((maps = r_io_map_get_for_fd (core->io, id))) {
 			r_list_foreach (maps, iter, map) {
 				r_cons_printf ("om %d 0x%"PFMT64x" 0x%"PFMT64x" 0x%"PFMT64x" %s%s%s\n", fdc,
-					map->itv.addr, map->itv.size, map->delta, r_str_rwx_i(map->flags),
+					map->itv.addr, map->itv.size, map->delta, r_str_rwx_i (map->perm),
 					map->name ? " " : "", map->name ? map->name : "");
 			}
 			r_list_free (maps);

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1284,7 +1284,7 @@ static int r_core_rtr_gdb_run(RCore *core, int launch, const char *path) {
 		args = "";
 	}
 
-	if (!r_core_file_open (core, file, R_IO_READ, 0)) {
+	if (!r_core_file_open (core, file, R_PERM_R, 0)) {
 		eprintf ("Cannot open file (%s)\n", file);
 		return -1;
 	}
@@ -1714,7 +1714,7 @@ static void r_rap_packet_fill(ut8 *buf, const ut8* src, int len) {
 
 static bool r_core_rtr_rap_run(RCore *core, const char *input) {
 	char *file = r_str_newf ("rap://%s", input);
-	int flags = R_IO_READ | R_IO_WRITE;
+	int flags = R_PERM_RW;
 	RIODesc *fd = r_io_open_nomap (core->io, file, flags, 0644);
 	if (fd) {
 		if (r_io_is_listener (core->io)) {

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1937,7 +1937,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			break;
 		case 'a':
 		{
-			if (core->file && core->io && !(r_io_desc_get (core->io, core->file->fd)->flags & 2)) {
+			if (core->file && core->io && !(r_io_desc_get (core->io, core->file->fd)->perm & R_PERM_W)) {
 				r_cons_printf ("\nFile has been opened in read-only mode. Use -w flag\n");
 				r_cons_any_key (NULL);
 				return true;
@@ -2148,7 +2148,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 				}
 				return true;
 			}
-			if (core->file && core->io && !(r_io_desc_get (core->io, core->file->fd)->flags & 2)) {
+			if (core->file && core->io && !(r_io_desc_get (core->io, core->file->fd)->perm & R_PERM_W)) {
 				r_cons_printf ("\nFile has been opened in read-only mode. Use -w flag\n");
 				r_cons_any_key (NULL);
 				return true;

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -45,11 +45,11 @@ static int perform_mapped_file_yank(RCore *core, ut64 offset, ut64 len, const ch
 	if (filename && *filename) {
 		ut64 load_align = r_config_get_i (core->config, "file.loadalign");
 		RIOMap *map = NULL;
-		yankdesc = r_io_open_nomap (core->io, filename, R_IO_READ, 0644);
+		yankdesc = r_io_open_nomap (core->io, filename, R_PERM_R, 0644);
 		// map the file in for IO operations.
 		if (yankdesc && load_align) {
 			yank_file_sz = r_io_size (core->io);
-			map = r_io_map_add_next_available (core->io, yankdesc->fd, R_IO_READ, 0, 0, yank_file_sz, load_align);
+			map = r_io_map_add_next_available (core->io, yankdesc->fd, R_PERM_R, 0, 0, yank_file_sz, load_align);
 			loadaddr = map? map->itv.addr: -1;
 			if (yankdesc && map && loadaddr != -1) {
 				// ***NOTE*** this is important, we need to

--- a/libr/debug/ddesc.c
+++ b/libr/debug/ddesc.c
@@ -82,8 +82,8 @@ R_API int r_debug_desc_list(RDebug *dbg, int rad) {
 			list = dbg->h->desc.list (dbg->pid);
 			r_list_foreach (list, iter, p) {
 				dbg->cb_printf ("%i 0x%"PFMT64x" %c%c%c %s\n", p->fd, p->off,
-						(p->perm & R_IO_READ)?'r':'-',
-						(p->perm & R_IO_WRITE)?'w':'-',
+						(p->perm & R_PERM_R)?'r':'-',
+						(p->perm & R_PERM_W)?'w':'-',
 						p->type, p->path);
 			}
 			r_list_purge (list);

--- a/libr/debug/esil.c
+++ b/libr/debug/esil.c
@@ -74,7 +74,7 @@ static int esilbreak_check_pc (RDebug *dbg, ut64 pc) {
 		pc = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 	}
 	r_list_foreach (EWPS, iter, ew) {
-		if (ew->rwx & R_IO_EXEC) {
+		if (ew->rwx & R_PERM_X) {
 			if (exprmatch (dbg, pc, ew->expr)) {
 				return 1;
 			}
@@ -88,7 +88,7 @@ static int esilbreak_mem_read(RAnalEsil *esil, ut64 addr, ut8 *buf, int len) {
 	RListIter *iter;
 	eprintf (Color_GREEN"MEM READ 0x%"PFMT64x"\n"Color_RESET, addr);
 	r_list_foreach (EWPS, iter, ew) {
-		if (ew->rwx & R_IO_READ && ew->dev == 'm') {
+		if (ew->rwx & R_PERM_R && ew->dev == 'm') {
 			if (exprmatch (dbg, addr, ew->expr)) {
 				has_match = 1;
 				return 1;
@@ -103,7 +103,7 @@ static int esilbreak_mem_write(RAnalEsil *esil, ut64 addr, const ut8 *buf, int l
 	RListIter *iter;
 	eprintf (Color_RED"MEM WRTE 0x%"PFMT64x"\n"Color_RESET, addr);
 	r_list_foreach (EWPS, iter, ew) {
-		if (ew->rwx & R_IO_WRITE && ew->dev == 'm') {
+		if (ew->rwx & R_PERM_W && ew->dev == 'm') {
 			if (exprmatch (dbg, addr, ew->expr)) {
 				has_match = 1;
 				return 1;
@@ -122,7 +122,7 @@ static int esilbreak_reg_read(RAnalEsil *esil, const char *regname, ut64 *num, i
 	}
 	eprintf (Color_YELLOW"REG READ %s\n"Color_RESET, regname);
 	r_list_foreach (EWPS, iter, ew) {
-		if (ew->rwx & R_IO_READ && ew->dev == 'r') {
+		if (ew->rwx & R_PERM_R && ew->dev == 'r') {
 			// XXX: support array of regs in expr
 			if (!strcmp (regname, ew->expr)) {
 				has_match = 1;
@@ -198,7 +198,7 @@ static int esilbreak_reg_write(RAnalEsil *esil, const char *regname, ut64 *num) 
 	}
 	eprintf (Color_MAGENTA"REG WRTE %s 0x%"PFMT64x"\n"Color_RESET, regname, *num);
 	r_list_foreach (EWPS, iter, ew) {
-		if (ew->rwx & R_IO_WRITE && ew->dev == 'r') {
+		if ((ew->rwx & R_PERM_W) && (ew->dev == 'r')) {
 			// XXX: support array of regs in expr
 			if (exprmatchreg (dbg, regname, ew->expr)) {
 				has_match = 1;

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -104,8 +104,7 @@ static RList *r_debug_gdb_map_get(RDebug* dbg) { //TODO
 				return NULL;
 			}
 			RDebugMap *map;
-			if (!(map = r_debug_map_new ("", baddr, baddr,
-						     R_IO_READ | R_IO_EXEC, 0))) {
+			if (!(map = r_debug_map_new ("", baddr, baddr, R_PERM_RX, 0))) {
 				r_list_free (retlist);
 				return NULL;
 			}
@@ -196,9 +195,9 @@ static RList *r_debug_gdb_map_get(RDebug* dbg) { //TODO
 		perm = 0;
 		for (i = 0; perms[i] && i < 5; i++) {
 			switch (perms[i]) {
-			case 'r': perm |= R_IO_READ; break;
-			case 'w': perm |= R_IO_WRITE; break;
-			case 'x': perm |= R_IO_EXEC; break;
+			case 'r': perm |= R_PERM_R; break;
+			case 'w': perm |= R_PERM_W; break;
+			case 'x': perm |= R_PERM_X; break;
 			case 'p': map_is_shared = false; break;
 			case 's': map_is_shared = true; break;
 			}
@@ -981,7 +980,7 @@ static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set
 	}
 	bpsize = b->size;
         // TODO handle conditions
-	switch (b->rwx){
+	switch (b->perm) {
 	case R_BP_PROT_EXEC : {
 		if (set) {
 			ret = b->hw?
@@ -993,7 +992,7 @@ static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set
 		break;
 	}
 	// TODO handle size (area of watch in upper layer and then bpsize. For the moment watches are set on exact on byte
-	case R_BP_PROT_WRITE : {
+	case R_PERM_W: {
 		if (set) {
 			gdbr_set_hww (desc, b->addr, "", 1);
 		} else {
@@ -1001,7 +1000,7 @@ static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set
 		}
 		break;
 	}
-	case R_BP_PROT_READ : {
+	case R_PERM_R: {
 		if (set) {
 			gdbr_set_hwr (desc, b->addr, "", 1);
 		} else {
@@ -1009,7 +1008,7 @@ static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set
 		}
 		break;
 	}
-	case R_BP_PROT_ACCESS : {
+	case R_PERM_ACCESS: {
 		if (set) {
 			gdbr_set_hwa (desc, b->addr, "", 1);
 		} else {

--- a/libr/debug/p/native/drx.c
+++ b/libr/debug/p/native/drx.c
@@ -190,7 +190,7 @@ void drx_enable(drxt *r, int n, int enabled) {
 bool drx_add(RDebug *dbg, RBreakpoint *bp, RBreakpointItem *b) {
 	if (bp->nhwbps < 4) {
 		r_debug_reg_sync (dbg, R_REG_TYPE_DRX, false);
-		r_debug_drx_set (dbg, bp->nhwbps, b->addr, b->size, b->rwx, 0);
+		r_debug_drx_set (dbg, bp->nhwbps, b->addr, b->size, b->perm, 0);
 		r_debug_reg_sync (dbg, R_REG_TYPE_DRX, true);
 		bp->nhwbps++;
 		return true;

--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -334,7 +334,7 @@ static bool dump_this_map(char *buff_smaps, linux_map_entry_t *entry, ut8 filter
 		return false;
 	}
 	/* if the map doesn't have r/w quit right here */
-	if ((!(perms & R_IO_READ) && !(perms & R_IO_WRITE))) {
+	if ((!(perms & R_PERM_R) && !(perms & R_PERM_W))) {
 		free (identity);
 		return false;
 	}
@@ -649,7 +649,7 @@ static int get_info_mappings(linux_map_entry_t *me_head, size_t *maps_size) {
 	int n_entries;
 	for (n_entries = 0, p = me_head; p; p = p->n) {
 		/* We don't count maps which does not have r/w perms */
-		if (((p->perms & R_IO_READ) || (p->perms & R_IO_WRITE)) && p->dumpeable) {
+		if (((p->perms & R_PERM_R) || (p->perms & R_PERM_W)) && p->dumpeable) {
 			*maps_size += p->end_addr - p->start_addr;
 			n_entries++;
 		}
@@ -723,7 +723,7 @@ static bool dump_elf_pheaders(RBuffer *dest, linux_map_entry_t *maps, elf_offset
 
 	/* write program headers */
 	for (me_p = maps; me_p; me_p = me_p->n) {
-		if ((!(me_p->perms & R_IO_READ) && !(me_p->perms & R_IO_WRITE)) || !me_p->dumpeable) {
+		if ((!(me_p->perms & R_PERM_R) && !(me_p->perms & R_PERM_W)) || !me_p->dumpeable) {
 			continue;
 		}
 		phdr.p_type = PT_LOAD;

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -997,10 +997,10 @@ RList *linux_desc_list (int pid) {
 		}
 		if (lstat(path, &st) != -1) {
 			if (st.st_mode & S_IRUSR) {
-				perm |= R_IO_READ;
+				perm |= R_PERM_R;
 			}
 			if (st.st_mode & S_IWUSR) {
-				perm |= R_IO_WRITE;
+				perm |= R_PERM_W;
 			}
 		}
 		//TODO: Offset

--- a/libr/debug/p/native/maps/windows.c
+++ b/libr/debug/p/native/maps/windows.c
@@ -31,25 +31,25 @@ static RDebugMap *add_map(RList *list, const char *name, ut64 addr, ut64 len, ME
 
 	switch (mbi->Protect) {
 	case PAGE_EXECUTE:
-		perm = R_IO_EXEC;
+		perm = R_PERM_X;
 		break;
 	case PAGE_EXECUTE_READ:
-		perm = R_IO_READ | R_IO_EXEC;
+		perm = R_PERM_RX;
 		break;
 	case PAGE_EXECUTE_READWRITE:
-		perm = R_IO_READ | R_IO_WRITE | R_IO_EXEC;
+		perm = R_PERM_RWX;
 		break;
 	case PAGE_READONLY:
-		perm = R_IO_READ;
+		perm = R_PERM_R;
 		break;
 	case PAGE_READWRITE:
-		perm = R_IO_READ | R_IO_WRITE;
+		perm = R_PERM_RW;
 		break;
 	case PAGE_WRITECOPY:
-		perm = R_IO_WRITE;
+		perm = R_PERM_W;
 		break;
 	case PAGE_EXECUTE_WRITECOPY:
-		perm = R_IO_EXEC;
+		perm = R_PERM_X;
 		break;
 	default:
 		perm = 0;
@@ -59,9 +59,8 @@ static RDebugMap *add_map(RList *list, const char *name, ut64 addr, ut64 len, ME
 		perror ("r_str_newf");
 		goto err_add_map;
 	}
-	mr = r_debug_map_new (map_name,
-				addr,
-				addr + len, perm, mbi->Type == MEM_PRIVATE);
+	mr = r_debug_map_new (map_name, addr,
+		addr + len, perm, mbi->Type == MEM_PRIVATE);
 	if (mr) {
 		r_list_append (list, mr);
 	}

--- a/libr/debug/session.c
+++ b/libr/debug/session.c
@@ -43,7 +43,7 @@ R_API RDebugSession *r_debug_session_add(RDebug *dbg, RListIter **tail) {
 	RListIter *iter;
 	RDebugMap *map;
 	ut64 addr;
-	int i, perms = R_IO_RW;
+	int i, perms = R_PERM_RW;
 
 	addr = r_debug_reg_get (dbg, dbg->reg->name[R_REG_NAME_PC]);
 	/* Session has already existed at this addr? */

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -14,11 +14,6 @@ extern "C" {
 
 R_LIB_VERSION_HEADER (r_bin);
 
-#define R_BIN_SCN_EXECUTABLE (1 << 0)
-#define R_BIN_SCN_WRITABLE   (1 << 1)
-#define R_BIN_SCN_READABLE   (1 << 2)
-#define R_BIN_SCN_SHAREABLE  (1 << 3)
-
 #define R_BIN_DBG_STRIPPED 0x01
 #define R_BIN_DBG_STATIC   0x02
 #define R_BIN_DBG_LINENUMS 0x04
@@ -445,7 +440,7 @@ typedef struct r_bin_section_t {
 	ut64 vsize;
 	ut64 vaddr;
 	ut64 paddr;
-	ut32 srwx;
+	ut32 perm;
 	// per section platform info
 	const char *arch;
 	char *format;

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -47,7 +47,7 @@ typedef struct r_bp_item_t {
 	int size; /* size of breakpoint area */
 	int recoil; /* recoil */
 	bool swstep; 	/* is this breakpoint from a swstep? */
-	int rwx;
+	int perm;
 	int hw;
 	int trace;
 	int internal; /* used for internal purposes */
@@ -85,6 +85,7 @@ typedef struct r_bp_t {
 	st64 delta;
 } RBreakpoint;
 
+// DEPRECATED: USE R_PERM
 enum {
 	R_BP_PROT_EXEC = 1,
 	R_BP_PROT_WRITE = 2,
@@ -114,7 +115,7 @@ R_API int r_bp_use(RBreakpoint *bp, const char *name, int bits);
 R_API int r_bp_plugin_del(RBreakpoint *bp, const char *name);
 R_API void r_bp_plugin_list(RBreakpoint *bp);
 
-R_API int r_bp_in(RBreakpoint *bp, ut64 addr, int rwx);
+R_API int r_bp_in(RBreakpoint *bp, ut64 addr, int perm);
 // deprecate?
 R_API int r_bp_list(RBreakpoint *bp, int rad);
 R_API int r_bp_size(RBreakpoint *bp);
@@ -133,14 +134,14 @@ R_API int r_bp_get_index_at (RBreakpoint *bp, ut64 addr);
 R_API RBreakpointItem *r_bp_item_new (RBreakpoint *bp);
 
 R_API RBreakpointItem *r_bp_get_at (RBreakpoint *bp, ut64 addr);
-R_API RBreakpointItem *r_bp_get_in (RBreakpoint *bp, ut64 addr, int rwx);
+R_API RBreakpointItem *r_bp_get_in (RBreakpoint *bp, ut64 addr, int perm);
 
 R_API int r_bp_add_cond(RBreakpoint *bp, const char *cond);
 R_API int r_bp_del_cond(RBreakpoint *bp, int idx);
-R_API int r_bp_add_fault(RBreakpoint *bp, ut64 addr, int size, int rwx);
+R_API int r_bp_add_fault(RBreakpoint *bp, ut64 addr, int size, int perm);
 
-R_API RBreakpointItem *r_bp_add_sw(RBreakpoint *bp, ut64 addr, int size, int rwx);
-R_API RBreakpointItem *r_bp_add_hw(RBreakpoint *bp, ut64 addr, int size, int rwx);
+R_API RBreakpointItem *r_bp_add_sw(RBreakpoint *bp, ut64 addr, int size, int perm);
+R_API RBreakpointItem *r_bp_add_hw(RBreakpoint *bp, ut64 addr, int size, int perm);
 R_API void r_bp_restore_one(RBreakpoint *bp, RBreakpointItem *b, bool set);
 R_API int r_bp_restore(RBreakpoint *bp, bool set);
 R_API bool r_bp_restore_except(RBreakpoint *bp, bool set, ut64 addr);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -711,7 +711,7 @@ typedef struct {
 	ut32 in_functions;
 	ut32 symbols;
 	ut32 strings;
-	ut32 rwx;
+	ut32 perm;
 } RCoreAnalStatsItem;
 typedef struct {
 	RCoreAnalStatsItem *block;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -11,15 +11,6 @@
 #include "r_util.h"
 #include "r_vector.h"
 
-#define R_IO_READ	4
-#define R_IO_WRITE	2
-#define R_IO_EXEC	1
-#define R_IO_RW		(R_IO_READ|R_IO_WRITE)
-#define R_IO_RWX	(R_IO_READ|R_IO_WRITE|R_IO_EXEC)
-#define R_IO_PRIV	16
-#define R_IO_SHAR	32
-#define R_IO_CREAT	64
-
 #define R_IO_SEEK_SET	0
 #define R_IO_SEEK_CUR	1
 #define R_IO_SEEK_END	2
@@ -98,7 +89,7 @@ typedef struct r_io_t {
 
 typedef struct r_io_desc_t {
 	int fd;
-	int flags;
+	int perm;
 	int obsz;	//optimal blocksize// do we really need this here?
 	char *uri;
 	char *name;
@@ -166,7 +157,7 @@ typedef struct r_io_plugin_t {
 
 typedef struct r_io_map_t {
 	int fd;
-	int flags;
+	int perm;
 	ut32 id;
 	RInterval itv;
 	ut64 delta; //this delta means paddr when talking about section
@@ -178,13 +169,14 @@ typedef struct r_io_map_skyline_t {
 	RInterval itv;
 } RIOMapSkyline;
 
+// XXX must be deprecated maps should be enough
 typedef struct r_io_section_t {
 	char *name;
 	ut64 paddr;
 	ut64 size;
 	ut64 vaddr;
 	ut64 vsize;
-	int flags;
+	int perm;
 	ut32 id;
 	ut32 bin_id;
 	int arch;

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -42,6 +42,19 @@
 #undef R_NEWCOPY
 #endif
 
+// used in debug, io, bin, anal, ...
+#define R_PERM_R	4
+#define R_PERM_W	2
+#define R_PERM_X	1
+#define R_PERM_RW	(R_PERM_R|R_PERM_W)
+#define R_PERM_RX	(R_PERM_R|R_PERM_X)
+#define R_PERM_RWX	(R_PERM_R|R_PERM_W|R_PERM_X)
+#define R_PERM_WX	(R_PERM_W|R_PERM_X)
+#define R_PERM_SHAR	8
+#define R_PERM_PRIV	16
+#define R_PERM_ACCESS	32
+#define R_PERM_CREAT	64
+
 // HACK to fix capstone-android-mips build
 #undef mips
 #define mips mips

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -70,7 +70,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 		isdev = true;
 	}
 
-	rw |= R_IO_WRITE;
+	rw |= R_PERM_W;
 	if (isdev) {
 		port = strchr (host, '@');
 		if (port) {
@@ -127,7 +127,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 		} else if ((i_pid = desc->pid) < 0) {
 			i_pid = -1;
 		}
-		riogdb = r_io_desc_new (io, &r_io_plugin_gdb, file, R_IO_RWX, mode, riog);
+		riogdb = r_io_desc_new (io, &r_io_plugin_gdb, file, R_PERM_RWX, mode, riog);
 	}
 	// Get name
 	if (riogdb) {

--- a/libr/io/p/io_ihex.c
+++ b/libr/io/p/io_ihex.c
@@ -49,7 +49,7 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	RBufferSparse *rbs;
 	RListIter *iter;
 
-	if (!fd || !fd->data || (fd->flags & R_IO_WRITE) == 0 || count <= 0) {
+	if (!fd || !fd->data || (fd->perm & R_PERM_W) == 0 || count <= 0) {
 		return -1;
 	}
 	rih = fd->data;

--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -418,10 +418,10 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 		: strdup ("kernel");
 	if (!strncmp (file, "smach://", 8)) {
 		ret = r_io_desc_new (io, &r_io_plugin_mach, &file[1],
-			       rw | R_IO_EXEC, mode, iodd);
+			       rw | R_PERM_X, mode, iodd);
 	} else {
 		ret = r_io_desc_new (io, &r_io_plugin_mach, file,
-			       rw | R_IO_EXEC, mode, iodd);
+			       rw | R_PERM_X, mode, iodd);
 	}
 	ret->name = pidpath;
 	return ret;

--- a/libr/io/p/io_malloc.c
+++ b/libr/io/p/io_malloc.c
@@ -182,7 +182,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			mal->buf = calloc (1, mal->size + 1);
 		}
 		if (mal->buf) {
-			return r_io_desc_new (io, &r_io_plugin_malloc, pathname, R_IO_RW | rw, mode, mal);
+			return r_io_desc_new (io, &r_io_plugin_malloc, pathname, R_PERM_RW | rw, mode, mal);
 		}
 		eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname + 9, mal->size);
 		free (mal);

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -113,7 +113,7 @@ static int r_io_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	}
 	mmo = fd->data;
 	addr = io->off;
-	if ( !(mmo->flags & R_IO_WRITE)) {
+	if ( !(mmo->flags & R_PERM_W)) {
 		return -1;
 	}
 	if ( (count + addr > mmo->buf->length) || mmo->buf->empty) {

--- a/libr/io/p/io_ptrace.c
+++ b/libr/io/p/io_ptrace.c
@@ -205,7 +205,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 			}
 			riop->pid = riop->tid = pid;
 			open_pidmem (riop);
-			desc = r_io_desc_new (io, &r_io_plugin_ptrace, file, rw | R_IO_EXEC, mode, riop);
+			desc = r_io_desc_new (io, &r_io_plugin_ptrace, file, rw | R_PERM_X, mode, riop);
 			desc->name = r_sys_pid_to_path (pid);
 		}
 	}

--- a/libr/io/p/io_r2k.c
+++ b/libr/io/p/io_r2k.c
@@ -102,8 +102,7 @@ static char *r2k__system(RIO *io, RIODesc *fd, const char *cmd) {
 
 static RIODesc *r2k__open(RIO *io, const char *pathname, int rw, int mode) {
 	if (!strncmp (pathname, "r2k://", 6)) {
-		rw |= R_IO_WRITE;
-		rw |= R_IO_EXEC;
+		rw |= R_PERM_WX;
 #if __WINDOWS__
 		RIOW32 *w32 = R_NEW0 (RIOW32);
 		if (Init (&pathname[6]) == FALSE) {

--- a/libr/io/p/io_w32dbg.c
+++ b/libr/io/p/io_w32dbg.c
@@ -149,7 +149,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 		}
 		pidpath = r_sys_pid_to_path (dbg->pid);
 		ret = r_io_desc_new (io, &r_io_plugin_w32dbg,
-				file, rw | R_IO_EXEC, mode, dbg);
+				file, rw | R_PERM_X, mode, dbg);
 		ret->name = pidpath;
 		return ret;
 	}

--- a/libr/io/p_cache.c
+++ b/libr/io/p_cache.c
@@ -306,7 +306,7 @@ static int __desc_cache_commit_cb(void *user, const char *k, const char *v) {
 
 R_API bool r_io_desc_cache_commit(RIODesc *desc) {
 	RIODesc *current;
-	if (!desc || !(desc->flags & R_IO_WRITE) || !desc->io || !desc->io->files || !desc->io->p_cache) {
+	if (!desc || !(desc->perm & R_PERM_W) || !desc->io || !desc->io->files || !desc->io->p_cache) {
 		return false;
 	}
 	if (!desc->cache) {

--- a/libr/io/plugin.c
+++ b/libr/io/plugin.c
@@ -126,7 +126,7 @@ R_API int r_io_plugin_list_json(RIO *io) {
 }
 
 R_API int r_io_plugin_read(RIODesc *desc, ut8 *buf, int len) {
-	if (!buf || !desc || !desc->plugin || len < 1 || !(desc->flags & R_IO_READ)) {
+	if (!buf || !desc || !desc->plugin || len < 1 || !(desc->perm & R_PERM_R)) {
 		return 0;
 	}
 	if (!desc->plugin->read) {
@@ -136,7 +136,7 @@ R_API int r_io_plugin_read(RIODesc *desc, ut8 *buf, int len) {
 }
 
 R_API int r_io_plugin_write(RIODesc *desc, const ut8 *buf, int len) {
-	if (!buf || !desc || !desc->plugin || len < 1 || !(desc->flags & R_IO_WRITE)) {
+	if (!buf || !desc || !desc->plugin || len < 1 || !(desc->perm & R_PERM_W)) {
 		return 0;
 	}
 	if (!desc->plugin->write) {

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -234,8 +234,8 @@ R_API ut64 r_buf_size (RBuffer *b) {
 }
 
 // rename to new?
-R_API RBuffer *r_buf_mmap (const char *file, int flags) {
-	int rw = flags & R_IO_WRITE ? true : false;
+R_API RBuffer *r_buf_mmap (const char *file, int perm) {
+	int rw = perm & R_PERM_W? true : false;
 	RBuffer *b = r_buf_new ();
 	if (!b) {
 		return NULL;
@@ -255,11 +255,8 @@ R_API RBuffer *r_buf_mmap (const char *file, int flags) {
 
 R_API RBuffer *r_buf_new_file(const char *file, bool newFile) {
 	const int mode = 0644;
-	int flags = O_RDWR;
-	if (newFile) {
-		flags |= O_CREAT;
-	}
-	int fd = r_sandbox_open (file, flags, mode);
+	const int perm = newFile? O_RDWR|O_CREAT: O_RDWR;
+	int fd = r_sandbox_open (file, perm, mode);
 	if (fd != -1) {
 		RBuffer *b = r_buf_new ();
 		if (!b) {

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -2651,7 +2651,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "constant_pool");
 			section->size = bin->cp_size;
 			section->paddr = bin->cp_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
 		}
@@ -2663,7 +2663,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "fields");
 			section->size = bin->fields_size;
 			section->paddr = bin->fields_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
 			section = NULL;
@@ -2676,7 +2676,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 					snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
 					section->paddr = fm_type->attr_offset + baddr;
-					section->srwx = R_BIN_SCN_READABLE;
+					section->perm = R_PERM_R;
 					section->add = true;
 					r_list_append (sections, section);
 				}
@@ -2689,7 +2689,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "methods");
 			section->size = bin->methods_size;
 			section->paddr = bin->methods_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			section->perm = R_PERM_RX;
 			section->add = true;
 			r_list_append (sections, section);
 			section = NULL;
@@ -2702,7 +2702,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 					snprintf (section->name, R_BIN_SIZEOF_STRINGS, "attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
 					section->paddr = fm_type->attr_offset + baddr;
-					section->srwx = R_BIN_SCN_READABLE;
+					section->perm = R_PERM_R;
 					section->add = true;
 					r_list_append (sections, section);
 				}
@@ -2715,7 +2715,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "interfaces");
 			section->size = bin->interfaces_size;
 			section->paddr = bin->interfaces_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
 		}
@@ -2727,7 +2727,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 			strcpy (section->name, "attributes");
 			section->size = bin->attrs_size;
 			section->paddr = bin->attrs_offset + baddr;
-			section->srwx = R_BIN_SCN_READABLE;
+			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
 		}


### PR DESCRIPTION
    Unify R_IO, R_BIN, R_BP, .. into R_PERM_* using 1 letter syntax