### PR TITLE
Added missing header file in bin_avr.c

### DIFF
--- a/libr/bin/p/bin_avr.c
+++ b/libr/bin/p/bin_avr.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2016-2017 - pancake */
 
 #include <r_bin.h>
+#include <r_lib.h>
 
 #define CHECK4INSTR(b, instr, size) \
 	if (!instr (b) ||\


### PR DESCRIPTION
`RLibStruct` and `R_LIB_TYPE_BIN` are used in `bin_avr.c` but the header `r_lib.h` was not included and so was giving an error.