### PR TITLE
fix issue #12507

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5011,12 +5011,8 @@ toro:
 		}
 
 		ds_begin_json_line (ds);
-		// f = r_anal_get_fcn_in (core->anal, ds->addr, 0);
 		f = fcnIn (ds, ds->addr, 0);
-		if (ds_print_labels (ds, f)) {
-			ds_show_functions (ds);
-			ds_show_xrefs (ds);
-		}
+		ds_print_labels (ds, f);
 		ds_setup_print_pre (ds, false, false);
 		ds_print_lines_left (ds);
 		core->print->resetbg = (ds->asm_highlight == UT64_MAX);


### PR DESCRIPTION
Fixes issue #12507 with duplicate output of CODE XREFS for local labels.

Before:
```
0x00400710      eb0f           jmp 0x400721                ; main.exit
0x00400712      bf41084000     mov edi, str.Invalid_Password
0x00400717      e84cfeffff     call sym.imp.puts
0x0040071c      b801000000     mov eax, 1
; CODE XREF from main (0x400710)
.exit:
; CODE XREF from main (0x400710)
0x00400721      c9             leave
0x00400722      c3             ret
```

After:
```
0x00400710      eb0f           jmp 0x400721                ; main.exit
0x00400712      bf41084000     mov edi, str.Invalid_Password
0x00400717      e84cfeffff     call sym.imp.puts
0x0040071c      b801000000     mov eax, 1
; CODE XREF from main (0x400710)
.exit:
0x00400721      c9             leave
0x00400722      c3             ret
```

Not sure what ds_show_functions was good for at that location, but it's also called immediately before ds_show_xrefs further up in the code, i.e. it likely also created duplicate output.

Also removed old code that was commented out.
