### PR TITLE
[WIP] Fix #11978: Filter out gdb_io requests when they are out of sections if sections are available

### DIFF
--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -9,6 +9,7 @@
 #include <libgdbr.h>
 #include <gdbclient/commands.h>
 #include <r_core.h>
+#include <r_bin.h>
 
 typedef struct {
 	libgdbr_t desc;

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -172,13 +172,13 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		return -1;
 	}
 
-	RCore * core = io->user;
+	RCore *core = io->user;
 	RList *sections = r_bin_get_sections (core->bin);
-	if (sections && r_list_length(sections)) {
+	if (sections && r_list_length (sections)) {
 		RListIter *iter;
 		RBinSection *section;
 		r_list_foreach (sections, iter, section) {
-			if (section->vaddr <= addr  && addr < section->vaddr + section->size) {
+			if (section->vaddr <= addr && addr < section->vaddr + section->size) {
 				return debug_gdb_read_at (buf, count, addr);
 			}
 		}


### PR DESCRIPTION
in this first patch I do the filtering out.
But I need to add commands in order to allow hand crafting sections
this PR is related to #11978