### PR TITLE
Revert "Fix PDB crash freeing streams with the right function instead…

### DIFF
--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -552,17 +552,17 @@ static void finish_pdb_parse(R_PDB *pdb) {
 		switch (i) {
 		case 1:
 			pdb_info_stream = (SPDBInfoStream *) r_list_iter_get (it);
-			free_pdb_stream (pdb_info_stream);
+			pdb_info_stream->free_(pdb_info_stream);
 			free (pdb_info_stream);
 			break;
 		case 2:
 			tpi_stream = (STpiStream *) r_list_iter_get (it);
-			free_pdb_stream (tpi_stream);
+			tpi_stream->free_(tpi_stream);
 			free (tpi_stream);
 			break;
 		case 3:
 			dbi_stream = (SDbiStream *) r_list_iter_get (it);
-			free_pdb_stream (dbi_stream);
+			dbi_stream->free_(dbi_stream);
 			free (dbi_stream);
 			break;
 		default:
@@ -571,7 +571,7 @@ static void finish_pdb_parse(R_PDB *pdb) {
 				break;
 			}
 			pdb_stream = (R_PDB_STREAM *) r_list_iter_get (it);
-			free_pdb_stream (pdb_stream);
+			pdb_stream->free_(pdb_stream);
 			free (pdb_stream);
 			break;
 		}


### PR DESCRIPTION
… of assuming the delegate is not corrupted ##bin"

This reverts commit 42f6272c34799958db5b09ac8eb8442991931aba.