### PR TITLE
Fix asm.flags.inbytes not showing in graph

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2958,6 +2958,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI ("graph.linemode", 1, "Graph edges (0=diagonal, 1=square)");
 	SETPREF ("graph.font", "Courier", "Font for dot graphs");
 	SETPREF ("graph.offset", "false", "Show offsets in graphs");
+	SETPREF ("graph.bytes", "false", "Show opcode bytes in graphs");
 	SETPREF ("graph.web", "false", "Display graph in web browser (VV)");
 	SETI ("graph.from", UT64_MAX, "Lower bound address when drawing global graphs");
 	SETI ("graph.to", UT64_MAX, "Upper bound address when drawing global graphs");

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -1989,6 +1989,7 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 		"asm.comments", "asm.cmt.right", NULL);
 	const bool o_comments = r_config_get_i (core->config, "graph.comments");
 	const bool o_cmtright = r_config_get_i (core->config, "graph.cmtright");
+	const bool o_bytes = r_config_get_i (core->config, "graph.bytes");
 	const bool o_graph_offset = r_config_get_i (core->config, "graph.offset");
 	int o_cursor = core->print->cur_enabled;
 
@@ -2000,6 +2001,7 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 	r_config_set_i (core->config, "asm.marks", false);
 	r_config_set_i (core->config, "asm.cmt.right", (opts & BODY_SUMMARY) || o_cmtright);
 	r_config_set_i (core->config, "asm.comments", (opts & BODY_SUMMARY) || o_comments);
+	r_config_set_i (core->config, "asm.bytes", (opts & (BODY_SUMMARY | BODY_OFFSETS)) || o_bytes);
 	r_config_set_i (core->config, "asm.bb.middle", false);
 	core->print->cur_enabled = false;
 
@@ -2007,12 +2009,6 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 		r_config_set_i (core->config, "asm.offset", true);
 	} else {
 		r_config_set_i (core->config, "asm.offset", false);
-	}
-
-	if (opts & BODY_OFFSETS || opts & BODY_SUMMARY) {
-		r_config_set_i (core->config, "asm.bytes", true);
-	} else {
-		r_config_set_i (core->config, "asm.bytes", false);
 	}
 
 	bool html = r_config_get_i (core->config, "scr.html");

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -1990,6 +1990,7 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 	const bool o_comments = r_config_get_i (core->config, "graph.comments");
 	const bool o_cmtright = r_config_get_i (core->config, "graph.cmtright");
 	const bool o_bytes = r_config_get_i (core->config, "graph.bytes");
+	const bool o_flags_in_bytes = r_config_get_i (core->config, "asm.flags.inbytes");
 	const bool o_graph_offset = r_config_get_i (core->config, "graph.offset");
 	int o_cursor = core->print->cur_enabled;
 
@@ -2001,7 +2002,8 @@ static char *get_body(RCore *core, ut64 addr, int size, int opts) {
 	r_config_set_i (core->config, "asm.marks", false);
 	r_config_set_i (core->config, "asm.cmt.right", (opts & BODY_SUMMARY) || o_cmtright);
 	r_config_set_i (core->config, "asm.comments", (opts & BODY_SUMMARY) || o_comments);
-	r_config_set_i (core->config, "asm.bytes", (opts & (BODY_SUMMARY | BODY_OFFSETS)) || o_bytes);
+	r_config_set_i (core->config, "asm.bytes", 
+		(opts & (BODY_SUMMARY | BODY_OFFSETS)) || o_bytes || o_flags_in_bytes);
 	r_config_set_i (core->config, "asm.bb.middle", false);
 	core->print->cur_enabled = false;
 


### PR DESCRIPTION
Fix #12046

Added `graph.bytes` option to show opcode bytes in graph view. 
With that enables, it is possible to see the effect of `asm.flags.inbytes`.