### PR TITLE
Disable dbg.follow in aaft to prevent seek changes

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -17,11 +17,12 @@ enum {
 
 static bool r_anal_emul_init(RCore *core, RConfigHold *hc) {
 	r_config_save_num (hc, "esil.romem", "asm.trace", "dbg.trace",
-			"esil.nonull", NULL);
+			"esil.nonull", "dbg.follow", NULL);
 	r_config_set (core->config, "esil.romem", "true");
 	r_config_set (core->config, "asm.trace", "true");
 	r_config_set (core->config, "dbg.trace", "true");
 	r_config_set (core->config, "esil.nonull", "true");
+	r_config_set_i (core->config, "dbg.follow", false);
 	const char *bp = r_reg_get_name (core->anal->reg, R_REG_NAME_BP);
 	const char *sp = r_reg_get_name (core->anal->reg, R_REG_NAME_SP);
 	if ((bp && !r_reg_getv (core->anal->reg, bp)) && (sp && !r_reg_getv (core->anal->reg, sp))) {


### PR DESCRIPTION
Fix #11505 

* Before 
![after_aaft](https://user-images.githubusercontent.com/18589720/50723556-7c558980-1105-11e9-8395-94f77bd45f3b.png)

* After 
![before_aaft](https://user-images.githubusercontent.com/18589720/50723561-85def180-1105-11e9-8fa0-70bd7a0b957a.png)

Hopefully this should fix the issue , without making tarvis angry :) , @Maijin pls verify !