### PR TITLE
Added usable prefix field for oLj command

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -158,6 +158,7 @@ typedef struct r_io_plugin_t {
 	char *author;
 	char *license;
 	void *widget;
+	const char *uris;
 	int (*listener)(RIODesc *io);
 	int (*init)(void);
 	RIOUndo undo;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -92,8 +92,9 @@ static int r_io_ar_close(RIODesc *fd) {
 
 RIOPlugin r_io_plugin_ar = {
 	.name = "ar",
-	.desc = "Open ar/lib files [ar|lib]://[file//path]",
+	.desc = "Open ar/lib files",
 	.license = "LGPL3",
+	.uris = "ar://,lib://",
 	.open = r_io_ar_open,
 	.open_many = r_io_ar_open_many,
 	.write = r_io_ar_write,

--- a/libr/io/p/io_bfdbg.c
+++ b/libr/io/p/io_bfdbg.c
@@ -194,8 +194,9 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_bfdbg = {
 	.name = "bfdbg",
-	.desc = "BrainFuck Debugger (bfdbg://path/to/file)",
+	.desc = "Attach to brainFuck Debugger instance",
 	.license = "LGPL3",
+	.uris = "bfdbg://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_bochs.c
+++ b/libr/io/p/io_bochs.c
@@ -108,8 +108,9 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 
 RIOPlugin r_io_plugin_bochs = {
 	.name = "bochs",
-	.desc = "Attach to a BOCHS debugger",
+	.desc = "Attach to a BOCHS debugger instance",
 	.license = "LGPL3",
+	.uris = "bochs://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -648,8 +648,9 @@ static int __close (RIODesc *desc) {
 
 RIOPlugin r_io_plugin_debug = {
 	.name = "debug",
-	.desc = "Native debugger (dbg:///bin/ls dbg://1388 pidof:// waitfor://)",
+	.desc = "Attach to native debugger instance",
 	.license = "LGPL3",
+	.uris = "dbg://,pidof://,waitfor://",
 	.author = "pancake",
 	.version = "0.2.0",
 	.open = __open,

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -408,8 +408,9 @@ static char *__system(RIO *io, RIODesc *desc, const char *cmd) {
 
 RIOPlugin r_io_plugin_default = {
 	.name = "default",
-	.desc = "open local files using def_mmap://",
+	.desc = "Open local files",
 	.license = "LGPL3",
+	.uris = "file://,nocache://",
 	.open = __open_default,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -351,7 +351,8 @@ RIOPlugin r_io_plugin_gdb = {
 	//void *plugin;
 	.name = "gdb",
 	.license = "LGPL3",
-	.desc = "Attach to gdbserver, 'qemu -s', gdb://localhost:1234",
+	.desc = "Attach to gdbserver instance",
+	.uris = "gdb://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_gprobe.c
+++ b/libr/io/p/io_gprobe.c
@@ -1220,8 +1220,9 @@ static char *__system (RIO *io, RIODesc *fd, const char *cmd) {
 
 RIOPlugin r_io_plugin_gprobe = {
 	.name = "gprobe",
-	.desc = "open gprobe connection using gprobe://",
+	.desc = "Open gprobe connection",
 	.license = "LGPL3",
+	.uris = "gprobe://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_gzip.c
+++ b/libr/io/p/io_gzip.c
@@ -179,8 +179,9 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_gzip = {
 	.name = "gzip",
-	.desc = "read/write gzipped files",
+	.desc = "Read/write gzipped files",
 	.license = "LGPL3",
+	.uris = "gzip://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_http.c
+++ b/libr/io/p/io_http.c
@@ -104,12 +104,13 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_http = {
 	.name = "http",
-        .desc = "http get (http://rada.re/)",
+	.desc = "Make http get requests",
+	.uris = "http://",
 	.license = "LGPL3",
-        .open = __open,
-        .close = __close,
+	.open = __open,
+	.close = __close,
 	.read = __read,
-        .check = __plugin_open,
+	.check = __plugin_open,
 	.lseek = __lseek,
 	.write = __write,
 };

--- a/libr/io/p/io_ihex.c
+++ b/libr/io/p/io_ihex.c
@@ -422,12 +422,13 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 size) {
 
 RIOPlugin r_io_plugin_ihex = {
 	.name = "ihex",
-        .desc = "Intel HEX file (ihex://eeproms.hex)",
+	.desc = "Open intel HEX file",
+	.uris = "ihex://",
 	.license = "LGPL",
-        .open = __open,
-        .close = __close,
+	.open = __open,
+	.close = __close,
 	.read = __read,
-        .check = __plugin_open,
+	.check = __plugin_open,
 	.lseek = __lseek,
 	.write = __write,
 	.resize = __resize
@@ -436,7 +437,7 @@ RIOPlugin r_io_plugin_ihex = {
 #ifndef CORELIB
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_IO,
-	.data = &r_io_plugin_hex,
+	.data = &r_io_plugin_ihex,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -553,8 +553,9 @@ static int __get_pid (RIODesc *desc) {
 // TODO: rename ptrace to io_mach .. err io.ptrace ??
 RIOPlugin r_io_plugin_mach = {
 	.name = "mach",
-	.desc = "mach debugger io plugin (mach://pid)",
+	.desc = "Attach to mach debugger instance",
 	.license = "LGPL",
+	.uris = "attach://,mach://,smach://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_malloc.c
+++ b/libr/io/p/io_malloc.c
@@ -192,7 +192,8 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_malloc = {
 	.name = "malloc",
-	.desc = "memory allocation (malloc://1024 hex://cd8090)",
+	.desc = "Memory allocation plugin",
+	.uris = "malloc://,hex://",
 	.license = "LGPL3",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -193,7 +193,8 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 size) {
 
 struct r_io_plugin_t r_io_plugin_mmap = {
 	.name = "mmap",
-	.desc = "open file using mmap://",
+	.desc = "Open files using mmap",
+	.uris = "mmap://",
 	.license = "LGPL3",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_null.c
+++ b/libr/io/p/io_null.c
@@ -102,8 +102,9 @@ static RIODesc* __open(RIO* io, const char* pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_null = {
 	.name = "null",
-	.desc = "null-plugin (null://23)",
+	.desc = "Null plugin",
 	.license = "LGPL3",
+	.uris = "null://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_procpid.c
+++ b/libr/io/p/io_procpid.c
@@ -127,8 +127,9 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 
 RIOPlugin r_io_plugin_procpid = {
 	.name = "procpid",
-	.desc = "/proc/pid/mem io",
+	.desc = "Open /proc/[pid]/mem io",
 	.license = "LGPL3",
+	.uris = "procpid://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_ptrace.c
+++ b/libr/io/p/io_ptrace.c
@@ -294,8 +294,9 @@ static int __getpid (RIODesc *fd) {
 // TODO: rename ptrace to io_ptrace .. err io.ptrace ??
 RIOPlugin r_io_plugin_ptrace = {
 	.name = "ptrace",
-	.desc = "ptrace and /proc/pid/mem (if available) io",
+	.desc = "Ptrace and /proc/pid/mem (if available) io plugin",
 	.license = "LGPL3",
+	.uris = "ptrace://,attach://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_qnx.c
+++ b/libr/io/p/io_qnx.c
@@ -151,7 +151,8 @@ static char *__system (RIO *io, RIODesc *fd, const char *cmd) {
 RIOPlugin r_io_plugin_qnx = {
 	.name = "qnx",
 	.license = "LGPL3",
-	.desc = "Attach to QNX pdebug instance, qnx://host:1234",
+	.desc = "Attach to QNX pdebug instance",
+	.uris = "qnx://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_r2k.c
+++ b/libr/io/p/io_r2k.c
@@ -131,7 +131,8 @@ static RIODesc *r2k__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_r2k = {
 	.name = "r2k",
-	.desc = "kernel access API io (r2k://)",
+	.desc = "Kernel access API io",
+	.uris = "r2k://",
 	.license = "LGPL3",
 	.open = r2k__open,
 	.close = r2k__close,

--- a/libr/io/p/io_r2pipe.c
+++ b/libr/io/p/io_r2pipe.c
@@ -178,12 +178,13 @@ static char *__system(RIO *io, RIODesc *fd, const char *msg) {
 
 RIOPlugin r_io_plugin_r2pipe = {
 	.name = "r2pipe",
-        .desc = "r2pipe io plugin",
+	.desc = "r2pipe io plugin",
 	.license = "MIT",
-        .open = __open,
-        .close = __close,
+	.uris = "r2pipe://",
+	.open = __open,
+	.close = __close,
 	.read = __read,
-        .check = __check,
+	.check = __check,
 	.lseek = __lseek,
 	.write = __write,
 	.system = __system

--- a/libr/io/p/io_r2web.c
+++ b/libr/io/p/io_r2web.c
@@ -139,7 +139,8 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 
 RIOPlugin r_io_plugin_r2web = {
 	.name = "r2web",
-	.desc = "r2web io client (r2web://cloud.rada.re/cmd/)",
+	.desc = "r2web io client plugin",
+	.uris = "r2web://",
 	.license = "LGPL3",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_rap.c
+++ b/libr/io/p/io_rap.c
@@ -369,7 +369,8 @@ static char *__rap_system(RIO *io, RIODesc *fd, const char *command) {
 
 RIOPlugin r_io_plugin_rap = {
 	.name = "rap",
-	.desc = "remote binary protocol (rap://:port rap://host:port/file)",
+	.desc = "Remote binary protocol plugin",
+	.uris = "rap://,raps://",
 	.license = "MIT",
 	.listener = __rap_listener,
 	.open = __rap_open,

--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -47,7 +47,8 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_rbuf = {
 	.name = "rbuf",
-	.desc = "RBuffer IO plugin: rbuf://",
+	.desc = "RBuffer IO plugin",
+	.uris = "rbuf://",
 	.license = "LGPL",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -366,7 +366,8 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 
 RIOPlugin r_io_plugin_self = {
 	.name = "self",
-	.desc = "read memory from myself using 'self://'",
+	.desc = "Read memory from self",
+	.uris = "self://",
 	.license = "LGPL3",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_shm.c
+++ b/libr/io/p/io_shm.c
@@ -120,7 +120,8 @@ static RIODesc *shm__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_shm = {
 	.name = "shm",
-	.desc = "shared memory resources (shm://key)",
+	.desc = "Shared memory resources plugin",
+	.uris = "shm://",
 	.license = "LGPL3",
 	.open = shm__open,
 	.close = shm__close,

--- a/libr/io/p/io_sparse.c
+++ b/libr/io/p/io_sparse.c
@@ -101,7 +101,8 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_sparse = {
 	.name = "sparse",
-	.desc = "sparse buffer allocation (sparse://1024 sparse://)",
+	.desc = "Sparse buffer allocation plugin",
+	.uris = "sparse://",
 	.license = "LGPL3",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_tcp.c
+++ b/libr/io/p/io_tcp.c
@@ -159,12 +159,13 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 
 RIOPlugin r_io_plugin_tcp = {
 	.name = "tcp",
-        .desc = "load files via TCP (listen or connect)",
+	.desc = "Load files via TCP (listen or connect)",
+	.uris = "tcp://",
 	.license = "LGPL3",
-        .open = __open,
-        .close = __close,
+	.open = __open,
+	.close = __close,
 	.read = __read,
-        .check = __plugin_open,
+	.check = __plugin_open,
 	.lseek = __lseek,
 	.write = __write,
 };

--- a/libr/io/p/io_w32.c
+++ b/libr/io/p/io_w32.c
@@ -77,6 +77,7 @@ RIOPlugin r_io_plugin_w32 = {
 	.name = "w32",
 	.desc = "w32 API io",
 	.license = "LGPL3",
+	.uris = "w32://",
 	.open = w32__open,
 	.close = w32__close,
 	.read = w32__read,

--- a/libr/io/p/io_w32dbg.c
+++ b/libr/io/p/io_w32dbg.c
@@ -224,8 +224,9 @@ static bool __getbase (RIODesc *fd, ut64 *base) {
 
 RIOPlugin r_io_plugin_w32dbg = {
 	.name = "w32dbg",
-	.desc = "w32dbg io",
+	.desc = "w32 debugger io plugin",
 	.license = "LGPL3",
+	.uris = "w32dbg://,attach://",
 	.open = __open,
 	.close = __close,
 	.read = __read,

--- a/libr/io/p/io_windbg.c
+++ b/libr/io/p/io_windbg.c
@@ -99,7 +99,8 @@ static int __close(RIODesc *fd) {
 
 RIOPlugin r_io_plugin_windbg = {
 	.name = "windbg",
-	.desc = "Attach to a KD debugger (windbg://socket)",
+	.desc = "Attach to a KD debugger",
+	.uris = "windbg://",
 	.license = "LGPL3",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_winedbg.c
+++ b/libr/io/p/io_winedbg.c
@@ -357,12 +357,13 @@ const char *msg =
 
 RIOPlugin r_io_plugin_winedbg = {
 	.name = "winedbg",
-        .desc = "Wine-dbg io and debug.io plugin for r2",
+	.desc = "Wine-dbg io and debug.io plugin",
+	.uris = "winedbg://",
 	.license = "MIT",
-        .open = __open,
-        .close = __close,
+	.open = __open,
+	.close = __close,
 	.read = __read,
-        .check = __plugin_open,
+	.check = __plugin_open,
 	.lseek = __lseek,
 	.write = __write,
 	.system = __system,

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -650,7 +650,8 @@ static int r_io_zip_close(RIODesc *fd) {
 
 RIOPlugin r_io_plugin_zip = {
 	.name = "zip",
-	.desc = "Open zip files [apk|ipa|zip|zipall]://[file//path]",
+	.desc = "Open zip files",
+	.uris = "zip://,apk://,ipa://,jar://,zipall://,apkall://,ipaall://,jarall://",
 	.license = "BSD",
 	.open = r_io_zip_open,
 	.open_many = r_io_zip_open_many,


### PR DESCRIPTION
For issue #12620

Example output for `oLj` now is:

`{"IO_Plugins":[{"Permissions":"rw_","Name":"ar","Description":"Open ar/lib files [ar|lib]://[file//path]","License":"LGPL3","prefix":"ar://, lib://"},{"Permissions":"rw_","Name":"bfdbg","Description":"BrainFuck Debugger (bfdbg://path/to/file)","License":"LGPL3","prefix":"bfdbg://"}....}`

Please let me know if any more changes are to be done