### PR TITLE
Fix another assert when printing blocks

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5088,32 +5088,14 @@ static void cmd_anal_blocks(RCore *core, const char *input) {
 	ut64 from , to;
 	char *arg = strchr (input, ' ');
 	r_cons_break_push (NULL, NULL);
-#if 0
-	ls_foreach (core->io->sections, iter, s) {
-		/* is executable */
-		if (!(s->flags & R_PERM_X)) {
-			continue;
-		}
-		min = s->vaddr;
-		max = s->vaddr + s->vsize;
-		r_core_cmdf (core, "abb%s 0x%08"PFMT64x" @ 0x%08"PFMT64x, input, (max - min), min);
-		if (r_cons_is_breaked ()) {
-			goto ctrl_c;
-		}
-	}
-	if (ls_empty (core->io->sections)) {
-		min = core->offset;
-		max = 0xffff + min;
-		r_core_cmdf (core, "abb%s 0x%08"PFMT64x" @ 0x%08"PFMT64x, input, (max - min), min);
-		if (r_cons_is_breaked ()) {
-			goto ctrl_c;
-		}
-	}
-#endif
 	if (!arg) {
 		RList *list = r_core_get_boundaries_prot (core, R_PERM_X, NULL, "anal");
 		RListIter *iter;
 		RIOMap* map;
+		if (!list) {
+			R_LOG_WARN ("Cannot get analysis boundaries\n");
+			goto ctrl_c;
+		}
 		r_list_foreach (list, iter, map) {
 			from = map->itv.addr;
 			to = r_itv_end (map->itv);
@@ -5249,6 +5231,7 @@ static void cmd_anal_calls(RCore *core, const char *input, bool printCommands, b
 			RIOMap *m = R_NEW0 (RIOMap);
 			m->itv.addr = addr;
 			m->itv.size = len;
+			ranges = r_list_newf ((RListFree)free);
 			r_list_append (ranges, m);
 		} else {
 			ranges = r_core_get_boundaries_prot (core, R_PERM_X, NULL, "anal");
@@ -6802,6 +6785,10 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 			RList *list = r_core_get_boundaries_prot (core, R_PERM_X, NULL, "anal");
 			RListIter *iter;
 			RIOMap* map;
+			if (!list) {
+				R_LOG_WARN ("Cannot get anal boundaries\n");
+				return 0;
+			}
 			r_list_foreach (list, iter, map) {
 				from = map->itv.addr;
 				to = r_itv_end (map->itv);
@@ -7022,6 +7009,10 @@ static void cmd_anal_aav(RCore *core, const char *input) {
 		RList *list = r_core_get_boundaries_prot (core, 0, "dbg.map", "anal");
 		RListIter *iter;
 		RIOMap *map;
+		if (!list) {
+			R_LOG_WARN ("Cannot get anal boundaries\n");
+			goto beach;
+		}
 		r_list_foreach (list, iter, map) {
 			if (r_cons_is_breaked ()) {
 				break;
@@ -7034,6 +7025,10 @@ static void cmd_anal_aav(RCore *core, const char *input) {
 		r_list_free (list);
 	} else {
 		RList *list = r_core_get_boundaries_prot (core, 0, NULL, "anal");
+		if (!list) {
+			R_LOG_WARN ("Cannot get anal boundaries\n");
+			goto beach;
+		}
 		RListIter *iter, *iter2;
 		RIOMap *map, *map2;
 		ut64 from = UT64_MAX;
@@ -7066,6 +7061,7 @@ static void cmd_anal_aav(RCore *core, const char *input) {
 		}
 		r_list_free (list);
 	}
+beach:
 	r_cons_break_pop ();
 	// end
 	seti ("search.align", o_align);
@@ -7284,6 +7280,10 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		RListIter *iter;
 		RIOMap *map;
 		RList *list = r_core_get_boundaries_prot (core, R_PERM_X, NULL, "anal");
+		if (!list) {
+			R_LOG_WARN ("Cannot get anal boundaries\n");
+			break;
+		}
 		r_list_foreach (list, iter, map) {
 			r_core_seek (core, map->itv.addr, 1);
 			r_config_set_i (core->config, "anal.hasnext", 1);
@@ -7313,6 +7313,10 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			RIOMap *map;
 			RListIter *iter;
 			RList *list = r_core_get_boundaries_prot (core, -1, NULL, "anal");
+			if (!list) {
+				R_LOG_WARN ("Cannot get anal boundaries\n");
+				break;
+			}
 			r_list_foreach (list, iter, map) {
 				r_core_seek (core, map->itv.addr, 1);
 				r_core_anal_esil (core, "$SS", NULL);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5093,7 +5093,6 @@ static void cmd_anal_blocks(RCore *core, const char *input) {
 		RListIter *iter;
 		RIOMap* map;
 		if (!list) {
-			R_LOG_WARN ("Cannot get analysis boundaries\n");
 			goto ctrl_c;
 		}
 		r_list_foreach (list, iter, map) {
@@ -5243,9 +5242,11 @@ static void cmd_anal_calls(RCore *core, const char *input, bool printCommands, b
 		RIOMap *map;
 		r_list_free (ranges);
 		ranges = r_core_get_boundaries_prot (core, 0, NULL, "anal");
-		r_list_foreach (ranges, iter, map) {
-			ut64 addr = map->itv.addr;
-			_anal_calls (core, addr, r_itv_end (map->itv), printCommands, importsOnly);
+		if (ranges) {
+			r_list_foreach (ranges, iter, map) {
+				ut64 addr = map->itv.addr;
+				_anal_calls (core, addr, r_itv_end (map->itv), printCommands, importsOnly);
+			}
 		}
 	} else {
 		RListIter *iter;
@@ -6786,7 +6787,6 @@ R_API int r_core_anal_refs(RCore *core, const char *input) {
 			RListIter *iter;
 			RIOMap* map;
 			if (!list) {
-				R_LOG_WARN ("Cannot get anal boundaries\n");
 				return 0;
 			}
 			r_list_foreach (list, iter, map) {
@@ -7010,7 +7010,6 @@ static void cmd_anal_aav(RCore *core, const char *input) {
 		RListIter *iter;
 		RIOMap *map;
 		if (!list) {
-			R_LOG_WARN ("Cannot get anal boundaries\n");
 			goto beach;
 		}
 		r_list_foreach (list, iter, map) {
@@ -7026,7 +7025,6 @@ static void cmd_anal_aav(RCore *core, const char *input) {
 	} else {
 		RList *list = r_core_get_boundaries_prot (core, 0, NULL, "anal");
 		if (!list) {
-			R_LOG_WARN ("Cannot get anal boundaries\n");
 			goto beach;
 		}
 		RListIter *iter, *iter2;
@@ -7281,7 +7279,6 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		RIOMap *map;
 		RList *list = r_core_get_boundaries_prot (core, R_PERM_X, NULL, "anal");
 		if (!list) {
-			R_LOG_WARN ("Cannot get anal boundaries\n");
 			break;
 		}
 		r_list_foreach (list, iter, map) {
@@ -7314,7 +7311,6 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			RListIter *iter;
 			RList *list = r_core_get_boundaries_prot (core, -1, NULL, "anal");
 			if (!list) {
-				R_LOG_WARN ("Cannot get anal boundaries\n");
 				break;
 			}
 			r_list_foreach (list, iter, map) {

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -427,7 +427,6 @@ static int cmd_help(void *data, const char *input) {
 		k = r_str_trim_ro (input + 1);
 		tmp = r_core_get_boundaries_prot (core, -1, k, "search");
 		if (!tmp) {
-			R_LOG_WARN ("Cannot get boundaries\n");
 			return false;
 		}
 		r_list_foreach (tmp, iter, map) {

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -426,6 +426,10 @@ static int cmd_help(void *data, const char *input) {
 	case 'B': // "?B"
 		k = r_str_trim_ro (input + 1);
 		tmp = r_core_get_boundaries_prot (core, -1, k, "search");
+		if (!tmp) {
+			R_LOG_WARN ("Cannot get boundaries\n");
+			return false;
+		}
 		r_list_foreach (tmp, iter, map) {
 			r_cons_printf ("0x%"PFMT64x" 0x%"PFMT64x"\n", map->itv.addr, r_itv_end (map->itv));
 		}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2495,7 +2495,6 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 	{
 		RList *list = r_core_get_boundaries_prot (core, -1, NULL, "search");
 		if (!list) {
-			R_LOG_WARN ("Couldn't get boundaries\n");
 			return 1;
 		}
 		RIOMap *map = r_list_first (list);
@@ -5875,7 +5874,7 @@ static int cmd_print(void *data, const char *input) {
 			RIOMap* map;
 			RListIter *iter;
 			RList *list = r_core_get_boundaries_prot (core, -1, NULL, "zoom");
-			if (list) {
+			if (list && r_list_length (list) > 0) {
 				RListIter *iter1 = list->head;
 				RIOMap* map1 = iter1->data;
 				from = map1->itv.addr;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2494,6 +2494,10 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 	ut64 to = 0;
 	{
 		RList *list = r_core_get_boundaries_prot (core, -1, NULL, "search");
+		if (!list) {
+			R_LOG_WARN ("Couldn't get boundaries\n");
+			return 1;
+		}
 		RIOMap *map = r_list_first (list);
 		if (map) {
 			from = map->itv.addr;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2741,6 +2741,10 @@ static void cmd_print_bars(RCore *core, const char *input) {
 	RListIter *iter;
 	ut64 from = 0, to = 0;
 	RList *list = r_core_get_boundaries_prot (core, -1, NULL, "zoom");
+	if (!list) {
+		goto beach;
+	}
+
 	ut64 blocksize = 0;
 	int mode = 'b'; // e, p, b, ...
 	int submode = 0; // q, j, ...
@@ -2787,9 +2791,8 @@ static void cmd_print_bars(RCore *core, const char *input) {
 		eprintf ("Invalid block size: %d\n", (int)blocksize);
 		goto beach;
 	}
-	if (list) {
-		RListIter *iter1 = list->head;
-		RIOMap* map1 = iter1->data;
+	RIOMap* map1 = r_list_first (list);
+	if (map1) {
 		from = map1->itv.addr;
 		r_list_foreach (list, iter, map) {
 			to = r_itv_end (map->itv);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -341,7 +341,6 @@ R_API int r_core_search_preludes(RCore *core) {
 	RIOMap *p;
 
 	if (!list) {
-		R_LOG_WARN ("Cannot get search boundaries\n");
 		return -1;
 	}
 
@@ -623,7 +622,13 @@ static bool maskMatches(int perm, int mask, bool only) {
 
 // TODO(maskray) returns RList<RInterval>
 R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode, const char *prefix) {
+	r_return_val_if_fail (core, NULL);
+
 	RList *list = r_list_newf (free); // XXX r_io_map_free);
+	if (!list) {
+		return NULL;
+	}
+
 	char bound_in[32];
 	char bound_from[32];
 	char bound_to[32];
@@ -638,10 +643,6 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode,
 	}
 	if (perm == -1) {
 		perm = R_PERM_RWX;
-	}
-	if (!core) {
-		r_list_free (list);
-		return NULL;
 	}
 	if (!r_config_get_i (core->config, "cfg.debug") && !core->io->va) {
 		append_bound (list, core->io, search_itv, 0, r_io_size (core->io), 7);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -628,12 +628,6 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode,
 	const ut64 search_from = r_config_get_i (core->config, bound_from),
 	      search_to = r_config_get_i (core->config, bound_to);
 	const RInterval search_itv = {search_from, search_to - search_from};
-#if 0
-	int fd = -1;
-	if (core && core->io && core->io->cur) {
-		fd = core->io->cur->fd;
-	}
-#endif
 	if (!mode) {
 		mode = r_config_get (core->config, bound_in);
 	}
@@ -899,10 +893,6 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode,
 			}
 			append_bound (list, core->io, search_itv, from, to - from, 5);
 		}
-	}
-	if (r_list_empty (list)) {
-		r_list_free (list);
-		list = NULL;
 	}
 	return list;
 }

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -340,6 +340,11 @@ R_API int r_core_search_preludes(RCore *core) {
 	RListIter *iter;
 	RIOMap *p;
 
+	if (!list) {
+		R_LOG_WARN ("Cannot get search boundaries\n");
+		return -1;
+	}
+
 	int fc0 = count_functions (core);
 	r_list_foreach (list, iter, p) {
 		eprintf ("\r[>] Scanning %s 0x%"PFMT64x " - 0x%"PFMT64x " ",

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -664,6 +664,10 @@ static bool search(RCore *core, bool rad) {
 	// Bytes search
 	if (useBytes) {
 		list = r_core_get_boundaries_prot (core, -1, mode, "search");
+		if (!list) {
+			R_LOG_WARN ("Cannot get boundaries\n");
+			return false;
+		}
 		r_list_foreach (list, iter, map) {
 			eprintf ("[+] searching 0x%08"PFMT64x" - 0x%08"PFMT64x"\n", map->itv.addr, r_itv_end (map->itv));
 			retval &= searchRange (core, map->itv.addr, r_itv_end (map->itv), rad, &bytes_search_ctx);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -665,7 +665,6 @@ static bool search(RCore *core, bool rad) {
 	if (useBytes) {
 		list = r_core_get_boundaries_prot (core, -1, mode, "search");
 		if (!list) {
-			R_LOG_WARN ("Cannot get boundaries\n");
 			return false;
 		}
 		r_list_foreach (list, iter, map) {


### PR DESCRIPTION
From the git commit comment:
An empty list is different than a NULL return value. The caller has to
call r_list_free anyway on the returned list, so there's no real
advantage in returning NULL, it just makes the caller's life harder
because it cannot understand if NULL is returned because the list was
empty (e.g. there are no IO maps, etc.) or because there were some
errors.