### PR TITLE
Add the missing fail arc for SBRx instruction

### DIFF
--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -1453,6 +1453,7 @@ INST_HANDLER (sbrx) {	// SBRC Rr, b
 			cpu);
 	r_strbuf_fini (&next_op.esil);
 	op->jump = op->addr + next_op.size + 2;
+	op->fail = op->addr + 2;
 
 	// cycles
 	op->cycles = 1;	// XXX: This is a bug, because depends on eval state,


### PR DESCRIPTION
Fixes #12612 