### PR TITLE
anal: cannot extract reg args if no calling convention is present

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -451,10 +451,10 @@ R_API int r_anal_var_rename(RAnal *a, ut64 addr, int scope, char kind, const cha
 }
 
 // Used for linking reg based arg and local-var like "mov [local_8h], rsi"
-static void r_anal_var_link (RAnal *a, ut64 addr, RAnalVar *var) {
-	const char *inst_key = sdb_fmt ("inst.0x%"PFMT64x ".lvar", addr);
-	const char *var_def = sdb_fmt ("0x%"PFMT64x ",%c,0x%x,0x%x", var->addr,
-			var->kind, var->scope, var->delta);
+static void r_anal_var_link(RAnal *a, ut64 addr, RAnalVar *var) {
+	const char *inst_key = sdb_fmt ("inst.0x%" PFMT64x ".lvar", addr);
+	const char *var_def = sdb_fmt ("0x%" PFMT64x ",%c,0x%x,0x%x", var->addr,
+		var->kind, var->scope, var->delta);
 	sdb_set (DB, inst_key, var_def, 0);
 }
 
@@ -609,12 +609,12 @@ static const char *get_regname(RAnal *anal, RAnalValue *value) {
 }
 
 static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg, const char *sign, char type) {
-	char sigstr[16] = {0};
+	char sigstr[16] = { 0 };
 	st64 ptr;
 	char *addr;
-	if (!anal || !fcn || !op) {
-		return;
-	}
+
+	r_return_if_fail (anal && fcn && op);
+
 	snprintf (sigstr, sizeof (sigstr), ",%s,%s", reg, sign);
 	const char *op_esil = r_strbuf_get (&op->esil);
 	if (!op_esil) {
@@ -670,9 +670,13 @@ R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_s
 	const char *opdreg = NULL;
 	int i, argc = 0;
 
-	if (!anal || !op || !fcn) {
+	r_return_if_fail (anal && op && fcn);
+
+	if (!fcn->cc) {
+		R_LOG_INFO ("No cc information for function at %" PFMT64x " to extract register arguments\n", fcn->addr);
 		return;
 	}
+
 	char *fname = fcn->name;
 	Sdb *TDB = anal->sdb_types;
 	int max_count = r_anal_cc_max_arg (anal, fcn->cc);
@@ -734,11 +738,10 @@ R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_s
 }
 
 R_API void extract_vars(RAnal *anal, RAnalFunction *fcn, RAnalOp *op) {
-	if (!anal || !fcn || !op) {
-		return;
-	}
+	r_return_if_fail (anal && fcn && op);
+
 	const char *BP = anal->reg->name[R_REG_NAME_BP];
-	const char *SP =  anal->reg->name[R_REG_NAME_SP];
+	const char *SP = anal->reg->name[R_REG_NAME_SP];
 	extract_arg (anal, fcn, op, BP, "+", 'b');
 	extract_arg (anal, fcn, op, BP, "-", 'b');
 	extract_arg (anal, fcn, op, SP, "+", 's');

--- a/libr/bin/p/bin_nes.c
+++ b/libr/bin/p/bin_nes.c
@@ -15,7 +15,14 @@ static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut
 	return check_bytes (buf, sz);
 }
 
-static RBinInfo* info(RBinFile *bf) {
+static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
+	if (!check_bytes (r_buf_get_at (buf, 0, NULL), buf->length)) {
+		return NULL;
+	}
+	return r_buf_new ();
+}
+
+static RBinInfo *info(RBinFile *bf) {
 	RBinInfo *ret = NULL;
 	ines_hdr ihdr;
 	memset (&ihdr, 0, INES_HDR_SIZE);
@@ -106,10 +113,10 @@ static RList* sections(RBinFile *bf) {
 	return ret;
 }
 
-static RList *mem (RBinFile *bf) {
+static RList *mem(RBinFile *bf) {
 	RList *ret;
 	RBinMem *m, *n;
-	if (!(ret = r_list_new())) {
+	if (!(ret = r_list_new ())) {
 		return NULL;
 	}
 	ret->free = free;
@@ -210,6 +217,7 @@ RBinPlugin r_bin_plugin_nes = {
 	.desc = "NES",
 	.license = "LGPL3",
 	.load_bytes = &load_bytes,
+	.load_buffer = &load_buffer,
 	.baddr = &baddr,
 	.check_bytes = &check_bytes,
 	.entries = &entries,


### PR DESCRIPTION
some archs do not even have a default calling convention, so let's just
skip them for now and print a log. It means we probably need to
implement other things to make arguments analysis work on those archs.