### PR TITLE
Add relocation search in disassembly jump substituion.

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4649,6 +4649,11 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 		flag = r_flag_get_i2 (f, addr);
 		if (flag) {
 			name = flag->name;
+		} else {
+			RBinReloc *rel = getreloc(ds->core, addr, ds->analop.size);
+			if (rel && rel->import && rel->import->name) {
+				name = rel->import->name;
+			}
 		}
 	}
 	if (name) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4650,7 +4650,7 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 		if (flag) {
 			name = flag->name;
 		} else {
-			RBinReloc *rel = getreloc(ds->core, addr, ds->analop.size);
+			RBinReloc *rel = getreloc (ds->core, addr, ds->analop.size);
 			if (rel && rel->import && rel->import->name) {
 				name = rel->import->name;
 			}


### PR DESCRIPTION
This PR adds relocation lookups for `e asm.jmpsub=true` to give better disassembly using relocations.

While disassembling Pwnable.KR's softmmu kernel module (http://pwnable.kr/bin/softmmu
), the disassembly of `sym.mmuinit` previously failed to substitute in `printk` instead for improperly decoded calls.