### PR TITLE
Allow oo reopen file in debugger when appropriate

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1468,7 +1468,9 @@ static int cmd_open(void *data, const char *input) {
 			}
 			break;
 		case '\0': // "oo"
-			if (core && core->io && core->io->desc) {
+			if (core->dbg) {
+				r_core_file_reopen_debug (core, input + 2);
+			} else if (core && core->io && core->io->desc) {
 				//does not work for debugging
 				int fd;
 				if ((ptr = strrchr (input, ' ')) && ptr[1]) {


### PR DESCRIPTION
This patch allows oo behave as ood when r2 is in debugger mode.

Fix #12292 