### PR TITLE
Fix agfj -- invalid json

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1230,20 +1230,19 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 			}
 			r_cons_printf (",\"colorize\":%d", bbi->colorize);
 			r_cons_printf (",\"ops\":");
+			r_cons_print ("[");
 			if (buf) {
 				r_io_read_at (core->io, bbi->addr, buf, bbi->size);
 				if (is_json_format_disasm) {
 					r_core_print_disasm (core->print, core, bbi->addr, buf, bbi->size, bbi->size, 0, 1, true, NULL);
 				} else {
-					r_cons_print ("[");
 					r_core_print_disasm_json (core, bbi->addr, buf, bbi->size, 0);
-					r_cons_print ("]");
 				}
 				free (buf);
 			} else {
 				eprintf ("cannot allocate %d byte(s)\n", bbi->size);
 			}
-			r_cons_print ("}");
+			r_cons_print ("]}");
 			continue;
 		}
 		if (bbi->jump != UT64_MAX) {


### PR DESCRIPTION
Hi there,
i discovered that agfj produces invalid json in some circumstances. If a function, for what ever reason, contains a basic block with negative size the json will not be valid. Although this does not fix the root cause of the problem, i still think i better to at least get a valid json output. The main problem with invalid json for me is, that it fails silently when using r2pipe (in python).

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             | Manjaro x86 64
| File format of the file you reverse (mandatory)      | ELF
| Architecture/bits of the file (mandatory)            | x86/64
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.3.0-git 20947 @ linux-x86-64 git.3.1.3-565-g7f8495dea commit: 7f8495dea766b7b88931b253f7bc55f84198ef91 build: 2019-02-11__16:29:24

### Expected behavior
```
$ r2 /usr/bin/containerd-shim
[0x00458850]> s 5590128
[0x00554c70]> e anal.ijmp=true
[0x00554c70]> e anal.datarefs=true
[0x00554c70]> e anal.cjmpref=true 
[0x00554c70]> aaaa
[0x00554c70]> agfj
cannot allocate -4 byte(s)
(still outputs valid json)
```

### Actual behavior
```
$ r2 /usr/bin/containerd-shim
[0x00458850]> s 5590128
[0x00554c70]> e anal.ijmp=true
[0x00554c70]> e anal.datarefs=true
[0x00554c70]> e anal.cjmpref=true 
[0x00554c70]> aaaa
[0x00554c70]> agfj
cannot allocate -4 byte(s)
(outputs invalid json)
```

### Steps to reproduce the behavior 
execute the steps above using (extracted) 
[containerd-shim.zip](https://github.com/radare/radare2/files/2852248/containerd-shim.zip)

### Additional Logs, screenshots, source-code,  configuration dump, ...
#### Invalid json:
```
[{"name":"fcn.00554c70","offset":5590128,"ninstr":88,"nargs":5,"nlocals":12,"size":434,"stack":104,"type":"fcn","blocks":[{"offset":5590128,"size":19,"jump":5590552,"fail":5590147,"colorize":0,"ops":[{"offset":5590128,"ptr":-8,"esil":"0x8,[8],rcx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590553,"size":9,"opcode":"mov rcx, qword fs:[0xfffffffffffffff8]","disasm":"mov rcx, qword fs:[0xfffffffffffffff8]","bytes":"64488b0c25f8ffffff","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"flags":["fcn.00554c70"],"xrefs":[{"addr":5590557,"type":"CODE"},{"addr":7538552,"type":"DATA"}]},{"offset":5590137,"ptr":16,"esil":"0x10,rcx,+,[8],rsp,==,$z,zf,=,$b64,cf,=,$p,pf,=,$s,sf,=,$o,of,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"cmp rsp, qword [rcx + 0x10]","disasm":"cmp rsp, qword [rcx + 0x10]","bytes":"483b6110","family":"cpu","type":"cmp","reloc":false,"type_num":15,"type2_num":0},{"offset":5590141,"esil":"zf,cf,|,?{,5590552,rip,=,}","refptr":false,"fcn_addr":5590128,"fcn_last":5590556,"size":6,"opcode":"jbe 0x554e18","disasm":"jbe 0x554e18","bytes":"0f8695010000","family":"cpu","type":"cjmp","reloc":false,"type_num":2147483649,"type2_num":0,"jump":5590552,"fail":5590147}]},{"offset":5590147,"size":67,"jump":5590496,"fail":5590214,"colorize":0,"ops":[{"offset":5590147,"val":104,"esil":"104,rsp,-=,$o,of,=,$s,sf,=,$z,zf,=,$p,pf,=,$b64,cf,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"sub rsp, 0x68","disasm":"sub rsp, 0x68","bytes":"4883ec68","family":"cpu","type":"sub","reloc":false,"type_num":18,"type2_num":0},{"offset":5590151,"esil":"rbp,0x60,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x60], rbp","disasm":"mov qword [var_60h], rbp","bytes":"48896c2460","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590156,"ptr":96,"esil":"0x60,rsp,+,rbp,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"lea rbp, [rsp + 0x60]","disasm":"lea rbp, [var_60h]","bytes":"488d6c2460","family":"cpu","type":"lea","reloc":false,"type_num":33,"type2_num":0},{"offset":5590161,"ptr":112,"esil":"0x70,rsp,+,[8],rax,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rax, qword [rsp + 0x70]","disasm":"mov rax, qword [arg_70h]","bytes":"488b442470","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590166,"esil":"rax,rsp,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rsp], rax","disasm":"mov qword [rsp], rax","bytes":"48890424","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590170,"val":0,"esil":"0,0x8,rsp,+,=[1]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov byte [rsp + 8], 0","disasm":"mov byte [var_8h], 0","bytes":"c644240800","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590175,"esil":"5569936,rip,8,rsp,-=,rsp,=[],rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"call 0x54fd90","disasm":"call fcn.0054fd90","bytes":"e8ecb0ffff","family":"cpu","type":"call","reloc":false,"type_num":3,"type2_num":0,"jump":5569936,"fail":5590180},{"offset":5590180,"ptr":48,"esil":"0x30,rsp,+,[8],rax,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rax, qword [rsp + 0x30]","disasm":"mov rax, qword [var_30h]","bytes":"488b442430","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590185,"ptr":40,"esil":"0x28,rsp,+,[8],rcx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rcx, qword [rsp + 0x28]","disasm":"mov rcx, qword [var_28h]","bytes":"488b4c2428","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590190,"ptr":32,"esil":"0x20,rsp,+,[8],rdx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rdx, qword [rsp + 0x20]","disasm":"mov rdx, qword [var_20h]","bytes":"488b542420","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590195,"ptr":24,"esil":"0x18,rsp,+,[8],rbx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rbx, qword [rsp + 0x18]","disasm":"mov rbx, qword [var_18h]","bytes":"488b5c2418","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590200,"ptr":16,"esil":"0x10,rsp,+,[8],rsi,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rsi, qword [rsp + 0x10]","disasm":"mov rsi, qword [var_10h]","bytes":"488b742410","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590205,"esil":"0,rcx,rcx,&,==,$z,zf,=,$p,pf,=,$s,sf,=,$0,cf,=,$0,of,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590559,"size":3,"opcode":"test rcx, rcx","disasm":"test rcx, rcx","bytes":"4885c9","family":"cpu","type":"acmp","reloc":false,"type_num":16,"type2_num":0},{"offset":5590208,"esil":"zf,!,?{,5590496,rip,=,}","refptr":false,"fcn_addr":5590128,"fcn_last":5590556,"size":6,"opcode":"jne 0x554de0","disasm":"jne 0x554de0","bytes":"0f851a010000","family":"cpu","type":"cjmp","reloc":false,"type_num":2147483649,"type2_num":0,"jump":5590496,"fail":5590214}]},{"offset":5590214,"size":24,"jump":5590522,"fail":5590238,"colorize":0,"ops":[{"offset":5590214,"ptr":120,"esil":"0x78,rsp,+,[8],rcx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rcx, qword [rsp + 0x78]","disasm":"mov rcx, qword [arg_78h]","bytes":"488b4c2478","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590219,"ptr":0,"esil":"0,al,rcx,[1],&,==,$z,zf,=,$p,pf,=,$s,sf,=,$0,cf,=,$0,of,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590560,"size":2,"opcode":"test byte [rcx], al","disasm":"test byte [rcx], al","bytes":"8401","family":"cpu","type":"acmp","reloc":false,"type_num":16,"type2_num":0},{"offset":5590221,"ptr":289,"esil":"0x121,rcx,+,r8,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"lea r8, [rcx + 0x121]","disasm":"lea r8, [rcx + 0x121]","bytes":"4c8d8121010000","family":"cpu","type":"lea","reloc":false,"type_num":33,"type2_num":0},{"offset":5590228,"ptr":0,"val":0,"esil":"0,r8,[1],==,$z,zf,=,$b8,cf,=,$p,pf,=,$s,sf,=,$o,of,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"cmp byte [r8], 0","disasm":"cmp byte [r8], 0","bytes":"41803800","family":"cpu","type":"cmp","reloc":false,"type_num":15,"type2_num":0},{"offset":5590232,"esil":"zf,!,?{,5590522,rip,=,}","refptr":false,"fcn_addr":5590128,"fcn_last":5590556,"size":6,"opcode":"jne 0x554dfa","disasm":"jne 0x554dfa","bytes":"0f851c010000","family":"cpu","type":"cjmp","reloc":false,"type_num":2147483649,"type2_num":0,"jump":5590522,"fail":5590238}]},{"offset":5590238,"size":61,"jump":5590483,"fail":5590299,"colorize":0,"ops":[{"offset":5590238,"ptr":112,"esil":"0x70,rsp,+,[8],rdi,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rdi, qword [rsp + 0x70]","disasm":"mov rdi, qword [arg_70h]","bytes":"488b7c2470","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590243,"ptr":16,"esil":"0x10,rdi,+,[8],r8,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov r8, qword [rdi + 0x10]","disasm":"mov r8, qword [rdi + 0x10]","bytes":"4c8b4710","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590247,"esil":"r8,0x50,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x50], r8","disasm":"mov qword [var_50h], r8","bytes":"4c89442450","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590252,"ptr":8,"esil":"0x8,rdi,+,[8],r9,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov r9, qword [rdi + 8]","disasm":"mov r9, qword [rdi + 8]","bytes":"4c8b4f08","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590256,"esil":"r9,0x48,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x48], r9","disasm":"mov qword [var_48h], r9","bytes":"4c894c2448","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590261,"ptr":0,"esil":"rdi,[8],r10,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590559,"size":3,"opcode":"mov r10, qword [rdi]","disasm":"mov r10, qword [rdi]","bytes":"4c8b17","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590264,"esil":"r10,0x58,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x58], r10","disasm":"mov qword [var_58h], r10","bytes":"4c89542458","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590269,"ptr":24,"esil":"0x18,rdi,+,[8],r11,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov r11, qword [rdi + 0x18]","disasm":"mov r11, qword [rdi + 0x18]","bytes":"4c8b5f18","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590273,"esil":"r11,0x40,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x40], r11","disasm":"mov qword [var_40h], r11","bytes":"4c895c2440","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590278,"esil":"rbx,0x8,rdi,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rdi + 8], rbx","disasm":"mov qword [rdi + 8], rbx","bytes":"48895f08","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590282,"esil":"rdx,0x10,rdi,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rdi + 0x10], rdx","disasm":"mov qword [rdi + 0x10], rdx","bytes":"48895710","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590286,"ptr":10080480,"val":0,"esil":"0,0x4483cb,rip,+,[4],==,$z,zf,=,$b32,cf,=,$p,pf,=,$s,sf,=,$o,of,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"cmp dword [rip + 0x4483cb], 0","disasm":"cmp dword [0x0099d0e0], 0","bytes":"833dcb83440000","family":"cpu","type":"cmp","reloc":false,"type_num":15,"type2_num":0},{"offset":5590293,"esil":"zf,!,?{,5590483,rip,=,}","refptr":false,"fcn_addr":5590128,"fcn_last":5590556,"size":6,"opcode":"jne 0x554dd3","disasm":"jne 0x554dd3","bytes":"0f85b8000000","family":"cpu","type":"cjmp","reloc":false,"type_num":2147483649,"type2_num":0,"jump":5590483,"fail":5590299}]},{"offset":5590299,"size":-4,"jump":5590302,"colorize":0,"ops":},{"offset":5590302,"size":120,"jump":5590465,"fail":5590422,"colorize":0,"ops":[{"offset":5590302,"val":0,"esil":"0,0x18,rdi,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590554,"size":8,"opcode":"mov qword [rdi + 0x18], 0","disasm":"mov qword [rdi + 0x18], 0","bytes":"48c7471800000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"xrefs":[{"addr":5590491,"type":"CODE"}]},{"offset":5590310,"ptr":240,"esil":"0xf0,rcx,+,[8],rax,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"mov rax, qword [rcx + 0xf0]","disasm":"mov rax, qword [rcx + 0xf0]","bytes":"488b81f0000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590317,"ptr":232,"esil":"0xe8,rcx,+,[8],rdx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"mov rdx, qword [rcx + 0xe8]","disasm":"mov rdx, qword [rcx + 0xe8]","bytes":"488b91e8000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590324,"ptr":280,"esil":"0x118,rcx,+,[8],rbx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"mov rbx, qword [rcx + 0x118]","disasm":"mov rbx, qword [rcx + 0x118]","bytes":"488b9918010000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590331,"ptr":128,"esil":"0x80,rsp,+,[8],rsi,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590554,"size":8,"opcode":"mov rsi, qword [rsp + 0x80]","disasm":"mov rsi, qword [arg_80h]","bytes":"488bb42480000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590339,"esil":"0xc0,rcx,+,[8],rsi,+=,$o,of,=,$s,sf,=,$z,zf,=,$c63,cf,=,$p,pf,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"add rsi, qword [rcx + 0xc0]","disasm":"add rsi, qword [rcx + 0xc0]","bytes":"4803b1c0000000","family":"cpu","type":"add","reloc":false,"type_num":17,"type2_num":0},{"offset":5590346,"esil":"rbx,0x18,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x18], rbx","disasm":"mov qword [var_18h], rbx","bytes":"48895c2418","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590351,"esil":"rdi,rsp,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rsp], rdi","disasm":"mov qword [rsp], rdi","bytes":"48893c24","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590355,"esil":"rdx,0x8,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 8], rdx","disasm":"mov qword [var_8h], rdx","bytes":"4889542408","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590360,"esil":"rax,0x10,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x10], rax","disasm":"mov qword [var_10h], rax","bytes":"4889442410","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590365,"val":0,"esil":"0,0x20,rsp,+,=[1]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov byte [rsp + 0x20], 0","disasm":"mov byte [var_20h], 0","bytes":"c644242000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590370,"esil":"rsi,0x28,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 0x28], rsi","disasm":"mov qword [var_28h], rsi","bytes":"4889742428","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590375,"esil":"5573936,rip,8,rsp,-=,rsp,=[],rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"call 0x550d30","disasm":"call fcn.00550d30","bytes":"e8c4bfffff","family":"cpu","type":"call","reloc":false,"type_num":3,"type2_num":0,"jump":5573936,"fail":5590380},{"offset":5590380,"ptr":56,"esil":"0x38,rsp,+,[8],rax,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rax, qword [rsp + 0x38]","disasm":"mov rax, qword [var_38h]","bytes":"488b442438","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590385,"ptr":48,"esil":"0x30,rsp,+,[8],rcx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rcx, qword [rsp + 0x30]","disasm":"mov rcx, qword [var_30h]","bytes":"488b4c2430","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590390,"ptr":72,"esil":"0x48,rsp,+,[8],rdx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rdx, qword [rsp + 0x48]","disasm":"mov rdx, qword [var_48h]","bytes":"488b542448","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590395,"ptr":112,"esil":"0x70,rsp,+,[8],rdi,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rdi, qword [rsp + 0x70]","disasm":"mov rdi, qword [arg_70h]","bytes":"488b7c2470","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590400,"esil":"rdx,0x8,rdi,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rdi + 8], rdx","disasm":"mov qword [rdi + 8], rdx","bytes":"48895708","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590404,"ptr":80,"esil":"0x50,rsp,+,[8],rdx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rdx, qword [rsp + 0x50]","disasm":"mov rdx, qword [var_50h]","bytes":"488b542450","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590409,"esil":"rdx,0x10,rdi,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rdi + 0x10], rdx","disasm":"mov qword [rdi + 0x10], rdx","bytes":"48895710","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590413,"ptr":10080480,"val":0,"esil":"0,0x44834c,rip,+,[4],==,$z,zf,=,$b32,cf,=,$p,pf,=,$s,sf,=,$o,of,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"cmp dword [rip + 0x44834c], 0","disasm":"cmp dword [0x0099d0e0], 0","bytes":"833d4c83440000","family":"cpu","type":"cmp","reloc":false,"type_num":15,"type2_num":0},{"offset":5590420,"esil":"zf,!,?{,5590465,rip,=,}","refptr":false,"fcn_addr":5590128,"fcn_last":5590560,"size":2,"opcode":"jne 0x554dc1","disasm":"jne 0x554dc1","bytes":"752b","family":"cpu","type":"cjmp","reloc":false,"type_num":2147483649,"type2_num":0,"jump":5590465,"fail":5590422}]},{"offset":5590422,"size":8,"jump":5590430,"colorize":0,"ops":[{"offset":5590422,"ptr":88,"esil":"0x58,rsp,+,[8],rdx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rdx, qword [rsp + 0x58]","disasm":"mov rdx, qword [var_58h]","bytes":"488b542458","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590427,"esil":"rdx,rdi,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590559,"size":3,"opcode":"mov qword [rdi], rdx","disasm":"mov qword [rdi], rdx","bytes":"488917","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0}]},{"offset":5590430,"size":35,"colorize":0,"ops":[{"offset":5590430,"ptr":64,"esil":"0x40,rsp,+,[8],rdx,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rdx, qword [rsp + 0x40]","disasm":"mov rdx, qword [var_40h]","bytes":"488b542440","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"xrefs":[{"addr":5590481,"type":"CODE"}]},{"offset":5590435,"esil":"rdx,0x18,rdi,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rdi + 0x18], rdx","disasm":"mov qword [rdi + 0x18], rdx","bytes":"48895718","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590439,"esil":"rcx,0x88,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590554,"size":8,"opcode":"mov qword [rsp + 0x88], rcx","disasm":"mov qword [arg_88h], rcx","bytes":"48898c2488000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590447,"esil":"rax,0x90,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590554,"size":8,"opcode":"mov qword [rsp + 0x90], rax","disasm":"mov qword [arg_90h], rax","bytes":"4889842490000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590455,"ptr":96,"esil":"0x60,rsp,+,[8],rbp,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rbp, qword [rsp + 0x60]","disasm":"mov rbp, qword [var_60h]","bytes":"488b6c2460","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590460,"val":104,"esil":"104,rsp,+=,$o,of,=,$s,sf,=,$z,zf,=,$c63,cf,=,$p,pf,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"add rsp, 0x68","disasm":"add rsp, 0x68","bytes":"4883c468","family":"cpu","type":"add","reloc":false,"type_num":17,"type2_num":0},{"offset":5590464,"esil":"rsp,[8],rip,=,8,rsp,+=","refptr":false,"fcn_addr":5590128,"fcn_last":5590561,"size":1,"opcode":"ret","disasm":"ret","bytes":"c3","family":"cpu","type":"ret","reloc":false,"type_num":5,"type2_num":0}]},{"offset":5590465,"size":18,"jump":5590430,"colorize":0,"ops":[{"offset":5590465,"esil":"rax,rdx,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590559,"size":3,"opcode":"mov rdx, rax","disasm":"mov rdx, rax","bytes":"4889c2","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"xrefs":[{"addr":5590420,"type":"CODE"}]},{"offset":5590468,"ptr":88,"esil":"0x58,rsp,+,[8],rax,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rax, qword [rsp + 0x58]","disasm":"mov rax, qword [var_58h]","bytes":"488b442458","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590473,"esil":"4550848,rip,8,rsp,-=,rsp,=[],rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"call 0x4570c0","disasm":"call sym.go.runtime.gcWriteBarrier","bytes":"e8f222f0ff","family":"cpu","type":"call","reloc":false,"type_num":3,"type2_num":0,"jump":4550848,"fail":5590478},{"offset":5590478,"esil":"rdx,rax,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590559,"size":3,"opcode":"mov rax, rdx","disasm":"mov rax, rdx","bytes":"4889d0","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590481,"esil":"0x554d9e,rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590560,"size":2,"opcode":"jmp 0x554d9e","disasm":"jmp 0x554d9e","bytes":"ebcb","family":"cpu","type":"jmp","reloc":false,"type_num":1,"type2_num":0,"jump":5590430}]},{"offset":5590483,"size":13,"jump":5590302,"colorize":0,"ops":[{"offset":5590483,"esil":"rsi,rax,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590559,"size":3,"opcode":"mov rax, rsi","disasm":"mov rax, rsi","bytes":"4889f0","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"xrefs":[{"addr":5590293,"type":"CODE"}]},{"offset":5590486,"esil":"4550848,rip,8,rsp,-=,rsp,=[],rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"call 0x4570c0","disasm":"call sym.go.runtime.gcWriteBarrier","bytes":"e8e522f0ff","family":"cpu","type":"call","reloc":false,"type_num":3,"type2_num":0,"jump":4550848,"fail":5590491},{"offset":5590491,"esil":"0x554d1e,rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"jmp 0x554d1e","disasm":"jmp 0x554d1e","bytes":"e93effffff","family":"cpu","type":"jmp","reloc":false,"type_num":1,"type2_num":0,"jump":5590302}]},{"offset":5590496,"size":26,"colorize":0,"ops":[{"offset":5590496,"esil":"rcx,0x88,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590554,"size":8,"opcode":"mov qword [rsp + 0x88], rcx","disasm":"mov qword [arg_88h], rcx","bytes":"48898c2488000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"xrefs":[{"addr":5590208,"type":"CODE"}]},{"offset":5590504,"esil":"rax,0x90,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590554,"size":8,"opcode":"mov qword [rsp + 0x90], rax","disasm":"mov qword [arg_90h], rax","bytes":"4889842490000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590512,"ptr":96,"esil":"0x60,rsp,+,[8],rbp,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov rbp, qword [rsp + 0x60]","disasm":"mov rbp, qword [var_60h]","bytes":"488b6c2460","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590517,"val":104,"esil":"104,rsp,+=,$o,of,=,$s,sf,=,$z,zf,=,$c63,cf,=,$p,pf,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"add rsp, 0x68","disasm":"add rsp, 0x68","bytes":"4883c468","family":"cpu","type":"add","reloc":false,"type_num":17,"type2_num":0},{"offset":5590521,"esil":"rsp,[8],rip,=,8,rsp,+=","refptr":false,"fcn_addr":5590128,"fcn_last":5590561,"size":1,"opcode":"ret","disasm":"ret","bytes":"c3","family":"cpu","type":"ret","reloc":false,"type_num":5,"type2_num":0}]},{"offset":5590522,"size":30,"jump":5590552,"colorize":0,"ops":[{"offset":5590522,"ptr":7022656,"esil":"0x15da3f,rip,+,rax,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"lea rax, [rip + 0x15da3f]","disasm":"lea rax, [0x006b2840]","bytes":"488d053fda1500","family":"cpu","type":"lea","reloc":false,"type_num":33,"type2_num":0,"xrefs":[{"addr":5590232,"type":"CODE"}]},{"offset":5590529,"esil":"rax,rsp,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590558,"size":4,"opcode":"mov qword [rsp], rax","disasm":"mov qword [rsp], rax","bytes":"48890424","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590533,"ptr":7741952,"esil":"0x20d3f4,rip,+,rax,=","refptr":true,"fcn_addr":5590128,"fcn_last":5590555,"size":7,"opcode":"lea rax, [rip + 0x20d3f4]","disasm":"lea rax, [0x00762200]","bytes":"488d05f4d32000","family":"cpu","type":"lea","reloc":false,"type_num":33,"type2_num":0},{"offset":5590540,"esil":"rax,0x8,rsp,+,=[8]","refptr":true,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"mov qword [rsp + 8], rax","disasm":"mov qword [var_8h], rax","bytes":"4889442408","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":5590545,"esil":"4365568,rip,8,rsp,-=,rsp,=[],rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"call 0x429d00","disasm":"call sym.go.runtime.gopanic","bytes":"e8ea4eedff","family":"cpu","type":"call","reloc":false,"type_num":3,"type2_num":0,"jump":4365568,"fail":5590550},{"offset":5590550,"esil":"","refptr":false,"fcn_addr":5590128,"fcn_last":5590560,"size":2,"opcode":"ud2","disasm":"ud2","bytes":"0f0b","family":"cpu","type":"null","reloc":false,"type_num":0,"type2_num":0}]},{"offset":5590552,"size":10,"jump":5590128,"colorize":0,"ops":[{"offset":5590552,"esil":"4543152,rip,8,rsp,-=,rsp,=[],rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"call 0x4552b0","disasm":"call sym.go.runtime.morestack_noctxt","bytes":"e89304f0ff","family":"cpu","type":"call","reloc":false,"type_num":3,"type2_num":0,"jump":4543152,"fail":5590557,"xrefs":[{"addr":5590141,"type":"CODE"}]},{"offset":5590557,"esil":"0x554c70,rip,=","refptr":false,"fcn_addr":5590128,"fcn_last":5590557,"size":5,"opcode":"jmp 0x554c70","disasm":"jmp fcn.00554c70","bytes":"e94efeffff","family":"cpu","type":"jmp","reloc":false,"type_num":1,"type2_num":0,"jump":5590128}]}]}]
```