### PR TITLE
Stop analysis after no-return function

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -603,17 +603,7 @@ R_API bool r_anal_noreturn_at(RAnal *anal, ut64 addr) {
 			return true;
 		}
 	}
-	int oss = anal->flb.f->space_strict;
-	int ofs = anal->flb.f->space_idx;
-	anal->flb.set_fs (anal->flb.f, "imports");
-	anal->flb.f->space_strict = true;
-	RFlagItem *fi = anal->flb.get_at (anal->flb.f, addr, false);
-	if (!fi) {
-		anal->flb.set_fs (anal->flb.f, "symbols");
-		fi = anal->flb.get_at (anal->flb.f, addr, false);
-	}
-	anal->flb.f->space_idx = ofs;
-	anal->flb.f->space_strict = oss;
+	RFlagItem *fi = r_flag_get_i2 (anal->flb.f, addr);
 	if (fi) {
 		if (r_anal_noreturn_at_name (anal, fi->name)) {
 			return true;


### PR DESCRIPTION
Fixes #11672 

@Maijin i have found out that , this issue was not specific to `__GI_` prefixed function,  there were other cases were analysis failed to stop after no return function (it was present for long time), see the bin from r2r below

* Before

```
[0x00008150]> pdf
            ;-- section..text:
            ;-- $a:
            ;-- _start:
            ;-- pc:
            ;-- r15:
/ (fcn) entry0 56
|   entry0 ();
|           0x00008150      24c09fe5       ldr ip, loc._d_2            ; [0x817c:4]=0x8b00 sym.__libc_csu_fini ; [03] -r-x section size 381864 named .text
|           0x00008154      00b0a0e3       mov fp, 0
|           0x00008158      04109de4       pop {r1}
|           0x0000815c      0d20a0e1       mov r2, sp
|           0x00008160      04202de5       str r2, [sp, -4]!
|           0x00008164      04002de5       str r0, [sp, -4]!
|           0x00008168      10009fe5       ldr r0, sym.main            ; [0x8180:4]=0x8290 sym.main
|           0x0000816c      10309fe5       ldr r3, sym.__libc_csu_init ; [0x8184:4]=0x8b48 sym.__libc_csu_init
|           0x00008170      04c02de5       str ip, [sp, -4]!
|           0x00008174      b80000eb       bl sym.__libc_start_main    ; int __libc_start_main(func main, int argc, char **ubp_av, func init, func fini, func rtld_fini, void *stack_end)
|           0x00008178      a40200eb       bl sym.abort                ; void abort(void)
|           ;-- $d:
|           ; DATA XREF from entry0 (0x8150)
|           0x0000817c      008b0000       andeq r8, r0, r0, lsl 22
|           ; DATA XREF from entry0 (0x8168)
|           0x00008180      90820000       muleq r0, r0, r2
|           ; DATA XREF from entry0 (0x816c)
\           0x00008184      488b0000       andeq r8, r0, r8, asr 22
[0x00008150]>
```

* After 

```
[0x00008150]> pdf
            ;-- section..text:
            ;-- $a:
            ;-- pc:
            ;-- r15:
/ (fcn) entry0 40
|   entry0 ();
|           ; UNKNOWN XREF from segment.LOAD0 (+0x18)
|           0x00008150      24c09fe5       ldr ip, loc._d_2            ; [0x817c:4]=0x8b00 sym.__libc_csu_fini ; [03] -r-x section size 381864 named .text
|           ; CODE XREFS from sym.__libc_start_main (0x8612, 0x8616)
|           0x00008154      00b0a0e3       mov fp, 0
|           0x00008158      04109de4       pop {r1}                    ; int argc
|           ; CODE XREF from sym.__libc_start_main (0x861e)
|           0x0000815c      0d20a0e1       mov r2, sp                  ; char **ubp_av
|           ; CODE XREF from sym.__libc_start_main (0x8622)
|           0x00008160      04202de5       str r2, [sp, -4]!
|           0x00008164      04002de5       str r0, [sp, -4]!
|           0x00008168      10009fe5       ldr r0, sym.main            ; [0x8180:4]=0x8290 sym.main ; func main
|           0x0000816c      10309fe5       ldr r3, sym.__libc_csu_init ; [0x8184:4]=0x8b48 sym.__libc_csu_init ; func init
|           ; CODE XREF from sym.__libc_start_main (0x862e)
|           0x00008170      04c02de5       str ip, [sp, -4]!
\           0x00008174      b80000eb       bl sym.__libc_start_main    ; int __libc_start_main(func main, int argc, char **ubp_av, func init, func fini, func rtld_fini, void *stack_end)

[0x00008150]>
```

```
[0x00008150]> k anal/types/*~__libc_start_main
__libc_start_main=func
func.__libc_start_main.arg.0=func,main
...
func.__libc_start_main.noreturn=true
func.__libc_start_main.ret=int
```
Fixed a test in r2r [#1506](https://github.com/radare/radare2-regressions/pull/1506)