### PR TITLE
Fix borrow flag handling for SUB/SBB on x86

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1356,7 +1356,7 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 			// We use $b rather than $c here as the carry flag really
 			// represents a "borrow"
 			esilprintf (op, "%s,%s,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b%d,cf,=",
-				src, dst, size);
+				src, dst, (size*8));
 		}
 		break;
 	case X86_INS_SBB:
@@ -1365,7 +1365,7 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 			src = getarg (&gop, 1, 0, NULL, SRC_AR);
 			dst = getarg (&gop, 0, 0, NULL, DST_AR);
 			ut64 size = INSOP(0).size;
-			esilprintf (op, "cf,%s,+,%s,-=,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b%d,cf,=", src, dst, size);
+			esilprintf (op, "cf,%s,+,%s,-=,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b%d,cf,=", src, dst, (size*8));
 		}
 		break;
 	case X86_INS_LIDT:


### PR DESCRIPTION
At  the end of the following code $cf=1. But 0x10-0x1=0x9 should not cause a borrow!
```
mov ebx, 0x10
mov eax, 1
sub ebx, eax
```
The esil code corresponding to `sub` is:
```eax,ebx,-=,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b4,cf,=```
Note that borrow is set on the 4th bit instead of the 32th one.