### PR TITLE
Fix missing exported symbols

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2962,7 +2962,7 @@ static int Elf_(fix_symbols)(ELFOBJ *bin, int nsym, int type, RBinElfSymbol **sy
 			while (!p->last) {
 				if (p->offset && d->offset == p->offset) {
 					p->in_shdr = true;
-					if (*p->name && strcmp (d->name, p->name)) {
+					if (*p->name && *d->name && (r_str_startswith (d->name, p->name) || r_str_startswith (d->name, "$"))) {
 						strcpy (d->name, p->name);
 					}
 				}


### PR DESCRIPTION
Hi there,
when analyzing shared libraries some of the exported symbols get "lost".  This happens if multiple symbols point to the same location. This patch aims to fix this behaviour. Tests will be added soonish.

Questions | Answers
-- | --
OS/arch/bits (mandatory) | Manjaro x86 64
File format of the file you reverse (mandatory) | ELF
Architecture/bits of the file (mandatory) | x86/64
r2 -v full output, not truncated (mandatory) | radare2 3.2.0-git 20508 @ linux-x86-64 git.3.1.3-139-ge7451c6a0 commit: e7451c6a0b074a4a1602f3ffcac1cc58ed25ecf3 build: 2018-12-24__16:44:50

### Expected behavior
```
$ r2 /usr/lib/libc.so.6
[0x00023af0]> is~getpid
3577 0x000c9420 0x000c9420  LOCAL   FUNC   12 __GI___getpid
3807 0x000c9420 0x000c9420  LOCAL   FUNC   12 __GI_getpid
6267 0x000c9420 0x000c9420   WEAK   FUNC   12 getpid
8102 0x000c9420 0x000c9420 GLOBAL   FUNC   12 __getpid
[0x00024330]> f~getpid
0x000c9420 12 sym.__GI___getpid
0x000c9420 12 sym.__GI_getpid
0x000c9420 12 sym.getpid
0x000c9420 12 sym.__getpid
```
Behaviour shall be similar to readelf:
```
$ readelf -s /usr/lib/libc.so.6 | grep getpid
   581: 00000000000c9420    12 FUNC    WEAK   DEFAULT   14 getpid@@GLIBC_2.2.5
   965: 00000000000c9420    12 FUNC    GLOBAL DEFAULT   14 __getpid@@GLIBC_2.2.5
  3577: 00000000000c9420    12 FUNC    LOCAL  DEFAULT   14 __GI___getpid
  3807: 00000000000c9420    12 FUNC    LOCAL  DEFAULT   14 __GI_getpid
  6267: 00000000000c9420    12 FUNC    WEAK   DEFAULT   14 getpid
  8102: 00000000000c9420    12 FUNC    GLOBAL DEFAULT   14 __getpid
```
However, I don't fully understand why the \@\@GLIBC symbols are not just added to the list of symbols in general, as from my understanding a program might very well link against those symbols. Maybe this could also be clarified here.

### Actual behavior
```
$ r2 /usr/lib/libc.so.6 
[0x00024330]> is~getpid
3577 0x000c9420 0x000c9420  LOCAL   FUNC   12 __getpid
3807 0x000c9420 0x000c9420  LOCAL   FUNC   12 __getpid
6267 0x000c9420 0x000c9420   WEAK   FUNC   12 __getpid
8102 0x000c9420 0x000c9420 GLOBAL   FUNC   12 __getpid
[0x00024330]> f~getpid
0x000c9420 12 sym.__getpid
```

### Steps to reproduce the behavior 
see above

### Additional Logs, screenshots, source-code,  configuration dump, ...
[libc.so.6.zip](https://github.com/radare/radare2/files/2707547/libc.so.6.zip)