### PR TITLE
Fix compilation error

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3528,7 +3528,7 @@ R_API void r_core_visual_title(RCore *core, int color) {
 		if (tabsCount > 0) {
 			const char *kolor = core->cons->pal.prompt;
 			char *tabstring = visual_tabstring (core, kolor);
-			if (tabstrings) {
+			if (tabstring) {
 				title = r_str_append (title, tabstring);
 				free (tabstring);
 			}


### PR DESCRIPTION
During compilation of the current master, the following error occures
```
visual.c: In function ‘r_core_visual_title’:
visual.c:3531:8: error: ‘tabstrings’ undeclared (first use in this function); did you mean ‘tabstring’?
    if (tabstrings) {
        ^~~~~~~~~~
        tabstring
```
This patch aims to fix this issue