### PR TITLE
Fixed bad varsub with bold font 

### DIFF
--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -123,25 +123,13 @@ static char *findNextNumber(char *op) {
 		if (p[0] == 0x1b && p[1] == '[') {
 			ansi_found = true;
 			p += 2;
-			if (p[0] && p[1] == ';') {
-				// "\x1b[%d;2;%d;%d;%dm", fgbg, r, g, b
-				// "\x1b[%d;5;%dm", fgbg, rgb (r, g, b)
-				for (; p[0] && p[1] && p[0] != 0x1b && p[1] != '\\'; p++) {
-					;
-				}
-				if (p[0] && p[1] == '\\') {
-					p++;
-				}
-			} else {
-				// "\x1b[%dm", 30 + k
-				for (; *p && *p != 'J' && *p != 'm' && *p != 'H'; p++) {
-					;
-				}
-				if (*p) {
-					p++;
-					if (!*p) {
-						break;
-					}
+			for (; *p && *p != 'J' && *p != 'm' && *p != 'H'; p++) {
+				;
+			}
+			if (*p) {
+				p++;
+				if (!*p) {
+					break;
 				}
 			}
 			o = p - 1;


### PR DESCRIPTION
Closes #11889 
The `findNextNumber` function in parse.c did not parse correctly ascii escapes that began with `\x1b[1;...`, 
now we just skip everything until we hit a `m`, `J` or `H` like in `r_str_ansi_filter`