### PR TITLE
r_util: use char * instead of void *

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -98,7 +98,7 @@ R_API bool r_sys_tts(const char *txt, bool bg);
 #define r_sys_breakpoint() __asm__ volatile ("bkpt $0");
 #else
 #warning r_sys_breakpoint not implemented for this platform
-#define r_sys_breakpoint() { void *a = NULL; *a = 0; }
+#define r_sys_breakpoint() { char *a = NULL; *a = 0; }
 #endif
 #endif
 


### PR DESCRIPTION
On some architectures it is not valid to dereference a void * (I'm
getting this error when trying to compile on ppc64le and s390x), so
let's switch to char *, which is valid.