### PR TITLE
Minor fix when opening a new panel ##panels

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -1501,6 +1501,7 @@ static void createNewPanel(RCore *core, char *name, char *cmd, bool caching) {
 	addPanelFrame (core, panels, name, cmd, caching);
 	changePanelNum (panels, panels->n_panels - 1, 0);
 	r_core_panels_layout (panels);
+	panels->curnode = 0;
 	setRefreshAll (panels, false);
 }
 


### PR DESCRIPTION
The new panel should be focused when they are created with n/N command or M command.