### PR TITLE
Fix buffer overrun on pdb file read

### DIFF
--- a/libr/bin/mangling/microsoft_demangle.c
+++ b/libr/bin/mangling/microsoft_demangle.c
@@ -146,7 +146,7 @@ int copy_string(STypeCodeStr *type_code_str, char *str_for_copy, unsigned int co
 	}
 
 	if (str_for_copy) {
-		strcpy  (dst, str_for_copy);
+		r_str_ncpy  (dst, str_for_copy, str_for_copy_len + 1);
 	} else {
 		memset (dst, 0, str_for_copy_len);
 	}


### PR DESCRIPTION
The issue can be triggered by long (over 1033 bytes) symbol names in _pdb_ file. Usually default allocation can handle the copied string, but when it is large `strcpy` overruns destination buffer, since `str_for_copy_len` holds value of `copy_len` while the string itself is way longer.