### PR TITLE
Add user * to REvent Hooking

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -26,35 +26,35 @@ R_API void r_anal_unset_limits(RAnal *anal) {
 }
 
 static void meta_unset_for(REvent *ev, int type, void *user, void *data) {
-	RSpaces *s = (RSpaces *)user;
+	RSpaces *s = (RSpaces *)ev->user;
 	RAnal *anal = container_of (s, RAnal, meta_spaces);
 	RSpaceEvent *se = (RSpaceEvent *)data;
 	r_meta_space_unset_for (anal, se->data.unset.space);
 }
 
 static void meta_count_for(REvent *ev, int type, void *user, void *data) {
-	RSpaces *s = (RSpaces *)user;
+	RSpaces *s = (RSpaces *)ev->user;
 	RAnal *anal = container_of (s, RAnal, meta_spaces);
 	RSpaceEvent *se = (RSpaceEvent *)data;
 	se->res = r_meta_space_count_for (anal, se->data.count.space);
 }
 
 static void zign_unset_for(REvent *ev, int type, void *user, void *data) {
-	RSpaces *s = (RSpaces *)user;
+	RSpaces *s = (RSpaces *)ev->user;
 	RAnal *anal = container_of (s, RAnal, zign_spaces);
 	RSpaceEvent *se = (RSpaceEvent *)data;
 	r_sign_space_unset_for (anal, se->data.unset.space);
 }
 
 static void zign_count_for(REvent *ev, int type, void *user, void *data) {
-	RSpaces *s = (RSpaces *)user;
+	RSpaces *s = (RSpaces *)ev->user;
 	RAnal *anal = container_of (s, RAnal, zign_spaces);
 	RSpaceEvent *se = (RSpaceEvent *)data;
 	se->res = r_sign_space_count_for (anal, se->data.count.space);
 }
 
 static void zign_rename_for(REvent *ev, int type, void *user, void *data) {
-	RSpaces *s = (RSpaces *)user;
+	RSpaces *s = (RSpaces *)ev->user;
 	RAnal *anal = container_of (s, RAnal, zign_spaces);
 	RSpaceEvent *se = (RSpaceEvent *)data;
 	r_sign_space_rename_for (anal, se->data.rename.space,
@@ -167,13 +167,13 @@ R_API RAnal *r_anal_new() {
 	anal->opt.depth = 32;
 	anal->opt.noncode = false; // do not analyze data by default
 	r_spaces_init (&anal->meta_spaces, "CS");
-	r_event_hook (anal->meta_spaces.event, R_SPACE_EVENT_UNSET, meta_unset_for);
-	r_event_hook (anal->meta_spaces.event, R_SPACE_EVENT_COUNT, meta_count_for);
+	r_event_hook (anal->meta_spaces.event, R_SPACE_EVENT_UNSET, meta_unset_for, NULL);
+	r_event_hook (anal->meta_spaces.event, R_SPACE_EVENT_COUNT, meta_count_for, NULL);
 
 	r_spaces_init (&anal->zign_spaces, "zs");
-	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_UNSET, zign_unset_for);
-	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_COUNT, zign_count_for);
-	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_RENAME, zign_rename_for);
+	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_UNSET, zign_unset_for, NULL);
+	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_COUNT, zign_count_for, NULL);
+	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_RENAME, zign_rename_for, NULL);
 	anal->sdb_fcns = sdb_ns (anal->sdb, "fcns", 1);
 	anal->sdb_meta = sdb_ns (anal->sdb, "meta", 1);
 	anal->sdb_hints = sdb_ns (anal->sdb, "hints", 1);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2296,7 +2296,7 @@ R_API bool r_core_init(RCore *core) {
 	}
 	r_core_setenv (core);
 	core->ev = r_event_new (core);
-	r_event_hook (core->ev, R_EVENT_ALL, cb_event_handler);
+	r_event_hook (core->ev, R_EVENT_ALL, cb_event_handler, NULL);
 	core->lock = r_th_lock_new (true);
 	core->max_cmd_depth = R_CORE_CMD_DEPTH + 1;
 	core->cmd_depth = core->max_cmd_depth;

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -202,14 +202,14 @@ static bool unset_flags_space(RFlagItem *fi, void *user) {
 }
 
 static void count_flags_in_space(REvent *ev, int type, void *user, void *data) {
-	RSpaces *sp = (RSpaces *)user;
+	RSpaces *sp = (RSpaces *)ev->user;
 	RFlag *f = container_of (sp, RFlag, spaces);
 	RSpaceEvent *spe = (RSpaceEvent *)data;
 	r_flag_foreach_space (f, spe->data.count.space, count_flags, &spe->res);
 }
 
 static void unset_flagspace(REvent *ev, int type, void *user, void *data) {
-	RSpaces *sp = (RSpaces *)user;
+	RSpaces *sp = (RSpaces *)ev->user;
 	RFlag *f = container_of (sp, RFlag, spaces);
 	const RSpaceEvent *spe = (const RSpaceEvent *)data;
 	r_flag_foreach_space (f, spe->data.unset.space, unset_flags_space, NULL);
@@ -217,8 +217,8 @@ static void unset_flagspace(REvent *ev, int type, void *user, void *data) {
 
 static void new_spaces(RFlag *f) {
 	r_spaces_init (&f->spaces, "fs");
-	r_event_hook (f->spaces.event, R_SPACE_EVENT_COUNT, count_flags_in_space);
-	r_event_hook (f->spaces.event, R_SPACE_EVENT_UNSET, unset_flagspace);
+	r_event_hook (f->spaces.event, R_SPACE_EVENT_COUNT, count_flags_in_space, NULL);
+	r_event_hook (f->spaces.event, R_SPACE_EVENT_UNSET, unset_flagspace, NULL);
 }
 
 R_API RFlag *r_flag_new() {

--- a/libr/include/r_util/r_event.h
+++ b/libr/include/r_util/r_event.h
@@ -15,7 +15,7 @@ typedef struct r_event_t {
 	bool incall;
 	HtUP *callbacks;
 	RVector *all_callbacks;
-	int hook_handle_next;
+	int next_handle;
 } REvent;
 
 typedef struct r_event_callback_handle_t {

--- a/libr/include/r_util/r_event.h
+++ b/libr/include/r_util/r_event.h
@@ -13,7 +13,16 @@ typedef struct r_event_t {
 	void *user;
 	bool incall;
 	HtUP *callbacks;
+	int hook_handle_next;
 } REvent;
+
+typedef void (*REventCallback)(REvent *ev, int type, void *user, void *data);
+
+typedef struct r_event_callback_hook_t {
+	REventCallback cb;
+	void *user;
+	int handle;
+} REventCallbackHook;
 
 typedef enum {
 	R_EVENT_ALL = 0,
@@ -29,12 +38,11 @@ typedef struct r_event_meta_t {
 	const char *string;
 } REventMeta;
 
-typedef void (*REventCallback)(REvent *ev, int type, void *user, void *data);
 
 R_API REvent *r_event_new(void *user);
 R_API void r_event_free(REvent *ev);
-R_API void r_event_hook(REvent *ev, int type, REventCallback cb);
-R_API void r_event_unhook(REvent *ev, int type, REventCallback cb);
+R_API int r_event_hook(REvent *ev, int type, REventCallback cb, void *user);
+R_API void r_event_unhook(REvent *ev, int type, int handle);
 R_API void r_event_send(REvent *ev, int type, void *data);
 
 #ifdef __cplusplus

--- a/libr/include/r_util/r_event.h
+++ b/libr/include/r_util/r_event.h
@@ -16,13 +16,12 @@ typedef struct r_event_t {
 	int hook_handle_next;
 } REvent;
 
-typedef void (*REventCallback)(REvent *ev, int type, void *user, void *data);
-
-typedef struct r_event_callback_hook_t {
-	REventCallback cb;
-	void *user;
+typedef struct r_event_callback_handle_t {
 	int handle;
-} REventCallbackHook;
+	int type;
+} REventCallbackHandle;
+
+typedef void (*REventCallback)(REvent *ev, int type, void *user, void *data);
 
 typedef enum {
 	R_EVENT_ALL = 0,
@@ -41,8 +40,8 @@ typedef struct r_event_meta_t {
 
 R_API REvent *r_event_new(void *user);
 R_API void r_event_free(REvent *ev);
-R_API int r_event_hook(REvent *ev, int type, REventCallback cb, void *user);
-R_API void r_event_unhook(REvent *ev, int type, int handle);
+R_API REventCallbackHandle r_event_hook(REvent *ev, int type, REventCallback cb, void *user);
+R_API void r_event_unhook(REvent *ev, REventCallbackHandle handle);
 R_API void r_event_send(REvent *ev, int type, void *data);
 
 #ifdef __cplusplus

--- a/libr/include/r_util/r_event.h
+++ b/libr/include/r_util/r_event.h
@@ -8,11 +8,13 @@ extern "C" {
 #endif
 
 #include <sdb/ht_up.h>
+#include <r_vector.h>
 
 typedef struct r_event_t {
 	void *user;
 	bool incall;
 	HtUP *callbacks;
+	RVector *all_callbacks;
 	int hook_handle_next;
 } REvent;
 

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -125,6 +125,10 @@ R_API void *r_vector_shrink(RVector *vec);
 	if ((vec) && (vec)->a) \
 		for (it = (void *)(vec)->a; (char *)it != (char *)(vec)->a + ((vec)->len * (vec)->elem_size); it = (void *)((char *)it + (vec)->elem_size))
 
+#define r_vector_enumerate(vec, it, i) \
+	if ((vec) && (vec)->a) \
+		for (it = (void *)(vec)->a, i = 0; i < (vec)->len; it = (void *)((char *)it + (vec)->elem_size), i++)
+
 
 // RPVector
 


### PR DESCRIPTION
Unit tests for REvent: https://github.com/radare/radare2-regressions/pull/1677

After these changes, the ht uses RVector<REventCallbackHook> as the key instead of RPVector. Also, hooked callbacks are referred by a unique handle.