### PR TITLE
Fix ptrace musl compability

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -26,12 +26,12 @@
 #include <sys/ptrace.h>
 #endif
 
-#if defined(__APPLE__) || __sun || __FreeBSD__ || __OpenBSD__
-typedef int r_ptrace_request_t;
-typedef int r_ptrace_data_t;
-#else
+#if defined(__GLIBC__) && defined(__linux__)
 typedef enum __ptrace_request r_ptrace_request_t;
 typedef void * r_ptrace_data_t;
+#else
+typedef int r_ptrace_request_t;
+typedef int r_ptrace_data_t;
 #endif
 #endif
 


### PR DESCRIPTION
musl libc doesn't use `enum __ptrace_request`. This causes two problems when trying to compile for it:

`libr/include/r_io.h` defaults to `__enum ptrace_request`, inverting the logic and only using the enum when building for glibc fixes this.

`shlr/ptrace_wrap` uses `enum __ptrace_request`. I see no option to disable `ptrace_wrap` at configure time without patching the meson or configure files. Using the same `typedef` as in `libr/include/r_io.h` fixes `ptrace_wrap` for musl.