### PR TITLE
Disable ptrace-wrap for WSL

### DIFF
--- a/configure
+++ b/configure
@@ -80,6 +80,9 @@ if [ -e "${VPATH}/config.guess" ]; then
 fi
 CPU="`uname -m|sed -e 's, ,,g'|cut -d - -f 1`"
 OS="`uname -s|tr A-Z a-z`"
+if uname -a | grep -qE "(Microsoft|WSL)"; then
+	OS="wsl"
+fi
 GNU="`uname --help 2>&1 | grep gnu`"
 [ "${GNU}" ] && OS="${OS}-gnu"
 [ "${CPU}" = ppc ] && CPU="powerpc"
@@ -576,6 +579,9 @@ else
 if [ "$HOST_OS" = "mingw32_nt" ]; then
 USEROSTYPE="mingw32"
 else
+if [ "$HOST_OS" = "wsl" ]; then
+USEROSTYPE="wsl"
+else
 if [ "$HOST_OS" = "linux" ]; then
 USEROSTYPE="gnulinux"
 else
@@ -600,12 +606,16 @@ if [ "$HOST_OS" = "openbsd" ]; then
 USEROSTYPE="bsd"
 else
 if [ "$HOST_OS" = "darwin" ]; then
-USEROSTYPE="darwin"; fi; fi; fi; fi; fi; fi; fi; fi; fi; fi; fi
+USEROSTYPE="darwin"; fi; fi; fi; fi; fi; fi; fi; fi; fi; fi; fi; fi
 if [ "$LIBVERSION" = "xxx" ]; then
 LIBVERSION="$VERSION"; fi
 if [ "$USEROSTYPE" = "gnulinux" ]; then
 HAVE_PTRACE="1"
 USE_PTRACE_WRAP="1"
+else
+if [ "$USEROSTYPE" = "wsl" ]; then
+HAVE_PTRACE="1"
+USE_PTRACE_WRAP="0"
 else
 if [ "$USEROSTYPE" = "android" ]; then
 HAVE_PTRACE="1"
@@ -620,7 +630,7 @@ HAVE_PTRACE="0"
 USE_PTRACE_WRAP="0"
 else
 HAVE_PTRACE="1"
-USE_PTRACE_WRAP="0"; fi; fi; fi; fi
+USE_PTRACE_WRAP="0"; fi; fi; fi; fi; fi
 if [ "$DEBUGGER" = "0" ]; then
 HAVE_PTRACE="0"; fi
 if [ "$WANT_PTRACE_WRAP" = "0" ]; then

--- a/configure.acr
+++ b/configure.acr
@@ -132,6 +132,9 @@ IFEQ USEROSTYPE auto ; {
 	IFEQ HOST_OS mingw32_nt ; {
 		USEROSTYPE = mingw32 ;
 	}{
+	IFEQ HOST_OS wsl ; {
+		USEROSTYPE =  wsl ;
+	}{
 	IFEQ HOST_OS linux ; {
 		USEROSTYPE = gnulinux ;
 	}{
@@ -158,7 +161,7 @@ IFEQ USEROSTYPE auto ; {
 	}{
 	IFEQ HOST_OS darwin ; {
 		USEROSTYPE = darwin ;
-	} } } } } } } } } }
+	} } } } } } } } } } }
 }
 
 (( this hack is required for openbsd ports ))
@@ -172,6 +175,10 @@ IFEQ LIBVERSION xxx ; {
 IFEQ USEROSTYPE gnulinux ; {
 	HAVE_PTRACE = 1 ;
 	USE_PTRACE_WRAP = 1 ;
+}{
+IFEQ USEROSTYPE wsl ; {
+	HAVE_PTRACE = 1 ;
+	USE_PTRACE_WRAP = 0 ;
 }{
 IFEQ USEROSTYPE android ; {
 	HAVE_PTRACE = 1 ;
@@ -187,7 +194,7 @@ IFEQ USEROSTYPE solaris ; {
 }{
 	HAVE_PTRACE = 1 ;
 	USE_PTRACE_WRAP = 0 ;
-} } } }
+} } } } }
 
 IFNOT DEBUGGER {
 	HAVE_PTRACE = 0 ;


### PR DESCRIPTION
First, this requires radare/acr#20, so that we can auto-generate a configure that can recognize 'wsl'