### PR TITLE
No invalid instruction error on debug

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -958,7 +958,9 @@ repeat:
 			return R_ANAL_RET_ERROR;
 		}
 		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + addrbytes * idx, len - addrbytes * idx, R_ANAL_OP_MASK_ALL)) < 1) {
-			eprintf ("Invalid instruction (possibly truncated) at 0x%"PFMT64x"\n", addr + idx);
+			if (!anal->coreb.core || !anal->coreb.cfggeti || !anal->coreb.cfggeti (anal->coreb.core, "cfg.debug")) { // HACK
+				eprintf ("Invalid instruction (possibly truncated) at 0x%"PFMT64x"\n", addr + idx);
+			}
 			gotoBeach (R_ANAL_RET_END);
 		}
 		if (op.hint.new_bits) {


### PR DESCRIPTION
"Fix" #12112 by restoring previous behavior on debug. This doesn't break [this test](https://github.com/radare/radare2-regressions/blob/abc85cf8ceb387402fb3676fdf36ffad7ea23e09/new/db/cmd/cmd_af#L165-L167) in `cmd_af`.