### PR TITLE
Support PDB ages higher than 15

### DIFF
--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -72,7 +72,7 @@ typedef struct _PE_RESOURCE {
 	Pe_image_resource_data_entry *data;
 } r_pe_resource;
 
-#define GUIDSTR_LEN 34
+#define GUIDSTR_LEN 41
 #define DBG_FILE_NAME_LEN 255
 
 typedef struct SDebugInfo {


### PR DESCRIPTION
`GUIDSTR_LEN` is currently set to 34, which gives 32 characters for the PDB GUID, 1 character for the PDB age (which is tacked on the end), and the null terminator. However, PDB ages are stored as a uint32, and can thus have a maximum value of 0xFFFFFFFF, which requires up to 8 characters. PDB ages over 15 can easily be reached by automatic build processes using incremental linking.

I'm afraid I haven't built or tested this locally as I'm not currently setup for it, I ran into this issue while using `radare2` for the first time for some static analysis work. A cursory glance through and it seems that `GUIDSTR_LEN` is used consistently, so it doesn't look like any other buffers will have trouble with this.

A binary with a PDB age of 119 (0x77) can be download from here: https://crash.limetech.org/csgo-server-radare2-age-bug.dll. The GUID for this binary is currently shown by r2's `iI` command to be `14D366484A7948D2BEE7DD256C770C747` but the correct value is `14D366484A7948D2BEE7DD256C770C7477` (the 2nd 7 is missing from the end).