### PR TITLE
SPARC Fixes

### DIFF
--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -145,6 +145,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			break;
 		case SPARC_INS_RETT:
 			op->type = R_ANAL_OP_TYPE_RET;
+			op->delay = 1;
 			break;
 		case SPARC_INS_UNIMP:
 			op->type = R_ANAL_OP_TYPE_UNK;
@@ -156,9 +157,11 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 				break;
 			case SPARC_OP_REG:
 				op->type = R_ANAL_OP_TYPE_UCALL;
+				op->delay = 1;
 				break;
 			default:
 				op->type = R_ANAL_OP_TYPE_CALL;
+				op->delay = 1;
 				op->jump = INSOP(0).imm;
 				break;
 			}
@@ -172,6 +175,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		case SPARC_INS_JMP:
 		case SPARC_INS_JMPL:
 			op->type = R_ANAL_OP_TYPE_JMP;
+			op->delay = 1;
 			op->jump = INSOP(0).imm;
 			break;
 		case SPARC_INS_LDD:
@@ -212,20 +216,22 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			switch (INSOP(0).type) {
 			case SPARC_OP_REG:
 				op->type = R_ANAL_OP_TYPE_CJMP;
+				op->delay = 1;
 				if (INSCC != SPARC_CC_ICC_N) { // never
 					op->jump = INSOP (1).imm;
 				}
 				if (INSCC != SPARC_CC_ICC_A) { // always
-					op->fail = addr + 4;
+					op->fail = addr + 8;
 				}
 				break;
 			case SPARC_OP_IMM:
 				op->type = R_ANAL_OP_TYPE_CJMP;
+				op->delay = 1;
 				if (INSCC != SPARC_CC_ICC_N) { // never
 					op->jump = INSOP (0).imm;
 				}
 				if (INSCC != SPARC_CC_ICC_A) { // always
-					op->fail = addr + 4;
+					op->fail = addr + 8;
 				}
 				break;
 			default:

--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -144,6 +144,8 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			op->type = R_ANAL_OP_TYPE_MOV;
 			break;
 		case SPARC_INS_RETT:
+		case SPARC_INS_RET:
+		case SPARC_INS_RETL:
 			op->type = R_ANAL_OP_TYPE_RET;
 			op->delay = 1;
 			break;


### PR DESCRIPTION
Fixes the Capstone back-end to have branch delay slots and to handle the aliased form of the return instruction (#12078).

I'm not super familiar with SPARC, it just came up in a project I was working on today. I think SPARC has a delay slot for all instructions that update PC, but I could be wrong. I'm also not too clear on when Capstone returns the ```SPARC_INS_RETL``` alias, but I think it is equivalent to ```SPARC_INS_RETT```, or at least also should be treated as an unconditional return.

These changes are only for the Capstone back-end. The GNU version (```sparc.gnu```) I left alone.