### PR TITLE
Fix mount shell and ed commands

### DIFF
--- a/libr/fs/shell.c
+++ b/libr/fs/shell.c
@@ -175,7 +175,6 @@ R_API int r_fs_shell_prompt(RFSShell* shell, RFS* fs, const char* root) {
 			if (file) {
 				r_fs_read (fs, file, 0, file->size);
 				write (1, file->data, file->size);
-				free (file->data);
 				r_fs_close (fs, file);
 			} else {
 				eprintf ("Cannot open file\n");
@@ -218,7 +217,6 @@ R_API int r_fs_shell_prompt(RFSShell* shell, RFS* fs, const char* root) {
 			if (file) {
 				r_fs_read (fs, file, 0, file->size);
 				r_file_dump (input, file->data, file->size, 0);
-				free (file->data);
 				r_fs_close (fs, file);
 			} else {
 				input -= 2; //OMFG!!!! O_O

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -565,7 +565,7 @@ R_API bool r_file_hexdump(const char *file, const ut8 *buf, int len, int append)
 		return false;
 	}
 	if (append) {
-		fd = r_sandbox_fopen (file, "awb");
+		fd = r_sandbox_fopen (file, "ab");
 	} else {
 		r_sys_truncate (file, 0);
 		fd = r_sandbox_fopen (file, "wb");
@@ -607,7 +607,7 @@ R_API bool r_file_dump(const char *file, const ut8 *buf, int len, bool append) {
 		return false;
 	}
 	if (append) {
-		fd = r_sandbox_fopen (file, "awb");
+		fd = r_sandbox_fopen (file, "ab");
 	} else {
 		r_sys_truncate (file, 0);
 		fd = r_sandbox_fopen (file, "wb");


### PR DESCRIPTION
This fixes double free crashes on the `cat` and `get` commands on the mount shell and the `ed` command on Windows (`awb` is an invalid file open mode)