### PR TITLE
Add free_all to RVector ##util

### DIFF
--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -38,6 +38,7 @@ extern "C" {
 
 typedef int (*RPVectorComparator)(const void *a, const void *b);
 typedef void (*RVectorFree)(void *e, void *user);
+typedef void (*RVectorFreeAll)(void *user);
 typedef void (*RPVectorFree)(void *e);
 
 typedef struct r_vector_t {
@@ -47,6 +48,8 @@ typedef struct r_vector_t {
 	size_t elem_size;
 	RVectorFree free;
 	void *free_user;
+	RVectorFreeAll free_all;
+	void *free_all_user;
 } RVector;
 
 // RPVector directly wraps RVector for type safety
@@ -111,6 +114,12 @@ R_API void *r_vector_reserve(RVector *vec, size_t capacity);
 
 // shrink capacity to len.
 R_API void *r_vector_shrink(RVector *vec);
+
+// set free function that will be executed once for the whole vector
+static inline void r_vector_set_free_all(RVector *vec, RVectorFreeAll free_all, void *user) {
+	vec->free_all = free_all;
+	vec->free_all_user = user;
+}
 
 /*
  * example:
@@ -198,6 +207,10 @@ static inline void **r_pvector_reserve(RPVector *vec, size_t capacity) {
 
 static inline void **r_pvector_shrink(RPVector *vec) {
 	return (void **)r_vector_shrink (&vec->v);
+}
+
+static inline void r_pvector_set_free_all(RPVector *vec, RVectorFreeAll free_all, void *user) {
+	r_vector_set_free_all (&vec->v, free_all, user);
 }
 
 /*

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -33,6 +33,8 @@ R_API void r_vector_init(RVector *vec, size_t elem_size, RVectorFree free, void 
 	vec->elem_size = elem_size;
 	vec->free = free;
 	vec->free_user = free_user;
+	vec->free_all = NULL;
+	vec->free_all_user = NULL;
 }
 
 R_API RVector *r_vector_new(size_t elem_size, RVectorFree free, void *free_user) {
@@ -45,6 +47,9 @@ R_API RVector *r_vector_new(size_t elem_size, RVectorFree free, void *free_user)
 }
 
 static void vector_free_elems(RVector *vec) {
+	if (vec->free_all) {
+		vec->free_all (vec->free_all_user);
+	}
 	if (vec->free) {
 		while (vec->len > 0) {
 			vec->free (r_vector_index_ptr (vec, --vec->len), vec->free_user);
@@ -72,6 +77,8 @@ static bool vector_clone(RVector *dst, RVector *src) {
 	dst->elem_size = src->elem_size;
 	dst->free = src->free;
 	dst->free_user = src->free_user;
+	dst->free_all = src->free_all;
+	dst->free_all_user = src->free_all_user;
 	if (!dst->len) {
 		dst->a = NULL;
 	} else {


### PR DESCRIPTION
The idea is that you can do things like having a single buffer like the following:
`"hello\0r2\0is\0cool\0"`
Then saving pointers to each individual string in an RPVector and freeing the buffer once automatically when the RPVector is freed. This is especially useful when fetching sdb arrays, where you can just allocate the whole string once and set each ',' to zero.

Tests: https://github.com/radare/radare2-regressions/pull/1620