### PR TITLE
WASM branches and enrichment

### DIFF
--- a/libr/asm/p/asm_wasm.c
+++ b/libr/asm/p/asm_wasm.c
@@ -14,6 +14,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	WasmOp wop = {0};
 	int ret = wasm_dis (&wop, buf, len);
 	r_asm_op_set_asm (op, wop.txt);
+	free (wop.txt);
 	op->size = ret;
 	return op->size;
 }

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -67,18 +67,19 @@ R_API int r_parse_is_c_file (const char *file);
 R_API char *r_parse_immtrim (char *opstr);
 
 /* plugin pointers */
-extern RParsePlugin r_parse_plugin_dummy;
-extern RParsePlugin r_parse_plugin_att2intel;
-extern RParsePlugin r_parse_plugin_x86_pseudo;
+extern RParsePlugin r_parse_plugin_6502_pseudo;
 extern RParsePlugin r_parse_plugin_arm_pseudo;
-extern RParsePlugin r_parse_plugin_mips_pseudo;
+extern RParsePlugin r_parse_plugin_att2intel;
+extern RParsePlugin r_parse_plugin_avr_pseudo;
 extern RParsePlugin r_parse_plugin_dalvik_pseudo;
+extern RParsePlugin r_parse_plugin_dummy;
+extern RParsePlugin r_parse_plugin_m68k_pseudo;
+extern RParsePlugin r_parse_plugin_mips_pseudo;
 extern RParsePlugin r_parse_plugin_mreplace;
 extern RParsePlugin r_parse_plugin_ppc_pseudo;
 extern RParsePlugin r_parse_plugin_sh_pseudo;
-extern RParsePlugin r_parse_plugin_avr_pseudo;
-extern RParsePlugin r_parse_plugin_6502_pseudo;
-extern RParsePlugin r_parse_plugin_m68k_pseudo;
+extern RParsePlugin r_parse_plugin_wasm_pseudo;
+extern RParsePlugin r_parse_plugin_x86_pseudo;
 extern RParsePlugin r_parse_plugin_z80_pseudo;
 #endif
 

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -305,6 +305,7 @@ parse_plugins = [
   'mreplace',
   'ppc_pseudo',
   'sh_pseudo',
+  'wasm_pseudo',
   'x86_pseudo',
   'z80_pseudo'
 ]

--- a/libr/parse/meson.build
+++ b/libr/parse/meson.build
@@ -11,6 +11,7 @@ r_parse_sources = [
   'p/parse_mreplace.c',
   'p/parse_ppc_pseudo.c',
   'p/parse_sh_pseudo.c',
+  'p/parse_wasm_pseudo.c',
   'p/parse_x86_pseudo.c',
   'p/parse_z80_pseudo.c',
   'p/parse_mreplace/mreplace.c',

--- a/libr/parse/p/Makefile
+++ b/libr/parse/p/Makefile
@@ -13,7 +13,7 @@ all: ${ALL_TARGETS}
 ALL_TARGETS=
 ARCHS=att2intel.mk x86_pseudo.mk mreplace.mk
 ARCHS+=arm_pseudo.mk z80_pseudo.mk ppc_pseudo.mk 6502_pseudo.mk
-ARCHS+=m68k_pseudo.mk sh_pseudo.mk avr_pseudo.mk
+ARCHS+=m68k_pseudo.mk sh_pseudo.mk avr_pseudo.mk wasm_pseudo.mk
 include $(ARCHS)
 
 clean:

--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -258,9 +258,9 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 	RList *vars, *args, *spargs;
 
 	if (!p->varlist) {
-                free (tstr);
+		free (tstr);
 		return false;
-        }
+	}
 	vars = p->varlist (p->anal, f, 'v');
 	args = p->varlist (p->anal, f, 'a');
 	spargs = p->varlist (p->anal, f, 'e');

--- a/libr/parse/p/parse_wasm_pseudo.c
+++ b/libr/parse/p/parse_wasm_pseudo.c
@@ -1,0 +1,50 @@
+/* radare - LGPL - Copyright 2015-2018 - pancake */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <r_lib.h>
+#include <r_util.h>
+#include <r_flag.h>
+#include <r_anal.h>
+#include <r_parse.h>
+
+static char* get_fcn_name(RAnal *anal, ut32 fcn_id) {
+	r_cons_push ();
+	char *s = anal->coreb.cmdstrf (anal->coreb.core, "isq~0x0[2:%u]", fcn_id);
+	r_cons_pop ();
+	if (s) {
+		size_t namelen = strlen (s);
+		s[namelen - 1] = 0;
+	}
+	return s;
+}
+
+static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
+	char *fcn_name = NULL;
+	str[0] = 0;
+	if (!strncmp (data, "call ", 5)) {
+		ut32 fcn_id = (ut32) r_num_get (NULL, data + 5);
+		if (!(fcn_name = get_fcn_name (p->anal, fcn_id))) {
+			return false;
+		}
+		snprintf (str, len, "call sym.%s", fcn_name);
+		free (fcn_name);
+		return true;
+	}
+	return false;
+}
+
+RParsePlugin r_parse_plugin_wasm_pseudo = {
+	.name = "wasm.pseudo",
+	.desc = "WASM pseudo syntax",
+	.varsub = &varsub,
+};
+
+#ifndef CORELIB
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_PARSE,
+	.data = &r_parse_plugin_wasm_pseudo,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/parse/p/wasm_pseudo.mk
+++ b/libr/parse/p/wasm_pseudo.mk
@@ -1,0 +1,18 @@
+OBJ_WASMPSEUDO+=parse_wasm_pseudo.o
+
+TARGET_WASMPSEUDO=parse_wasm_pseudo.${EXT_SO}
+STATIC_OBJ+=${OBJ_WASMPSEUDO}
+ifeq ($(CC),cccl)
+LIBDEPS=-L../../util -llibr_util
+LIBDEPS+=-L../../flag -llibr_flag
+else
+LIBDEPS=-L../../util -lr_util
+LIBDEPS+=-L../../flag -lr_flag
+endif
+
+ifeq ($(WITHPIC),1)
+ALL_TARGETS+=${TARGET_WASMPSEUDO}
+${TARGET_WASMPSEUDO}: ${OBJ_WASMPSEUDO}
+	${CC} $(call libname,parse_wasm_pseudo) ${LIBDEPS} $(LDFLAGS) \
+		$(LDFLAGS_SHARED) ${CFLAGS} -o ${TARGET_WASMPSEUDO} ${OBJ_WASMPSEUDO}
+endif

--- a/plugins.bin.cfg
+++ b/plugins.bin.cfg
@@ -31,6 +31,7 @@ parse.mips_pseudo
 parse.dalvik_pseudo
 parse.x86_pseudo
 parse.6502_pseudo
+parse.wasm_pseudo
 asm.arc
 asm.ppc_cs
 anal.ppc_cs

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -253,6 +253,7 @@ parse.mips_pseudo
 parse.mreplace
 parse.ppc_pseudo
 parse.sh_pseudo
+parse.wasm_pseudo
 parse.avr_pseudo
 parse.x86_pseudo
 parse.z80_pseudo"

--- a/plugins.nogpl.cfg
+++ b/plugins.nogpl.cfg
@@ -144,6 +144,7 @@ parse.att2intel
 parse.dalvik_pseudo
 parse.mips_pseudo
 parse.mreplace
+parse.wasm_pseudo
 parse.x86_pseudo"
 SHARED="asm.6502
 asm.snes

--- a/plugins.static.cfg
+++ b/plugins.static.cfg
@@ -211,13 +211,14 @@ lang.vala
 parse.6502_pseudo
 parse.arm_pseudo
 parse.att2intel
+parse.avr_pseudo
 parse.dalvik_pseudo
 parse.m68k_pseudo
 parse.mips_pseudo
 parse.mreplace
 parse.ppc_pseudo
 parse.sh_pseudo
-parse.avr_pseudo
+parse.wasm_pseudo
 parse.x86_pseudo
 parse.z80_pseudo"
 SHARED="io.shm

--- a/plugins.static.nogpl.cfg
+++ b/plugins.static.nogpl.cfg
@@ -203,6 +203,7 @@ parse.mreplace
 parse.ppc_pseudo
 parse.sh_pseudo
 parse.avr_pseudo
+parse.wasm_pseudo
 parse.x86_pseudo
 parse.z80_pseudo"
 SHARED="io.shm


### PR DESCRIPTION
new output:
```
[0x000073c9]> pdf
            ;-- entry0:
            ;-- pc:
╭ (fcn) sym.fcn.1 40
│   sym.fcn.1 ();
│           0x000073c9      027f           block (result i32)
│           0x000073cb      230a           get_global 10
│           0x000073cd      2101           set_local 1
│           0x000073cf      230a           get_global 10
│           0x000073d1      2000           get_local 0
│           0x000073d3      6a             i32.add
│           0x000073d4      240a           set_global 10
│           0x000073d6      230a           get_global 10
│           0x000073d8      410f           i32.const 15
│           0x000073da      6a             i32.add
│           0x000073db      4170           i32.const 112
│           0x000073dd      71             i32.and
│           0x000073de      240a           set_global 10
│           0x000073e0      230a           get_global 10
│           0x000073e2      230b           get_global 11
│           0x000073e4      4e             i32.ge_s
│       ╭─< 0x000073e5      0440           if
│       │   0x000073e7      2000           get_local 0
│       │   0x000073e9      1003           call sym.fcn.4              ; 0x740c
│       ╰─> 0x000073eb      0b             end
│           0x000073ec      2001           get_local 1
│           0x000073ee      0f             return
│           0x000073ef      0b             end
╰           0x000073f0      0b             end
```