### PR TITLE
include/r_types: remove R_NOTNULL

### DIFF
--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -57,9 +57,8 @@ R_API RBinObject *r_bin_object_new(RBinFile *binfile, RBinPlugin *plugin, ut64 b
 		if (sz < bsz) {
 			bsz = sz;
 		}
-		o->bin_obj = plugin->load_bytes (binfile, bytes + offset, sz,
-						 loadaddr, sdb);
-		if (!o->bin_obj) {
+		if (!plugin->load_bytes (binfile, &o->bin_obj, bytes + offset, sz,
+					 loadaddr, sdb)) {
 			bprintf (
 				"Error in r_bin_object_new: load_bytes failed "
 				"for %s plugin\n",

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -63,19 +63,20 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return ao? ao->kv: NULL;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb){
 	ArtObj *ao = R_NEW0 (ArtObj);
 	if (!ao) {
-		return NULL;
+		return false;
 	}
 	ao->kv = sdb_new0 ();
 	if (!ao->kv) {
 		free (ao);
-		return NULL;
+		return false;
 	}
 	art_header_load (&ao->art, bf->buf, ao->kv);
 	sdb_ns_set (sdb, "info", ao->kv);
-	return ao;
+	*bin_obj = ao;
+	return true;
 }
 
 static bool load(RBinFile *bf) {

--- a/libr/bin/p/bin_avr.c
+++ b/libr/bin/p/bin_avr.c
@@ -68,9 +68,8 @@ static bool check_bytes(const ut8 *b, ut64 length) {
 	return check_bytes_rjmp (b, length);
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	check_bytes (buf, sz);
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static RBinInfo* info(RBinFile *bf) {

--- a/libr/bin/p/bin_bf.c
+++ b/libr/bin/p/bin_bf.c
@@ -5,8 +5,8 @@
 #include <r_lib.h>
 #include <r_bin.h>
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return true;
 }
 
 static bool load(RBinFile *bf) {

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -7,25 +7,25 @@
 #include <r_io.h>
 #include "bflt/bflt.h"
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *sdb) {
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	RBuffer *tbuf = r_buf_new ();
 	if (!tbuf) {
-		return NULL;
+		return false;
 	}
 	r_buf_set_bytes (tbuf, buf, sz);
 	struct r_bin_bflt_obj *res = r_bin_bflt_new_buf (tbuf);
 	r_buf_free (tbuf);
-	return res? res: NULL;
+	*bin_obj = res;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
 	const ut8 *bytes = r_buf_buffer (bf->buf);
 	ut64 sz = r_buf_size (bf->buf);
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
-	return bf->o->bin_obj? true: false;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static RList *entries(RBinFile *bf) {

--- a/libr/bin/p/bin_bios.c
+++ b/libr/bin/p/bin_bios.c
@@ -21,11 +21,8 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
-	if (!check_bytes (buf, sz)) {
-		return NULL;
-	}
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+	return check_bytes (buf, sz);
 }
 
 static bool load(RBinFile *bf) {

--- a/libr/bin/p/bin_bootimg.c
+++ b/libr/bin/p/bin_bootimg.c
@@ -82,22 +82,23 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return ao? ao->kv: NULL;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb) {
 	BootImageObj *bio = R_NEW0 (BootImageObj);
 	if (!bio) {
-		return NULL;
+		return false;
 	}
 	bio->kv = sdb_new0 ();
 	if (!bio->kv) {
 		free (bio);
-		return NULL;
+		return false;
 	}
 	if (!bootimg_header_load (&bio->bi, bf->buf, bio->kv)) {
 		free(bio);
-		return NULL;
+		return false;
 	}
 	sdb_ns_set (sdb, "info", bio->kv);
-	return bio;
+	*bin_obj = bio;
+	return true;
 }
 
 static bool load(RBinFile *bf) {

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -19,15 +19,15 @@ static Sdb* get_sdb(RBinFile *bf) {
 	return NULL;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	RBuffer *tbuf = r_buf_new();
 	r_buf_set_bytes (tbuf, buf, sz);
-	void *res = r_bin_coff_new_buf (tbuf, bf->rbin->verbose);
+	*bin_obj = r_bin_coff_new_buf (tbuf, bf->rbin->verbose);
 	r_buf_free (tbuf);
-	return res;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -37,8 +37,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
-	return bf->o->bin_obj ? true: false;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -710,20 +710,19 @@ static Sdb *get_sdb (RBinFile *bf) {
 	return bin? bin->kv: NULL;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	void *res = NULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	RBuffer *tbuf = NULL;
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	tbuf = r_buf_new ();
 	if (!tbuf) {
-		return NULL;
+		return false;
 	}
 	r_buf_set_bytes (tbuf, buf, sz);
-	res = r_bin_dex_new_buf (tbuf);
+	*bin_obj = r_bin_dex_new_buf (tbuf);
 	r_buf_free (tbuf);
-	return res;
+	return true;
 }
 
 static void * load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
@@ -737,8 +736,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
-	return bf->o->bin_obj ? true: false;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static ut64 baddr(RBinFile *bf) {

--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -45,21 +45,21 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (buf, "\x00\x00\x01\x00\x00\x00", 6));
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	bool has_dol_extension = false;
 	DolHeader *dol;
 	char *lowername, *ext;
 	if (!bf || sz < sizeof (DolHeader)) {
-		return NULL;
+		return false;
 	}
 	dol = R_NEW0 (DolHeader);
 	if (!dol) {
-		return NULL;
+		return false;
 	}
 	lowername = strdup (bf->file);
 	if (!lowername) {
 		free (dol);
-		return NULL;
+		return false;
 	}
 	r_str_case (lowername, 0);
 	ext = strstr (lowername, ".dol");
@@ -71,12 +71,12 @@ static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sd
 		r_buf_fread_at (bf->buf, 0, (void *) dol, "67I", 1);
 		// r_buf_fread_at (bf->buf, 0, (void*)dol, "67i", 1);
 		if (bf && bf->o && bf->o->bin_obj) {
-			bf->o->bin_obj = dol;
+			*bin_obj = bf->o->bin_obj = dol;
 		}
-		return (void *) dol;
+		return true;
 	}
 	free (dol);
-	return NULL;
+	return false;
 }
 
 static bool load(RBinFile *bf) {
@@ -85,7 +85,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes,
+	load_bytes (bf, &bf->o->bin_obj, bytes,
 		sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }

--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -872,15 +872,15 @@ static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
 	return cache;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
-	return (void *) (size_t) check_bytes (buf, sz);
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+	return check_bytes (buf, sz);
 }
 
 static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf ? r_buf_buffer (bf->buf) : NULL;
 	ut64 sz = bf ? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o) ? bf->o->loadaddr: 0;
-	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL) != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static RList *entries(RBinFile *bf) {

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -84,10 +84,10 @@ static void * load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
 	return res;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	struct Elf_(r_bin_elf_obj_t) *res;
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	RBuffer *tbuf = r_buf_new ();
 	// NOOOEES must use io!
@@ -97,7 +97,8 @@ static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, S
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	return res;
+	*bin_obj = res;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -106,8 +107,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
-	return bf->o->bin_obj != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_fs.c
+++ b/libr/bin/p/bin_fs.c
@@ -53,18 +53,15 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return p != NULL;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	if (check_bytes (buf, sz)) {
-		return R_NOTNULL;
-	}
-	return NULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf ? r_buf_buffer (bf->buf) : NULL;
 	ut64 sz = bf ? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o) ? bf->o->loadaddr: 0;
-	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL) != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -74,22 +74,22 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return NULL;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	struct r_bin_java_obj_t *bin_obj = NULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	struct r_bin_java_obj_t *tmp_bin_obj = NULL;
 	RBuffer *tbuf = NULL;
-	void *res = NULL;
 	if (!buf || sz == 0 || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	tbuf = r_buf_new ();
 	r_buf_set_bytes (tbuf, buf, sz);
-	res = bin_obj = r_bin_java_new_buf (tbuf, loadaddr, sdb);
-	add_bin_obj_to_sdb (bin_obj);
+	tmp_bin_obj = r_bin_java_new_buf (tbuf, loadaddr, sdb);
+	*bin_obj = tmp_bin_obj;
+	add_bin_obj_to_sdb (tmp_bin_obj);
 	if (bf && bf->file) {
-		bin_obj->file = strdup (bf->file);
+		tmp_bin_obj->file = strdup (bf->file);
 	}
 	r_buf_free (tbuf);
-	return res;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -102,7 +102,7 @@ static bool load(RBinFile *bf) {
 		return false;
 	}
 
-	bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, (void **) &bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 
 	if (bin_obj) {
 		if (!bf->o->kv) {

--- a/libr/bin/p/bin_mbn.c
+++ b/libr/bin/p/bin_mbn.c
@@ -71,15 +71,15 @@ static bool check_bytes(const ut8 *buf, ut64 bufsz) {
 	return false;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	return (void*)(size_t)check_bytes (buf, sz);
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static bool load(RBinFile *bf) {
 	if (bf && bf->buf) {
 		const ut8 *bytes = r_buf_buffer (bf->buf);
 		ut64 sz = r_buf_size (bf->buf);
-		return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb) != NULL;
+		return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 	}
 	return false;
 }

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -183,12 +183,12 @@ static RList* libs(RBinFile *bf) {
 	return ret;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	RBuffer *tbuf;
 	struct r_bin_mdmp_obj *res;
 
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 
 	tbuf = r_buf_new ();
@@ -198,7 +198,12 @@ static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sd
 	}
 	r_buf_free (tbuf);
 
-	return res;
+	if (res) {
+		*bin_obj = res;
+		return true;
+	} else {
+		return false;
+	}
 }
 
 static bool load(RBinFile *bf) {
@@ -209,9 +214,7 @@ static bool load(RBinFile *bf) {
 		return false;
 	}
 
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
-
-	return bf->o->bin_obj ? true : false;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static RList *sections(RBinFile *bf) {

--- a/libr/bin/p/bin_menuet.c
+++ b/libr/bin/p/bin_menuet.c
@@ -62,15 +62,15 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	return (void*)(size_t)check_bytes (buf, sz);
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf ? r_buf_buffer (bf->buf) : NULL;
 	ut64 sz = bf ? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o) ? bf->o->loadaddr: 0;
-	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL) != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static ut64 baddr(RBinFile *bf) {

--- a/libr/bin/p/bin_mz.c
+++ b/libr/bin/p/bin_mz.c
@@ -76,12 +76,12 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return true;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz,
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz,
 		ut64 loadaddr, Sdb *sdb) {
-	const struct r_bin_mz_obj_t *res = NULL;
+	struct r_bin_mz_obj_t *res = NULL;
 	RBuffer *tbuf = NULL;
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	tbuf = r_buf_new ();
 	r_buf_set_bytes (tbuf, buf, sz);
@@ -90,7 +90,8 @@ static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz,
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	return (void *)res;
+	*bin_obj = res;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -99,9 +100,7 @@ static bool load(RBinFile *bf) {
 	}
 	const ut8 *bytes = r_buf_buffer (bf->buf);
 	ut64 sz = r_buf_size (bf->buf);
-	const void *res = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
-	bf->o->bin_obj = (void *)res;
-	return res != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_nes.c
+++ b/libr/bin/p/bin_nes.c
@@ -11,9 +11,8 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (buf, INES_MAGIC, 4));
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	check_bytes (buf, sz);
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static RBinInfo* info(RBinFile *bf) {

--- a/libr/bin/p/bin_nin3ds.c
+++ b/libr/bin/p/bin_nin3ds.c
@@ -17,7 +17,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (buf, "FIRM", 4));
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	return memcpy (&loaded_header, buf, sizeof (struct n3ds_firm_hdr));
 }
 
@@ -27,7 +27,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -20,8 +20,9 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (ninlogohead, "\x24\xff\xae\x51\x69\x9a", 6))? true: false;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
-	return memcpy (&loaded_header, buf, sizeof(struct nds_hdr));
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+	*bin_obj = memcpy (&loaded_header, buf, sizeof(struct nds_hdr));
+	return (*bin_obj != NULL);
 }
 
 static bool load(RBinFile *bf) {
@@ -30,7 +31,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -7,8 +7,8 @@
 #include <string.h>
 #include "../format/nin/nin.h"
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	return &load_bytes;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return true;
 }
 
 static bool check_bytes(const ut8 *buf, ut64 length) {
@@ -27,7 +27,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, la, bf->sdb);
+	load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_nro.c
+++ b/libr/bin/p/bin_nro.c
@@ -37,10 +37,10 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	RBinNXOObj *bin = R_NEW0 (RBinNXOObj);
 	if (!bin) {
-		return NULL;
+		return false;
 	}
 	ut64 ba = baddr (bf);
 	bin->methods_list = r_list_newf ((RListFree)free);
@@ -48,7 +48,8 @@ static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sd
 	bin->classes_list = r_list_newf ((RListFree)free);
 	ut32 mod0 = readLE32 (bf->buf, NRO_OFFSET_MODMEMOFF);
 	parseMod (bf->buf, bin, mod0, ba);
-	return (void *) bin;//(size_t) check_bytes (buf, sz);
+	*bin_obj = bin;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -58,7 +59,7 @@ static bool load(RBinFile *bf) {
 	const ut64 sz = r_buf_size (bf->buf);
 	const ut64 la = bf->o->loadaddr;
 	const ut8 *bytes = r_buf_buffer (bf->buf);
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, la, bf->sdb);
+	load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf->sdb);
 	return bf->o->bin_obj != NULL;
 }
 

--- a/libr/bin/p/bin_nso.c
+++ b/libr/bin/p/bin_nso.c
@@ -54,7 +54,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	RBin *rbin = bf->rbin;
 	RBinNXOObj *bin = R_NEW0 (RBinNXOObj);
 	ut32 toff = readLE32 (bf->buf, NSO_OFF (text_memoffset));
@@ -90,11 +90,12 @@ static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sd
 	eprintf ("MOD Offset = 0x%"PFMT64x"\n", (ut64)modoff);
 	parseMod (newbuf, bin, modoff, ba);
 	r_buf_free (newbuf);
-	return (void *) bin;
+	*bin_obj = bin;
+	return true;
 fail:
 	r_buf_free (newbuf);
 	free (bin);
-	return NULL;
+	return false;
 }
 
 static bool load(RBinFile *bf) {
@@ -104,8 +105,7 @@ static bool load(RBinFile *bf) {
 	const ut64 sz = r_buf_size (bf->buf);
 	const ut64 la = bf->o->loadaddr;
 	const ut8 *bytes = r_buf_buffer (bf->buf);
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, la, bf->sdb);
-	return bf->o->bin_obj != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_omf.c
+++ b/libr/bin/p/bin_omf.c
@@ -6,11 +6,12 @@
 #include <r_bin.h>
 #include "omf/omf.h"
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 size, ut64 loadaddrn, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 size, ut64 loadaddrn, Sdb *sdb) {
 	if (!buf || !size || size == UT64_MAX) {
-		return NULL;
+		return false;
 	}
-	return r_bin_internal_omf_load (buf, size);
+	*bin_obj = r_bin_internal_omf_load (buf, size);
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -19,8 +20,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, byte, size, bf->o->loadaddr, bf->sdb);
-	return bf->o->bin_obj != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, byte, size, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -13,15 +13,15 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	return (void *) (size_t) check_bytes (buf, sz);
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf? r_buf_buffer (bf->buf): NULL;
 	ut64 sz = bf? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o)? bf->o->loadaddr: 0;
-	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL);
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -16,11 +16,11 @@ static Sdb* get_sdb (RBinFile *bf) {
 	return bin? bin->kv: NULL;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	struct PE_(r_bin_pe_obj_t) *res = NULL;
 	RBuffer *tbuf = NULL;
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	tbuf = r_buf_new ();
 	r_buf_set_bytes (tbuf, buf, sz);
@@ -29,7 +29,8 @@ static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, S
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	return res;
+	*bin_obj = res;
+	return true;
 }
 
 static void * load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
@@ -45,7 +46,6 @@ static void * load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
 }
 
 static bool load(RBinFile *bf) {
-	void *res;
 	const ut8 *bytes;
 	ut64 sz;
 
@@ -54,9 +54,7 @@ static bool load(RBinFile *bf) {
 	}
 	bytes = r_buf_buffer (bf->buf);
 	sz = r_buf_size (bf->buf);
-	res = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
- 	bf->o->bin_obj = res;
-	return res? true: false;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -39,10 +39,8 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (length > 7 && !memcmp (buf, "PBLAPP\x00\x00", 8));
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	check_bytes (buf, sz);
-	// XXX: this may be wrong if check_bytes is true
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static bool load(RBinFile *bf) {

--- a/libr/bin/p/bin_psxexe.c
+++ b/libr/bin/p/bin_psxexe.c
@@ -13,9 +13,8 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return !memcmp (buf, PSXEXE_ID, PSXEXE_ID_LEN);
 }
 
-static void* load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
-	check_bytes (buf, sz);
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+	return check_bytes (buf, sz);
 }
 
 static RBinInfo* info(RBinFile* bf) {

--- a/libr/bin/p/bin_sfc.c
+++ b/libr/bin/p/bin_sfc.c
@@ -33,8 +33,8 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (cksum1 == (ut16)~cksum2);
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	return check_bytes (buf, sz) ? R_NOTNULL : NULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static RBinInfo* info(RBinFile *bf) {

--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -102,9 +102,8 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	check_bytes (buf, sz);
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static RBinInfo *info(RBinFile *bf) {

--- a/libr/bin/p/bin_sms.c
+++ b/libr/bin/p/bin_sms.c
@@ -32,9 +32,8 @@ static bool check_bytes(const ut8 *bs, ut64 length) {
 	return false;
 }
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	check_bytes (buf, sz);
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static RBinInfo* info(RBinFile *bf) {

--- a/libr/bin/p/bin_spc700.c
+++ b/libr/bin/p/bin_spc700.c
@@ -12,9 +12,8 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 }
 
 
-static void * load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	check_bytes (buf, sz);
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 static RBinInfo* info(RBinFile *bf) {

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -16,12 +16,12 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return bin? bin->kv: NULL;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	struct r_bin_te_obj_t *res = NULL;
 	RBuffer *tbuf = NULL;
 
 	if (!buf || sz == 0 || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	tbuf = r_buf_new ();
 	r_buf_set_bytes (tbuf, buf, sz);
@@ -30,7 +30,8 @@ static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sd
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	return res;
+	*bin_obj = res;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -40,7 +41,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return bf->o->bin_obj? true: false;
 }
 

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -13,14 +13,15 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (buf && length >= 4 && !memcmp (buf, R_BIN_WASM_MAGIC_BYTES, 4));
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	if (!buf || !sz || sz == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	if (!check_bytes (buf, sz)) {
-		return NULL;
+		return false;
 	}
-	return r_bin_wasm_init (bf);
+	*bin_obj = r_bin_wasm_init (bf);
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -29,8 +30,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
-	return bf->o->bin_obj != NULL;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -77,11 +77,12 @@ static bool check_bytes (const ut8 *buf, ut64 length) {
 	return magic == r_read_be32 (buf);
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	if (check_bytes (r_buf_buffer (bf->buf), sz)) {
-		return memcpy (&n64_header, buf, sizeof (N64Header));
+		*bin_obj = memcpy (&n64_header, buf, sizeof (N64Header));
+		return true;
 	}
-	return NULL;
+	return false;
 }
 
 static bool load(RBinFile *bf) {
@@ -90,7 +91,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_zimg.c
+++ b/libr/bin/p/bin_zimg.c
@@ -14,17 +14,18 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return bin? bin->kv: NULL;
 }
 
-static void *load_bytes(RBinFile *bf, const ut8 *buf, ut64 size, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 size, ut64 loadaddr, Sdb *sdb){
 	void *res = NULL;
 	RBuffer *tbuf = NULL;
 	if (!buf || size == 0 || size == UT64_MAX) {
-		return NULL;
+		return false;
 	}
 	tbuf = r_buf_new ();
 	r_buf_set_bytes (tbuf, buf, size);
 	res = r_bin_zimg_new_buf (tbuf);
 	r_buf_free (tbuf);
-	return res;
+	*bin_obj = res;
+	return true;
 }
 
 static bool load(RBinFile *bf) {
@@ -33,8 +34,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	bf->o->bin_obj = load_bytes (bf, bytes, size, bf->o->loadaddr, bf->sdb);
-	return bf->o->bin_obj? true: false;
+	return load_bytes (bf, &bf->o->bin_obj, bytes, size, bf->o->loadaddr, bf->sdb);
 }
 
 static ut64 baddr(RBinFile *bf) {

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -394,7 +394,7 @@ typedef struct r_bin_plugin_t {
 	int (*fini)(void *user);
 	Sdb * (*get_sdb)(RBinFile *obj);
 	bool (*load)(RBinFile *arch);
-	void *(*load_bytes)(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb);
+	bool (*load_bytes)(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb);
 	void *(*load_buffer)(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb);
 	ut64 (*size)(RBinFile *bin); // return ut64 maybe? meh
 	int (*destroy)(RBinFile *arch);

--- a/libr/include/r_types_base.h
+++ b/libr/include/r_types_base.h
@@ -60,8 +60,6 @@ typedef struct _utX{
 #include <stdbool.h>
 
 #define R_FAIL -1
-// must be deprecated
-#define R_NOTNULL (void*)(size_t)1
 #define R_EMPTY { 0 }
 #define R_EMPTY2 {{ 0 }}
 


### PR DESCRIPTION
First step of refactoring. load_bytes() first parameter may not be
needed because of bf, depending on its use cases. Needs further testing.

Closes #11553