### PR TITLE
Make Lisp fortune work with Clojure(Script)

### DIFF
--- a/doc/fortunes.fun
+++ b/doc/fortunes.fun
@@ -202,7 +202,7 @@ Quantum dissasemble: it's there as long as you don't observe it
 Ceci n'est pas une r2pipe
 Buy a mac
 (gdb) ^D
-((fn [f s n] (cat [(f f s n) "dare2"])) (fn [f s n] (pr s) (if (> n 0) (f f (cat [s "ra"]) (dec n)) s)) "" Infty)
+((fn [f s n] (str (f f s n) "dare2")) (fn [f s n] (pr s) (if (> n 0) (f f (str s "ra") (dec n)) s)) "" (/ 1.0 0))
 There's no way you could crash radare2. No. Way.
 When in doubt, try 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; pd;'
 .-. .- -.. .- .-. . ..---


### PR DESCRIPTION
I've noticed that this fun one-liner looks very much like Clojure code, but doesn't actually work, so I took the liberty to fix it. It also works in ClojureScript as tested with lumo.