### PR TITLE
Fix #11759 - aac now names import trampolines

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -767,12 +767,9 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 						fcnpfx = r_config_get (core->config, "anal.fcnprefix");
 					}
 					fcn->name = r_str_newf ("%s.%08"PFMT64x, fcnpfx, fcn->addr);
-					/* Autoname PE import thunk */
-					RBinInfo *info;
+					/* Import trampoline naming */
 					if (r_list_length (fcn->bbs) == 1
-					    && ((RAnalBlock *) r_list_first (fcn->bbs))->ninstr == 1
-					    && (info = r_bin_get_info (core->bin))
-					    && !strcmp (info->rclass, "pe")) {
+					    && ((RAnalBlock *) r_list_first (fcn->bbs))->ninstr == 1) {
 						RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 						if (refs && r_list_length (refs) == 1) {
 							RAnalRef *ref = r_list_first (refs);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -767,9 +767,12 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 						fcnpfx = r_config_get (core->config, "anal.fcnprefix");
 					}
 					fcn->name = r_str_newf ("%s.%08"PFMT64x, fcnpfx, fcn->addr);
-					/* Import trampoline naming */
+					/* Autoname PE import thunk */
+					RBinInfo *info;
 					if (r_list_length (fcn->bbs) == 1
-					    && ((RAnalBlock *) r_list_first (fcn->bbs))->ninstr == 1) {
+					    && ((RAnalBlock *) r_list_first (fcn->bbs))->ninstr == 1
+					    && (info = r_bin_get_info (core->bin))
+					    && !strcmp (info->rclass, "pe")) {
 						RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 						if (refs && r_list_length (refs) == 1) {
 							RAnalRef *ref = r_list_first (refs);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -773,10 +773,12 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 						RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
 						if (refs && r_list_length (refs) == 1) {
 							RAnalRef *ref = r_list_first (refs);
-							RFlagItem *flg = r_flag_get_i (core->flags, ref->addr);
-							if (flg && r_str_startswith (flg->name, "sym.imp.")) {
-								R_FREE (fcn->name);
-								fcn->name = r_str_newf ("sub.%s", flg->name + 8);
+							if (ref->type != R_ANAL_REF_TYPE_CALL) { /* Some fcns don't return */
+								RFlagItem *flg = r_flag_get_i (core->flags, ref->addr);
+								if (flg && r_str_startswith (flg->name, "sym.imp.")) {
+									R_FREE (fcn->name);
+									fcn->name = r_str_newf ("sub.%s", flg->name + 8);
+								}
 							}
 						}
 					}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -650,6 +650,22 @@ static void function_rename(RFlag *flags, RAnalFunction *fcn) {
 	}
 }
 
+static void autoname_imp_trampoline(RCore *core, RAnalFunction *fcn) {
+	if (r_list_length (fcn->bbs) == 1 && ((RAnalBlock *) r_list_first (fcn->bbs))->ninstr == 1) {
+		RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
+		if (refs && r_list_length (refs) == 1) {
+			RAnalRef *ref = r_list_first (refs);
+			if (ref->type != R_ANAL_REF_TYPE_CALL) { /* Some fcns don't return */
+				RFlagItem *flg = r_flag_get_i (core->flags, ref->addr);
+				if (flg && r_str_startswith (flg->name, "sym.imp.")) {
+					R_FREE (fcn->name);
+					fcn->name = r_str_newf ("sub.%s", flg->name + 8);
+				}
+			}
+		}
+	}
+}
+
 static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth) {
 	if (depth < 0) {
 //		printf ("Too deep for 0x%08"PFMT64x"\n", at);
@@ -767,21 +783,7 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 						fcnpfx = r_config_get (core->config, "anal.fcnprefix");
 					}
 					fcn->name = r_str_newf ("%s.%08"PFMT64x, fcnpfx, fcn->addr);
-					/* Import trampoline naming */
-					if (r_list_length (fcn->bbs) == 1
-					    && ((RAnalBlock *) r_list_first (fcn->bbs))->ninstr == 1) {
-						RList *refs = r_anal_fcn_get_refs (core->anal, fcn);
-						if (refs && r_list_length (refs) == 1) {
-							RAnalRef *ref = r_list_first (refs);
-							if (ref->type != R_ANAL_REF_TYPE_CALL) { /* Some fcns don't return */
-								RFlagItem *flg = r_flag_get_i (core->flags, ref->addr);
-								if (flg && r_str_startswith (flg->name, "sym.imp.")) {
-									R_FREE (fcn->name);
-									fcn->name = r_str_newf ("sub.%s", flg->name + 8);
-								}
-							}
-						}
-					}
+					autoname_imp_trampoline (core, fcn);
 				}
 				/* Add flag */
 				r_flag_space_push (core->flags, "functions");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2607,7 +2607,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETICB ("anal.graph_depth", 256, &cb_analgraphdepth, "Max depth for path search");
 	SETICB ("anal.sleep", 0, &cb_analsleep, "Sleep N usecs every so often during analysis. Avoid 100% CPU usage");
 	SETPREF ("anal.calls", "false", "Make basic af analysis walk into calls");
-	SETPREF ("anal.autoname", "true", "Automatically set a name for the functions, may result in some false positives");
+	SETPREF ("anal.autoname", "true", "Speculatively set a name for the functions, may result in some false positives");
 	SETPREF ("anal.hasnext", "false", "Continue analysis after each function");
 	SETPREF ("anal.esil", "false", "Use the new ESIL code analysis");
 	SETCB ("anal.strings", "false", &cb_analstrings, "Identify and register strings during analysis (aar only)");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7715,7 +7715,8 @@ static int cmd_anal_all(RCore *core, const char *input) {
 					goto jacuzzi;
 				}
 				if (r_config_get_i (core->config, "anal.autoname")) {
-					oldstr = r_print_rowlog (core->print, "Constructing a function name for fcn.* and sym.func.* functions (aan)");
+					oldstr = r_print_rowlog (core->print, "Speculatively constructing a function name "
+					                         "for fcn.* and sym.func.* functions (aan)");
 					r_core_anal_autoname_all_fcns (core);
 					r_print_rowlog_done (core->print, oldstr);
 				}


### PR DESCRIPTION
Fixes #11759.