### PR TITLE
First stage of supporting xrefs in Panels Disassembly.

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -3102,6 +3102,11 @@ repeat:
 	case '_':
 		r_core_visual_hud (core);
 		break;
+	case 'x':
+		r_core_visual_refs (core, true);
+		core->panels->panel[core->panels->curnode].addr = core->offset;
+		setRefreshAll (panels);
+		break;
 	case 'X':
 		delCurPanel (panels);
 		setRefreshAll (panels);


### PR DESCRIPTION
Future plan would be to support some options that splits the screen of disassembly in two, one for before xref-jump and the other for after xref-jump.