### PR TITLE
Move Palette to RConsContext

### DIFF
--- a/libr/cons/canvas_line.c
+++ b/libr/cons/canvas_line.c
@@ -52,17 +52,17 @@ static void apply_line_style(RConsCanvas *c, int x, int y, int x2, int y2,
 	RCons *cons = r_cons_singleton ();
 	switch (style->color) {
 	case LINE_UNCJMP:
-		c->attr = cons->pal.graph_trufae;
+		c->attr = cons->context->pal.graph_trufae;
 		break;
 	case LINE_TRUE:
-		c->attr = cons->pal.graph_true;
+		c->attr = cons->context->pal.graph_true;
 		break;
 	case LINE_FALSE:
-		c->attr = cons->pal.graph_false;
+		c->attr = cons->context->pal.graph_false;
 		break;
 	case LINE_NONE:
 	default:
-		c->attr = cons->pal.graph_trufae;
+		c->attr = cons->context->pal.graph_trufae;
 		break;
 	}
 	if (!c->color) {

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -114,9 +114,11 @@ static void cons_context_init(RConsContext *context, R_NULLABLE RConsContext *pa
 	context->log_callback = NULL;
 
 	if (parent) {
+		context->color = parent->color;
 		// TODO: copy
 		r_cons_pal_init (context);
 	} else {
+		context->color = COLOR_MODE_DISABLED;
 		r_cons_pal_init (context);
 	}
 }
@@ -152,7 +154,7 @@ static inline void r_cons_write(const char *buf, int len) {
 
 R_API RColor r_cons_color_random(ut8 alpha) {
 	RColor rcolor = {0};
-	if (I.color > COLOR_MODE_16) {
+	if (I.context->color > COLOR_MODE_16) {
 		rcolor.r = r_num_rand (0xff);
 		rcolor.g = r_num_rand (0xff);
 		rcolor.b = r_num_rand (0xff);
@@ -428,7 +430,6 @@ R_API RCons *r_cons_new() {
 	I.highlight = NULL;
 	I.is_wine = -1;
 	I.fps = 0;
-	I.color = COLOR_MODE_DISABLED;
 	I.blankline = true;
 	I.teefile = NULL;
 	I.fix_columns = 0;

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -100,7 +100,7 @@ static void cons_stack_load(RConsStack *data, bool free_current) {
 	}
 }
 
-static void cons_context_init(RConsContext *context) {
+static void cons_context_init(RConsContext *context, R_NULLABLE RConsContext *parent) {
 	context->breaked = false;
 	context->buffer = NULL;
 	context->buffer_sz = 0;
@@ -112,11 +112,19 @@ static void cons_context_init(RConsContext *context) {
 	context->event_interrupt_data = NULL;
 	context->pageable = true;
 	context->log_callback = NULL;
+
+	if (parent) {
+		// TODO: copy
+		r_cons_pal_init (context);
+	} else {
+		r_cons_pal_init (context);
+	}
 }
 
 static void cons_context_deinit(RConsContext *context) {
 	r_stack_free (context->cons_stack);
 	r_stack_free (context->break_stack);
+	r_cons_pal_free (context);
 }
 
 static void break_signal(int sig) {
@@ -439,7 +447,7 @@ R_API RCons *r_cons_new() {
 	I.lines = 0;
 
 	I.context = &r_cons_context_default;
-	cons_context_init (I.context);
+	cons_context_init (I.context, NULL);
 
 	r_cons_get_size (&I.pagesize);
 	I.num = NULL;
@@ -470,7 +478,6 @@ R_API RCons *r_cons_new() {
 	I.mouse = 0;
 	r_cons_reset ();
 	r_cons_rgb_init ();
-	r_cons_pal_init ();
 
 	r_print_set_is_interrupted_cb (r_cons_is_breaked);
 
@@ -482,7 +489,6 @@ R_API RCons *r_cons_free() {
 	if (I.refcnt != 0) {
 		return NULL;
 	}
-	r_cons_pal_free ();
 	if (I.line) {
 		r_line_free ();
 		I.line = NULL;
@@ -678,12 +684,12 @@ R_API void r_cons_pop() {
 	cons_stack_free ((void *)data);
 }
 
-R_API RConsContext *r_cons_context_new(void) {
+R_API RConsContext *r_cons_context_new(R_NULLABLE RConsContext *parent) {
 	RConsContext *context = R_NEW0 (RConsContext);
 	if (!context) {
 		return NULL;
 	}
-	cons_context_init (context);
+	cons_context_init (context, parent);
 	return context;
 	/*
 	RStack *stack = r_stack_newf (6, cons_stack_free);
@@ -1562,9 +1568,9 @@ R_API void r_cons_breakword(R_NULLABLE const char *s) {
  * "command2", "args2", "description"}; */
 R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 	RCons *cons = r_cons_singleton ();
-	const char *pal_args_color = use_color ? cons->pal.args : "",
-			*pal_help_color = use_color ? cons->pal.help : "",
-			*pal_reset = use_color ? cons->pal.reset : "";
+	const char *pal_args_color = use_color ? cons->context->pal.args : "",
+			*pal_help_color = use_color ? cons->context->pal.help : "",
+			*pal_reset = use_color ? cons->context->pal.reset : "";
 	int i, max_length = 0;
 	const char *usage_str = "Usage:";
 

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -451,8 +451,8 @@ static void selection_widget_draw() {
 	}
 	sel_widget->w = R_MIN (sel_widget->w, R_SELWIDGET_MAXW);
 
-	char *background_color = cons->color ? cons->pal.widget_bg : Color_INVERT_RESET;
-	char *selected_color = cons->color ? cons->pal.widget_sel : Color_INVERT;
+	char *background_color = cons->color ? cons->context->pal.widget_bg : Color_INVERT_RESET;
+	char *selected_color = cons->color ? cons->context->pal.widget_sel : Color_INVERT;
 	bool scrollbar = sel_widget->options_len > R_SELWIDGET_MAXH;
 	int scrollbar_y = 0, scrollbar_l = 0;
 	if (scrollbar) {

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -451,8 +451,8 @@ static void selection_widget_draw() {
 	}
 	sel_widget->w = R_MIN (sel_widget->w, R_SELWIDGET_MAXW);
 
-	char *background_color = cons->color ? cons->context->pal.widget_bg : Color_INVERT_RESET;
-	char *selected_color = cons->color ? cons->context->pal.widget_sel : Color_INVERT;
+	char *background_color = cons->context->color ? cons->context->pal.widget_bg : Color_INVERT_RESET;
+	char *selected_color = cons->context->color ? cons->context->pal.widget_sel : Color_INVERT;
 	bool scrollbar = sel_widget->options_len > R_SELWIDGET_MAXH;
 	int scrollbar_y = 0, scrollbar_l = 0;
 	if (scrollbar) {

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -477,7 +477,7 @@ R_API void r_cons_grepbuf() {
 				Color_RESET,
 				NULL
 			};
-			char *out = r_print_json_indent (buf, I (color), "  ", palette);
+			char *out = r_print_json_indent (buf, I (context->color), "  ", palette);
 			if (!out) {
 				return;
 			}

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -470,10 +470,10 @@ R_API void r_cons_grepbuf() {
 			R_FREE (grep->json_path);
 		} else {
 			const char *palette[] = {
-				cons->pal.graph_false, // f
-				cons->pal.graph_true, // t
-				cons->pal.num, // k
-				cons->pal.comment, // v
+				cons->context->pal.graph_false, // f
+				cons->context->pal.graph_true, // t
+				cons->context->pal.num, // k
+				cons->context->pal.comment, // v
 				Color_RESET,
 				NULL
 			};

--- a/libr/cons/hud.c
+++ b/libr/cons/hud.c
@@ -128,7 +128,7 @@ static RList *hud_filter(RList *list, char *user_input, int top_entry_n, int *cu
 				r_list_append (res, r_str_newf (" %c %s", first_line? '-': ' ', current_entry));
 			} else {
 				// otherwise we need to emphasize the matching part
-				if (I (color)) {
+				if (I (context->color)) {
 					int last_color_change = 0;
 					int last_mask = 0;
 					char *str = r_str_newf (" %c ", first_line? '-': ' ');

--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -234,7 +234,7 @@ R_API int r_cons_arrow_to_hjkl(int ch) {
 R_API int r_cons_fgets(char *buf, int len, int argc, const char **argv) {
 #define RETURN(x) { ret=x; goto beach; }
 	RCons *cons = r_cons_singleton ();
-	int ret = 0, color = cons->pal.input && *cons->pal.input;
+	int ret = 0, color = cons->context->pal.input && *cons->context->pal.input;
 	if (cons->echo) {
 		r_cons_set_raw (false);
 		r_cons_show_cursor (true);
@@ -252,7 +252,7 @@ R_API int r_cons_fgets(char *buf, int len, int argc, const char **argv) {
 	fflush (stdout);
 	*buf = '\0';
 	if (color) {
-		const char *p = cons->pal.input;
+		const char *p = cons->context->pal.input;
 		int len = p? strlen (p): 0;
 		if (len > 0) {
 			fwrite (p, len, 1, stdout);

--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -103,7 +103,6 @@ struct {
 };
 
 static void cons_pal_update_event(RConsContext *ctx);
-static void cons_rainbow_free(RConsContext *ctx);
 
 static inline ut8 rgbnum(const char ch1, const char ch2) {
 	ut8 r = 0, r2 = 0;
@@ -447,7 +446,7 @@ R_API void r_cons_pal_show() {
 			colors[i].bgcode,
 			colors[i].name);
 	}
-	switch (r_cons_singleton ()->color) {
+	switch (r_cons_singleton ()->context->color) {
 	case COLOR_MODE_256: // 256 color palette
 		r_cons_pal_show_gs ();
 		r_cons_pal_show_256 ();
@@ -455,6 +454,8 @@ R_API void r_cons_pal_show() {
 	case COLOR_MODE_16M: // 16M (truecolor)
 		r_cons_pal_show_gs ();
 		r_cons_pal_show_rgb ();
+		break;
+	default:
 		break;
 	}
 }
@@ -573,7 +574,7 @@ static void cons_pal_update_event(RConsContext *ctx) {
 		if (*color) {
 			R_FREE (*color);
 		}
-		*color = r_cons_rgb_str (NULL, 0, rcolor);
+		*color = r_cons_rgb_str_mode (ctx->color, NULL, 0, rcolor);
 		const char *rgb = sdb_fmt ("rgb:%02x%02x%02x", rcolor->r, rcolor->g, rcolor->b);
 		sdb_set (db, rgb, "1", 0);
 	}

--- a/libr/cons/rgb.c
+++ b/libr/cons/rgb.c
@@ -182,7 +182,7 @@ R_API char *r_cons_rgb_str_off(char *outstr, size_t sz, ut64 off) {
 }
 
 /* Compute color string depending on cons->color */
-static void r_cons_rgb_gen(char *outstr, size_t sz, ut8 attr, ut8 a, ut8 r, ut8 g, ut8 b) {
+static void r_cons_rgb_gen(RConsColorMode mode, char *outstr, size_t sz, ut8 attr, ut8 a, ut8 r, ut8 g, ut8 b) {
 	ut8 fgbg = (a == ALPHA_BG)? 48: 38; // ANSI codes for Background/Foreground
 
 	if (sz < 4) { // must have at least room for "<esc>[m\0"
@@ -212,7 +212,7 @@ static void r_cons_rgb_gen(char *outstr, size_t sz, ut8 attr, ut8 a, ut8 r, ut8 
 	}
 
 	int written = -1;
-	switch (r_cons_singleton ()->color) {
+	switch (mode) {
 	case COLOR_MODE_256: // 256 color palette
 		written = snprintf (outstr + i, sz - i, "%d;5;%dm", fgbg, rgb (r, g, b));
 		break;
@@ -243,8 +243,8 @@ static void r_cons_rgb_gen(char *outstr, size_t sz, ut8 attr, ut8 a, ut8 r, ut8 
 	}
 }
 
-/* Return the computed color string for the specified color */
-R_API char *r_cons_rgb_str(char *outstr, size_t sz, RColor *rcolor) {
+/* Return the computed color string for the specified color in the specified mode */
+R_API char *r_cons_rgb_str_mode(RConsColorMode mode, char *outstr, size_t sz, RColor *rcolor) {
 	if (!rcolor) {
 		return NULL;
 	}
@@ -259,13 +259,18 @@ R_API char *r_cons_rgb_str(char *outstr, size_t sz, RColor *rcolor) {
 	}
 	// If the color handles both foreground and background, also add background
 	if (rcolor->a == ALPHA_FGBG) {
-		r_cons_rgb_gen (outstr, sz, 0, ALPHA_BG, rcolor->r2, rcolor->g2, rcolor->b2);
+		r_cons_rgb_gen (mode, outstr, sz, 0, ALPHA_BG, rcolor->r2, rcolor->g2, rcolor->b2);
 	}
 	// APPEND
 	size_t len = strlen (outstr);
-	r_cons_rgb_gen (outstr + len, sz - len, rcolor->attr, rcolor->a, rcolor->r, rcolor->g, rcolor->b);
+	r_cons_rgb_gen (mode, outstr + len, sz - len, rcolor->attr, rcolor->a, rcolor->r, rcolor->g, rcolor->b);
 
 	return outstr;
+}
+
+/* Return the computed color string for the specified color */
+R_API char *r_cons_rgb_str(char *outstr, size_t sz, RColor *rcolor) {
+	return r_cons_rgb_str_mode (r_cons_singleton ()->context->color, outstr, sz, rcolor);
 }
 
 R_API char *r_cons_rgb_tostring(ut8 r, ut8 g, ut8 b) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3486,7 +3486,7 @@ R_API int r_core_anal_data(RCore *core, ut64 addr, int count, int depth, int wor
 	r_io_read_at (core->io, addr, buf, len);
 	buf[len - 1] = 0;
 
-	RConsPrintablePalette *pal = r_config_get_i (core->config, "scr.color")? &r_cons_singleton ()->pal: NULL;
+	RConsPrintablePalette *pal = r_config_get_i (core->config, "scr.color")? &r_cons_singleton ()->context->pal: NULL;
 	for (i = j = 0; j < count; j++) {
 		if (i >= len) {
 			r_io_read_at (core->io, addr + i, buf, len);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1096,7 +1096,7 @@ static int cb_color_getter(void *user, RConfigNode *node) {
 	(void)user;
 	node->i_value = r_cons_singleton ()->context->color;
 	char buf[128];
-	snprintf (buf, sizeof (buf) - 1, "%" PFMT64d, node->i_value);
+	r_config_node_value_format_i (buf, sizeof (buf), r_cons_singleton ()->context->color, node);
 	if (!node->value || strcmp (node->value, buf) != 0) {
 		free (node->value);
 		node->value = strdup (buf);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1370,7 +1370,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 
 	// Variables required for setting up ESIL to REIL conversion
 	if (use_color) {
-		color = core->cons->pal.label;
+		color = core->cons->context->pal.label;
 	}
 	switch (fmt) {
 	case 'j':
@@ -3084,7 +3084,7 @@ static void __anal_reg_list(RCore *core, int type, int bits, char mode) {
 	int use_colors = r_config_get_i (core->config, "scr.color");
 	if (use_colors) {
 #undef ConsP
-#define ConsP(x) (core->cons && core->cons->pal.x)? core->cons->pal.x
+#define ConsP(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 		use_color = ConsP (creg) : Color_BWHITE;
 	} else {
 		use_color = NULL;
@@ -3156,7 +3156,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 	char *arg;
 
 	if (use_colors) {
-#define ConsP(x) (core->cons && core->cons->pal.x)? core->cons->pal.x
+#define ConsP(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 		use_color = ConsP (creg)
 		: Color_BWHITE;
 	} else {
@@ -5745,7 +5745,7 @@ static char *get_buf_asm(RCore *core, ut64 from, ut64 addr, RAnalFunction *fcn, 
 	free (ba);
 	if (color && has_color) {
 		buf_asm = r_print_colorize_opcode (core->print, str,
-				core->cons->pal.reg, core->cons->pal.num, false, fcn ? fcn->addr : 0);
+				core->cons->context->pal.reg, core->cons->context->pal.num, false, fcn ? fcn->addr : 0);
 	} else {
 		buf_asm = r_str_new (str);
 	}
@@ -6029,7 +6029,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 								str, sizeof (str), core->print->big_endian);
 						if (has_color) {
 							buf_asm = r_print_colorize_opcode (core->print, str,
-									core->cons->pal.reg, core->cons->pal.num, false, fcn ? fcn->addr : 0);
+									core->cons->context->pal.reg, core->cons->context->pal.num, false, fcn ? fcn->addr : 0);
 						} else {
 							buf_asm = r_str_new (str);
 						}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1839,7 +1839,7 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 	RRegItem *r;
 	if (use_colors) {
 #undef ConsP
-#define ConsP(x) (core->cons && core->cons->pal.x)? core->cons->pal.x
+#define ConsP(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 		use_color = ConsP(creg): Color_BWHITE;
 	} else {
 		use_color = NULL;
@@ -2102,7 +2102,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 	}
 	if (use_colors) {
 #undef ConsP
-#define ConsP(x) (core->cons && core->cons->pal.x)? core->cons->pal.x
+#define ConsP(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 		use_color = ConsP(creg): Color_BWHITE;
 	} else {
 		use_color = NULL;

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -351,7 +351,7 @@ static int cmd_eval(void *data, const char *input) {
 	case 'c': // "ec"
 		switch (input[1]) {
 		case 'd': // "ecd"
-			r_cons_pal_init ();
+			r_cons_pal_init (core->cons->context);
 			break;
 		case '?':
 			r_core_cmd_help (core, help_msg_ec);
@@ -472,7 +472,7 @@ static int cmd_eval(void *data, const char *input) {
 				return true;
 			}
 			char *str = r_meta_get_string (core->anal, R_META_TYPE_HIGHLIGHT, core->offset);
-			char *dup = r_str_newf ("%s \"%s%s\"", str?str:"", word?word:"", color_code?color_code:r_cons_singleton ()->pal.wordhl);
+			char *dup = r_str_newf ("%s \"%s%s\"", str?str:"", word?word:"", color_code?color_code:r_cons_singleton ()->context->pal.wordhl);
 			r_meta_set_string (core->anal, R_META_TYPE_HIGHLIGHT, core->offset, dup);
 			r_str_argv_free (argv);
 			R_FREE (word);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1440,7 +1440,7 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 
 		// r_print_offset (core->print, addr + i, 0, 0, 0, 0, NULL);
 		if (usecolor) {
-			append (ebytes, core->cons->pal.offset);
+			append (ebytes, core->cons->context->pal.offset);
 		}
 		ebytes += sprintf (ebytes, "0x%08"PFMT64x, addr);
 		if (usecolor) {
@@ -1845,7 +1845,7 @@ static void cmd_print_pwn(const RCore *core) {
 }
 
 static int cmd_print_pxA(RCore *core, int len, const char *data) {
-	RConsPrintablePalette *pal = &core->cons->pal;
+	RConsPrintablePalette *pal = &core->cons->context->pal;
 	int show_offset = true;
 	int cols = r_config_get_i (core->config, "hex.cols");
 	int show_color = r_config_get_i (core->config, "scr.color");
@@ -2154,7 +2154,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	bool asm_emu = r_config_get_i (core->config, "asm.emu");
 	bool emu_str = r_config_get_i (core->config, "emu.str");
 	r_config_set_i (core->config, "emu.str", true);
-	RConsPrintablePalette *pal = &core->cons->pal;
+	RConsPrintablePalette *pal = &core->cons->context->pal;
 	// force defaults
 	r_config_set_i (core->config, "asm.offset", true);
 	r_config_set_i (core->config, "scr.color", COLOR_MODE_DISABLED);
@@ -3456,7 +3456,7 @@ dsmap {
 }
 #endif
 
-#define P(x) (core->cons && core->cons->pal.x)? core->cons->pal.x
+#define P(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 #if 0
 static void disasm_recursive_old(RCore *core, ut64 addr, char type_print) {
 	bool push[512];
@@ -6141,7 +6141,7 @@ R_API void r_print_offset_sg(RPrint *p, ut64 off, int invert, int offseg, int se
 	bool show_color = p->flags & R_PRINT_FLAGS_COLOR;
 	if (show_color) {
 		char rgbstr[32];
-		const char *k = r_cons_singleton ()->pal.offset; // TODO etooslow. must cache
+		const char *k = r_cons_singleton ()->context->pal.offset; // TODO etooslow. must cache
 		if (p->flags & R_PRINT_FLAGS_RAINBOW) {
 			k = r_cons_rgb_str_off (rgbstr, sizeof (rgbstr), off);
 		}

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1152,7 +1152,7 @@ static void print_rop(RCore *core, RList *hitlist, char mode, bool *json_first) 
 				r_cons_printf ("%s\n", opstr);
 			} else if (colorize) {
 				buf_asm = r_print_colorize_opcode (core->print, r_asm_op_get_asm (&asmop),
-					core->cons->pal.reg, core->cons->pal.num, false, 0);
+					core->cons->context->pal.reg, core->cons->context->pal.num, false, 0);
 				r_cons_printf (" %s%s;", buf_asm, Color_RESET);
 				free (buf_asm);
 			} else {
@@ -1192,7 +1192,7 @@ static void print_rop(RCore *core, RList *hitlist, char mode, bool *json_first) 
 			}
 			if (colorize) {
 				char *buf_asm = r_print_colorize_opcode (core->print, r_asm_op_get_asm (&asmop),
-					core->cons->pal.reg, core->cons->pal.num, false, 0);
+					core->cons->context->pal.reg, core->cons->context->pal.num, false, 0);
 				otype = r_print_color_op_type (core->print, analop.type);
 				if (comment) {
 					r_cons_printf ("  0x%08"PFMT64x " %18s%s  %s%s ; %s\n",

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1944,7 +1944,7 @@ static char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, int depth) {
 	}
 	{
 		ut8 buf[128], widebuf[256];
-		const char *c = r_config_get_i (core->config, "scr.color")? core->cons->pal.ai_ascii: "";
+		const char *c = r_config_get_i (core->config, "scr.color")? core->cons->context->pal.ai_ascii: "";
 		const char *cend = (c && *c) ? Color_RESET: "";
 		int len, r;
 		if (r_io_read_at (core->io, value, buf, sizeof (buf))) {
@@ -2015,19 +2015,19 @@ R_API const char *r_core_anal_optype_colorfor(RCore *core, ut64 addr, bool verbo
 	}
 	type = r_core_anal_address (core, addr);
 	if (type & R_ANAL_ADDR_TYPE_EXEC) {
-		return core->cons->pal.ai_exec; //Color_RED;
+		return core->cons->context->pal.ai_exec; //Color_RED;
 	}
 	if (type & R_ANAL_ADDR_TYPE_WRITE) {
-		return core->cons->pal.ai_write; //Color_BLUE;
+		return core->cons->context->pal.ai_write; //Color_BLUE;
 	}
 	if (type & R_ANAL_ADDR_TYPE_READ) {
-		return core->cons->pal.ai_read; //Color_GREEN;
+		return core->cons->context->pal.ai_read; //Color_GREEN;
 	}
 	if (type & R_ANAL_ADDR_TYPE_SEQUENCE) {
-		return core->cons->pal.ai_seq; //Color_MAGENTA;
+		return core->cons->context->pal.ai_seq; //Color_MAGENTA;
 	}
 	if (type & R_ANAL_ADDR_TYPE_ASCII) {
-		return core->cons->pal.ai_ascii; //Color_YELLOW;
+		return core->cons->context->pal.ai_ascii; //Color_YELLOW;
 	}
 	return NULL;
 }
@@ -2644,8 +2644,8 @@ static void set_prompt (RCore *r) {
 	}
 #if __UNIX__
 	if (r_config_get_i (r->config, "scr.color")) {
-		BEGIN = r->cons->pal.prompt;
-		END = r->cons->pal.reset;
+		BEGIN = r->cons->context->pal.prompt;
+		END = r->cons->context->pal.reset;
 	}
 #endif
 	// TODO: also in visual prompt and disasm/hexdump ?

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -529,8 +529,8 @@ static RDisasmState * ds_init(RCore *core) {
 	}
 	ds->core = core;
 	ds->strip = r_config_get (core->config, "asm.strip");
-	ds->pal_comment = core->cons->pal.comment;
-	#define P(x) (core->cons && core->cons->pal.x)? core->cons->pal.x
+	ds->pal_comment = core->cons->context->pal.comment;
+	#define P(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 	ds->color_comment = P(comment): Color_CYAN;
 	ds->color_usrcmt = P(usercomment): Color_CYAN;
 	ds->color_fname = P(fname): Color_RED;
@@ -1516,7 +1516,7 @@ static void ds_show_functions_argvar(RDisasmState *ds, RAnalVar *var, const char
 }
 
 static void printVarSummary(RDisasmState *ds, RList *list) {
-	const char *numColor = ds->core->cons->pal.num;
+	const char *numColor = ds->core->cons->context->pal.num;
 	RAnalVar *var;
 	RListIter *iter;
 	int bp_vars = 0;
@@ -5740,7 +5740,7 @@ R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mo
 					RAnalFunction *f = fcnIn (ds, ds->vat, R_ANAL_FCN_TYPE_NULL);
 					r_anal_op (core->anal, &aop, addr, buf+i, l-i, R_ANAL_OP_MASK_ALL);
 					char *buf_asm = r_print_colorize_opcode (core->print, str,
-							core->cons->pal.reg, core->cons->pal.num, false, f ? f->addr : 0);
+							core->cons->context->pal.reg, core->cons->context->pal.num, false, f ? f->addr : 0);
 					if (buf_asm) {
 						r_cons_printf ("%s%s\n", r_print_color_op_type (core->print, aop.type), buf_asm);
 						free (buf_asm);

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -391,9 +391,9 @@ static void normal_RANode_print(const RAGraph *g, const RANode *n, int cur) {
 	// This info must be stored inside RANode* from RCore*
 	RCons *cons = r_cons_singleton ();
 	if (cur) {
-		r_cons_canvas_box (g->can, n->x, n->y, n->w, n->h, cons->pal.graph_box2);
+		r_cons_canvas_box (g->can, n->x, n->y, n->w, n->h, cons->context->pal.graph_box2);
 	} else {
-		r_cons_canvas_box (g->can, n->x, n->y, n->w, n->h, cons->pal.graph_box);
+		r_cons_canvas_box (g->can, n->x, n->y, n->w, n->h, cons->context->pal.graph_box);
 	}
 }
 
@@ -3445,11 +3445,11 @@ static void sdb_set_enc(Sdb *db, const char *key, const char *v, ut32 cas) {
 static void agraph_sdb_init(const RAGraph *g) {
 	sdb_bool_set (g->db, "agraph.is_callgraph", g->is_callgraph, 0);
 	RCons *cons = r_cons_singleton ();
-	sdb_set_enc (g->db, "agraph.color_box", cons->pal.graph_box, 0);
-	sdb_set_enc (g->db, "agraph.color_box2", cons->pal.graph_box2, 0);
-	sdb_set_enc (g->db, "agraph.color_box3", cons->pal.graph_box3, 0);
-	sdb_set_enc (g->db, "agraph.color_true", cons->pal.graph_true, 0);
-	sdb_set_enc (g->db, "agraph.color_false", cons->pal.graph_false, 0);
+	sdb_set_enc (g->db, "agraph.color_box", cons->context->pal.graph_box, 0);
+	sdb_set_enc (g->db, "agraph.color_box2", cons->context->pal.graph_box2, 0);
+	sdb_set_enc (g->db, "agraph.color_box3", cons->context->pal.graph_box3, 0);
+	sdb_set_enc (g->db, "agraph.color_true", cons->context->pal.graph_true, 0);
+	sdb_set_enc (g->db, "agraph.color_false", cons->context->pal.graph_false, 0);
 }
 
 R_API Sdb *r_agraph_get_sdb(RAGraph *g) {

--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -322,9 +322,9 @@ static void panelPrint(RCore *core, RConsCanvas *can, RPanel *panel, int color) 
 		defaultPanelPrint (core, can, panel, panel->sx, panel->sy, w, h, color);
 	}
 	if (color) {
-		r_cons_canvas_box (can, panel->pos.x, panel->pos.y, w, h, core->cons->pal.graph_box2);
+		r_cons_canvas_box (can, panel->pos.x, panel->pos.y, w, h, core->cons->context->pal.graph_box2);
 	} else {
-		r_cons_canvas_box (can, panel->pos.x, panel->pos.y, w, h, core->cons->pal.graph_box);
+		r_cons_canvas_box (can, panel->pos.x, panel->pos.y, w, h, core->cons->context->pal.graph_box);
 	}
 }
 
@@ -344,7 +344,7 @@ static void defaultPanelPrint(RCore *core, RConsCanvas *can, RPanel *panel, int 
 	char title[128], *text, *cmdStr = NULL;
 	if (color) {
 		snprintf (title, sizeof (title) - 1,
-				"%s[x] %s"Color_RESET, core->cons->pal.graph_box2, panel->title);
+				"%s[x] %s"Color_RESET, core->cons->context->pal.graph_box2, panel->title);
 	} else {
 		snprintf (title, sizeof (title) - 1,
 				"   %s   ", panel->title);
@@ -2511,7 +2511,7 @@ R_API void r_core_panels_refresh(RCore *core) {
 	if (panels->mode == PANEL_MODE_MENU) {
 		strcpy (title, "> ");
 	}
-	const char *color = panels->mode == PANEL_MODE_MENU ? core->cons->pal.graph_box : core->cons->pal.graph_box2;
+	const char *color = panels->mode == PANEL_MODE_MENU ? core->cons->context->pal.graph_box : core->cons->context->pal.graph_box2;
 	if (panels->mode == PANEL_MODE_ZOOM) {
 		snprintf (str, sizeof (title) - 1, "%s Zoom Mode | Press Enter or q to quit"Color_RESET, color);
 		strcat (title, str);

--- a/libr/core/task.c
+++ b/libr/core/task.c
@@ -202,7 +202,7 @@ R_API RCoreTask *r_core_task_new(RCore *core, bool create_cons, const char *cmd,
 	}
 
 	if (create_cons) {
-		task->cons_context = r_cons_context_new ();
+		task->cons_context = r_cons_context_new (r_cons_singleton ()->context);
 		if (!task->cons_context) {
 			goto hell;
 		}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -388,9 +388,9 @@ R_API void r_core_visual_jump(RCore *core, ut8 ch) {
 R_API void r_core_visual_append_help(RStrBuf *p, const char *title, const char **help) {
 	int i, max_length = 0, padding = 0;
 	RCons *cons = r_cons_singleton ();
-	const char *pal_args_color = cons->color ? cons->pal.args : "",
-		   *pal_help_color = cons->color ? cons->pal.help : "",
-		   *pal_reset = cons->color ? cons->pal.reset : "";
+	const char *pal_args_color = cons->color ? cons->context->pal.args : "",
+		   *pal_help_color = cons->color ? cons->context->pal.help : "",
+		   *pal_reset = cons->color ? cons->context->pal.reset : "";
 	for (i = 0; help[i]; i += 2) {
 		max_length = R_MAX (max_length, strlen (help[i]));
 	}
@@ -3428,7 +3428,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 R_API void r_core_visual_title(RCore *core, int color) {
 	bool showDelta = r_config_get_i (core->config, "scr.slow");
 	static ut64 oldpc = 0;
-	const char *BEGIN = core->cons->pal.prompt;
+	const char *BEGIN = core->cons->context->pal.prompt;
 	const char *filename;
 	char pos[512], bar[512], pcs[32];
 	if (!oldpc) {
@@ -3624,7 +3624,7 @@ R_API void r_core_visual_title(RCore *core, int color) {
 		}
 		const int tabsCount = core->visual.tabs? r_list_length (core->visual.tabs): 0;
 		if (tabsCount > 0) {
-			const char *kolor = core->cons->pal.prompt;
+			const char *kolor = core->cons->context->pal.prompt;
 			char *tabstring = visual_tabstring (core, kolor);
 			if (tabstring) {
 				title = r_str_append (title, tabstring);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -333,7 +333,7 @@ R_API int r_core_visual_hud(RCore *core) {
 	char *homehud = r_str_home (R2_HOME_HUD);
 	char *res = NULL;
 	char *p = 0;
-	r_cons_singleton ()->color = use_color;
+	r_cons_singleton ()->context->color = use_color;
 
 	r_core_visual_showcursor (core, true);
 	if (c && *c && r_file_exists (c)) {
@@ -387,10 +387,10 @@ R_API void r_core_visual_jump(RCore *core, ut8 ch) {
 
 R_API void r_core_visual_append_help(RStrBuf *p, const char *title, const char **help) {
 	int i, max_length = 0, padding = 0;
-	RCons *cons = r_cons_singleton ();
-	const char *pal_args_color = cons->color ? cons->context->pal.args : "",
-		   *pal_help_color = cons->color ? cons->context->pal.help : "",
-		   *pal_reset = cons->color ? cons->context->pal.reset : "";
+	RConsContext *cons_ctx = r_cons_singleton ()->context;
+	const char *pal_args_color = cons_ctx->color ? cons_ctx->pal.args : "",
+		   *pal_help_color = cons_ctx->color ? cons_ctx->pal.help : "",
+		   *pal_reset = cons_ctx->color ? cons_ctx->pal.reset : "";
 	for (i = 0; help[i]; i += 2) {
 		max_length = R_MAX (max_length, strlen (help[i]));
 	}

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -66,8 +66,8 @@ static char *colorize_asm_string(RCore *core, const char *buf_asm, int optype, u
 	char *tmp, *spacer = NULL;
 	char *source = (char*)buf_asm;
 	bool use_color = core->print->flags & R_PRINT_FLAGS_COLOR;
-	const char *color_num = core->cons->pal.num;
-	const char *color_reg = core->cons->pal.reg;
+	const char *color_num = core->cons->context->pal.num;
+	const char *color_reg = core->cons->context->pal.reg;
 	RAnalFunction* fcn = r_anal_get_fcn_in (core->anal, addr, R_ANAL_FCN_TYPE_NULL);
 
 	if (!use_color) {
@@ -323,7 +323,7 @@ static bool edit_bits (RCore *core) {
 				r_cons_printf (" |");
 			}
 			if (use_color) {
-				r_cons_printf (" %5s'%s%c"Color_RESET"'", " ", core->cons->pal.btext, ch);
+				r_cons_printf (" %5s'%s%c"Color_RESET"'", " ", core->cons->context->pal.btext, ch);
 			} else {
 				r_cons_printf (" %5s'%c'", " ", ch);
 			}
@@ -346,7 +346,7 @@ static bool edit_bits (RCore *core) {
 		}
 		r_cons_printf ("\nbit: ");
 		if (use_color) {
-			r_cons_print (core->cons->pal.b0x7f);
+			r_cons_print (core->cons->context->pal.b0x7f);
 			colorBits = true;
 		}
 		for (i = 0; i < 8; i++) {
@@ -506,7 +506,7 @@ static int sdbforcb (void *p, const char *k, const char *v) {
 	const char *pre = " ";
 	RCoreVisualTypes *vt = (RCoreVisualTypes*)p;
 	bool use_color = vt->core->print->flags & R_PRINT_FLAGS_COLOR;
-	char *color_sel = vt->core->cons->pal.prompt;
+	char *color_sel = vt->core->cons->context->pal.prompt;
 	if (vt->optword) {
 		if (!strcmp (vt->type, "struct")) {
 			char *s = r_str_newf ("struct.%s.", vt->optword);
@@ -626,10 +626,10 @@ R_API int r_core_visual_types(RCore *core) {
 		for (i = 0; opts[i]; i++) {
 			if (use_color) {
 				if (h_opt == i) {
-					r_cons_printf ("%s[%s]%s ", core->cons->pal.call, 
+					r_cons_printf ("%s[%s]%s ", core->cons->context->pal.call,
 						opts[i], Color_RESET);
 				} else {
-					r_cons_printf ("%s%s%s  ", core->cons->pal.other, 
+					r_cons_printf ("%s%s%s  ", core->cons->context->pal.other,
 						opts[i], Color_RESET);
 				}
 			} else {
@@ -972,7 +972,7 @@ static void *show_class(RCore *core, int mode, int idx, RBinClass *_c, const cha
 						i, clr, c->addr, c->name);
 				} else {
 					r_cons_printf ("-  %02d %s0x%08"PFMT64x Color_RESET"  %s\n",
-						i, core->cons->pal.offset, c->addr, c->name);
+						i, core->cons->context->pal.offset, c->addr, c->name);
 				}
 			} else {
 				r_cons_printf ("%s %02d 0x%08"PFMT64x"  %s\n",
@@ -1022,7 +1022,7 @@ static void *show_class(RCore *core, int mode, int idx, RBinClass *_c, const cha
 						i, clr, m->vaddr, mflags, name);
 				} else {
 					r_cons_printf ("-  %02d %s0x%08"PFMT64x Color_RESET" %s %s\n",
-						i, core->cons->pal.offset, m->vaddr, mflags, name);
+						i, core->cons->context->pal.offset, m->vaddr, mflags, name);
 				}
 			} else {
 				r_cons_printf ("%s %02d 0x%08"PFMT64x" %s %s\n",
@@ -2682,8 +2682,8 @@ static ut64 var_functions_show(RCore *core, int idx, int show) {
 	(void)r_cons_get_size (&window);
 	window -= 8; // Size of printed things
 	bool color = r_config_get_i (core->config, "scr.color");
-	const char *color_addr = core->cons->pal.offset;
-	const char *color_fcn = core->cons->pal.fname;
+	const char *color_addr = core->cons->context->pal.offset;
+	const char *color_fcn = core->cons->context->pal.fname;
 
 	r_list_foreach (core->anal->fcns, iter, fcn) {
 		if (i >= wdelta) {
@@ -2821,7 +2821,7 @@ static ut64 r_core_visual_anal_refresh (RCore *core) {
 	// Show functions list help in visual mode
 	case 0:
 		if (color) {
-			r_cons_strcat (core->cons->pal.prompt);
+			r_cons_strcat (core->cons->context->pal.prompt);
 		}
 		if (selectPanel) {
 			r_cons_printf ("-- functions -----------------[ %s ]-->>", printCmds[printMode]);

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -3786,7 +3786,7 @@ R_API void r_core_visual_colors(RCore *core) {
 	char *color = calloc (1, 64), cstr[32];
 	char preview_cmd[128] = "pd $r";
 	int ch, opt = 0, oopt = -1;
-	bool truecolor = r_cons_singleton ()->color == COLOR_MODE_16M;
+	bool truecolor = r_cons_singleton ()->context->color == COLOR_MODE_16M;
 	char *rgb_xxx_fmt = truecolor ? "rgb:%2.2x%2.2x%2.2x ":"rgb:%x%x%x ";
 	const char *k;
 	RColor rcolor;

--- a/libr/include/r_config.h
+++ b/libr/include/r_config.h
@@ -88,6 +88,7 @@ R_API void r_config_list(RConfig *cfg, const char *str, int rad);
 R_API RConfigNode *r_config_node_get(RConfig *cfg, const char *name);
 R_API RConfigNode *r_config_node_new(const char *name, const char *value);
 R_API void r_config_node_free(void *n);
+R_API void r_config_node_value_format_i(char *buf, size_t buf_size, const ut64 i, R_NULLABLE RConfigNode *node);
 R_API int r_config_toggle(RConfig *cfg, const char *name);
 R_API int r_config_readonly (RConfig *cfg, const char *key);
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -307,10 +307,6 @@ typedef struct r_cons_printable_palette_t {
 	int rainbow_sz; // size of rainbow
 } RConsPrintablePalette;
 
-R_API char *r_cons_rainbow_get(int idx, int last, bool bg);
-R_API void r_cons_rainbow_free(void);
-R_API void r_cons_rainbow_new(int sz);
-
 typedef void (*RConsEvent)(void *);
 
 #define CONS_MAX_ATTR_SZ 16
@@ -413,6 +409,9 @@ typedef struct r_cons_context_t {
 	bool lastMode;
 	bool lastEnabled;
 	bool pageable;
+
+	RConsPalette cpal;
+	RConsPrintablePalette pal;
 } RConsContext;
 
 typedef struct r_cons_t {
@@ -462,8 +461,6 @@ typedef struct r_cons_t {
 	int null; // if set, does not show anything
 	int mouse;
 	int is_wine;
-	RConsPalette cpal;
-	RConsPrintablePalette pal;
 	struct r_line_t *line;
 	const char **vline;
 	int refcnt;
@@ -701,7 +698,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, int empty);
 
 R_API void r_cons_push(void);
 R_API void r_cons_pop(void);
-R_API RConsContext *r_cons_context_new(void);
+R_API RConsContext *r_cons_context_new(R_NULLABLE RConsContext *parent);
 R_API void r_cons_context_free(RConsContext *context);
 R_API void r_cons_context_load(RConsContext *context);
 R_API void r_cons_context_reset(void);
@@ -775,8 +772,8 @@ R_API int r_cons_eof(void);
 R_API int r_cons_palette_init(const unsigned char *pal);
 R_API int r_cons_pal_set(const char *key, const char *val);
 R_API void r_cons_pal_update_event(void);
-R_API void r_cons_pal_free(void);
-R_API void r_cons_pal_init(void);
+R_API void r_cons_pal_free(RConsContext *ctx);
+R_API void r_cons_pal_init(RConsContext *ctx);
 R_API char *r_cons_pal_parse(const char *str, RColor *outcol);
 R_API void r_cons_pal_random(void);
 R_API RColor r_cons_pal_get(const char *key);
@@ -792,6 +789,9 @@ R_API bool r_cons_isatty(void);
 R_API int r_cons_get_cursor(int *rows);
 R_API int r_cons_arrow_to_hjkl(int ch);
 R_API char *r_cons_html_filter(const char *ptr, int *newlen);
+R_API char *r_cons_rainbow_get(int idx, int last, bool bg);
+R_API void r_cons_rainbow_free(RConsContext *ctx);
+R_API void r_cons_rainbow_new(RConsContext *ctx, int sz);
 
 // TODO: use gets() .. MUST BE DEPRECATED
 R_API int r_cons_fgets(char *buf, int len, int argc, const char **argv);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -149,8 +149,6 @@ enum {
 };
 #endif
 
-enum { COLOR_MODE_DISABLED = 0, COLOR_MODE_16, COLOR_MODE_256, COLOR_MODE_16M };
-
 enum { ALPHA_RESET = 0x00, ALPHA_FG = 0x01, ALPHA_BG = 0x02, ALPHA_FGBG = 0x03 };
 enum { R_CONS_ATTR_BOLD = 1 << 1 };
 
@@ -389,6 +387,8 @@ typedef void *(*RConsSleepBeginCallback)(void *core);
 typedef void (*RConsSleepEndCallback)(void *core, void *user);
 typedef void (*RConsQueueTaskOneshot)(void *core, void *task, void *user);
 
+typedef enum { COLOR_MODE_DISABLED = 0, COLOR_MODE_16, COLOR_MODE_256, COLOR_MODE_16M } RConsColorMode;
+
 typedef struct r_cons_context_t {
 	RConsGrep grep;
 	RStack *cons_stack;
@@ -410,6 +410,7 @@ typedef struct r_cons_context_t {
 	bool lastEnabled;
 	bool pageable;
 
+	RConsColorMode color;
 	RConsPalette cpal;
 	RConsPrintablePalette pal;
 } RConsContext;
@@ -456,7 +457,6 @@ typedef struct r_cons_t {
 	 * current window. If NULL or "" no pager is used. */
 	char *pager;
 	int blankline;
-	int color; // 0 = none, 1 = ansi (16), 2 = palette (256), 3 = truecolor (16M)
 	char *highlight;
 	int null; // if set, does not show anything
 	int mouse;
@@ -812,6 +812,7 @@ R_API void r_cons_grepbuf();
 R_API void r_cons_rgb(ut8 r, ut8 g, ut8 b, ut8 a);
 R_API void r_cons_rgb_fgbg(ut8 r, ut8 g, ut8 b, ut8 R, ut8 G, ut8 B);
 R_API void r_cons_rgb_init(void);
+R_API char *r_cons_rgb_str_mode(RConsColorMode mode, char *outstr, size_t sz, RColor *rcolor);
 R_API char *r_cons_rgb_str(char *outstr, size_t sz, RColor *rcolor);
 R_API char *r_cons_rgb_str_off(char *outstr, size_t sz, ut64 off);
 R_API void r_cons_color(int fg, int r, int g, int b);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -53,7 +53,7 @@ R_LIB_VERSION_HEADER(r_core);
 #define R_GRAPH_FORMAT_CMD          5
 
 ///
-#define R_CONS_COLOR_DEF(x, def) ((core->cons && core->cons->pal.x)? core->cons->pal.x: def)
+#define R_CONS_COLOR_DEF(x, def) ((core->cons && core->cons->context->pal.x)? core->cons->context->pal.x: def)
 #define R_CONS_COLOR(x) R_CONS_COLOR_DEF (x, "")
 
 /* rtr */

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -391,7 +391,7 @@ R_API void r_print_addr(RPrint *p, ut64 addr) {
 		0
 	};
 	const char *white = "";
-#define PREOFF(x) (p && p->cons && p->cons->pal.x)? p->cons->pal.x
+#define PREOFF(x) (p && p->cons && p->cons->context && p->cons->context->pal.x)? p->cons->context->pal.x
 	PrintfCallback printfmt = (PrintfCallback) (p? p->cb_printf: libc_printf);
 	bool use_segoff = p? (p->flags & R_PRINT_FLAGS_SEGOFF): false;
 	bool use_color = p? (p->flags & R_PRINT_FLAGS_COLOR): false;
@@ -482,7 +482,7 @@ R_API char* r_print_hexpair(RPrint *p, const char *str, int n) {
 	int ch, i;
 
 	if (colors) {
-#define P(x) (p->cons && p->cons->pal.x)? p->cons->pal.x
+#define P(x) (p->cons && p->cons->context->pal.x)? p->cons->context->pal.x
 		color_0x00 = P (b0x00): Color_GREEN;
 		color_0x7f = P (b0x7f): Color_YELLOW;
 		color_0xff = P (b0xff): Color_RED;
@@ -556,7 +556,7 @@ R_API char* r_print_hexpair(RPrint *p, const char *str, int n) {
 }
 
 static char colorbuffer[64];
-#define P(x) (p->cons && p->cons->pal.x)? p->cons->pal.x
+#define P(x) (p->cons && p->cons->context->pal.x)? p->cons->context->pal.x
 R_API const char *r_print_byte_color(RPrint *p, int ch) {
 	if (p->flags & R_PRINT_FLAGS_RAINBOW) {
 		// EXPERIMENTAL
@@ -683,7 +683,7 @@ static bool isAllZeros(const ut8 *buf, int len) {
 	return true;
 }
 
-#define Pal(x,y) (x->cons && x->cons->pal.y)? x->cons->pal.y
+#define Pal(x,y) (x->cons && x->cons->context->pal.y)? x->cons->context->pal.y
 R_API void r_print_hexii(RPrint *rp, ut64 addr, const ut8 *buf, int len, int step) {
 	PrintfCallback p = (PrintfCallback) rp->cb_printf;
 	bool c = rp->flags & R_PRINT_FLAGS_COLOR;
@@ -1052,7 +1052,7 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 					// stub for colors
 					if (p && p->colorfor) {
 						if (!p->iob.addr_is_mapped (p->iob.io, addr + j)) {
-							a = p->cons->pal.ai_unmap;
+							a = p->cons->context->pal.ai_unmap;
 						} else {
 							a = p->colorfor (p->user, n, true);
 						}
@@ -1707,16 +1707,17 @@ R_API void r_print_2bpp_tiles(RPrint *p, ut8 *buf, ut32 tiles) {
 }
 
 R_API const char* r_print_color_op_type(RPrint *p, ut64 anal_type) {
+	RConsPrintablePalette *pal = &p->cons->context->pal;
 	switch (anal_type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_NOP:
-		return p->cons->pal.nop;
+		return pal->nop;
 	case R_ANAL_OP_TYPE_ADD:
 	case R_ANAL_OP_TYPE_SUB:
 	case R_ANAL_OP_TYPE_MUL:
 	case R_ANAL_OP_TYPE_DIV:
 	case R_ANAL_OP_TYPE_MOD:
 	case R_ANAL_OP_TYPE_LENGTH:
-		return p->cons->pal.math;
+		return pal->math;
 	case R_ANAL_OP_TYPE_AND:
 	case R_ANAL_OP_TYPE_OR:
 	case R_ANAL_OP_TYPE_XOR:
@@ -1728,23 +1729,23 @@ R_API const char* r_print_color_op_type(RPrint *p, ut64 anal_type) {
 	case R_ANAL_OP_TYPE_ROL:
 	case R_ANAL_OP_TYPE_ROR:
 	case R_ANAL_OP_TYPE_CPL:
-		return p->cons->pal.bin;
+		return pal->bin;
 	case R_ANAL_OP_TYPE_IO:
-		return p->cons->pal.swi;
+		return pal->swi;
 	case R_ANAL_OP_TYPE_JMP:
 	case R_ANAL_OP_TYPE_UJMP:
 	case R_ANAL_OP_TYPE_IJMP:
 	case R_ANAL_OP_TYPE_RJMP:
 	case R_ANAL_OP_TYPE_IRJMP:
 	case R_ANAL_OP_TYPE_MJMP:
-		return p->cons->pal.jmp;
+		return pal->jmp;
 	case R_ANAL_OP_TYPE_CJMP:
 	case R_ANAL_OP_TYPE_UCJMP:
 	case R_ANAL_OP_TYPE_SWITCH:
-		return p->cons->pal.cjmp;
+		return pal->cjmp;
 	case R_ANAL_OP_TYPE_CMP:
 	case R_ANAL_OP_TYPE_ACMP:
-		return p->cons->pal.cmp;
+		return pal->cmp;
 	case R_ANAL_OP_TYPE_UCALL:
 	case R_ANAL_OP_TYPE_ICALL:
 	case R_ANAL_OP_TYPE_RCALL:
@@ -1752,35 +1753,35 @@ R_API const char* r_print_color_op_type(RPrint *p, ut64 anal_type) {
 	case R_ANAL_OP_TYPE_UCCALL:
 	case R_ANAL_OP_TYPE_CALL:
 	case R_ANAL_OP_TYPE_CCALL:
-		return p->cons->pal.call;
+		return pal->call;
 	case R_ANAL_OP_TYPE_NEW:
 	case R_ANAL_OP_TYPE_SWI:
-		return p->cons->pal.swi;
+		return pal->swi;
 	case R_ANAL_OP_TYPE_ILL:
 	case R_ANAL_OP_TYPE_TRAP:
-		return p->cons->pal.trap;
+		return pal->trap;
 	case R_ANAL_OP_TYPE_CRET:
 	case R_ANAL_OP_TYPE_RET:
-		return p->cons->pal.ret;
+		return pal->ret;
 	case R_ANAL_OP_TYPE_CAST:
 	case R_ANAL_OP_TYPE_MOV:
 	case R_ANAL_OP_TYPE_LEA:
 	case R_ANAL_OP_TYPE_CMOV: // TODO: add cmov cathegory?
-		return p->cons->pal.mov;
+		return pal->mov;
 	case R_ANAL_OP_TYPE_PUSH:
 	case R_ANAL_OP_TYPE_UPUSH:
 	case R_ANAL_OP_TYPE_LOAD:
-		return p->cons->pal.push;
+		return pal->push;
 	case R_ANAL_OP_TYPE_POP:
 	case R_ANAL_OP_TYPE_STORE:
-		return p->cons->pal.pop;
+		return pal->pop;
 	case R_ANAL_OP_TYPE_CRYPTO:
-		return p->cons->pal.crypto;
+		return pal->crypto;
 	case R_ANAL_OP_TYPE_NULL:
-		return p->cons->pal.other;
+		return pal->other;
 	case R_ANAL_OP_TYPE_UNK:
 	default:
-		return p->cons->pal.invalid;
+		return pal->invalid;
 	}
 }
 
@@ -1913,7 +1914,7 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 				j += strlen (reset);
 				o[j] = p[i];
 				if (!(p[i+1] == '$' || ((p[i+1] > '0') && (p[i+1] < '9')))) {
-					const char *color = found_var ? print->cons->pal.func_var_type : reg;
+					const char *color = found_var ? print->cons->context->pal.func_var_type : reg;
 					ut32 color_len = strlen (color);
 					if (color_len + j + 10 >= COLORIZE_BUFSIZE) {
 						eprintf ("r_print_colorize_opcode(): buffer overflow!\n");


### PR DESCRIPTION
TODO:
- Copy palette instead of initializing default when creating a new context, so a new task inherits the palette from the one it is started from
- Kill the global `curtheme` (and maybe `getNext`) in cmd_eval.c and move it to RConsContext

fixes #12644