### PR TITLE
Add new command: pifc and pifcj

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2341,6 +2341,26 @@ static int fcn_list_default(RCore *core, RList *fcns, bool quiet) {
 	return 0;
 }
 
+// for a given function returns an RList of all functions that were called in it
+R_API RList *r_core_anal_fcn_get_calls (RCore *core, RAnalFunction *fcn) {
+	RList *refs = NULL;
+	RAnalRef *refi;
+	RListIter *iter;
+
+	// get all references from this function
+	refs = r_anal_fcn_get_refs (core->anal, fcn);
+	// sanity check
+	if (!r_list_empty (refs)) {
+		// iterate over all the references and remove these which aren't of type call
+		r_list_foreach (refs, iter, refi) {
+			if (refi->type != R_ANAL_REF_TYPE_CALL) {
+				r_list_delete (refs, iter);
+			}
+		}
+	}
+	return refs;
+}
+
 // Lists function names and their calls (uniqified)
 static int fcn_print_makestyle(RCore *core, RList *fcns, char mode) {
 	RListIter *refiter;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2378,7 +2378,7 @@ static int fcn_print_makestyle(RCore *core, RList *fcns, char mode) {
 	// Iterate over all functions
 	r_list_foreach (fcns, fcniter, fcn) {
 		// Get all refs for a function
-		refs = r_anal_fcn_get_refs (core->anal, fcn);
+		refs = r_core_anal_fcn_get_calls (core, fcn);
 		// Uniquify the list by ref->addr
 		refs = r_list_uniq (refs, (RListComparator)RAnalRef_cmp);
 	
@@ -2401,9 +2401,6 @@ static int fcn_print_makestyle(RCore *core, RList *fcns, char mode) {
 			}
 			// Iterate over all refs from a function
 			r_list_foreach (refs, refiter, refi) {
-				if (refi->type != R_ANAL_REF_TYPE_CALL) {
-					continue;
-				}
 				RFlagItem *f = r_flag_get_i (core->flags, refi->addr);
 				char *dst = r_str_newf ((f? f->name: "0x%08"PFMT64x), refi->addr);
 				if (pj) { // Append calee json item

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4675,6 +4675,11 @@ static int cmd_print(void *data, const char *input) {
 				// get function in current offset
 				RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset,
 					R_ANAL_FCN_TYPE_FCN | R_ANAL_FCN_TYPE_SYM);
+
+				// validate that a function was found in the given address
+				if (!f) {
+					break;
+				}
 				// get all the calls of the function
 				refs = r_core_anal_fcn_get_calls (core, f);
 

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -539,6 +539,7 @@ R_API RList* r_core_anal_graph_to(RCore *core, ut64 addr, int n);
 R_API int r_core_anal_ref_list(RCore *core, int rad);
 R_API int r_core_anal_all(RCore *core);
 R_API RList* r_core_anal_cycles (RCore *core, int ccl);
+R_API RList *r_core_anal_fcn_get_calls (RCore *core, RAnalFunction *fcn); // get all calls from a function
 
 /*tp.c*/
 R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn);


### PR DESCRIPTION
This command will print all the `CALLS` from a given function. The API is now also used by `aflm` which was introduced last week and was adapted in this PR. 
While `aflm` will print all the calls from all the functions, the new `pifc` command would do that only for a specific function.

```
[0x00001347]> pifc
0x0000135d call sym.imp.puts
0x00001369 call sym.imp.puts
0x00001382 call sym.beet
0x00001392 call sym.imp.puts
0x000013a0 call sym.imp.puts
```

and in a JSON format:
```
[0x00001347]> pifcj~{}
[
  {
    "dest": "sym.imp.puts",
    "addr": 4160,
    "at": 4957
  },
  {
    "dest": "sym.imp.puts",
    "addr": 4160,
    "at": 4969
  },
  {
    "dest": "sym.beet",
    "addr": 4822,
    "at": 4994
  },
  {
    "dest": "sym.imp.puts",
    "addr": 4160,
    "at": 5010
  },
  {
    "dest": "sym.imp.puts",
    "addr": 4160,
    "at": 5024
  }
]
```


Screenshot:
![image](https://user-images.githubusercontent.com/20182642/51597634-5b15db00-1f04-11e9-82da-e30383d3de4b.png)
