### PR TITLE
Do not use a fake RBinFile/RBinObject when creating a file

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -898,12 +898,8 @@ int main(int argc, char **argv) {
 		if (!bits) {
 			bits = 32;
 		}
-		if (!r_bin_use_arch (bin, arch, bits, create)) {
-			eprintf ("Cannot set arch\n");
-			r_core_fini (&core);
-			return 1;
-		}
-		b = r_bin_create (bin, code, codelen, data, datalen);
+
+		b = r_bin_create (bin, code, codelen, data, datalen, arch, bits, create);
 		if (b) {
 			if (r_file_dump (file, b->buf, b->length, 0)) {
 				eprintf ("Dumped %"PFMT64d" bytes in '%s'\n", b->length, file);
@@ -913,7 +909,7 @@ int main(int argc, char **argv) {
 			}
 			r_buf_free (b);
 		} else {
-			eprintf ("Cannot create binary for this format '%s'.\n", create);
+			eprintf ("Cannot create binary for this format '%s/%d/%s'.\n", arch, bits, create);
 		}
 		r_core_fini (&core);
 		return 0;

--- a/binr/ragg2/ragg2.c
+++ b/binr/ragg2/ragg2.c
@@ -68,21 +68,17 @@ static void list(REgg *egg) {
 
 static int create(const char *format, const char *arch, int bits, const ut8 *code, int codelen) {
 	RBin *bin = r_bin_new ();
-	RBuffer *b;
-	if (!r_bin_use_arch (bin, arch, bits, format)) {
-		eprintf ("Cannot set arch\n");
-		r_bin_free (bin);
-		return 1;
-	}
-	b = r_bin_create (bin, code, codelen, NULL, 0); //data, datalen);
+	int ret = 0;
+	RBuffer *b = r_bin_create (bin, code, codelen, NULL, 0, arch, bits, format);
 	if (b) {
 		write (1, b->buf, b->length);
 		r_buf_free (b);
 	} else {
-		eprintf ("Cannot create binary for this format '%s'.\n", format);
+		eprintf ("Cannot create binary for this format '%s/%d/%s'.\n", arch, bits, format);
+		ret = 1;
 	}
 	r_bin_free (bin);
-	return 0;
+	return ret;
 }
 
 static int openfile(const char *f, int x) {

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -427,7 +427,7 @@ R_API bool r_bin_open_io(RBin *bin, RBinOptions *opt) {
 	return true;
 }
 
-R_IPI RBinPlugin *r_bin_get_binplugin_by_name(RBin *bin, const char *name) {
+R_API RBinPlugin *r_bin_get_binplugin_by_name(RBin *bin, const char *name) {
 	RBinPlugin *plugin;
 	RListIter *it;
 
@@ -950,39 +950,20 @@ R_API int r_bin_use_arch(RBin *bin, const char *arch, int bits, const char *name
 	r_return_val_if_fail (bin && arch, false);
 
 	RBinFile *binfile = r_bin_file_find_by_arch_bits (bin, arch, bits);
-	RBinObject *obj = NULL;
-	if (binfile) {
-		obj = r_bin_object_find_by_arch_bits (binfile, arch, bits, name);
-		if (!obj && binfile->xtr_data) {
-			RBinXtrData *xtr_data = r_list_get_n (binfile->xtr_data, 0);
-			if (xtr_data && !xtr_data->loaded) {
-				if (!r_bin_file_object_new_from_xtr_data (bin, binfile,
-					    UT64_MAX, r_bin_get_laddr (bin), xtr_data)) {
-					return false;
-				}
-			}
-			obj = r_list_get_n (binfile->objs, 0);
-		}
-	} else {
-		void *plugin = r_bin_get_binplugin_by_name (bin, name);
-		if (plugin) {
-			if (bin->cur) {
-				bin->cur->curplugin = plugin;
-			}
-			binfile = r_bin_file_new (bin, "-", NULL, 0, 0, 0, 999, NULL, NULL, false);
-			if (!binfile) {
+	if (!binfile) {
+		return false;
+	}
+
+	RBinObject *obj = r_bin_object_find_by_arch_bits (binfile, arch, bits, name);
+	if (!obj && binfile->xtr_data) {
+		RBinXtrData *xtr_data = r_list_get_n (binfile->xtr_data, 0);
+		if (xtr_data && !xtr_data->loaded) {
+			if (!r_bin_file_object_new_from_xtr_data (bin, binfile,
+				    UT64_MAX, r_bin_get_laddr (bin), xtr_data)) {
 				return false;
 			}
-			// create object and set arch/bits
-			obj = r_bin_object_new (binfile, plugin, 0, 0, 0, 1024);
-			if (!obj) {
-				return false;
-			}
-			binfile->o = obj;
-			obj->info = R_NEW0 (RBinInfo);
-			obj->info->arch = strdup (arch);
-			obj->info->bits = bits;
 		}
+		obj = r_list_get_n (binfile->objs, 0);
 	}
 	return r_bin_file_set_cur_binfile_obj (bin, binfile, obj);
 }
@@ -1220,19 +1201,25 @@ R_API void r_bin_bind(RBin *bin, RBinBind *b) {
 }
 
 R_API RBuffer *r_bin_create(RBin *bin, const ut8 *code, int codelen,
-			     const ut8 *data, int datalen) {
-	RBinFile *a = r_bin_cur (bin);
-	RBinPlugin *plugin = r_bin_file_cur_plugin (a);
+	const ut8 *data, int datalen, const char *arch, int bits, const char *pluginname) {
+	r_return_val_if_fail (pluginname, NULL);
+
+	RBinPlugin *plugin = r_bin_get_binplugin_by_name (bin, pluginname);
+	if (!plugin) {
+		R_LOG_ERROR ("No plugin named '%s'\n", pluginname);
+		return NULL;
+	} else if (!plugin->create) {
+		R_LOG_ERROR ("Plugin '%s' does not support create method\n", pluginname);
+		return NULL;
+	}
+
 	if (codelen < 0) {
 		codelen = 0;
 	}
 	if (datalen < 0) {
 		datalen = 0;
 	}
-	if (plugin && plugin->create) {
-		return plugin->create (bin, code, codelen, data, datalen);
-	}
-	return NULL;
+	return plugin->create (bin, arch, bits, code, codelen, data, datalen);
 }
 
 R_API RBuffer *r_bin_package(RBin *bin, const char *type, const char *file, RList *files) {

--- a/libr/bin/i/private.h
+++ b/libr/bin/i/private.h
@@ -18,7 +18,6 @@ R_IPI bool r_bin_file_set_bytes(RBinFile *binfile, const ut8 *bytes, ut64 sz, bo
 
 R_IPI RBinPlugin *r_bin_get_binplugin_any(RBin *bin);
 R_IPI RBinXtrPlugin *r_bin_get_xtrplugin_by_name(RBin *bin, const char *name);
-R_IPI RBinPlugin *r_bin_get_binplugin_by_name(RBin *bin, const char *name);
 
 R_IPI void r_bin_section_free(RBinSection *bs);
 

--- a/libr/bin/p/bin_cgc.c
+++ b/libr/bin/p/bin_cgc.c
@@ -10,7 +10,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return buf && length > 4 && !memcmp (buf, CGCMAG, SCGCMAG) && buf[4] != 2;
 }
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	ut32 filesize, code_va, code_pa, phoff;
 	ut32 p_start, p_phoff, p_phdr;
 	ut32 p_ehdrsz, p_phdrsz;

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -20,7 +20,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 extern struct r_bin_dbginfo_t r_bin_dbginfo_elf;
 extern struct r_bin_write_t r_bin_write_elf;
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	ut32 filesize, code_va, code_pa, phoff;
 	ut32 p_start, p_phoff, p_phdr;
 	ut32 p_ehdrsz, p_phdrsz;

--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -33,7 +33,7 @@ static void headers64(RBinFile *bf) {
 	p ("0x00000028  ShOff       0x%08"PFMT64x"\n", r_read_le64 (buf + 0x28));
 }
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	ut32 p_start, p_phoff, p_phdr;
 	ut32 p_vaddr, p_paddr, p_fs, p_fs2;
 	ut32 p_ehdrsz, p_phdrsz;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -591,7 +591,7 @@ typedef struct r_bin_create_t {
 } RBinCreate;
 #endif
 
-static RBuffer* create(RBin* bin, const ut8 *code, int clen, const ut8 *data, int dlen) {
+static RBuffer* create(RBin* bin, const char *arch, int bits, const ut8 *code, int clen, const ut8 *data, int dlen) {
 	const bool use_pagezero = true;
 	const bool use_main = true;
 	const bool use_dylinker = true;
@@ -604,10 +604,10 @@ static RBuffer* create(RBin* bin, const ut8 *code, int clen, const ut8 *data, in
 	ut32 p_cmdsize = 0, p_entry = 0, p_tmp = 0;
 	ut32 baddr = 0x1000;
 
-	bool is_arm = strstr (bin->cur->o->info->arch, "arm");
+	bool is_arm = strstr (arch, "arm");
 	RBuffer *buf = r_buf_new ();
 #ifndef R_BIN_MACH064
-	if (bin->cur->o->info->bits == 64) {
+	if (bits == 64) {
 		eprintf ("TODO: Please use mach064 instead of mach0\n");
 		free (buf);
 		return NULL;

--- a/libr/bin/p/bin_mach064.c
+++ b/libr/bin/p/bin_mach064.c
@@ -15,7 +15,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	const bool use_pagezero = true;
 	const bool use_main = true;
 	const bool use_dylinker = true;

--- a/libr/bin/p/bin_menuet.c
+++ b/libr/bin/p/bin_menuet.c
@@ -191,7 +191,7 @@ static ut64 size(RBinFile *bf) {
 #if !R_BIN_P9
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	RBuffer *buf = r_buf_new ();
 #define B(x,y) r_buf_append_bytes(buf,(const ut8*)(x),y)
 #define D(x) r_buf_append_ut32(buf,x)

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -205,7 +205,7 @@ static ut64 size(RBinFile *bf) {
 #if !R_BIN_P9
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer *create(RBin *bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	RBuffer *buf = r_buf_new ();
 #define B(x, y) r_buf_append_bytes (buf, (const ut8 *) (x), y)
 #define D(x) r_buf_append_ut32 (buf, x)

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -29,7 +29,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 }
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	ut32 hdrsize, p_start, p_opthdr, p_sections, p_lsrlc, n;
 	ut32 baddr = 0x400000;
 	RBuffer *buf = r_buf_new ();

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -276,7 +276,7 @@ static ut64 size(RBinFile *bf) {
 }
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer *create(RBin *bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen) {
 	RBuffer *buf = r_buf_new ();
 #define B(x, y) r_buf_append_bytes (buf, (const ut8 *) (x), y)
 #define D(x) r_buf_append_ut32 (buf, x)

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -416,7 +416,7 @@ typedef struct r_bin_plugin_t {
 	int (*get_offset)(RBinFile *arch, int type, int idx);
 	char* (*get_name)(RBinFile *arch, int type, int idx);
 	ut64 (*get_vaddr)(RBinFile *arch, ut64 baddr, ut64 paddr, ut64 vaddr);
-	RBuffer* (*create)(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
+	RBuffer* (*create)(RBin *bin, const char *arch, int bits, const ut8 *code, int codelen, const ut8 *data, int datalen);
 	char* (*demangle)(const char *str);
 	char* (*regstate)(RBinFile *arch);
 	int (*file_type)(RBinFile *arch);
@@ -629,6 +629,7 @@ R_API int r_bin_list(RBin *bin, int json);
 R_API int r_bin_list_plugin(RBin *bin, const char *name, int json);
 R_API RBinPlugin *r_bin_file_cur_plugin(RBinFile *binfile);
 R_API RBinPlugin *r_bin_get_binplugin_by_bytes(RBin *bin, const ut8 *bytes, ut64 sz);
+R_API RBinPlugin *r_bin_get_binplugin_by_name(RBin *bin, const char *name);
 R_API void r_bin_force_plugin(RBin *bin, const char *pname);
 
 // get/set various bin information
@@ -667,7 +668,7 @@ R_API int r_bin_select(RBin *bin, const char *arch, int bits, const char *name);
 R_API int r_bin_select_by_ids(RBin *bin, ut32 binfile_id, ut32 binobj_id);
 R_API int r_bin_use_arch(RBin *bin, const char *arch, int bits, const char *name);
 R_API void r_bin_list_archs(RBin *bin, int mode);
-R_API RBuffer *r_bin_create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
+R_API RBuffer *r_bin_create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen, const char *arch, int bits, const char *pluginname);
 R_API RBuffer *r_bin_package(RBin *bin, const char *type, const char *file, RList *files);
 
 R_API const char *r_bin_string_type(int type);


### PR DESCRIPTION
The fact that we are creating a file, means there is no
RBinFile/RBinObject and creating a fake one just to pass arch/bits seems
a bit overkill, plus the fact that all r_binfile/r_binobj APIs wouldn't
work well because the fake binfiles wouldn't contain anything.