### PR TITLE
Fix #12397 - Colorize grep words if scr.color.grep is set

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -377,14 +377,8 @@ static char *preprocess_filter_expr(char *cmd, const char *quotes) {
 }
 
 R_API void r_cons_grep_parsecmd(char *cmd, const char *quotestr) {
-	char *ptr;
-
-	if (!cmd) {
-		return;
-	}
-
-	ptr = preprocess_filter_expr (cmd, quotestr);
-
+	r_return_if_fail (cmd && quotestr);
+	char *ptr = preprocess_filter_expr (cmd, quotestr);
 	if (ptr) {
 		r_str_trim (cmd);
 		parse_grep_expression (ptr);
@@ -392,7 +386,7 @@ R_API void r_cons_grep_parsecmd(char *cmd, const char *quotestr) {
 	}
 }
 
-R_API char * r_cons_grep_strip(char *cmd, const char *quotestr) {
+R_API char *r_cons_grep_strip(char *cmd, const char *quotestr) {
 	char *ptr = NULL;
 
 	if (cmd) {
@@ -593,8 +587,21 @@ R_API int r_cons_grepbuf(char *buf, int len) {
 			}
 			if (ret > 0) {
 				if (show) {
-					memcpy (out, tline, ret);
-					memcpy (out + ret, "\n", 1);
+					if (cons->grep_highlight && grep->str) {
+						char *str = r_str_ndup (tline, ret);
+						char *newstr = r_str_newf (Color_INVERT"%s"Color_RESET, grep->str);
+						if (str && newstr) {
+							str = r_str_replace (str, grep->str, newstr, 1);
+							ret = strlen (str);
+							memcpy (out, str, ret);
+							memcpy (out + ret, "\n", 2);
+						}
+						free (str);
+						free (newstr);
+					} else {
+						memcpy (out, tline, ret);
+						memcpy (out + ret, "\n", 2);
+					}
 					out += ret + 1;
 					buffer_len += ret + 1;
 				}
@@ -662,17 +669,17 @@ R_API int r_cons_grep_line(char *buf, int len) {
 	RCons *cons = r_cons_singleton ();
 	RConsGrep *grep = &cons->context->grep;
 	const char *delims = " |,;=\t";
-	char *in, *out, *tok = NULL;
-	int hit = grep->neg;
+	char *tok = NULL;
+	bool hit = grep->neg;
 	int outlen = 0;
 	bool use_tok = false;
 	size_t i;
 
-	in = calloc (1, len + 1);
+	char *in = calloc (1, len + 1);
 	if (!in) {
 		return 0;
 	}
-	out = calloc (1, len + 2);
+	char *out = calloc (1, len + 2);
 	if (!out) {
 		free (in);
 		return 0;
@@ -695,7 +702,7 @@ R_API int r_cons_grep_line(char *buf, int len) {
 				continue;
 			}
 			if (grep->begin) {
-				hit = (p == in)? 1: 0;
+				hit = (p == in);
 			} else {
 				hit = !grep->neg;
 			}
@@ -727,7 +734,6 @@ R_API int r_cons_grep_line(char *buf, int len) {
 		if (use_tok && grep->tokens_used) {
 			for (i = 0; i < R_CONS_GREP_TOKENS; i++) {
 				tok = strtok (i? NULL: in, delims);
-
 				if (tok) {
 					if (grep->tokens[i]) {
 						int toklen = strlen (tok);
@@ -741,16 +747,14 @@ R_API int r_cons_grep_line(char *buf, int len) {
 						}
 					}
 				} else {
-					if (!(*out)) {
-						free (in);
-						free (out);
-						return 0;
-					} else {
+					if ((*out)) {
 						break;
 					}
+					free (in);
+					free (out);
+					return 0;
 				}
 			}
-
 			outlen = outlen > 0? outlen - 1: 0;
 			if (outlen > len) { // should never happen
 				eprintf ("r_cons_grep_line: wtf, how you reach this?\n");
@@ -758,7 +762,6 @@ R_API int r_cons_grep_line(char *buf, int len) {
 				free (out);
 				return -1;
 			}
-
 			memcpy (buf, out, len);
 			len = outlen;
 		}
@@ -947,4 +950,3 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 	}
 	return r_strbuf_drain (res);
 }
-

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1713,6 +1713,13 @@ static int cb_scr_color_grep(void *user, void *data) {
 	return true;
 }
 
+static int cb_scr_color_grep_highlight(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	core->cons->grep_highlight = node->i_value;
+	return true;
+}
+
 static int cb_pager(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -3097,6 +3104,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("scr.scrollbar", "false", "Show scrollbar in visual mode");
 	SETPREF ("scr.randpal", "false", "Random color palete or just get the next one from 'eco'");
 	SETCB ("scr.color.grep", "false", &cb_scr_color_grep, "Enable colors when using ~grep");
+	SETCB ("scr.highlight.grep", "false", &cb_scr_color_grep_highlight, "Highlight (INVERT) the grepped words");
 	SETPREF ("scr.pipecolor", "false", "Enable colors when using pipes");
 	SETPREF ("scr.prompt.file", "false", "Show user prompt file (used by r2 -q)");
 	SETPREF ("scr.prompt.flag", "false", "Show flag name in the prompt");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -481,6 +481,7 @@ typedef struct r_cons_t {
 	int break_word_len;
 	ut64 timeout;
 	bool grep_color;
+	bool grep_highlight;
 	bool use_tts;
 	bool filter;
 	char* (*rgbstr)(char *str, size_t sz, ut64 addr);


### PR DESCRIPTION
<img width="1030" alt="screenshot 2018-12-24 at 01 57 46" src="https://user-images.githubusercontent.com/917142/50388743-877ce280-071f-11e9-8402-2d2f68943344.png">
