### PR TITLE
PE parsing: Fix the call to parse_symbol_table to correctly append the COFF symbols

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2745,7 +2745,7 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 		}
 		exports[i].last = 1;
 	}
-	exp = parse_symbol_table (bin, exports, exports_sz - 1);
+	exp = parse_symbol_table (bin, exports, exports_sz - sizeof (struct r_bin_pe_export_t));
 	if (exp) {
 		exports = exp;
 	}


### PR DESCRIPTION
Fix #12940 