### PR TITLE
Fix aae - set pc to current offset

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4427,6 +4427,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 				continue;
 			}
 			r_anal_esil_set_pc (ESIL, cur);
+			r_reg_setv(core->anal->reg, pcname, cur + op.size);
 			(void)r_anal_esil_parse (ESIL, esilstr);
 			// looks like ^C is handled by esil_parse !!!!
 			//r_anal_esil_dumpstack (ESIL);


### PR DESCRIPTION
Hi there,
when executing `aae` the pc register (in case of x96 64 rip) is not set to the current offset. This leads to weird behaviour when analyzing refs. For instance when looking into the example below: At first `lea rax, [0x00003d50]` (ESIL: `0x2743,rip,+,rax,=`) shall be emulated. This results in `0x3d13` being written into `rax` and also being added as reference. This patch aims to fix this.

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.3.0-git 20822 @ linux-x86-64 git.3.1.3-443-g99f27b6ee commit: 99f27b6ee97aaf5ad405ba012f642bd8022c8b68 build: 2019-01-28__15:37:42

### Expected behavior
```
$ r2 animals
[0x00001250]> aaa
[0x00001250]> s sym.Bat::Bat
[0x000015f0]> agrj~{}
... same as current
[0x000015f0]> aae
[0x000015f0]> agrj~{}
{
  "nodes": [
    {
      "id": 0,
      "title": "sym.Bat::Bat",
      "body": "",
      "out_nodes": [
        1,
        2,
        3,
        4,
        5,
        6,
        7,
        2,
        2,
        8
      ]
    },
    {
      "id": 1,
      "title": "method.Mammal.Mammal",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 2,
      "title": "0x00000008",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 3,
      "title": "0x00002080",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 4,
      "title": "method.Bird.Bird",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 5,
      "title": "0x00003d50",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 6,
      "title": "str.Bat::Bat",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 7,
      "title": "0x00003d20",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 8,
      "title": "method.std::basic_ostream_char_std::char_traits_char___std::operator___std.char_traits_char___std::basic_ostream_char_std::char_traits_char____charconst___clone.constprop.2",
      "body": "",
      "out_nodes": [
        
      ]
    }
  ]
}

```

### Actual behavior
```
$ r2 animals
[0x00001250]> aaa
[0x00001250]> s sym.Bat::Bat
[0x000015f0]> agf
[0x000015f0]> VV @ sym.Bat::Bat (nodes 1 edges 0 zoom 100%) BB-NORM mouse:canvas-y mov-speed:5
.---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------.
|  0x15f0                                                                                                                                                                               |
| ;-- method.Bat.Bat:                                                                                                                                                                   |
| (fcn) sym.Bat::Bat 75                                                                                                                                                                 |
|   sym.Bat::Bat (int arg1);                                                                                                                                                            |
| ; var int local_8h @ rsp+0x8                                                                                                                                                          |
| ; arg int arg1 @ rdi                                                                                                                                                                  |
| ; CALL XREF from sym.main (0x11a3)                                                                                                                                                    |
| ; CALL XREF from sym.Bat2::Bat2 (0x1648)                                                                                                                                              |
| push rbx                                                                                                                                                                              |
| ; arg1                                                                                                                                                                                |
| mov rbx, rdi                                                                                                                                                                          |
| sub rsp, 0x10                                                                                                                                                                         |
| call sym.Mammal::Mammal;[ga]                                                                                                                                                          |
| lea rdi, [rbx + 8]                                                                                                                                                                    |
| call sym.Bird::Bird;[gb]                                                                                                                                                              |
| lea rax, [0x00003d50]                                                                                                                                                                 |
| ; 0x2084                                                                                                                                                                              |
| ; "Bat::Bat\n"                                                                                                                                                                        |
| lea rdi, str.Bat::Bat                                                                                                                                                                 |
| lea rdx, [rax - 0x30]                                                                                                                                                                 |
| mov qword [local_8h], rdx                                                                                                                                                             |
| ; [0x8:8]=0                                                                                                                                                                           |
| movq xmm0, qword [local_8h]                                                                                                                                                           |
| mov qword [local_8h], rax                                                                                                                                                             |
| ; [0x8:8]=0                                                                                                                                                                           |
| movhps xmm0, qword [local_8h]                                                                                                                                                         |
| movups xmmword [rbx], xmm0                                                                                                                                                            |
| call sym.std::basic_ostream_char_std::char_traits_char___std::operator___std::char_traits_char___std::basic_ostream_char_std::char_traits_char____charconst___clone.constprop.2;[gc]  |
| add rsp, 0x10                                                                                                                                                                         |
| pop rbx                                                                                                                                                                               |
| ret                                                                                                                                                                                   |
`---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------'
[0x000015f0]> agrj~{}
{
  "nodes": [
    {
      "id": 0,
      "title": "sym.Bat::Bat",
      "body": "",
      "out_nodes": [
        1,
        2,
        3,
        4,
        5,
        2,
        2,
        6
      ]
    },
    {
      "id": 1,
      "title": "method.Mammal.Mammal",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 2,
      "title": "0x00000008",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 3,
      "title": "method.Bird.Bird",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 4,
      "title": "0x00003d50",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 5,
      "title": "str.Bat::Bat",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 6,
      "title": "method.std::basic_ostream_char_std::char_traits_char___std::operator___std.char_traits_char___std::basic_ostream_char_std::char_traits_char____charconst___clone.constprop.2",
      "body": "",
      "out_nodes": [
        
      ]
    }
  ]
}
[0x000015f0]> aae
[0x000015f0]> agrj~{}
{
  "nodes": [
    {
      "id": 0,
      "title": "sym.Bat::Bat",
      "body": "",
      "out_nodes": [
        1,
        2,
        3,
        4,
        5,
        6,
        7,
        8,
        9,
        2,
        2,
        10
      ]
    },
    {
      "id": 1,
      "title": "method.Mammal.Mammal",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 2,
      "title": "0x00000008",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 3,
      "title": "0x00000a9e",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 4,
      "title": "method.Bird.Bird",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 5,
      "title": "0x00003d13",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 6,
      "title": "0x00003d50",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 7,
      "title": "0x00002040",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 8,
      "title": "str.Bat::Bat",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 9,
      "title": "0x00003ce3",
      "body": "",
      "out_nodes": [
        
      ]
    },
    {
      "id": 10,
      "title": "method.std::basic_ostream_char_std::char_traits_char___std::operator___std.char_traits_char___std::basic_ostream_char_std::char_traits_char____charconst___clone.constprop.2",
      "body": "",
      "out_nodes": [
        
      ]
    }
  ]
}
```

### Steps to reproduce the behavior 
Execute steps as shown above using  [animals.zip](https://github.com/radare/radare2/files/2803544/animals.zip)