### PR TITLE
 meson: Do not use glob with meson

### DIFF
--- a/libr/anal/meson.build
+++ b/libr/anal/meson.build
@@ -145,8 +145,7 @@ r_anal = library('r_anal', files,
 r_anal_dep = declare_dependency(link_with: r_anal,
                                 include_directories: r_anal_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_anal],
+pkgconfig_mod.generate(r_anal,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_anal',

--- a/libr/asm/meson.build
+++ b/libr/asm/meson.build
@@ -195,8 +195,7 @@ r_asm = library('r_asm', files,
 r_asm_dep = declare_dependency(link_with: r_asm,
                                include_directories: r_asm_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_asm],
+pkgconfig_mod.generate(r_asm,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_asm',

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -139,8 +139,7 @@ r_bin = library('r_bin', files,
 r_bin_dep = declare_dependency(link_with: r_bin,
                                include_directories: r_bin_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_bin],
+pkgconfig_mod.generate(r_bin,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_bin',

--- a/libr/bp/meson.build
+++ b/libr/bp/meson.build
@@ -24,8 +24,7 @@ r_bp = library('r_bp', files,
 r_bp_dep = declare_dependency(link_with: r_bp,
                               include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_bp],
+pkgconfig_mod.generate(r_bp,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_bp',

--- a/libr/config/meson.build
+++ b/libr/config/meson.build
@@ -17,8 +17,7 @@ r_config = library('r_config', files,
 r_config_dep = declare_dependency(link_with: r_config,
                                   include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_config],
+pkgconfig_mod.generate(r_config,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_config',

--- a/libr/cons/meson.build
+++ b/libr/cons/meson.build
@@ -31,8 +31,7 @@ r_cons = library('r_cons', files,
 r_cons_dep = declare_dependency(link_with: r_cons,
                                 include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_cons],
+pkgconfig_mod.generate(r_cons,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_cons',

--- a/libr/crypto/meson.build
+++ b/libr/crypto/meson.build
@@ -33,8 +33,7 @@ r_crypto = library('r_crypto', files,
 r_crypto_dep = declare_dependency(link_with: r_crypto,
                                   include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_crypto],
+pkgconfig_mod.generate(r_crypto,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_crypto',

--- a/libr/debug/meson.build
+++ b/libr/debug/meson.build
@@ -99,8 +99,7 @@ r_debug = library('r_debug', files,
 r_debug_dep = declare_dependency(link_with: r_debug,
                                  include_directories: r_debug_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_debug],
+pkgconfig_mod.generate(r_debug,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_debug',

--- a/libr/egg/meson.build
+++ b/libr/egg/meson.build
@@ -31,8 +31,7 @@ r_egg = library('r_egg', files,
 r_egg_dep = declare_dependency(link_with: r_egg,
                                include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_egg],
+pkgconfig_mod.generate(r_egg,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_egg',

--- a/libr/flag/meson.build
+++ b/libr/flag/meson.build
@@ -21,8 +21,7 @@ r_flag = library('r_flag', files,
 r_flag_dep = declare_dependency(link_with: r_flag,
                                 include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_flag],
+pkgconfig_mod.generate(r_flag,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_flag',

--- a/libr/fs/meson.build
+++ b/libr/fs/meson.build
@@ -41,8 +41,7 @@ r_fs = library('r_fs', files,
 r_fs_dep = declare_dependency(link_with: r_fs,
                               include_directories: platform_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_fs],
+pkgconfig_mod.generate(r_fs,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_fs',

--- a/libr/hash/meson.build
+++ b/libr/hash/meson.build
@@ -35,8 +35,7 @@ r_hash = library('r_hash', files,
 r_hash_dep = declare_dependency(link_with: r_hash,
                                 include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_hash],
+pkgconfig_mod.generate(r_hash,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_hash',

--- a/libr/io/meson.build
+++ b/libr/io/meson.build
@@ -64,7 +64,8 @@ r_io_deps = [
   windbg_dep,
   qnx_dep,
   zip_dep,
-  ar_dep
+  ar_dep,
+  pth
 ]
 
 if use_ptrace_wrap
@@ -83,8 +84,7 @@ r_io = library('r_io', files,
 r_io_dep = declare_dependency(link_with: r_io,
                               include_directories: platform_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_io],
+pkgconfig_mod.generate(r_io,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_io',

--- a/libr/lang/meson.build
+++ b/libr/lang/meson.build
@@ -22,8 +22,7 @@ r_lang = library('r_lang', files,
 r_lang_dep = declare_dependency(link_with: r_lang,
                                 include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_lang],
+pkgconfig_mod.generate(r_lang,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_lang',

--- a/libr/magic/meson.build
+++ b/libr/magic/meson.build
@@ -29,8 +29,7 @@ else
     include_directories: platform_inc
   )
 
-  pkgconfig_mod.generate(
-    libraries: [r_magic],
+  pkgconfig_mod.generate(r_magic,
     subdirs: 'libr',
     version: r2_version,
     name: 'r_magic',

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -309,16 +309,129 @@ parse_plugins = [
   'z80_pseudo'
 ]
 
-include_files = run_command(glob_cmd + ['include/*.h']).stdout().strip().split(';')
-install_headers(include_files, subdir: 'libr')
+include_files =[
+  'include/r2naked.h',
+  'include/r_anal_ex.h',
+  'include/r_anal.h',
+  'include/r_asm.h',
+  'include/r_bind.h',
+  'include/r_bin_dwarf.h',
+  'include/r_bin.h',
+  'include/r_binheap.h',
+  'include/r_bp.h',
+  'include/r_cmd.h',
+  'include/r_config.h',
+  'include/r_cons.h',
+  'include/r_core.h',
+  'include/r_crypto.h',
+  'include/r_debug.h',
+  'include/r_diff.h',
+  'include/r_egg.h',
+  'include/r_endian.h',
+  'include/r_flag.h',
+  'include/r_flist.h',
+  'include/r_fs.h',
+  'include/r_hash.h',
+  'include/r_heap_glibc.h',
+  'include/r_heap_jemalloc.h',
+  'include/r_io.h',
+  'include/r_lang.h',
+  'include/r_lib.h',
+  'include/r_list.h',
+  'include/r_magic.h',
+  'include/r_parse.h',
+  'include/r_pdb.h',
+  'include/r_qrcode.h',
+  'include/r_regex.h',
+  'include/r_reg.h',
+  'include/r_search.h',
+  'include/r_sign.h',
+  'include/r_skiplist.h',
+  'include/r_socket.h',
+  'include/r_syscall.h',
+  'include/r_th.h',
+  'include/r_types_base.h',
+  'include/r_types.h',
+  'include/r_util.h',
+  'include/r_vector.h',
+  'include/sdb.h'
+]
+install_headers(include_files,
+  subdir: 'libr')
 
-r_util_files = run_command(glob_cmd + ['include/r_util/*.h']).stdout().strip().split(';')
+r_util_files = [
+  'include/r_util/pj.h',
+  'include/r_util/r_ascii_table.h',
+  'include/r_util/r_asn1.h',
+  'include/r_util/r_assert.h',
+  'include/r_util/r_base64.h',
+  'include/r_util/r_base91.h',
+  'include/r_util/r_big.h',
+  'include/r_util/r_bitmap.h',
+  'include/r_util/r_buf.h',
+  'include/r_util/r_cache.h',
+  'include/r_util/r_constr.h',
+  'include/r_util/r_ctypes.h',
+  'include/r_util/r_debruijn.h',
+  'include/r_util/r_event.h',
+  'include/r_util/r_file.h',
+  'include/r_util/r_graph.h',
+  'include/r_util/r_hex.h',
+  'include/r_util/r_idpool.h',
+  'include/r_util/r_itv.h',
+  'include/r_util/r_json.h',
+  'include/r_util/r_log.h',
+  'include/r_util/r_mem.h',
+  'include/r_util/r_name.h',
+  'include/r_util/r_num.h',
+  'include/r_util/r_panels.h',
+  'include/r_util/r_pkcs7.h',
+  'include/r_util/r_pool.h',
+  'include/r_util/r_print.h',
+  'include/r_util/r_punycode.h',
+  'include/r_util/r_queue.h',
+  'include/r_util/r_range.h',
+  'include/r_util/r_rbtree.h',
+  'include/r_util/r_sandbox.h',
+  'include/r_util/r_signal.h',
+  'include/r_util/r_spaces.h',
+  'include/r_util/r_stack.h',
+  'include/r_util/r_strbuf.h',
+  'include/r_util/r_str.h',
+  'include/r_util/r_strpool.h',
+  'include/r_util/r_str_util.h',
+  'include/r_util/r_sys.h',
+  'include/r_util/r_time.h',
+  'include/r_util/r_tree.h',
+  'include/r_util/r_uleb128.h',
+  'include/r_util/r_utf16.h',
+  'include/r_util/r_utf32.h',
+  'include/r_util/r_utf8.h',
+  'include/r_util/r_x509.h'
+]
 install_headers(r_util_files, subdir: 'libr/r_util')
 
-r_crypto_files = run_command(glob_cmd + ['include/r_crypto/*.h']).stdout().strip().split(';')
+r_crypto_files = [
+  'include/r_crypto/r_des.h'
+]
 install_headers(r_crypto_files, subdir: 'libr/r_crypto')
 
-sdb_files = run_command(glob_cmd + ['include/sdb/*.h']).stdout().strip().split(';')
+sdb_files = [
+  'include/sdb/buffer.h',
+  'include/sdb/cdb.h',
+  'include/sdb/cdb_make.h',
+  'include/sdb/config.h',
+  'include/sdb/dict.h',
+  'include/sdb/ht_inc.h',
+  'include/sdb/ht_pp.h',
+  'include/sdb/ht_up.h',
+  'include/sdb/ht_uu.h',
+  'include/sdb/ls.h',
+  'include/sdb/sdb.h',
+  'include/sdb/sdbht.h',
+  'include/sdb/sdb_version.h',
+  'include/sdb/types.h'
+]
 install_headers(sdb_files, subdir: 'libr/sdb')
 
 sflib_common_files = [

--- a/libr/parse/meson.build
+++ b/libr/parse/meson.build
@@ -36,8 +36,7 @@ r_parse = library('r_parse', files,
 r_parse_dep = declare_dependency(link_with: r_parse,
                                  include_directories: platform_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_parse],
+pkgconfig_mod.generate(r_parse,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_parse',

--- a/libr/reg/meson.build
+++ b/libr/reg/meson.build
@@ -19,8 +19,7 @@ r_reg = library('r_reg', files,
 r_reg_dep = declare_dependency(link_with: r_reg,
                                include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_reg],
+pkgconfig_mod.generate(r_reg,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_reg',

--- a/libr/search/meson.build
+++ b/libr/search/meson.build
@@ -22,8 +22,7 @@ r_search = library('r_search', files,
 r_search_dep = declare_dependency(link_with: r_search,
                                   include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_search],
+pkgconfig_mod.generate(r_search,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_search',

--- a/libr/socket/meson.build
+++ b/libr/socket/meson.build
@@ -27,8 +27,7 @@ r_socket = library('r_socket', files,
 r_socket_dep = declare_dependency(link_with: r_socket,
                                   include_directories: [platform_inc])
 
-pkgconfig_mod.generate(
-  libraries: [r_socket],
+pkgconfig_mod.generate(r_socket,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_socket',

--- a/libr/syscall/meson.build
+++ b/libr/syscall/meson.build
@@ -18,7 +18,7 @@ r_syscall = library('r_syscall', files,
 r_syscall_dep = declare_dependency(link_with: r_syscall,
                                    include_directories: [platform_inc])
 
-pkgconfig_mod.generate(libraries: [r_syscall],
+pkgconfig_mod.generate(r_syscall,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_syscall',

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -97,8 +97,7 @@ r_util = library('r_util', files,
 r_util_dep = declare_dependency(link_with: r_util,
                                 include_directories: platform_inc)
 
-pkgconfig_mod.generate(
-  libraries: [r_util],
+pkgconfig_mod.generate(r_util,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_util',

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,6 @@ project('radare2', 'c', license: 'LGPL3', meson_version: '>=0.47.0')
 py3_exe = import('python').find_installation('python3')
 git_exe = find_program('git', required: false)
 pkgconfig_mod = import('pkgconfig')
-glob_cmd = [py3_exe, '-c', 'from sys import argv; print(";".join(__import__("glob").glob(argv[1])))']
 
 # Get r2 version
 r2_version = 'unknown-error'
@@ -321,13 +320,12 @@ endif
 ok = cc.has_header_symbol('sys/personality.h', 'ADDR_NO_RANDOMIZE')
 userconf.set10('HAVE_DECL_ADDR_NO_RANDOMIZE', ok)
 
-func_pfx_lists = [
+foreach item : [
   ['arc4random_uniform', '#include <stdlib.h>'],
   ['explicit_bzero', '#include <string.h>'],
   ['explicit_memset', '#include <string.h>'],
-  ['clock_nanosleep', '#include <time.h>'],
+  ['clock_nanosleep', '#include <time.h>']
 ]
-foreach item : func_pfx_lists
   func = item[0]
   ok = cc.has_function(func, prefix: item[1])
   userconf.set10('HAVE_@0@'.format(func.to_upper()), ok)
@@ -450,13 +448,33 @@ if get_option('use_webui')
   )
 endif
 
-fortunes_files = run_command(glob_cmd + ['doc/fortunes.*']).stdout().strip().split(';')
+fortunes_files = [
+  'doc/fortunes.creepy',
+  'doc/fortunes.fun',
+  'doc/fortunes.nsfw',
+  'doc/fortunes.tips'
+]
 install_data(fortunes_files,
   install_dir: r2_fortunes
 )
 
-man1_files = run_command(glob_cmd + ['man/*.1']).stdout().strip().split(';')
-man7_files = run_command(glob_cmd + ['man/*.7']).stdout().strip().split(';')
+man1_files = [
+  'man/r2agent.1',
+  'man/r2-docker.1',
+  'man/r2pm.1',
+  'man/rabin2.1',
+  'man/radare2.1',
+  'man/radiff2.1',
+  'man/rafind2.1',
+  'man/ragg2.1',
+  'man/rahash2.1',
+  'man/rarun2.1',
+  'man/rasm2.1',
+  'man/rax2.1'
+]
+man7_files = [
+  'man/esil.7'
+]
 install_man(man1_files, man7_files)
 
 install_data('doc/hud',
@@ -464,7 +482,16 @@ install_data('doc/hud',
   rename: 'main'
 )
 
-zshcomp_files = run_command(glob_cmd + ['doc/zsh/_r*']).stdout().strip().split(';')
+zshcomp_files = [
+  'doc/zsh/_r2',
+  'doc/zsh/_rabin2',
+  'doc/zsh/_radiff2',
+  'doc/zsh/_rafind2',
+  'doc/zsh/_ragg2',
+  'doc/zsh/_rahash2',
+  'doc/zsh/_rasm2',
+  'doc/zsh/_rax2'
+]
 install_data(zshcomp_files,
   install_dir: r2_zsh_compdir
 )

--- a/meson.build
+++ b/meson.build
@@ -321,11 +321,11 @@ ok = cc.has_header_symbol('sys/personality.h', 'ADDR_NO_RANDOMIZE')
 userconf.set10('HAVE_DECL_ADDR_NO_RANDOMIZE', ok)
 
 foreach item : [
-  ['arc4random_uniform', '#include <stdlib.h>'],
-  ['explicit_bzero', '#include <string.h>'],
-  ['explicit_memset', '#include <string.h>'],
-  ['clock_nanosleep', '#include <time.h>']
-]
+    ['arc4random_uniform', '#include <stdlib.h>'],
+    ['explicit_bzero', '#include <string.h>'],
+    ['explicit_memset', '#include <string.h>'],
+    ['clock_nanosleep', '#include <time.h>']
+  ]
   func = item[0]
   ok = cc.has_function(func, prefix: item[1])
   userconf.set10('HAVE_@0@'.format(func.to_upper()), ok)
@@ -448,17 +448,15 @@ if get_option('use_webui')
   )
 endif
 
-fortunes_files = [
+install_data(
   'doc/fortunes.creepy',
   'doc/fortunes.fun',
   'doc/fortunes.nsfw',
-  'doc/fortunes.tips'
-]
-install_data(fortunes_files,
+  'doc/fortunes.tips',
   install_dir: r2_fortunes
 )
 
-man1_files = [
+install_man(
   'man/r2agent.1',
   'man/r2-docker.1',
   'man/r2pm.1',
@@ -470,19 +468,16 @@ man1_files = [
   'man/rahash2.1',
   'man/rarun2.1',
   'man/rasm2.1',
-  'man/rax2.1'
-]
-man7_files = [
+  'man/rax2.1',
   'man/esil.7'
-]
-install_man(man1_files, man7_files)
+)
 
 install_data('doc/hud',
   install_dir: r2_hud,
   rename: 'main'
 )
 
-zshcomp_files = [
+install_data(
   'doc/zsh/_r2',
   'doc/zsh/_rabin2',
   'doc/zsh/_radiff2',
@@ -490,8 +485,6 @@ zshcomp_files = [
   'doc/zsh/_ragg2',
   'doc/zsh/_rahash2',
   'doc/zsh/_rasm2',
-  'doc/zsh/_rax2'
-]
-install_data(zshcomp_files,
+  'doc/zsh/_rax2',
   install_dir: r2_zsh_compdir
 )


### PR DESCRIPTION
**Note**: This PR should be merge after updating the sdb vendor (After merging radare/sdb#181). 

Fix deprecated warnings in Meson 0.49.0, examples:

```
libr/socket/meson.build:30: DEPRECATION: Library r_socket was passed to the "libraries" keyword argument of a previous call to generate() method instead of first positional argument. Adding r_socket to "Requires" field, but this is a deprecated behaviour that will change in a future version of Meson. Please report the issue if this warning cannot be avoided in your case.
```
