### PR TITLE
Fix different behaviour of agfv and agfj

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2938,10 +2938,11 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 	if (is_json) {
 		r_cons_printf ("[");
 	}
+
 	r_list_foreach (core->anal->fcns, iter, fcni) {
 		if (fcni->type & (R_ANAL_FCN_TYPE_SYM | R_ANAL_FCN_TYPE_FCN |
 		                  R_ANAL_FCN_TYPE_LOC) &&
-		    (addr == UT64_MAX || r_anal_fcn_in (fcni, addr))) {
+		    (addr == UT64_MAX || r_anal_get_fcn_in(core->anal, addr, R_ANAL_FCN_TYPE_ROOT) == fcni)) {
 			if (addr == UT64_MAX && (from != UT64_MAX && to != UT64_MAX)) {
 				if (fcni->addr < from || fcni->addr > to) {
 					continue;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6469,7 +6469,7 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 			}
 		case 'v': // "agfv"
 			eprintf ("\rRendering graph...");
-			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
+			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, R_ANAL_FCN_TYPE_ROOT);
 			if (fcn) {
 				r_core_visual_graph (core, NULL, fcn, 1);
 			}


### PR DESCRIPTION
Hi there,
when trying to analyze some binaries (in my case the program ls) somehow the behaviour of agfv and agfj differs.

Questions | Answers
-- | --
OS/arch/bits (mandatory) |  Manjaro x86 64
File format of the file you reverse (mandatory) | ELF
Architecture/bits of the file (mandatory) | amd64
r2 -v full output, not truncated (mandatory) | radare2 3.2.0-git 20447 @ linux-x86-64 git.3.1.3-98-gd2133cbdf commit: d2133cbdf843cef278f7a22e763b9c6485c2b55a build: 2018-12-18__02:41:14

**Expected Behaviour**

> $r2 /usr/bin/ls
[0x00005ae0]> aaa
...
[0x00005ae0]> agfv
(shows graph of entry0)
[0x00005ae0]> agfj
(returns json containing instructions of entry0)
[0x00005ae0]> sf main
[0x00004070]> agfv
(shows graph of main)
[0x00005ae0]> agfj
(returns json containing instructions of main)

**Observed Behaviour**
> $r2 /usr/bin/ls
[0x00005ae0]> aaa
...
[0x00005ae0]> agfv
(shows graph of main)
[0x00005ae0]> agfj
(returns json containing instructions of entry0)
[0x00005ae0]> sf main
[0x00004070]> agfv
(shows graph of main)
[0x00005ae0]> agfj
(returns json containing instructions starting at sym._obstack_free)

Please note, that there are actually two things that are odd. First when the current position is still set to entry0 agv already shows the graph of the main. The other things is that when seeking to main, the graph view is correct, but the generated json starts at a different position. This patch aims to fix these misbehaviours.