### PR TITLE
Optimize ds_align_comment() ##disasm

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -588,6 +588,10 @@ R_API const char *r_cons_get_buffer() {
 	return I.context->buffer_len? I.context->buffer : NULL;
 }
 
+R_API int r_cons_get_buffer_len() {
+	return I.context->buffer_len;
+}
+
 R_API void r_cons_filter() {
 	/* grep */
 	if (I.filter || I.context->grep.nstrings > 0 || I.context->grep.tokens_used || I.context->grep.less || I.context->grep.json) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4216,23 +4216,23 @@ static void print_fcn_arg(RCore *core, const char *type, const char *name,
 }
 
 static void delete_last_comment(RDisasmState *ds) {
-	if (ds->show_comment_right_default) {
-		int len = 0;
-		char *ll = r_cons_lastline (&len);
-		if (ll) {
-			const char *begin = r_str_nstr (ll, "; ", len);
-			if (begin) {
-				// const int cstrlen = begin + len - ll;
-				// r_cons_drop (cstrlen - (int)(begin - ll));
-				ds_newline (ds);
-				if (ds->use_json) {
-					ds_begin_line (ds);
-				} else {
-					ds_setup_print_pre (ds, false, false);
-					ds_print_lines_left (ds);
-				}
-			}
-		}
+	if (!ds->show_comment_right_default) {
+		return;
+	}
+	int len = 0;
+	const char *ll = r_cons_get_buffer ();
+	if (!ll) {
+		return;
+	}
+	ll += ds->buf_line_begin;
+	const char *begin = r_str_nstr (ll, "; ", len);
+	if (begin) {
+		// const int cstrlen = begin + len - ll;
+		// r_cons_drop (cstrlen - (int)(begin - ll));
+		ds_newline (ds);
+		ds_begin_line (ds);
+		ds_setup_print_pre (ds, false, false);
+		ds_print_lines_left (ds);
 	}
 }
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -796,6 +796,7 @@ R_API char *r_cons_hud_string(const char *s);
 R_API char *r_cons_hud_file(const char *f);
 
 R_API const char *r_cons_get_buffer(void);
+R_API int r_cons_get_buffer_len();
 R_API void r_cons_grep_help(void);
 R_API void r_cons_grep_parsecmd(char *cmd, const char *quotestr);
 R_API char * r_cons_grep_strip(char *cmd, const char *quotestr);

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -37,6 +37,7 @@ R_API int r_str_bounds(const char *str, int *h);
 R_API char *r_str_crop(const char *str, unsigned int x, unsigned int y, unsigned int x2, unsigned int y2);
 R_API bool r_str_range_in(const char *r, ut64 addr);
 R_API int r_str_len_utf8(const char *s);
+R_API int r_str_len_utf8_ansi(const char *str);
 R_API int r_str_len_utf8char(const char *s, int left);
 R_API void r_str_filter_zeroline(char *str, int len);
 R_API int r_str_utf8_codepoint(const char *s, int left);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2019,6 +2019,26 @@ R_API int r_str_len_utf8(const char *s) {
 	return j + fullwidths;
 }
 
+
+R_API int r_str_len_utf8_ansi(const char *str) {
+	int i = 0, len = 0, fullwidths = 0;
+	while (str[i]) {
+		char ch = str[i];
+		if (ch == 0x1b && str[i + 1] == '[') {
+			for (++i; str[i] && str[i] != 'J' && str[i] != 'm' && str[i] != 'H'; i++) {
+				;
+			}
+		} else if ((ch & 0xc0) != 0x80) {
+			len++;
+			if (r_str_char_fullwidth (str + i, 4)) {
+				fullwidths++;
+			}
+		}
+		i++;
+	}
+	return len + fullwidths;
+}
+
 R_API const char *r_str_casestr(const char *a, const char *b) {
 	// That's a GNUism that works in many places.. but we dont want it
 	// return strcasestr (a, b);


### PR DESCRIPTION
`ds_align_comment()` is currently the bottleneck for `agJ`. The idea here is to save the position in the cons buffer of the start of the current line and calculate the line length starting from there, excluding ansi escape sequences and respecting utf-8.

## Comparison
Before:
```
[florian@florian-desktop radare2]$ time r2 /bin/ls -qc "s main;af;agJ" > /dev/null

real	0m0,440s
user	0m0,428s
sys	0m0,012s
```

After:
```
[florian@florian-desktop radare2]$ time r2 /bin/ls -qc "s main;af;agJ" > /dev/null

real	0m0,153s
user	0m0,139s
sys	0m0,013s
```

Here is the comparison of a seek in cutter from outside a function to inside a function, which causes a call to `agJ`:
Before:
![bildschirmfoto vom 2018-12-25 12-50-25](https://user-images.githubusercontent.com/1460997/50421882-45998c80-0844-11e9-9840-4c12dbbc4179.png)

After:
![bildschirmfoto vom 2018-12-25 12-50-42](https://user-images.githubusercontent.com/1460997/50421885-4af6d700-0844-11e9-968a-65e28302ad9a.png)
