### PR TITLE
Fix GNU-based RAsm plugins to use RStrBuf API properly

### DIFF
--- a/libr/asm/arch/include/disas-asm.h
+++ b/libr/asm/arch/include/disas-asm.h
@@ -280,7 +280,7 @@ extern int print_insn_little_mips	(bfd_vma, disassemble_info *);
 extern int print_insn_little_nios2	(bfd_vma, disassemble_info *);
 extern int print_insn_little_powerpc	(bfd_vma, disassemble_info *);
 extern int print_insn_riscv		(bfd_vma, disassemble_info *);
-extern int print_insn_little_score      (bfd_vma, disassemble_info *); 
+extern int print_insn_little_score      (bfd_vma, disassemble_info *);
 extern int print_insn_lm32		(bfd_vma, disassemble_info *);
 extern int print_insn_m32c	        (bfd_vma, disassemble_info *);
 extern int print_insn_m32r		(bfd_vma, disassemble_info *);
@@ -430,6 +430,27 @@ extern int print_insn_tricore (bfd_vma memaddr, struct disassemble_info *info);
   init_disassemble_info (&(INFO), (STREAM), (fprintf_ftype) (FPRINTF_FUNC))
 #define INIT_DISASSEMBLE_INFO_NO_ARCH(INFO, STREAM, FPRINTF_FUNC) \
   init_disassemble_info (&(INFO), (STREAM), (fprintf_ftype) (FPRINTF_FUNC))
+
+#define DECLARE_GENERIC_FPRINTF_FUNC() \
+static int generic_fprintf_func(void *stream, const char *format, ...) { \
+	int ret; \
+	va_list ap; \
+	if (!buf_global || !format) { \
+		return 0; \
+	} \
+	va_start (ap, format); \
+	ret = r_strbuf_vappendf (buf_global, format, ap); \
+	va_end (ap); \
+	return ret; \
+}
+
+#define DECLARE_GENERIC_PRINT_ADDRESS_FUNC() \
+static void generic_print_address_func(bfd_vma address, struct disassemble_info *info) { \
+	if (!buf_global) { \
+		return; \
+	} \
+	r_strbuf_appendf (buf_global, "0x%08"PFMT64x, (ut64)address); \
+}
 
 
 #ifdef __cplusplus

--- a/libr/asm/p/asm_arc.c
+++ b/libr/asm/p/asm_arc.c
@@ -41,26 +41,8 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[64];
-	if (buf_global) {
-		sprintf (tmp, "0x%08"PFMT64x"", (ut64)address);
-		r_strbuf_append (buf_global, tmp);
-	}
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	va_list ap;
-	char tmp[1024];
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-	vsnprintf (tmp, sizeof (tmp), format, ap);
-	r_strbuf_append (buf_global, tmp);
-	va_end (ap);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	static struct disassemble_info disasm_obj;
@@ -81,9 +63,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &arc_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = !a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 	disasm_obj.mach = 0;
 	r_strbuf_set (&op->buf_asm, "");

--- a/libr/asm/p/asm_arm_gnu.c
+++ b/libr/asm/p/asm_arm_gnu.c
@@ -91,26 +91,8 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	// --
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global) {
-		return;
-	}
-	sprintf (tmp, "0x%08"PFMT64x "", (ut64) address);
-	r_strbuf_append (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	va_list ap;
-	char tmp[1024];
-	if (!buf_global || !format) {
-		return false;
-	}
-	va_start (ap, format);
-	vsnprintf (tmp, sizeof (tmp), format, ap);
-	r_strbuf_append (buf_global, tmp);
-	return true;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	static char *oldcpu = NULL;
@@ -166,9 +148,9 @@ cpucode = 66471;
 	obj.read_memory_func = &arm_buffer_read_memory;
 	obj.symbol_at_address_func = &symbol_at_address;
 	obj.memory_error_func = &memory_error_func;
-	obj.print_address_func = &print_address;
+	obj.print_address_func = &generic_print_address_func;
 	obj.endian = !a->big_endian;
-	obj.fprintf_func = &buf_fprintf;
+	obj.fprintf_func = &generic_fprintf_func;
 	obj.stream = stdout;
 	obj.bytes_per_chunk =
 		obj.bytes_per_line = (a->bits / 8);

--- a/libr/asm/p/asm_cris_gnu.c
+++ b/libr/asm/p/asm_cris_gnu.c
@@ -22,7 +22,7 @@ http://developer.axis.com/old/documentation/hw/etraxfs/iop_howto/iop_howto.pdf
 
 
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static unsigned char bytes[8];
 
 static int cris_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
@@ -38,38 +38,8 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global) {
-		return;
-	}
-	sprintf(tmp, "0x%08"PFMT64x"", (ut64)address);
-	strcat(buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	int flen, glen;
-	va_list ap;
-	char *tmp;
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-		flen = strlen (format);
-		glen = strlen (buf_global);
-		tmp = malloc (flen + glen + 2);
-		if (!tmp) {
-			return 0;
-		}
-		memcpy (tmp, buf_global, glen);
-		memcpy (tmp+glen, format, flen);
-		tmp[flen+glen] = 0;
-// XXX: overflow here?
-	vsprintf (buf_global, tmp, ap);
-	va_end (ap);
-	free (tmp);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 //static int print_insn_crisv10_v32_with_register_prefix (bfd_vma vma, disassemble_info *info);
 int print_insn_crisv10_v32_without_register_prefix (bfd_vma vma, disassemble_info *info);
@@ -82,7 +52,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	if (len < 4) {
 		return -1;
 	}
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	memcpy (bytes, buf, R_MIN (len, 8)); // TODO handle thumb
 
@@ -93,9 +63,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &cris_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = !a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
 	if (a->cpu && *a->cpu) {

--- a/libr/asm/p/asm_hexagon_gnu.c
+++ b/libr/asm/p/asm_hexagon_gnu.c
@@ -16,7 +16,7 @@ hexagon_get_disassembler_from_mach(
   unsigned long big_p
 );
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int hexagon_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, unsigned int length, struct disassemble_info *info) {
@@ -32,25 +32,8 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global)
-		return;
-	sprintf (tmp, "0x%08"PFMT64x"", (ut64)address);
-	strcat (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	va_list ap;
-	char tmp[1024];
-	if (!buf_global)
-		return 0;
-	va_start (ap, format);
-	vsnprintf (tmp, sizeof (tmp), format, ap);
-	strcat (buf_global, tmp);
-	va_end (ap);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	static int (*print_insn_hexagon)(bfd_vma, struct disassemble_info *);
@@ -58,7 +41,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	if (len < 4) {
 		return -1;
 	}
-	buf_global = op->buf_asm;
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	// disasm inverted
 	r_mem_swapendian (bytes, buf, 4); // TODO handle thumb
@@ -69,22 +52,22 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &hexagon_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 	disasm_obj.mach = 0;
 
-	op->buf_asm[0] = '\0';
-print_insn_hexagon = hexagon_get_disassembler_from_mach(0,0);
+	r_strbuf_set (&op->buf_asm, "");
+	print_insn_hexagon = hexagon_get_disassembler_from_mach (0, 0);
 	op->size = print_insn_hexagon ((bfd_vma)Offset, &disasm_obj);
 
-	if (!strncmp (op->buf_asm, "unknown", 7)) {
-		strncpy (op->buf_asm, "invalid", R_ASM_BUFSIZE);
+	if (!strncmp ( r_strbuf_get (&op->buf_asm), "unknown", 7)) {
+		r_strbuf_set (&op->buf_asm, "invalid");
 	}
 
 	if (op->size == -1) {
-		strncpy (op->buf_asm, " (data)", R_ASM_BUFSIZE);
+		r_strbuf_set (&op->buf_asm, "(data)");
 	}
 	return op->size;
 }

--- a/libr/asm/p/asm_hppa_gnu.c
+++ b/libr/asm/p/asm_hppa_gnu.c
@@ -13,7 +13,7 @@
 
 
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int hppa_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
@@ -39,44 +39,15 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global) {
-		return;
-	}
-	snprintf (tmp, sizeof (tmp) - 1, "0x%08"PFMT64x"", (ut64)address);
-	strcat (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	int flen, glen;
-	va_list ap;
-	char *tmp;
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-	flen = strlen (format);
-	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (tmp) {
-		memcpy (tmp, buf_global, glen);
-		memcpy (tmp + glen, format, flen);
-		tmp[flen + glen] = 0;
-		// XXX: overflow here?
-		vsprintf (buf_global, tmp, ap);
-	}
-	va_end (ap);
-	free (tmp);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	struct disassemble_info disasm_obj;
 	if (len < 4) {
 		return -1;
 	}
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	memcpy (bytes, buf, 4); // TODO handle thumb
 
@@ -87,9 +58,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &hppa_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = BFD_ENDIAN_BIG;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
 	op->size = print_insn_hppa ((bfd_vma)Offset, &disasm_obj);

--- a/libr/asm/p/asm_lanai_gnu.c
+++ b/libr/asm/p/asm_lanai_gnu.c
@@ -10,7 +10,7 @@
 #include "disas-asm.h"
 
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static int buf_global_size = 64; // hardcoded sizeof (RStrBuf.buf);
 static unsigned char bytes[4];
 
@@ -27,46 +27,15 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global) {
-		return;
-	}
-	sprintf(tmp, "0x%08"PFMT64x"", (ut64)address);
-	strcat (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	int flen, glen;
-	va_list ap;
-	char *tmp;
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-	flen = strlen (format);
-	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) {
-		va_end (ap);
-		return 0;
-	}
-	memcpy (tmp, buf_global, glen);
-	memcpy (tmp+glen, format, flen);
-	tmp[flen + glen] = 0;
-	// XXX: overflow here?
-	vsnprintf (buf_global, buf_global_size, tmp, ap);
-	free (tmp);
-	va_end (ap);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	struct disassemble_info disasm_obj;
 	if (len < 4) {
 		return -1;
 	}
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	memcpy (bytes, buf, 4); // TODO handle thumb
 
@@ -77,9 +46,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &lanai_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = BFD_ENDIAN_BIG;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
 	op->size = print_insn_lanai ((bfd_vma)Offset, &disasm_obj);

--- a/libr/asm/p/asm_nios2.c
+++ b/libr/asm/p/asm_nios2.c
@@ -15,7 +15,7 @@
 int print_insn_big_nios2 (bfd_vma address, disassemble_info *info);
 int print_insn_little_nios2 (bfd_vma address, disassemble_info *info);
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int nios2_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
@@ -31,44 +31,15 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	if (buf_global) {
-		char tmp[32];
-		snprintf (tmp, sizeof (tmp), "0x%08"PFMT64x"", (ut64)address);
-		strcat (buf_global, tmp);
-	}
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	int flen, glen;
-	va_list ap;
-	char *tmp;
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-	flen = strlen (format);
-	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) {
-		return 0;
-	}
-	memcpy (tmp, buf_global, glen);
-	memcpy (tmp+glen, format, flen);
-	tmp[flen + glen] = 0;
-	// XXX: overflow here?
-	vsprintf (buf_global, tmp, ap);
-	va_end (ap);
-	free (tmp);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, struct r_asm_op_t *op, const ut8 *buf, int len) {
 	struct disassemble_info disasm_obj;
 	if (len < 4) {
 		return -1;
 	}
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	memcpy (bytes, buf, 4); // TODO handle thumb
 
@@ -79,9 +50,9 @@ static int disassemble(RAsm *a, struct r_asm_op_t *op, const ut8 *buf, int len) 
 	disasm_obj.read_memory_func = &nios2_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = !a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
 	if (disasm_obj.endian == BFD_ENDIAN_BIG) {

--- a/libr/asm/p/asm_ppc_gnu.c
+++ b/libr/asm/p/asm_ppc_gnu.c
@@ -13,7 +13,7 @@
 
 
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int ppc_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
@@ -29,44 +29,15 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (buf_global) {
-		sprintf (tmp, "0x%08"PFMT64x"", (ut64)address);
-		strcat (buf_global, tmp);
-	}
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	int flen, glen;
-	va_list ap;
-	char *tmp;
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-	flen = strlen (format);
-	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) {
-		return 0;
-	}
-	memcpy (tmp, buf_global, glen);
-	memcpy (tmp+glen, format, flen);
-	tmp[flen+glen] = 0;
-// XXX: overflow here?
-	vsprintf (buf_global, tmp, ap);
-	va_end (ap);
-	free (tmp);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	struct disassemble_info disasm_obj;
 	if (len<4) {
 		return -1;
 	}
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	memcpy (bytes, buf, 4); // TODO handle thumb
 
@@ -77,9 +48,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &ppc_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = !a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 	if (a->big_endian) {
 		op->size = print_insn_big_powerpc ((bfd_vma)Offset, &disasm_obj);

--- a/libr/asm/p/asm_sh.c
+++ b/libr/asm/p/asm_sh.c
@@ -10,7 +10,7 @@
 #include "disas-asm.h"
 
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int sh_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, unsigned int length, struct disassemble_info *info) {
@@ -30,40 +30,15 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global) {
-		return;
-	}
-	sprintf (tmp, "0x%08"PFMT64x"", (ut64)address);
-	strcat (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	va_list ap;
-	char *tmp;
-	int ret;
-	if (!buf_global) {
-		return 0;
-	}
-	tmp = malloc (strlen (format)+strlen (buf_global)+2);
-	if (!tmp) {
-		return 0;
-	}
-	va_start (ap, format);
-	sprintf (tmp, "%s%s", buf_global, format);
-	ret = vsprintf (buf_global, tmp, ap);
-	va_end (ap);
-	free (tmp);
-	return ret;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	static struct disassemble_info disasm_obj;
 	if (len < 2) {
 		return -1;
 	}
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	memcpy (bytes, buf, 2);
 
@@ -73,9 +48,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &sh_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = !a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
 	if (disasm_obj.endian == BFD_ENDIAN_BIG) {

--- a/libr/asm/p/asm_sparc_gnu.c
+++ b/libr/asm/p/asm_sparc_gnu.c
@@ -27,26 +27,8 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32] = {0};
-	if (!buf_global) {
-		return;
-	}
-	sprintf (tmp, "0x%08"PFMT64x"", (ut64)address);
-	r_strbuf_append (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	va_list ap;
-	char tmp[1024] = {0};
-	va_start (ap, format);
-	if (buf_global) {
-		vsnprintf (tmp, sizeof (tmp), format, ap);
-		r_strbuf_append (buf_global, tmp);
-	}
-	va_end (ap);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	static struct disassemble_info disasm_obj;
@@ -65,9 +47,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &sparc_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 	disasm_obj.mach = ((a->bits == 64)
 			   ? bfd_mach_sparc_v9b

--- a/libr/asm/p/asm_tricore.c
+++ b/libr/asm/p/asm_tricore.c
@@ -13,7 +13,7 @@
 
 
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static ut8 bytes[128];
 
 static int tricore_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
@@ -32,84 +32,25 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[64];
-	if (!buf_global) {
-		return;
-	}
-	sprintf (tmp, "0x%08" PFMT64x, (ut64) address);
-	strcat (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	int flen, glen;
-	char *escaped = NULL;
-	va_list ap;
-	char *tmp = NULL;
-	va_start (ap, format);
-	if (!buf_global) {
-		return 0;
-	}
-	flen = strlen (format);
-	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) {
-		return 0;
-	}
-
-	if (strchr (buf_global, '%')) {
-		char *buf_local = strdup (buf_global);
-		if (!buf_local) {
-			free (tmp);
-			return 0;
-		}
-		escaped = r_str_replace (buf_local, "%", "%%", true);
-	} else {
-		escaped = strdup (buf_global);
-		if (!escaped) {
-			free (tmp);
-			return 0;
-		}
-	}
-
-	if (escaped) {
-		glen = strlen (escaped);
-		memcpy (tmp, escaped, glen);
-		memcpy (tmp+glen, format, flen);
-		tmp[flen+glen] = 0;
-		free (escaped);
-		/* this code can produce a buffer overflow or a format string */
-#define IN_CASE_OF_SEGFAULT 0
-#if IN_CASE_OF_SEGFAULT
-		strcpy (buf_global, tmp);
-#else
-		vsprintf (buf_global, tmp, ap);
-#endif
-		free (tmp);
-		va_end (ap);
-		return 0;
-	}
-	free (tmp);
-	va_end (ap);
-	return -1;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	struct disassemble_info disasm_obj;
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	memcpy (bytes, buf, R_MIN (len, 8)); // TODO handle thumb
 
 	/* prepare disassembler */
 	memset (&disasm_obj, '\0', sizeof (struct disassemble_info));
-	disasm_obj.disassembler_options=(a->bits==64)?"64":"";
+	disasm_obj.disassembler_options = (a->bits==64)?"64":"";
 	disasm_obj.buffer = bytes;
 	disasm_obj.read_memory_func = &tricore_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = BFD_ENDIAN_LITTLE;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
 	disasm_obj.mach = 2; // select CPU TYPE

--- a/libr/asm/p/asm_vax.c
+++ b/libr/asm/p/asm_vax.c
@@ -15,7 +15,7 @@
 #include "../arch/vax/vax.h"
 
 static unsigned long Offset = 0;
-static char *buf_global = NULL;
+static RStrBuf *buf_global = NULL;
 static const ut8 *bytes = NULL;
 static int bytes_size = 0;
 
@@ -39,45 +39,15 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global) {
-		return;
-	}
-	sprintf (tmp, "0x%08"PFMT64x, (ut64)address);
-	strcat (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	int flen, glen;
-	va_list ap;
-	char *tmp;
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-	flen = strlen (format);
-	glen = strlen (buf_global);
-	tmp = malloc (flen + glen + 2);
-	if (!tmp) {
-		return 0;
-	}
-	memcpy (tmp, buf_global, glen);
-	memcpy (tmp+glen, format, flen);
-	tmp[flen+glen] = 0;
-// XXX: overflow here?
-	vsprintf (buf_global, tmp, ap);
-	va_end (ap);
-	free (tmp);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	struct disassemble_info disasm_obj;
 	if (len < 4) {
 		return -1;
 	}
-	buf_global = r_strbuf_get (&op->buf_asm);
+	buf_global = &op->buf_asm;
 	bytes = buf;
 	bytes_size = len;
 	Offset = a->pc;
@@ -88,9 +58,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &vax_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = BFD_ENDIAN_LITTLE;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 	op->size = print_insn_vax ((bfd_vma)Offset, &disasm_obj);
 

--- a/libr/asm/p/asm_xtensa.c
+++ b/libr/asm/p/asm_xtensa.c
@@ -33,27 +33,8 @@ static void memory_error_func(int status, bfd_vma memaddr, struct disassemble_in
 	//--
 }
 
-static void print_address(bfd_vma address, struct disassemble_info *info) {
-	char tmp[32];
-	if (!buf_global) {
-		return;
-	}
-	sprintf (tmp, "0x%08"PFMT64x"", (ut64)address);
-	r_strbuf_append (buf_global, tmp);
-}
-
-static int buf_fprintf(void *stream, const char *format, ...) {
-	va_list ap;
-	char tmp[1024];
-	if (!buf_global) {
-		return 0;
-	}
-	va_start (ap, format);
-	vsprintf (tmp, format, ap);
-	r_strbuf_append (buf_global, tmp);
-	va_end (ap);
-	return 0;
-}
+DECLARE_GENERIC_PRINT_ADDRESS_FUNC()
+DECLARE_GENERIC_FPRINTF_FUNC()
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	struct disassemble_info disasm_obj;
@@ -72,9 +53,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.read_memory_func = &xtensa_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
-	disasm_obj.print_address_func = &print_address;
+	disasm_obj.print_address_func = &generic_print_address_func;
 	disasm_obj.endian = !a->big_endian;
-	disasm_obj.fprintf_func = &buf_fprintf;
+	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
 	op->size = print_insn_xtensa ((bfd_vma)offset, &disasm_obj);


### PR DESCRIPTION
Yeah looks ugly but it is better than to have 14 different implementations of the same function. The best way is to implement `generic_fprintf()` and `generic_print_address()` functions but they requires address of `RStrBuf`. Can we reuse `stream` field of `disassemble_info` struct too access it (see example below)? Now `stream` value is set to `stdout` but it seems that is not used anywhere.
```c
int generic_fprintf(void *stream, const char *format, ...) {
	...
	ret = r_strbuf_vappendf ( (RStrBuf *)stream, format, ap);
	...
}

void generic_print_address(bfd_vma address, struct disassemble_info *info) {
	...
	r_strbuf_appendf ((RStrBuf *)info->stream, "0x%08"PFMT64x, (ut64)address);
}

static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
	struct disassemble_info disasm_obj;
	...
	disasm_obj.print_address_func = &generic_print_address;
	disasm_obj.fprintf_func = &generic_fprintf;
        disasm_obj.stream = (void *)op->asm_buf;
        ...
}
```