### PR TITLE
Fix toggle emu.str in visual mode

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3178,12 +3178,14 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			}
 			break;
 		case '(':
-		case ')':
 			snowMode = !snowMode;
 			if (!snowMode) {
 				r_list_free (snows);
 				snows = NULL;
 			}
+			break;
+		case ')':
+			rotateAsmemu (core);
 			break;
 		case '#':
 			r_config_toggle (core->config, "asm.bytes");


### PR DESCRIPTION
Fixing the visual mode toggle for emu.str.

This was broken in this commit: https://github.com/radare/radare2/commit/5234164ab2a227a83e32dbf96fe9a2a52980572e

Currently '(' and ')' toggle snow. This PR restores ')' to toggle emu.str