### PR TITLE
drj cmd: change value format to llu instead of lld

### DIFF
--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -176,7 +176,7 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 				r_reg_arena_swap (dbg->reg, false);
 				delta = value-diff;
 				if (tolower (rad) == 'j') {
-					snprintf (strvalue, sizeof (strvalue),"%"PFMT64d, value);
+					snprintf (strvalue, sizeof (strvalue),"%"PFMT64u, value);
 				} else {
 					snprintf (strvalue, sizeof (strvalue),"0x%08"PFMT64x, value);
 				}


### PR DESCRIPTION
This fixes #11637 

new behavior:
~~~
Process with PID 12760 started...
= attach 12760 12760
bin.baddr 0x5654becb0000
Using 0x5654becb0000
asm.bits 64
0x00000000 ->0xfffffa8004cc6b30
{"rax":18446738026476104496,"rbx":0,"rcx":0,"rdx":0,"r8":0,"r9":0,"r10":0,"r11":0,"r12":0,"r13":0,"r14":0,"r15":0,"rsi":0,"rdi":0,"rsp":140734553100096,"rbp":0,"rip":140251687882896,"rflags":512,"orax":59}
~~~