### PR TITLE
disasm.c: Realign after sparse to start of basic block if needed

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4830,13 +4830,19 @@ toro:
 		}
 		if (ds->pdf) {
 			static bool sparse = false;
-			if (!r_anal_fcn_bbget_in (ds->pdf, ds->at)) {
+			RAnalBlock *bb = r_anal_fcn_bbget_in (ds->pdf, ds->at);
+			if (!bb) {
 				inc = ds->oplen;
 				r_anal_op_fini (&ds->analop);
 				if (!sparse) {
 					r_cons_printf ("..\n");
 					sparse = true;
 				}
+				continue;
+			} else if (sparse && bb->addr < ds->at) {
+				inc = -(ds->at - bb->addr);
+				sparse = false;
+				r_anal_op_fini (&ds->analop);
 				continue;
 			}
 			sparse = false;


### PR DESCRIPTION
Relevant to the realignment problem shown in https://github.com/radare/radare2/issues/4007#issuecomment-175016985.

Commands:
```
$ r2 bins/pe/3ba51ca4-d4ca-11e5-906b-78db8180b654.png
e asm.bytes=false
e asm.comments=false
s 0x560e67
af
pdf
```
Before:
```
|     ::    0x00560e67      push esi
|    ,====< 0x00560e68      jmp 0x560e7d
..
|    ,====< 0x00560e80      jmp 0x560e96
..
|   | ::    0x00560e9a      add byte [eax], al
|   | ::    0x00560e9c      add byte [eax + 0x6452dc36], ch
..
|   ||::    0x00560eb2      pop eax
```
After
```
|     ::    0x00560e67      push esi
|    ,====< 0x00560e68      jmp 0x560e7d
..
|    `----> 0x00560e7d      pop esi
|     ::    0x00560e7e      push eax
|     ::    0x00560e7f      push edx
|    ,====< 0x00560e80      jmp 0x560e96
..
|   |`----> 0x00560e96      rdtsc
|   | ::    0x00560e98      jmp 0x560eb1
..
|   ||::    0x00560eb1      pop edx
```