### PR TITLE
Fix demangling of relocs and exported symbols

### DIFF
--- a/libr/bin/mangling/cxx.c
+++ b/libr/bin/mangling/cxx.c
@@ -57,8 +57,15 @@ R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr) {
 	}
 	// remove CXXABI suffix
 	char *cxxabi = strstr (p, "@@CXXABI");
+	char *glibcxx = strstr (p, "@GLIBCXX");
 	if (cxxabi) {
 		*cxxabi = '\0';
+	} else if (glibcxx) {
+		if (p < glibcxx && glibcxx[-1] == '@') {
+			glibcxx[-1] = '\0';
+		} else {
+			*glibcxx = '\0';
+		}
 	}
 #if WITH_GPL
 	char *out = cplus_demangle_v3 (p, flags);


### PR DESCRIPTION
Hi there,
in some occasions relocs and exported symbols are not demangled. This patch aims to fix this.

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.3.0-git 20852 @ linux-x86-64 git.3.2.1-152-g21cde44c7 commit: 21cde44c7d70dbd27e4622af90e53664d8723e3d build: 2019-01-22__22:39:06

### Expected behavior
```
$ r2 /usr/lib/libstdc++.so.6
[0x00089020]> iE
...
5533 0x000bbe70 0x000bbe70 GLOBAL   FUNC    5 std::_V2::error_category::~error_category()
5541 0x0008de40 0x0008de40 GLOBAL   FUNC   75 std::__future_base::_State_base::~_State_base()
5548 0x001465eb 0x001465eb GLOBAL    OBJ    1 std::placeholders::_11
1569 0x0008d0d0 0x0008d0d0 GLOBAL   FUNC   14 std::basic_ifstream<char,std::char_traits<char>>::is_open()const
1790 0x0008d200 0x0008d200 GLOBAL   FUNC  327 std::basic_istream<wchar_t,std::char_traits<wchar_t>>::ignore()
2060 0x0008d180 0x0008d180 GLOBAL   FUNC   32 std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>::_M_disjunct(wchar_tconst*)const

...
[0x00089020]> s 0x00091004
[0x00091004]> pd 1
            0x00091004      488b159d880f.  mov rdx, qword [reloc.vtableforstd::bad_alloc_168] ; [0x1898a8:8]=0 [0x1898a8:8]=0
[0x00091004]> irj~{}
[
  ...
  {
    "name": "_ZTISt9bad_alloc",
    "demname": "typeinfoforstd::bad_alloc",
    "type": "SET_64",
    "vaddr": 1617992,
    "paddr": 1613896,
    "is_ifunc": false
  },
  ...
]
```

### Actual behavior
```
$ r2 /usr/lib/libstdc++.so.6
[0x00089020]> iE
...
5533 0x000bbe70 0x000bbe70 GLOBAL   FUNC    5 std::_V2::error_category::~error_category()
5541 0x0008de40 0x0008de40 GLOBAL   FUNC   75 std::__future_base::_State_base::~_State_base()
5548 0x001465eb 0x001465eb GLOBAL    OBJ    1 std::placeholders::_11
1569 0x0008d0d0 0x0008d0d0 GLOBAL   FUNC   14 _ZNKSt14basic_ifstreamIcSt11char_traitsIcEE7is_openEv@GLIBCXX_3.4
1790 0x0008d200 0x0008d200 GLOBAL   FUNC  327 _ZNSt13basic_istreamIwSt11char_traitsIwEE6ignoreEv@@GLIBCXX_3.4.5
2060 0x0008d180 0x0008d180 GLOBAL   FUNC   32 _ZNKSbIwSt11char_traitsIwESaIwEE11_M_disjunctEPKw@GLIBCXX_3.4
...
[0x00089020]> s 0x00091004
[0x00091004]> pd 1
            0x00091004      488b159d880f.  mov rdx, qword [reloc._ZTVSt9bad_alloc_168] ; [0x1898a8:8]=0
[0x00091004]> irj~{}
[
  ...
  {
    "name": "_ZTISt9bad_alloc",
    "type": "SET_64",
    "vaddr": 1617992,
    "paddr": 1613896,
    "is_ifunc": false
  },
  ...
]
```

### Steps to reproduce the behavior 
Execute the steps shown above using extracted  [libstdc++.so.zip](https://github.com/radare/radare2/files/2784742/libstdc%2B%2B.so.zip)