### PR TITLE
Do not show types/vars comments in the hexadecimal mode view

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1505,7 +1505,7 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 
 		if (core->print->use_comments) {
 			for (j = 0; j < nb_cols; j++) {
-				const char *comment = core->print->get_comments (core->print->user, addr + j);
+				const char *comment = core->print->get_comments (core->print->user, addr + j, false);
 				if (comment) {
 					r_cons_printf (" ; %s", comment);
 				}
@@ -2158,7 +2158,7 @@ r_cons_pop();
 		if (addr != UT64_MAX) {
 			const char *str = NULL;
 			if (show_comments) {
-				char *comment = r_core_anal_get_comments (core, addr);
+				char *comment = r_core_anal_get_comments (core, addr, true);
 				if (comment) {
 					if (show_offset) {
 						r_cons_printf ("%s0x%08"PFMT64x" ", use_color? pal->offset: "", addr);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1967,17 +1967,19 @@ static char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, int depth) {
 	return r_strbuf_drain (s);
 }
 
-R_API char *r_core_anal_get_comments(RCore *core, ut64 addr) {
+R_API char *r_core_anal_get_comments(RCore *core, ut64 addr, bool vartype) {
 	if (core) {
 		char *type = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, addr);
 		char *cmt = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
-		if (type && cmt) {
-			char *ret = r_str_newf ("%s %s", type, cmt);
-			free (type);
-			free (cmt);
-			return ret;
-		} else if (type) {
-			return type;
+		if (vartype) {
+			if (type && cmt) {
+				char *ret = r_str_newf ("%s %s", type, cmt);
+				free (type);
+				free (cmt);
+				return ret;
+			} else if (type) {
+				return type;
+			}
 		} else if (cmt) {
 			return cmt;
 		}
@@ -2178,8 +2180,8 @@ static char *hasrefs_cb(void *user, ut64 addr, bool verbose) {
 	return r_core_anal_hasrefs ((RCore *)user, addr, verbose);
 }
 
-static char *get_comments_cb(void *user, ut64 addr) {
-	return r_core_anal_get_comments ((RCore *)user, addr);
+static char *get_comments_cb(void *user, ut64 addr, bool vartype) {
+	return r_core_anal_get_comments ((RCore *)user, addr, vartype);
 }
 
 R_API bool r_core_init(RCore *core) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -720,7 +720,7 @@ typedef struct {
 R_API bool core_anal_bbs(RCore *core, const char* input);
 R_API bool core_anal_bbs_range (RCore *core, const char* input);
 R_API char *r_core_anal_hasrefs(RCore *core, ut64 value, bool verbose);
-R_API char *r_core_anal_get_comments(RCore *core, ut64 addr);
+R_API char *r_core_anal_get_comments(RCore *core, ut64 addr, bool vartype);
 R_API RCoreAnalStats* r_core_anal_get_stats (RCore *a, ut64 from, ut64 to, ut64 step);
 R_API void r_core_anal_stats_free (RCoreAnalStats *s);
 

--- a/libr/include/r_print.h
+++ b/libr/include/r_print.h
@@ -29,7 +29,7 @@ extern "C" {
 
 typedef int (*RPrintZoomCallback)(void *user, int mode, ut64 addr, ut8 *bufz, ut64 size);
 typedef const char *(*RPrintNameCallback)(void *user, ut64 addr);
-typedef char *(*RPrintCommentCallback)(void *user, ut64 addr);
+typedef char *(*RPrintCommentCallback)(void *user, ut64 addr, bool vartype);
 typedef const char *(*RPrintColorFor)(void *user, ut64 addr, bool verbose);
 typedef char *(*RPrintHasRefs)(void *user, ut64 addr, bool verbose);
 

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1060,7 +1060,7 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 				printfmt (" ");
 			}
 			for (j = i; j < i + inc; j++) {
-				char *comment = p->get_comments (p->user, addr + j);
+				char *comment = p->get_comments (p->user, addr + j, false);
 				if (comment) {
 					if (p && p->colorfor) {
 						a = p->colorfor (p->user, addr + j, true);


### PR DESCRIPTION
Fixes #11427 

![comment](https://user-images.githubusercontent.com/18589720/46906296-c839cd80-cf1e-11e8-9d02-d9e80c869b2d.png)
