### PR TITLE
WIP: Refactoring of get_import_addr in format/elf

### DIFF
--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -116,6 +116,7 @@ struct Elf_(r_bin_elf_obj_t) {
 	RBinElfSymbol *g_imports;
 	RBinElfSymbol *phdr_symbols;
 	RBinElfSymbol *phdr_imports;
+	HtUP *rel_cache;
 };
 
 int Elf_(r_bin_elf_has_va)(struct Elf_(r_bin_elf_obj_t) *bin);


### PR DESCRIPTION
Before the patch, the relocations in .rel.plt (or the others) were
traversed every time an imported symbol needed to be found. With the
refactoring, relocations are parsed only one time, placed in a hashtable
for fast lookup and stored in a cache.