### PR TITLE
Fix typo initiatized -> initialized

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -25,7 +25,7 @@ static bool r_anal_emul_init(RCore *core, RConfigHold *hc) {
 	const char *bp = r_reg_get_name (core->anal->reg, R_REG_NAME_BP);
 	const char *sp = r_reg_get_name (core->anal->reg, R_REG_NAME_SP);
 	if ((bp && !r_reg_getv (core->anal->reg, bp)) && (sp && !r_reg_getv (core->anal->reg, sp))) {
-		eprintf ("Stack isn't initiatized.\n");
+		eprintf ("Stack isn't initialized.\n");
 		eprintf ("Try running aei and aeim commands before aftm for default stack initialization\n");
 		return false;
 	}


### PR DESCRIPTION
I saw this message during analysis that wasn't using proper English
> Stack isn't initiatized.

The correct word is initialized. Not sure if this was a typo or a mistake by a non-native speaker. It doesn't really matter. Here's a quick fix.