### PR TITLE
Fix noreturn handling of reloc functions

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -642,8 +642,8 @@ static bool r_anal_noreturn_at_name(RAnal *anal, const char *name) {
 		}
 		free (tmp);
 	}
-	if (r_str_startswith(name, "reloc.")) {
-		return r_anal_noreturn_at_name(anal, name + 6);
+	if (r_str_startswith (name, "reloc.")) {
+		return r_anal_noreturn_at_name (anal, name + 6);
 	}
 	return false;
 }

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -642,6 +642,9 @@ static bool r_anal_noreturn_at_name(RAnal *anal, const char *name) {
 		}
 		free (tmp);
 	}
+	if (r_str_startswith(name, "reloc.")) {
+		return r_anal_noreturn_at_name(anal, name + 6);
+	}
 	return false;
 }
 


### PR DESCRIPTION
Hi there,
when analyzing a binary the current implementation of r2 does not handle noreturn of reloc-functions corrently. This patch aims to fix this.

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro x86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64 
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.3.0-git 20744 @ linux-x86-64 git.3.1.3-325-g82b6496a2 commit: 82b6496a274bdc9687fe45cfc1be66c31b28540a build: 2019-01-14__20:19:36

### Expected behavior
```
$ r2 /usr/bin/ls
[0x00005ae0]> aaa
[0x00005ae0]> s sub.__printf_chk_80b0
[0x000080b0]> agv
```
Taken from Binary Ninja:
![screenshot from 2019-01-14 20-24-08](https://user-images.githubusercontent.com/30472652/51135716-f7701b80-183a-11e9-992b-516527f393cc.png)

### Actual behavior
```
$ r2 /usr/bin/ls
[0x00005ae0]> aaa
[0x00005ae0]> s sub.__printf_chk_80b0
[0x000080b0]> agv
```
![screenshot from 2019-01-14 20-23-36](https://user-images.githubusercontent.com/30472652/51135643-d90a2000-183a-11e9-8f6b-d903f0958cac.png)

### Steps to reproduce the behavior 
execute the steps above using (extracted) 
[ls.zip](https://github.com/radare/radare2/files/2756767/ls.zip)