### PR TITLE
Some fixes for RStrBuf API

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -318,6 +318,8 @@ static inline void *r_new_copy(int size, void *data) {
 	((char *)(((size_t)(v) + (t - 1)) \
 	& ~(t - 1)))
 
+#define R_ALIGN_NEXT(v, t) (((v) + ((t) - 1)) & ~((t) - 1))
+
 #define R_BIT_SET(x,y) (((ut8*)x)[y>>4] |= (1<<(y&0xf)))
 #define R_BIT_UNSET(x,y) (((ut8*)x)[y>>4] &= ~(1<<(y&0xf)))
 #define R_BIT_TOGGLE(x, y) ( R_BIT_CHK (x, y) ? \


### PR DESCRIPTION
* Align size of allocated blocks in `r_strbuf_setbin()` and `r_strbuf_append_n()`
* Reallocate memory if possible in `r_strbuf_setbin()`
* Fix potential memleak in `r_strbuf_setbin()`
* Use output of `vsnprintf` in `r_strbuf_vsetf()` and `r_strbuf_vappendf()`