### PR TITLE
rbin: simplify load_bytes() signature ##refactor

### DIFF
--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -182,7 +182,7 @@ R_IPI RBinObject *r_bin_object_new(RBinFile *binfile, RBinPlugin *plugin, ut64 b
 		if (sz < bsz) {
 			bsz = sz;
 		}
-		if (!plugin->load_bytes (binfile, &o->bin_obj, bytes + offset, sz,
+		if (!plugin->load_bytes (binfile, bytes + offset, sz,
 					 loadaddr, sdb)) {
 			bprintf (
 				"Error in r_bin_object_new: load_bytes failed "
@@ -192,6 +192,7 @@ R_IPI RBinObject *r_bin_object_new(RBinFile *binfile, RBinPlugin *plugin, ut64 b
 			free (o);
 			return NULL;
 		}
+		o->bin_obj = binfile->o->bin_obj;
 	} else if (plugin->load) {
 		R_LOG_WARN ("Plugin %s should implement load_buffer method instead of load.\n", plugin->name);
 		// XXX - haha, this is a hack.

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -75,7 +75,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb)
 	}
 	art_header_load (&ao->art, bf->buf, ao->kv);
 	sdb_ns_set (sdb, "info", ao->kv);
-	*bin_obj = ao;
+	bf->o->bin_obj = ao;
 	return true;
 }
 

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -63,7 +63,7 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return ao? ao->kv: NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb){
 	ArtObj *ao = R_NEW0 (ArtObj);
 	if (!ao) {
 		return false;

--- a/libr/bin/p/bin_avr.c
+++ b/libr/bin/p/bin_avr.c
@@ -68,7 +68,7 @@ static bool check_bytes(const ut8 *b, ut64 length) {
 	return check_bytes_rjmp (b, length);
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_bf.c
+++ b/libr/bin/p/bin_bf.c
@@ -5,7 +5,7 @@
 #include <r_lib.h>
 #include <r_bin.h>
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return true;
 }
 

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -7,7 +7,7 @@
 #include <r_io.h>
 #include "bflt/bflt.h"
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *sdb) {
 	if (!buf || !sz || sz == UT64_MAX) {
 		return false;
 	}

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -25,7 +25,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *
 static bool load(RBinFile *bf) {
 	const ut8 *bytes = r_buf_buffer (bf->buf);
 	ut64 sz = r_buf_size (bf->buf);
-	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static RList *entries(RBinFile *bf) {

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -18,7 +18,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loaddr, Sdb *
 	r_buf_set_bytes (tbuf, buf, sz);
 	struct r_bin_bflt_obj *res = r_bin_bflt_new_buf (tbuf);
 	r_buf_free (tbuf);
-	*bin_obj = res;
+	bf->o->bin_obj = res;
 	return true;
 }
 

--- a/libr/bin/p/bin_bios.c
+++ b/libr/bin/p/bin_bios.c
@@ -21,7 +21,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_bootimg.c
+++ b/libr/bin/p/bin_bootimg.c
@@ -82,7 +82,7 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return ao? ao->kv: NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb) {
 	BootImageObj *bio = R_NEW0 (BootImageObj);
 	if (!bio) {
 		return false;

--- a/libr/bin/p/bin_bootimg.c
+++ b/libr/bin/p/bin_bootimg.c
@@ -97,7 +97,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 la, Sdb *sdb)
 		return false;
 	}
 	sdb_ns_set (sdb, "info", bio->kv);
-	*bin_obj = bio;
+	bf->o->bin_obj = bio;
 	return true;
 }
 

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -25,7 +25,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 	}
 	RBuffer *tbuf = r_buf_new();
 	r_buf_set_bytes (tbuf, buf, sz);
-	*bin_obj = r_bin_coff_new_buf (tbuf, bf->rbin->verbose);
+	bf->o->bin_obj = r_bin_coff_new_buf (tbuf, bf->rbin->verbose);
 	r_buf_free (tbuf);
 	return true;
 }

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -19,7 +19,7 @@ static Sdb* get_sdb(RBinFile *bf) {
 	return NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	if (!buf || !sz || sz == UT64_MAX) {
 		return false;
 	}

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -37,7 +37,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -711,7 +711,7 @@ static Sdb *get_sdb (RBinFile *bf) {
 	return bin->kv;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	RBuffer *tbuf = NULL;
 	if (!buf || !sz || sz == UT64_MAX) {
 		return false;

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -721,7 +721,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 		return false;
 	}
 	r_buf_set_bytes (tbuf, buf, sz);
-	*bin_obj = r_bin_dex_new_buf (tbuf);
+	bf->o->bin_obj = r_bin_dex_new_buf (tbuf);
 	r_buf_free (tbuf);
 	return true;
 }

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -737,7 +737,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static ut64 baddr(RBinFile *bf) {

--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -86,8 +86,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	load_bytes (bf, &bf->o->bin_obj, bytes,
-		sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -45,7 +45,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (buf, "\x00\x00\x01\x00\x00\x00", 6));
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	bool has_dol_extension = false;
 	DolHeader *dol;
 	char *lowername, *ext;

--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -71,7 +71,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 		r_buf_fread_at (bf->buf, 0, (void *) dol, "67I", 1);
 		// r_buf_fread_at (bf->buf, 0, (void*)dol, "67i", 1);
 		if (bf && bf->o && bf->o->bin_obj) {
-			*bin_obj = bf->o->bin_obj = dol;
+			bf->o->bin_obj = dol;
 		}
 		free (dol);
 		return true;

--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -873,7 +873,7 @@ static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf ? r_buf_buffer (bf->buf) : NULL;
 	ut64 sz = bf ? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o) ? bf->o->loadaddr: 0;
-	return load_bytes (bf, bf? &bf->o->bin_obj: NULL, bytes, sz, la, bf? bf->sdb: NULL);
+	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static RList *entries(RBinFile *bf) {

--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -865,7 +865,7 @@ static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
 	return cache;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -86,7 +86,7 @@ static void * load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
 	return res;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	struct Elf_(r_bin_elf_obj_t) *res;
 	if (!buf || !sz || sz == UT64_MAX) {
 		return false;

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -109,7 +109,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -99,7 +99,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	*bin_obj = res;
+	bf->o->bin_obj = res;
 	return true;
 }
 

--- a/libr/bin/p/bin_fs.c
+++ b/libr/bin/p/bin_fs.c
@@ -61,7 +61,7 @@ static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf ? r_buf_buffer (bf->buf) : NULL;
 	ut64 sz = bf ? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o) ? bf->o->loadaddr: 0;
-	return load_bytes (bf, bf? &bf->o->bin_obj: NULL, bytes, sz, la, bf? bf->sdb: NULL);
+	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_fs.c
+++ b/libr/bin/p/bin_fs.c
@@ -53,7 +53,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return p != NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -83,7 +83,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 	tbuf = r_buf_new ();
 	r_buf_set_bytes (tbuf, buf, sz);
 	tmp_bin_obj = r_bin_java_new_buf (tbuf, loadaddr, sdb);
-	*bin_obj = tmp_bin_obj;
+	bf->o->bin_obj = tmp_bin_obj;
 	add_bin_obj_to_sdb (tmp_bin_obj);
 	if (bf && bf->file) {
 		tmp_bin_obj->file = strdup (bf->file);

--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -74,7 +74,7 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	struct r_bin_java_obj_t *tmp_bin_obj = NULL;
 	RBuffer *tbuf = NULL;
 	if (!buf || sz == 0 || sz == UT64_MAX) {

--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -102,7 +102,7 @@ static bool load(RBinFile *bf) {
 		return false;
 	}
 
-	load_bytes (bf, (void **) &bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 
 	if (bin_obj) {
 		if (!bf->o->kv) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -75,7 +75,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 	if (!bf->o || !bf->o->bin_obj) {
 		MACH0_(mach0_free) (bf->o->bin_obj);
 		return false;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -33,7 +33,7 @@ static char *entitlements(RBinFile *bf, bool json) {
 	return strdup ((char*) bin->signature);
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	struct MACH0_(obj_t) *res = NULL;
 	if (!buf || !sz || sz == UT64_MAX) {
 		return false;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -50,7 +50,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	*bin_obj = res;
+	bf->o->bin_obj = res;
 	return true;
 }
 

--- a/libr/bin/p/bin_mbn.c
+++ b/libr/bin/p/bin_mbn.c
@@ -79,7 +79,7 @@ static bool load(RBinFile *bf) {
 	if (bf && bf->buf) {
 		const ut8 *bytes = r_buf_buffer (bf->buf);
 		ut64 sz = r_buf_size (bf->buf);
-		return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+		return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 	}
 	return false;
 }

--- a/libr/bin/p/bin_mbn.c
+++ b/libr/bin/p/bin_mbn.c
@@ -71,7 +71,7 @@ static bool check_bytes(const ut8 *buf, ut64 bufsz) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -200,7 +200,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 	r_buf_free (tbuf);
 
 	if (res) {
-		*bin_obj = res;
+		bf->o->bin_obj = res;
 		return true;
 	} else {
 		return false;

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -184,7 +184,7 @@ static RList* libs(RBinFile *bf) {
 	return ret;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	RBuffer *tbuf;
 	struct r_bin_mdmp_obj *res;
 

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -225,7 +225,7 @@ static bool load(RBinFile *bf) {
 		return false;
 	}
 
-	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static RList *sections(RBinFile *bf) {

--- a/libr/bin/p/bin_menuet.c
+++ b/libr/bin/p/bin_menuet.c
@@ -62,7 +62,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_menuet.c
+++ b/libr/bin/p/bin_menuet.c
@@ -70,7 +70,7 @@ static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf ? r_buf_buffer (bf->buf) : NULL;
 	ut64 sz = bf ? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o) ? bf->o->loadaddr: 0;
-	return load_bytes (bf, bf? &bf->o->bin_obj: NULL, bytes, sz, la, bf? bf->sdb: NULL);
+	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static ut64 baddr(RBinFile *bf) {

--- a/libr/bin/p/bin_nes.c
+++ b/libr/bin/p/bin_nes.c
@@ -11,7 +11,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (buf, INES_MAGIC, 4));
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_nin3ds.c
+++ b/libr/bin/p/bin_nin3ds.c
@@ -27,7 +27,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_nin3ds.c
+++ b/libr/bin/p/bin_nin3ds.c
@@ -17,7 +17,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (buf, "FIRM", 4));
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	return memcpy (&loaded_header, buf, sizeof (struct n3ds_firm_hdr));
 }
 

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -20,7 +20,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (ninlogohead, "\x24\xff\xae\x51\x69\x9a", 6))? true: false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	*bin_obj = memcpy (&loaded_header, buf, sizeof(struct nds_hdr));
 	return (*bin_obj != NULL);
 }

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -22,7 +22,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 
 static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	bf->o->bin_obj = memcpy (&loaded_header, buf, sizeof(struct nds_hdr));
-	return (*bin_obj != NULL);
+	return (bf->o->bin_obj != NULL);
 }
 
 static bool load(RBinFile *bf) {
@@ -31,7 +31,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -21,7 +21,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 }
 
 static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
-	*bin_obj = memcpy (&loaded_header, buf, sizeof(struct nds_hdr));
+	bf->o->bin_obj = memcpy (&loaded_header, buf, sizeof(struct nds_hdr));
 	return (*bin_obj != NULL);
 }
 

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -27,7 +27,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf->sdb);
+	load_bytes (bf, bytes, sz, la, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include "../format/nin/nin.h"
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return true;
 }
 

--- a/libr/bin/p/bin_nro.c
+++ b/libr/bin/p/bin_nro.c
@@ -59,7 +59,7 @@ static bool load(RBinFile *bf) {
 	const ut64 sz = r_buf_size (bf->buf);
 	const ut64 la = bf->o->loadaddr;
 	const ut8 *bytes = r_buf_buffer (bf->buf);
-	load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf->sdb);
+	load_bytes (bf, bytes, sz, la, bf->sdb);
 	return bf->o->bin_obj != NULL;
 }
 

--- a/libr/bin/p/bin_nro.c
+++ b/libr/bin/p/bin_nro.c
@@ -48,7 +48,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 	bin->classes_list = r_list_newf ((RListFree)free);
 	ut32 mod0 = readLE32 (bf->buf, NRO_OFFSET_MODMEMOFF);
 	parseMod (bf->buf, bin, mod0, ba);
-	*bin_obj = bin;
+	bf->o->bin_obj = bin;
 	return true;
 }
 

--- a/libr/bin/p/bin_nro.c
+++ b/libr/bin/p/bin_nro.c
@@ -37,7 +37,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	RBinNXOObj *bin = R_NEW0 (RBinNXOObj);
 	if (!bin) {
 		return false;

--- a/libr/bin/p/bin_nso.c
+++ b/libr/bin/p/bin_nso.c
@@ -54,7 +54,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	RBin *rbin = bf->rbin;
 	RBinNXOObj *bin = R_NEW0 (RBinNXOObj);
 	ut32 toff = readLE32 (bf->buf, NSO_OFF (text_memoffset));

--- a/libr/bin/p/bin_nso.c
+++ b/libr/bin/p/bin_nso.c
@@ -90,7 +90,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 	eprintf ("MOD Offset = 0x%"PFMT64x"\n", (ut64)modoff);
 	parseMod (newbuf, bin, modoff, ba);
 	r_buf_free (newbuf);
-	*bin_obj = bin;
+	bf->o->bin_obj = bin;
 	return true;
 fail:
 	r_buf_free (newbuf);

--- a/libr/bin/p/bin_nso.c
+++ b/libr/bin/p/bin_nso.c
@@ -105,7 +105,7 @@ static bool load(RBinFile *bf) {
 	const ut64 sz = r_buf_size (bf->buf);
 	const ut64 la = bf->o->loadaddr;
 	const ut8 *bytes = r_buf_buffer (bf->buf);
-	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, la, bf->sdb);
+	return load_bytes (bf, bytes, sz, la, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_omf.c
+++ b/libr/bin/p/bin_omf.c
@@ -10,7 +10,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 size, ut64 loadaddrn, 
 	if (!buf || !size || size == UT64_MAX) {
 		return false;
 	}
-	*bin_obj = r_bin_internal_omf_load (buf, size);
+	bf->o->bin_obj = r_bin_internal_omf_load (buf, size);
 	return true;
 }
 

--- a/libr/bin/p/bin_omf.c
+++ b/libr/bin/p/bin_omf.c
@@ -20,7 +20,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	return load_bytes (bf, &bf->o->bin_obj, byte, size, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, byte, size, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_omf.c
+++ b/libr/bin/p/bin_omf.c
@@ -6,7 +6,7 @@
 #include <r_bin.h>
 #include "omf/omf.h"
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 size, ut64 loadaddrn, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 size, ut64 loadaddrn, Sdb *sdb) {
 	if (!buf || !size || size == UT64_MAX) {
 		return false;
 	}

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -21,7 +21,7 @@ static bool load(RBinFile *bf) {
 	const ut8 *bytes = bf? r_buf_buffer (bf->buf): NULL;
 	ut64 sz = bf? r_buf_size (bf->buf): 0;
 	ut64 la = (bf && bf->o)? bf->o->loadaddr: 0;
-	return load_bytes (bf, bf? &bf->o->bin_obj: NULL, bytes, sz, la, bf? bf->sdb: NULL);
+	return load_bytes (bf, bytes, sz, la, bf? bf->sdb: NULL);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -13,7 +13,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -55,7 +55,7 @@ static bool load(RBinFile *bf) {
 	}
 	bytes = r_buf_buffer (bf->buf);
 	sz = r_buf_size (bf->buf);
-	return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static int destroy(RBinFile *bf) {

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -30,7 +30,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	*bin_obj = res;
+	bf->o->bin_obj = res;
 	return true;
 }
 

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -17,7 +17,7 @@ static Sdb* get_sdb (RBinFile *bf) {
 	return bin? bin->kv: NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	struct PE_(r_bin_pe_obj_t) *res = NULL;
 	RBuffer *tbuf = NULL;
 	if (!buf || !sz || sz == UT64_MAX) {

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -39,7 +39,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (length > 7 && !memcmp (buf, "PBLAPP\x00\x00", 8));
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_psxexe.c
+++ b/libr/bin/p/bin_psxexe.c
@@ -14,7 +14,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return !memcmp (buf, PSXEXE_ID, PSXEXE_ID_LEN);
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_sfc.c
+++ b/libr/bin/p/bin_sfc.c
@@ -33,7 +33,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (cksum1 == (ut16)~cksum2);
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -102,7 +102,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_sms.c
+++ b/libr/bin/p/bin_sms.c
@@ -38,7 +38,7 @@ static bool check_bytes(const ut8 *buf, ut64 len) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	return check_buffer (bf->buf);
 }
 

--- a/libr/bin/p/bin_spc700.c
+++ b/libr/bin/p/bin_spc700.c
@@ -12,7 +12,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 }
 
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	return check_bytes (buf, sz);
 }
 

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -16,7 +16,7 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return bin? bin->kv: NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
 	struct r_bin_te_obj_t *res = NULL;
 	RBuffer *tbuf = NULL;
 

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -30,7 +30,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 		sdb_ns_set (sdb, "info", res->kv);
 	}
 	r_buf_free (tbuf);
-	*bin_obj = res;
+	bf->o->bin_obj = res;
 	return true;
 }
 

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -41,7 +41,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return bf->o->bin_obj? true: false;
 }
 

--- a/libr/bin/p/bin_vsf.c
+++ b/libr/bin/p/bin_vsf.c
@@ -39,7 +39,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 	return (!memcmp (buf, VICE_MAGIC, VICE_MAGIC_LEN));
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	ut64 offset = 0;
 	struct r_bin_vsf_obj* res = NULL;
 	if (check_bytes (buf, sz)) {

--- a/libr/bin/p/bin_vsf.c
+++ b/libr/bin/p/bin_vsf.c
@@ -103,7 +103,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb
 		res->kv = sdb_new0 ();
 		sdb_ns_set (sdb, "info", res->kv);
 	}
-	*bin_obj = res;
+	bf->o->bin_obj = res;
 	return true;
 }
 

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -79,7 +79,7 @@ static bool check_bytes (const ut8 *buf, ut64 length) {
 
 static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	if (check_bytes (r_buf_buffer (bf->buf), sz)) {
-		*bin_obj = memcpy (&n64_header, buf, sizeof (N64Header));
+		bf->o->bin_obj = memcpy (&n64_header, buf, sizeof (N64Header));
 		return true;
 	}
 	return false;

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -91,7 +91,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
+	load_bytes (bf, bytes, sz, bf->o->loadaddr, bf->sdb);
 	return check_bytes (bytes, sz);
 }
 

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -77,7 +77,7 @@ static bool check_bytes (const ut8 *buf, ut64 length) {
 	return magic == r_read_be32 (buf);
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
 	if (check_bytes (r_buf_buffer (bf->buf), sz)) {
 		*bin_obj = memcpy (&n64_header, buf, sizeof (N64Header));
 		return true;

--- a/libr/bin/p/bin_zimg.c
+++ b/libr/bin/p/bin_zimg.c
@@ -24,7 +24,7 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 size, ut64 loadaddr, S
 	r_buf_set_bytes (tbuf, buf, size);
 	res = r_bin_zimg_new_buf (tbuf);
 	r_buf_free (tbuf);
-	*bin_obj = res;
+	bf->o->bin_obj = res;
 	return true;
 }
 

--- a/libr/bin/p/bin_zimg.c
+++ b/libr/bin/p/bin_zimg.c
@@ -14,7 +14,7 @@ static Sdb *get_sdb(RBinFile *bf) {
 	return bin? bin->kv: NULL;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 size, ut64 loadaddr, Sdb *sdb){
+static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 size, ut64 loadaddr, Sdb *sdb){
 	void *res = NULL;
 	RBuffer *tbuf = NULL;
 	if (!buf || size == 0 || size == UT64_MAX) {

--- a/libr/bin/p/bin_zimg.c
+++ b/libr/bin/p/bin_zimg.c
@@ -34,7 +34,7 @@ static bool load(RBinFile *bf) {
 	if (!bf || !bf->o) {
 		return false;
 	}
-	return load_bytes (bf, &bf->o->bin_obj, bytes, size, bf->o->loadaddr, bf->sdb);
+	return load_bytes (bf, bytes, size, bf->o->loadaddr, bf->sdb);
 }
 
 static ut64 baddr(RBinFile *bf) {

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -386,7 +386,7 @@ typedef struct r_bin_plugin_t {
 	int (*fini)(void *user);
 	Sdb * (*get_sdb)(RBinFile *obj);
 	bool (*load)(RBinFile *arch);
-	bool (*load_bytes)(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb);
+	bool (*load_bytes)(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb);
 	void *(*load_buffer)(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb);
 	ut64 (*size)(RBinFile *bin); // return ut64 maybe? meh
 	int (*destroy)(RBinFile *arch);


### PR DESCRIPTION
load_bytes() has a void **bin_obj parameter which is only used to set bf->o->bin_obj of RBinFile. As it already receives the relevant RBinFile parameter, this patch sets bin_obj directly on bf->o->bin_obj.