### PR TITLE
Implemented ax. command

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5911,6 +5911,18 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case '*': // "ax*"
 		r_anal_xrefs_list (core->anal, input[0]);
 		break;
+	case '.': { // "ax."
+		char *tInput = strdup (input);
+		if (r_str_replace_ch (tInput, '.', 't', false)) {
+			cmd_anal_refs (core, tInput);
+		}
+		char *fInput = strdup (input);
+		if (r_str_replace_ch (fInput, '.', 'f', false)) {
+			cmd_anal_refs (core, fInput);
+		}
+		free (tInput);
+		free (fInput);
+	} break;
 	case 't': { // "axt"
 		RList *list = NULL;
 		RAnalFunction *fcn;


### PR DESCRIPTION
For issue #12690.

The code produced the output:
 
<img width="930" alt="screen shot 2019-02-13 at 11 41 34 pm" src="https://user-images.githubusercontent.com/20895544/52733542-00463f80-2fe9-11e9-86a6-e19a0dc12800.png">

The outputs of `axt` and `axf` along with their subcommands are not similar at all. This is the simplest implementation that I could think of without rewriting the same code under `ax.`. Please tell me if I could have done something better or any changes that I should make.