### PR TITLE
Fix debugging in FreeBSD 11.2

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3916,7 +3916,7 @@ static int cmd_print(void *data, const char *input) {
 		}
 	}
 
-	if (input[0] && input[0] != 'z' && input[1] == 'f') {
+	if (input[0] && input[0] != 'z' && input[1] == 'f' && input[2]!='?') {
 		RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset, 0);
 		// R_ANAL_FCN_TYPE_FCN|R_ANAL_FCN_TYPE_SYM);
 		if (f) {

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -221,8 +221,7 @@ static int r_debug_native_continue_syscall (RDebug *dbg, int pid, int num) {
 #elif __BSD__
 	ut64 pc = r_debug_reg_get (dbg, "PC");
 	errno = 0;
-	int retVal = ptrace (PTRACE_SYSCALL, pid, (void*)(size_t)pc, 0);
-	return 0==retVal;
+	return ptrace (PTRACE_SYSCALL, pid, (void*)(size_t)pc, 0) == 0;
 #else
 	eprintf ("TODO: continue syscall not implemented yet\n");
 	return -1;


### PR DESCRIPTION
In FreeBSD 11.2 (stable) radare2 has issues with debugging - it does not disable/enable breakpoints correctly leading to wrong analysis and also to unusable debugging. This patch fixes this issue.