### PR TITLE
Rewrite r_num_abs as function (fix #12060) and r_num_units

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -354,8 +354,8 @@ dotherax:
 		fflush (stdout);
 		return true;
 	} else if (flags & (1 << 10)) { // -u
-		char buf[80];
-		r_num_units (buf, r_num_math (NULL, str));
+		char buf[8];
+		r_num_units (buf, sizeof (buf), r_num_math (NULL, str));
 		printf ("%s\n", buf);
 		return true;
 	} else if (flags & (1 << 11)) { // -t
@@ -400,7 +400,7 @@ dotherax:
 		}
 		return false;
 	} else if (flags & (1 << 18)) { // -r
-		char *asnum, unit[32];
+		char *asnum, unit[8];
 		char out[128];
 		ut32 n32, s, a;
 		double d;
@@ -419,7 +419,7 @@ dotherax:
 		/* decimal, hexa, octal */
 		s = n >> 16 << 12;
 		a = n & 0x0fff;
-		r_num_units (unit, n);
+		r_num_units (unit, sizeof (unit), n);
 #if 0
 		eprintf ("%" PFMT64d " 0x%" PFMT64x " 0%" PFMT64o
 			" %s %04x:%04x ",

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -761,9 +761,9 @@ R_API void r_cons_flush(void) {
 				return;
 			}
 #else
-			char buf[64];
-			char *buflen = r_num_units (buf, I.context->buffer_len);
-			if (buflen && !r_cons_yesno ('n',"Do you want to print %s chars? (y/N)", buflen)) {
+			char buf[8];
+			r_num_units (buf, sizeof (buf), I.context->buffer_len);
+			if (!r_cons_yesno ('n', "Do you want to print %s chars? (y/N)", buf)) {
 				r_cons_reset ();
 				return;
 			}

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2177,10 +2177,10 @@ static void list_section_visual(RIO *io, RList *sections, ut64 seek, ut64 len, i
 	mul = (max-min) / width;
 	if (min != -1 && mul != 0) {
 		const char * color = "", *color_end = "";
-		char buf[128];
+		char humansz[8];
 		i = 0;
 		ls_foreach (sections, iter, s) {
-			r_num_units (buf, s->size);
+			r_num_units (humansz, sizeof (humansz), s->size);
 			if (use_color) {
 				color_end = Color_RESET;
 				if (s->perm & R_PERM_X) { // exec bit
@@ -2213,11 +2213,11 @@ static void list_section_visual(RIO *io, RList *sections, ut64 seek, ut64 len, i
 			}
 			if (io->va) {
 				io->cb_printf ("| %s0x%08"PFMT64x"%s %5s %s  %04s\n",
-						color, s->vaddr + s->vsize, color_end, buf,
+						color, s->vaddr + s->vsize, color_end, humansz,
 						r_str_rwx_i (s->perm), s->name);
 			} else {
 				io->cb_printf ("| %s0x%08"PFMT64x"%s %5s %s  %04s\n",
-						color, s->paddr+s->size, color_end, buf,
+						color, s->paddr+s->size, color_end, humansz,
 						r_str_rwx_i (s->perm), s->name);
 			}
 
@@ -3251,17 +3251,15 @@ static void bin_pe_resources(RCore *r, int mode) {
 					"\"vaddr\":%"PFMT64d", \"size\":%d, \"lang\":\"%s\"}",
 					index? ",": "", name, index, type, vaddr, size, lang);
 		} else {
-			char *humanSize = r_num_units (NULL, size);
+			char humansz[8];
+			r_num_units (humansz, sizeof (humansz), size);
 			r_cons_printf ("Resource %d\n", index);
 			r_cons_printf ("  name: %d\n", name);
 			r_cons_printf ("  timestamp: %s\n", timestr);
 			r_cons_printf ("  vaddr: 0x%08"PFMT64x"\n", vaddr);
-			if (humanSize) {
-				r_cons_printf ("  size: %s\n", humanSize);
-			}
+			r_cons_printf ("  size: %s\n", humansz);
 			r_cons_printf ("  type: %s\n", type);
 			r_cons_printf ("  language: %s\n", lang);
-			free (humanSize);
 		}
 
 		R_FREE (timestr);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1245,9 +1245,9 @@ static int cmd_resize(void *data, const char *input) {
 	case 'h':
 		if (core->file) {
 			if (oldsize != -1) {
-				char *s = r_num_units (NULL, oldsize);
-				r_cons_printf ("%s\n", s);
-				free (s);
+				char humansz[8];
+				r_num_units (humansz, sizeof (humansz), oldsize);
+				r_cons_printf ("%s\n", humansz);
 			}
 		}
 		return true;

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -476,15 +476,15 @@ static int cmd_help(void *data, const char *input) {
 		break;
 	case 'u': // "?u"
 		{
-			char unit[32];
+			char unit[8];
 			n = r_num_math (core->num, input+1);
-			r_num_units (unit, n);
+			r_num_units (unit, sizeof (unit), n);
 			r_cons_println (unit);
 		}
 		break;
 	case ' ': // "? "
 		{
-			char *asnum, unit[32];
+			char *asnum, unit[8];
 			ut32 s, a;
 			double d;
 			float f;
@@ -504,7 +504,7 @@ static int cmd_help(void *data, const char *input) {
 				/* decimal, hexa, octal */
 				s = n >> 16 << 12;
 				a = n & 0x0fff;
-				r_num_units (unit, n);
+				r_num_units (unit, sizeof (unit), n);
 				r_cons_printf ("hex     0x%"PFMT64x"\n", n);
 				r_cons_printf ("octal   0%"PFMT64o"\n", n);
 				r_cons_printf ("unit    %s\n", unit);

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -180,12 +180,10 @@ static void r_core_file_info(RCore *core, int mode) {
 			ut64 fsz = r_io_desc_size (desc);
 			r_cons_printf (",\"fd\":%d", desc->fd);
 			if (fsz != UT64_MAX) {
+				char humansz[8];
 				r_cons_printf (",\"size\":%"PFMT64d, fsz);
-				char *humansz = r_num_units (NULL, fsz);
-				if (humansz) {
-					r_cons_printf (",\"humansz\":\"%s\"", humansz);
-					free (humansz);
-				}
+				r_num_units (humansz, sizeof (humansz), fsz);
+				r_cons_printf (",\"humansz\":\"%s\"", humansz);
 			}
 			r_cons_printf (",\"iorw\":%s", r_str_bool ( io_cache || desc->perm & R_PERM_W));
 			r_cons_printf (",\"mode\":\"%s\"", r_str_rwx_i (desc->perm & R_PERM_RWX));
@@ -237,12 +235,10 @@ static void r_core_file_info(RCore *core, int mode) {
 		if (desc) {
 			ut64 fsz = r_io_desc_size (desc);
 			if (fsz != UT64_MAX) {
+				char humansz[8];
 				pair ("size", sdb_itoca (fsz));
-				char *humansz = r_num_units (NULL, fsz);
-				if (humansz) {
-					pair ("humansz", humansz);
-					free (humansz);
-				}
+				r_num_units (humansz, sizeof (humansz), fsz);
+				pair ("humansz", humansz);
 			}
 		}
 		if (info) {

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -133,18 +133,18 @@ static void GH(print_arena_stats)(RCore *core, GHT m_arena, MallocState *main_ar
 			r_cons_printf ("f binmap.%d = 0x%"PFMT64x, i, (ut64)main_arena->binmap[i]);
 		}
 		{	/* maybe use SDB instead of flags for this? */
-			char *units = r_num_units (NULL, main_arena->GH(max_system_mem));
+			char units[8];
+			r_num_units (units, sizeof (units), main_arena->GH(max_system_mem));
 			r_cons_printf ("f heap.maxmem = %s\n", units);
-			free (units);
-			units = r_num_units (NULL, main_arena->GH(system_mem));
+
+			r_num_units (units, sizeof (units), main_arena->GH(system_mem));
 			r_cons_printf ("f heap.sysmem = %s\n", units);
-			free (units);
-			units = r_num_units (NULL, main_arena->GH(next_free));
+
+			r_num_units (units, sizeof (units), main_arena->GH(next_free));
 			r_cons_printf ("f heap.nextfree = %s\n", units);
-			free (units);
-			units = r_num_units (NULL, main_arena->GH(next));
+
+			r_num_units (units, sizeof (units), main_arena->GH(next));
 			r_cons_printf ("f heap.next= %s\n", units);
-			free (units);
 		}
 		return;
 	}

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -2,7 +2,6 @@
 #define R_NUM_H
 
 #define R_NUMCALC_STRSZ 1024
-#define r_num_abs(x) x>0?x:-x
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,7 +50,7 @@ typedef const char *(*RNumCallback2)(struct r_num_t *self, ut64, int *ok);
 
 R_API RNum *r_num_new(RNumCallback cb, RNumCallback2 cb2, void *ptr);
 R_API void r_num_free(RNum *num);
-R_API char *r_num_units(char *buf, ut64 num);
+R_API char *r_num_units(char *buf, size_t len, ut64 number);
 R_API int r_num_conditional(RNum *num, const char *str);
 R_API ut64 r_num_calc(RNum *num, const char *str, const char **err);
 R_API const char *r_num_calc_index(RNum *num, const char *p);
@@ -79,6 +78,10 @@ R_API int r_num_str_len(const char *str);
 R_API int r_num_str_split(char *str);
 R_API RList *r_num_str_split_list(char *str);
 R_API void *r_num_dup(ut64 n);
+
+static inline st64 r_num_abs(st64 num) {
+	return num < 0 ? -num : num;
+}
 
 #ifdef __cplusplus
 }

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -95,6 +95,7 @@ R_API void r_num_free(RNum *num) {
 R_API char *r_num_units(char *buf, size_t len, ut64 num) {
 	long double fnum;
 	char unit;
+	const char *fmt_str;
 	if (!buf) {
 		buf = malloc (len + 1);
 		if (!buf) {
@@ -108,10 +109,12 @@ R_API char *r_num_units(char *buf, size_t len, ut64 num) {
 	if (num >= GB) { unit = 'G'; fnum /= GB; } else
 	if (num >= MB) { unit = 'M'; fnum /= MB; } else
 	if (num >= KB) { unit = 'K'; fnum /= KB; } else {
-		snprintf (buf, len, "%" PFMT64u, num);
-		return buf;
+		unit = '\0';
 	}
-	snprintf (buf, len, "%.1" LDBLFMT "%c", fnum, unit);
+	fmt_str = (ceill (fnum) == fnum)
+		? "%.0" LDBLFMT "%c"
+		: "%.1" LDBLFMT "%c";
+	snprintf (buf, len, fmt_str, fnum, unit);
 	return buf;
 }
 

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #endif
 
+#include <math.h>  /* for ceill */
 #include <r_util.h>
 #define R_NUM_USE_CALC 1
 


### PR DESCRIPTION
r_num_abs:

- Make r_num_abs static inline
- Use unsigned long long type when defining TB macro
- Use st64 instead of long long

r_num_units:

- Add len argument for buf in r_num_units
- Add PB and EB for r_num_units
- Always display one number after decimal point

  * This change simplifies the code
- Use long double type as assigning from ut64 to double cause data loss

r_num_tail_base:

- Use isxdigit (fast) instead of isHexDigit (slower)
- Rename nth to get_nth_nibble

Update all functions to use with new r_num_units:

- Remove side effect when using in other functions like cb_printf
