### PR TITLE
Fix afns and add JSON support

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -356,6 +356,7 @@ static const char *help_msg_afn[] = {
 	"afn", " [name]", "rename the function",
 	"afna", "", "construct a function name for the current offset",
 	"afns", "", "list all strings associated with the current function",
+	"afnsj", "", "list all strings associated with the current function in JSON format",
 	NULL
 };
 
@@ -2825,11 +2826,16 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 	case 'n': // "afn"
 		switch (input[2]) {
 		case 's': // "afns"
-			free (r_core_anal_fcn_autoname (core, core->offset, 1));
+			if (input[3] == 'j') { // "afnsj"
+				free (r_core_anal_fcn_autoname (core, core->offset, 1, input[3]));
+			}
+			else {
+				free (r_core_anal_fcn_autoname (core, core->offset, 1, 0));
+			}
 			break;
 		case 'a': // "afna"
 			{
-			char *name = r_core_anal_fcn_autoname (core, core->offset, 0);
+			char *name = r_core_anal_fcn_autoname (core, core->offset, 0, 0);
 			if (name) {
 				r_cons_printf ("afn %s 0x%08" PFMT64x "\n", name, core->offset);
 				free (name);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2828,8 +2828,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		case 's': // "afns"
 			if (input[3] == 'j') { // "afnsj"
 				free (r_core_anal_fcn_autoname (core, core->offset, 1, input[3]));
-			}
-			else {
+			} else {
 				free (r_core_anal_fcn_autoname (core, core->offset, 1, 0));
 			}
 			break;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -523,7 +523,7 @@ R_API int r_core_anal_bb(RCore *core, RAnalFunction *fcn, ut64 at, int head);
 R_API ut64 r_core_anal_get_bbaddr(RCore *core, ut64 addr);
 R_API int r_core_anal_bb_seek(RCore *core, ut64 addr);
 R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth);
-R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump);
+R_API char *r_core_anal_fcn_autoname(RCore *core, ut64 addr, int dump, int mode);
 R_API void r_core_anal_autoname_all_fcns(RCore *core);
 R_API void r_core_anal_autoname_all_golang_fcns(RCore *core);
 R_API int r_core_anal_fcn_list(RCore *core, const char *input, const char *rad);


### PR DESCRIPTION
The following pull request fixes the broken `afns`. 
`afns` is being used to print all the strings referenced in a function. Previously, when executed `afns` it used to print a single flag, which wasn't necessarily a string. This was because the `break;` keyword prevents the loop to iterate over the referenced flags. This PR fixes it.
Moreover, it implements a proper JSON support for `afnsj`.


```
[0x00001347]> afns
0x00001356 0x00002004 str..::_Megabeets_::.
0x00001362 0x00002019 str.Think_you_can_make_it
0x0000138b 0x00002030 str.Success
0x00001399 0x0000203a str.Nop__Wrong_argument.

[0x00001347]> afnsj~{}
[
  {
    "addr": 4950,
    "ref": 8196,
    "flag": "str..::_Megabeets_::."
  },
  {
    "addr": 4962,
    "ref": 8217,
    "flag": "str.Think_you_can_make_it"
  },
  {
    "addr": 5003,
    "ref": 8240,
    "flag": "str.Success"
  },
  {
    "addr": 5017,
    "ref": 8250,
    "flag": "str.Nop__Wrong_argument."
  }
]
```