### PR TITLE
capstone.sh: Fix shellcheck warning

### DIFF
--- a/shlr/capstone.sh
+++ b/shlr/capstone.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 CS_URL="$1" # url
 CS_BRA="$2" # branch name
 CS_TIP="$3" # tip commit
@@ -6,13 +6,13 @@ CS_REV="$4" # revert
 CS_DEPTH_CLONE=10
 
 fatal_msg() {
-	>&2 printf '[capstone] %s\n' "$1"
+	printf '[capstone] %s\n' "$1" >&2
 	exit 1
 }
 
 patch_capstone() {
 	for patchfile in ../capstone-patches/*.patch ; do
-		yes n | patch --reverse --strip 1 --input "${patchfile}"
+		yes n | patch -R -p 1 -i "${patchfile}"
 	done
 }
 
@@ -58,26 +58,26 @@ update_capstone_git() {
 }
 
 if [ -d capstone ] && [ ! -d capstone/.git ]; then
-	>&2 printf '[capstone] release with no git?\n'
+	printf '[capstone] release with no git?\n' >&2
 	cd capstone && patch_capstone
 	cd - || fatal_msg 'Cannot change working directory'
 else
 	clone_capstone
 
 	if [ "${BRANCH}" != "${CS_BRA}" ]; then
-		>&2 printf '[capstone] Reset capstone\n'
+		printf '[capstone] Reset capstone\n' >&2
 		rm -rf capstone
 		clone_capstone
 	fi
 
 	if [ "${HEAD}" = "${CS_TIP}" ]; then
-		>&2 printf '[capstone] Already in TIP, no need to update from git\n'
+		printf '[capstone] Already in TIP, no need to update from git\n' >&2
 		exit 0
 	fi
 
-	>&2 printf '[capstone] Updating capstone from git...\n'
-	>&2 printf 'HEAD %s\n' "${HEAD}"
-	>&2 printf 'TIP %s\n' "${CS_TIP}"
+	printf '[capstone] Updating capstone from git...\n' >&2
+	printf 'HEAD %s\n' "${HEAD}" >&2
+	printf 'TIP %s\n' "${CS_TIP}" >&2
 
 	cd capstone && update_capstone_git
 	cd - || fatal_msg 'Cannot change working directory'

--- a/shlr/capstone.sh
+++ b/shlr/capstone.sh
@@ -1,58 +1,84 @@
-#!/bin/sh
+#! /bin/sh
 CS_URL="$1" # url
 CS_BRA="$2" # branch name
 CS_TIP="$3" # tip commit
 CS_REV="$4" # revert
+CS_DEPTH_CLONE=10
 
-clone_capstone() {
-	if [ ! -d capstone ]; then 
-		git clone -q -b "${CS_BRA}" --depth 10 "${CS_URL}" capstone || exit 1
-	fi
-	cd capstone || exit 1
-	if [ -n "${CS_REV}" ]; then
-		HEAD="`git log|grep ^commit | head -n2|tail -n1 | awk '{print $2}'`"
-	else
-		HEAD="`git log|head -n1 | awk '{print $2}'`"
-	fi
-	BRANCH="`git branch | grep '*' | cut -d'*' -f2 | cut -d' ' -f2`"
-
-	if [ "${HEAD}" = "${CS_TIP}" ]; then
-		echo "[capstone] Already in TIP, no need to update from git"
-		exit 0
-	fi
+fatal_msg() {
+	>&2 printf '[capstone] %s\n' "$1"
+	exit 1
 }
 
-if [ -d capstone -a ! -d capstone/.git ]; then
-	echo "[capstone] release with no git?"
-	cd capstone
-	for PATCH in ../capstone-patches/* ; do
-		yes n | patch -Rp1 < $PATCH
+patch_capstone() {
+	for patchfile in ../capstone-patches/*.patch ; do
+		yes n | patch --reverse --strip 1 --input "${patchfile}"
 	done
-else
-	clone_capstone
+}
 
-	if [ "${BRANCH}" != "${CS_BRA}" ]; then
-	    echo "[capstone] Reset capstone"
-	    cd ..
-	    rm -rf capstone
-	    clone_capstone
+parse_capstone_tip() {
+	if [ -n "${CS_REV}" ]; then
+		HEAD="$(git rev-parse --verify HEAD^)"
+	else
+		HEAD="$(git rev-parse --verify HEAD)"
 	fi
+	BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+}
 
-	echo "[capstone] Updating capstone from git..."
-	echo "HEAD ${HEAD}"
-	echo "TIP ${CS_TIP}"
+clone_capstone() {
+	if [ ! -d capstone ]; then
+		git clone --quiet --single-branch --branch "${CS_BRA}" \
+		    --depth "$CS_DEPTH_CLONE" "${CS_URL}" capstone \
+		  || fatal_msg 'Cannot clone capstone from git'
+	fi
+	cd capstone && parse_capstone_tip
+	cd - || fatal_msg 'Cannot change working directory'
+}
 
-	git reset --hard HEAD^^^
-	git checkout "${CS_BRA}" || exit 1
-	git pull
+update_capstone_git() {
+	git checkout "${CS_BRA}" || fatal_msg "Cannot checkout to branch $CS_BRA"
 	if [ -n "${CS_TIP}" ]; then
+		# if our shallow clone not contains CS_TIP, clone until it
+		# contain that commit.
+		cur_depth="$CS_DEPTH_CLONE"
+		until git cat-file -e "${CS_TIP}"'^{commit}'; do
+			cur_depth=$(( cur_depth + 10 ))
+			git pull --depth="$cur_depth"
+		done
 		git reset --hard "${CS_TIP}"
 	fi
-	if [ -n "${CS_REV}" ]; then 
+	if [ -n "${CS_REV}" ]; then
 		if ! git config user.name ; then
 			git config user.name "radare-travis"
 			git config user.email "radare-travis@foo.com"
 		fi
-		EDITOR=cat git revert --no-edit ${CS_REV}
+		env EDITOR=cat git revert --no-edit "${CS_REV}"
 	fi
+	return 0
+}
+
+if [ -d capstone ] && [ ! -d capstone/.git ]; then
+	>&2 printf '[capstone] release with no git?\n'
+	cd capstone && patch_capstone
+	cd - || fatal_msg 'Cannot change working directory'
+else
+	clone_capstone
+
+	if [ "${BRANCH}" != "${CS_BRA}" ]; then
+		>&2 printf '[capstone] Reset capstone\n'
+		rm -rf capstone
+		clone_capstone
+	fi
+
+	if [ "${HEAD}" = "${CS_TIP}" ]; then
+		>&2 printf '[capstone] Already in TIP, no need to update from git\n'
+		exit 0
+	fi
+
+	>&2 printf '[capstone] Updating capstone from git...\n'
+	>&2 printf 'HEAD %s\n' "${HEAD}"
+	>&2 printf 'TIP %s\n' "${CS_TIP}"
+
+	cd capstone && update_capstone_git
+	cd - || fatal_msg 'Cannot change working directory'
 fi


### PR DESCRIPTION
- Use $( ... ) instead of legacy \` ... \`
- Use git rev-parse instead of grepping and parsing git branch
- Prefer [ p ] && [ q ] as [ p -a q ] is not well defined
- Clone until our needed TIP commit
