### PR TITLE
refactor: remove redundant continue in for loops

### DIFF
--- a/libr/asm/arch/mips/gnu/mips-dis.c
+++ b/libr/asm/arch/mips/gnu/mips-dis.c
@@ -1832,9 +1832,7 @@ print_mips16_insn_arg (char type,
               (*info->fprintf_func) (info->stream, ", %s",
                                      mips_gpr_names[i == 8 ? 30 : (16 + i)]);
               /* Skip over string of set bits.  */
-	      for (j = i; smask & (2 << j); j++) {
-		      continue;
-	      }
+	      for (j = i; smask & (2 << j); j++) {}
 	      if (j > i) {
 		      (*info->fprintf_func) (info->stream, "-%s",
 			      mips_gpr_names[j == 8 ? 30 : (16 + j)]);

--- a/libr/magic/apprentice.c
+++ b/libr/magic/apprentice.c
@@ -1252,9 +1252,7 @@ static int parse(RMagic *ms, struct r_magic_entry **mentryp, ut32 *nmentryp, con
 		++l;
 		m->flag |= NOSPACE;
 	}
-	for (i = 0; (m->desc[i++] = *l++) != '\0' && i < sizeof (m->desc);) {
-		continue;
-	}
+	for (i = 0; (m->desc[i++] = *l++) != '\0' && i < sizeof (m->desc);) {}
 	if (i == sizeof (m->desc)) {
 		m->desc[sizeof (m->desc) - 1] = '\0';
 		if (ms->flags & R_MAGIC_CHECK) {
@@ -1308,9 +1306,7 @@ static int parse_mime(RMagic *ms, struct r_magic_entry **mentryp, ut32 *nmentryp
 	EATAB;
 	for (i = 0;
 		*l && ((isascii ((ut8)*l) && isalnum ((ut8)*l)) || strchr ("-+/.", *l)) && i < sizeof (m->mimetype);
-		m->mimetype[i++] = *l++) {
-		continue;
-	}
+		m->mimetype[i++] = *l++) {}
 	if (i == sizeof (m->mimetype)) {
 		m->desc[sizeof (m->mimetype) - 1] = '\0';
 		if (ms->flags & R_MAGIC_CHECK) {

--- a/libr/magic/softmagic.c
+++ b/libr/magic/softmagic.c
@@ -300,9 +300,7 @@ char * strdupn(const char *str, size_t n) {
 	size_t len;
 	char *copy;
 
-	for (len = 0; len < n && str[len]; len++) {
-		continue;
-	}
+	for (len = 0; len < n && str[len]; len++) {}
 	if (!(copy = malloc (len + 1))) {
 		return NULL;
 	}


### PR DESCRIPTION
simplifies some for loops and removes a redundant `continue;`. this is consistent with other parts of the code that don't have the `continue;` (e.g., [here](https://github.com/radare/radare2/blob/master/libr/core/cmd_flag.c#L216) and [here](https://github.com/radare/radare2/blob/master/shlr/sdb/src/util.c#L172))