### PR TITLE
Clarify aes /Ca help message

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -94,7 +94,7 @@ static const char *help_msg_slash_a[] = {
 
 static const char *help_msg_slash_C[] = {
 	"Usage: /C", "", "Search for crypto materials",
-	"/Ca", "", "Search for AES keys",
+	"/Ca", "", "Search for AES keys expanded in memory",
 	"/Cc", "[algo] [digest]", "Find collisions (bruteforce block length values until given checksum is found)",
 	"/Cd", "", "Search for ASN1/DER certificates",
 	"/Cr", "", "Search for private RSA keys",


### PR DESCRIPTION
Make sure that the help message states that the key in question is "expanded in memory" (whatever that means).

Related to https://github.com/radare/radare2book/pull/168