### PR TITLE
improve MSVC demangling

### DIFF
--- a/libr/bin/blang.c
+++ b/libr/bin/blang.c
@@ -77,10 +77,7 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 	bool isPe = strstr (ft, "pe");
 
 	if (unknownType || !(isMacho || isElf || isPe)) {
-		cantbe.swift = true;
-		cantbe.cxx = true;
-		cantbe.objc = true;
-		cantbe.dlang = true;
+		return R_BIN_NM_NONE;
 	}
 
 	r_list_foreach (o->symbols, iter, sym) {

--- a/libr/bin/blang.c
+++ b/libr/bin/blang.c
@@ -76,6 +76,13 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 	bool isElf = strstr (ft, "elf");
 	bool isPe = strstr (ft, "pe");
 
+	if (unknownType || !(isMacho || isElf || isPe)) {
+		cantbe.swift = true;
+		cantbe.cxx = true;
+		cantbe.objc = true;
+		cantbe.dlang = true;
+	}
+
 	r_list_foreach (o->symbols, iter, sym) {
 		char *lib;
 		if (!cantbe.rust) {
@@ -86,10 +93,6 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 		}
 		if (!cantbe.swift) {
 			bool hasswift = false;
-			if (unknownType || !(isMacho || isElf)) {
-				cantbe.swift = false;
-				continue;
-			}
 			if (!swiftIsChecked) {
 				r_list_foreach (o->libs, iter2, lib) {
 					if (strstr (lib, "swift")) {
@@ -106,16 +109,16 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 		}
 		if (!cantbe.cxx) {
 			bool hascxx = false;
-			if (unknownType || !(isMacho || isElf)) {
-				cantbe.swift = false;
-				continue;
-			}
 			if (!cxxIsChecked) {
 				r_list_foreach (o->libs, iter2, lib) {
 					if (strstr (lib, "stdc++") ||
 					    strstr (lib, "c++")) {
 						hascxx = true;
 						break;
+					}
+					if (strstr (lib, "msvcp")) {
+						info->lang = "msvc";
+						return R_BIN_NM_MSVC;
 					}
 				}
 				cxxIsChecked = true;
@@ -126,10 +129,6 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 			}
 		}
 		if (!cantbe.objc) {
-			if (unknownType || !(isMacho || isElf)) {
-				cantbe.objc = true;
-				continue;
-			}
 			if (check_objc (sym)) {
 				info->lang = "objc";
 				return R_BIN_NM_OBJC;
@@ -137,10 +136,6 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 		}
 		if (!cantbe.dlang) {
 			bool hasdlang = false;
-			if (unknownType && !(isMacho || isElf || isPe)) {
-				cantbe.dlang = true;
-				continue;
-			}
 			if (!phobosIsChecked) {
 				r_list_foreach (o->libs, iter2, lib) {
 					if (strstr (lib, "phobos")) {

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -88,11 +88,29 @@ R_API char *r_bin_demangle(RBinFile *binfile, const char *def, const char *str, 
 		return NULL;
 	}
 	RBin *bin = binfile? binfile->rbin: NULL;
+	RBinObject *o = binfile? binfile->o: NULL;
+	RListIter *iter;
+	const char *lib;
+	if (!strncmp (str, "reloc.", 6)) {
+		str += 6;
+	}
 	if (!strncmp (str, "sym.", 4)) {
 		str += 4;
 	}
 	if (!strncmp (str, "imp.", 4)) {
 		str += 4;
+	}
+	if (o) {
+		r_list_foreach (o->libs, iter, lib) {
+			size_t len = strlen(lib);
+			if (!strncasecmp (str, lib, len)) {
+				str += len;
+				if (*str == '_') {
+					str++;
+				}
+				break;
+			}
+		}
 	}
 	if (!strncmp (str, "__", 2)) {
 		if (str[2] == 'T') {
@@ -115,6 +133,7 @@ R_API char *r_bin_demangle(RBinFile *binfile, const char *def, const char *str, 
 	case R_BIN_NM_OBJC: return r_bin_demangle_objc (NULL, str);
 	case R_BIN_NM_SWIFT: return r_bin_demangle_swift (str, bin? bin->demanglercmd: false);
 	case R_BIN_NM_CXX: return r_bin_demangle_cxx (binfile, str, vaddr);
+	case R_BIN_NM_MSVC: return r_bin_demangle_msvc (str);
 	case R_BIN_NM_DLANG: return r_bin_demangle_plugin (bin, "dlang", str);
 	}
 	return NULL;

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -102,7 +102,7 @@ R_API char *r_bin_demangle(RBinFile *binfile, const char *def, const char *str, 
 	}
 	if (o) {
 		r_list_foreach (o->libs, iter, lib) {
-			size_t len = strlen(lib);
+			size_t len = strlen (lib);
 			if (!r_str_ncasecmp (str, lib, len)) {
 				str += len;
 				if (*str == '_') {

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -103,7 +103,7 @@ R_API char *r_bin_demangle(RBinFile *binfile, const char *def, const char *str, 
 	if (o) {
 		r_list_foreach (o->libs, iter, lib) {
 			size_t len = strlen(lib);
-			if (!strncasecmp (str, lib, len)) {
+			if (!r_str_ncasecmp (str, lib, len)) {
 				str += len;
 				if (*str == '_') {
 					str++;


### PR DESCRIPTION
- fix language type detection logic when handling variables
  unknownType, is{Macho, isElf, isPe}
- set language as msvc when an import library that has "msvcp" is
  found
- demangle symbols that have a dll name such as sym.imp.*.dll_*