### PR TITLE
Better fix for abspath for Windows

### DIFF
--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -440,18 +440,18 @@ static int cmd_cp(void *data, const char *input) {
 		eprintf ("Usage: cp.orig  # cp $file $file.orig\n");
 		return false;
 	}
-	char *src = strdup (input + 2);
-	char *dst = strchr (src, ' ');
-	if (dst) {
-		*dst++ = 0;
-		r_str_trim (src);
-		r_str_trim (dst);
-		bool rc = r_file_copy (src, dst);
-		free (src);
-		return rc;
+	char *cmd = strdup (input + 2);
+	if (cmd) {
+		char **files = r_str_argv (cmd, NULL);
+		if (files[0] && files[1]) {
+			bool rc = r_file_copy (files[0], files[1]);
+			free (cmd);
+			free (files);
+			return rc;
+		}
+		free (files);
 	}
 	eprintf ("Usage: cp src dst\n");
-	free (src);
 	return false;
 }
 

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -190,13 +190,14 @@ R_API int r_file_is_abspath(const char *file) {
 }
 
 R_API char *r_file_abspath(const char *file) {
-	char *ret = NULL;
+	char *cwd, *ret = NULL;
 	if (!file || !strcmp (file, ".") || !strcmp (file, "./")) {
 		return r_sys_getdir ();
 	}
 	if (strstr (file, "://")) {
 		return strdup (file);
 	}
+	cwd = r_sys_getdir ();
 	if (!strncmp (file, "~/", 2) || !strncmp (file, "~\\", 2)) {
 		ret = r_str_home (file + 2);
 	} else {
@@ -219,6 +220,7 @@ R_API char *r_file_abspath(const char *file) {
 		}
 #endif
 	}
+	free (cwd);
 	if (!ret) {
 		ret = strdup (file);
 	}

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1052,8 +1052,8 @@ R_API bool r_file_copy (const char *src, const char *dst) {
 #if HAVE_COPYFILE_H
 	return copyfile (src, dst, 0, COPYFILE_DATA | COPYFILE_XATTR) != -1;
 #elif __WINDOWS__
-	char *esrc = r_str_replace (strdup (src), "\"", "^\"", 1);
-	char *edst = r_str_replace (strdup (dst), "\"", "^\"", 1);
+	char *esrc = r_str_replace (strdup (src), "\"", "\"\"", 1);
+	char *edst = r_str_replace (strdup (dst), "\"", "\"\"", 1);
 	char *s = r_file_abspath (esrc);
 	char *d = r_file_abspath (edst);
 	bool ret = r_sys_cmdf ("copy \"%s\" \"%s\"", s, d);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1052,15 +1052,14 @@ R_API bool r_file_copy (const char *src, const char *dst) {
 #if HAVE_COPYFILE_H
 	return copyfile (src, dst, 0, COPYFILE_DATA | COPYFILE_XATTR) != -1;
 #elif __WINDOWS__
-	char *esrc = r_str_replace (strdup (src), "\"", "\"\"", 1);
-	char *edst = r_str_replace (strdup (dst), "\"", "\"\"", 1);
-	char *s = r_file_abspath (esrc);
-	char *d = r_file_abspath (edst);
-	bool ret = r_sys_cmdf ("copy \"%s\" \"%s\"", s, d);
+	char *s = r_file_abspath (src);
+	char *d = r_file_abspath (dst);
+	bool ret = CopyFile (s, d, 0);
+	if (!ret) {
+		eprintf ("File not found\n");
+	}
 	free (s);
 	free (d);
-	free (esrc);
-	free (edst);
 	return ret;
 #else
 	char *src2 = r_str_replace (strdup (src), "'", "\\'", 1);


### PR DESCRIPTION
This uses the native Windows API to do the parsing.
Fixes the problems it had with `../example` paths and `folder/file`
+Fix for copy command