### PR TITLE
More fix for Vg and VG ##visual

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2742,10 +2742,8 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			if (core->io->va) {
 				RIOMap *map = r_io_map_get (core->io, core->offset);
 				if (!map) {
-					map = ls_pop (core->io->maps);
-					if (map) {
-						ls_append (core->io->maps, map);
-					}
+					SdbListIter *i = ls_tail (core->io->maps);
+					map = ls_iter_get (i);
 				}
 				if (map) {
 					r_core_seek (core, r_itv_begin (map->itv), 1);
@@ -2760,10 +2758,8 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			{
 				RIOMap *map = r_io_map_get (core->io, core->offset);
 				if (!map) {
-					map = ls_pop_head (core->io->maps);
-					if (map) {
-						ls_prepend (core->io->maps, map);
-					}
+					SdbListIter *i = ls_head (core->io->maps);
+					map = ls_iter_get (i);
 				}
 				if (map) {
 					RPrint *p = core->print;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2740,7 +2740,13 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			break;
 		case 'g':
 			if (core->io->va) {
-				RIOMap *map = core->io->maps->tail->data;
+				RIOMap *map = r_io_map_get (core->io, core->offset);
+				if (!map) {
+					map = ls_pop (core->io->maps);
+					if (map) {
+						ls_append (core->io->maps, map);
+					}
+				}
 				if (map) {
 					r_core_seek (core, r_itv_begin (map->itv), 1);
 				}
@@ -2752,7 +2758,13 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 		case 'G':
 			ret = -1;
 			{
-				RIOMap *map = core->io->maps->head->data;
+				RIOMap *map = r_io_map_get (core->io, core->offset);
+				if (!map) {
+					map = ls_pop_head (core->io->maps);
+					if (map) {
+						ls_prepend (core->io->maps, map);
+					}
+				}
 				if (map) {
 					RPrint *p = core->print;
 					int scr_rows;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2740,11 +2740,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			break;
 		case 'g':
 			if (core->io->va) {
-				ut64 offset = r_io_section_get_paddr_at (core->io, 0LL);
-				if (offset == -1) {
-					offset = 0;
-				}
-				RIOMap *map = r_io_map_get (core->io, core->offset);
+				RIOMap *map = core->io->maps->tail->data;
 				if (map) {
 					r_core_seek (core, r_itv_begin (map->itv), 1);
 				}
@@ -2756,7 +2752,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 		case 'G':
 			ret = -1;
 			{
-				RIOMap *map = r_io_map_get (core->io, core->offset);
+				RIOMap *map = core->io->maps->head->data;
 				if (map) {
 					RPrint *p = core->print;
 					int scr_rows;


### PR DESCRIPTION
For example, s 0 -> Vg nor VG works so fixed.