### PR TITLE
Fix args escape and unescape bugs when debug

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -880,8 +880,8 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 		return;
 	}
 	int bits = core->assembler->bits;
-	char *oldname = r_file_abspath (binpath);
-	char *newfile = r_str_newf ("dbg://%s %s", oldname, args);
+	char *escaped_path = r_str_arg_escape (binpath);
+	char *newfile = r_str_newf ("dbg://%s %s", escaped_path, args);
 	char *newfile2 = strdup (newfile);
 	desc->uri = newfile;
 	desc->referer = NULL;
@@ -905,7 +905,7 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 	}
 #endif
 	r_core_cmd0 (core, "sr PC");
-	free (oldname);
+	free (escaped_path);
 	free (binpath);
 	free (newfile);
 }

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -63,6 +63,7 @@ R_API int r_str_replace_char_once(char *s, int a, int b);
 R_API const char *r_str_rwx_i(int rwx);
 R_API void r_str_writef(int fd, const char *fmt, ...);
 R_API char *r_str_arg_escape(const char *arg);
+R_API int r_str_arg_unescape(char *arg);
 R_API char **r_str_argv(const char *str, int *_argc);
 R_API void r_str_argv_free(char **argv);
 R_API char *r_str_new(const char *str);

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -46,7 +46,6 @@
 
 
 static void trace_me (void);
-static char *get_and_escape_path (char *str);
 
 /*
  * Creates a new process and returns the result:
@@ -381,9 +380,7 @@ static int fork_and_ptraceme_for_mac(RIO *io, int bits, const char *cmd) {
 			}
 		}
 		// XXX: this is a workaround to fix spawning programs with spaces in path
-		if (strstr (argv[0], "\\ ")) {
-			argv[0] = r_str_replace (argv[0], "\\ ", " ", true);
-		}
+		r_str_arg_unescape (argv[0]);
 
 		ret = posix_spawnp (&p, argv[0], &fileActions, &attr, argv, NULL);
 		handle_posix_error (ret);
@@ -426,46 +423,6 @@ static int fork_and_ptraceme_for_mac(RIO *io, int bits, const char *cmd) {
 }
 #endif
 
-static char *get_and_escape_path (char *str) {
-#if __APPLE__ && !__POWERPC__
-// wat
-	return NULL;
-#else
-	char *path_bin = strdup (str);
-	if (!path_bin) {
-		return NULL;
-	}
-	char *p = (char*) r_str_lchr (str, '/');
-	char *pp = (char*) r_str_tok (p, ' ', -1);
-
-	if (!pp) {
-		// There is nothing more to parse
-		free (path_bin);
-		return str;
-	}
-
-	path_bin[pp - str] = '\0';
-	if (strstr (path_bin, "\\ ")) {
-		path_bin = r_str_replace (path_bin, "\\ ", " ", true);
-	}
-	char *args = path_bin + (pp - str) + 1;
-	char *path_bin_escaped = r_str_arg_escape (path_bin);
-	int len = strlen (path_bin_escaped);
-
-	char *pbe = realloc (path_bin_escaped, len + 2);
-	if (pbe) {
-		path_bin_escaped = pbe;
-		strcpy (path_bin_escaped + len, " ");
-		char *final = r_str_append (path_bin_escaped, args);
-		free (path_bin);
-		return final;
-	}
-	free (path_bin_escaped);
-	free (path_bin);
-	return NULL;
-#endif
-}
-
 typedef struct fork_child_data_t {
 	RIO *io;
 	int bits;
@@ -494,14 +451,9 @@ static void fork_child_callback(void *user) {
 		char *_cmd = data->io->args ?
 					 r_str_appendf (strdup (data->cmd), " %s", data->io->args) :
 					 strdup (data->cmd);
-		char *path_escaped = get_and_escape_path (_cmd);
 		trace_me ();
-		char **argv = r_str_argv (path_escaped, NULL);
-		if (argv && strstr (argv[0], "\\ ")) {
-			argv[0] = r_str_replace (argv[0], "\\ ", " ", true);
-		}
+		char **argv = r_str_argv (_cmd, NULL);
 		if (!argv) {
-			free (path_escaped);
 			free (_cmd);
 			return;
 		}
@@ -509,6 +461,9 @@ static void fork_child_callback(void *user) {
 			int i;
 			for (i = 3; i < 1024; i++) {
 				(void)close (i);
+			}
+			for (i = 0; argv[i]; i++) {
+				r_str_arg_unescape (argv[i]);
 			}
 			if (execvp (argv[0], argv) == -1) {
 				eprintf ("Could not execvp: %s\n", strerror (errno));
@@ -518,7 +473,6 @@ static void fork_child_callback(void *user) {
 			eprintf ("Invalid execvp\n");
 		}
 		r_str_argv_free (argv);
-		free (path_escaped);
 		free (_cmd);
 	}
 }

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1800,6 +1800,27 @@ R_API char *r_str_arg_escape(const char *arg) {
 	return realloc (str, (strlen(str)+1) * sizeof (char));
 }
 
+// Unescape the string arg to its original format
+R_API int r_str_arg_unescape(char *arg) {
+	int dest_i = 0, src_i = 0;
+	if (!arg) {
+		return 0;
+	}
+	for (src_i = 0; arg[src_i] != '\0'; src_i++) {
+		char c = arg[src_i];
+		if (c == '\\') {
+			if (arg[++src_i] == '\0') {
+				break;
+			}
+			arg[dest_i++] = arg[src_i];
+		} else {
+			arg[dest_i++] = c;
+		}
+	}
+	arg[dest_i] = '\0';
+	return dest_i;
+}
+
 R_API char **r_str_argv(const char *cmdline, int *_argc) {
 	int argc = 0;
 	int argv_len = 128; // Begin with that, argv will reallocated if necessary


### PR DESCRIPTION
e973deadca3c6c417825bcb04b02e2a38202f143 is useless after 41cb6ef0d2f39469cd30961fe81b6f7836dd504b, because the file path we get with `fd_get_name` is already an absolute path:
https://github.com/radare/radare2/blob/7b01b96f9070bbce45407f16b6382924c64ec479/libr/bin/bin.c#L217

What has been done in #9353 is totally wrong. It's impossible to separate unescaped args in a string. We should escape args before, separate and unescape them when we need them.

I think the Linux part of #11075 has been fixed.

By the way, I'm curious that is it proper to use the absolute path when we use `ood` to debug bins, even if we use relative path when we debug it in the first time? At least `argv[0]` has been changed and it may have an effect on running.
