### PR TITLE
Fix Windows path with / in the last position

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -211,12 +211,9 @@ R_API char *r_file_abspath(const char *file) {
 			return strdup (file);
 		}
 		if (cwd && !strchr (file, ':')) {
-			int len = strlen (file) - 1;
-			char * nfile = file[len] == '/' ? r_str_ndup (file, len) : file;
+			char * nfile = r_str_ndup (file, strlen (file) - r_str_endswith (file, "/"));
 			ret = r_str_newf ("%s\\%s", cwd, nfile);
-			if (nfile != file) {
-				free (nfile);
-			}
+			free (nfile);
 		}
 #endif
 	}

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -212,13 +212,11 @@ R_API char *r_file_abspath(const char *file) {
 		}
 		if (cwd && !strchr (file, ':')) {
 			int len = strlen (file) - 1;
-			char * nfile;
-			if (file[len] == '/') {
-				nfile = r_str_ndup (file, len);
-			} else {
-				nfile = file;
-			}
+			char * nfile = file[len] == '/' ? r_str_ndup (file, len) : file;
 			ret = r_str_newf ("%s\\%s", cwd, nfile);
+			if (nfile != file) {
+				free (nfile);
+			}
 		}
 #endif
 	}

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -211,7 +211,14 @@ R_API char *r_file_abspath(const char *file) {
 			return strdup (file);
 		}
 		if (cwd && !strchr (file, ':')) {
-			ret = r_str_newf ("%s\\%s", cwd, file);
+			int len = strlen (file) - 1;
+			char * nfile;
+			if (file[len] == '/') {
+				nfile = r_str_ndup (file, len);
+			} else {
+				nfile = file;
+			}
+			ret = r_str_newf ("%s\\%s", cwd, nfile);
 		}
 #endif
 	}


### PR DESCRIPTION
Before, if you set for example:
`e dir.projects = myprojects/`
It would result in an invalid path when creating a file:
`C:\path\to\myprojects/\file`