### PR TITLE
Fix incorrect set of asm.cpu

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -468,9 +468,6 @@ static int cb_asmarch(void *user, void *data) {
 		eprintf ("asm.arch: cannot find (%s)\n", node->value);
 		return false;
 	}
-	//we should strdup here otherwise will crash if any r_config_set
-	//free the old value
-	char *asm_cpu = strdup (r_config_get (core->config, "asm.cpu"));
 	if (core->assembler->cur) {
 		const char *newAsmCPU = core->assembler->cur->cpus;
 		if (newAsmCPU) {
@@ -543,8 +540,6 @@ static int cb_asmarch(void *user, void *data) {
 	// set endian of display to match binary
 	core->print->big_endian = bigbin;
 
-	r_asm_set_cpu (core->assembler, asm_cpu);
-	free (asm_cpu);
 	RConfigNode *asmcpu = r_config_node_get (core->config, "asm.cpu");
 	if (asmcpu) {
 		update_asmcpu_options (core, asmcpu);


### PR DESCRIPTION
I don't understand what problems was fixed in d9fb5713db4b09b41135935e7fa81382069b5ddc.
`core->assembler->cpu` is cleared by `r_asm_use` and set by `r_config_set` if necessary, and `asm_cpu` is the old value of `asm.cpu`, we should't set it again, otherwise it will lead to a mess.