### PR TITLE
DragonflyBSD build fix.

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -50,7 +50,7 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 #include <limits.h>
 #define R_DEBUG_REG_T struct reg
 #include "native/procfs.h"
-#if __KFBSD__
+#if __KFBSD__ || __DragonFly__
 #include <sys/user.h>
 #endif
 #include "native/procfs.h"
@@ -671,6 +671,15 @@ static RList *r_debug_native_pids (RDebug *dbg, int pid) {
 # define KP_PPID(x) (x)->p_ppid
 # define KP_UID(x) (x)->p_uid
 # define KINFO_PROC kinfo_proc
+#elif __DragonFly__
+# define KVM_OPEN_FLAG O_RDONLY
+# define KVM_GETPROCS(kd, opt, arg, cntptr) \
+	kvm_getprocs (kd, opt, arg, cntptr)
+# define KP_COMM(x) (x)->kp_comm
+# define KP_PID(x) (x)->kp_pid
+# define KP_PPID(x) (x)->kp_ppid
+# define KP_UID(x) (x)->kp_uid
+# define KINFO_PROC kinfo_proc
 #else
 # define KVM_OPEN_FLAG O_RDONLY
 # define KVM_GETPROCS(kd, opt, arg, cntptr) \
@@ -735,7 +744,7 @@ static RList *r_debug_native_threads (RDebug *dbg, int pid) {
 #endif
 }
 
-#if __sun || __NetBSD__ || __KFBSD__ || __OpenBSD__
+#if __sun || __NetBSD__ || __KFBSD__ || __OpenBSD__ || __DragonFly__
 
 //Function to read register from Linux, BSD, Android systems
 static int bsd_reg_read (RDebug *dbg, int type, ut8* buf, int size) {
@@ -809,7 +818,7 @@ static int r_debug_native_reg_read (RDebug *dbg, int type, ut8 *buf, int size) {
 	return xnu_reg_read (dbg, type, buf, size);
 #elif __linux__
 	return linux_reg_read (dbg, type, buf, size);
-#elif __sun || __NetBSD__ || __KFBSD__ || __OpenBSD__
+#elif __sun || __NetBSD__ || __KFBSD__ || __OpenBSD__ || __DragonFly__
 	return bsd_reg_read (dbg, type, buf, size);
 #else
 	#warning dbg-native not supported for this platform
@@ -843,7 +852,7 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 		return w32_reg_write(dbg, type, buf, size);
 #elif __linux__
 		return linux_reg_write (dbg, type, buf, size);
-#elif __sun || __NetBSD__ || __KFBSD__ || __OpenBSD__
+#elif __sun || __NetBSD__ || __KFBSD__ || __OpenBSD__ || __DragonFly__
 		int ret = ptrace (PTRACE_SETREGS, dbg->pid,
 			(void*)(size_t)buf, sizeof (R_DEBUG_REG_T));
 		if (sizeof (R_DEBUG_REG_T) < size)

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -136,7 +136,7 @@
   #define __BSD__ 0
   #define __UNIX__ 1
 #endif
-#if __KFBSD__ || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#if __KFBSD__ || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
   #define __BSD__ 1
   #define __UNIX__ 1
 #endif

--- a/libr/io/p/io_gprobe.c
+++ b/libr/io/p/io_gprobe.c
@@ -23,7 +23,7 @@
 #include <tchar.h>
 #include <windows.h>
 #else
-#if !__linux__ && !__APPLE__ && !__OpenBSD__ && !__FreeBSD__ && !__NetBSD__
+#if !__linux__ && !__APPLE__ && !__OpenBSD__ && !__FreeBSD__ && !__NetBSD__ && !__DragonFly__
 #include <stropts.h>
 #endif
 #include <termios.h>

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -47,7 +47,7 @@
 #endif
 #if defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <util.h>
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 #include <libutil.h>
 #endif
 #endif

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -57,6 +57,10 @@ ifneq ($(shell expr "`uname -r`" : '[0-9]\.'), 2)
 endif
 endif
 
+ifeq (${BUILD_OS},dragonfly)
+  LDFLAGS+=-lexecinfo
+endif
+
 EXTRA_PRE+=sdb_version
 EXTRA_PRE+=spp_config
 

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -27,7 +27,7 @@
 static char** env = NULL;
 
 #if (__linux__ && __GNU_LIBRARY__) || defined(NETBSD_WITH_BACKTRACE) || \
-  defined(FREEBSD_WITH_BACKTRACE)
+  defined(FREEBSD_WITH_BACKTRACE) || __DragonFly__
 # include <execinfo.h>
 #endif
 #if __APPLE__
@@ -212,7 +212,8 @@ R_API char *r_sys_cmd_strf(const char *fmt, ...) {
 #endif
 
 #if (__linux__ && __GNU_LIBRARY__) || (__APPLE__ && APPLE_WITH_BACKTRACE) || \
-  defined(NETBSD_WITH_BACKTRACE) || defined(FREEBSD_WITH_BACKTRACE)
+  defined(NETBSD_WITH_BACKTRACE) || defined(FREEBSD_WITH_BACKTRACE) || \
+  __DragonFly__
 #define HAVE_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
including backtrace support. the manpage mentions FreeBSD 10 release
and DragonflyBSD has different versioning, and radare not into
their port tree yet anyway, it might safe enough.