### PR TITLE
Fix #11736 doc/fortunes.tips - improper entry

### DIFF
--- a/doc/fortunes.tips
+++ b/doc/fortunes.tips
@@ -77,7 +77,6 @@ Run your own r2 scripts in awk using the r2awk program.
 Use '-e bin.strings=false' to disable automatic string search when loading the binary.
 The unix-like reverse engineering framework.
 This code was intentionally left blank, try 'e asm.arch = ws'
-For a full list of commands see `strings /dev/urandom`
 Thanks for using radare2!
 give | and > a try piping and redirection
 Run .dmm* to load the flags of the symbols of all modules loaded in the debugger


### PR DESCRIPTION
Fix #11736 
Removed the following entry:
For a full list of commands see `strings /dev/urandom`