### PR TITLE
Fix arm relsub when both pointer addr and pointed-to addr have flags

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3525,7 +3525,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 	bool aligned = false;
 	int refptr = ds->analop.refptr;
 	RFlagItem *f, *f2 = NULL;
-	bool f2_in_opstr = false;
+	bool f2_in_opstr = false;  /* Also if true, f exists */
 	if (!ds->show_comments || !ds->show_slow) {
 		return;
 	}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3668,12 +3668,15 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 								refptrstr = s->name;
 							}
 						}
-						ds_comment (ds, true, "; [%s%s0x%" PFMT64x":%d]=%s%s0x%" PFMT64x "%s%s",
-							f2_in_opstr ? f->name : "",  f2_in_opstr ? " " : "",
-							refaddr, refptr, refptrstr, *refptrstr?".":"",
-							n, (flag && *flag) ? " " : "", flag);
 						if (f2_in_opstr) {
+							ds_comment (ds, true, "; [%s:%d]=%s%s0x%" PFMT64x "%s%s",
+								f->name, refptr, refptrstr, *refptrstr ? "." : "",
+								n, (flag && *flag) ? " " : "", flag);
 							flag_printed = true;
+						} else {
+							ds_comment (ds, true, "; [0x%" PFMT64x":%d]=%s%s0x%" PFMT64x "%s%s",
+								refaddr, refptr, refptrstr, *refptrstr ? "." : "",
+								n, (flag && *flag) ? " " : "", flag);
 						}
 					}
 					free (msg2);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3524,7 +3524,8 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 	ut64 refaddr = p;
 	bool aligned = false;
 	int refptr = ds->analop.refptr;
-	RFlagItem *f;
+	RFlagItem *f, *f2 = NULL;
+	bool f2_in_opstr = false;
 	if (!ds->show_comments || !ds->show_slow) {
 		return;
 	}
@@ -3593,9 +3594,18 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 		if (((st64)p) > 0) {
 			f = r_flag_get_i (core->flags, p);
 			if (f) {
+				int relsub_addr = core->parser->relsub_addr;  // TODO: int??
+				if (relsub_addr && relsub_addr != p) {
+					f2 = r_flag_get_i2 (core->flags, relsub_addr);
+					if (!f2) {
+						f2 = r_flag_get_i (core->flags, relsub_addr);
+					}
+					f2_in_opstr = f2 && ds->opstr && strstr (ds->opstr, f2->name);
+				}
 				refaddr = p;
 				if (!flag_printed && !is_filtered_flag (ds, f->name)
-				    && (!ds->opstr || !strstr (ds->opstr, f->name))) {
+				    && (!ds->opstr || !strstr (ds->opstr, f->name))
+				    && !f2_in_opstr) {
 					ds_begin_comment (ds);
 					ds_comment (ds, true, "; %s", f->name);
 					ds->printed_flag_addr = p;
@@ -3621,7 +3631,6 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 					}
 				}
 			} else {
-				f = NULL;
 				if (n == UT32_MAX || n == UT64_MAX) {
 					ds_begin_comment (ds);
 					ds_comment (ds, true, "; [0x%" PFMT64x":%d]=-1",
@@ -3633,9 +3642,9 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 				} else {
 					const char *kind, *flag = "";
 					char *msg2 = NULL;
-					f = r_flag_get_i (core->flags, n);
-					if (f) {
-						flag = f->name;
+					RFlagItem *f2_ = r_flag_get_i (core->flags, n);
+					if (f2_) {
+						flag = f2_->name;
 					} else {
 						msg2 = calloc (sizeof (char), len);
 						r_io_read_at (core->io, n, (ut8*)msg2, len - 1);
@@ -3659,9 +3668,13 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 								refptrstr = s->name;
 							}
 						}
-						ds_comment (ds, true, "; [0x%" PFMT64x":%d]=%s%s0x%" PFMT64x "%s%s",
+						ds_comment (ds, true, "; [%s%s0x%" PFMT64x":%d]=%s%s0x%" PFMT64x "%s%s",
+							f2_in_opstr ? f->name : "",  f2_in_opstr ? " " : "",
 							refaddr, refptr, refptrstr, *refptrstr?".":"",
 							n, (flag && *flag) ? " " : "", flag);
+						if (f2_in_opstr) {
+							flag_printed = true;
+						}
 					}
 					free (msg2);
 				}

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -203,6 +203,7 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 	RFlagItem *flag;
 	ut64 off;
 	bool x86 = false;
+	bool arm = false;
 	bool computed = false;
 	if (p && p->cur && p->cur->name) {
 		if (strstr (p->cur->name, "x86")) {
@@ -210,6 +211,9 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 		}
 		if (strstr (p->cur->name, "m68k")) {
 			x86 = true;
+		}
+		if (strstr (p->cur->name, "arm")) {
+			arm = true;
 		}
 	}
 	if (!data || !p) {
@@ -271,13 +275,13 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 				if (!flag) {
 					flag = r_flag_get_i (f, off);
 				}
-				if (!flag && p->relsub_addr) {
+				if ((!flag || arm) && p->relsub_addr) {
 					computed = true;
 					flag2 = r_flag_get_i2 (f, p->relsub_addr);
 					if (!flag2) {
 						flag2 = r_flag_get_i (f, p->relsub_addr);
 					}
-					if (!flag) {
+					if (!flag || arm) {
 						flag = flag2;
 					}
 				}


### PR DESCRIPTION
```
$ r2 bins/elf/analysis/arm_32_flags0
 -- Most of commands accept '?' as a suffix. Use it to understand how they work :)
[0x000102c8]> e asm.bytes=false; pd 1 @ 0x000102e0; pd 1 @ 0x000102e8
```

Before:
```
0x000102e0 ldr ip, loc._d_2            ; [0x102f8:4]=0x10494 sym.__libc_csu_fini
0x000102e8 ldr r0, sym.main            ; [0x102fc:4]=0x10408 sym.main
```

After:
```
0x000102e0 ldr ip, sym.__libc_csu_fini ; [loc._d_2 0x102f8:4]=0x10494 sym.__libc_csu_fini
0x000102e8 ldr r0, sym.main            ; [0x102fc:4]=0x10408 sym.main
```

