### PR TITLE
Print marks on flags  if asm.offset=false

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -439,17 +439,6 @@ static void ds_comment_lineup(RDisasmState *ds) {
 	_ALIGN;
 }
 
-static void ds_begin_comment(RDisasmState *ds) {
-	if (ds->show_comment_right) {
-		_ALIGN;
-	} else {
-		if (ds->use_json) {
-			ds_begin_json_line (ds);
-		}
-		ds_pre_xrefs (ds, false);
-	}
-}
-
 static void ds_comment_(RDisasmState *ds, bool align, bool nl, const char *format, va_list ap) {
 	if (ds->show_comments) {
 		if (ds->show_comment_right && align) {
@@ -1408,6 +1397,17 @@ static void ds_pre_xrefs(RDisasmState *ds, bool no_fcnlines) {
 	ds->line = tmp;
 }
 
+static void ds_begin_comment(RDisasmState *ds) {
+	if (ds->show_comment_right) {
+		_ALIGN;
+	} else {
+		if (ds->use_json) {
+			ds_begin_json_line (ds);
+		}
+		ds_pre_xrefs (ds, false);
+	}
+}
+
 static int var_comparator(const RAnalVar *a, const RAnalVar *b){
 	if (a && b) {
 		return a->delta > b->delta;
@@ -1981,11 +1981,14 @@ static void ds_show_flags(RDisasmState *ds) {
 		}
 		ds_begin_json_line (ds);
 
+
 		bool fake_flag_marks = (!ds->show_offset && ds->show_marks);
-		if (ds->show_flgoff && ds->show_offset) {
+		if (ds->show_flgoff) {
 			ds_beginline (ds);
 			ds_print_offset (ds);
-			r_cons_printf (" ");
+			if (!fake_flag_marks) {
+				r_cons_printf (" ");
+			}
 		} else {
 			bool no_fcn_lines = (f && f->addr == flag->offset);
 			ds_pre_xrefs (ds, no_fcn_lines);
@@ -2007,7 +2010,7 @@ static void ds_show_flags(RDisasmState *ds) {
 			}
 		}
 
-		if (!ds->show_flgoff) {
+		if (!ds->show_flgoff || fake_flag_marks) {
 			r_cons_printf (";-- ");
 		}
 


### PR DESCRIPTION
closes #11062 

Now if offset is disabled and marks are enabled, mark space will be printed on flags too.
This avoid ugly alignment like this:
```
/ (fcn) fcn.00401000 31
|   fcn.00401000 ();
|           ; var int local_8h @ ebp-0x8
|           ; var int local_4h @ ebp-0x4
|                push ebp
|                mov  ebp, esp
|                sub  esp, 8
|                nop
|                mov  eax, 0x402000
|                mov  dword [local_4h], eax
```
and substitutes with this
```
/ (fcn) fcn.00401000 31
|   fcn.00401000 ();
|               ; var int local_8h @ ebp-0x8
|               ; var int local_4h @ ebp-0x4
|                push ebp
|                mov  ebp, esp
|                sub  esp, 8
|                nop
|                mov  eax, 0x402000
|                mov  dword [local_4h], eax
```
This will duplicate marks on flags, though. I didn't do it, but if it's a problem I can easily change it to whitespace only