### PR TITLE
bin/filter: correctly allocate strings when filtering them

### DIFF
--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -28,7 +28,7 @@ R_API char *r_bin_filter_name(RBinFile *bf, Sdb *db, ut64 vaddr, char *name) {
 	r_return_val_if_fail (db && name, NULL);
 
 	const char *uname;
-	char *resname = strdup (name);
+	char *resname = name;
 	ut32 vhash, hash;
 	int count;
 

--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -22,8 +22,7 @@ static char *hashify(char *s, ut64 vaddr) {
 	return os;
 }
 
-// TODO: optimize this api:
-// - bin plugins should call r_bin_filter_name() before appending
+// - name should be allocated on the heap
 R_API char *r_bin_filter_name(RBinFile *bf, Sdb *db, ut64 vaddr, char *name) {
 	r_return_val_if_fail (db && name, NULL);
 
@@ -42,10 +41,16 @@ R_API char *r_bin_filter_name(RBinFile *bf, Sdb *db, ut64 vaddr, char *name) {
 	}
 	sdb_num_set (db, sdb_fmt ("%x", vhash), 1, 0);
 	if (vaddr) {
-		resname = hashify (resname, vaddr);
+		char *p = hashify (resname, vaddr);
+		if (p) {
+			resname = p;
+		}
 	}
 	if (count > 1) {
-		resname = r_str_appendf (resname, "_%d", count - 1);
+		char *p = r_str_appendf (resname, "_%d", count - 1);
+		if (p) {
+			resname = p;
+		}
 
 		// two symbols at different addresses and same name wtf
 		//	eprintf ("Symbol '%s' dupped!\n", sym->name);
@@ -117,7 +122,10 @@ R_API void r_bin_filter_sections(RBinFile *bf, RList *list) {
 	Sdb *db = sdb_new0 ();
 	RListIter *iter;
 	r_list_foreach (list, iter, sec) {
-		sec->name = r_bin_filter_name (bf, db, sec->vaddr, sec->name);
+		char *p = r_bin_filter_name (bf, db, sec->vaddr, sec->name);
+		if (p) {
+			sec->name = p;
+		}
 	}
 	sdb_free (db);
 }

--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -241,7 +241,7 @@ static void filter_classes(RBinFile *bf, RList *list) {
 		char *namepad = malloc (namepad_len + 1);
 		if (namepad) {
 			strcpy (namepad, cls->name);
-			r_bin_filter_name (bf, db, cls->index, namepad, namepad_len);
+			namepad = r_bin_filter_name (bf, db, cls->index, namepad);
 			free (cls->name);
 			cls->name = namepad;
 			r_list_foreach (cls->methods, iter2, sym) {

--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -240,8 +240,12 @@ static void filter_classes(RBinFile *bf, RList *list) {
 		int namepad_len = strlen (cls->name) + 32;
 		char *namepad = malloc (namepad_len + 1);
 		if (namepad) {
+			char *p;
 			strcpy (namepad, cls->name);
-			namepad = r_bin_filter_name (bf, db, cls->index, namepad);
+			p = r_bin_filter_name (bf, db, cls->index, namepad);
+			if (p) {
+				namepad = p;
+			}
 			free (cls->name);
 			cls->name = namepad;
 			r_list_foreach (cls->methods, iter2, sym) {

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -725,7 +725,7 @@ R_API RList *r_bin_get_mem(RBin *bin);
 R_API void r_bin_load_filter(RBin *bin, ut64 rules);
 R_API void r_bin_filter_symbols(RBinFile *bf, RList *list);
 R_API void r_bin_filter_sections(RBinFile *bf, RList *list);
-R_API void r_bin_filter_name(RBinFile *bf, Sdb *db, ut64 addr, char *name, int maxlen);
+R_API char *r_bin_filter_name(RBinFile *bf, Sdb *db, ut64 addr, char *name);
 R_API void r_bin_filter_sym(RBinFile *bf, Sdb *db, ut64 vaddr, RBinSymbol *sym);
 R_API bool r_bin_strpurge(RBin *bin, const char *str, ut64 addr);
 R_API bool r_bin_string_filter(RBin *bin, const char *str, ut64 addr);


### PR DESCRIPTION
Directly reallocate strings when filtering them, because it is very hard for
the caller to know before hand the correct size of the string otherwise. The
patch uses r_str_ APIs to makes this easy.

This fixes an ASAN detected overflow : https://travis-ci.org/radare/radare2/jobs/453150808#L1039 .