### PR TITLE
Introduce fnj command

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -37,6 +37,7 @@ static const char *help_msg_f[] = {
 	"fla"," [glob]","automatically compute the size of all flags matching glob",
 	"fm"," addr","move flag at current offset to new address",
 	"fn","","list flags displaying the real name (demangled)",
+	"fnj","","list flags displaying the real name (demangled) in JSON format",
 	"fo","","show fortunes",
 	"fO", " [glob]", "flag as ordinals (sym.* func.* method.*)",
 	//" fc [name] [cmt]  ; set execution command for a specific flag"
@@ -845,7 +846,7 @@ rep:
 		}
 		break;
 	case '\0':
-	case 'n': // "fn"
+	case 'n': // "fn" "fnj"
 	case '*': // "f*"
 	case 'j': // "fj"
 	case 'q': // "fq"


### PR DESCRIPTION
Introduce fnj command which behaves similar to fj, except for the fact that demangled names are used instead.

```
r2 bins/elf/demangle-test-cpp
[0x000010d0]> fnj~{245}
{"name":"reloc.operatordelete(void*)","size":8,"offset":16432}
[0x000010d0]> fj~{245}
{"name":"reloc._ZdlPv","size":8,"offset":16432}
```