### PR TITLE
Fixed issue 12934

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2655,13 +2655,14 @@ static void cmd_print_pv(RCore *core, const char *input, const ut8* block) {
 
 static int cmd_print_blocks(RCore *core, const char *input) {
 	char mode = input[0];
+	while (mode && mode != ' ') {
+		input++;
+		mode = input[0];
+	}
+
 	if (mode == '?') {
 		r_core_cmd_help (core, help_msg_p_minus);
 		return 0;
-	}
-
-	if (mode && mode != ' ') {
-		input++;
 	}
 
 	int w = (input[0] == ' ')

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2655,19 +2655,23 @@ static void cmd_print_pv(RCore *core, const char *input, const ut8* block) {
 
 static int cmd_print_blocks(RCore *core, const char *input) {
 	char mode = input[0];
-	while (mode && mode != ' ') {
-		input++;
-		mode = input[0];
-	}
-
 	if (mode == '?') {
 		r_core_cmd_help (core, help_msg_p_minus);
 		return 0;
 	}
 
+	if (mode && mode != ' '){
+		input++;
+	}
+
 	int w = (input[0] == ' ')
 		? (int)r_num_math (core->num, input + 1)
 		: (int)(core->print->cols * 2.7);
+
+	if (w == 0){
+		r_core_cmd_help (core, help_msg_p_minus);
+		return 0;
+	}
 
 	ut64 off = core->offset;
 	ut64 from = UT64_MAX;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -793,7 +793,7 @@ static void cmd_pCx(RCore *core, const char *input, const char *xcmd) {
 	r_config_set_i (core->config, "hex.cols", hex_cols);
 }
 
-static char get_string_type(const ut8 *buf, ut64 len){
+static char get_string_type(const ut8 *buf, ut64 len) {
 	ut64 needle = 0;
 	int rc, i;
 	char str_type = 0;
@@ -868,7 +868,7 @@ static void cmd_print_eq_dict(RCore *core, const ut8 *block, int bsz) {
 	r_cons_printf ("size (of block):  %d  0x%x\n", bsz, bsz);
 }
 
-R_API void r_core_set_asm_configs(RCore *core, char *arch, ut32 bits, int segoff){
+R_API void r_core_set_asm_configs(RCore *core, char *arch, ut32 bits, int segoff) {
 	r_config_set (core->config, "asm.arch", arch);
 	r_config_set_i (core->config, "asm.bits", bits);
 	// XXX - this needs to be done here, because
@@ -2660,7 +2660,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 		return 0;
 	}
 
-	if (mode && mode != ' '){
+	if (mode && mode != ' ') {
 		input++;
 	}
 
@@ -2668,7 +2668,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 		? (int)r_num_math (core->num, input + 1)
 		: (int)(core->print->cols * 2.7);
 
-	if (w == 0){
+	if (w == 0) {
 		r_core_cmd_help (core, help_msg_p_minus);
 		return 0;
 	}


### PR DESCRIPTION
Before, w could be 0 in special cases at line 2667, therefore crashing at line 2690 due to a division by 0. Now it gets rid of all spaces in between commands. 
*Note that code line numbers have changed, I am referring to old code line numbers*