### PR TITLE
print hit breakpoint message on stderr

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -167,10 +167,8 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 
 	/* inform the user of what happened */
 	if (dbg->hitinfo) {
-		//eprintf ("hit %spoint at: %"PFMT64x "\n",
-		//		b->trace ? "trace" : "break", pc);
-		r_cons_printf ("hit %spoint at: %"PFMT64x "\n",
-			b->trace ? "trace" : "break", pc);
+		eprintf ("hit %spoint at: %"PFMT64x "\n",
+				b->trace ? "trace" : "break", pc);
 	}
 
 	/* now that we've cleaned up after the breakpoint, call the other


### PR DESCRIPTION
avoid polluting stdout when using r2pipe and cmdj.

I have a case here where i'm trying to create a Python script with r2pipe over a debug plugin.

The following part of the script fails:
~~~Python
    while not interrupted:
        # continue
        r2.cmd('dc')
        # get registers
        registers = r2.cmdj('drj')
        # bp hit !
        object_attributes_addr = registers['r8']
~~~ 
Like this (I added debug output in r2pipe)
~~~
r2pipe.cmdj.Error: Expecting value: line 1 column 1 (char 0)
"hit breakpoint at: fffff8000299424c", len 35
Traceback (most recent call last):
  File "examples/watch_syscall.py", line 100, in <module>
    ret = main(args)
  File "examples/watch_syscall.py", line 90, in main
    object_attributes_addr = registers['r8']
~~~

I think it's best to keep writing on stderr otherwise `r2.cmdj()` parses the previous command output, and fails.