### PR TITLE
Parse add instruction in mips.pseudo

### DIFF
--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -30,6 +30,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		char *str;
 		int max_operands;
 	} ops[] = {
+		{ "add", "1 = 2 + 3", 3},
 		{ "addi",  "1 = 2 + 3", 3},
 		{ "addiu",  "1 = 2 + 3", 3},
 		{ "addu",  "1 = 2 + 3", 3},


### PR DESCRIPTION
For some reason the `add` instruction is missing, so I added it.