### PR TITLE
format/elf: fix is_in_pphdr function (fix #11377)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,4 +19,5 @@ AllowShortLoopsOnASingleLine: false
 AlignAfterOpenBracket: DontAlign
 AlignTrailingComments: false
 AlignOperands: false
+Cpp11BracedListStyle: false
 ForEachMacros: ['r_list_foreach', 'ls_foreach', 'fcn_tree_foreach_intersect', 'r_skiplist_foreach', 'graph_foreach_anode']

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -140,24 +140,33 @@ R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr) {
 		"reloc.",
 		"sym.imp.",
 		"imp.",
-		NULL
+		NULL,
 	};
-	if (str[0] == str[1] && *str == '_') {
-		str++;
+	char *tmpstr, *tmpptr;
+
+	tmpstr = tmpptr = strdup (str);
+	if (tmpptr[0] == tmpptr[1] && *tmpptr == '_') {
+		tmpptr++;
 	}
 	for (i = 0; prefixes[i]; i++) {
 		int plen = strlen (prefixes[i]);
-		if (!strncmp (str, prefixes[i], plen)) {
-			str += plen;
+		if (!strncmp (tmpptr, prefixes[i], plen)) {
+			tmpptr += plen;
 			break;
 		}
 	}
+	// remove CXXABI suffix
+	char *cxxabi = strstr (tmpptr, "@@CXXABI");
+	if (cxxabi) {
+		*cxxabi = '\0';
+	}
 #if WITH_GPL
-	char *out = cplus_demangle_v3 (str, flags);
+	char *out = cplus_demangle_v3 (tmpptr, flags);
 #else
 	/* TODO: implement a non-gpl alternative to c++v3 demangler */
 	char *out = NULL;
 #endif
+	free (tmpstr);
 	if (out) {
 		r_str_replace_char (out, ' ', 0);
 	}

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -140,28 +140,28 @@ R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr) {
 		"reloc.",
 		"sym.imp.",
 		"imp.",
-		NULL,
+		NULL
 	};
-	char *tmpstr, *tmpptr;
+	char *tmpstr = strdup (str);
+	char *p = tmpstr;
 
-	tmpstr = tmpptr = strdup (str);
-	if (tmpptr[0] == tmpptr[1] && *tmpptr == '_') {
-		tmpptr++;
+	if (p[0] == p[1] && *p == '_') {
+		p++;
 	}
 	for (i = 0; prefixes[i]; i++) {
 		int plen = strlen (prefixes[i]);
-		if (!strncmp (tmpptr, prefixes[i], plen)) {
-			tmpptr += plen;
+		if (!strncmp (p, prefixes[i], plen)) {
+			p += plen;
 			break;
 		}
 	}
 	// remove CXXABI suffix
-	char *cxxabi = strstr (tmpptr, "@@CXXABI");
+	char *cxxabi = strstr (p, "@@CXXABI");
 	if (cxxabi) {
 		*cxxabi = '\0';
 	}
 #if WITH_GPL
-	char *out = cplus_demangle_v3 (tmpptr, flags);
+	char *out = cplus_demangle_v3 (p, flags);
 #else
 	/* TODO: implement a non-gpl alternative to c++v3 demangler */
 	char *out = NULL;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3300,7 +3300,7 @@ static int is_in_pphdr(Elf_(Phdr) * p, ut64 addr) {
 }
 
 static int is_in_vphdr(Elf_(Phdr) * p, ut64 addr) {
-	return addr >= p->p_vaddr && addr < p->p_vaddr + p->p_memsz;
+	return addr >= p->p_vaddr && addr < p->p_vaddr + p->p_filesz;
 }
 
 /* Deprecated temporarily. Use r_bin_elf_p2v_new in new code for now. */

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3295,14 +3295,13 @@ ELFOBJ* Elf_(r_bin_elf_new_buf)(RBuffer *buf, bool verbose) {
 	return bin;
 }
 
-static int is_in_pphdr (Elf_(Phdr) *p, ut64 addr) {
-	return addr >= p->p_offset && addr < p->p_offset + p->p_memsz;
+static int is_in_pphdr(Elf_(Phdr) * p, ut64 addr) {
+	return addr >= p->p_offset && addr < p->p_offset + p->p_filesz;
 }
 
-static int is_in_vphdr (Elf_(Phdr) *p, ut64 addr) {
+static int is_in_vphdr(Elf_(Phdr) * p, ut64 addr) {
 	return addr >= p->p_vaddr && addr < p->p_vaddr + p->p_memsz;
 }
-
 
 /* Deprecated temporarily. Use r_bin_elf_p2v_new in new code for now. */
 ut64 Elf_(r_bin_elf_p2v) (ELFOBJ *bin, ut64 paddr) {


### PR DESCRIPTION
That function should check if an address is in the file "side" of the
phdr, so it should check for filesz and not memsz