### PR TITLE
Removing wsl from configure's HAVE_LIB_DL=1 section breaks wsl building

### DIFF
--- a/configure
+++ b/configure
@@ -354,7 +354,7 @@ echo "ERROR: ${CC} cannot create executables" >&2 ;
 exit 1 ; fi
 printf "checking for dynamic library... "
 HAVE_LIB_DL=0
-for OS in gnulinux linux gnu/kfreebsd syllable sunos darwin beos solaris ; do
+for OS in gnulinux linux gnu/kfreebsd syllable sunos darwin beos solaris wsl; do
 if [ "${HOST_OS}" = "${OS}" ]; then
 	HAVE_LIB_DL=1
 	break;


### PR DESCRIPTION
Reverts the change to the configuration line since it breaks building on wsl with the following error:
```
$sys/install.sh 
...
CC rax2.c
LD rax2
/home/gl/src/radare2/libr/util/libr_util.so: undefined reference to `dlopen'
/home/gl/src/radare2/libr/util/libr_util.so: undefined reference to `dlclose'
/home/gl/src/radare2/libr/util/libr_util.so: undefined reference to `dlerror'
/home/gl/src/radare2/libr/util/libr_util.so: undefined reference to `dlsym'
collect2: error: ld returned 1 exit status
../rules.mk:70: recipe for target 'rax2' failed
make[2]: *** [rax2] Error 1
Makefile:14: recipe for target 'all' failed
```

The commit previous to this compiles fine, and building works when wsl is re-added to this line.