### PR TITLE
Fix avj - in case of no vtables [] shall be returned

### DIFF
--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -233,9 +233,6 @@ R_API void r_anal_list_vtables(RAnal *anal, int rad) {
 	RVTableInfo* table;
 
 	RList* vtables = r_anal_vtable_search (&context);
-	if (!vtables) {
-		return;
-	}
 
 	if (rad == 'j') {
 		bool isFirstElement = true;


### PR DESCRIPTION
Hi,
when executing `avj` in cases where no virtual tables are present nothing is returned. This is not "broken" per se, but differs from the behavior of other output-in-json-commands. For instance when using r2pipe in python NoneType is returned in such a case. In other cases (i.e. `dmj`) an empty list is returned if there is nothing to show. This patch aims to fix this.

Please note that removing that check has no impact on the behavior of the function, except that it prints `[]` in the case described above, because each further action is covered by a `r_list_foreach`-statement which does nothing in case the given list is a nullptr. 

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro X86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.3.0-git 20822 @ linux-x86-64 git.3.1.3-443-g99f27b6ee commit: 99f27b6ee97aaf5ad405ba012f642bd8022c8b68 build: 2019-01-28__15:37:42

### Expected behavior
```
$ r2 /usr/bin/file
[0x00002ce0]> av
No virtual tables found
[0x00002ce0]> avj
No virtual tables found
[]
```

### Actual behavior
```
$ r2 /usr/bin/file
[0x00002ce0]> av
No virtual tables found
[0x00002ce0]> avj
No virtual tables found
```

### Steps to reproduce the behavior 
Execute the steps above using  [file.zip](https://github.com/radare/radare2/files/2803875/file.zip)

