### PR TITLE
Fix addressing of instructions in aef

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4862,7 +4862,7 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 				while (pc < end) {
 					left = R_MIN (end - pc, 32);
 					r_asm_set_pc (core->assembler, pc);
-					ret = r_anal_op (core->anal, &op, pc, buf + pc - bb->addr, left, R_ANAL_OP_MASK_ESIL); // read overflow
+					ret = r_anal_op (core->anal, &op, pc, buf + pc - bb->addr, left, R_ANAL_OP_MASK_HINT | R_ANAL_OP_MASK_ESIL); // read overflow
 					if (op.type == R_ANAL_OP_TYPE_RET) {
 						break;
 					}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4862,7 +4862,10 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 				while (pc < end) {
 					left = R_MIN (end - pc, 32);
 					r_asm_set_pc (core->assembler, pc);
-					ret = r_anal_op (core->anal, &op, addr, buf, left, R_ANAL_OP_MASK_ESIL); // read overflow
+					ret = r_anal_op (core->anal, &op, pc, buf + pc - bb->addr, left, R_ANAL_OP_MASK_ESIL); // read overflow
+					if (op.type == R_ANAL_OP_TYPE_RET) {
+						break;
+					}
 					if (ret) {
 						r_reg_set_value_by_role (core->anal->reg, R_REG_NAME_PC, pc);
 						r_anal_esil_parse (esil, R_STRBUF_SAFEGET (&op.esil));


### PR DESCRIPTION
Hi there,
when executing aef on a function currently only the first instruction of each basic block will get emulated (over and over again). This is because the buffer pointer is not incremented. This patch aims to fix this.

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.3.0-git 20775 @ linux-x86-64 git.3.1.3-354-gc3bf8d161 commit: c3bf8d161b4835e59d7923aafe6d44de3b5234d0 build: 2019-01-17__23:24:22

### Expected behavior
```
r2 /usr/lib/libc.so.6
[0x00024330]> f~sym.strstr
0x0008a540 37 sym.strstr
[0x00024330]> s 0x0008a540
[0x0008a540]> afr
[0x0008a540]> agf
[0x0008a540]> VV @ sym.strstr (nodes 1 edges 0 zoom 100%) BB-NORM mouse:canvas-y mov-speed:5
.-------------------------------------------------------.
|  0x8a540                                              |
| ;-- __libc_strstr_ifunc:                              |
| ;-- __libc_strstr:                                    |
| (fcn) sym.strstr 37                                   |
|   char *sym.strstr (const char *s1, const char *s2);  |
| endbr64                                               |
| ; [0x1bde28:8]=0                                      |
| mov rax, qword [reloc._rtld_global_ro]                |
| ; sym.__GI_strstr                                     |
| ; 0x8a0a0                                             |
| lea rdx, sym.__strstr_sse2                            |
| ; [0xb4:1]=4                                          |
| test byte [rax + 0xb4], 0x10                          |
| ; 0xa3340                                             |
| lea rax, sym.__strstr_sse2_unaligned                  |
| cmove rax, rdx                                        |
| ret                                                   |
`-------------------------------------------------------'
[0x0008a540]> aei
[0x0008a540]> aef
[0x0008a540]> aer
rax = 0x0008a099
rbx = 0x00000000
rcx = 0x00000000
rdx = 0x0008a099
rsi = 0x00000000
rdi = 0x00000000
r8 = 0x00000000
r9 = 0x00000000
r10 = 0x00000000
r11 = 0x00000000
r12 = 0x00000000
r13 = 0x00000000
r14 = 0x00000000
r15 = 0x00000000
rip = 0x0008a560
rbp = 0x00000000
rflags = 0x00000044
rsp = 0x00000000
```

### Actual behavior
```
r2 /usr/lib/libc.so.6
[0x00024330]>f~sym.strstr
0x0008a540 37 sym.strstr
[0x00024330]> s 0x0008a540
[0x0008a540]> afr
[0x0008a540]> agf
[0x0008a540]> VV @ sym.strstr (nodes 1 edges 0 zoom 100%) BB-NORM mouse:canvas-y mov-speed:5
.-------------------------------------------------------.
|  0x8a540                                              |
| ;-- __libc_strstr_ifunc:                              |
| ;-- __libc_strstr:                                    |
| (fcn) sym.strstr 37                                   |
|   char *sym.strstr (const char *s1, const char *s2);  |
| endbr64                                               |
| ; [0x1bde28:8]=0                                      |
| mov rax, qword [reloc._rtld_global_ro]                |
| ; sym.__GI_strstr                                     |
| ; 0x8a0a0                                             |
| lea rdx, sym.__strstr_sse2                            |
| ; [0xb4:1]=4                                          |
| test byte [rax + 0xb4], 0x10                          |
| ; 0xa3340                                             |
| lea rax, sym.__strstr_sse2_unaligned                  |
| cmove rax, rdx                                        |
| ret                                                   |
`-------------------------------------------------------'
[0x0008a540]> aei
[0x0008a540]> aef
[0x0008a540]> aer
rax = 0x00000000
rbx = 0x00000000
rcx = 0x00000000
rdx = 0x00000000
rsi = 0x00000000
rdi = 0x00000000
r8 = 0x00000000
r9 = 0x00000000
r10 = 0x00000000
r11 = 0x00000000
r12 = 0x00000000
r13 = 0x00000000
r14 = 0x00000000
r15 = 0x00000000
rip = 0x0008a560
rbp = 0x00000000
rflags = 0x00000000
rsp = 0x00000000
```

### Steps to reproduce the behavior 
Execute steps above using [libc.so.6.zip](https://github.com/radare/radare2/files/2770879/libc.so.6.zip)

