### PR TITLE
Fix demangling of relocs and other imported symbols

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1369,6 +1369,7 @@ static void set_bin_relocs(RCore *r, RBinReloc *reloc, ut64 addr, Sdb **db, char
 			} else {
 				realname = sdb_fmt ("reloc.%s", demname);
 			}
+			r_name_filter(realname, 0);
 			r_flag_item_set_realname (fi, realname);
 		}
 	} else {


### PR DESCRIPTION
Hi there,
some of the reloc symbols are not shown demangled in the list of flags. This patch aims to fix this. Moreover this patch also aims to fix the issue described in https://github.com/radare/radare2/issues/12742

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64 
| r2 -v full output, **not truncated** (mandatory)     |radare2 3.3.0-git 20868 @ linux-x86-64 git.3.1.3-442-gaec7d579d commit: aec7d579dadcb2914cd1cbe5b27a16b3808a0a8c build: 2019-01-27__18:50:12

### Expected behavior
```
$ r2 bins/elf/demangle-test-cpp 
[0x000010d0]> f~reloc
0x00003fd8 8 reloc.__cxa_finalize
0x00003fe0 8 reloc._ITM_deregisterTMCloneTable
0x00003fe8 8 reloc.__libc_start_main
0x00003ff0 8 reloc.__gmon_start
0x00003ff8 8 reloc._ITM_registerTMCloneTable
0x00004018 8 reloc.std::__throw_bad_alloc
0x00004020 8 reloc.__cxa_begin_catch
0x00004028 8 reloc.std::__throw_length_error_charconst
0x00004030 8 reloc.operatordelete_void
0x00004038 8 reloc.operatornew_unsignedlong
0x00004040 8 reloc.__stack_chk_fail
0x00004048 8 reloc.__cxa_rethrow
0x00004050 8 reloc.memmove
0x00004058 8 reloc.__cxa_end_catch
0x00004060 8 reloc._Unwind_Resume
0x00004078 8 reloc.__gxx_personality_v0
```

### Actual behavior
```
$ r2 bins/elf/demangle-test-cpp
[0x000010d0]> f~reloc
0x00003fd8 8 reloc.__cxa_finalize
0x00003fe0 8 reloc._ITM_deregisterTMCloneTable
0x00003fe8 8 reloc.__libc_start_main
0x00003ff0 8 reloc.__gmon_start
0x00003ff8 8 reloc._ITM_registerTMCloneTable
0x00004018 8 reloc._ZSt17__throw_bad_allocv
0x00004020 8 reloc.__cxa_begin_catch
0x00004028 8 reloc._ZSt20__throw_length_errorPKc
0x00004030 8 reloc._ZdlPv
0x00004038 8 reloc._Znwm
0x00004040 8 reloc.__stack_chk_fail
0x00004048 8 reloc.__cxa_rethrow
0x00004050 8 reloc.memmove
0x00004058 8 reloc.__cxa_end_catch
0x00004060 8 reloc._Unwind_Resume
0x00004078 8 reloc.__gxx_personality_v0
```

### Steps to reproduce the behavior 
Execute the steps as shown above using extracted [demangle-test-cpp.zip](https://github.com/radare/radare2/files/2800321/demangle-test-cpp.zip)
