### PR TITLE
Fix ARM aarch64 assemble "b ." ("b 0x0") to wrong result(00000017).

### DIFF
--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -418,7 +418,7 @@ static ut32 branch(ArmOp *op, ut64 addr, int k) {
 	if (op->operands[0].type & ARM_CONSTANT) {
 		n = op->operands[0].immediate;
 		if (!(n & 0x3 || n > 0x7ffffff)) {
-			if (n > addr) {
+			if (n >= addr) {
 				n -= addr;
 			} else {
 				n -= addr;


### PR DESCRIPTION
When resolving unconditional branch to current address ("b ."), the code dose not resolve n == addr condition correctly.