### PR TITLE
Fix NULL pointer dereference in data references analyzer

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1847,7 +1847,7 @@ R_API void r_core_anal_datarefs(RCore *core, ut64 addr) {
 		r_list_foreach (refs, iter, ref) {
 			RBinObject *obj = r_bin_cur_object (core->bin);
 			RBinSection *binsec = r_bin_get_section_at (obj, ref->addr, true);
-			if (binsec->is_data) {
+			if (binsec && binsec->is_data) {
 				if (!found) {
 					r_cons_printf ("agn %s\n", me);
 					found = true;


### PR DESCRIPTION
Data references analyzer assumes that each function reference maps
to a certain section, but this is not the case for raw binary files
like shellcodes/firmware images/etc.

This bug was introduced in #10117.