### PR TITLE
Implement support for nword in ahi ##anal

### DIFF
--- a/libr/anal/hint.c
+++ b/libr/anal/hint.c
@@ -20,10 +20,9 @@ R_API void r_anal_hint_del(RAnal *a, ut64 addr, int size) {
 }
 
 static void unsetHint(RAnal *a, const char *type, ut64 addr) {
-	int idx;
 	char key[128];
 	setf (key, "hint.0x%08"PFMT64x, addr);
-	idx = sdb_array_indexof (DB, key, type, 0);
+	int idx = sdb_array_indexof (DB, key, type, 0);
 	if (idx != -1) {
 		sdb_array_delete (DB, key, idx, 0);
 		sdb_array_delete (DB, key, idx, 0);
@@ -31,10 +30,9 @@ static void unsetHint(RAnal *a, const char *type, ut64 addr) {
 }
 
 static void setHint(RAnal *a, const char *type, ut64 addr, const char *s, ut64 ptr) {
-	int idx;
 	char key[128], val[128], *nval = NULL;
 	setf (key, "hint.0x%08"PFMT64x, addr);
-	idx = sdb_array_indexof (DB, key, type, 0);
+	int idx = sdb_array_indexof (DB, key, type, 0);
 	if (s) {
 		nval = sdb_encode ((const ut8*)s, -1);
 	} else {
@@ -56,6 +54,10 @@ static void setHint(RAnal *a, const char *type, ut64 addr, const char *s, ut64 p
 
 R_API void r_anal_hint_set_offset(RAnal *a, ut64 addr, const char* typeoff) {
 	setHint (a, "Offset:", addr, r_str_trim_ro (typeoff), 0);
+}
+
+R_API void r_anal_hint_set_nword(RAnal *a, ut64 addr, int nword) {
+	setHint (a, "nword:", addr, NULL, nword);
 }
 
 R_API void r_anal_hint_set_jump(RAnal *a, ut64 addr, ut64 ptr) {
@@ -242,6 +244,7 @@ R_API RAnalHint *r_anal_hint_from_string(RAnal *a, ut64 addr, const char *str) {
 			case 'j': hint->jump = sdb_atoi (nxt); break;
 			case 'f': hint->fail = sdb_atoi (nxt); break;
 			case 'p': hint->ptr  = sdb_atoi (nxt); break;
+			case 'n': hint->nword = sdb_atoi (nxt); break;
 			case 'r': hint->ret  = sdb_atoi (nxt); break;
 			case 'b': hint->bits = sdb_atoi (nxt); break;
 			case 'B': hint->new_bits = sdb_atoi (nxt); break;
@@ -267,8 +270,5 @@ R_API RAnalHint *r_anal_hint_get(RAnal *a, ut64 addr) {
 	char key[64];
 	setf (key, "hint.0x%08"PFMT64x, addr);
 	const char *s = sdb_const_get (DB, key, 0);
-	if (!s) {
-		return NULL;
-	}
-	return r_anal_hint_from_string (a, addr, s);
+	return s? r_anal_hint_from_string (a, addr, s): NULL;
 }

--- a/libr/anal/hint.c
+++ b/libr/anal/hint.c
@@ -150,6 +150,10 @@ R_API void r_anal_hint_unset_arch(RAnal *a, ut64 addr) {
 	unsetHint(a, "arch:", addr);
 }
 
+R_API void r_anal_hint_unset_nword(RAnal *a, ut64 addr) {
+	unsetHint(a, "nword:", addr);
+}
+
 R_API void r_anal_hint_unset_syntax(RAnal *a, ut64 addr) {
 	unsetHint(a, "Syntax:", addr);
 }

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6001,8 +6001,14 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 	case 'i': // "ahi"
 		if (input[1] == '?') {
 			r_core_cmd_help (core, help_msg_ahi);
-		} else if (input[1] == ' ') {
-		// You can either specify immbase with letters, or numbers
+		} else if (isdigit (input[1])) {
+			r_anal_hint_set_nword (core->anal, core->offset, input[1] - '0');
+			input++;
+		} else if (input[1] == '-') { // "ahi-"
+			r_anal_hint_set_immbase (core->anal, core->offset, 0);
+		}
+		if (input[1] == ' ') {
+			// You can either specify immbase with letters, or numbers
 			const int base =
 				(input[2] == 's') ? 1 :
 				(input[2] == 'b') ? 2 :
@@ -6014,9 +6020,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 				(input[2] == 'S') ? 80 : // syscall
 				(int) r_num_math (core->num, input + 1);
 			r_anal_hint_set_immbase (core->anal, core->offset, base);
-		} else if (input[1] == '-') { // "ahi-"
-			r_anal_hint_set_immbase (core->anal, core->offset, 0);
-		} else {
+		} else if (input[1] != '?' && input[1] != '-') {
 			eprintf ("|ERROR| Usage: ahi [base]\n");
 		}
 		break;

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -2890,7 +2890,8 @@ R_API void r_core_visual_define(RCore *core, const char *args, int distance) {
 		," e    end of function"
 		," f    analyze function"
 		," F    format"
-		," i    immediate base (b(in), o(ct), d(ec), h(ex), s(tr))"
+		," i    (ahi) immediate base (b(in), o(ct), d(ec), h(ex), s(tr))"
+		," I    (ahi1) immediate base (b(in), o(ct), d(ec), h(ex), s(tr))"
 		," j    merge down (join this and next functions)"
 		," k    merge up (join this and previous function)"
 		," h    define anal hint"
@@ -2954,6 +2955,16 @@ onemoretime:
 			r_line_set_prompt ("immbase: ");
 			if (r_cons_fgets (str, sizeof (str), 0, NULL) > 0) {
 				r_core_cmdf (core, "ahi %s @ 0x%"PFMT64x, str, off);
+			}
+		}
+		break;
+	case 'I':
+		{
+			char str[128];
+			r_cons_show_cursor (true);
+			r_line_set_prompt ("immbase: ");
+			if (r_cons_fgets (str, sizeof (str), 0, NULL) > 0) {
+				r_core_cmdf (core, "ahi1 %s @ 0x%"PFMT64x, str, off);
 			}
 		}
 		break;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -732,6 +732,7 @@ typedef struct r_anal_hint_t {
 #endif
 	int immbase;
 	bool high; // highlight hint
+	int nword;
 } RAnalHint;
 
 typedef struct r_anal_var_access_t {
@@ -1630,6 +1631,7 @@ R_API void r_anal_hint_free (RAnalHint *h);
 R_API RAnalHint *r_anal_hint_get(RAnal *anal, ut64 addr);
 R_API void r_anal_hint_set_syntax (RAnal *a, ut64 addr, const char *syn);
 R_API void r_anal_hint_set_jump (RAnal *a, ut64 addr, ut64 ptr);
+R_API void r_anal_hint_set_nword(RAnal *a, ut64 addr, int nword);
 R_API void r_anal_hint_set_offset (RAnal *a, ut64 addr, const char *typeoff);
 R_API void r_anal_hint_set_immbase (RAnal *a, ut64 addr, int base);
 R_API void r_anal_hint_set_fail (RAnal *a, ut64 addr, ut64 ptr);

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -389,7 +389,7 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 		}
 		if (p->hint) {
 			const int nw = p->hint->nword;
-			if (nw != -1 && count != nw) {
+			if (count != nw) {
 				ptr = ptr2;
 				continue;
 			}

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -222,7 +222,8 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 	ptr2 = NULL;
 	// remove "dword" 2
 	char *nptr;
-	while ((nptr = findNextNumber (ptr))) {
+	int count = 0;
+	for (count = 0; (nptr = findNextNumber (ptr)) ; count++) {
 #if 0
 		char *optr = ptr;
 		if (nptr[1]== ' ') {
@@ -370,7 +371,7 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 					}
 					return true;
 				}
-				if (p->tailsub) { //  && off > UT32_MAX && addr > UT32_MAX) {
+				if (p->tailsub) { //  && off > UT32_MAX && addr > UT32_MAX)
 					if (off != UT64_MAX) {
 						if (off == addr) {
 							insert (ptr, "$$");
@@ -387,6 +388,11 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 			}
 		}
 		if (p->hint) {
+			const int nw = p->hint->nword;
+			if (nw != -1 && count != nw) {
+				ptr = ptr2;
+				continue;
+			}
 			int pnumleft, immbase = p->hint->immbase;
 			char num[256] = {0}, *pnum, *tmp;
 			bool is_hex = false;


### PR DESCRIPTION
- ahi0 == ahi
- any digit from 0 to 9 is valid
- This breaks some behaviour in visual mode that needs to be fixed in Vdi

	$ r2 -qcq - << EOF
	wx c7458843c6ff00
	pd 1
	ahi 10
	pd 1
	ahi-
	ahi1 10
	pd 1
	EOF

	mov dword [rbp - 0x78], 0xffc643
	mov dword [rbp - 120], 0xffc643
	mov dword [rbp - 0x78], 16762435