### PR TITLE
fix help message of oba command

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -52,7 +52,7 @@ static const char *help_msg_o_star[] = {
 };
 
 static const char *help_msg_oa[] = {
-	"Usage:", "oa [addr] ([filename])", " # load bininfo and update flags",
+	"Usage:", "oba [addr] ([filename])", " # load bininfo and update flags",
 	"oba", " [addr]", "Open bin info from the given address",
 	"oba", " [addr] [filename]", "Open file and load bin info at given address",
 	NULL


### PR DESCRIPTION
the `oba` help message is confusing and should be fixed.
![screenshot_20181122_110400](https://user-images.githubusercontent.com/964610/48895849-5ff7d900-ee46-11e8-96fb-d6daf0e6f4b7.png)
