### PR TITLE
Fix cyclomatic complexity computation when jump tables are involved ##anal

### DIFF
--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2010-2016 - pancake, nibble */
+/* radare - LGPL - Copyright 2010-2018 - pancake, nibble */
 
 #include <r_anal.h>
 #include <r_util.h>

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1967,7 +1967,10 @@ R_API int r_anal_fcn_cc(RAnalFunction *fcn) {
 
 	r_list_foreach (fcn->bbs, iter, bb) {
 		N++; // nodes
-		if (bb->jump == UT64_MAX) {
+		if (bb->jump == UT64_MAX && bb->fail != UT64_MAX) {
+			eprintf ("Warning: invalid bb jump/fail pair\n");
+		}
+		if (bb->jump == UT64_MAX && bb->fail == UT64_MAX) {
 			P++; // exit nodes
 		} else {
 			E++; // edges
@@ -1975,8 +1978,17 @@ R_API int r_anal_fcn_cc(RAnalFunction *fcn) {
 				E++;
 			}
 		}
+		if (bb->cases) { // dead code ?
+			E += r_list_length (bb->cases);
+		}
+		if (bb->switch_op && bb->switch_op->cases) {
+			E += r_list_length (bb->switch_op->cases);
+		}
 	}
-	return E - N + 2; // (2 * P);
+
+	int result = E - N + (2 * P);
+	r_return_val_if_fail (result > 0, 0);
+	return result;
 }
 
 R_API char *r_anal_fcn_to_string(RAnal *a, RAnalFunction *fs) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2517,7 +2517,6 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn) {
 				fcn->diff->type == R_ANAL_DIFF_TYPE_MATCH?"MATCH":
 				fcn->diff->type == R_ANAL_DIFF_TYPE_UNMATCH?"UNMATCH":"NEW");
 	}
-
 	r_cons_printf ("\nnum-bbs: %d", r_list_length (fcn->bbs));
 	r_cons_printf ("\nedges: %d", r_anal_fcn_count_edges (fcn, &ebbs));
 	r_cons_printf ("\nend-bbs: %d", ebbs);
@@ -2579,7 +2578,7 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn) {
 		if (fcn->diff->addr != -1) {
 			r_cons_printf ("addr: 0x%"PFMT64x, fcn->diff->addr);
 		}
-		if (fcn->diff->name != NULL) {
+		if (fcn->diff->name) {
 			r_cons_printf ("function: %s", fcn->diff->name);
 		}
 	}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7536,6 +7536,7 @@ static int cmd_anal(void *data, const char *input) {
 	case 'f': // "af"
 		{
 		int res = cmd_anal_fcn (core, input);
+		run_pending_anal (core);
 		if (!res) {
 			return false;
 		}


### PR DESCRIPTION
* Add asserts and checks to ensure the graph is correct before analysis
* Use correct E-N+2P formulae
* Run afbe right after af to get the jmptbl info loaded asap