### PR TITLE
Add RBinArchOptions type

### DIFF
--- a/binr/rabin2/rabin2.c
+++ b/binr/rabin2/rabin2.c
@@ -899,18 +899,9 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 		codelen = r_hex_str2bin (p, code);
-		if (!arch) {
-			arch = R_SYS_ARCH;
-		}
-		if (!bits) {
-			bits = 32;
-		}
-		if (!r_bin_use_arch (bin, arch, bits, create)) {
-			eprintf ("Cannot set arch\n");
-			r_core_fini (&core);
-			return 1;
-		}
-		b = r_bin_create (bin, code, codelen, data, datalen);
+		RBinArchOptions opts;
+		r_bin_arch_options_init (&opts, arch, bits);
+		b = r_bin_create (bin, create, code, codelen, data, datalen, &opts);
 		if (b) {
 			if (r_file_dump (file, b->buf, b->length, 0)) {
 				eprintf ("Dumped %"PFMT64d" bytes in '%s'\n", b->length, file);

--- a/binr/ragg2/ragg2.c
+++ b/binr/ragg2/ragg2.c
@@ -68,13 +68,10 @@ static void list(REgg *egg) {
 
 static int create(const char *format, const char *arch, int bits, const ut8 *code, int codelen) {
 	RBin *bin = r_bin_new ();
+	RBinArchOptions opts;
 	RBuffer *b;
-	if (!r_bin_use_arch (bin, arch, bits, format)) {
-		eprintf ("Cannot set arch\n");
-		r_bin_free (bin);
-		return 1;
-	}
-	b = r_bin_create (bin, code, codelen, NULL, 0); //data, datalen);
+	r_bin_arch_options_init (&opts, arch, bits);
+	b = r_bin_create (bin, format, code, codelen, NULL, 0, &opts);
 	if (b) {
 		write (1, b->buf, b->length);
 		r_buf_free (b);

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -125,9 +125,8 @@ R_API void r_bin_options_init(RBinOptions *opt, int fd, ut64 baseaddr, ut64 load
 }
 
 R_API void r_bin_arch_options_init(RBinArchOptions *opt, const char *arch, int bits) {
-	memset (opt, 0, sizeof (*opt));
 	opt->arch = arch? arch: R_SYS_ARCH;
-	opt->bits = bits? bits: 32;
+	opt->bits = bits? bits: R_SYS_BITS;
 }
 
 R_API void r_bin_info_free(RBinInfo *rb) {
@@ -1217,7 +1216,8 @@ R_API RBuffer *r_bin_create(RBin *bin, const char *plugin_name,
 	if (!plugin) {
 		R_LOG_WARN ("Cannot find RBin plugin named '%s'.\n", plugin_name);
 		return NULL;
-	} else if (!plugin->create) {
+	}
+	if (!plugin->create) {
 		R_LOG_WARN ("RBin plugin '%s' does not implement \"create\" method.\n", plugin_name);
 		return NULL;
 	}

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -956,39 +956,21 @@ R_API int r_bin_use_arch(RBin *bin, const char *arch, int bits, const char *name
 	r_return_val_if_fail (bin && arch, false);
 
 	RBinFile *binfile = r_bin_file_find_by_arch_bits (bin, arch, bits);
-	RBinObject *obj = NULL;
-	if (binfile) {
-		obj = r_bin_object_find_by_arch_bits (binfile, arch, bits, name);
-		if (!obj && binfile->xtr_data) {
-			RBinXtrData *xtr_data = r_list_get_n (binfile->xtr_data, 0);
-			if (xtr_data && !xtr_data->loaded) {
-				if (!r_bin_file_object_new_from_xtr_data (bin, binfile,
-					    UT64_MAX, r_bin_get_laddr (bin), xtr_data)) {
-					return false;
-				}
-			}
-			obj = r_list_get_n (binfile->objs, 0);
-		}
-	} else {
-		void *plugin = r_bin_get_binplugin_by_name (bin, name);
-		if (plugin) {
-			if (bin->cur) {
-				bin->cur->curplugin = plugin;
-			}
-			binfile = r_bin_file_new (bin, "-", NULL, 0, 0, 0, 999, NULL, NULL, false);
-			if (!binfile) {
+	if (!binfile) {
+		R_LOG_WARN ("Cannot find binfile with arch/bits %s/%d\n", arch, bits);
+		return false;
+	}
+
+	RBinObject *obj = r_bin_object_find_by_arch_bits (binfile, arch, bits, name);
+	if (!obj && binfile->xtr_data) {
+		RBinXtrData *xtr_data = r_list_get_n (binfile->xtr_data, 0);
+		if (xtr_data && !xtr_data->loaded) {
+			if (!r_bin_file_object_new_from_xtr_data (bin, binfile,
+				    UT64_MAX, r_bin_get_laddr (bin), xtr_data)) {
 				return false;
 			}
-			// create object and set arch/bits
-			obj = r_bin_object_new (binfile, plugin, 0, 0, 0, 1024);
-			if (!obj) {
-				return false;
-			}
-			binfile->o = obj;
-			obj->info = R_NEW0 (RBinInfo);
-			obj->info->arch = strdup (arch);
-			obj->info->bits = bits;
 		}
+		obj = r_list_get_n (binfile->objs, 0);
 	}
 	return r_bin_file_set_cur_binfile_obj (bin, binfile, obj);
 }

--- a/libr/bin/p/bin_cgc.c
+++ b/libr/bin/p/bin_cgc.c
@@ -10,7 +10,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return buf && length > 4 && !memcmp (buf, CGCMAG, SCGCMAG) && buf[4] != 2;
 }
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	ut32 filesize, code_va, code_pa, phoff;
 	ut32 p_start, p_phoff, p_phdr;
 	ut32 p_ehdrsz, p_phdrsz;

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -20,7 +20,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 extern struct r_bin_dbginfo_t r_bin_dbginfo_elf;
 extern struct r_bin_write_t r_bin_write_elf;
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	ut32 filesize, code_va, code_pa, phoff;
 	ut32 p_start, p_phoff, p_phdr;
 	ut32 p_ehdrsz, p_phdrsz;
@@ -29,9 +29,9 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	ut32 baddr;
 	int is_arm = 0;
 	RBuffer *buf = r_buf_new ();
-	if (bin && bin->cur && bin->cur->o && bin->cur->o->info) {
-		is_arm = !strcmp (bin->cur->o->info->arch, "arm");
-	}
+
+	r_return_val_if_fail (bin && opt && opt->arch, NULL);
+	is_arm = !strcmp (opt->arch, "arm");
 	// XXX: hardcoded
 	if (is_arm) {
 		baddr = 0x40000;

--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -33,7 +33,7 @@ static void headers64(RBinFile *bf) {
 	p ("0x00000028  ShOff       0x%08"PFMT64x"\n", r_read_le64 (buf + 0x28));
 }
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	ut32 p_start, p_phoff, p_phdr;
 	ut32 p_vaddr, p_paddr, p_fs, p_fs2;
 	ut32 p_ehdrsz, p_phdrsz;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -581,17 +581,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-#if 0
-typedef struct r_bin_create_t {
-	int arch;
-	ut8 *code;
-	int clen;
-	ut8 *data;
-	int dlen;
-} RBinCreate;
-#endif
-
-static RBuffer* create(RBin* bin, const ut8 *code, int clen, const ut8 *data, int dlen) {
+static RBuffer* create(RBin* bin, const ut8 *code, int clen, const ut8 *data, int dlen, RBinArchOptions *opt) {
 	const bool use_pagezero = true;
 	const bool use_main = true;
 	const bool use_dylinker = true;
@@ -604,10 +594,12 @@ static RBuffer* create(RBin* bin, const ut8 *code, int clen, const ut8 *data, in
 	ut32 p_cmdsize = 0, p_entry = 0, p_tmp = 0;
 	ut32 baddr = 0x1000;
 
-	bool is_arm = strstr (bin->cur->o->info->arch, "arm");
+	r_return_val_if_fail (bin && opt, NULL);
+
+	bool is_arm = strstr (opt->arch, "arm");
 	RBuffer *buf = r_buf_new ();
 #ifndef R_BIN_MACH064
-	if (bin->cur->o->info->bits == 64) {
+	if (opt->bits == 64) {
 		eprintf ("TODO: Please use mach064 instead of mach0\n");
 		free (buf);
 		return NULL;

--- a/libr/bin/p/bin_mach064.c
+++ b/libr/bin/p/bin_mach064.c
@@ -15,7 +15,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	const bool use_pagezero = true;
 	const bool use_main = true;
 	const bool use_dylinker = true;

--- a/libr/bin/p/bin_menuet.c
+++ b/libr/bin/p/bin_menuet.c
@@ -191,7 +191,7 @@ static ut64 size(RBinFile *bf) {
 #if !R_BIN_P9
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	RBuffer *buf = r_buf_new ();
 #define B(x,y) r_buf_append_bytes(buf,(const ut8*)(x),y)
 #define D(x) r_buf_append_ut32(buf,x)

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -205,7 +205,7 @@ static ut64 size(RBinFile *bf) {
 #if !R_BIN_P9
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	RBuffer *buf = r_buf_new ();
 #define B(x, y) r_buf_append_bytes (buf, (const ut8 *) (x), y)
 #define D(x) r_buf_append_ut32 (buf, x)

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -29,7 +29,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 }
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	ut32 hdrsize, p_start, p_opthdr, p_sections, p_lsrlc, n;
 	ut32 baddr = 0x400000;
 	RBuffer *buf = r_buf_new ();

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -295,7 +295,7 @@ static ut64 size(RBinFile *bf) {
 }
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
-static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen) {
+static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt) {
 	RBuffer *buf = r_buf_new ();
 #define B(x, y) r_buf_append_bytes (buf, (const ut8 *) (x), y)
 #define D(x) r_buf_append_ut32 (buf, x)

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -376,6 +376,11 @@ typedef struct r_bin_ldr_plugin_t {
 	bool (*load)(RBin *bin);
 } RBinLdrPlugin;
 
+typedef struct r_bin_arch_options_t {
+	const char *arch;
+	int bits;
+} RBinArchOptions;
+
 typedef struct r_bin_plugin_t {
 	char *name;
 	char *desc;
@@ -416,7 +421,7 @@ typedef struct r_bin_plugin_t {
 	int (*get_offset)(RBinFile *arch, int type, int idx);
 	char* (*get_name)(RBinFile *arch, int type, int idx);
 	ut64 (*get_vaddr)(RBinFile *arch, ut64 baddr, ut64 paddr, ut64 vaddr);
-	RBuffer* (*create)(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
+	RBuffer* (*create)(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt);
 	char* (*demangle)(const char *str);
 	char* (*regstate)(RBinFile *arch);
 	int (*file_type)(RBinFile *arch);
@@ -612,6 +617,7 @@ typedef void (*RBinSymbolCallback)(RBinObject *obj, RBinSymbol *symbol);
 
 // options functions
 R_API void r_bin_options_init(RBinOptions *opt, int fd, ut64 baseaddr, ut64 loadaddr, int rawstr);
+R_API void r_bin_arch_options_init(RBinArchOptions *opt, const char *arch, int bits);
 
 // open/close/reload functions
 R_API RBin *r_bin_new(void);
@@ -667,7 +673,7 @@ R_API int r_bin_select(RBin *bin, const char *arch, int bits, const char *name);
 R_API int r_bin_select_by_ids(RBin *bin, ut32 binfile_id, ut32 binobj_id);
 R_API int r_bin_use_arch(RBin *bin, const char *arch, int bits, const char *name);
 R_API void r_bin_list_archs(RBin *bin, int mode);
-R_API RBuffer *r_bin_create(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
+R_API RBuffer *r_bin_create(RBin *bin, const char *plugin_name, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt);
 R_API RBuffer *r_bin_package(RBin *bin, const char *type, const char *file, RList *files);
 
 R_API const char *r_bin_string_type(int type);


### PR DESCRIPTION
For now I put the RBinArchOptions in r_bin.h. It can be easily moved if it needs to be used elsewhere in the future. The reasons I did that is because I'm not sure we will be able to easily extend this structure and use it everywhere... Some places do require `os`, others don't. Some places do require `cpu`, others do not, etc... So I think the best thing is to keep it as simple as possible for now and choose in the future when we have a better view.