### PR TITLE
restore fd when loading symbols from file with oba

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -276,6 +276,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			char *arg = strdup (input + 3);
 			char *filename = strchr (arg, ' ');
 			if (filename) {
+				int saved_fd = r_io_fd_get_current (core->io);
 				RIODesc *desc = r_io_open (core->io, filename + 1, R_PERM_R, 0);
 				if (desc) {
 					*filename = 0;
@@ -285,6 +286,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 					r_bin_open_io (core->bin, &opt);
 					r_io_desc_close (desc);
 					r_core_cmd0 (core, ".is*");
+					r_io_use_fd (core->io, saved_fd);
 				} else {
 					eprintf ("Cannot open %s\n", filename + 1);
 				}


### PR DESCRIPTION
the command `oba` with a filename was erasing the original fd:
![screenshot_20181122_101858](https://user-images.githubusercontent.com/964610/48895334-178beb80-ee45-11e8-98cc-987638e2d0ea.png)

This is fixed by this PR.