### PR TITLE
Support of Apple/LLVM blocks extension

### DIFF
--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -142,6 +142,7 @@ struct MACH0_(obj_t) {
 	int has_canary;
 	int has_retguard;
 	int has_sanitizers;
+	int has_blocks_ext;
 	int dbg_info;
 	const char *lang;
 	int uuidn;

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -1036,6 +1036,9 @@ static void lookup_symbols(RBinFile *bf, RBinInfo *ret) {
 			if (ret->has_canary == true && is_rust == true) {
 				break;
 			}
+			if (!strcmp (symbol->name, "_NSConcreteGlobalBlock")) {
+				ret->lang = !strcmp (ret->lang, "c++") ? "c++ blocks ext." : "c blocks ext.";
+			}
 			if (strstr (symbol->name, "__stack_chk_fail") || strstr (symbol->name, "__stack_smash_handler")) {
 				ret->has_canary = true;
 			}

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -334,6 +334,9 @@ static RList* symbols(RBinFile *bf) {
 		ptr->ordinal = i;
 		bin->dbg_info = strncmp (ptr->name, "radr://", 7)? 0: 1;
 		sdb_set (symcache, sdb_fmt ("sym0x%"PFMT64x, ptr->vaddr), "found", 0);
+		if (!strncmp (ptr->name, "__Z", 3)) {
+			lang = "c++";
+		}
 		if (!strncmp (ptr->name, "type.", 5)) {
 			lang = "go";
 		} else if (!strcmp (ptr->name, "_rust_oom")) {
@@ -376,6 +379,11 @@ static RList* symbols(RBinFile *bf) {
 			}
 		}
 	}
+
+	if (bin->has_blocks_ext) {
+		lang = !strcmp (lang, "c++") ? "c++ blocks ext." : "c blocks ext.";
+	}
+
 	bin->lang = lang;
 	if (isStripped) {
 		bin->dbg_info |= R_BIN_DBG_STRIPPED;
@@ -407,6 +415,7 @@ static RList* imports(RBinFile *bf) {
 	bin->has_canary = false;
 	bin->has_retguard = -1;
 	bin->has_sanitizers = false;
+	bin->has_blocks_ext = false;
 	for (i = 0; !imports[i].last; i++) {
 		if (!(ptr = R_NEW0 (RBinImport))) {
 			break;
@@ -439,6 +448,9 @@ static RList* imports(RBinFile *bf) {
 		if (!strcmp (name, "__asan_init") ||
                    !strcmp (name, "__tsan_init")) {
 			bin->has_sanitizers = true;
+		}
+		if (!strcmp (name, "_NSConcreteGlobalBlock")) {
+			bin->has_blocks_ext = true;
 		}
 		r_list_append (ret, ptr);
 	}


### PR DESCRIPTION
Apple toolchain and LLVM provides closure extension for C/C++,
using as possible the most reliable identifier rather than
functions owners where names can appear too generics.