### PR TITLE
Catching leaked mem

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -486,7 +486,7 @@ R_API bool r_bin_load_io2(RBin *bin, int fd, ut64 baseaddr, ut64 loadaddr, int x
 			bin, fname, buf_bytes, sz, file_sz, bin->rawstr,
 			baseaddr, loadaddr, fd, name, NULL, offset, true);
 	} else {
-		R_FREE (buf_bytes);
+		free (buf_bytes);
 	}
 	return binfile? r_bin_file_set_cur_binfile (bin, binfile): false;
 }

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -485,9 +485,9 @@ R_API bool r_bin_load_io2(RBin *bin, int fd, ut64 baseaddr, ut64 loadaddr, int x
 		binfile = r_bin_file_new_from_bytes (
 			bin, fname, buf_bytes, sz, file_sz, bin->rawstr,
 			baseaddr, loadaddr, fd, name, NULL, offset, true);
+	} else {
+		R_FREE (buf_bytes);
 	}
-	
-	R_FREE (buf_bytes);
 	return binfile? r_bin_file_set_cur_binfile (bin, binfile): false;
 }
 

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -486,6 +486,10 @@ R_API bool r_bin_load_io2(RBin *bin, int fd, ut64 baseaddr, ut64 loadaddr, int x
 			bin, fname, buf_bytes, sz, file_sz, bin->rawstr,
 			baseaddr, loadaddr, fd, name, NULL, offset, true);
 	}
+	
+	if (buf_bytes) {
+		R_FREE (buf_bytes);
+	}
 	return binfile? r_bin_file_set_cur_binfile (bin, binfile): false;
 }
 

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -487,9 +487,7 @@ R_API bool r_bin_load_io2(RBin *bin, int fd, ut64 baseaddr, ut64 loadaddr, int x
 			baseaddr, loadaddr, fd, name, NULL, offset, true);
 	}
 	
-	if (buf_bytes) {
-		R_FREE (buf_bytes);
-	}
+	R_FREE (buf_bytes);
 	return binfile? r_bin_file_set_cur_binfile (bin, binfile): false;
 }
 


### PR DESCRIPTION
Ref #11692. I did put a conditional in this free since at line 459 it gets freed and not necessarily recreated:

```
 459                         R_FREE (buf_bytes);
 460                         if (tfd < 0) {
 461                             tfd = iob->fd_open (io, fname, R_PERM_R, 0);
 462                         }
 463                         sz = iob->fd_size (io, tfd);
 464                         if (sz != UT64_MAX) {
 465                             buf_bytes = calloc (1, sz + 1);
 466                             if (buf_bytes) {
 467                                 (void) iob->fd_read_at (io, tfd, 0, buf_bytes, sz);
 468                             }
 469                         }
```

Does radare have a conditional free? Similar to R_FREE but only frees if the value is non-null?