### PR TITLE
Do not check vaddr for isValidSymbol

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3268,7 +3268,7 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 static bool isValidSymbol(RBinSymbol *symbol) {
 	if (symbol && symbol->type) {
 		const char *type = symbol->type;
-		return (symbol->paddr != UT64_MAX || symbol->vaddr) && (!strcmp (type, R_BIN_TYPE_FUNC_STR) || !strcmp (type, R_BIN_TYPE_METH_STR));
+		return (symbol->paddr != UT64_MAX) && (!strcmp (type, R_BIN_TYPE_FUNC_STR) || !strcmp (type, R_BIN_TYPE_METH_STR));
 	}
 	return false;
 }


### PR DESCRIPTION
The only fact that there is no paddr, means the symbol is not present in
the file, so there's nothing to analyze (at least statically)