### PR TITLE
Improve io map lookup performance in presence of many maps ##performance

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -88,6 +88,7 @@ typedef struct r_io_t {
 	RIDPool *map_ids;
 	SdbList *maps; //from tail backwards maps with higher priority are found
 	RPVector map_skyline; // map parts that are not covered by others
+	RPVector map_skyline_shadow; // map parts that are not covered by others
 	SdbList *sections;
 	RIDStorage *files;
 	RCache *buffer;
@@ -305,8 +306,9 @@ R_API bool r_io_map_exists (RIO *io, RIOMap *map);
 R_API bool r_io_map_exists_for_id (RIO *io, ut32 id);
 R_API RIOMap *r_io_map_resolve (RIO *io, ut32 id);
 R_API RIOMap *r_io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
-R_API RIOMap *r_io_map_get (RIO *io, ut64 addr);		//returns the map at vaddr with the highest priority
-R_API RIOMap *r_io_map_get_paddr (RIO *io, ut64 paddr);		//returns the map at paddr with the highest priority
+R_API RIOMap *r_io_map_get(RIO *io, ut64 addr);		//returns the map at vaddr with the highest priority
+R_API bool r_io_map_is_mapped(RIO* io, ut64 addr);
+R_API RIOMap *r_io_map_get_paddr(RIO *io, ut64 paddr);		//returns the map at paddr with the highest priority
 R_API void r_io_map_reset(RIO* io);
 R_API bool r_io_map_del (RIO *io, ut32 id);
 R_API bool r_io_map_del_for_fd (RIO *io, int fd);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -106,6 +106,7 @@ R_API RIO* r_io_init(RIO* io) {
 	io->addrbytes = 1;
 	r_io_desc_init (io);
 	r_pvector_init (&io->map_skyline, free);
+	r_pvector_init (&io->map_skyline_shadow, free);
 	r_io_map_init (io);
 	r_io_section_init (io);
 	r_io_cache_init (io);

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -139,6 +139,9 @@ R_API bool r_io_is_valid_offset(RIO* io, ut64 offset, int hasperm) {
 		return false;
 	}
 	if (io->va) {
+		if (hasperm == 0) {
+			return r_io_map_is_mapped (io, offset);
+		}
 		if ((map = r_io_map_get (io, offset))) {
 			return ((map->perm & hasperm) == hasperm);
 		}


### PR DESCRIPTION
- add the “skyline shadow” concept
- add `r_io_map_is_mapped` which binary-searches the skyline shadow to tell if a pointer belongs to any map
- rewrite `r_io_map_get` so that it binary-searches the skyline instead of linearly scanning the whole maps list

The "skyline shadow" is a vector of sorted coalesced intervals taken from the skyline. It's useful in presence of thousands of io maps to efficiently determine if a pointer belongs to any map (without caring about which map). Here's a depiction of this concept:

![skyline-shadow](https://user-images.githubusercontent.com/4139069/50247884-722f4d80-03d9-11e9-98ee-7033054b0c24.png)
