### PR TITLE
Remove logic from _CbInRangeAav when arch equal to arm/thumb

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6987,46 +6987,20 @@ static void cmd_anal_aad(RCore *core, const char *input) {
 	r_list_free (list);
 }
 
-
-static bool archIsArmOrThumb(RCore *core) {
+bool archIsMips(RCore *core) {
 	RAsm *as = core ? core->assembler : NULL;
-	if (as && as->cur && as->cur->arch) {
-		if (r_str_startswith (as->cur->arch, "mips")) {
-			return true;
-		}
-		if (r_str_startswith (as->cur->arch, "arm")) {
-			if (as->bits < 64) {
-				return true;
-			}
-		}
+	if (as && as->cur && as->cur->name) {
+		return strstr (as->cur->name, "mips");
 	}
 	return false;
 }
 
-bool archIsMips (RCore *core) {
-	return strstr (core->assembler->cur->name, "mips");
-}
-
 void _CbInRangeAav(RCore *core, ut64 from, ut64 to, int vsize, bool asterisk, int count) {
-	bool isarm = archIsArmOrThumb (core);
-	if (isarm) {
-		if (to & 1) {
-			// .dword 0x000080b9 in reality is 0x000080b8
-			to--;
-			r_anal_hint_set_bits (core->anal, to, 16);
-			// can we assume is gonna be always a function?
-		} else {
-			r_core_seek_archbits (core, from);
-			ut64 bits = r_config_get_i (core->config, "asm.bits");
-			r_anal_hint_set_bits (core->anal, from, bits);
-		}
-	} else {
-		bool ismips = archIsMips (core);
-		if (ismips) {
-			if (from % 4 || to % 4) {
-				eprintf ("False positive\n");
-				return;
-			}
+	bool ismips = archIsMips (core);
+	if (ismips) {
+		if (from % 4 || to % 4) {
+			eprintf ("False positive\n");
+			return;
 		}
 	}
 	if (asterisk) {


### PR DESCRIPTION
It was assumed all the values were functions but that might not be
true and then wrong hints would be set.

This should be handled by ESIL which is the only one it will know whether
a call is gonna be made with the data under analysis.

The issue #12340 shows how data is wrongly interpreted.

const int a = 0x000103c9;
```
int main()
{
	int b;
	b = 2;
	b = b + a;
	return 0;
}
```
It gets translated to
```
┌ (fcn) main 56
│   main (int argc, char **argv, char **envp);
│           ; UNKNOWN XREF from entry0 (+0x34)
│           0x000103c8      04b02de5       str fp, [sp, -4]!
│           0x000103cc      00b08de2       add fp, sp, 0
│           0x000103d0      0cd04de2       sub sp, sp, 0xc
│           0x000103d4      0230a0e3       mov r3, 2
│           0x000103d8      08300be5       str r3, [local_8h]          ; 8
│           0x000103dc      1c209fe5       ldr r2, aav.0x000103c9       ; [0x10400:4]=0x103c9 aav.0x000103c9
│           0x000103e0      08301be5       ldr r3, [local_8h]          ; 8
│           0x000103e4      023083e0       add r3, r3, r2
│           0x000103ec      0030a0e3       mov r3, 0
│           0x000103f0      0300a0e1       mov r0, r3
│           0x000103f4      00d08be2       add sp, fp, 0
│           0x000103f8      04b09de4       pop {fp}
└           0x000103fc      1eff2fe1       bx lr
            ; DATA XREF from main (0x103dc)
            0x00010400      .dword 0x000103c9 ; main
```
There are other cases where they should be handled elsewhere like below
```
|       #   0x000102f8      0c009fe5       ldr r0, [0x0001030c]        ; [0x1030c:4]=0x103c8 main
|       #   0x000102fc      0c309fe5       ldr r3, aav.0x00010404       ; [0x10310:4]=0x10404 aav.0x00010404
|       #   0x00010300      ebffffeb       bl sym.imp.__libc_start_main ;[1]   ; int __libc_start_main(func main, int argc, char **ubp_av, func init, func fini, func rtld_fini, void *stack_end)
        #   0x00010304      f0ffffeb       bl sym.imp.abort            ;[2]   ; void abort(void)
```

r2 should handle __libc_start_main to detect those functions but aav
should not make those assumptions