### PR TITLE
Fixing issue #11834 (FreeBSD usleep with HAS_CLOCK_NANOSLEEP macro flagging bug)

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -9,12 +9,6 @@
 #define R_SYS_DEVNULL "/dev/null"
 #endif
 
-/* #if __linux__ || __FreeBSD__ || __NetBSD__
-#define HAS_CLOCK_NANOSLEEP 1
-#else
-#define HAS_CLOCK_NANOSLEEP 0
-#endif */ 
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -9,11 +9,11 @@
 #define R_SYS_DEVNULL "/dev/null"
 #endif
 
-#if __linux__ || __FreeBSD__ || __NetBSD__
+/* #if __linux__ || __FreeBSD__ || __NetBSD__
 #define HAS_CLOCK_NANOSLEEP 1
 #else
 #define HAS_CLOCK_NANOSLEEP 0
-#endif
+#endif */ 
 
 #ifdef __cplusplus
 extern "C" {

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -249,7 +249,7 @@ R_API void r_sys_backtrace(void) {
 }
 
 R_API int r_sys_sleep(int secs) {
-#if HAS_CLOCK_NANOSLEEP
+#if __linux__
 	struct timespec rqtp;
 	rqtp.tv_sec = secs;
 	rqtp.tv_nsec = 0;
@@ -263,7 +263,7 @@ R_API int r_sys_sleep(int secs) {
 }
 
 R_API int r_sys_usleep(int usecs) {
-#if HAS_CLOCK_NANOSLEEP
+#if __linux__
 	struct timespec rqtp;
 	rqtp.tv_sec = usecs / 1000000;
 	rqtp.tv_nsec = (usecs - (rqtp.tv_sec * 1000000)) * 1000;


### PR DESCRIPTION
Considering the FreeBSD9 CC (not clang) version that is actually unaffected to this bug  HAS_CLOCK_NANOSLEEP, see report log.