### PR TITLE
Set gittap even in release tarball

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,11 @@ endif
 if get_option('r2_gittap') != ''
   gittap = get_option('r2_gittap')
 endif
+# gittap is used for the version of each r_ library
+# in case it has not been set (e.g. a release tarball) set it
+if gittap == ''
+  gittap = r2_version
+endif
 
 if get_option('r2_gittip') != ''
   gittip = get_option('r2_gittip')


### PR DESCRIPTION
I noticed when releasing 3.2.0 on Fedora that the libraries did not have any version (e.g. r_anal_version, r_core_version, etc.) because gittap was empty. This patch falls back to r2_version if gittap is not set (e.g. a release tarball does not have any gittap)