### PR TITLE
Fix offline build w.r.t. capstone

### DIFF
--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -255,7 +255,6 @@ capstone-clean:
 	cd capstone ; $(MAKE) clean
 
 capstone: capstone-$(CS_VER).tar.gz
-	curl -o capstone-$(CS_VER).tar.gz $(CS_TAR)
 	tar xzvf capstone-$(CS_VER).tar.gz
 	rm -rf capstone
 	mv capstone-$(CS_VER) capstone


### PR DESCRIPTION
If the user already provides a capstone tarball, the buildsystem should not try
to download it again.