### PR TITLE
Fixed BOF on heap when get long asm line (issue about crash with DEX)

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5485,7 +5485,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		}
 		{
 			char *aop = r_asm_op_get_asm (&asmop);
-			char *buf = malloc (128);
+			char *buf = malloc (strlen (aop) + 128);
 			if (buf) {
 				strcpy (buf, aop);
 				r_parse_filter (core->parser, ds->vat, core->flags, buf,


### PR DESCRIPTION
Related to radareorg/cutter#803

![image](https://user-images.githubusercontent.com/14978853/47744369-3ce86800-dc92-11e8-882a-6108329ca0fc.png)
