### PR TITLE
Support r2core.js for Emscripten >=v1.37.24

### DIFF
--- a/binr/radare2/Makefile
+++ b/binr/radare2/Makefile
@@ -20,6 +20,10 @@ ifeq (${COMPILER},emscripten)
 # -s INLINING_LIMIT=1
 # --memory-init-file 0
 CFLAGS+=-s EXPORTED_FUNCTIONS='["_r2_asmjs_new", "_r2_asmjs_cmd", "_r2_asmjs_free", "_r2_asmjs_openurl"]'
+CFLAGS+=-s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap"]'
+CFLAGS+=-s TOTAL_MEMORY=33554432
+CFLAGS+=-s ALLOW_MEMORY_GROWTH=1
+CFLAGS+=-s ABORTING_MALLOC=0
 #CFLAGS+=-Oz --memory-init-file 0
 endif
 

--- a/plugins.emscripten.cfg
+++ b/plugins.emscripten.cfg
@@ -6,12 +6,14 @@ asm.x86_cs
 asm.x86_nz
 asm.mips_cs
 asm.avr
+asm.wasm
 anal.avr
 anal.mips_cs
 anal.x86_cs
 anal.arm_cs
 anal.java
 anal.dalvik
+anal.wasm
 bin.any
 bin.elf
 bin.elf64
@@ -22,6 +24,7 @@ bin.mz
 bin.pe64
 bin.mach0
 bin.mach064
+bin.wasm
 bin_xtr.xtr_fatmach0
 core.java
 core.a2f


### PR DESCRIPTION
Emscripten v1.37.24 excludes `cwrap` from default exports and requires setting EXTRA_EXPORTED_RUNTIME_METHODS to put it back. Also, it seemed like `malloc` crashed when trying to do `e asm.arch=x86`, so I gave it some more memory (which worked). 33554432 is the least power of 2 that is greater than the default (16777216).

The second commit was because r2 emits the following (kinda ugly) warning every time the core gets created:

    > var r2core = require('./radare2.js');
    > var r2i = r2core._r2_asmjs_new();
    r_config_get: variable 'asm.arch' not found
    anal.arch: cannot find 'wasm'
    asm.arch: cannot find (wasm)
    e asm.bits: Cannot set value, no plugins defined yet
    e asm.bits: Cannot set value, no plugins defined yet
    asm.arch: cannot find (wasm)
    > r2i != 0  // the instance does get successfully created, despite above warnings.
    true

Feel free to omit it if you think it is unnecessary. btw is https://www.npmjs.com/package/r2core no longer maintained?