### PR TITLE
Add scr.wideoff to make offsets and reg values depend on asm.bits ##visual

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -366,6 +366,13 @@ static int cb_scrlast(void *user, void *data) {
 	return true;
 }
 
+static int cb_scr_wideoff(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	core->print->wide_offsets = node->i_value;
+	return true;
+}
+
 static int cb_scrrainbow(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -2655,6 +2662,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.middle", "false", "Allow disassembling jumps in the middle of an instruction");
 	SETPREF ("asm.noisy", "true", "Show comments considered noisy but possibly useful");
 	SETPREF ("asm.offset", "true", "Show offsets at disassembly");
+	SETCB ("scr.wideoff", "false", &cb_scr_wideoff, "Adjust offsets to match asm.bits");
 	SETCB ("scr.rainbow", "false", &cb_scrrainbow, "Shows rainbow colors depending of address");
 	SETCB ("scr.last", "true", &cb_scrlast, "Cache last output after flush to make _ command work (disable for performance)");
 	SETPREF ("asm.reloff", "false", "Show relative offsets instead of absolute address in disasm");

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -6063,7 +6063,11 @@ R_API void r_print_offset_sg(RPrint *p, ut64 off, int invert, int offseg, int se
 					white = r_str_pad (' ', 10 - strlen (space));
 					r_cons_printf ("%s%s%s%s", k, white, space, reset);
 				} else {
-					r_cons_printf ("%s0x%08"PFMT64x "%s", k, off, reset);
+					if (p->wide_offsets) {
+						r_cons_printf ("%s0x%016"PFMT64x "%s", k, off, reset);
+					} else {
+						r_cons_printf ("%s0x%08"PFMT64x "%s", k, off, reset);
+					}
 				}
 			}
 		}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2620,7 +2620,11 @@ static void set_prompt (RCore *r) {
 		}
 
 		if (!promptset) {
-			snprintf (p, sizeof (p), "0x%08" PFMT64x, r->offset);
+			if (r->dbg->bits & R_SYS_BITS_64) {
+				snprintf (p, sizeof (p), "0x%016" PFMT64x, r->offset);
+			} else {
+				snprintf (p, sizeof (p), "0x%08" PFMT64x, r->offset);
+			}
 		}
 		snprintf (tmp, sizeof (tmp), "%s%s", sec, p);
 	}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2620,7 +2620,7 @@ static void set_prompt (RCore *r) {
 		}
 
 		if (!promptset) {
-			if (r->dbg->bits & R_SYS_BITS_64) {
+			if (r->print->wide_offsets && r->dbg->bits & R_SYS_BITS_64) {
 				snprintf (p, sizeof (p), "0x%016" PFMT64x, r->offset);
 			} else {
 				snprintf (p, sizeof (p), "0x%08" PFMT64x, r->offset);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1163,8 +1163,14 @@ repeat:
 
 	r_cons_clear00 ();
 	r_cons_gotoxy (1, 1);
-	r_cons_printf ("[%s%srefs]> 0x%08"PFMT64x" # (TAB/jk/q/?) ",
-			xrefsMode? "fcn.": "addr.", xref ? "x": "", addr);
+	{
+		char *address = (core->dbg->bits & R_SYS_BITS_64)
+			? r_str_newf ("0x%016"PFMT64x, addr)
+			: r_str_newf ("0x%08"PFMT64x, addr);
+		r_cons_printf ("[%s%srefs]> %s # (TAB/jk/q/?) ",
+				xrefsMode? "fcn.": "addr.", xref ? "x": "", address);
+		free (address);
+	}
 	if (!xrefs || r_list_empty (xrefs)) {
 		r_list_free (xrefs);
 		xrefs = NULL;
@@ -3484,9 +3490,12 @@ R_API void r_core_visual_title(RCore *core, int color) {
 	}
 	{
 		char *title;
+		char *address = (core->dbg->bits & R_SYS_BITS_64)
+			? r_str_newf ("0x%016"PFMT64x, core->offset)
+			: r_str_newf ("0x%08"PFMT64x, core->offset);
 		if (__ime) {
-			title = r_str_newf ("[0x%08"PFMT64x " + %d> * INSERT MODE *\n",
-				core->offset, core->print->cur);
+			title = r_str_newf ("[%s + %d> * INSERT MODE *\n",
+				address, core->print->cur);
 		} else {
 			char pm[32] = "[XADVC]";
 			int i;
@@ -3499,20 +3508,20 @@ R_API void r_core_visual_title(RCore *core, int color) {
 			}
 			if (core->print->cur_enabled) {
 				if (core->print->ocur == -1) {
-					title = r_str_newf ("[0x%08"PFMT64x " *0x%08"PFMT64x" %s ($$+0x%x)]> %s %s\n",
-						core->offset, core->offset + core->print->cur,
+					title = r_str_newf ("[%s *0x%08"PFMT64x" %s ($$+0x%x)]> %s %s\n",
+						address, core->offset + core->print->cur,
 						pm, core->print->cur,
 						bar, pos);
 				} else {
-					title = r_str_newf ("[0x%08"PFMT64x " 0x%08"PFMT64x" %s [0x%x..0x%x] %d]> %s %s\n",
-						core->offset, core->offset + core->print->cur,
+					title = r_str_newf ("[%s 0x%08"PFMT64x" %s [0x%x..0x%x] %d]> %s %s\n",
+						address, core->offset + core->print->cur,
 						core->print->ocur, core->print->cur,
 						pm, R_ABS (core->print->cur - core->print->ocur) + 1,
 						bar, pos);
 				}
 			} else {
-				title = r_str_newf ("[0x%08"PFMT64x " %s %s%d %s]> %s %s\n",
-					core->offset, pm, pcs, core->blocksize, filename, bar, pos);
+				title = r_str_newf ("[%s %s %s%d %s]> %s %s\n",
+					address, pm, pcs, core->blocksize, filename, bar, pos);
 			}
 		}
 		const int tabsCount = core->visual.tabs? r_list_length (core->visual.tabs): 0;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3490,7 +3490,7 @@ R_API void r_core_visual_title(RCore *core, int color) {
 	}
 	{
 		char *title;
-		char *address = (core->dbg->bits & R_SYS_BITS_64)
+		char *address = (core->print->wide_offsets && core->dbg->bits & R_SYS_BITS_64)
 			? r_str_newf ("0x%016"PFMT64x, core->offset)
 			: r_str_newf ("0x%08"PFMT64x, core->offset);
 		if (__ime) {
@@ -3515,8 +3515,8 @@ R_API void r_core_visual_title(RCore *core, int color) {
 				} else {
 					title = r_str_newf ("[%s 0x%08"PFMT64x" %s [0x%x..0x%x] %d]> %s %s\n",
 						address, core->offset + core->print->cur,
-						core->print->ocur, core->print->cur,
-						pm, R_ABS (core->print->cur - core->print->ocur) + 1,
+						pm, core->print->ocur, core->print->cur,
+						R_ABS (core->print->cur - core->print->ocur) + 1,
 						bar, pos);
 				}
 			} else {

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -178,7 +178,11 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 				if (tolower ((ut8)rad) == 'j') {
 					snprintf (strvalue, sizeof (strvalue),"%"PFMT64u, value);
 				} else {
-					snprintf (strvalue, sizeof (strvalue),"0x%08"PFMT64x, value);
+					if (dbg->bits & R_SYS_BITS_64) {
+						snprintf (strvalue, sizeof (strvalue),"0x%016"PFMT64x, value);
+					} else {
+						snprintf (strvalue, sizeof (strvalue),"0x%08"PFMT64x, value);
+					}
 				}
 			} else {
 				value = r_reg_get_value_big (dbg->reg, item, &valueBig);

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -178,7 +178,7 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 				if (tolower ((ut8)rad) == 'j') {
 					snprintf (strvalue, sizeof (strvalue),"%"PFMT64u, value);
 				} else {
-					if (dbg->bits & R_SYS_BITS_64) {
+					if (pr->wide_offsets && dbg->bits & R_SYS_BITS_64) {
 						snprintf (strvalue, sizeof (strvalue),"0x%016"PFMT64x, value);
 					} else {
 						snprintf (strvalue, sizeof (strvalue),"0x%08"PFMT64x, value);

--- a/libr/include/r_util/r_print.h
+++ b/libr/include/r_util/r_print.h
@@ -97,6 +97,7 @@ typedef struct r_print_t {
 	int lines_cache_sz;
 	int lines_abs;
 	bool esc_bslash;
+	bool wide_offsets;
 	const char *strconv_mode;
 	RList *vars;
 

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -454,7 +454,7 @@ R_API void r_print_addr(RPrint *p, ut64 addr) {
 			} else {
 				if (p->wide_offsets) {
 					// TODO: make %016 depend on asm.bits
-					printfmt ("%s0x%016" PFMT64x "%s%c", pre, addr, fin, ch);
+					printfmt ("0x%016" PFMT64x "%c", addr, ch);
 				} else {
 					printfmt ("0x%08" PFMT64x "%c", addr, ch);
 				}

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -441,13 +441,23 @@ R_API void r_print_addr(RPrint *p, ut64 addr) {
 			if (dec) {
 				printfmt ("%s%s%" PFMT64d "%s%c", pre, white, addr, fin, ch);
 			} else {
-				printfmt ("%s0x%08" PFMT64x "%s%c", pre, addr, fin, ch);
+				if (p->wide_offsets) {
+					// TODO: make %016 depend on asm.bits
+					printfmt ("%s0x%016" PFMT64x "%s%c", pre, addr, fin, ch);
+				} else {
+					printfmt ("%s0x%08" PFMT64x "%s%c", pre, addr, fin, ch);
+				}
 			}
 		} else {
 			if (dec) {
 				printfmt ("%s%" PFMT64d "%c", white, addr, ch);
 			} else {
-				printfmt ("0x%08" PFMT64x "%c", addr, ch);
+				if (p->wide_offsets) {
+					// TODO: make %016 depend on asm.bits
+					printfmt ("%s0x%016" PFMT64x "%s%c", pre, addr, fin, ch);
+				} else {
+					printfmt ("0x%08" PFMT64x "%c", addr, ch);
+				}
 			}
 		}
 	}
@@ -847,6 +857,9 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 					printfmt ("..offset..");
 				} else {
 					printfmt ("- offset -");
+					if (p->wide_offsets) {
+						printfmt ("       ");
+					}
 				}
 				if (use_segoff) {
 					ut32 s, a;


### PR DESCRIPTION
TODO:

* [x] honor scr.wideoff in hexdump and disasm