### PR TITLE
Speed up RBinReloc retrieval ##optimization

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -752,32 +752,13 @@ R_API RList *r_bin_get_libs(RBin *bin) {
 	return o ? o->libs : NULL;
 }
 
-R_API RList *r_bin_patch_relocs(RBin *bin) {
+R_API RBNode *r_bin_patch_relocs(RBin *bin) {
 	r_return_val_if_fail (bin, NULL);
-	static bool first = true;
 	RBinObject *o = r_bin_cur_object (bin);
-	if (!o) {
-		return NULL;
-	}
-	// r_bin_object_set_items set o->relocs but there we don't have access
-	// to io
-	// so we need to be run from bin_relocs, free the previous reloc and get
-	// the patched ones
-	if (first && o->plugin && o->plugin->patch_relocs) {
-		RList *tmp = o->plugin->patch_relocs (bin);
-		first = false;
-		if (!tmp) {
-			return o->relocs;
-		}
-		r_list_free (o->relocs);
-		o->relocs = tmp;
-		REBASE_PADDR (o, o->relocs, RBinReloc);
-		first = false;
-	}
-	return o->relocs;
+	return o? r_bin_object_patch_relocs (bin, o): NULL;
 }
 
-R_API RList *r_bin_get_relocs(RBin *bin) {
+R_API RBNode *r_bin_get_relocs(RBin *bin) {
 	r_return_val_if_fail (bin, NULL);
 	RBinObject *o = r_bin_cur_object (bin);
 	return o ? o->relocs : NULL;

--- a/libr/bin/i/private.h
+++ b/libr/bin/i/private.h
@@ -29,6 +29,7 @@ R_IPI void r_bin_object_set_baddr(RBinObject *o, ut64 baddr);
 R_IPI RBinObject *r_bin_object_new(RBinFile *binfile, RBinPlugin *plugin, ut64 baseaddr, ut64 loadaddr, ut64 offset, ut64 sz);
 R_IPI RBinObject *r_bin_object_get_cur(RBin *bin);
 R_IPI RBinObject *r_bin_object_find_by_arch_bits(RBinFile *binfile, const char *arch, int bits, const char *name);
+R_IPI RBNode *r_bin_object_patch_relocs(RBin *bin, RBinObject *o);
 
 R_IPI const char *r_bin_lang_tostring(int lang);
 R_IPI int r_bin_lang_type(RBinFile *binfile, const char *def, const char *sym);

--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -19,9 +19,15 @@ static void mem_free(void *data) {
 }
 
 static int reloc_cmp(const void *a, const RBNode *b) {
-	RBinReloc *ar = (const RBinReloc *)a;
-	RBinReloc *br = container_of (b, const RBinReloc, vrb);
-	return ar->vaddr - br->vaddr;
+	const RBinReloc *ar = (const RBinReloc *)a;
+	const RBinReloc *br = container_of (b, const RBinReloc, vrb);
+	if (ar->vaddr > br->vaddr) {
+		return 1;
+	} else if (ar->vaddr < br->vaddr) {
+		return -1;
+	} else {
+		return 0;
+	}
 }
 
 static void reloc_free(RBNode *rbn) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3866,7 +3866,8 @@ static RBinReloc *getreloc(RCore *core, ut64 addr, int size) {
 	if (size < 1 || addr == UT64_MAX) {
 		return NULL;
 	}
-	list = r_bin_get_relocs (core->bin);
+	/* list = r_bin_get_relocs (core->bin); */
+	list = r_list_new();
 	r_list_foreach (list, iter, r) {
 		if ((r->vaddr >= addr) && (r->vaddr < (addr + size))) {
 			return r;

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -229,7 +229,7 @@ typedef struct r_bin_object_t {
 	RList/*<??>*/ *entries;
 	RList/*<??>*/ *fields;
 	RList/*<??>*/ *libs;
-	RList/*<RBinReloc>*/ *relocs;
+	RBNode/*<RBinReloc>*/ *relocs;
 	RList/*<??>*/ *strings;
 	RList/*<RBinClass>*/ *classes;
 	RList/*<RBinDwarfRow>*/ *lines;
@@ -525,6 +525,7 @@ typedef struct r_bin_reloc_t {
 	 * cf. https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
 	 */
 	bool is_ifunc;
+	RBNode vrb;
 } RBinReloc;
 
 typedef struct r_bin_string_t {
@@ -651,8 +652,8 @@ R_API RList *r_bin_get_entries(RBin *bin);
 R_API RList *r_bin_get_fields(RBin *bin);
 R_API RList *r_bin_get_imports(RBin *bin);
 R_API RList *r_bin_get_libs(RBin *bin);
-R_API RList *r_bin_patch_relocs(RBin *bin);
-R_API RList *r_bin_get_relocs(RBin *bin);
+R_API RBNode *r_bin_patch_relocs(RBin *bin);
+R_API RBNode *r_bin_get_relocs(RBin *bin);
 R_API RList *r_bin_get_sections(RBin *bin);
 R_API RList *r_bin_get_classes(RBin *bin);
 R_API RList *r_bin_get_strings(RBin *bin);


### PR DESCRIPTION
Use RBTree to speed up relocation search, in particular during disassembly.

On a Linux Kernel with debug info which has 17569271 relocations, this is a huge performance improvement. Without this patch, it was very slow to scroll in visual mode while disassembling.