### PR TITLE
Fix #11834 clock_nanosleep/FreeBSD.

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -9,7 +9,7 @@
 #define R_SYS_DEVNULL "/dev/null"
 #endif
 
-#if __linux__ || (__FreeBSD__ && __FreeBSD_version >= 1101000) || __NetBSD__
+#if __linux__ || (__FreeBSD__ && __FreeBSD_version >= 1101000) || (__NetBSD__ && __NetBSD_Version__ >= 700000000)
 #define HAS_CLOCK_NANOSLEEP 1
 #else
 #define HAS_CLOCK_NANOSLEEP 0

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -9,7 +9,7 @@
 #define R_SYS_DEVNULL "/dev/null"
 #endif
 
-#if __linux__ || __FreeBSD__ || __NetBSD__
+#if __linux__ || (__FreeBSD__ && __FreeBSD_version >= 1101000) || __NetBSD__
 #define HAS_CLOCK_NANOSLEEP 1
 #else
 #define HAS_CLOCK_NANOSLEEP 0


### PR DESCRIPTION
Appears only from 11.1 release.