### PR TITLE
Remove invalid sleep from cmd_open()

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1210,7 +1210,6 @@ static int cmd_open(void *data, const char *input) {
 		}
 		{
 			const char *argv0 = argv ? argv[0] : ptr;
-			void *bed = r_cons_sleep_begin ();
 			if ((file = r_core_file_open (core, argv0, perms, addr))) {
 				fd = file->fd;
 				if (!silence) {
@@ -1221,7 +1220,6 @@ static int cmd_open(void *data, const char *input) {
 				eprintf ("cannot open file %s\n", argv0);
 			}
 			r_str_argv_free (argv);
-			r_cons_sleep_end (bed);
 		}
 		r_core_block_read (core);
 		return 0;


### PR DESCRIPTION
This is more than just wrong. Sleep should only be used when absolutely no global stuff is accessed while active. And what is done here is the exact opposite of that.
Maybe something inside `r_core_file_open()` or `r_core_bin_load()` could be wrapped in sleep, but definitely not the whole functions.