### PR TITLE
Fixed wrong bounds check while PE file resources is being parsed

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2305,7 +2305,7 @@ static void _parse_resource_directory(struct PE_(r_bin_pe_obj_t) *bin, Pe_image_
 			break;
 		}
 		off = rsrc_base + entry.u2.OffsetToData;
-		if (off > bin->size || off + sizeof (data) > bin->size) {
+		if (off > bin->size || off + sizeof (*data) > bin->size) {
 			free (data);
 			break;
 		}


### PR DESCRIPTION
Pointer size was checked (*wrong*) instead of `struct Pe_image_resource_data_entry` size