### PR TITLE
Use ptrace_wrap_func() for backtrace ##debug 

### DIFF
--- a/libr/debug/p/native/bt.c
+++ b/libr/debug/p/native/bt.c
@@ -21,6 +21,20 @@ static void prepend_current_pc (RDebug *dbg, RList *list) {
 	}
 }
 
+
+#if HAVE_PTRACE
+struct frames_proxy_args {
+	RDebugFrameCallback cb;
+	RDebug *dbg;
+	ut64 at;
+};
+
+static void *backtrace_proxy(void *user) {
+	struct frames_proxy_args *args = user;
+	return args->cb (args->dbg, args->at);
+}
+#endif
+
 static RList *r_debug_native_frames(RDebug *dbg, ut64 at) {
 	RDebugFrameCallback cb = NULL;
 	if (dbg->btalgo) {
@@ -42,7 +56,18 @@ static RList *r_debug_native_frames(RDebug *dbg, ut64 at) {
 		}
 	}
 
-	RList *list = (dbg->btalgo && !strcmp (dbg->btalgo, "trace")) ? r_list_clone (dbg->call_frames) : cb (dbg, at);
+	RList *list;
+	if(dbg->btalgo && !strcmp (dbg->btalgo, "trace")) {
+		r_list_clone (dbg->call_frames);
+	} else {
+#if HAVE_PTRACE
+		struct frames_proxy_args args = { cb, dbg, at };
+		list = r_debug_ptrace_func (dbg, backtrace_proxy, &args);
+#else
+		cb (dbg, at);
+#endif
+	}
+
 	prepend_current_pc (dbg, list);
 	return list;
 }

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -609,6 +609,10 @@ R_API bool r_debug_continue_back(RDebug *dbg);
 static inline long r_debug_ptrace(RDebug *dbg, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data) {
 	return dbg->iob.ptrace (dbg->iob.io, request, pid, addr, data);
 }
+
+static inline void *r_debug_ptrace_func(RDebug *dbg, void *(*func)(void *), void *user) {
+	return dbg->iob.ptrace_func (dbg->iob.io, func, user);
+}
 #endif
 
 /* plugin pointers */

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -257,6 +257,7 @@ typedef RIOSection *(*RIOSectionVgetSec) (RIO *io, ut64 vaddr);
 typedef RIOSection *(*RIOSectionAdd) (RIO *io, ut64 addr, ut64 vaddr, ut64 size, ut64 vsize, int rwx, const char *name, ut32 bin_id, int fd);
 #if HAVE_PTRACE
 typedef long (*RIOPtraceFn) (RIO *io, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data);
+typedef void *(*RIOPtraceFuncFn) (RIO *io, void *(*func)(void *), void *user);
 #endif
 
 typedef struct r_io_bind_t {
@@ -290,6 +291,7 @@ typedef struct r_io_bind_t {
 	RIOSectionAdd section_add;
 #if HAVE_PTRACE
 	RIOPtraceFn ptrace;
+	RIOPtraceFuncFn ptrace_func;
 #endif
 } RIOBind;
 
@@ -496,6 +498,7 @@ R_API bool r_io_write_i (RIO* io, ut64 addr, ut64 *val, int size, bool endian);
 #if HAVE_PTRACE
 R_API long r_io_ptrace(RIO *io, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data);
 R_API pid_t r_io_ptrace_fork(RIO *io, void (*child_callback)(void *), void *child_callback_user);
+R_API void *r_io_ptrace_func(RIO *io, void *(*func)(void *), void *user);
 #endif
 
 extern RIOPlugin r_io_plugin_procpid;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -562,6 +562,7 @@ R_API void r_io_bind(RIO *io, RIOBind *bnd) {
 	bnd->sect_vget = r_io_section_vget;
 #if HAVE_PTRACE
 	bnd->ptrace = r_io_ptrace;
+	bnd->ptrace_func = r_io_ptrace_func;
 #endif
 }
 
@@ -672,6 +673,17 @@ R_API pid_t r_io_ptrace_fork(RIO *io, void (*child_callback)(void *), void *chil
 #endif
 }
 #endif
+
+
+R_API void *r_io_ptrace_func(RIO *io, void *(*func)(void *), void *user) {
+#if USE_PTRACE_WRAP
+	ptrace_wrap_instance *wrap = io_ptrace_wrap_instance (io);
+	if (wrap) {
+		return ptrace_wrap_func (wrap, func, user);
+	}
+#endif
+	return func (user);
+}
 
 
 //remove all descs and maps

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -185,7 +185,7 @@ ptrace-wrap-sync sync-ptrace-wrap:
 	sed -e "s, library(, static_library(," -e "s,project(,# project(," -e "s,subdir(,# subdir(," ptrace-wrap.vc/meson.build > ptrace-wrap/meson.build
 	printf "include ../../libr/config.mk\ninclude ../../mk/platform.mk\ninclude ../../mk/${COMPILER}.mk\n\n" | cat - ptrace-wrap.vc/Makefile > ptrace-wrap/Makefile
 	rm -rf ptrace-wrap.vc
-	printf "CFLAGS+=-I\$$(STOP)/ptrace-wrap/include\nLINK+=\$$(STOP)/ptrace-wrap/libptrace_wrap.\$$(EXT_AR)\n" > ptrace-wrap/deps.mk
+	printf "CFLAGS+=-I\$$(STOP)/ptrace-wrap/include\nLINK+=\$$(STOP)/ptrace-wrap/libptrace_wrap.\$$(EXT_AR)\nPTRACEWRAP_OBJS=\$$(STOP)/ptrace-wrap/src/ptrace_wrap.o\n" > ptrace-wrap/deps.mk
 
 ptrace-wrap:
 	$(MAKE) -C ptrace-wrap all

--- a/shlr/ptrace-wrap/README.md
+++ b/shlr/ptrace-wrap/README.md
@@ -1,7 +1,7 @@
 
 # ptrace-wrap
 
-ptrace has one major issue: When one process attaches to another, the tracer's pid is
+ptrace on Linux has one major issue: When one process attaches to another, the tracer's pid is
 associated to the tracee's pid.
 However, because different threads in the tracer have different tids, which are actually just
 pids on Linux, only the one thread that started the trace can continue to call ptrace for

--- a/shlr/ptrace-wrap/include/ptrace_wrap.h
+++ b/shlr/ptrace-wrap/include/ptrace_wrap.h
@@ -31,8 +31,11 @@ typedef int ptrace_wrap_ptrace_request;
 typedef enum {
 	PTRACE_WRAP_REQUEST_TYPE_STOP,
 	PTRACE_WRAP_REQUEST_TYPE_PTRACE,
-	PTRACE_WRAP_REQUEST_TYPE_FORK
+	PTRACE_WRAP_REQUEST_TYPE_FORK,
+	PTRACE_WRAP_REQUEST_TYPE_FUNC
 } ptrace_wrap_request_type;
+
+typedef void *(*ptrace_wrap_func_func)(void *);
 
 typedef struct ptrace_wrap_request_t {
 	ptrace_wrap_request_type type;
@@ -49,6 +52,10 @@ typedef struct ptrace_wrap_request_t {
 			void *child_callback_user;
 			int *_errno;
 		} fork;
+		struct {
+			ptrace_wrap_func_func func;
+			void *user;
+		} func;
 	};
 } ptrace_wrap_request;
 
@@ -60,6 +67,7 @@ typedef struct ptrace_wrap_instance_t {
 	union {
 		long ptrace_result;
 		pid_t fork_result;
+		void *func_result;
 	};
 } ptrace_wrap_instance;
 
@@ -67,5 +75,6 @@ int ptrace_wrap_instance_start(ptrace_wrap_instance *inst);
 void ptrace_wrap_instance_stop(ptrace_wrap_instance *inst);
 long ptrace_wrap(ptrace_wrap_instance *inst, ptrace_wrap_ptrace_request request, pid_t pid, void *addr, void *data);
 pid_t ptrace_wrap_fork(ptrace_wrap_instance *inst, void (*child_callback)(void *), void *child_callback_user);
+void *ptrace_wrap_func(ptrace_wrap_instance *inst, ptrace_wrap_func_func func, void *user);
 
 #endif //PTRACE_WRAP_H


### PR DESCRIPTION
Fix #12022

The idea is to not push every single ptrace call separately to the ptrace-wrap thread and wait for it, but to execute a whole, bigger function on the ptrace-wrap thread, so synchronization only happens once at the begin and the end.