### PR TITLE
fixed #12409 - wasm function ids

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -354,12 +354,12 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 			goto beach;
 		}
 		switch (ptr->kind) {
-		case 0: // Function
+		case R_BIN_WASM_EXTERNALKIND_Function: // Function
 			if (!(consume_u32_r (b, max, &ptr->type_f))) {
 				goto beach;
 			}
 			break;
-		case 1: // Table
+		case R_BIN_WASM_EXTERNALKIND_Table: // Table
 			if (!(consume_s7_r (b, max, (st8*)&ptr->type_t.elem_type))) {
 				goto beach;
 			}
@@ -367,12 +367,12 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 				goto beach;
 			}
 			break;
-		case 2: // Memory
+		case R_BIN_WASM_EXTERNALKIND_Memory: // Memory
 			if (!(consume_limits_r (b, max, &ptr->type_m.limits))) {
 				goto beach;
 			}
 			break;
-		case 3: // Global
+		case R_BIN_WASM_EXTERNALKIND_Global: // Global
 			if (!(consume_s7_r (b, max, (st8*)&ptr->type_g.content_type))) {
 				goto beach;
 			}
@@ -545,7 +545,7 @@ beach:
 static RList *r_bin_wasm_get_symtab_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmSymbol *ptr = NULL;
-
+	size_t read = 0;
 	if (!(ret = r_list_newf ((RListFree)free))) {
 		return NULL;
 	}
@@ -563,8 +563,8 @@ static RList *r_bin_wasm_get_symtab_entries (RBinWasmObj *bin, RBinWasmSection *
 		if (!(ptr = R_NEW0 (RBinWasmSymbol))) {
 			return ret;
 		}
-		ptr->id = b->buf[b->cur];
-		ut32 tmp = b->buf[b->cur + 1];
+		read = read_u32_leb128 (&b->buf[b->cur], &b->buf[b->cur + 5], &ptr->id);
+		ut32 tmp = b->buf[b->cur + read];
 		if (tmp == R_BIN_WASM_STRING_LENGTH) {
 			tmp = R_BIN_WASM_STRING_LENGTH - 1;
 		}

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -545,7 +545,7 @@ beach:
 static RList *r_bin_wasm_get_symtab_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmSymbol *ptr = NULL;
-	size_t read = 0;
+	ut64 read = 0;
 	if (!(ret = r_list_newf ((RListFree)free))) {
 		return NULL;
 	}

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -354,12 +354,12 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 			goto beach;
 		}
 		switch (ptr->kind) {
-		case R_BIN_WASM_EXTERNALKIND_Function: // Function
+		case 0: // Function
 			if (!(consume_u32_r (b, max, &ptr->type_f))) {
 				goto beach;
 			}
 			break;
-		case R_BIN_WASM_EXTERNALKIND_Table: // Table
+		case 1: // Table
 			if (!(consume_s7_r (b, max, (st8*)&ptr->type_t.elem_type))) {
 				goto beach;
 			}
@@ -367,12 +367,12 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 				goto beach;
 			}
 			break;
-		case R_BIN_WASM_EXTERNALKIND_Memory: // Memory
+		case 2: // Memory
 			if (!(consume_limits_r (b, max, &ptr->type_m.limits))) {
 				goto beach;
 			}
 			break;
-		case R_BIN_WASM_EXTERNALKIND_Global: // Global
+		case 3: // Global
 			if (!(consume_s7_r (b, max, (st8*)&ptr->type_g.content_type))) {
 				goto beach;
 			}

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -63,7 +63,7 @@ struct r_bin_wasm_resizable_limits_t {
 };
 
 typedef struct r_bin_wasm_symbol_t {
-	ut8 id;
+	ut32 id;
 	ut32 name_len;
 	char name[R_BIN_WASM_STRING_LENGTH];
 } RBinWasmSymbol;

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -18,7 +18,7 @@ static bool check_bytes_buf(RBuffer* rbuf) {
 	return rbuf && r_buf_read_at (rbuf, R_BUF_CUR, buf, 4) == 4 && !memcmp (buf, R_BIN_WASM_MAGIC_BYTES, 4);
 }
 
-static int find_symbol(const ut8 *p, const RBinWasmSymbol* q) {
+static int find_symbol(const ut32 *p, const RBinWasmSymbol* q) {
 	return q->id != (*p);
 }
 
@@ -171,7 +171,7 @@ static RList *symbols(RBinFile *bf) {
 		r_list_append (ret, ptr);
 	}
 
-	ut8 fcn_id = 0;
+	ut32 fcn_id = 0;
 	RListIter *sym_it = NULL;
 	RBinWasmCodeEntry *func;
 	RBinWasmSymbol *wasm_sym = NULL;

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -18,11 +18,11 @@ static bool check_bytes_buf(RBuffer* rbuf) {
 	return rbuf && r_buf_read_at (rbuf, R_BUF_CUR, buf, 4) == 4 && !memcmp (buf, R_BIN_WASM_MAGIC_BYTES, 4);
 }
 
-static int find_symbol(const ut32 *p, const RBinWasmSymbol* q) {
+static bool find_symbol(const ut32 *p, const RBinWasmSymbol* q) {
 	return q->id != (*p);
 }
 
-static int find_export(const ut32 *p, const RBinWasmExportEntry* q) {
+static bool find_export(const ut32 *p, const RBinWasmExportEntry* q) {
 	if (q->kind != R_BIN_WASM_EXTERNALKIND_Function) {
 		return false;
 	}


### PR DESCRIPTION
exports now are used also to fill symbols