### PR TITLE
sys/user.sh: Allow setting an install path

### DIFF
--- a/sys/user.sh
+++ b/sys/user.sh
@@ -13,8 +13,33 @@ fi
 # find root
 cd "$(dirname "$0")" ; cd ..
 
+export WITHOUT_PULL=0
+ROOT=
+
+while [ $# -gt 0 ]
+do
+	case "$1" in
+		"--without-pull")
+			WITHOUT_PULL=1
+			;;
+		"--install-path")
+			shift
+			if [ -n "$1" ]; then
+				ROOT="$1"
+				BINDIR="$1/bin"
+			else
+				echo "ERROR: install-path must not be empty"
+				exit 1
+			fi
+			;;
+		*)
+			echo "WARNING: unknown argument \"$1\""
+	esac
+	shift
+done
+
 # update
-if [ "$1" != "--without-pull" ]; then
+if [ $WITHOUT_PULL -eq 0 ]; then
 	if [ -d .git ]; then
 		git branch | grep "^\* master" > /dev/null
 		if [ $? = 0 ]; then
@@ -22,22 +47,22 @@ if [ "$1" != "--without-pull" ]; then
 			git pull
 		fi
 	fi
-else
-	export WITHOUT_PULL=1
-	shift
 fi
 
-if [ -z "${HOME}" ]; then
-	echo "HOME not set"
-	exit 1
+if [ -z "${ROOT}" ]; then
+	if [ -z "${HOME}" ]; then
+		echo "HOME not set"
+		exit 1
+	fi
+
+	if [ ! -d "${HOME}" ]; then
+		echo "HOME is not a directory"
+		exit 1
+	fi
+	ROOT="${HOME}/bin/prefix/radare2"
+	BINDIR="${HOME}/bin"
 fi
 
-if [ ! -d "${HOME}" ]; then
-	echo "HOME is not a directory"
-	exit 1
-fi
-
-ROOT="${HOME}/bin/prefix/radare2"
 mkdir -p "${ROOT}/lib"
 
 if [ "${M32}" = 1 ]; then
@@ -53,7 +78,7 @@ if [ $? != 0 ]; then
 fi
 ${MAKE} user-install
 echo
-echo "radare2 is now installed in ${HOME}/bin"
+echo "radare2 is now installed in ${BINDIR}"
 echo
-echo "Now add ${HOME}/bin to your PATH"
+echo "Now add ${BINDIR} to your PATH"
 echo


### PR DESCRIPTION
Users may want to install radare2 to a different directory than `~/bin`.
Parse `--install-path` in `sys/user.sh` to allow for users to do so.