### PR TITLE
remove extra print in @@@F

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3220,7 +3220,6 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 			RAnalFunction *fcn;
 			list = core->anal->fcns;
 			r_list_foreach (list, iter, fcn) {
-				r_cons_printf ("[0x%08"PFMT64x"  %s\n", fcn->addr, fcn->name);
 				r_core_seek (core, fcn->addr, 1);
 				r_core_cmd0 (core, cmd);
 			}


### PR DESCRIPTION


Before:
```
[0x00001060]> fd @@@F
[0x00001060  entry0
entry0
[0x00001090  sym.deregister_tm_clones
sym.deregister_tm_clones
[0x000010c0  sym.register_tm_clones
sym.register_tm_clones
[0x00001100  sym.__do_global_dtors_aux
entry.fini0
[0x00001150  entry.init0
entry.init0
[0x00001420  sym.__libc_csu_fini
sym.__libc_csu_fini
...
...
```


After:
```
[0x00001060]> fd @@@F
entry0
sym.deregister_tm_clones
sym.register_tm_clones
entry.fini0
entry.init0
sym.__libc_csu_fini
...
...
```