### PR TITLE
Fix missing reloc symbols in agfj

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5582,7 +5582,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		}
 
 		// f = r_anal_get_fcn_in (core->anal, at,
-		f = fcnIn (ds, at, R_ANAL_FCN_TYPE_FCN | R_ANAL_FCN_TYPE_SYM);
+		f = fcnIn (ds, at, R_ANAL_FCN_TYPE_FCN | R_ANAL_FCN_TYPE_SYM | R_ANAL_FCN_TYPE_LOC);
 		if (ds->varsub && f) {
 			core->parser->varlist = r_anal_var_list_dynamic;
 			int ba_len = r_strbuf_length (&asmop.buf_asm) + 128;


### PR DESCRIPTION
Hi there,
r2 is missing the resolution of some reloc symbols in agfj. This patch aims to fix this.

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.2.0-git 20627 @ linux-x86-64 git.3.1.3-217-g399fcc24a commit: 399fcc24aad065fe08fefc6d74bebdbc53e0181a build: 2019-01-04__23:00:04

### Expected behavior
```
$ r2 /usr/bin/ls        
[0x00005ae0]> aa;aac
...
[0x00005ae0]> sf loc.0000f190
[0x0000f190]> agfj~{}
[
    {
        ...
        "blocks" : [
            ...,
          {
            "offset": 61857,
            "ptr": 138400,
            "esil": "0x12af9,rip,+,[8],rip,=",
            "refptr": true,
            "fcn_addr": 61840,
            "fcn_last": 61857,
            "size": 6,
            "opcode": "jmp qword [rip + 0x12af9]",
            "disasm": "jmp qword [reloc.free]",
            "bytes": "ff25f92a0100",
            "family": "cpu",
            "type": "ujmp",
            "type_num": 402653186,
            "type2_num": 0
          }

        ]
    }
]
```

### Actual behavior
```
$ r2 /usr/bin/ls        
[0x00005ae0]> aa;aac
...
[0x00005ae0]> sf loc.0000f190
[0x0000f190]> agfj~{}
[
    {
        ...
        "blocks" : [
            ...,
          {
            "offset": 61857,
            "ptr": 138400,
            "esil": "0x12af9,rip,+,[8],rip,=",
            "refptr": true,
            "fcn_addr": 61840,
            "fcn_last": 61857,
            "size": 6,
            "opcode": "jmp qword [rip + 0x12af9]",
            "disasm": "jmp qword [rip + 0x12af9]",
            "bytes": "ff25f92a0100",
            "family": "cpu",
            "type": "ujmp",
            "type_num": 402653186,
            "type2_num": 0
          }

        ]
    }
]
```
Please note that in other modes, for instance the visual mode, the behaviour is already as expected:
![screenshot from 2019-01-06 02-41-07](https://user-images.githubusercontent.com/30472652/50731089-a4bca280-115c-11e9-849e-22571b68bed0.png)


### Steps to reproduce the behavior 
Execute the steps as shown above using (extracted) 
[ls.zip](https://github.com/radare/radare2-regressions/files/2730048/ls.zip)
