### PR TITLE
Fix assembler for Windows

### DIFF
--- a/libr/asm/arch/arm/armass.c
+++ b/libr/asm/arch/arm/armass.c
@@ -443,7 +443,7 @@ static ut64 getnum(const char *str) {
 	while (*str == '$' || *str == '#') {
 		str++;
 	}
-	val = strtol (str, &endptr, 0);
+	val = strtoll (str, &endptr, 0);
 	if (str != endptr && *endptr == '\0') {
 		return val;
 	}
@@ -565,7 +565,7 @@ static ut32 getthimmed12(const char *str) {
 	ut64 result = 0;
 	if (num <= 0xff) {
 		return num << 8;
-	} else 	if ( ((num & 0xff00ff00) == 0) && ((num & 0x00ff0000) == ((num & 0x000000ff) << 16)) ) {
+	} else if ( ((num & 0xff00ff00) == 0) && ((num & 0x00ff0000) == ((num & 0x000000ff) << 16)) ) {
 		result |= (num & 0x000000ff) << 8;
 		result |= 0x00000010;
 		return result;

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -107,7 +107,7 @@ typedef struct operand_t {
 	};
 	union {
 		struct {
-			long offset;
+			ut64 offset;
 			st8 offset_sign;
 			Register regs[2];
 			int scale[2];


### PR DESCRIPTION
This fixes all failing assembler tests for Windows (I think).