### PR TITLE
Change argument type to ut8 before passing to ctype.h function

### DIFF
--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -83,7 +83,7 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 		if (no_alias && (o->pinfo & INSN_ALIAS)) {
 			continue;
 		}
-		if (isdigit ((int)(o->subset[0])) && atoi (o->subset) != xlen) {
+		if (isdigit ((ut8)(o->subset[0])) && atoi (o->subset) != xlen) {
 			continue;
 		} else {
 			break;

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4296,22 +4296,22 @@ LookupTable oplookup[] = {
 
 static x86newTokenType getToken(const char *str, size_t *begin, size_t *end) {
 	// Skip whitespace
-	while (begin && isspace ((int)str[*begin])) {
+	while (begin && isspace ((ut8)str[*begin])) {
 		++(*begin);
 	}
 
 	if (!str[*begin]) {                // null byte
 		*end = *begin;
 		return TT_EOF;
-	} else if (isalpha ((int)str[*begin])) {   // word token
+	} else if (isalpha ((ut8)str[*begin])) {   // word token
 		*end = *begin;
-		while (end && isalnum ((int)str[*end])) {
+		while (end && isalnum ((ut8)str[*end])) {
 			++(*end);
 		}
 		return TT_WORD;
-	} else if (isdigit ((int)str[*begin])) {   // number token
+	} else if (isdigit ((ut8)str[*begin])) {   // number token
 		*end = *begin;
-		while (end && isalnum ((int)str[*end])) {     // accept alphanumeric characters, because hex.
+		while (end && isalnum ((ut8)str[*end])) {     // accept alphanumeric characters, because hex.
 			++(*end);
 		}
 		return TT_NUMBER;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2839,7 +2839,7 @@ static int get_debug_info(struct PE_(r_bin_pe_obj_t)* bin, PE_(image_debug_direc
 	}
 
 	while (i < 33) {
-		res->guidstr[i] = toupper ((int) res->guidstr[i]);
+		res->guidstr[i] = toupper ((ut8) res->guidstr[i]);
 		i++;
 	}
 

--- a/libr/bin/mangling/microsoft_demangle.c
+++ b/libr/bin/mangling/microsoft_demangle.c
@@ -164,7 +164,7 @@ copy_string_err:
 int get_template (char *buf, SStrInfo *str_info) {
 	int len = 0;
 	unsigned int i = 0;
-	char *str_type_code = 0;
+	char *str_type_code = NULL;
 	char *tmp = strstr(buf, "@");
 	STypeCodeStr type_code_str;
 	// RListIter *it = NULL;
@@ -237,11 +237,11 @@ get_template_err:
 int get_namespace_and_name(	char *buf, STypeCodeStr *type_code_str,
 							int *amount_of_names)
 {
-	char *curr_pos = 0, *prev_pos = 0;
-	char *tmp = 0;
-	RList /* <SStrInfo *> */ *names_l = 0;
-	RListIter *it = 0;
-	SStrInfo *str_info = 0;
+	char *curr_pos = NULL, *prev_pos = NULL;
+	char *tmp = NULL;
+	RList /* <SStrInfo *> */ *names_l = NULL;
+	RListIter *it = NULL;
+	SStrInfo *str_info = NULL;
 
 	int len = 0, read_len = 0, tmp_len = 0;
 
@@ -402,7 +402,7 @@ int get_namespace_and_name(	char *buf, STypeCodeStr *type_code_str,
 			continue;
 		}
 
-		if (isdigit ((int)*tmp)) {
+		if (isdigit ((ut8)*tmp)) {
 			tmp = r_list_get_n (abbr_names, *tmp - '0');
 			if (!tmp) {
 				goto get_namespace_and_name_err;
@@ -642,7 +642,7 @@ DEF_STATE_ACTION(V)
 ///////////////////////////////////////////////////////////////////////////////
 char* get_num(SStateInfo *state)
 {
-	char *ptr = 0;
+	char *ptr = NULL;
 	if (*state->buff_for_parsing >= '0' && *state->buff_for_parsing <= '8') {
 		ptr = (char *) malloc (2);
 		ptr[0] = *state->buff_for_parsing + 1;
@@ -682,7 +682,7 @@ char* get_num(SStateInfo *state)
 #define MODIFIER(modifier_str) { \
 	unsigned int i = 0; \
 	EDemanglerErr err = eDemanglerErrOK; \
-	char *tmp = 0; \
+	char *tmp = NULL; \
 	STypeCodeStr tmp_str; \
 	STypeCodeStr modifier; \
 	int flag__64ptr = 0; \
@@ -786,11 +786,11 @@ DEF_STATE_ACTION(S)
 DEF_STATE_ACTION(P)
 {
 	// function pointer
-	if (isdigit ((int)*state->buff_for_parsing)) {
+	if (isdigit ((ut8)*state->buff_for_parsing)) {
 		if (*state->buff_for_parsing++ == '6') {
-			char *call_conv = 0;
-			char *ret_type = 0;
-			char *arg = 0;
+			char *call_conv = NULL;
+			char *ret_type = NULL;
+			char *arg = NULL;
 			unsigned int i = 0;
 			unsigned int is_abbr_type = 0;
 			EDemanglerErr err;
@@ -1033,7 +1033,7 @@ static EDemanglerErr get_type_code_string(char *sym, unsigned int *amount_of_rea
 	while (state.state != eTCStateEnd) {
 		run_state (&state, &type_code_str);
 		if (state.err != eTCStateMachineErrOK) {
-			*str_type_code = 0;
+			*str_type_code = NULL;
 			*amount_of_read_chars = 0;
 			switch (state.err) {
 			case eTCStateMachineErrUncorrectTypeCode:
@@ -1072,23 +1072,23 @@ static EDemanglerErr parse_microsoft_mangled_name(char *sym, char **demangled_na
 	int is_static = 0;
 	unsigned int is_abbr_type = 0;
 
-	char *access_modifier = 0;
-	char *memb_func_access_code = 0;
-	char *call_conv = 0;
-	char *storage_class_code_for_ret = 0;
-	char *ret_type = 0;
-	char *__64ptr = 0;
-	RList /* <char *> */ *func_args = 0;
-	RListIter *it = 0;
-	SStrInfo *str_arg = 0;
+	char *access_modifier = NULL;
+	char *memb_func_access_code = NULL;
+	char *call_conv = NULL;
+	char *storage_class_code_for_ret = NULL;
+	char *ret_type = NULL;
+	char *__64ptr = NULL;
+	RList /* <char *> */ *func_args = NULL;
+	RListIter *it = NULL;
+	SStrInfo *str_arg = NULL;
 
 	unsigned int i = 0;
 	unsigned int len = 0;
 
 	char *curr_pos = sym;
-	char *tmp = 0;
-	char *ptr64 = 0;
-	char *storage_class = 0;
+	char *tmp = NULL;
+	char *ptr64 = NULL;
+	char *storage_class = NULL;
 
 	memset(&type_code_str, 0, sizeof(type_code_str));
 

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1667,7 +1667,7 @@ static void r_w32_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
 	SECURITY_ATTRIBUTES sa;
 	HANDLE pipe[2] = {NULL, NULL};
 	int fd_out = -1, cons_out = -1;
-	char *_shell_cmd;
+	char *_shell_cmd = NULL;
 	LPTSTR _shell_cmd_ = NULL;
 
 	sa.nLength = sizeof (SECURITY_ATTRIBUTES);
@@ -1687,7 +1687,7 @@ static void r_w32_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
 	si.dwFlags |= STARTF_USESTDHANDLES;
 	si.cb = sizeof (si);
 	_shell_cmd = shell_cmd;
-	while (*_shell_cmd && isspace (*_shell_cmd)) {
+	while (*_shell_cmd && isspace ((ut8)*_shell_cmd)) {
 		_shell_cmd++;
 	}
 	_shell_cmd_ = r_sys_conv_utf8_to_utf16 (_shell_cmd);
@@ -3089,7 +3089,7 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 			r_list_foreach (obj->sections, it, sec){
 				ut64 addr = sec->vaddr;
 				ut64 size = sec->vsize;
-				// TODO: 
+				// TODO:
 				//if (R_BIN_SCN_EXECUTABLE & sec->perm) {
 				//	continue;
 				//}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5300,7 +5300,7 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 	case 'c': // "asc"
 		if (input[1] == 'a') {
 			if (input[2] == ' ') {
-				if (!isalpha (input[3]) && (n = r_num_math (num, input + 3)) >= 0 ) {
+				if (!isalpha ((ut8)input[3]) && (n = r_num_math (num, input + 3)) >= 0 ) {
 					si = r_syscall_get (core->anal->syscall, n, -1);
 					if (si) {
 						r_cons_printf (".equ SYS_%s %s\n", si->name, syscallNumber (n));
@@ -5324,7 +5324,7 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 			}
 		} else {
 			if (input[1] == ' ') {
-				if (!isalpha (input[2]) && (n = r_num_math (num, input + 2)) >= 0 ) {
+				if (!isalpha ((ut8)input[2]) && (n = r_num_math (num, input + 2)) >= 0 ) {
 					si = r_syscall_get (core->anal->syscall, n, -1);
 					if (si) {
 						r_cons_printf ("#define SYS_%s %s\n", si->name, syscallNumber (n));
@@ -5353,7 +5353,7 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 		break;
 	case 'l': // "asl"
 		if (input[1] == ' ') {
-			if (!isalpha (input[2]) && (n = r_num_math (num, input + 2)) >= 0 ) {
+			if (!isalpha ((ut8)input[2]) && (n = r_num_math (num, input + 2)) >= 0 ) {
 				si = r_syscall_get (core->anal->syscall, n, -1);
 				if (si)
 					r_cons_println (si->name);
@@ -6833,7 +6833,7 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 	return r_core_anal_search_xrefs (core, from, to, rad);
 }
 
-static const char *oldstr = NULL; 
+static const char *oldstr = NULL;
 
 static int compute_coverage(RCore *core) {
 	RListIter *iter;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1950,7 +1950,7 @@ static void cmd_reg_profile (RCore *core, char from, const char *str) { // "arp"
 		break;
 	case ' ': // "drp "
 		ptr = str + 2;
-		while (isspace (*ptr)) {
+		while (isspace ((ut8)*ptr)) {
 			ptr++;
 		}
 		if (r_str_startswith (ptr, "gdb ")) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2280,7 +2280,7 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 		r_str_case (r_asm_op_get_asm (&ds->asmop), 1);
 	} else if (ds->capitalize) {
 		char *ba = r_asm_op_get_asm (&ds->asmop);
-		*ba = toupper (*ba);
+		*ba = toupper ((ut8)*ba);
 	}
 	if (info && mt_sz != UT64_MAX) {
 		ds->oplen = mt_sz;

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1122,7 +1122,7 @@ static int r_core_rtr_gdb_cb(libgdbr_t *g, void *core_ptr, const char *cmd,
 		case 'r': // dr
 			r_debug_reg_sync (core->dbg, R_REG_TYPE_ALL, false);
 			be = r_config_get_i (core->config, "cfg.bigendian");
-			if (isspace (cmd[2])) { // dr reg
+			if (isspace ((ut8)cmd[2])) { // dr reg
 				const char *name, *val_ptr;
 				char new_cmd[128] = { 0 };
 				int off = 0;

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -175,7 +175,7 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 				diff = r_reg_get_value (dbg->reg, item);
 				r_reg_arena_swap (dbg->reg, false);
 				delta = value-diff;
-				if (tolower (rad) == 'j') {
+				if (tolower ((ut8)rad) == 'j') {
 					snprintf (strvalue, sizeof (strvalue),"%"PFMT64u, value);
 				} else {
 					snprintf (strvalue, sizeof (strvalue),"0x%08"PFMT64x, value);

--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -175,19 +175,19 @@ static proc_per_thread_t *get_proc_thread_content(int pid, int tid) {
 		free (t);
 		return NULL;
 	}
-	while (!isdigit (*temp_p_sigpend++)) {
+	while (!isdigit ((ut8)*temp_p_sigpend++)) {
 		//empty body
 	}
 	p_sigpend = temp_p_sigpend - 1;
-	while (isdigit (*temp_p_sigpend++)) {
+	while (isdigit ((ut8)*temp_p_sigpend++)) {
 		//empty body
 	}
 	p_sigpend[temp_p_sigpend - p_sigpend - 1] = '\0';
-	while (!isdigit (*temp_p_sighold++)) {
+	while (!isdigit ((ut8)*temp_p_sighold++)) {
 		//empty body
 	}
 	p_sighold = temp_p_sighold - 1;
-	while (isdigit (*temp_p_sighold++)) {
+	while (isdigit ((ut8)*temp_p_sighold++)) {
 		//empty body
 	}
 	p_sighold[temp_p_sighold - p_sighold - 1] = '\0';
@@ -281,7 +281,7 @@ static bool getAnonymousValue(char *keyw) {
 	if (!keyw) {
 		return false;
 	}
-	while (*keyw && isspace (*keyw)) {
+	while (*keyw && isspace ((ut8)*keyw)) {
 		keyw ++;
 	}
 	return *keyw && *keyw != '0';
@@ -831,11 +831,11 @@ static proc_per_process_t *get_proc_process_content (RDebug *dbg) {
 	temp_p_gid = strstr (buff, "Gid:");
 	/* Uid */
 	if (temp_p_uid) {
-		while (!isdigit (*temp_p_uid++))  {
+		while (!isdigit ((ut8)*temp_p_uid++))  {
 			//empty body
 		}
 		p_uid = temp_p_uid - 1;
-		while (isdigit (*temp_p_uid++)) {
+		while (isdigit ((ut8)*temp_p_uid++)) {
 			//empty body
 		}
 		p_uid[temp_p_uid - p_uid - 1] = '\0';
@@ -846,11 +846,11 @@ static proc_per_process_t *get_proc_process_content (RDebug *dbg) {
 
 	/* Gid */
 	if (temp_p_gid) {
-		while (!isdigit (*temp_p_gid++)) {
+		while (!isdigit ((ut8)*temp_p_gid++)) {
 			//empty body
 		}
 		p_gid = temp_p_gid - 1;
-		while (isdigit (*temp_p_gid++)) {
+		while (isdigit ((ut8)*temp_p_gid++)) {
 			//empty body
 		}
 		p_gid[temp_p_gid - p_gid - 1] = '\0';

--- a/libr/hash/hash.c
+++ b/libr/hash/hash.c
@@ -294,7 +294,7 @@ R_API ut64 r_hash_name_to_bits(const char *name) {
 	do {
 		/* Eat everything up to the comma */
 		for (i = 0; *ptr && *ptr != ',' && i < sizeof (tmp) - 1; i++) {
-			tmp[i] = tolower (*ptr++);
+			tmp[i] = tolower ((ut8)*ptr++);
 		}
 
 		/* Safety net */

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -229,7 +229,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	}
 	if (r_str_startswith (cmd, "pktsz")) {
 		const char *ptr = r_str_trim_ro (cmd + 5);
-		if (!isdigit (*ptr)) {
+		if (!isdigit ((ut8)*ptr)) {
 			io->cb_printf ("packet size: %u bytes\n",
 				       desc->stub_features.pkt_sz);
 			return NULL;
@@ -244,7 +244,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	}
 	if (r_str_startswith (cmd, "detach")) {
 		int res;
-		if (!isspace (cmd[6]) || !desc->stub_features.multiprocess) {
+		if (!isspace ((ut8)cmd[6]) || !desc->stub_features.multiprocess) {
 			res = gdbr_detach (desc) >= 0;
 		} else {
 			int pid = 0;
@@ -280,7 +280,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	}
 	if (r_str_startswith (cmd, "monitor")) {
 		const char *qrcmd = cmd + 8;
-		if (!isspace (cmd[7])) {
+		if (!isspace ((ut8)cmd[7])) {
 			qrcmd = "help";
 		}
 		if (gdbr_send_qRcmd (desc, qrcmd, io->cb_printf) < 0) {
@@ -296,13 +296,13 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	if (r_str_startswith (cmd, "exec_file")) {
 		const char *ptr = cmd + strlen ("exec_file");
 		char *file;
-		if (!isspace (*ptr)) {
+		if (!isspace ((ut8)*ptr)) {
 			file = gdbr_exec_file_read (desc, 0);
 		} else {
-			while (isspace (*ptr)) {
+			while (isspace ((ut8)*ptr)) {
 				ptr++;
 			}
-			if (isdigit (*ptr)) {
+			if (isdigit ((ut8)*ptr)) {
 				int pid = atoi (ptr);
 				file = gdbr_exec_file_read (desc, pid);
 			} else {
@@ -318,7 +318,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	// These are internal, not available to user directly
 	if (r_str_startswith (cmd, "retries")) {
 		int num_retries;
-		if (isspace (cmd[7]) && isdigit (cmd[8])) {
+		if (isspace ((ut8)cmd[7]) && isdigit ((ut8)cmd[8])) {
 			if ((num_retries = atoi (cmd + 8)) >= 1) {
 				desc->num_retries = num_retries;
 			}
@@ -329,7 +329,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	}
 	if (r_str_startswith (cmd, "page_size")) {
 		int page_size;
-		if (isspace (cmd[9]) && isdigit (cmd[10])) {
+		if (isspace ((ut8)cmd[9]) && isdigit ((ut8)cmd[10])) {
 			if ((page_size = atoi (cmd + 10)) >= 64) {
 				desc->page_size = page_size;
 			}

--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -326,7 +326,7 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 	char bp[32];
 	if (p->anal->reg->name[R_REG_NAME_BP]) {
 		strncpy (bp, p->anal->reg->name[R_REG_NAME_BP], sizeof (bp) -1);
-		if (isupper (*str)) {
+		if (isupper ((ut8)*str)) {
 			r_str_case (bp, true);
 		}
 		bp[sizeof(bp) - 1] = 0;

--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -427,7 +427,7 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 	char *ireg = NULL;
 	if (p->get_op_ireg) {
 		ireg = p->get_op_ireg(p->user, addr);
-	}	
+	}
 	r_list_foreach (spargs, spiter, sparg) {
 		// assuming delta always positive?
 		mk_reg_str (p->anal->reg->name[R_REG_NAME_SP], sparg->delta, true, att, ireg, oldstr, sizeof (oldstr));
@@ -504,7 +504,7 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 	char bp[32];
 	if (p->anal->reg->name[R_REG_NAME_BP]) {
 		strncpy (bp, p->anal->reg->name[R_REG_NAME_BP], sizeof (bp) - 1);
-		if (isupper (*str)) {
+		if (isupper ((ut8)*str)) {
 			r_str_case (bp, true);
 		}
 		bp[sizeof (bp) - 1] = 0;

--- a/libr/reg/profile.c
+++ b/libr/reg/profile.c
@@ -258,7 +258,7 @@ static int gdb_to_r2_profile(char *gdb) {
 	// Name Number Rel Offset Size Type Groups
 
 	// Skip whitespace at beginning of line and empty lines
-	while (isspace (*ptr)) {
+	while (isspace ((ut8)*ptr)) {
 		ptr++;
 	}
 	// It's possible someone includes the heading line too. Skip it
@@ -270,7 +270,7 @@ static int gdb_to_r2_profile(char *gdb) {
 	}
 	for (;;) {
 		// Skip whitespace at beginning of line and empty lines
-		while (isspace (*ptr)) {
+		while (isspace ((ut8)*ptr)) {
 			ptr++;
 		}
 		if (!*ptr) {

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -119,8 +119,8 @@ R_API char *r_hex_from_c_str(char *out, const char **code) {
 			case 'r': *out++='0';*out++='d';break;
 			case 'n': *out++='0';*out++='a';break;
 			case 'x': {
-				char c1 = iter[1];
-				char c2 = iter[2];
+				ut8 c1 = iter[1];
+				ut8 c2 = iter[2];
 				iter += 2;
 				if (c1 == '\0' || c2 == '\0') {
 					return NULL;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1692,7 +1692,8 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 	memset (o, 0, COLORIZE_BUFSIZE);
 	for (i = j = 0; p[i]; i++, j++) {
 		/* colorize numbers */
-		if ((ishexprefix (&p[i]) && previous != ':') || (isdigit (p[i]) && issymbol (previous))) {
+		if ((ishexprefix (&p[i]) && previous != ':') \
+		     || (isdigit ((ut8)p[i]) && issymbol (previous))) {
 			int nlen = strlen (num);
 			if (nlen + j >= sizeof (o)) {
 				eprintf ("Colorize buffer is too small\n");

--- a/libr/util/regex/engine.c
+++ b/libr/util/regex/engine.c
@@ -194,7 +194,7 @@ matcher(struct re_guts *g, char *string, size_t nmatch, RRegexMatch pmatch[],
 		/* where? */
 		if (!m->coldp) {
 			break;
-		}	
+		}
 		for (;;) {
 			NOTE("finding start");
 			endp = slow(m, m->coldp, stop, gf, gl);
@@ -243,14 +243,14 @@ matcher(struct re_guts *g, char *string, size_t nmatch, RRegexMatch pmatch[],
 		}
 		if (dp) {
 			break;
-		}			
+		}
 		/* uh-oh... we couldn't find a subexpression-level match */
 		if (!g->backrefs) {	/* must be back references doing it */
 			break;
-		}	
+		}
 		if (g->nplus || !m->lastpos) {
 			break;
-		}	
+		}
 		for (;;) {
 			if (dp != NULL || endp <= m->coldp)
 				break;		/* defeat */
@@ -263,7 +263,7 @@ matcher(struct re_guts *g, char *string, size_t nmatch, RRegexMatch pmatch[],
 			for (i = 1; i <= m->g->nsub; i++) {
 				if (m->pmatch[i].rm_so != -1) {
 					break;
-				}					
+				}
 				if (m->pmatch[i].rm_eo != -1) {
 					break;
 				}
@@ -419,7 +419,7 @@ dissect(struct match *m, char *start, char *stop, sopno startst, sopno stopst)
 				ssp = oldssp;
 			}
 			if (sep == rest) {	/* must exhaust substring */
-				if (slow(m, ssp, sep, ssub, esub) == rest) { 
+				if (slow(m, ssp, sep, ssub, esub) == rest) {
 					dp = dissect(m, ssp, sep, ssub, esub);
 					if (dp == sep) {
 						sp = rest;
@@ -988,7 +988,7 @@ step(struct re_guts *g,
 		case OOR2:		/* propagate OCH_'s marking */
 			FWD(aft, aft, 1);
 			if (OP(g->strip[pc+OPND(s)]) != O_CH) {
-				if (OP(g->strip[pc+OPND(s)]) == OOR2) {	
+				if (OP(g->strip[pc+OPND(s)]) == OOR2) {
 					FWD(aft, aft, OPND(s));
 				}
 			}
@@ -1060,7 +1060,7 @@ pchar(int ch)
 {
 	static char pbuf[10];
 
-	if (isprint(ch) || ch == ' ')
+	if (isprint((ut8)ch) || ch == ' ')
 		(void)snprintf(pbuf, sizeof pbuf, "%c", ch);
 	else
 		(void)snprintf(pbuf, sizeof pbuf, "\\%o", ch);

--- a/libr/util/regex/regex2.h
+++ b/libr/util/regex/regex2.h
@@ -155,4 +155,4 @@ struct re_guts {
 /* misc utilities */
 #undef OUT
 #define	OUT	(CHAR_MAX+1)	/* a non-character value */
-#define	ISWORD(c)	(isalnum(c) || (c) == '_')
+#define	ISWORD(c)	(isalnum((ut8)(c)) || (c) == '_')

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -673,7 +673,7 @@ R_API ut64 r_get_input_num_value(RNum *num, const char *input_value){
 }
 
 static bool isHexDigit (const char _ch) {
-	const char ch = tolower (_ch);
+	const char ch = tolower ((ut8)_ch);
 	if (IS_DIGIT (ch)) {
 		return true;
 	}


### PR DESCRIPTION
The behavior of the `<ctype.h>` functions is undefined for negative
arguments (other than `EOF`). In such a situation, the argument should
be cast to `unsiged char` for safety.

References:
 - C Programming: A Modern Approach, 2nd Edition: page 612, chapter 23.5