### PR TITLE
Fix env. vars. not being parsed in !! in Windows

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -552,7 +552,7 @@ R_API void r_cons_grepbuf() {
 	while ((int) (size_t) (in - buf) < len) {
 		char *p = strchr (in, '\n');
 		if (!p) {
-			return;
+			break;
 		}
 		l = p - in;
 		if (l > 0) {
@@ -584,9 +584,9 @@ R_API void r_cons_grepbuf() {
 			if (ret > 0) {
 				if (show) {
 					char *str = r_str_ndup (tline, ret);
-					int i;
-					for (i = 0; i < grep->nstrings; i++) {
-						if (cons->grep_highlight) {
+					if (cons->grep_highlight) {
+						int i;
+						for (i = 0; i < grep->nstrings; i++) {
 							char *newstr = r_str_newf (Color_INVERT"%s"Color_RESET, grep->strings[i]);
 							if (str && newstr) {
 								if (grep->icase) {

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -619,6 +619,7 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 	}
 	if (output) {
 		*output = result;
+		*len = strlen (result);
 	}
 	if (result) {
 		return true;

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -91,6 +91,7 @@ R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE out) {
 	PROCESS_INFORMATION pi = {0};
 	STARTUPINFO si = {0};
 	LPTSTR cmdline_;
+	char _cmdline_[32768];
 	bool ret;
 
 	// Set up members of the STARTUPINFO structure.
@@ -101,15 +102,16 @@ R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE out) {
 	si.hStdInput = NULL;
 	si.dwFlags |= STARTF_USESTDHANDLES;
 	cmdline_ = r_sys_conv_utf8_to_utf16 (cmdline);
+	ExpandEnvironmentStrings (cmdline_, _cmdline_, 32767);
 	if ((ret = CreateProcess (NULL,
-			cmdline_,// command line
+			_cmdline_,     // command line
 			NULL,          // process security attributes
 			NULL,          // primary thread security attributes
 			TRUE,          // handles are inherited
 			0,             // creation flags
 			NULL,          // use parent's environment
 			NULL,          // use parent's current directory
-			&si,  // STARTUPINFO pointer
+			&si,           // STARTUPINFO pointer
 			&pi))) {  // receives PROCESS_INFORMATION 
 		ret = 1;
 		CloseHandle (pi.hProcess);

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -91,8 +91,14 @@ R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE out) {
 	PROCESS_INFORMATION pi = {0};
 	STARTUPINFO si = {0};
 	LPTSTR cmdline_;
-	char _cmdline_[32768];
 	bool ret;
+	const size_t max_length = 32768;
+	char *_cmdline_ = malloc (max_length);
+
+	if (!_cmdline_) {
+		R_LOG_ERROR ("Failed to allocate memory\n");
+		return false;
+	}
 
 	// Set up members of the STARTUPINFO structure.
 	// This structure specifies the STDIN and STDOUT handles for redirection.
@@ -102,7 +108,7 @@ R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE out) {
 	si.hStdInput = NULL;
 	si.dwFlags |= STARTF_USESTDHANDLES;
 	cmdline_ = r_sys_conv_utf8_to_utf16 (cmdline);
-	ExpandEnvironmentStrings (cmdline_, _cmdline_, 32767);
+	ExpandEnvironmentStrings (cmdline_, _cmdline_, max_length - 1);
 	if ((ret = CreateProcess (NULL,
 			_cmdline_,     // command line
 			NULL,          // process security attributes


### PR DESCRIPTION
This will hopefully fix some tests that are failing for Windows.