### PR TITLE
anal.jmpmid: Continue analysis after jump to middle of instruction (x86, no loops only)

### DIFF
--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -266,3 +266,22 @@ R_API ut64 r_anal_bb_opaddr_at(RAnalBlock *bb, ut64 off) {
 	}
 	return UT64_MAX;
 }
+
+/* return true if an instruction starts at a given address of the given
+ * basic block. */
+R_API bool r_anal_bb_op_starts_at(RAnalBlock *bb, ut64 addr) {
+	ut16 off, inst_off;
+	int i;
+
+	if (!r_anal_bb_is_in_offset (bb, addr)) {
+		return false;
+	}
+	off = addr - bb->addr;
+	for (i = 0; i < bb->ninstr; i++) {
+		inst_off = r_anal_bb_offset_inst (bb, i);
+		if (off == inst_off) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -328,6 +328,7 @@ R_API void r_anal_fcn_free(void *_fcn) {
 	free (fcn);
 }
 
+// TODO: overlapping basic blocks can cause problems here
 static RAnalBlock *bbget(RAnalFunction *fcn, ut64 addr) {
 	RListIter *iter;
 	RAnalBlock *bb;
@@ -883,6 +884,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 		0
 	};
 	char tmp_buf[MAX_FLG_NAME_SIZE + 5] = "skip";
+	bool x86 = anal->cur->arch && !strcmp (anal->cur->arch, "x86");
 
 	if (r_cons_is_breaked ()) {
 		return R_ANAL_RET_END;
@@ -912,11 +914,13 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 	}
 	bb = bbget (fcn, addr);
 	if (bb) {
-		r_anal_fcn_split_bb (anal, fcn, bb, addr);
-		if (anal->opt.recont) {
-			return R_ANAL_RET_END;
+		if (!anal->opt.jmpmid || !x86 || r_anal_bb_op_starts_at (bb, addr)) {
+			r_anal_fcn_split_bb (anal, fcn, bb, addr);
+			if (anal->opt.recont) {
+				return R_ANAL_RET_END;
+			}
+			return R_ANAL_RET_ERROR; // MUST BE NOT DUP
 		}
-		return R_ANAL_RET_ERROR; // MUST BE NOT DUP
 	}
 
 	bb = appendBasicBlock (anal, fcn, addr);
@@ -972,7 +976,8 @@ repeat:
 		}
 		if (idx > 0 && !overlapped) {
 			bbg = bbget (fcn, addr + idx);
-			if (bbg && bbg != bb) {
+			if (bbg && bbg != bb
+			    && (!anal->opt.jmpmid || !x86 || r_anal_bb_op_starts_at (bbg, addr + idx))) {
 				bb->jump = addr + idx;
 				overlapped = 1;
 				VERBOSE_ANAL eprintf("Overlapped at 0x%08"PFMT64x "\n", addr + idx);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -912,7 +912,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 	if (r_anal_get_fcn_at (anal, addr, 0)) {
 		return R_ANAL_RET_ERROR; // MUST BE NOT FOUND
 	}
-	bb = bbget (fcn, addr);
+	bb = bbget (fcn, addr); // TODO: bbget_all()
 	if (bb) {
 		if (!anal->opt.jmpmid || !x86 || r_anal_bb_op_starts_at (bb, addr)) {
 			r_anal_fcn_split_bb (anal, fcn, bb, addr);
@@ -975,7 +975,7 @@ repeat:
 			r_anal_hint_set_bits (anal, op.jump, op.hint.new_bits);
 		}
 		if (idx > 0 && !overlapped) {
-			bbg = bbget (fcn, addr + idx);
+			bbg = bbget (fcn, addr + idx); // TODO: bbget_all()
 			if (bbg && bbg != bb
 			    && (!anal->opt.jmpmid || !x86 || r_anal_bb_op_starts_at (bbg, addr + idx))) {
 				bb->jump = addr + idx;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2169,6 +2169,13 @@ static int cb_anal_followdatarefs(void *user, void *data) {
 	return true;
 }
 
+static int cb_anal_jmpmid(void *user, void *data) {
+	RCore *core = (RCore*) user;
+	RConfigNode *node = (RConfigNode*) data;
+	core->anal->opt.jmpmid = node->i_value;
+	return true;
+}
+
 static int cb_anal_searchstringrefs(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
@@ -2440,6 +2447,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("anal.jmpabove", "true", &cb_anal_jmpabove, "Jump above function pointer");
 	SETCB ("anal.datarefs", "false", &cb_anal_followdatarefs, "Follow data references for code coverage");
 	SETCB ("anal.brokenrefs", "false", &cb_anal_brokenrefs, "Follow function references as well if function analysis was failed");
+	SETCB ("anal.jmpmid", "false", &cb_anal_jmpmid, "Continue analysis after jump to middle of instruction (x86 only) [WIP no loops]");
 
 	SETCB ("anal.refstr", "false", &cb_anal_searchstringrefs, "Search string references in data references");
 	SETCB ("anal.bb.maxsize", "1024", &cb_anal_bb_max_size, "Maximum basic block size");

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -595,6 +595,7 @@ typedef struct r_anal_options_t {
 	int jmpref;
 	int jmpabove;
 	bool ijmp;
+	bool jmpmid; // continue analysis after jmp into middle of insn
 	int followdatarefs;
 	int searchstringrefs;
 	int followbrokenfcnsrefs;
@@ -1313,6 +1314,7 @@ R_API int r_anal_bb_is_in_offset(RAnalBlock *bb, ut64 addr);
 R_API bool r_anal_bb_set_offset(RAnalBlock *bb, int i, ut16 v);
 R_API ut16 r_anal_bb_offset_inst(RAnalBlock *bb, int i);
 R_API ut64 r_anal_bb_opaddr_at(RAnalBlock *bb, ut64 addr);
+R_API bool r_anal_bb_op_starts_at(RAnalBlock *bb, ut64 addr);
 R_API RAnalBlock *r_anal_bb_get_failbb(RAnalFunction *fcn, RAnalBlock *bb);
 R_API RAnalBlock *r_anal_bb_get_jumpbb(RAnalFunction *fcn, RAnalBlock *bb);
 


### PR DESCRIPTION
Partial fix for #10420. Currently anal.jmpmid defaults to false since WIP.