### PR TITLE
Cut flags inbytes string if too long

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2996,7 +2996,10 @@ static void ds_print_show_bytes(RDisasmState *ds) {
 		str = flagstr;
 		if (ds->nb > 0) {
 			k = ds->nb - strlen (flagstr) - 1;
-			if (k < 0 || k > sizeof (pad)) {
+			if (k < 0) {
+				str[ds->nb - 1] = '\0';
+			}
+			if (k > sizeof (pad)) {
 				k = 0;
 			}
 			for (j = 0; j < k; j++) {


### PR DESCRIPTION
Fix #12294 

if the `flagstr` is too long (longer than ds->nb - 1, which is the number of cells available for opcode bytes, that depends on asm.nbytes), cut it with a `\0` 