### PR TITLE
Fix emustr info

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3130,7 +3130,7 @@ static void found_xref(RCore *core, ut64 at, ut64 xref_to, RAnalRefType type, in
 		// Add to SDB
 		if (xref_to) {
 			r_anal_xrefs_set (core->anal, at, xref_to, type);
-		}	
+		}
 	} else if (rad == 'j') {
 		// Output JSON
 		if (count > 0) {
@@ -3193,7 +3193,7 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 		eprintf ("Error: cannot allocate a temp block\n");
 		free (buf);
 		return -1;
-	}	
+	}
 	if (rad == 'j') {
 		r_cons_printf ("{");
 	}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4379,15 +4379,22 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 				// function name not resolved
 				nargs = DEFAULT_NARGS;
 				if (fcn) {
-					nargs = fcn->nargs;
+					// fcn->nargs should be used
+					nargs = r_anal_var_count (core->anal, fcn, 's', 1) +
+							r_anal_var_count (core->anal, fcn, 'b', 1) +
+							r_anal_var_count (core->anal, fcn, 'r', 1);
 				}
 				if (nargs > 0) {
-					ds_comment_middle (ds, "; CALL: ");
+					if (fcn_name) {
+						ds_comment_middle (ds, "; %s(", fcn_name);
+					} else {
+						ds_comment_middle (ds, "; 0x%"PFMT64x"(", pcv);
+					}
 					for (i = 0; i < nargs; i++) {
-						ut64 v = r_debug_arg_get (core->dbg, R_ANAL_CC_TYPE_STDCALL, i);
+						ut64 v = r_debug_arg_get (core->dbg, R_ANAL_CC_TYPE_FASTCALL, i);
 						ds_comment_middle (ds, "%s0x%"PFMT64x, i?", ":"", v);
 					}
-					ds_comment_end (ds, "");
+					ds_comment_end (ds, ")");
 				}
 			}
 			r_reg_setv (core->anal->reg, sp, spv); // reset stack ptr

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4379,7 +4379,7 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 				// function name not resolved
 				nargs = DEFAULT_NARGS;
 				if (fcn) {
-					// fcn->nargs should be used
+					// @TODO: fcn->nargs should be updated somewhere and used here instead
 					nargs = r_anal_var_count (core->anal, fcn, 's', 1) +
 							r_anal_var_count (core->anal, fcn, 'b', 1) +
 							r_anal_var_count (core->anal, fcn, 'r', 1);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -194,8 +194,8 @@ enum {
 	R_ANAL_FQUALIFIER_VIRTUAL = 5,
 };
 
-/*--------------------Function Convnetions-----------*/
-//XXX dont use then in the future
+/*--------------------Function Conventions-----------*/
+//XXX dont use them in the future
 #define R_ANAL_CC_TYPE_STDCALL 0
 #define R_ANAL_CC_TYPE_PASCAL 1
 #define R_ANAL_CC_TYPE_FASTCALL 'A' // syscall


### PR DESCRIPTION
Changes:
 * hardcoded calling convention is now R_ANAL_CC_TYPE_FASTCALL since the stack based one seems to always provide incorrect values on 32 bits elfs anyway.
 * uses function name or its address in case there is no name yet
 * uses correct number of arguments computed with `r_anal_var_count` since fcn->nargs was never updated


Before

```asm
$ r2 tailcall
 -- Starting bitcoin miner in background...
[0x00401060]> s main; pd 10
            ;-- main:
            0x00401168           push rbp
            0x00401169           mov rbp, rsp
            0x0040116c           sub rsp, 0x10
            0x00401170           mov esi, 1
            0x00401175           mov edi, 5
            0x0040117a           call sym.factorial; CALL: 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
            0x0040117f           mov dword [rbp - 8], eax
            0x00401182           mov eax, dword [rbp - 8]
            0x00401185           mov edx, eax
            0x00401187           mov esi, 5
[0x00401168]> aa; pd 10
[x] Analyze all flags starting with sym. and entry0 (aa)
            ;-- main:
┌ (fcn) sym.main 111
│   sym.main (int argc, char **argv, char **envp);
│           ; var int local_8h @ rbp-0x8
│           ; var int local_4h @ rbp-0x4
│           ; DATA XREF from entry0 (0x40107d)
│           0x00401168           push rbp
│           0x00401169           mov rbp, rsp
│           0x0040116c           sub rsp, 0x10
│           0x00401170           mov esi, 1
│           0x00401175           mov edi, 5
│           0x0040117a           call sym.factorial
│           0x0040117f           mov dword [local_8h], eax
│           0x00401182           mov eax, dword [local_8h]
│           0x00401185           mov edx, eax
│           0x00401187           mov esi, 5
```


After
```asm
$ r2 tailcall
 -- Too bad there is no gif support in r2. Yet. -- @r2gif
[0x00401060]> s main; pd 10
            ;-- main:
            0x00401168           push rbp
            0x00401169           mov rbp, rsp
            0x0040116c           sub rsp, 0x10
            0x00401170           mov esi, 1
            0x00401175           mov edi, 5
            0x0040117a           call sym.factorial; sym.factorial(0x5, 0x1, 0x0, 0x0)
            0x0040117f           mov dword [rbp - 8], eax
            0x00401182           mov eax, dword [rbp - 8]
            0x00401185           mov edx, eax
            0x00401187           mov esi, 5
[0x00401168]> aa; pd 10
[x] Analyze all flags starting with sym. and entry0 (aa)
            ;-- main:
┌ (fcn) sym.main 111
│   sym.main (int argc, char **argv, char **envp);
│           ; var int local_8h @ rbp-0x8
│           ; var int local_4h @ rbp-0x4
│           ; DATA XREF from entry0 (0x40107d)
│           0x00401168           push rbp
│           0x00401169           mov rbp, rsp
│           0x0040116c           sub rsp, 0x10
│           0x00401170           mov esi, 1
│           0x00401175           mov edi, 5
│           0x0040117a           call sym.factorial; sym.factorial(0x5, 0x1)
│           0x0040117f           mov dword [local_8h], eax
│           0x00401182           mov eax, dword [local_8h]
│           0x00401185           mov edx, eax
│           0x00401187           mov esi, 5
```


Suggestions to make this PR calling convention independent and where to update fcn->nargs are welcome.