### PR TITLE
Fix wrong splitting of functions in aac

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1637,10 +1637,15 @@ R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dept
 			}
 			return true;
 		}
-		// split function if overlaps
-		r_anal_fcn_resize (core->anal, fcn, at - fcn->addr);
 	}
-	return core_anal_fcn (core, at, from, reftype, depth - 1);
+	if (core_anal_fcn (core, at, from, reftype, depth - 1)) {
+		// split function if overlaps
+		if (fcn) {
+			r_anal_fcn_resize (core->anal, fcn, at - fcn->addr);
+		}
+		return true;
+	}
+	return false;
 }
 
 /* if addr is 0, remove all functions


### PR DESCRIPTION
Hi there,
after analyzing libc.so with aa the function `sym.abort` is analyzed correctly. However, analyzing it with aac shows a different result (as shown in the pictures below). This is imho caused the wrong assumption that the function has overlapping blocks. And due to that the function is split. This patch aims to fix this misbehaviour.
[libc.so.6.zip](https://github.com/radare/radare2/files/2719632/libc.so.6.zip)


### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | 86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.2.0-git 20594 @ linux-x86-64 git.3.1.3-185-g0d99fa815 commit: 0d99fa8152fade9e258514c44406987453fa5391 build: 2019-01-01__20:42:23

### Expected behavior
```
r2 /usr/lib/libc.so.6
[0x00024330]> aa
[0x00024330]> f~sym.abort
0x0002254d 546 sym.abort
[0x00024330]> s 0x0002254d
[0x00024330]> agv
```
![screenshot from 2019-01-01 20-41-00](https://user-images.githubusercontent.com/30472652/50576314-b4ac4d80-0e0f-11e9-9fb8-f64c54105e24.png)
```
[0x00024330]> aac
[0x00024330]> agv
```
![screenshot from 2019-01-01 20-41-00](https://user-images.githubusercontent.com/30472652/50576314-b4ac4d80-0e0f-11e9-9fb8-f64c54105e24.png)

### Actual behavior
```
r2 /usr/lib/libc.so.6
[0x00024330]> aa
[0x00024330]> f~sym.abort
0x0002254d 546 sym.abort
[0x00024330]> s 0x0002254d
[0x00024330]> agv
```
![screenshot from 2019-01-01 20-41-00](https://user-images.githubusercontent.com/30472652/50576314-b4ac4d80-0e0f-11e9-9fb8-f64c54105e24.png)
```
[0x00024330]> aac
[0x00024330]> agv
```
![screenshot from 2019-01-01 20-41-29](https://user-images.githubusercontent.com/30472652/50576321-da395700-0e0f-11e9-9ef8-8c35937ccd2d.png)


### Steps to reproduce the behavior 
see above