### PR TITLE
Change unneeded global static vars to local static

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1221,8 +1221,8 @@ R_API void r_cons_show_cursor(int cursor) {
  * If you doesn't use this order you'll probably loss your terminal properties.
  *
  */
-static int oldraw = -1;
 R_API void r_cons_set_raw(bool is_raw) {
+	static int oldraw = -1;
 	if (oldraw != -1) {
 		if (is_raw == oldraw) {
 			return;

--- a/libr/debug/p/debug_io.c
+++ b/libr/debug/p/debug_io.c
@@ -69,8 +69,8 @@ static int __io_wait(RDebug *dbg, int pid) {
 	return true;
 }
 
-static int curPid = -1;
 static int __io_attach(RDebug *dbg, int pid) {
+	static int curPid = -1;
 	curPid = pid;
 	return true;
 }

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -32,11 +32,11 @@ R_API void r_num_irand() {
 	r_srand (r_sys_now ());
 }
 
-static int rand_initialized = 0;
 R_API int r_num_rand(int max) {
+	static bool rand_initialized = false;
 	if (!rand_initialized) {
 		r_num_irand ();
-		rand_initialized = 1;
+		rand_initialized = true;
 	}
 	if (!max) {
 		max = 1;


### PR DESCRIPTION
Why global when these variables are only used in one function.