### PR TITLE
WIP: Bincurat

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -937,3 +937,23 @@ R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file, RList/*<RBin
 	r_hash_free (ctx);
 	return true;
 }
+
+R_API RBinFile *r_bin_file_at(RBin *bin, ut64 addr) {
+	RBinFile *bf;
+	RListIter *iter;
+	RBinFile *obf = bin->cur; // XXX this must die
+	r_list_foreach (bin->binfiles, iter, bf) {
+		bin->cur = bf;
+		RList *sections = r_bin_get_sections (bin);
+		r_list_foreach (sections, iter, s) {
+			ut64 from = s->vaddr;
+			ut64 to = from + s->vsize;
+			if (R_BETWEEN (from, addr, to)) {
+				bin->cur = obf;
+				return bf;
+			}
+		}
+	}
+	bin->cur = obf;
+	return NULL;
+}

--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -948,7 +948,7 @@ R_API RBinFile *r_bin_file_at(RBin *bin, ut64 addr) {
 		r_list_foreach (sections, iter, s) {
 			ut64 from = s->vaddr;
 			ut64 to = from + s->vsize;
-			if (R_BETWEEN (from, addr, to)) {
+			if (R_BETWEEN (from, addr, to - 1)) {
 				bin->cur = obf;
 				return bf;
 			}

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -264,6 +264,7 @@ R_API void r_cons_strcat_at(const char *_str, int x, char y, int w, int h) {
 		}
 	}
 	if (len > 1) {
+		r_cons_gotoxy (x, y + rows);
 		r_cons_memcat (str + o, len);
 	}
 	r_cons_strcat (Color_RESET);

--- a/libr/core/vmenus_graph.c
+++ b/libr/core/vmenus_graph.c
@@ -205,7 +205,7 @@ R_API int __core_visual_view_graph_update(RCore *core, RCoreVisualViewGraph *sta
 	char *output = r_core_cmd_strf (core, "pd %d @e:asm.flags=0@ 0x%08"PFMT64x"; pds 256 @ 0x%08"PFMT64x"\n",
 		32, status->addr);
 	int disy = colh + 2;
-	r_cons_strcat_at (output, 10, disy, w, h-disy);
+	r_cons_strcat_at (output, 0, disy, w, h - disy);
 	free (output);
 	r_cons_flush();
 

--- a/libr/core/vmenus_graph.c
+++ b/libr/core/vmenus_graph.c
@@ -205,7 +205,7 @@ R_API int __core_visual_view_graph_update(RCore *core, RCoreVisualViewGraph *sta
 	char *output = r_core_cmd_strf (core, "pd %d @e:asm.flags=0@ 0x%08"PFMT64x"; pds 256 @ 0x%08"PFMT64x"\n",
 		32, status->addr);
 	int disy = colh + 2;
-	r_cons_strcat_at (output, 0, disy, w, h - disy);
+	r_cons_strcat_at (output, 10, disy, w, h - disy);
 	free (output);
 	r_cons_flush();
 


### PR DESCRIPTION
Random related comments:

* Should be r_bin_file_current()... but.. we really want to have that? i mean, a default binfile? and we should use descriptors, not pointers
* same happens with R_IO which assumes there's a current "filedescriptor".. this is in siol-speak used only when working in non-va mode

This function spots a bunch of bad design decisions in RBin and its not used anywhere yet, lets keep it as is for now.