### PR TITLE
bin/elf: Do not filter 0, because of external imports

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2920,6 +2920,15 @@ static RBinElfSymbol *Elf_(get_phdr_symbols)(ELFOBJ *bin, int type) {
 		: Elf_(r_bin_elf_get_phdr_imports) (bin);
 }
 
+static bool match_symbols(RBinElfSymbol *a, RBinElfSymbol *b) {
+	return a->is_value == b->is_value &&
+		a->offset == b->offset &&
+		a->size == b->size &&
+		a->bind == b->bind &&
+		a->ordinal == b->ordinal &&
+		a->type == b->type;
+}
+
 static int Elf_(fix_symbols)(ELFOBJ *bin, int nsym, int type, RBinElfSymbol **sym) {
 	int count = 0;
 	RBinElfSymbol *ret = *sym;
@@ -2931,7 +2940,7 @@ static int Elf_(fix_symbols)(ELFOBJ *bin, int nsym, int type, RBinElfSymbol **sy
 			/* find match in phdr */
 			p = phdr_symbols;
 			while (!p->last) {
-				if (p->offset && d->offset == p->offset) {
+				if (match_symbols (p, d)) {
 					p->in_shdr = true;
 					if (*p->name && strcmp (d->name, p->name)) {
 						strcpy (d->name, p->name);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3305,8 +3305,8 @@ R_API int r_core_anal_all(RCore *core) {
 				continue;
 			}
 			if (isValidSymbol (symbol)) {
-				ut64 addr = r_bin_get_vaddr (core->bin, symbol->paddr,
-					symbol->vaddr);
+				ut64 addr = r_bin_get_vaddr (core->bin,
+					symbol->paddr, symbol->vaddr);
 				r_core_anal_fcn (core, addr, -1,
 					R_ANAL_REF_TYPE_NULL, depth);
 			}


### PR DESCRIPTION
external imports like __libc_start_main do not usually have a physical
address in the file and the virtual address is set to 0 because it is
not known statically (it is set at runtime by the loader). Other
disassemblers (e.g. IDA) create a special fake section where they put
those things one after the other, probably just as a way for users to
see those things linearly instead of having all these symbols at the
same address 0.

This patch improves the way PHDR and SHDR symbols/imports are mixed
together, by checking more than just the offset and by not filtering for
toffset == 0, which is a valid value.