### PR TITLE
 Detect function prefixed with __libc_ and __GI_ 

### DIFF
--- a/libr/anal/d/types-linux.sdb.txt
+++ b/libr/anal/d/types-linux.sdb.txt
@@ -86,6 +86,53 @@ func.prctl.arg.3=unsigned long,v4
 func.prctl.arg.4=unsigned long,v5
 func.prctl.ret=int
 
+sigaction=func
+func.sigaction.args=3
+func.sigaction.arg.0=int,signum
+func.sigaction.arg.1=const struct sigaction *,act
+func.sigaction.arg.2=struct sigaction *,oldact
+func.sigaction.ret=int
+
+select=func
+func.select.args=5
+func.select.arg.0=int,nfds
+func.select.arg.1=fd_set *,readfds
+func.select.arg.2=fd_set *,writefds
+func.select.arg.3=fd_set *,exceptfds
+func.select.arg.4=struct timeval *,timeout
+func.select.ret=int
+
+nanosleep=func
+func.nanosleep.args=2
+func.nanosleep.arg.0=const struct timespec *,req
+func.nanosleep.arg.1=struct timespec *,rem
+func.nanosleep.ret=int
+
+getsockname=func
+func.getsockname.args=3
+func.getsockname.arg.0=int,sockfd
+func.getsockname.arg.1=struct sockaddr *,addr
+func.getsockname.arg.2=socklen_t *,addrlen
+func.getsockname.ret=int
+
+getsockopt=func
+func.getsockopt.args=5
+func.getsockopt.arg.0=int,sockfd
+func.getsockopt.arg.1=int,level
+func.getsockopt.arg.2=int,optname
+func.getsockopt.arg.3=void *,optval
+func.getsockopt.arg.4=socklen_t *,optlen
+func.getsockopt.ret=int
+
+setsockopt=func
+func.setsockopt.args=5
+func.setsockopt.arg.0=int,sockfd
+func.setsockopt.arg.1=int,level
+func.setsockopt.arg.2=int,optname
+func.setsockopt.arg.3=void *,optval
+func.setsockopt.arg.4=socklen_t,optlen
+func.setsockopt.ret=int
+
 waitpid=func
 func.waitpid.args=3
 func.waitpid.arg.0=pid_t,pid

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -526,7 +526,7 @@ R_API R_OWN char *r_type_func_guess(Sdb *TDB, R_NONNULL char *func_name) {
 	// strip common prefixes from standard lib functions
 	if (!strncmp (str, "__isoc99_", 9)) {
 		str += 9;
-	} else if (!strncmp (str, "__libc_", 7)) {
+	} else if (!strncmp (str, "__libc_", 7) && !strstr(str,"_main")) {
 		str += 7;
 	} else if (!strncmp (str, "__GI_", 5)) {
 		str += 5;

--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -523,8 +523,13 @@ R_API R_OWN char *r_type_func_guess(Sdb *TDB, R_NONNULL char *func_name) {
 	}
 	slen -= offset;
 	str += offset;
+	// strip common prefixes from standard lib functions
 	if (!strncmp (str, "__isoc99_", 9)) {
 		str += 9;
+	} else if (!strncmp (str, "__libc_", 7)) {
+		str += 7;
+	} else if (!strncmp (str, "__GI_", 5)) {
+		str += 5;
 	}
 	if ((result = type_func_try_guess (TDB, str))) {
 		return result;


### PR DESCRIPTION
Fixes #11647 

* After fix , we can detect function arguments for func with prefix __GI_ and __libc_

```
|           0x00018824      3c300be5       str r3, [ptr]
|           0x00018828      80301be5       ldr r3, [nbytes]
|           0x0001882c      0100a0e3       mov r0, 1       ; int fd
|           0x00018830      3c101be5       ldr r1, [ptr]   ; void *ptr
|           0x00018834      0320a0e1       mov r2, r3      ; size_t nbytes
|           0x00018838      3d2300eb       bl sym.__GI_write      ; ssize_t write(int fd, void *ptr, size_t nbytes)
```