### PR TITLE
Fix Wasm function rename to ignore memory and other non-function symbols

### DIFF
--- a/libr/parse/p/parse_wasm_pseudo.c
+++ b/libr/parse/p/parse_wasm_pseudo.c
@@ -11,7 +11,7 @@
 
 static char* get_fcn_name(RAnal *anal, ut32 fcn_id) {
 	r_cons_push ();
-	char *s = anal->coreb.cmdstrf (anal->coreb.core, "isq~0x0[2:%u]", fcn_id);
+	char *s = anal->coreb.cmdstrf (anal->coreb.core, "is~FUNC[6:%u]", fcn_id);
 	r_cons_pop ();
 	if (s) {
 		size_t namelen = strlen (s);


### PR DESCRIPTION
`call 0` is an index for functions. we must ignore memories and other symbols.