### PR TITLE
change brk_end calculation back

### DIFF
--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -94,7 +94,7 @@ static void GH(get_brks)(RCore *core, GHT *brk_start, GHT *brk_end) {
 		r_list_foreach (core->dbg->maps, iter, map) {
 			if (strstr (map->name, "[heap]")) {
 				*brk_start = map->addr;
-				*brk_end = map->addr + map->addr_end;
+				*brk_end = map->addr_end;
 				break;
 			}
 		}


### PR DESCRIPTION
This will fix #12789, but introduces the bug disclaimed in #12789.