### PR TITLE
Parse ObjC categories

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -59,7 +59,7 @@ static st64 read_sleb128(ulebr *r, ut8 *end) {
 	return result;
 }
 
-static ut64 entry_to_vaddr(struct MACH0_(obj_t)* bin) {
+static ut64 entry_to_vaddr(struct MACH0_(obj_t) *bin) {
 	switch (bin->main_cmd.cmd) {
 	case LC_MAIN:
 		return bin->entry + bin->baddr;
@@ -71,7 +71,7 @@ static ut64 entry_to_vaddr(struct MACH0_(obj_t)* bin) {
 	}
 }
 
-static ut64 addr_to_offset(struct MACH0_(obj_t)* bin, ut64 addr) {
+static ut64 addr_to_offset(struct MACH0_(obj_t) *bin, ut64 addr) {
 	ut64 segment_base, segment_size;
 	int i;
 
@@ -88,7 +88,7 @@ static ut64 addr_to_offset(struct MACH0_(obj_t)* bin, ut64 addr) {
 	return 0;
 }
 
-static int init_hdr(struct MACH0_(obj_t)* bin) {
+static int init_hdr(struct MACH0_(obj_t) *bin) {
 	ut8 magicbytes[4] = {0};
 	ut8 machohdrbytes[sizeof (struct MACH0_(mach_header))] = {0};
 	int len;
@@ -151,7 +151,7 @@ static int init_hdr(struct MACH0_(obj_t)* bin) {
 	return true;
 }
 
-static int parse_segments(struct MACH0_(obj_t)* bin, ut64 off) {
+static int parse_segments(struct MACH0_(obj_t) *bin, ut64 off) {
 	int i, j, k, sect, len;
 	ut32 size_sects;
 	ut8 segcom[sizeof (struct MACH0_(segment_command))] = {0};
@@ -305,7 +305,7 @@ static int parse_segments(struct MACH0_(obj_t)* bin, ut64 off) {
 	return true;
 }
 
-static int parse_symtab(struct MACH0_(obj_t)* bin, ut64 off) {
+static int parse_symtab(struct MACH0_(obj_t) *bin, ut64 off) {
 	struct symtab_command st;
 	ut32 size_sym;
 	int i;
@@ -384,7 +384,7 @@ static int parse_symtab(struct MACH0_(obj_t)* bin, ut64 off) {
 	return true;
 }
 
-static int parse_dysymtab(struct MACH0_(obj_t)* bin, ut64 off) {
+static int parse_dysymtab(struct MACH0_(obj_t) *bin, ut64 off) {
 	int len, i;
 	ut32 size_tab;
 	ut8 dysym[sizeof (struct dysymtab_command)] = {0};
@@ -607,7 +607,7 @@ static void parseCodeDirectory (RBuffer *b, int offset, int datasize) {
 	eprintf ("CodeSlots: %d\n", cscd.nCodeSlots);
 	free (identity);
 	free (teamId);
-	
+
 	int hashSize = 20; // SHA1 is default
 	int algoType = R_HASH_SHA1;
 	const char *hashName = "sha1";
@@ -832,7 +832,7 @@ static bool parse_signature(struct MACH0_(obj_t) *bin, ut64 off) {
 	return true;
 }
 
-static int parse_thread(struct MACH0_(obj_t)* bin, struct load_command *lc, ut64 off, bool is_first_thread) {
+static int parse_thread(struct MACH0_(obj_t) *bin, struct load_command *lc, ut64 off, bool is_first_thread) {
 	ut64 ptr_thread, pc = UT64_MAX, pc_offset = UT64_MAX;
 	ut32 flavor, count;
 	ut8 *arw_ptr = NULL;
@@ -999,7 +999,7 @@ wrong_read:
 	return false;
 }
 
-static int parse_function_starts (struct MACH0_(obj_t)* bin, ut64 off) {
+static int parse_function_starts (struct MACH0_(obj_t) *bin, ut64 off) {
 	struct linkedit_data_command fc;
 	ut8 sfc[sizeof (struct linkedit_data_command)] = {0};
 	ut8 *buf;
@@ -1044,7 +1044,7 @@ static int parse_function_starts (struct MACH0_(obj_t)* bin, ut64 off) {
 	return true;
 }
 
-static int parse_dylib(struct MACH0_(obj_t)* bin, ut64 off) {
+static int parse_dylib(struct MACH0_(obj_t) *bin, ut64 off) {
 	struct dylib_command dl;
 	int lib, len;
 	ut8 sdl[sizeof (struct dylib_command)] = {0};
@@ -1192,7 +1192,7 @@ static const char *cmd_to_string(ut32 cmd) {
 	return "";
 }
 
-static int init_items(struct MACH0_(obj_t)* bin) {
+static int init_items(struct MACH0_(obj_t) *bin) {
 	struct load_command lc = {0, 0};
 	ut8 loadc[sizeof (struct load_command)] = {0};
 	bool is_first_thread = true;
@@ -1484,7 +1484,7 @@ static int init_items(struct MACH0_(obj_t)* bin) {
 	return true;
 }
 
-static int init(struct MACH0_(obj_t)* bin) {
+static int init(struct MACH0_(obj_t) *bin) {
 	if (!init_hdr (bin)) {
 		bprintf ("Warning: File is not MACH0\n");
 		return false;
@@ -1496,7 +1496,7 @@ static int init(struct MACH0_(obj_t)* bin) {
 	return true;
 }
 
-void* MACH0_(mach0_free)(struct MACH0_(obj_t)* mo) {
+void *MACH0_(mach0_free)(struct MACH0_(obj_t) *mo) {
 	if (!mo) {
 		return NULL;
 	}
@@ -1506,6 +1506,9 @@ void* MACH0_(mach0_free)(struct MACH0_(obj_t)* mo) {
 	free (mo->symstr);
 	free (mo->indirectsyms);
 	free (mo->imports_by_ord);
+	if (mo->imports_by_name) {
+		ht_pp_free (mo->imports_by_name);
+	}
 	free (mo->dyld_info);
 	free (mo->toc);
 	free (mo->modtab);
@@ -1518,7 +1521,7 @@ void* MACH0_(mach0_free)(struct MACH0_(obj_t)* mo) {
 	return NULL;
 }
 
-void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile * bf) {
+void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile *bf) {
 	if (!options) {
 		return;
 	}
@@ -1531,7 +1534,19 @@ void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile * bf) {
 	}
 }
 
-struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, struct MACH0_(opts_t) *options) {
+static void *duplicate_ptr(void *p) {
+	return p;
+}
+
+static void free_only_key(HtPPKv *kv) {
+	free (kv->key);
+}
+
+static size_t ptr_size(void *c) {
+	return 8;
+}
+
+struct MACH0_(obj_t) *MACH0_(mach0_new)(const char *file, struct MACH0_(opts_t) *options) {
 	ut8 *buf;
 	struct MACH0_(obj_t) *bin;
 	if (!(bin = malloc (sizeof (struct MACH0_(obj_t))))) {
@@ -1558,15 +1573,16 @@ struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, struct MACH0_(opts_t) 
 	}
 	bin->imports_by_ord_size = 0;
 	bin->imports_by_ord = NULL;
+	bin->imports_by_name = ht_pp_new ((HtPPDupValue)duplicate_ptr, free_only_key, (HtPPCalcSizeV)ptr_size);
 	return bin;
 }
 
-struct MACH0_(obj_t)* MACH0_(new_buf)(RBuffer *buf, struct MACH0_(opts_t) *options) {
+struct MACH0_(obj_t) *MACH0_(new_buf)(RBuffer *buf, struct MACH0_(opts_t) *options) {
 	if (!buf) {
 		return NULL;
 	}
 
-	RBuffer * buf_ref = r_buf_ref (buf);
+	RBuffer *buf_ref = r_buf_ref (buf);
 	struct MACH0_(obj_t) *bin = R_NEW0 (struct MACH0_(obj_t));
 	if (!bin) {
 		return NULL;
@@ -1600,7 +1616,7 @@ static int prot2perm (int x) {
 	return r;
 }
 
-struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
+struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) *bin) {
 	struct section_t *sections;
 	char segname[32], sectname[32], raw_segname[17];
 	int i, j, to;
@@ -1675,7 +1691,7 @@ struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin) {
 	return sections;
 }
 
-static int parse_import_stub(struct MACH0_(obj_t)* bin, struct symbol_t *symbol, int idx) {
+static int parse_import_stub(struct MACH0_(obj_t) *bin, struct symbol_t *symbol, int idx) {
 	int i, j, nsyms, stridx;
 	const char *symstr;
 	if (idx < 0) {
@@ -1748,7 +1764,7 @@ static int inSymtab(HtPP *hash, const char *name, ut64 addr) {
 	return false;
 }
 
-static char *get_name(struct MACH0_(obj_t)* mo, ut32 stridx, bool filter) {
+static char *get_name(struct MACH0_(obj_t) *mo, ut32 stridx, bool filter) {
 	int i = 0;
 	if (stridx >= mo->symstrlen) {
 		return NULL;
@@ -1771,7 +1787,7 @@ static char *get_name(struct MACH0_(obj_t)* mo, ut32 stridx, bool filter) {
 	return NULL;
 }
 
-struct symbol_t* MACH0_(get_symbols)(struct MACH0_(obj_t)* bin) {
+struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin) {
 	struct symbol_t *symbols;
 	int j, s, stridx, symbols_size, symbols_count;
 	ut32 to, from, i;
@@ -1907,7 +1923,7 @@ struct symbol_t* MACH0_(get_symbols)(struct MACH0_(obj_t)* bin) {
 	return symbols;
 }
 
-static int parse_import_ptr(struct MACH0_(obj_t)* bin, struct reloc_t *reloc, int idx) {
+static int parse_import_ptr(struct MACH0_(obj_t) *bin, struct reloc_t *reloc, int idx) {
 	int i, j, sym, wordsize;
 	ut32 stype;
 	wordsize = MACH0_(get_bits)(bin) / 8;
@@ -1953,7 +1969,7 @@ static int parse_import_ptr(struct MACH0_(obj_t)* bin, struct reloc_t *reloc, in
 	return false;
 }
 
-struct import_t* MACH0_(get_imports)(struct MACH0_(obj_t)* bin) {
+struct import_t *MACH0_(get_imports)(struct MACH0_(obj_t) *bin) {
 	int i, j, idx, stridx;
 
 	r_return_val_if_fail (bin && bin->sects, NULL);
@@ -2003,19 +2019,22 @@ struct import_t* MACH0_(get_imports)(struct MACH0_(obj_t)* bin) {
 	return imports;
 }
 
-struct reloc_t* MACH0_(get_relocs)(struct MACH0_(obj_t)* bin) {
-	struct reloc_t *relocs = NULL;
-	int i = 0, len;
+static int reloc_comparator(struct reloc_t *a, struct reloc_t *b) {
+	return a->addr - b->addr;
+}
+
+RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
+	RSkipList *relocs;
 	ulebr ur = {NULL};
 	int wordsize = MACH0_(get_bits)(bin) / 8;
 	if (bin->dyld_info) {
 		ut8 *opcodes,*end, type = 0, rel_type = 0;
 		int lib_ord, seg_idx = -1, sym_ord = -1;
-		size_t j, count, skip, bind_size, lazy_size;
+		char *sym_name = NULL;
+		size_t j, count, skip, bind_size, lazy_size, weak_size;
 		st64 addend = 0;
 		ut64 segmentAddress = 0LL;
 		ut64 addr = 0LL;
-		ut8 done = 0;
 
 #define CASE(T) case ((T) / 8): rel_type = R_BIN_RELOC_ ## T; break
 		switch (wordsize) {
@@ -2028,6 +2047,7 @@ struct reloc_t* MACH0_(get_relocs)(struct MACH0_(obj_t)* bin) {
 #undef CASE
 		bind_size = bin->dyld_info->bind_size;
 		lazy_size = bin->dyld_info->lazy_bind_size;
+		weak_size = bin->dyld_info->weak_bind_size;
 
 		if (!bind_size || !lazy_size) {
 			return NULL;
@@ -2046,38 +2066,40 @@ struct reloc_t* MACH0_(get_relocs)(struct MACH0_(obj_t)* bin) {
 		if (bin->dyld_info->bind_off+bind_size+lazy_size > bin->size) {
 			return NULL;
 		}
-		// NOTE(eddyb) it's a waste of memory, but we don't know the actual number of relocs.
-		int amount = bind_size + lazy_size;
+		int amount = bind_size + lazy_size + weak_size;
 		if (amount < 0) {
-			amount = 0;
+			return NULL;
 		}
-		if (!(relocs = calloc (amount + 1, sizeof (struct reloc_t)))) {
+		relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
+		if (!relocs) {
 			return NULL;
 		}
 		opcodes = calloc (1, amount + 1);
 		if (!opcodes) {
-			free (relocs);
+			r_skiplist_free (relocs);
 			return NULL;
 		}
-		len = r_buf_read_at (bin->b, bin->dyld_info->bind_off, opcodes, bind_size);
-		int ls = r_buf_read_at (bin->b, bin->dyld_info->lazy_bind_off, opcodes + bind_size, lazy_size);
-		if (len < 1 || ls < 1) {
+
+		int len = r_buf_read_at (bin->b, bin->dyld_info->bind_off, opcodes, bind_size);
+		len += r_buf_read_at (bin->b, bin->dyld_info->lazy_bind_off, opcodes + bind_size, lazy_size);
+		len += r_buf_read_at (bin->b, bin->dyld_info->weak_bind_off, opcodes + bind_size + lazy_size, weak_size);
+		if (len < amount) {
 			bprintf ("Error: read (dyld_info bind) at 0x%08"PFMT64x"\n", (ut64)(size_t)bin->dyld_info->bind_off);
-			free (opcodes);
-			relocs[i].last = true;
-			return relocs;
+			R_FREE (opcodes);
+			r_skiplist_free (relocs);
+			return NULL;
 		}
-		// that +2 is a minimum required for uleb128, this may be wrong,
-		// the correct fix would be to make ULEB() must use rutil's
-		// implementation that already checks for buffer boundaries
-		for (ur.p = opcodes, end = opcodes + bind_size + lazy_size ; (ur.p+2 < end) && !done; ) {
+
+		for (ur.p = opcodes, end = opcodes + amount ; ur.p < end; ) {
 			ut8 imm = *ur.p & BIND_IMMEDIATE_MASK, op = *ur.p & BIND_OPCODE_MASK;
 			++ur.p;
+			if (ur.p >= end) {
+				break;
+			}
 			switch (op) {
 #define ULEB() read_uleb128 (&ur,end)
 #define SLEB() read_sleb128 (&ur,end)
 			case BIND_OPCODE_DONE:
-				done = 1;
 				break;
 			case BIND_OPCODE_SET_DYLIB_ORDINAL_IMM:
 				lib_ord = imm;
@@ -2089,8 +2111,7 @@ struct reloc_t* MACH0_(get_relocs)(struct MACH0_(obj_t)* bin) {
 				lib_ord = imm? (st8)(BIND_OPCODE_MASK | imm) : 0;
 				break;
 			case BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM: {
-				char *sym_name = (char*)ur.p;
-				//ut8 sym_flags = imm;
+				sym_name = (char*)ur.p;
 				while (*ur.p++ && ur.p<end) {
 					/* empty loop */
 				}
@@ -2128,8 +2149,9 @@ struct reloc_t* MACH0_(get_relocs)(struct MACH0_(obj_t)* bin) {
 				if (seg_idx < 0 || seg_idx >= bin->nsegs) {
 					bprintf ("Error: BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB"
 						" has unexistent segment %d\n", seg_idx);
-					R_FREE (relocs);
-					return 0; // early exit to avoid future mayhem
+					R_FREE (opcodes);
+					r_skiplist_free (relocs);
+					return NULL; // early exit to avoid future mayhem
 				} else {
 					addr = bin->segs[seg_idx].vmaddr + ULEB();
 					segmentAddress = bin->segs[seg_idx].vmaddr \
@@ -2140,18 +2162,22 @@ struct reloc_t* MACH0_(get_relocs)(struct MACH0_(obj_t)* bin) {
 				addr += ULEB();
 				break;
 #define DO_BIND() do {\
-if (sym_ord < 0 || seg_idx < 0 ) break;\
-if (i >= (bind_size + lazy_size)) break;\
-relocs[i].addr = addr;\
-relocs[i].offset = addr - bin->segs[seg_idx].vmaddr + bin->segs[seg_idx].fileoff;\
-if (type == BIND_TYPE_TEXT_PCREL32)\
-	relocs[i].addend = addend - (bin->baddr + addr);\
-else relocs[i].addend = addend;\
-/* library ordinal ??? */ \
-relocs[i].ord = lib_ord;\
-relocs[i].ord = sym_ord;\
-relocs[i].type = rel_type;\
-relocs[i++].last = 0;\
+	if ((sym_ord < 0 && !sym_name) || seg_idx < 0 ) break;\
+	if (!addr) break;\
+	struct reloc_t *reloc = R_NEW0 (struct reloc_t);\
+	reloc->addr = addr;\
+	reloc->offset = addr - bin->segs[seg_idx].vmaddr + bin->segs[seg_idx].fileoff;\
+	if (type == BIND_TYPE_TEXT_PCREL32)\
+		reloc->addend = addend - (bin->baddr + addr);\
+	else\
+		reloc->addend = addend;\
+	/* library ordinal ??? */ \
+	reloc->ord = lib_ord;\
+	reloc->ord = sym_ord;\
+	reloc->type = rel_type;\
+	if (sym_name)\
+		strlcpy (reloc->name, sym_name, 256);\
+	r_skiplist_insert (relocs, reloc);\
 } while (0)
 			case BIND_OPCODE_DO_BIND:
 				if (addr >= segmentAddress) {
@@ -2194,12 +2220,11 @@ relocs[i++].last = 0;\
 #undef SLEB
 			default:
 				bprintf ("Error: unknown bind opcode 0x%02x in dyld_info\n", *ur.p);
-				free (opcodes);
-				relocs[i].last = 1;
+				R_FREE (opcodes);
 				return relocs;
 			}
 		}
-		free (opcodes);
+		R_FREE (opcodes);
 	} else {
 		int j;
 		if (!bin->symtab || !bin->symstr || !bin->sects || !bin->indirectsyms) {
@@ -2209,31 +2234,29 @@ relocs[i++].last = 0;\
 		if (amount < 0) {
 			amount = 0;
 		}
-		if (!(relocs = calloc (amount + 1, sizeof (struct reloc_t)))) {
+		relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
+		if (!relocs) {
 			return NULL;
 		}
 		for (j = 0; j < amount; j++) {
-			if (parse_import_ptr (bin, &relocs[i], bin->dysymtab.iundefsym + j)) {
-				relocs[i].ord = j;
-				relocs[i++].last = false;
+			struct reloc_t *reloc = R_NEW0 (struct reloc_t);
+			if (parse_import_ptr (bin, reloc, bin->dysymtab.iundefsym + j)) {
+				reloc->ord = j;
 			}
 		}
 	}
 beach:
-	if (relocs) {
-		relocs[i].last = true;
-	}
 	return relocs;
 }
 
-struct addr_t* MACH0_(get_entrypoint)(struct MACH0_(obj_t)* bin) {
+struct addr_t *MACH0_(get_entrypoint)(struct MACH0_(obj_t) *bin) {
 	r_return_val_if_fail (bin && bin->sects, NULL);
 
 	/* it's probably a dylib */
 	if (!bin->entry) {
 		return NULL;
 	}
-	
+
 	struct addr_t *entry = R_NEW0 (struct addr_t);
 	if (!entry) {
 		return NULL;
@@ -2266,14 +2289,14 @@ struct addr_t* MACH0_(get_entrypoint)(struct MACH0_(obj_t)* bin) {
 	return entry;
 }
 
-void MACH0_(kv_loadlibs)(struct MACH0_(obj_t)* bin) {
+void MACH0_(kv_loadlibs)(struct MACH0_(obj_t) *bin) {
 	int i;
 	for (i = 0; i < bin->nlibs; i++) {
 		sdb_set (bin->kv, sdb_fmt ("libs.%d.name", i), bin->libs[i], 0);
 	}
 }
 
-struct lib_t* MACH0_(get_libs)(struct MACH0_(obj_t)* bin) {
+struct lib_t *MACH0_(get_libs)(struct MACH0_(obj_t) *bin) {
 	struct lib_t *libs;
 	int i;
 
@@ -2293,7 +2316,7 @@ struct lib_t* MACH0_(get_libs)(struct MACH0_(obj_t)* bin) {
 	return libs;
 }
 
-ut64 MACH0_(get_baddr)(struct MACH0_(obj_t)* bin) {
+ut64 MACH0_(get_baddr)(struct MACH0_(obj_t) *bin) {
 	int i;
 
 	if (bin->hdr.filetype != MH_EXECUTE && bin->hdr.filetype != MH_DYLINKER) {
@@ -2307,7 +2330,7 @@ ut64 MACH0_(get_baddr)(struct MACH0_(obj_t)* bin) {
 	return 0;
 }
 
-char* MACH0_(get_class)(struct MACH0_(obj_t)* bin) {
+char *MACH0_(get_class)(struct MACH0_(obj_t) *bin) {
 #if R_BIN_MACH064
 	return r_str_new ("MACH064");
 #else
@@ -2318,7 +2341,7 @@ char* MACH0_(get_class)(struct MACH0_(obj_t)* bin) {
 //XXX we are mixing up bits from cpu and opcodes
 //since thumb use 16 bits opcode but run in 32 bits
 //cpus  so here we should only return 32 or 64
-int MACH0_(get_bits)(struct MACH0_(obj_t)* bin) {
+int MACH0_(get_bits)(struct MACH0_(obj_t) *bin) {
 	if (bin) {
 		int bits = MACH0_(get_bits_from_hdr) (&bin->hdr);
 		if (bin->hdr.cputype == CPU_TYPE_ARM && bin->entry & 1) {
@@ -2329,7 +2352,7 @@ int MACH0_(get_bits)(struct MACH0_(obj_t)* bin) {
 	return 32;
 }
 
-int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header)* hdr) {
+int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header) *hdr) {
 	if (hdr->magic == MH_MAGIC_64 || hdr->magic == MH_CIGAM_64) {
 		return 64;
 	}
@@ -2342,7 +2365,7 @@ int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header)* hdr) {
 	return 32;
 }
 
-bool MACH0_(is_big_endian)(struct MACH0_(obj_t)* bin) {
+bool MACH0_(is_big_endian)(struct MACH0_(obj_t) *bin) {
 	if (bin) {
 		const int cpu = bin->hdr.cputype;
 		return cpu == CPU_TYPE_POWERPC || cpu == CPU_TYPE_POWERPC64;
@@ -2350,11 +2373,11 @@ bool MACH0_(is_big_endian)(struct MACH0_(obj_t)* bin) {
 	return false;
 }
 
-const char* MACH0_(get_intrp)(struct MACH0_(obj_t)* bin) {
+const char *MACH0_(get_intrp)(struct MACH0_(obj_t) *bin) {
 	return bin? bin->intrp: NULL;
 }
 
-const char* MACH0_(get_os)(struct MACH0_(obj_t)* bin) {
+const char *MACH0_(get_os)(struct MACH0_(obj_t) *bin) {
 	if (bin) {
 		switch (bin->os) {
 		case 1: return "macos";
@@ -2366,7 +2389,7 @@ const char* MACH0_(get_os)(struct MACH0_(obj_t)* bin) {
 	return "darwin";
 }
 
-const char* MACH0_(get_cputype_from_hdr)(struct MACH0_(mach_header) *hdr) {
+const char *MACH0_(get_cputype_from_hdr)(struct MACH0_(mach_header) *hdr) {
 	const char *archstr = "unknown";
 	switch (hdr->cputype) {
 	case CPU_TYPE_VAX:
@@ -2413,7 +2436,7 @@ const char* MACH0_(get_cputype_from_hdr)(struct MACH0_(mach_header) *hdr) {
 	return archstr;
 }
 
-const char* MACH0_(get_cputype)(struct MACH0_(obj_t)* bin) {
+const char *MACH0_(get_cputype)(struct MACH0_(obj_t) *bin) {
 	return bin? MACH0_(get_cputype_from_hdr) (&bin->hdr): "unknown";
 }
 
@@ -2566,28 +2589,28 @@ static const char *cpusubtype_tostring (ut32 cputype, ut32 cpusubtype) {
 	return "Unknown cputype";
 }
 
-char* MACH0_(get_cpusubtype_from_hdr)(struct MACH0_(mach_header) *hdr) {
+char *MACH0_(get_cpusubtype_from_hdr)(struct MACH0_(mach_header) *hdr) {
 	r_return_val_if_fail (hdr, NULL);
 	return strdup (cpusubtype_tostring (hdr->cputype, hdr->cpusubtype));
 }
 
-char* MACH0_(get_cpusubtype)(struct MACH0_(obj_t)* bin) {
+char *MACH0_(get_cpusubtype)(struct MACH0_(obj_t) *bin) {
 	if (bin) {
 		return MACH0_(get_cpusubtype_from_hdr) (&bin->hdr);
 	}
 	return strdup ("Unknown");
 }
 
-bool MACH0_(is_pie)(struct MACH0_(obj_t)* bin) {
+bool MACH0_(is_pie)(struct MACH0_(obj_t) *bin) {
 	return (bin && bin->hdr.filetype == MH_EXECUTE && bin->hdr.flags & MH_PIE);
 }
 
-bool MACH0_(has_nx)(struct MACH0_(obj_t)* bin) {
+bool MACH0_(has_nx)(struct MACH0_(obj_t) *bin) {
 	return (bin && bin->hdr.filetype == MH_EXECUTE &&
 		bin->hdr.flags & MH_NO_HEAP_EXECUTION);
 }
 
-char* MACH0_(get_filetype_from_hdr)(struct MACH0_(mach_header) *hdr) {
+char *MACH0_(get_filetype_from_hdr)(struct MACH0_(mach_header) *hdr) {
 	const char *mhtype = "Unknown";
 	switch (hdr->filetype) {
 	case MH_OBJECT:     mhtype = "Relocatable object"; break;
@@ -2604,14 +2627,14 @@ char* MACH0_(get_filetype_from_hdr)(struct MACH0_(mach_header) *hdr) {
 	return strdup (mhtype);
 }
 
-char* MACH0_(get_filetype)(struct MACH0_(obj_t)* bin) {
+char *MACH0_(get_filetype)(struct MACH0_(obj_t) *bin) {
 	if (bin) {
 		return MACH0_(get_filetype_from_hdr) (&bin->hdr);
 	}
 	return strdup ("Unknown");
 }
 
-ut64 MACH0_(get_main)(struct MACH0_(obj_t)* bin) {
+ut64 MACH0_(get_main)(struct MACH0_(obj_t) *bin) {
 	ut64 addr = 0LL;
 	struct symbol_t *symbols;
 	int i;
@@ -2764,7 +2787,7 @@ void MACH0_(mach_headerfields)(RBinFile *file) {
 	free (mh);
 }
 
-RList* MACH0_(mach_fields)(RBinFile *bf) {
+RList *MACH0_(mach_fields)(RBinFile *bf) {
 	struct MACH0_(mach_header) *mh = MACH0_(get_hdr_from_bytes)(bf->buf);
 	if (!mh) {
 		return NULL;
@@ -2790,7 +2813,7 @@ RList* MACH0_(mach_fields)(RBinFile *bf) {
 	return ret;
 }
 
-struct MACH0_(mach_header) * MACH0_(get_hdr_from_bytes)(RBuffer *buf) {
+struct MACH0_(mach_header) *MACH0_(get_hdr_from_bytes)(RBuffer *buf) {
 	ut8 magicbytes[sizeof (ut32)] = {0};
 	ut8 machohdrbytes[sizeof (struct MACH0_(mach_header))] = {0};
 	int len;

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2176,7 +2176,7 @@ RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
 	reloc->ord = sym_ord;\
 	reloc->type = rel_type;\
 	if (sym_name)\
-		strlcpy (reloc->name, sym_name, 256);\
+		r_str_ncpy (reloc->name, sym_name, 256);\
 	r_skiplist_insert (relocs, reloc);\
 } while (0)
 			case BIND_OPCODE_DO_BIND:

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -69,6 +69,7 @@ struct reloc_t {
 	ut8 type;
 	int ord;
 	int last;
+	char name[256];
 };
 
 struct addr_t {
@@ -106,31 +107,32 @@ struct MACH0_(opts_t) {
 
 struct MACH0_(obj_t) {
 	struct MACH0_(mach_header) hdr;
-	struct MACH0_(segment_command)* segs;
+	struct MACH0_(segment_command) *segs;
 	char *intrp;
 	int nsegs;
-	struct MACH0_(section)* sects;
+	struct MACH0_(section) *sects;
 	int nsects;
-	struct MACH0_(nlist)* symtab;
-	ut8* symstr;
-	ut8* func_start; //buffer that hold the data from LC_FUNCTION_STARTS
+	struct MACH0_(nlist) *symtab;
+	ut8 *symstr;
+	ut8 *func_start; //buffer that hold the data from LC_FUNCTION_STARTS
 	int symstrlen;
 	int nsymtab;
-	ut32* indirectsyms;
+	ut32 *indirectsyms;
 	int nindirectsyms;
 
 	RBinImport **imports_by_ord;
 	size_t imports_by_ord_size;
+	HtPP *imports_by_name;
 
 	struct dysymtab_command dysymtab;
 	struct load_command main_cmd;
 	struct dyld_info_command *dyld_info;
-	struct dylib_table_of_contents* toc;
+	struct dylib_table_of_contents *toc;
 	int ntoc;
-	struct MACH0_(dylib_module)* modtab;
+	struct MACH0_(dylib_module) *modtab;
 	int nmodtab;
 	struct thread_command thread;
-	ut8* signature;
+	ut8 *signature;
 	union {
 		struct x86_thread_state32 x86_32;
 		struct x86_thread_state64 x86_64;
@@ -145,8 +147,8 @@ struct MACH0_(obj_t) {
 	ut64 baddr;
 	ut64 entry;
 	bool big_endian;
-	const char* file;
-	RBuffer* b;
+	const char *file;
+	RBuffer *b;
 	int os;
 	Sdb *kv;
 	int has_crypto;
@@ -160,38 +162,38 @@ struct MACH0_(obj_t) {
 	int func_size;
 	bool verbose;
 	ut64 header_at;
-	void * user;
+	void *user;
 	ut64 (*va2pa)(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf);
 };
 
-void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile * bf);
-struct MACH0_(obj_t)* MACH0_(mach0_new)(const char* file, struct MACH0_(opts_t) *options);
-struct MACH0_(obj_t)* MACH0_(new_buf)(RBuffer *buf, struct MACH0_(opts_t) *options);
-void* MACH0_(mach0_free)(struct MACH0_(obj_t)* bin);
-struct section_t* MACH0_(get_sections)(struct MACH0_(obj_t)* bin);
-struct symbol_t* MACH0_(get_symbols)(struct MACH0_(obj_t)* bin);
-void MACH0_(pull_symbols)(struct MACH0_(obj_t)* mo, RBinSymbolCallback cb, void *user);
-struct import_t* MACH0_(get_imports)(struct MACH0_(obj_t)* bin);
-struct reloc_t* MACH0_(get_relocs)(struct MACH0_(obj_t)* bin);
-struct addr_t* MACH0_(get_entrypoint)(struct MACH0_(obj_t)* bin);
-struct lib_t* MACH0_(get_libs)(struct MACH0_(obj_t)* bin);
-ut64 MACH0_(get_baddr)(struct MACH0_(obj_t)* bin);
-char* MACH0_(get_class)(struct MACH0_(obj_t)* bin);
-int MACH0_(get_bits)(struct MACH0_(obj_t)* bin);
-bool MACH0_(is_big_endian)(struct MACH0_(obj_t)* bin);
-bool MACH0_(is_pie)(struct MACH0_(obj_t)* bin);
-bool MACH0_(has_nx)(struct MACH0_(obj_t)* bin);
-const char* MACH0_(get_intrp)(struct MACH0_(obj_t)* bin);
-const char* MACH0_(get_os)(struct MACH0_(obj_t)* bin);
-const char* MACH0_(get_cputype)(struct MACH0_(obj_t)* bin);
-char* MACH0_(get_cpusubtype)(struct MACH0_(obj_t)* bin);
-char* MACH0_(get_cpusubtype_from_hdr)(struct MACH0_(mach_header) *hdr);
-char* MACH0_(get_filetype)(struct MACH0_(obj_t)* bin);
-char* MACH0_(get_filetype_from_hdr)(struct MACH0_(mach_header) *hdr);
-ut64 MACH0_(get_main)(struct MACH0_(obj_t)* bin);
-const char* MACH0_(get_cputype_from_hdr)(struct MACH0_(mach_header) *hdr);
-int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header)* hdr);
-struct MACH0_(mach_header)* MACH0_(get_hdr_from_bytes)(RBuffer *buf);
+void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile *bf);
+struct MACH0_(obj_t) *MACH0_(mach0_new)(const char *file, struct MACH0_(opts_t) *options);
+struct MACH0_(obj_t) *MACH0_(new_buf)(RBuffer *buf, struct MACH0_(opts_t) *options);
+void *MACH0_(mach0_free)(struct MACH0_(obj_t) *bin);
+struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) *bin);
+struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin);
+void MACH0_(pull_symbols)(struct MACH0_(obj_t) *mo, RBinSymbolCallback cb, void *user);
+struct import_t *MACH0_(get_imports)(struct MACH0_(obj_t) *bin);
+RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin);
+struct addr_t *MACH0_(get_entrypoint)(struct MACH0_(obj_t) *bin);
+struct lib_t *MACH0_(get_libs)(struct MACH0_(obj_t) *bin);
+ut64 MACH0_(get_baddr)(struct MACH0_(obj_t) *bin);
+char *MACH0_(get_class)(struct MACH0_(obj_t) *bin);
+int MACH0_(get_bits)(struct MACH0_(obj_t) *bin);
+bool MACH0_(is_big_endian)(struct MACH0_(obj_t) *bin);
+bool MACH0_(is_pie)(struct MACH0_(obj_t) *bin);
+bool MACH0_(has_nx)(struct MACH0_(obj_t) *bin);
+const char *MACH0_(get_intrp)(struct MACH0_(obj_t) *bin);
+const char *MACH0_(get_os)(struct MACH0_(obj_t) *bin);
+const char *MACH0_(get_cputype)(struct MACH0_(obj_t) *bin);
+char *MACH0_(get_cpusubtype)(struct MACH0_(obj_t) *bin);
+char *MACH0_(get_cpusubtype_from_hdr)(struct MACH0_(mach_header) *hdr);
+char *MACH0_(get_filetype)(struct MACH0_(obj_t) *bin);
+char *MACH0_(get_filetype_from_hdr)(struct MACH0_(mach_header) *hdr);
+ut64 MACH0_(get_main)(struct MACH0_(obj_t) *bin);
+const char *MACH0_(get_cputype_from_hdr)(struct MACH0_(mach_header) *hdr);
+int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header) *hdr);
+struct MACH0_(mach_header) *MACH0_(get_hdr_from_bytes)(RBuffer *buf);
 void MACH0_(mach_headerfields)(RBinFile *bf);
-RList* MACH0_(mach_fields)(RBinFile *bf);
+RList *MACH0_(mach_fields)(RBinFile *bf);
 #endif

--- a/libr/bin/format/objc/mach0_classes.h
+++ b/libr/bin/format/objc/mach0_classes.h
@@ -17,7 +17,8 @@
 #ifndef MACH0_CLASSES_H
 #define MACH0_CLASSES_H
 
-R_API RList* MACH0_(parse_classes)(RBinFile *bf);
+R_API RList *MACH0_(parse_classes)(RBinFile *bf);
 R_API void MACH0_(get_class_t)(mach0_ut p, RBinFile *bf, RBinClass *klass, bool dupe);
+R_API void MACH0_(get_category_t)(mach0_ut p, RBinFile *bf, RBinClass *klass, RSkipList *relocs);
 
 #endif // MACH0_CLASSES_H

--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -1444,7 +1444,11 @@ static RList *classes(RBinFile *bf) {
 			if (sections[i].size == 0) {
 				continue;
 			}
-			if (!strstr (sections[i].name, "__objc_classlist")) {
+
+			bool is_classlist = strstr (sections[i].name, "__objc_classlist");
+			bool is_catlist = strstr (sections[i].name, "__objc_catlist");
+
+			if (!is_classlist && !is_catlist) {
 				continue;
 			}
 
@@ -1472,7 +1476,11 @@ static RList *classes(RBinFile *bf) {
 
 				bf->o->bin_obj = mach0;
 				bf->buf = cache->buf;
-				MACH0_(get_class_t) ((ut64) pointer_to_class, bf, klass, false);
+				if (is_classlist) {
+					MACH0_(get_class_t) ((ut64) pointer_to_class, bf, klass, false);
+				} else {
+					MACH0_(get_category_t) ((ut64) pointer_to_class, bf, klass, NULL);
+				}
 				bf->o->bin_obj = cache;
 				bf->buf = orig_buf;
 
@@ -1563,7 +1571,7 @@ static void header(RBinFile *bf) {
 	bin->cb_printf ("\nslide info (v%d):\n", version);
 	bin->cb_printf ("slide: 0x%"PFMT64x"\n", slide);
 	if (version == 2) {
-		RDyldRebaseInfo2 * info2 = (RDyldRebaseInfo2*) cache->rebase_info;
+		RDyldRebaseInfo2 *info2 = (RDyldRebaseInfo2*) cache->rebase_info;
 		bin->cb_printf ("page_starts_count: 0x%"PFMT64x"\n", info2->page_starts_count);
 		bin->cb_printf ("page_extras_count: 0x%"PFMT64x"\n", info2->page_extras_count);
 		bin->cb_printf ("delta_mask: 0x%"PFMT64x"\n", info2->delta_mask);
@@ -1571,7 +1579,7 @@ static void header(RBinFile *bf) {
 		bin->cb_printf ("delta_shift: 0x%"PFMT64x"\n", info2->delta_shift);
 		bin->cb_printf ("page_size: 0x%"PFMT64x"\n", info2->page_size);
 	} else if (version == 1) {
-		RDyldRebaseInfo1 * info1 = (RDyldRebaseInfo1*) cache->rebase_info;
+		RDyldRebaseInfo1 *info1 = (RDyldRebaseInfo1*) cache->rebase_info;
 		bin->cb_printf ("toc_count: 0x%"PFMT64x"\n", info1->toc_count);
 		bin->cb_printf ("entries_size: 0x%"PFMT64x"\n", info1->entries_size);
 		bin->cb_printf ("page_size: 0x%"PFMT64x"\n", 4096);


### PR DESCRIPTION
ObjC categories are now parsed as regular classes, their name is `TargetClass(CategoryName)`. They're handled correctly even if the target class in a reloc, even without symbol table present. Categories are parsed also in the dyld library cache.

Additional fixes in parsing relocs:
- correctly manage lazy and weak bindings
- reduce memory usage by using a dynamic list
- retain the symbol name from the dyld opcodes when no symtab is there

Example output:
```
[0x00000000]> ic~ class | grep ')$'
0x1b1b4df40 [0x180d9343c - 0x180ebc158] (sz 1215772) class 0 NSObject(NSObject)
0x1b1b4e0a8 [0x180db4c20 - 0x180ebc1d4] (sz 1078708) class 0 NSObject(NSKindOfAdditions)
0x1b1b4e448 [0x180dadfe0 - 0x180dadfe0] (sz 0) class 0 NSObject(__NSCFType)
0x1b1ca1100 [0x18151d930 - 0x18151d968] (sz 56) class 0 NSData(NSURLSession_Additions)
0x1b1ca1178 [0x18151dc78 - 0x18151dd18] (sz 160) class 0 NSURL(NSURLSession_Additions)
0x1b1d01050 [0x18184c634 - 0x1818f25a8] (sz 679796) class 0 NSObject(NSArchiverCallBack)
0x1b1d01250 [0x18184a08c - 0x1818f30b8] (sz 692268) class 0 NSArray(NSArray)
0x1b1d02298 [0x1818d1210 - 0x1818f5fec] (sz 151004) class 0 NSCalendar(NSCalendar)
0x1b1d02310 [0x18189ac50 - 0x1818d8f0c] (sz 254652) class 0 NSDateComponents(_)
0x1b1d02690 [0x181894e9c - 0x1818f731c] (sz 402560) class 0 _NSAutoCalendar(_)
0x1b1d02c88 [0x1818fa5a0 - 0x1818fa61c] (sz 124) class 0 NSDate(NSCalendarDateStuff)
0x1b1d02d18 [0x1818fc670 - 0x1818fc70c] (sz 156) class 0 NSDate(NSNaturalLanguageDate)
0x1b1d068e8 [0x18183fd64 - 0x1819086e0] (sz 821628) class 0 NSData(NSData)
0x1b1d07110 [0x18184bf7c - 0x181909620] (sz 775844) class 0 NSMutableData(NSMutableData)
0x1b1d07c68 [0x18184a0a0 - 0x18187f2e0] (sz 217664) class 0 NSDate(NSDate)
0x1b1d07e38 [0x18183fb50 - 0x18190b590] (sz 834112) class 0 NSDictionary(NSDictionary)
0x1b1d098d0 [0x181911944 - 0x181911b54] (sz 528) class 0 NSException(NSException)
0x1b1d0bb78 [0x181915c54 - 0x181915eb4] (sz 608) class 0 NSDictionary(NSFileAttributes)
[...]

[0x00000000]> ic NSMutableData(NSMutableData)
class NSMutableData(NSMutableData)
0x18188f348 method NSMutableData(NSMutableData)      _isCompact
0x181909498 method NSMutableData(NSMutableData)      resetBytesInRange:
0x181909620 method NSMutableData(NSMutableData)      initWithLength:
0x18190908c method NSMutableData(NSMutableData)      increaseLengthBy:
0x1818b59e4 method NSMutableData(NSMutableData)      replaceBytesInRange:withBytes:length:
0x1819091ac method NSMutableData(NSMutableData)      replaceBytesInRange:withBytes:
0x1819095dc method NSMutableData(NSMutableData)      initWithCapacity:
0x181908ae8 method NSMutableData(NSMutableData)      setLength:
0x181908aa4 method NSMutableData(NSMutableData)      mutableBytes
0x181908b3c method NSMutableData(NSMutableData)      appendBytes:length:
0x181908b28 method NSMutableData(NSMutableData)      classForCoder
0x1818de7c4 method NSMutableData(NSMutableData)      setData:
0x181908dcc method NSMutableData(NSMutableData)      appendData:
0x1818535c4 method NSMutableData(NSMutableData) c    dataWithCapacity:
0x18184bf7c method NSMutableData(NSMutableData) c    allocWithZone:
0x1818815b4 method NSMutableData(NSMutableData) c    dataWithLength:
```