### PR TITLE
Flush Visual stdin only if printable, \t or \n

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4039,7 +4039,7 @@ dodo:
 				ch = r_cons_readchar ();
 			}
 #ifndef __WINDOWS__
-			if (!r_config_get_i (core->config, "scr.wheel")) {
+			if (IS_PRINTABLE (ch) || ch == '\t' || ch == '\n') {
 				tcflush (STDIN_FILENO, TCIFLUSH);
 			}
 #endif


### PR DESCRIPTION
Partially fixes the runaway scrolling issue but shouldn't disable any key/mouse input.