### PR TITLE
Update cmd_print.c

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -15,7 +15,7 @@ static const char *help_msg_pa[] = {
 	"Usage: pa[edD]", "[asm|hex]", "print (dis)assembled",
 	"pae", "", "print assembled ESIL from hexpairs",
 	"pad", "", "print disassembled from hexpairs",
-	"paD", "", "print assembled from hexparis",
+	"paD", "", "print disassembled from hexpairs (and also show hexpairs)",
 	NULL
 };
 


### PR DESCRIPTION
Fixed typo for 'paD' help ("hexparis") and made description consistent with the description from rasm2 (https://github.com/radare/radare2/blob/4a722e80d8f7924cfbe2ddf72a55e2f36f1e23ac/binr/rasm2/rasm2.c#L227)