### PR TITLE
Limit the blocksize in visual mode

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3104,6 +3104,7 @@ R_API void r_core_visual_title(RCore *core, int color) {
 				// estimate new blocksize with the size of the last
 				// printed instructions
 				int new_sz = core->print->screen_bounds - core->offset + 32;
+				new_sz = R_MIN (new_sz, 16 * 1024);
 				if (new_sz > bsize) {
 					bsize = new_sz;
 				}


### PR DESCRIPTION
Otherwise it happened in some cases the block size became ridiculously big, leading to unnecessary performance issues (especially with already performance-challenging binaries like dyld library caches).

Not sure if hardcoding 16K it's a good idea, though.