### PR TITLE
asm.bb.middle: Realign disasm on bb start

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2536,6 +2536,7 @@ R_API int r_core_config_init(RCore *core) {
 		"3 = realign at middle flag if sym.*", NULL);
 	SETDESC (n, "Realign disassembly if there is a flag in the middle of an instruction");
 	SETCB ("asm.flags.real", "false", &cb_flag_realnames, "Show flags unfiltered realnames instead of names");
+	SETPREF ("asm.bb.middle", "true", "Realign disassembly if a basic block starts in the middle of an instruction");
 	SETPREF ("asm.lbytes", "true", "Align disasm bytes to left");
 	SETPREF ("asm.lines", "true", "Show ASCII-art lines at disassembly");
 	SETPREF ("asm.lines.bb", "true", "Show flow lines at jumps");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1376,7 +1376,7 @@ static int handleMidBB(RCore *core, RDisasmState *ds) {
 					ds->hasMidbb = true;
 					return bb->addr - ds->at;
 				} else {
-					i += bb->size;
+					i += bb->size - (ds->at - bb->addr);
 					continue;
 				}
 			}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1364,24 +1364,18 @@ static int handleMidFlags(RCore *core, RDisasmState *ds, bool print) {
 }
 
 static int handleMidBB(RCore *core, RDisasmState *ds) {
-	int i = 1;
+	int i;
 	// Unfortunately, can't just check the addr of the last insn byte since
 	// a bb (and fcn) can be as small as 1 byte
-	while (i < ds->oplen) {
+	for (i = 1; i < ds->oplen; i++) {
 		RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, ds->at + i, 0);
 		if (fcn) {
 			RAnalBlock *bb = r_anal_fcn_bbget_in (fcn, ds->at + i);
-			if (bb) {
-				if (bb->addr > ds->at) {
-					ds->hasMidbb = true;
-					return bb->addr - ds->at;
-				} else {
-					i += bb->size - (ds->at - bb->addr);
-					continue;
-				}
+			if (bb && bb->addr > ds->at) {
+				ds->hasMidbb = true;
+				return bb->addr - ds->at;
 			}
 		}
-		i++;
 	}
 	ds->hasMidbb = false;
 	return 0;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1364,18 +1364,24 @@ static int handleMidFlags(RCore *core, RDisasmState *ds, bool print) {
 }
 
 static int handleMidBB(RCore *core, RDisasmState *ds) {
-	int i;
+	int i = 1;
 	// Unfortunately, can't just check the addr of the last insn byte since
 	// a bb (and fcn) can be as small as 1 byte
-	for (i = 1; i < ds->oplen; i++) {
+	while (i < ds->oplen) {
 		RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, ds->at + i, 0);
 		if (fcn) {
 			RAnalBlock *bb = r_anal_fcn_bbget_in (fcn, ds->at + i);
-			if (bb && bb->addr > ds->at) {
-				ds->hasMidbb = true;
-				return bb->addr - ds->at;
+			if (bb) {
+				if (bb->addr > ds->at) {
+					ds->hasMidbb = true;
+					return bb->addr - ds->at;
+				} else {
+					i += bb->size;
+					continue;
+				}
 			}
 		}
+		i++;
 	}
 	ds->hasMidbb = false;
 	return 0;


### PR DESCRIPTION
Fixes the problem shown in https://github.com/radare/radare2/issues/4007#issuecomment-175016985. Currently for disasm only. Not sure whether defaulting it to true is ok performance-wise.