### PR TITLE
Replace r_str_utf16_encode() for escaping strings for json

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -63,7 +63,7 @@ static void pair_str(const char *key, const char *val, int mode, int last) {
 		if (!val) {
 			val = "";
 		}
-		char *encval = r_str_utf16_encode (val, -1);
+		char *encval = r_str_escape_utf8_to_json (val, -1);
 		if (encval) {
 			char *qs = r_str_newf ("\"%s\"", encval);
 			pair (key, qs, mode, last);
@@ -1677,7 +1677,7 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 		} else if (IS_MODE_SIMPLE (mode)) {
 			r_cons_println (symname);
 		} else if (IS_MODE_JSON (mode)) {
-			str = r_str_utf16_encode (symname, -1);
+			str = r_str_escape_utf8_to_json (symname, -1);
 			str = r_str_replace (str, "\"", "\\\"", 1);
 			r_cons_printf ("%s{\"ordinal\":%d,"
 				"\"bind\":\"%s\","
@@ -1969,7 +1969,7 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 					addr, symbol->size, sn.demname);
 			}
 		} else if (IS_MODE_JSON (mode)) {
-			char *str = r_str_utf16_encode (symbol->name, -1);
+			char *str = r_str_escape_utf8_to_json (symbol->name, -1);
 			// str = r_str_replace (str, "\"", "\\\"", 1);
 			r_cons_printf ("%s{\"name\":\"%s\","
 				"\"demname\":\"%s\","

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -170,7 +170,7 @@ static void r_core_file_info(RCore *core, int mode) {
 			}
 		}
 		{
-			char *escapedFile = r_str_utf16_encode (uri, -1);
+			char *escapedFile = r_str_escape_utf8_to_json (uri, -1);
 			r_cons_printf ("\"file\":\"%s\"", escapedFile);
 			free (escapedFile);
 		}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5547,13 +5547,13 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		}
 		r_cons_printf (",\"size\":%d", ds->analop.size);
 		{
-			char *escaped_str = r_str_utf16_encode (opstr, -1);
+			char *escaped_str = r_str_escape_utf8_to_json (opstr, -1);
 			if (escaped_str) {
 				r_cons_printf (",\"opcode\":\"%s\"", escaped_str);
 			}
 			free (escaped_str);
 
-			escaped_str = r_str_utf16_encode (str, -1);
+			escaped_str = r_str_escape_utf8_to_json (str, -1);
 			if (escaped_str) {
 				r_cons_printf (",\"disasm\":\"%s\"", escaped_str);
 			}

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -145,6 +145,7 @@ R_API char *r_str_uri_encode(const char *buf);
 R_API char *r_str_utf16_decode(const ut8 *s, int len);
 R_API int r_str_utf16_to_utf8(ut8 *dst, int len_dst, const ut8 *src, int len_src, int little_endian);
 R_API char *r_str_utf16_encode(const char *s, int len);
+R_API char *r_str_escape_utf8_to_json(const char *s, int len);
 R_API char *r_str_home(const char *str);
 R_API char *r_str_r2_prefix(const char *str);
 R_API int r_str_nlen(const char *s, int n);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2275,6 +2275,7 @@ R_API char *r_str_utf16_decode(const ut8 *s, int len) {
 	return result;
 }
 
+// TODO: kill this completely, it makes no sense:
 R_API char *r_str_utf16_encode(const char *s, int len) {
 	int i;
 	char ch[4], *d, *od, *tmp;
@@ -2302,7 +2303,7 @@ R_API char *r_str_utf16_encode(const char *s, int len) {
 			*d++ = *s;
 		} else {
 			*d++ = '\\';
-		//	*d++ = '\\';
+			//	*d++ = '\\';
 			*d++ = 'u';
 			*d++ = '0';
 			*d++ = '0';
@@ -2318,6 +2319,10 @@ R_API char *r_str_utf16_encode(const char *s, int len) {
 		return NULL;
 	}
 	return tmp;
+}
+
+R_API char *r_str_escape_utf8_to_json(const char *s, int len) {
+	return r_str_escape_utf (s, len, R_STRING_ENC_UTF8, false, true);
 }
 
 // TODO: merge print inside rutil


### PR DESCRIPTION
Fix #11395

I added the function `r_str_escape_utf8_to_json()`, which can be used to explicitly escape a utf-8 string for json.
`r_str_utf16_encode()` looks very wrong to me. All it does is go through the string byte by byte and print non-printable bytes as `\u00xx`, which is nonsense, because it corresponds to no real encoding and especially not to utf-16.