### PR TITLE
Fixed garbage printing for `psi`, `psb` and `psz` (missing \0-termina…

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4767,12 +4767,13 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'i': // "psi"
 			if (l > 0) {
-				ut8 *buf = malloc (1024);
+				ut8 *buf = malloc (1024 + 1);
 				int delta = 512;
 				ut8 *p, *e, *b;
 				if (!buf) {
 					return 0;
 				}
+				buf[1024] = 0;
 				if (core->offset < delta) {
 					delta = core->offset;
 				}
@@ -4809,7 +4810,7 @@ static int cmd_print(void *data, const char *input) {
 				char *s = malloc (core->blocksize + 1);
 				int i, j, hasnl = 0;
 				if (s) {
-					memset (s, 0, core->blocksize);
+					memset (s, 0, core->blocksize + 1);
 					if (!quiet) {
 						r_print_offset (core->print, core->offset, 0, 0, 0, 0, NULL);
 					}
@@ -4847,7 +4848,7 @@ static int cmd_print(void *data, const char *input) {
 				char *s = malloc (core->blocksize + 1);
 				int i, j;
 				if (s) {
-					memset (s, 0, core->blocksize);
+					memset (s, 0, core->blocksize + 1);
 					// TODO: filter more chars?
 					for (i = j = 0; i < core->blocksize; i++) {
 						char ch = (char) core->block[i];


### PR DESCRIPTION
…tor which led to heap read out of bounds error)

Problem description:
Having the following string in a binary:
![image](https://user-images.githubusercontent.com/14978853/47386143-955cba00-d714-11e8-9940-fa6818ede0fa.png)

`psz` command reads string wrong. This pull request solves the first one - reading additional memory lack of `\0`-terminator character while printing (marked in red)
![image](https://user-images.githubusercontent.com/14978853/47386110-84ac4400-d714-11e8-8489-197a800dec4e.png)

Other attempts to print this string:
![image](https://user-images.githubusercontent.com/14978853/47386317-043a1300-d715-11e8-9d45-dd3ae59c6a1c.png)

This PR doesn't solve strings truncation.