### PR TITLE
Fix #13190 - remove sz from classlisting

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2943,7 +2943,7 @@ static int bin_classes(RCore *r, int mode) {
 			}
 		} else {
 			int m = 0;
-			r_cons_printf ("0x%08"PFMT64x" [0x%08"PFMT64x" - 0x%08"PFMT64x"] (sz %"PFMT64d") class %d %s",
+			r_cons_printf ("0x%08"PFMT64x" [0x%08"PFMT64x" - 0x%08"PFMT64x"] %6"PFMT64d" class %d %s",
 				c->addr, at_min, at_max, (at_max - at_min), c->index, c->name);
 			if (c->super) {
 				r_cons_printf (" super: %s\n", c->super);


### PR DESCRIPTION
deleted the "sz" from classlisting. 