### PR TITLE
Fix odd behaviour of pdf (with regards to agfv and agfj)

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4565,6 +4565,9 @@ static int cmd_print(void *data, const char *input) {
 			} else {
 				ut32 bsz = core->blocksize;
 				RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset, R_ANAL_FCN_TYPE_ROOT);
+				if (!f) {
+					f = r_anal_get_fcn_in (core->anal, core->offset, 0);
+				}
 				RAnalFunction *tmp_func;
 				ut32 cont_size = 0;
 				RListIter *locs_it = NULL;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4564,7 +4564,7 @@ static int cmd_print(void *data, const char *input) {
 				processed_cmd = true;
 			} else {
 				ut32 bsz = core->blocksize;
-				RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset, 0);
+				RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset, R_ANAL_FCN_TYPE_ROOT);
 				RAnalFunction *tmp_func;
 				ut32 cont_size = 0;
 				RListIter *locs_it = NULL;


### PR DESCRIPTION
Hi there,
after analyzing a binary (i.e. the program ls) with the current offset set to the entry point the pdf command will show the content of main instead of entry0. This seems to be related to https://github.com/radare/radare2/pull/12512


Questions | Answers
-- | --
OS/arch/bits (mandatory) | Manjaro x86 64
File format of the file you reverse (mandatory) | ELF
Architecture/bits of the file (mandatory) | amd64
r2 -v full output, not truncated (mandatory) | radare2 3.2.0-git 20447 @ linux-x86-64 git.3.1.3-98-gd2133cbdf commit: d2133cbdf843cef278f7a22e763b9c6485c2b55a build: 2018-12-18__02:41:14

**Expected Behaviour**
> $r2 /usr/bin/ls
> [0x00005ae0]> aaa
> ...
> [0x00005ae0]> pdf
> (prints instructions of entry0)

**Observed Behaviour**
> $r2 /usr/bin/ls
> [0x00005ae0]> aaa
> ...
> [0x00005ae0]> pdf
> (prints instructions of main)

This patch aims to fix this misbehaviour.