### PR TITLE
Make afij ref-types more readable for human animals

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2368,10 +2368,10 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 			}
 			if (refi->type == R_ANAL_REF_TYPE_CODE ||
 			    refi->type == R_ANAL_REF_TYPE_CALL) {
-				r_cons_printf ("%s{\"addr\":%"PFMT64d",\"type\":\"%c\",\"at\":%"PFMT64d"}",
+				r_cons_printf ("%s{\"addr\":%"PFMT64d",\"type\":\"%s\",\"at\":%"PFMT64d"}",
 						first? "": ",",
 						refi->addr,
-						refi->type == R_ANAL_REF_TYPE_CALL?'C':'J',
+						r_anal_xrefs_type_tostring(refi->type),
 						refi->at);
 				first = false;
 			}
@@ -2399,10 +2399,10 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 			if (refi->type == R_ANAL_REF_TYPE_CODE ||
 			    refi->type == R_ANAL_REF_TYPE_CALL) {
 				indegree++;
-				r_cons_printf ("%s{\"addr\":%"PFMT64d",\"type\":\"%c\",\"at\":%"PFMT64d"}",
+				r_cons_printf ("%s{\"addr\":%"PFMT64d",\"type\":\"%s\",\"at\":%"PFMT64d"}",
 						first?"":",",
 						refi->addr,
-						refi->type==R_ANAL_REF_TYPE_CALL?'C':'J',
+						r_anal_xrefs_type_tostring(refi->type),
 						refi->at);
 				first = 0;
 			}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2371,7 +2371,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 				r_cons_printf ("%s{\"addr\":%"PFMT64d",\"type\":\"%s\",\"at\":%"PFMT64d"}",
 						first? "": ",",
 						refi->addr,
-						r_anal_xrefs_type_tostring(refi->type),
+						r_anal_xrefs_type_tostring (refi->type),
 						refi->at);
 				first = false;
 			}
@@ -2402,7 +2402,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn) {
 				r_cons_printf ("%s{\"addr\":%"PFMT64d",\"type\":\"%s\",\"at\":%"PFMT64d"}",
 						first?"":",",
 						refi->addr,
-						r_anal_xrefs_type_tostring(refi->type),
+						r_anal_xrefs_type_tostring (refi->type),
 						refi->at);
 				first = 0;
 			}


### PR DESCRIPTION
Now it would be more readable for humans:

```
...
"codexrefs": [
      {
        "addr": 4898,
        "type": "CALL",
        "at": 4441
      },
      {
        "addr": 4811,
        "type": "CODE",
        "at": 4472
      },
      {
        "addr": 4490,
        "type": "CODE",
        "at": 4553
      },

...
```