### PR TITLE
Fix #11919 - r_sleb128() checks for end

### DIFF
--- a/libr/util/uleb128.c
+++ b/libr/util/uleb128.c
@@ -114,6 +114,7 @@ R_API st64 r_sleb128(const ut8 **data, const ut8 *end) {
 	st64 result = 0;
 	int offset = 0;
 	ut8 value;
+	bool _;
  	do {
 		st64 chunk;
 		value = *p;
@@ -121,7 +122,7 @@ R_API st64 r_sleb128(const ut8 **data, const ut8 *end) {
 		result |= (chunk << offset);
 		offset += 7;
 	}
-	while (*p++ & 0x80);
+	while (_ = *p & 0x80 && p + 1 < end, p++, _);
 
 	if ((value & 0x40) != 0) {
 		result |= ~0UL << offset;


### PR DESCRIPTION
Associated clusterfuzz bin is already in r2r. I think I did the fix for #11126 before I discovered the joys of ASAN builds.