### PR TITLE
Fix invalid read in cmd_meta

### DIFF
--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -1011,6 +1011,8 @@ static int cmd_meta(void *data, const char *input) {
 		r_comment_vars (core, input + 1);
 		break;
 	case '\0': // "C"
+		r_meta_list (core->anal, R_META_TYPE_ANY, 0);
+		break;
 	case 'j': // "Cj"
 	case '*': { // "C*"
 		if (input[1] && input[1] == '.') {


### PR DESCRIPTION
### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 86
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.3.0-git 20640 @ linux-x86-64 git.3.1.3-278-g7ed7a5bae commit: 7ed7a5baee2a469e68d542a3377c15145a92cac5 build: 2019-01-10__14:02:54

Tested with valgrind
```
valgrind r2 bins/elf/analysis/x86-helloworld-gcc
==11786== Memcheck, a memory error detector
==11786== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==11786== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==11786== Command: r2 bins/elf/analysis/x86-helloworld-gcc
==11786== 
 -- This page intentionally left blank.
[0x08048300]> C
==11786== Invalid read of size 1
==11786==    at 0x4AB8B65: cmd_meta (cmd_meta.c:1016)
==11786==    by 0x4B97323: r_cmd_call (cmd_api.c:235)
==11786==    by 0x4AE3460: r_core_cmd_subst_i (cmd.c:2984)
==11786==    by 0x4AAAE8A: r_core_cmd_subst (cmd.c:1996)
==11786==    by 0x4AA6DCD: r_core_cmd (cmd.c:3700)
==11786==    by 0x4A92FF4: r_core_prompt_exec (core.c:2671)
==11786==    by 0x110716: main (radare2.c:1462)
==11786==  Address 0x8c869d2 is 0 bytes after a block of size 2 alloc'd
==11786==    at 0x483777F: malloc (vg_replace_malloc.c:299)
==11786==    by 0x657C49E: strdup (in /usr/lib/libc-2.28.so)
==11786==    by 0x4AAA9D0: r_core_cmd_subst (cmd.c:1916)
==11786==    by 0x4AA6DCD: r_core_cmd (cmd.c:3700)
==11786==    by 0x4A92FF4: r_core_prompt_exec (core.c:2671)
==11786==    by 0x110716: main (radare2.c:1462)
==11786== 
0x00000000 CCu "[29] ---- section size 599 named .strtab"
0x08048134 CCu "[01] -r-- section size 19 named .interp"
0x08048148 CCu "[02] -r-- section size 32 named .note.ABI_tag"
0x08048168 CCu "[03] -r-- section size 36 named .note.gnu.build_id"
0x0804818c CCu "[04] -r-- section size 32 named .gnu.hash"
0x080481ac CCu "[05] -r-- section size 80 named .dynsym"
0x080481fc CCu "[06] -r-- section size 74 named .dynstr"
0x08048246 CCu "[07] -r-- section size 10 named .gnu.version"
0x08048250 CCu "[08] -r-- section size 32 named .gnu.version_r"
0x08048270 CCu "[09] -r-- section size 8 named .rel.dyn"
0x08048278 CCu "[10] -r-- section size 24 named .rel.plt"
0x08048290 CCu "[11] -r-x section size 35 named .init"
0x080482c0 CCu "[12] -r-x section size 64 named .plt"
0x08048300 CCu "[13] -r-x section size 404 named .text"
0x08048494 CCu "[14] -r-x section size 20 named .fini"
0x080484a8 CCu "[15] -r-- section size 21 named .rodata"
0x080484c0 CCu "[16] -r-- section size 44 named .eh_frame_hdr"
0x080484ec CCu "[17] -r-- section size 176 named .eh_frame"
0x0804959c CCu "[18] -rw- section size 4 named .init_array"
0x080495a0 CCu "[19] -rw- section size 4 named .fini_array"
0x080495a4 CCu "[20] -rw- section size 4 named .jcr"
0x080495a8 CCu "[21] -rw- section size 232 named .dynamic"
0x08049690 CCu "[22] -rw- section size 4 named .got"
0x08049694 CCu "[23] -rw- section size 24 named .got.plt"
0x080496ac CCu "[24] -rw- section size 8 named .data"
0x080496b4 CCu "[25] -rw- section size 4 named .bss"
0x0804959c data Cd 4
0x080495a0 data Cd 4
0x08049690 data Cd 4
0x080496a0 data Cd 4
0x080496a4 data Cd 4
0x080496a8 data Cd 4
0x080484b0 ascii[13] "Hello world!"
[0x08048300]> q
==11786== 
==11786== HEAP SUMMARY:
==11786==     in use at exit: 72 bytes in 1 blocks
==11786==   total heap usage: 50,581 allocs, 50,580 frees, 54,988,018 bytes allocated
==11786== 
==11786== LEAK SUMMARY:
==11786==    definitely lost: 0 bytes in 0 blocks
==11786==    indirectly lost: 0 bytes in 0 blocks
==11786==      possibly lost: 0 bytes in 0 blocks
==11786==    still reachable: 72 bytes in 1 blocks
==11786==         suppressed: 0 bytes in 0 blocks
==11786== Rerun with --leak-check=full to see details of leaked memory
==11786== 
==11786== For counts of detected and suppressed errors, rerun with: -v
==11786== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```