### PR TITLE
r_bin_dwarf_expand_*: fix memory error

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -886,7 +886,8 @@ static int r_bin_dwarf_expand_die(RBinDwarfDIE* die) {
 	if (!tmp) {
 		return -ENOMEM;
 	}
-	memset ((ut8*)tmp + die->capacity, 0, die->capacity);
+	memset ((ut8*)tmp + die->capacity * sizeof (RBinDwarfAttrValue),
+			0, die->capacity * sizeof (RBinDwarfAttrValue));
 	die->attr_values = tmp;
 	die->capacity *= 2;
 	return 0;
@@ -918,7 +919,8 @@ static int r_bin_dwarf_expand_cu(RBinDwarfCompUnit *cu) {
 		return -ENOMEM;
 	}
 
-	memset ((ut8*)tmp + cu->capacity, 0, cu->capacity);
+	memset ((ut8*)tmp + cu->capacity * sizeof (RBinDwarfDIE),
+			0, cu->capacity * sizeof (RBinDwarfDIE));
 	cu->dies = tmp;
 	cu->capacity *= 2;
 
@@ -955,7 +957,9 @@ static int r_bin_dwarf_expand_abbrev_decl(RBinDwarfAbbrevDecl *ad) {
 		return -ENOMEM;
 	}
 
-	memset ((ut8*)tmp + ad->capacity, 0, ad->capacity);
+	// Set the area in the buffer past the length to 0
+	memset ((ut8*)tmp + ad->capacity * sizeof (RBinDwarfAttrSpec),
+			0, ad->capacity * sizeof (RBinDwarfAttrSpec));
 	ad->specs = tmp;
 	ad->capacity *= 2;
 
@@ -989,7 +993,8 @@ static int r_bin_dwarf_expand_debug_abbrev(RBinDwarfDebugAbbrev *da) {
 	if (!tmp) {
 		return -ENOMEM;
 	}
-	memset ((ut8*)tmp + da->capacity, 0, da->capacity);
+	memset ((ut8*)tmp + da->capacity * sizeof (RBinDwarfAbbrevDecl),
+			0, da->capacity * sizeof (RBinDwarfAbbrevDecl));
 
 	da->decls = tmp;
 	da->capacity *= 2;


### PR DESCRIPTION
## Summary

The use of memset to set the rest of the newly realloc'd buffer in
various `r_bin_dwarf_expand_*` functions was overwriting portions of
the buffer that had previously been written to.
    
The functions including said error were the following:
    
 - r_bin_dwarf_expand_die
 - r_bin_dwarf_expand_cu
 - r_bin_dwarf_expand_abbrev_decl
 - r_bin_dwarf_expand_debug_abbrev

## Example from `gdb`

```
Breakpoint 1, r_bin_dwarf_expand_abbrev_decl (ad=0x61c000014080) at dwarf.c:947
947             if (!ad || !ad->capacity || ad->capacity != ad->length) {
(gdb) print ad->capacity
$1 = 8
(gdb) x/2ugx ad->specs
0x60c00005a880: 0x0000000000000025      0x000000000000000e
(gdb) next 7
962             return 0;
(gdb) x/2ugx ad->specs
0x61100001b480: 0x0000000000000025      0x0000000000000000
```