### PR TITLE
Use pj for agfj (and others)

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1108,7 +1108,7 @@ static void core_anal_color_curr_node(RCore *core, RAnalBlock *bbi) {
 	free (pal_curr);
 }
 
-static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
+static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts, PJ *pj) {
 	int is_html = r_cons_singleton ()->is_html;
 	int is_json = opts & R_CORE_ANAL_JSON;
 	int is_json_format_disasm = opts & R_CORE_ANAL_JSON_FORMAT_DISASM;
@@ -1154,26 +1154,28 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 	} else if (is_json) {
 		// TODO: show vars, refs and xrefs
 		char *fcn_name_escaped = r_str_escape_utf8_for_json (fcn->name, -1);
-		r_cons_printf ("{\"name\":\"%s\"", r_str_get (fcn_name_escaped));
+		pj_o (pj);
+		pj_ks (pj, "name", r_str_get (fcn_name_escaped));
 		free (fcn_name_escaped);
-		r_cons_printf (",\"offset\":%"PFMT64d, fcn->addr);
-		r_cons_printf (",\"ninstr\":%"PFMT64d, (ut64)fcn->ninstr);
-		r_cons_printf (",\"nargs\":%d",
+		pj_kn (pj, "offset", fcn->addr);
+		pj_ki (pj, "ninstr", fcn->ninstr);
+		pj_ki (pj, "nargs",
 			r_anal_var_count (core->anal, fcn, 'r', 1) +
 			r_anal_var_count (core->anal, fcn, 's', 1) +
 			r_anal_var_count (core->anal, fcn, 'b', 1));
-		r_cons_printf (",\"nlocals\":%d",
+		pj_ki (pj, "nlocals",
 			r_anal_var_count (core->anal, fcn, 'r', 0) +
 			r_anal_var_count (core->anal, fcn, 's', 0) +
 			r_anal_var_count (core->anal, fcn, 'b', 0));
-		r_cons_printf (",\"size\":%d", r_anal_fcn_size (fcn));
-		r_cons_printf (",\"stack\":%d", fcn->maxstack);
-		r_cons_printf (",\"type\":\"%s\"", r_anal_fcn_type_tostring (fcn->type));
-		//r_cons_printf (",\"cc\":%d", fcn->call); // TODO: calling convention
+		pj_kn (pj, "size",  r_anal_fcn_size (fcn));
+		pj_ki (pj, "stack", fcn->maxstack);
+		pj_ks (pj, "type", r_anal_fcn_type_tostring (fcn->type));
+		//pj_ki (pj, "cc", fcn->call) // TODO: calling convention
 		if (fcn->dsc) {
-			r_cons_printf (",\"signature\":\"%s\"", fcn->dsc);
+			pj_ks (pj, "signature", fcn->dsc);
 		}
-		r_cons_printf (",\"blocks\":[");
+		pj_k (pj, "blocks");
+		pj_a (pj);
 	}
 	r_list_foreach (fcn->bbs, iter, bbi) {
 		count ++;
@@ -1185,64 +1187,60 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 		} else if (is_json) {
 			RDebugTracepoint *t = r_debug_trace_get (core->dbg, bbi->addr);
 			ut8 *buf = malloc (bbi->size);
-			if (count > 1) {
-				r_cons_printf (",");
-			}
-			r_cons_printf ("{\"offset\":%"PFMT64d",\"size\":%"PFMT64d, bbi->addr, (ut64)bbi->size);
+			pj_o (pj);
+			pj_kn (pj, "offset", bbi->addr);
+			pj_kn (pj, "size", bbi->size);
 			if (bbi->jump != UT64_MAX) {
-				r_cons_printf (",\"jump\":%"PFMT64d, bbi->jump);
+				pj_kn (pj, "jump", bbi->jump);
 			}
 			if (bbi->fail != -1) {
-				r_cons_printf (",\"fail\":%"PFMT64d, bbi->fail);
+				pj_kn (pj, "fail", bbi->fail);
 			}
 			if (bbi->switch_op) {
 				RAnalSwitchOp *op = bbi->switch_op;
-				r_cons_printf (
-						",\"switchop\":{\"offset\":%"PFMT64u
-						",\"defval\":%"PFMT64u
-						",\"maxval\":%"PFMT64u
-						",\"minval\":%"PFMT64u
-						",\"cases\":[",
-						op->addr, op->def_val, op->max_val, op->min_val);
-
+				pj_k (pj, "switchop");
+				pj_o (pj);
+				pj_kn (pj, "offset", op->addr);
+				pj_kn (pj, "defval", op->def_val);
+				pj_kn (pj, "maxval", op->max_val);
+				pj_kn (pj, "minval", op->min_val);
+				pj_k (pj, "cases");
+				pj_a (pj);
 				RAnalCaseOp *case_op;
 				RListIter *case_iter;
-				bool first_case = true;
 				r_list_foreach (op->cases, case_iter, case_op) {
-					if (!first_case) {
-						r_cons_print (",");
-					} else {
-						first_case = false;
-					}
-					r_cons_printf (
-							"{\"offset\":%"PFMT64u
-							",\"value\":%"PFMT64u
-							",\"jump\":%"PFMT64u"}",
-							case_op->addr, case_op->value, case_op->jump);
+					pj_o (pj);
+					pj_kn (pj, "offset", case_op->addr);
+					pj_kn (pj, "value", case_op->value);
+					pj_kn (pj, "jump", case_op->jump);
+					pj_end (pj);
 				}
-				r_cons_print ("]}");
+				pj_end (pj);
+				pj_end (pj);
 			}
 			if (t) {
-				r_cons_printf (
-					",\"trace\":{\"count\":%d,\"times\":%"
-					"d}",
-					t->count, t->times);
+				pj_k (pj, "trace");
+				pj_o (pj);
+				pj_ki (pj, "count", t->count);
+				pj_ki (pj, "times", t->times);
+				pj_end (pj);
 			}
-			r_cons_printf (",\"colorize\":%d", bbi->colorize);
-			r_cons_printf (",\"ops\":");
-			r_cons_print ("[");
+			pj_kn (pj, "colorize", bbi->colorize);
+			pj_k (pj, "ops");
+			pj_a (pj);
 			if (buf) {
 				r_io_read_at (core->io, bbi->addr, buf, bbi->size);
 				if (is_json_format_disasm) {
 					r_core_print_disasm (core->print, core, bbi->addr, buf, bbi->size, bbi->size, 0, 1, true, NULL);
 				} else {
-					r_core_print_disasm_json (core, bbi->addr, buf, bbi->size, 0);
+					r_core_print_disasm_json (core, bbi->addr, buf, bbi->size, 0, pj);
 				}
 				free (buf);
 			} else {
 				eprintf ("cannot allocate %d byte(s)\n", bbi->size);
 			}
-			r_cons_print ("]}");
+			pj_end (pj);
+			pj_end (pj);
 			continue;
 		}
 		if (bbi->jump != UT64_MAX) {
@@ -1432,7 +1430,8 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts) {
 		}
 	}
 	if (is_json) {
-		r_cons_print ("]}");
+		pj_end (pj);
+		pj_end (pj);
 	}
 	free (pal_jump);
 	free (pal_fail);
@@ -3058,7 +3057,7 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 	RAnalFunction *fcni;
 	RListIter *iter;
 	int nodes = 0;
-	int count = 0;
+	PJ *pj = NULL;
 
 	if (!addr) {
 		addr = core->offset;
@@ -3098,9 +3097,9 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 			"\tedge [%s];\n", font, gv_spline, gv_node, gv_edge);
 	}
 	if (is_json) {
-		r_cons_printf ("[");
+		pj = pj_new ();
+		pj_a (pj);
 	}
-
 	r_list_foreach (core->anal->fcns, iter, fcni) {
 		if (fcni->type & (R_ANAL_FCN_TYPE_SYM | R_ANAL_FCN_TYPE_FCN |
 		                  R_ANAL_FCN_TYPE_LOC) &&
@@ -3110,10 +3109,7 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 					continue;
 				}
 			}
-			if (is_json && count++ > 0) {
-				r_cons_printf (",");
-			}
-			nodes += core_anal_graph_nodes (core, fcni, opts);
+			nodes += core_anal_graph_nodes (core, fcni, opts, pj);
 			if (addr != UT64_MAX) {
 				break;
 			}
@@ -3129,7 +3125,9 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 		r_cons_printf ("}\n");
 	}
 	if (is_json) {
-		r_cons_printf ("]\n");
+		pj_end (pj);
+		r_cons_printf ("%s\n", pj_string (pj));
+		pj_free (pj);
 	}
 	r_config_restore (hc);
 	r_config_hold_free (hc);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3098,6 +3098,9 @@ R_API int r_core_anal_graph(RCore *core, ut64 addr, int opts) {
 	}
 	if (is_json) {
 		pj = pj_new ();
+		if (!pj) {
+			return false;
+		}
 		pj_a (pj);
 	}
 	r_list_foreach (core->anal->fcns, iter, fcni) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -881,23 +881,29 @@ static void cmd_pDj(RCore *core, const char *arg) {
 	if (bsize < 0) {
 		bsize = -bsize;
 	}
-	r_cons_print ("[");
+	PJ *pj = pj_new ();
+	pj_a (pj);
 	ut8 *buf = malloc (bsize);
 	if (buf) {
 		r_io_read_at (core->io, core->offset, buf, bsize);
-		r_core_print_disasm_json (core, core->offset, buf, bsize, 0);
+		r_core_print_disasm_json (core, core->offset, buf, bsize, 0, pj);
 		free (buf);
 	} else {
 		eprintf ("cannot allocate %d byte(s)\n", bsize);
 	}
-	r_cons_print ("]");
+	pj_end (pj);
+	r_cons_printf ("%s", pj_string (pj));
+	pj_free (pj);
 }
 
 static void cmd_pdj(RCore *core, const char *arg, ut8* block) {
 	int nblines = r_num_math (core->num, arg);
-	r_cons_print ("[");
-	r_core_print_disasm_json (core, core->offset, block, core->blocksize, nblines);
-	r_cons_print ("]\n");
+	PJ *pj = pj_new ();
+	pj_a (pj);
+	r_core_print_disasm_json (core, core->offset, block, core->blocksize, nblines, pj);
+	pj_end (pj);
+	r_cons_printf ("%s\n", pj_string (pj));
+	pj_free (pj);
 }
 
 static void helpCmdTasks(RCore *core) {
@@ -3639,8 +3645,10 @@ static void disasm_recursive(RCore *core, ut64 addr, int count, char type_print)
 	RAnalOp aop = {0};
 	int ret;
 	ut8 buf[128];
+	PJ *pj = NULL;
 	if (type_print == 'j') {
-		r_cons_print ("[");
+		pj = pj_new ();
+		pj_a (pj);
 	}
 	while (count-- > 0) {
 		r_io_read_at (core->io, addr, buf, sizeof (buf));
@@ -3652,10 +3660,7 @@ static void disasm_recursive(RCore *core, ut64 addr, int count, char type_print)
 		}
 	//	r_core_cmdf (core, "pD %d @ 0x%08"PFMT64x, aop.size, addr);
 		if (type_print == 'j') {
-			r_core_print_disasm_json (core, addr, buf, sizeof (buf), 1);
-			if (count) {
-				r_cons_print (",");
-			}
+			r_core_print_disasm_json (core, addr, buf, sizeof (buf), 1, pj);
 		} else {
 			r_core_cmdf (core, "pd 1 @ 0x%08"PFMT64x, addr);
 		}
@@ -3673,7 +3678,9 @@ static void disasm_recursive(RCore *core, ut64 addr, int count, char type_print)
 		addr += aop.size;
 	}
 	if (type_print == 'j') {
-		r_cons_print ("]\n");
+		pj_end (pj);
+		r_cons_printf ("%s\n", pj_string (pj));
+		pj_free (pj);
 	}
 }
 
@@ -3760,6 +3767,7 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 	RListIter *locs_it = NULL;
 	const char *orig_bb_middle = r_config_get (core->config, "asm.bb.middle");
 	r_config_set_i (core->config, "asm.bb.middle", false);
+	PJ *pj = NULL;
 
 	if (f->fcn_locs) {
 		locs_it = f->fcn_locs->head;
@@ -3776,8 +3784,8 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 	}
 	r_list_sort (f->bbs, (RListComparator) bbcmp);
 	if (input == 'j' && b) {
-		r_cons_print ("[");
-		bool isFirst = true;
+		pj = pj_new ();
+		pj_a (pj);
 		for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
 			if (r_cons_is_breaked ()) {
 				break;
@@ -3793,17 +3801,12 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 				break;
 			}
 			r_list_foreach (tmp_func->bbs, iter, b) {
-				if (isFirst) {
-					isFirst = false;
-				} else {
-					r_cons_print (",");
-				}
 // const char *cmd = (type_print == 'D')? "pDj": "pIj";
 // r_core_cmdf (core, "%s %d @ 0x%"PFMT64x, cmd, b->size, b->addr);
 				ut8 *buf = malloc (b->size);
 				if (buf) {
 					r_io_read_at (core->io, b->addr, buf, b->size);
-					r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
+					r_core_print_disasm_json (core, b->addr, buf, b->size, 0, pj);
 					free (buf);
 				} else {
 					eprintf ("cannot allocate %d byte(s)\n", b->size);
@@ -3818,11 +3821,6 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 					core->cons->null = false;
 				}
 			}
-			if (isFirst) {
-				isFirst = false;
-			} else {
-				r_cons_print (",");
-			}
 #if 0
 			r_core_print_disasm_json (core, core->offset, buf, bsize, 0);
 			const char *cmd = (type_print == 'D')? "pDj": "pIj";
@@ -3831,7 +3829,7 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 			ut8 *buf = malloc (b->size);
 			if (buf) {
 				r_io_read_at (core->io, b->addr, buf, b->size);
-				r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
+				r_core_print_disasm_json (core, b->addr, buf, b->size, 0, pj);
 				free (buf);
 			} else {
 				eprintf ("cannot allocate %d byte(s)\n", b->size);
@@ -3849,11 +3847,6 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 						core->cons->null = false;
 					}
 				}
-				if (isFirst) {
-					isFirst = false;
-				} else {
-					r_cons_print (",");
-				}
 #if 0
 				const char *cmd = (type_print == 'D')? "pDj": "pIj";
 				r_core_cmdf (core, "%s %d @0x%"PFMT64x, cmd, b->size, b->addr);
@@ -3861,14 +3854,17 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 				ut8 *buf = malloc (b->size);
 				if (buf) {
 					r_io_read_at (core->io, b->addr, buf, b->size);
-					r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
+					r_core_print_disasm_json (core, b->addr, buf, b->size, 0, pj);
 					free (buf);
 				} else {
 					eprintf ("cannot allocate %d byte(s)\n", b->size);
 				}
 			}
 		}
-		r_cons_print ("]");
+
+		pj_end (pj);
+		r_cons_printf ("%s", pj_string (pj));
+		pj_free (pj);
 	} else {
 		bool asm_lines = r_config_get_i (core->config, "asm.lines.bb");
 		bool emu = r_config_get_i (core->config, "asm.emu");
@@ -4085,6 +4081,7 @@ static int cmd_print(void *data, const char *input) {
 	const int addrbytes = core->io->addrbytes;
 	i = l = len = ret = 0;
 	n = off = from = to = at = ate = piece = 0;
+	PJ *pj = NULL;
 
 	r_print_init_rowoffsets (core->print);
 	off = UT64_MAX;
@@ -4739,9 +4736,12 @@ static int cmd_print(void *data, const char *input) {
 						r_io_read_at (core->io, b->addr, block, b->size);
 
 						if (input[2] == 'j') {
-							r_cons_print ("[");
-							r_core_print_disasm_json (core, b->addr, block, b->size, 0);
-							r_cons_print ("]\n");
+							pj = pj_new ();
+							pj_a (pj);
+							r_core_print_disasm_json (core, b->addr, block, b->size, 0, pj);
+							pj_end (pj);
+							r_cons_printf ("%s\n", pj_string (pj));
+							pj_free (pj);
 						} else {
 							core->num->value = r_core_print_disasm (
 								core->print, core, b->addr, block,
@@ -4802,15 +4802,15 @@ static int cmd_print(void *data, const char *input) {
 					const char *orig_bb_middle = r_config_get (core->config, "asm.bb.middle");
 					r_config_set_i (core->config, "asm.bb.middle", false);
 					cont_size = tmp_get_contsize (f);
-					r_cons_printf ("{");
-					r_cons_printf ("\"name\":\"%s\"", f->name);
-					r_cons_printf (",\"size\":%d", fcn_size);
-					r_cons_printf (",\"addr\":%"PFMT64u, f->addr);
-					r_cons_printf (",\"ops\":[");
+					pj = pj_new ();
+					pj_o (pj);
+					pj_ks (pj, "name", f->name);
+					pj_kn (pj, "size", fcn_size);
+					pj_kn (pj, "addr", f->addr);
+					pj_k (pj, "ops");
+					pj_a (pj);
 					// instructions are all outputted as a json list
 					//  DEAD CODE cont_size = f->_size > 0 ? f->_size : r_anal_fcn_realsize (f);
-					bool first = true;
-					bool prev_result = true;
 					// TODO: can loc jump to another locs?
 					for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
 						if (tmp_func->addr > f->addr) {
@@ -4819,45 +4819,33 @@ static int cmd_print(void *data, const char *input) {
 						cont_size = tmp_get_contsize (tmp_func);
 						loc_buf = calloc (cont_size, 1);
 						r_io_read_at (core->io, tmp_func->addr, loc_buf, cont_size);
-						if (!first && prev_result) {
-							r_cons_print (",");
-						}
-						prev_result = r_core_print_disasm_json (core, tmp_func->addr, loc_buf, cont_size, 0);
-						first = false;
+						r_core_print_disasm_json (core, tmp_func->addr, loc_buf, cont_size, 0, pj);
 						free (loc_buf);
 					}
-					prev_result = true;
 					r_list_foreach (f->bbs, locs_it, b) {
 
 						ut8 *buf = malloc (b->size);
 						if (buf) {
-							if (first) {
-								first = false;
-							} else if (!first && prev_result) {
-								r_cons_print (",");
-							}
 							r_io_read_at (core->io, b->addr, buf, b->size);
-							prev_result = r_core_print_disasm_json (core, b->addr, buf, b->size, 0);
+							r_core_print_disasm_json (core, b->addr, buf, b->size, 0, pj);
 							free (buf);
 						} else {
 							eprintf ("cannot allocate %d byte(s)\n", b->size);
 						}
 					}
-					prev_result = true;
 					for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
 						cont_size = tmp_get_contsize (tmp_func);
 						loc_buf = calloc (cont_size, 1);
 						if (loc_buf) {
 							r_io_read_at (core->io, tmp_func->addr, loc_buf, cont_size);
-							if (!first && prev_result) {
-								r_cons_print (",");
-							}
-							prev_result = r_core_print_disasm_json (core, tmp_func->addr, loc_buf, cont_size, 0);
-							first = false;
+							r_core_print_disasm_json (core, tmp_func->addr, loc_buf, cont_size, 0, pj);
 							free (loc_buf);
 						}
 					}
-					r_cons_printf ("]}\n");
+					pj_end (pj);
+					pj_end (pj);
+					r_cons_printf ("%s\n", pj_string (pj));
+					pj_free (pj);
 					pd_result = 0;
 					r_config_set (core->config, "asm.bb.middle", orig_bb_middle);
 				} else if (f) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -882,6 +882,9 @@ static void cmd_pDj(RCore *core, const char *arg) {
 		bsize = -bsize;
 	}
 	PJ *pj = pj_new ();
+	if (!pj) {
+		return;
+	}
 	pj_a (pj);
 	ut8 *buf = malloc (bsize);
 	if (buf) {
@@ -899,6 +902,9 @@ static void cmd_pDj(RCore *core, const char *arg) {
 static void cmd_pdj(RCore *core, const char *arg, ut8* block) {
 	int nblines = r_num_math (core->num, arg);
 	PJ *pj = pj_new ();
+	if (!pj) {
+		return;
+	}
 	pj_a (pj);
 	r_core_print_disasm_json (core, core->offset, block, core->blocksize, nblines, pj);
 	pj_end (pj);
@@ -3648,6 +3654,9 @@ static void disasm_recursive(RCore *core, ut64 addr, int count, char type_print)
 	PJ *pj = NULL;
 	if (type_print == 'j') {
 		pj = pj_new ();
+		if (!pj) {
+			return;
+		}
 		pj_a (pj);
 	}
 	while (count-- > 0) {
@@ -3785,6 +3794,9 @@ static void func_walk_blocks(RCore *core, RAnalFunction *f, char input, char typ
 	r_list_sort (f->bbs, (RListComparator) bbcmp);
 	if (input == 'j' && b) {
 		pj = pj_new ();
+		if (!pj) {
+			return;
+		}
 		pj_a (pj);
 		for (; locs_it && (tmp_func = locs_it->data); locs_it = locs_it->n) {
 			if (r_cons_is_breaked ()) {
@@ -4737,6 +4749,9 @@ static int cmd_print(void *data, const char *input) {
 
 						if (input[2] == 'j') {
 							pj = pj_new ();
+							if (!pj) {
+								break;
+							}
 							pj_a (pj);
 							r_core_print_disasm_json (core, b->addr, block, b->size, 0, pj);
 							pj_end (pj);
@@ -4803,6 +4818,9 @@ static int cmd_print(void *data, const char *input) {
 					r_config_set_i (core->config, "asm.bb.middle", false);
 					cont_size = tmp_get_contsize (f);
 					pj = pj_new ();
+					if (!pj) {
+						break;
+					}
 					pj_o (pj);
 					pj_ks (pj, "name", f->name);
 					pj_kn (pj, "size", fcn_size);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2209,7 +2209,6 @@ static char *get_comments_cb(void *user, ut64 addr) {
 R_IPI void spaces_list(RSpaces *sp, int mode) {
 	RSpaceIter it;
 	RSpace *s;
-	bool first = true;
 	const RSpace *cur = r_spaces_current (sp);
 	PJ *pj = NULL;
 	if (mode == 'j') {
@@ -2230,7 +2229,6 @@ R_IPI void spaces_list(RSpaces *sp, int mode) {
 			r_cons_printf ("%5d %c %s\n", count, (!cur || cur == s)? '*': '.',
 				s->name);
 		}
-		first = false;
 	}
 	if (mode == '*' && r_spaces_current (sp)) {
 		r_cons_printf ("%s %s # current\n", sp->name, r_spaces_current_name (sp));

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5648,14 +5648,14 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			r_list_foreach (ds->analop.switch_op->cases, iter, caseop ) {
 				pj_o (pj);
 				pj_kn (pj, "addr", caseop->addr);
-				pj_ksn (pj, "value", (st64) caseop->value);
+				pj_kN (pj, "value", (st64) caseop->value);
 				pj_kn (pj, "jump", caseop->jump);
 				pj_end (pj);
 			}
 			pj_end (pj);
 		}
 		if (ds->analop.jump != UT64_MAX ) {
-			pj_ksn (pj, "jump", ds->analop.jump);
+			pj_kN (pj, "jump", ds->analop.jump);
 			if (ds->analop.fail != UT64_MAX) {
 				pj_kn (pj, "fail", ds->analop.fail);
 			}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5434,7 +5434,6 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 	ut64 old_offset = core->offset;
 	ut64 at;
 	int dis_opcodes = 0;
-	//pj_a (pj);
 	int limit_by = 'b';
 	char str[512];
 

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5426,7 +5426,7 @@ R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opc
 	return len;
 }
 
-R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_bytes, int nb_opcodes) {
+R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_bytes, int nb_opcodes, PJ *pj) {
 	RAsmOp asmop;
 	RDisasmState *ds;
 	RAnalFunction *f;
@@ -5434,7 +5434,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 	ut64 old_offset = core->offset;
 	ut64 at;
 	int dis_opcodes = 0;
-	//r_cons_printf ("[");
+	//pj_a (pj);
 	int limit_by = 'b';
 	char str[512];
 
@@ -5464,7 +5464,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 				nb_opcodes ++;
 				if (!r_core_asm_bwdis_len (core, &nbytes, &addr, nb_opcodes)) {
 #endif
-					r_cons_printf ("]");
+					pj_end (pj);
 					return false;
 #if BWRETRY
 				}
@@ -5540,9 +5540,11 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		memset (&asmop, 0, sizeof (RAsmOp));
 		ret = r_asm_disassemble (core->assembler, &asmop, buf + i, nb_bytes - i);
 		if (ret < 1) {
-			r_cons_printf (j > 0 ? ",{" : "{");
-			r_cons_printf ("\"offset\":%"PFMT64d, at);
-			r_cons_printf (",\"size\":1,\"type\":\"invalid\"}");
+			pj_o (pj);
+			pj_kn (pj, "offset", at);
+			pj_ki (pj, "size", 1);
+			pj_ks (pj, "type", "invalid");
+			pj_end (pj);
 			i++;
 			k++;
 			j++;
@@ -5608,48 +5610,32 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			}
 		}
 
-		r_cons_printf (j > 0 ? ",{" : "{");
-		r_cons_printf ("\"offset\":%"PFMT64d, at);
+		pj_o (pj);
+		pj_kn (pj, "offset", at);
 		if (ds->analop.ptr != UT64_MAX) {
-			r_cons_printf (",\"ptr\":%"PFMT64d, ds->analop.ptr);
+			pj_kn (pj, "ptr", ds->analop.ptr);
 		}
 		if (ds->analop.val != UT64_MAX) {
-			r_cons_printf (",\"val\":%"PFMT64d, ds->analop.val);
+			pj_kn (pj, "val", ds->analop.val);
 		}
-		r_cons_printf (",\"esil\":\"%s\"", R_STRBUF_SAFEGET (&ds->analop.esil));
-		r_cons_printf (",\"refptr\":%s", r_str_bool (ds->analop.refptr));
-		if (f) {
-			r_cons_printf (",\"fcn_addr\":%"PFMT64d, f->addr);
-			r_cons_printf (",\"fcn_last\":%"PFMT64d, f->addr + r_anal_fcn_size (f) - ds->oplen);
-		} else {
-			r_cons_printf (",\"fcn_addr\":0");
-			r_cons_printf (",\"fcn_last\":0");
-		}
-		r_cons_printf (",\"size\":%d", ds->analop.size);
-		{
-			char *escaped_str = r_str_escape_utf8_for_json (opstr, -1);
-			if (escaped_str) {
-				r_cons_printf (",\"opcode\":\"%s\"", escaped_str);
-			}
-			free (escaped_str);
-
-			escaped_str = r_str_escape_utf8_for_json (str, -1);
-			if (escaped_str) {
-				r_cons_printf (",\"disasm\":\"%s\"", escaped_str);
-			}
-			free (escaped_str);
-		}
-		r_cons_printf (",\"bytes\":\"%s\"", r_asm_op_get_hex (&asmop));
-		r_cons_printf (",\"family\":\"%s\"",
-				r_anal_op_family_to_string (ds->analop.family));
-		r_cons_printf (",\"type\":\"%s\"", r_anal_optype_to_string (ds->analop.type));
+		pj_k (pj, "esil"); // split key and value to allow empty strings
+		pj_s (pj, R_STRBUF_SAFEGET (&ds->analop.esil));
+		pj_kb (pj, "refptr", ds->analop.refptr);
+		pj_kn (pj, "fcn_addr", f ? f->addr : 0);
+		pj_kn (pj, "fcn_last", f ? f->addr + r_anal_fcn_size (f) - ds->oplen : 0);
+		pj_ki (pj, "size", ds->analop.size);
+		pj_ks (pj, "opcode", opstr);
+		pj_ks (pj, "disasm", str);
+		pj_ks (pj, "bytes", r_asm_op_get_hex (&asmop));
+		pj_ks (pj, "family", r_anal_op_family_to_string (ds->analop.family));
+		pj_ks (pj, "type", r_anal_optype_to_string (ds->analop.type));
 		// indicate a relocated address
 		RBinReloc *rel = getreloc (core, ds->at, ds->analop.size);
 		// reloc is true if address in reloc table
-		r_cons_printf (",\"reloc\":%s", rel ? r_str_bool(true) : r_str_bool (false));
+		pj_kb (pj, "reloc", rel);
 		// wanted the numerical values of the type information
-		r_cons_printf (",\"type_num\":%"PFMT64d, ds->analop.type);
-		r_cons_printf (",\"type2_num\":%"PFMT64d, ds->analop.type2);
+		pj_kn (pj, "type_num", ds->analop.type);
+		pj_kn (pj, "type2_num", ds->analop.type2);
 		// handle switch statements
 		if (ds->analop.switch_op && r_list_length (ds->analop.switch_op->cases) > 0) {
 			// XXX - the java caseop will still be reported in the assembly,
@@ -5657,25 +5643,21 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			// represented during the analysis
 			RListIter *iter;
 			RAnalCaseOp *caseop;
-			int cnt = r_list_length (ds->analop.switch_op->cases);
-			r_cons_printf (", \"switch\":[");
+			pj_k (pj, "switch");
+			pj_a (pj);
 			r_list_foreach (ds->analop.switch_op->cases, iter, caseop ) {
-				cnt--;
-				r_cons_printf ("{");
-				r_cons_printf ("\"addr\":%"PFMT64d, caseop->addr);
-				r_cons_printf (", \"value\":%"PFMT64d, (st64) caseop->value);
-				r_cons_printf (", \"jump\":%"PFMT64d, caseop->jump);
-				r_cons_printf ("}");
-				if (cnt > 0) {
-					r_cons_printf (",");
-				}
+				pj_o (pj);
+				pj_kn (pj, "addr", caseop->addr);
+				pj_ksn (pj, "value", (st64) caseop->value);
+				pj_kn (pj, "jump", caseop->jump);
+				pj_end (pj);
 			}
-			r_cons_printf ("]");
+			pj_end (pj);
 		}
 		if (ds->analop.jump != UT64_MAX ) {
-			r_cons_printf (",\"jump\":%"PFMT64d, ds->analop.jump);
+			pj_ksn (pj, "jump", ds->analop.jump);
 			if (ds->analop.fail != UT64_MAX) {
-				r_cons_printf (",\"fail\":%"PFMT64d, ds->analop.fail);
+				pj_kn (pj, "fail", ds->analop.fail);
 			}
 		}
 		/* add flags */
@@ -5684,11 +5666,12 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			RFlagItem *flag;
 			RListIter *iter;
 			if (flags && !r_list_empty (flags)) {
-				r_cons_printf (",\"flags\":[");
+				pj_k (pj, "flags");
+				pj_a (pj);
 				r_list_foreach (flags, iter, flag) {
-					r_cons_printf ("%s\"%s\"", iter->p?",":"",flag->name);
+					pj_s (pj, flag->name);
 				}
-				r_cons_printf ("]");
+				pj_end (pj);
 			}
 		}
 		/* add comments */
@@ -5697,7 +5680,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, at);
 			if (comment) {
 				char *b64comment = sdb_encode ((const ut8*)comment, -1);
-				r_cons_printf (",\"comment\":\"%s\"", b64comment);
+				pj_ks (pj, "comment", b64comment);
 				free (comment);
 				free (b64comment);
 			}
@@ -5708,18 +5691,20 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			RListIter *iter;
 			RList *xrefs = r_anal_xrefs_get (core->anal, at);
 			if (xrefs && !r_list_empty (xrefs)) {
-				r_cons_printf (",\"xrefs\":[");
+				pj_k (pj, "xrefs");
+				pj_a (pj);
 				r_list_foreach (xrefs, iter, ref) {
-					r_cons_printf ("%s{\"addr\":%"PFMT64d",\"type\":\"%s\"}",
-							iter->p?",":"", ref->addr,
-						r_anal_xrefs_type_tostring (ref->type));
+					pj_o (pj);
+					pj_kn (pj, "addr", ref->addr);
+					pj_ks (pj, "type", r_anal_xrefs_type_tostring (ref->type));
+					pj_end (pj);
 				}
-				r_cons_printf ("]");
+				pj_end (pj);
 			}
 			r_list_free (xrefs);
 		}
 
-		r_cons_printf ("}");
+		pj_end (pj);
 		i += ds->oplen + asmop.payload + (ds->asmop.payload % ds->core->assembler->dataalign); // bytes
 		k += ds->oplen + asmop.payload + (ds->asmop.payload % ds->core->assembler->dataalign); // delta from addr
 		j++; // instructions
@@ -5737,7 +5722,8 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 	r_anal_op_fini (&ds->analop);
 	ds_free (ds);
 	if (!result) {
-		r_cons_printf ("{}");
+		pj_o (pj);
+		pj_end (pj);
 		result = true;
 	}
 	return result;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -571,7 +571,7 @@ R_API RList *r_core_asm_back_disassemble_instr (RCore *core, ut64 addr, int len,
 R_API RList *r_core_asm_back_disassemble_byte (RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API ut32 r_core_asm_bwdis_len (RCore* core, int* len, ut64* start_addr, ut32 l);
 R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int lines, int invbreak, int nbytes, bool json, RAnalFunction *pdf);
-R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, int lines);
+R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
 R_API int r_core_print_disasm_instructions (RCore *core, int len, int l);
 R_API int r_core_print_disasm_all (RCore *core, ut64 addr, int l, int len, int mode);
 R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt);

--- a/libr/include/r_util/pj.h
+++ b/libr/include/r_util/pj.h
@@ -27,6 +27,7 @@ R_API PJ *pj_a(PJ *j);
 /* keys, values */
 R_API PJ *pj_k(PJ *j, const char *k);
 R_API PJ *pj_kn(PJ *j, const char *k, ut64 n);
+R_API PJ *pj_ksn(PJ *j, const char *k, st64 n);
 R_API PJ *pj_ks(PJ *j, const char *k, const char *v);
 R_API PJ *pj_ki(PJ *j, const char *k, int d);
 R_API PJ *pj_kd(PJ *j, const char *k, double d);
@@ -35,6 +36,7 @@ R_API PJ *pj_kb(PJ *j, const char *k, bool v);
 R_API PJ *pj_b(PJ *j, bool v);
 R_API PJ *pj_s(PJ *j, const char *k);
 R_API PJ *pj_n(PJ *j, ut64 n);
+R_API PJ *pj_sn(PJ *j, st64 n);
 R_API PJ *pj_d(PJ *j, double d);
 R_API PJ *pj_f(PJ *j, float d);
 R_API PJ *pj_i(PJ *j, int d);

--- a/libr/include/r_util/pj.h
+++ b/libr/include/r_util/pj.h
@@ -27,7 +27,7 @@ R_API PJ *pj_a(PJ *j);
 /* keys, values */
 R_API PJ *pj_k(PJ *j, const char *k);
 R_API PJ *pj_kn(PJ *j, const char *k, ut64 n);
-R_API PJ *pj_ksn(PJ *j, const char *k, st64 n);
+R_API PJ *pj_kN(PJ *j, const char *k, st64 n);
 R_API PJ *pj_ks(PJ *j, const char *k, const char *v);
 R_API PJ *pj_ki(PJ *j, const char *k, int d);
 R_API PJ *pj_kd(PJ *j, const char *k, double d);
@@ -36,7 +36,7 @@ R_API PJ *pj_kb(PJ *j, const char *k, bool v);
 R_API PJ *pj_b(PJ *j, bool v);
 R_API PJ *pj_s(PJ *j, const char *k);
 R_API PJ *pj_n(PJ *j, ut64 n);
-R_API PJ *pj_sn(PJ *j, st64 n);
+R_API PJ *pj_N(PJ *j, st64 n);
 R_API PJ *pj_d(PJ *j, double d);
 R_API PJ *pj_f(PJ *j, float d);
 R_API PJ *pj_i(PJ *j, int d);

--- a/libr/util/pj.c
+++ b/libr/util/pj.c
@@ -117,6 +117,14 @@ R_API PJ *pj_kn(PJ *j, const char *k, ut64 n) {
 	return j;
 }
 
+R_API PJ *pj_ksn(PJ *j, const char *k, st64 n) {
+	if (j && k) {
+		pj_k (j, k);
+		pj_sn (j, n);
+	}
+	return j;
+}
+
 R_API PJ *pj_kd(PJ *j, const char *k, double d) {
 	if (j && k) {
 		pj_k (j, k);
@@ -190,6 +198,14 @@ R_API PJ *pj_n(PJ *j, ut64 n) {
 	if (j) {
 		pj_comma (j);
 		pj_raw (j, sdb_fmt ("%" PFMT64u, n));
+	}
+	return j;
+}
+
+R_API PJ *pj_sn(PJ *j, st64 n) {
+	if (j) {
+		pj_comma (j);
+		pj_raw (j, sdb_fmt ("%"PFMT64d, n));
 	}
 	return j;
 }

--- a/libr/util/pj.c
+++ b/libr/util/pj.c
@@ -117,10 +117,10 @@ R_API PJ *pj_kn(PJ *j, const char *k, ut64 n) {
 	return j;
 }
 
-R_API PJ *pj_ksn(PJ *j, const char *k, st64 n) {
+R_API PJ *pj_kN(PJ *j, const char *k, st64 n) {
 	if (j && k) {
 		pj_k (j, k);
-		pj_sn (j, n);
+		pj_N (j, n);
 	}
 	return j;
 }
@@ -202,7 +202,7 @@ R_API PJ *pj_n(PJ *j, ut64 n) {
 	return j;
 }
 
-R_API PJ *pj_sn(PJ *j, st64 n) {
+R_API PJ *pj_N(PJ *j, st64 n) {
 	if (j) {
 		pj_comma (j);
 		pj_raw (j, sdb_fmt ("%"PFMT64d, n));


### PR DESCRIPTION
As requested in PR https://github.com/radare/radare2/pull/13051 a port of agfj (and other commands) to pj.

The change is quite large, so you maybe want to make sure that i didn't mix up the types of  the variables that are put into the json