### PR TITLE
Improvements for emscripten (wasm/asm.js) ##port

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -452,6 +452,10 @@ static inline void *r_new_copy(int size, void *data) {
 #define R_SYS_ARCH "x86"
 #define R_SYS_BITS R_SYS_BITS_32
 #define R_SYS_ENDIAN 0
+#elif __EMSCRIPTEN__
+#define R_SYS_ARCH "wasm"
+#define R_SYS_BITS (R_SYS_BITS_32 | R_SYS_BITS_64)
+#define R_SYS_ENDIAN 0
 #elif __x86_64__
 #define R_SYS_ARCH "x86"
 #define R_SYS_BITS (R_SYS_BITS_32 | R_SYS_BITS_64)

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -97,6 +97,9 @@ R_API bool r_sys_tts(const char *txt, bool bg);
 #define r_sys_breakpoint() __asm__ volatile ("brk 0");
 #elif __arm__ || __thumb__
 #define r_sys_breakpoint() __asm__ volatile ("bkpt $0");
+#elif __EMSCRIPTEN__
+// TODO: cannot find a better way to breakpoint in wasm/asm.js
+#define r_sys_breakpoint() { char *a = NULL; *a = 0; }
 #else
 #warning r_sys_breakpoint not implemented for this platform
 #define r_sys_breakpoint() { char *a = NULL; *a = 0; }

--- a/mk/emscripten.mk
+++ b/mk/emscripten.mk
@@ -1,7 +1,7 @@
 ifeq (${_INCLUDE_MK_GCC_},)
 _INCLUDE_MK_GCC_=1
 EXT_EXE=.js
-EXT_SO=.js
+EXT_SO=.bc
 EXT_AR=a
 CC=emcc
 AR=emar
@@ -9,7 +9,8 @@ LINK=
 RANLIB=emranlib
 ONELIB=0
 CC_AR=emar q ${LIBAR}
-PARTIALLD=emld -r
+#PARTIALLD=emld -r
+PARTIALLD=emcc
 PIC_CFLAGS=-fPIC
 CFLAGS+=-MD
 CFLAGS_INCLUDE=-I

--- a/sys/emscripten.sh
+++ b/sys/emscripten.sh
@@ -12,8 +12,9 @@ unset LDFLAGS
 export CC="emcc --ignore-dynamic-linking -Oz"
 export AR="emar"
 
-CFGFLAGS="./configure --prefix=/usr --with-compiler=emscripten"
+CFGFLAGS="--prefix=/usr --with-compiler=emscripten"
 CFGFLAGS="${CFGFLAGS} --disable-debugger --with-libr"
+CFGFLAGS="${CFGFLAGS} --without-libuv --without-jemalloc"
 
 make mrproper
 cp -f plugins.emscripten.cfg plugins.cfg


### PR DESCRIPTION
This commit also includes changes in the jemalloc include files aiming to make non-linux targets compile with jemalloc. Still wip, but unrelated to this issue because i end up adding the --without-jemalloc