### PR TITLE
Make afcf also print args from vars (unified with disasm)

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -984,7 +984,7 @@ R_API void r_anal_fcn_vars_cache_fini(RAnalFcnVarsCache *cache) {
 	r_list_free (cache->svars);
 }
 
-R_API char *r_anal_fcn_format_sig(R_NONNULL RAnal *anal, R_NONNULL RAnalFunction *fcn, R_NULLABLE char *fcn_name, bool return_type,
+R_API char *r_anal_fcn_format_sig(R_NONNULL RAnal *anal, R_NONNULL RAnalFunction *fcn, R_NULLABLE char *fcn_name,
 		R_NULLABLE RAnalFcnVarsCache *reuse_cache, R_NULLABLE const char *fcn_name_pre, R_NULLABLE const char *fcn_name_post) {
 	RAnalFcnVarsCache *cache = NULL;
 
@@ -1003,15 +1003,13 @@ R_API char *r_anal_fcn_format_sig(R_NONNULL RAnal *anal, R_NONNULL RAnalFunction
 	Sdb *TDB = anal->sdb_types;
 	char *type_fcn_name = r_type_func_guess (TDB, fcn_name);
 	if (type_fcn_name && r_type_func_exist (TDB, type_fcn_name)) {
-		if (return_type) {
-			const char *fcn_type = r_type_func_ret (anal->sdb_types, type_fcn_name);
-			if (fcn_type) {
-				const char *sp = " ";
-				if (*fcn_type && (fcn_type[strlen (fcn_type) - 1] == '*')) {
-					sp = "";
-				}
-				r_strbuf_appendf (buf, "%s%s", fcn_type, sp);
+		const char *fcn_type = r_type_func_ret (anal->sdb_types, type_fcn_name);
+		if (fcn_type) {
+			const char *sp = " ";
+			if (*fcn_type && (fcn_type[strlen (fcn_type) - 1] == '*')) {
+				sp = "";
 			}
+			r_strbuf_appendf (buf, "%s%s", fcn_type, sp);
 		}
 	}
 

--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -207,13 +207,21 @@ R_API void r_core_print_func_args(RCore *core) {
 	r_anal_op_fini (op);
 }
 
+static void r_anal_fcn_arg_free(RAnalFuncArg *arg) {
+	if (!arg) {
+		return;
+	}
+	free (arg->orig_c_type);
+	free (arg);
+}
+
 /* Returns a list of RAnalFuncArg */
 R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 	if (!fcn_name || !core->anal) {
 		return NULL;
 	}
 	Sdb *TDB = core->anal->sdb_types;
-	RList *list = r_list_new ();
+	RList *list = r_list_newf (r_anal_fcn_arg_free);
 	char *key = resolve_fcn_name (core->anal, fcn_name);
 	if (!key) {
 		return NULL;
@@ -224,6 +232,7 @@ R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 	const char *src = r_anal_cc_arg (core->anal, cc, 1); // src of first argument
 	if (!cc) {
 		// unsupported calling convention
+		free (key);
 		return NULL;
 	}
 	int i;
@@ -256,5 +265,6 @@ R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 			r_list_append (list, arg);
 		}
 	}
+	free (key);
 	return list;
 }

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2199,6 +2199,79 @@ static void afCc(RCore *core, const char *input) {
 	}
 }
 
+static void cmd_anal_fcn_sig(RCore *core, const char *input) {
+	bool json = false;
+	if (input[0] == 'j') {
+		json = true;
+	}
+	char *p = strchr (input, ' ');
+	char *fcn_name = p ? r_str_trim (strdup (p)): NULL;
+	RListIter *iter;
+	RAnalFuncArg *arg;
+
+	RAnalFunction *fcn;
+	if (fcn_name) {
+		fcn = r_anal_fcn_find_name (core->anal, fcn_name);
+	} else {
+		fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
+		if (fcn) {
+			fcn_name = fcn->name;
+		}
+	}
+
+	if (json) {
+		PJ *j = pj_new ();
+		if (!j) {
+			return;
+		}
+		pj_a (j);
+
+		char *key = NULL;
+		if (fcn_name) {
+			key = resolve_fcn_name (core->anal, fcn_name);
+		}
+
+		if (key) {
+			const char *fcn_type = r_type_func_ret (core->anal->sdb_types, key);
+			int nargs = r_type_func_args_count (core->anal->sdb_types, key);
+			if (fcn_type) {
+				pj_o (j);
+				pj_ks (j, "name", r_str_get (key));
+				pj_ks (j, "return", r_str_get (fcn_type));
+				pj_ki (j, "count", nargs);
+				if (nargs) {
+					pj_k (j, "args");
+					pj_a (j);
+					RList *list = r_core_get_func_args (core, fcn_name);
+					r_list_foreach (list, iter, arg) {
+						char *type = arg->orig_c_type;
+						pj_o (j);
+						pj_ks (j, "name", arg->name);
+						pj_ks (j, "type", type);
+						pj_end (j);
+					}
+					pj_end (j);
+				}
+				pj_end (j);
+			}
+		} else {
+			eprintf ("no key :(\n");
+		}
+		pj_end (j);
+		char *s = pj_drain (j);
+		if (s) {
+			r_cons_printf ("%s\n", s);
+			free (s);
+		}
+	} else {
+		char *sig = r_anal_fcn_format_sig (core->anal, fcn, fcn_name, true, NULL, NULL, NULL);
+		if (sig) {
+			r_cons_printf ("%s\n", sig);
+			free (sig);
+		}
+	}
+}
+
 static int cmd_anal_fcn(RCore *core, const char *input) {
 	char i;
 
@@ -2527,80 +2600,9 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		case 'a': // "afca"
 			eprintf ("Todo\n");
 			break;
-		case 'f': { // "afcf"
-			bool json = false;
-			if (input[3] == 'j') {
-				json = true;
-				r_cons_printf ("[");
-			}
-			char *p = strchr (input, ' ');
-			const char *fcn_name = p ? r_str_trim (strdup (p)): NULL;
-			char *key = NULL;
-			RListIter *iter;
-			RAnalFuncArg *arg;
-			if (!fcn_name) {
-				fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
-				if (fcn) {
-					fcn_name = fcn->name;
-				}
-			}
-			if (fcn_name) {
-				key = resolve_fcn_name (core->anal, fcn_name);
-			}
-			if (key) {
-				const char *fcn_type = r_type_func_ret (core->anal->sdb_types, key);
-				int nargs = r_type_func_args_count (core->anal->sdb_types, key);
-				if (fcn_type) {
-					char *sp = " ";
-					if (*fcn_type && (fcn_type[strlen (fcn_type) - 1] == '*')) {
-						sp = "";
-					}
-					if (json) {
-						r_cons_printf ("{\"name\": \"%s\"",r_str_get (key));
-						r_cons_printf (",\"return\": \"%s\"",r_str_get (fcn_type));
-						r_cons_printf (",\"count\": %d", nargs);
-						if (nargs) {
-							r_cons_printf (",\"args\":[", nargs);
-						}
-					} else {
-						r_cons_printf ("%s%s%s(", r_str_get (fcn_type), sp, r_str_get (key));
-						if (!nargs) {
-							r_cons_println ("void)");
-							break;
-						}
-					}
-					bool first = true;
-					RList *list = r_core_get_func_args (core, fcn_name);
-					r_list_foreach (list, iter, arg) {
-						RListIter *nextele = r_list_iter_get_next (iter);
-						char *type = arg->orig_c_type;
-						char *sp1 = " ";
-						if (*type && (type[strlen (type) - 1] == '*')) {
-							sp1 = "";
-						}
-						if (json) {
-							r_cons_printf ("%s{\"name\": \"%s\",\"type\":\"%s\"}",
-									first? "": ",", arg->name, type);
-							first = false;
-						} else {
-							r_cons_printf ("%s%s%s%s", type, sp1, arg->name, nextele?", ":")");
-						}
-					}
-					if (json) {
-						if (nargs) {
-							r_cons_printf ("]");
-						}
-						r_cons_printf ("}");
-					} else {
-						r_cons_println ("");
-					}
-				}
-			}
-			if (json) {
-				r_cons_printf ("]\n");
-			}
+		case 'f': // "afcf"
+			cmd_anal_fcn_sig (core, input + 3);
 			break;
-		}
 		case 'k': // "afck"
 			r_core_cmd0 (core, "k anal/cc/*");
 			break;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2309,7 +2309,7 @@ static void cmd_anal_fcn_sig(RCore *core, const char *input) {
 		}
 		pj_free (j);
 	} else {
-		char *sig = r_anal_fcn_format_sig (core->anal, fcn, fcn_name, true, NULL, NULL, NULL);
+		char *sig = r_anal_fcn_format_sig (core->anal, fcn, fcn_name, NULL, NULL, NULL);
 		if (sig) {
 			r_cons_printf ("%s\n", sig);
 			free (sig);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1602,7 +1602,6 @@ static void printVarSummary(RDisasmState *ds, RList *list) {
 	ds_newline (ds);
 }
 
-
 static void ds_show_functions(RDisasmState *ds) {
 	RAnalFunction *f;
 	RCore *core = ds->core;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1686,7 +1686,7 @@ static void ds_show_functions(RDisasmState *ds) {
 			r_cons_print (COLOR (ds, color_fline));
 			ds_print_pre (ds);
 			r_cons_printf ("%s  ", COLOR_RESET (ds));
-			char *sig = r_anal_fcn_format_sig (core->anal, f, fcn_name, false, &vars_cache, COLOR (ds, color_fname), COLOR_RESET (ds));
+			char *sig = r_anal_fcn_format_sig (core->anal, f, fcn_name, &vars_cache, COLOR (ds, color_fname), COLOR_RESET (ds));
 			if (sig) {
 				r_cons_print (sig);
 				free (sig);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1515,6 +1515,19 @@ R_API void extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_s
 R_API RAnalVarAccess *r_anal_var_access_get(RAnal *anal, RAnalVar *var, ut64 from);
 R_API RAnalVar *r_anal_var_get_byname (RAnal *anal, ut64 addr, const char* name);
 
+
+typedef struct r_anal_fcn_vars_cache {
+	RList *bvars;
+	RList *rvars;
+	RList *svars;
+} RAnalFcnVarsCache;
+R_API void r_anal_fcn_vars_cache_init(RAnal *anal, RAnalFcnVarsCache *cache, RAnalFunction *fcn);
+R_API void r_anal_fcn_vars_cache_fini(RAnalFcnVarsCache *cache);
+
+R_API char *r_anal_fcn_format_sig(R_NONNULL RAnal *anal, R_NONNULL RAnalFunction *fcn, R_NULLABLE char *fcn_name, bool return_type,
+		R_NULLABLE RAnalFcnVarsCache *reuse_cache, R_NULLABLE const char *fcn_name_pre, R_NULLABLE const char *fcn_name_post);
+
+
 /* project */
 R_API bool r_anal_xrefs_init (RAnal *anal);
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1524,7 +1524,7 @@ typedef struct r_anal_fcn_vars_cache {
 R_API void r_anal_fcn_vars_cache_init(RAnal *anal, RAnalFcnVarsCache *cache, RAnalFunction *fcn);
 R_API void r_anal_fcn_vars_cache_fini(RAnalFcnVarsCache *cache);
 
-R_API char *r_anal_fcn_format_sig(R_NONNULL RAnal *anal, R_NONNULL RAnalFunction *fcn, R_NULLABLE char *fcn_name, bool return_type,
+R_API char *r_anal_fcn_format_sig(R_NONNULL RAnal *anal, R_NONNULL RAnalFunction *fcn, R_NULLABLE char *fcn_name,
 		R_NULLABLE RAnalFcnVarsCache *reuse_cache, R_NULLABLE const char *fcn_name_pre, R_NULLABLE const char *fcn_name_post);
 
 

--- a/libr/util/pj.c
+++ b/libr/util/pj.c
@@ -19,9 +19,11 @@ static void pj_comma(PJ *j) {
 
 R_API PJ *pj_new() {
 	PJ *j = R_NEW0 (PJ);
-	if (j) {
-		j->sb = r_strbuf_new ("");
+	if (!j) {
+		return NULL;
 	}
+	j->sb = r_strbuf_new ("");
+	j->is_first = true;
 	return j;
 }
 
@@ -54,10 +56,12 @@ static PJ *pj_begin(PJ *j, char type) {
 }
 
 R_API PJ *pj_o(PJ *j) {
+	pj_comma (j);
 	return pj_begin (j, '{');
 }
 
 R_API PJ *pj_a(PJ *j) {
+	pj_comma (j);
 	return pj_begin (j, '[');
 }
 


### PR DESCRIPTION
Please don't squash. I think the commits are clean enough.

Example:
```
[0x00005ae0]> s main
[0x00004070]> af
[0x00004070]> pd 1
┌ (fcn) main 4886
│   main (int argc, char **argv, char **envp);
│           ; arg int arg_5h @ rbp+0x5
│           ; var int local_8h @ rsp+0x8
│           ; var int local_17h @ rsp+0x17
│           ; var int local_28h @ rsp+0x28
│           ; var int local_30h @ rsp+0x30
│           ; var int local_32h @ rsp+0x32
│           ; var int local_38h @ rsp+0x38
│           ; var int local_45h @ rsp+0x45
│           ; var int local_46h @ rsp+0x46
│           ; var int local_47h @ rsp+0x47
│           ; var int local_48h @ rsp+0x48
│           ; arg int argc @ rdi
│           ; arg char **argv @ rsi
│           ; DATA XREF from main (0x5b01)
│           0x00004070      4157           push r15
[0x00004070]> afcf
int main (int argc, char **argv, char **envp);
[0x00004070]> afcfj
[{"name":"main","return":"int","args":[{"name":"argc","type":"int"},{"name":"argv","type":"char **"},{"name":"envp","type":"char **"}],"count":3}]
[0x00004070]> s 0x00015bb0
[0x00015bb0]> af
[0x00015bb0]> pd 1
┌ (fcn) fcn.00015bb0 21
│   fcn.00015bb0 (int arg1, int arg2);
│           ; arg int arg1 @ rdi
│           ; arg int arg2 @ rsi
│           0x00015bb0      488b4738       mov rax, qword [rdi + 0x38] ; [0x38:8]=0x1800190040000b ; '8' ; arg1
[0x00015bb0]> afcf
fcn.00015bb0 (int arg1, int arg2);
[0x00015bb0]> afcfj
[{"name":"fcn.00015bb0","args":[{"name":"arg1","type":"int"},{"name":"arg2","type":"int"}],"count":2}]
```

Both disasm and afcf now use the same code for formatting the function signature.