### PR TITLE
bin/bin.c: check if o->libs is NULL before calling r_list_length

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -945,7 +945,7 @@ R_API int r_bin_is_stripped(RBin *bin) {
 R_API int r_bin_is_static(RBin *bin) {
 	r_return_val_if_fail (bin, false);
 	RBinObject *o = r_bin_cur_object (bin);
-	if (o && r_list_length (o->libs) > 0) {
+	if (o && o->libs && r_list_length (o->libs) > 0) {
 		return R_BIN_DBG_STATIC & o->info->dbg_info;
 	}
 	return true;


### PR DESCRIPTION
The "iI" (and consequently "ia") commands were failing on assert because
of that.

Fixes #11881