### PR TITLE
Fix clang warnings

### DIFF
--- a/libr/bin/format/nxo/nxo.c
+++ b/libr/bin/format/nxo/nxo.c
@@ -11,9 +11,9 @@
 #include "nxo.h"
 
 ut32 readLE32(RBuffer *buf, int off) {
-	int left = 0;
+	//int left = 0;
 	ut32 num = 0;
-	(void)r_buf_read_at (buf, off, &num, 4);
+	(void)r_buf_read_at (buf, off, (ut8 *)&num, 4);
 	return num;
 	//const ut8 *data = r_buf_get_at (buf, off, &left);
 	//return left > 3? r_read_le32 (data): 0;

--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -181,7 +181,7 @@ R_IPI RBinObject *r_bin_object_new(RBinFile *binfile, RBinPlugin *plugin, ut64 b
 		}
 		ut8 *bytes = malloc (sz);
 		if (!bytes) {
-			eprintf ("Cannot allocate %d bytes\n", sz);
+			eprintf ("Cannot allocate %" PFMT64u " bytes\n", sz);
 			return NULL;
 		}
 		r_buf_read_at (binfile->buf, offset, bytes, sz);


### PR DESCRIPTION
Those are -Wformat, -Wincompatible-pointer-types, and -Wunused-variable.