### PR TITLE
Prevent runaway scrolling in Visual mode ##visual

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4038,6 +4038,9 @@ dodo:
 			} else {
 				ch = r_cons_readchar ();
 			}
+#ifndef __WINDOWS__
+			tcflush (STDIN_FILENO, TCIFLUSH);
+#endif
 			if (r_cons_is_breaked()) {
 				break;
 			}


### PR DESCRIPTION
... caused by holding down a movement key. Tested on Linux only.