### PR TITLE
Make ood use absolute path

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -96,7 +96,7 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 		}
 		// close old file
 	} else if (ofile) {
-		eprintf ("r_core_file_reopen: Cannot reopen file: %s with perms 0x%04x,"
+		eprintf ("r_core_file_reopen: Cannot reopen file: %s with perms 0x%x,"
 			" attempting to open read-only.\n", path, perm);
 		// lower it down back
 		//ofile = r_core_file_open (core, path, R_PERM_R, addr);

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -871,7 +871,8 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 		return;
 	}
 	int bits = core->assembler->bits;
-	char *escaped_path = r_str_arg_escape (binpath);
+	char *bin_abspath = r_file_abspath (binpath);
+	char *escaped_path = r_str_arg_escape (bin_abspath);
 	char *newfile = r_str_newf ("dbg://%s %s", escaped_path, args);
 	char *newfile2 = strdup (newfile);
 	desc->uri = newfile;
@@ -896,6 +897,7 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 	}
 #endif
 	r_core_cmd0 (core, "sr PC");
+	free (bin_abspath);
 	free (escaped_path);
 	free (binpath);
 	free (newfile);


### PR DESCRIPTION
It seems that if the binary hasn't been loaded, `r_bin_reload` won't be called when `ood`.
So it's better for us to retrieve e973deadca3c6c417825bcb04b02e2a38202f143.

The `perm` only ranges in 0~7,  so we shouldn't print it with `0x%04x`.