### PR TITLE
Pass RAnal instead of rbtree to fcn rbtree api

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -140,16 +140,16 @@ static RBNode *_fcn_tree_probe(FcnTreeIter *it, RBNode *x_, ut64 from, ut64 to) 
 	}
 }
 
-R_API bool r_anal_fcn_tree_delete(RBNode **root, RAnalFunction *data) {
-	return r_rbtree_aug_delete (root, data, _fcn_tree_cmp_addr, _fcn_tree_free, _fcn_tree_calc_max_addr);
+R_API bool r_anal_fcn_tree_delete(RAnal *anal, RAnalFunction *data) {
+	return r_rbtree_aug_delete (&anal->fcn_tree, data, _fcn_tree_cmp_addr, _fcn_tree_free, _fcn_tree_calc_max_addr);
 }
 
-R_API void r_anal_fcn_tree_insert(RBNode **root, RAnalFunction *fcn) {
-	r_rbtree_aug_insert (root, fcn, &(fcn->rb), _fcn_tree_cmp_addr, _fcn_tree_calc_max_addr);
+R_API void r_anal_fcn_tree_insert(RAnal *anal, RAnalFunction *fcn) {
+	r_rbtree_aug_insert (&anal->fcn_tree, fcn, &(fcn->rb), _fcn_tree_cmp_addr, _fcn_tree_calc_max_addr);
 }
 
-static void _fcn_tree_update_size(RBNode *root, RAnalFunction *fcn) {
-	r_rbtree_aug_update_sum (root, fcn, &(fcn->rb), _fcn_tree_cmp_addr, _fcn_tree_calc_max_addr);
+static void _fcn_tree_update_size(RAnal *anal, RAnalFunction *fcn) {
+	r_rbtree_aug_update_sum (anal->fcn_tree, fcn, &(fcn->rb), _fcn_tree_cmp_addr, _fcn_tree_calc_max_addr);
 }
 
 #if 0
@@ -248,7 +248,7 @@ static void _fcn_tree_iter_next(FcnTreeIter *it, ut64 from, ut64 to) {
 	}
 }
 
-R_API int r_anal_fcn_resize(const RAnal *anal, RAnalFunction *fcn, int newsize) {
+R_API int r_anal_fcn_resize(RAnal *anal, RAnalFunction *fcn, int newsize) {
 	ut64 eof; /* end of function */
 	RAnalBlock *bb;
 	RListIter *iter, *iter2;
@@ -1708,7 +1708,7 @@ R_API int r_anal_fcn_insert(RAnal *anal, RAnalFunction *fcn) {
 	}
 	/* TODO: sdbization */
 	r_list_append (anal->fcns, fcn);
-	r_anal_fcn_tree_insert (&anal->fcn_tree, fcn);
+	r_anal_fcn_tree_insert (anal, fcn);
 	if (anal->cb.on_fcn_new) {
 		anal->cb.on_fcn_new (anal, anal->user, fcn);
 	}
@@ -1764,7 +1764,7 @@ R_API int r_anal_fcn_del_locs(RAnal *anal, ut64 addr) {
 			continue;
 		}
 		if (r_anal_fcn_in (fcn, addr)) {
-			r_anal_fcn_tree_delete (&anal->fcn_tree, fcn);
+			r_anal_fcn_tree_delete (anal, fcn);
 			r_list_delete (anal->fcns, iter);
 		}
 	}
@@ -1780,7 +1780,7 @@ R_API int r_anal_fcn_del(RAnal *a, ut64 addr) {
 			if (a->cb.on_fcn_delete) {
 				a->cb.on_fcn_delete (a, a->user, fcni);
 			}
-			r_anal_fcn_tree_delete (&a->fcn_tree, fcni);
+			r_anal_fcn_tree_delete (a, fcni);
 			r_list_delete (a->fcns, iter);
 		}
 	}
@@ -2248,11 +2248,11 @@ R_API bool r_anal_fcn_bbadd(RAnalFunction *fcn, RAnalBlock *bb) {
 /* directly set the size of the function
  * if fcn is in ana RAnal's fcn_tree, the anal MUST be passed,
  * otherwise it can be NULL */
-R_API void r_anal_fcn_set_size(const RAnal *anal, RAnalFunction *fcn, ut32 size) {
+R_API void r_anal_fcn_set_size(RAnal *anal, RAnalFunction *fcn, ut32 size) {
 	r_return_if_fail (fcn);
 	fcn->_size = size;
 	if (anal) {
-		_fcn_tree_update_size (anal->fcn_tree, fcn);
+		_fcn_tree_update_size (anal, fcn);
 	}
 }
 

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -528,7 +528,7 @@ static void print_node(const RAnal *anal, const RFlirtNode *node, int indent) {
 	}
 }
 
-static int module_match_buffer(const RAnal *anal, const RFlirtModule *module,
+static int module_match_buffer(RAnal *anal, const RFlirtModule *module,
                                ut8 *b, ut64 address, ut32 buf_size) {
 	/* Returns true if module matches b, according to the signatures infos.
 	* Return false otherwise.
@@ -629,7 +629,7 @@ static int node_pattern_match(const RFlirtNode *node, ut8 *b, int buf_size) {
 	return true;
 }
 
-static int node_match_buffer(const RAnal *anal, const RFlirtNode *node, ut8 *b, ut64 address, ut32 buf_size, ut32 buf_idx) {
+static int node_match_buffer(RAnal *anal, const RFlirtNode *node, ut8 *b, ut64 address, ut32 buf_size, ut32 buf_idx) {
 	RListIter *node_child_it, *module_it;
 	RFlirtNode *child;
 	RFlirtModule *module;
@@ -653,7 +653,7 @@ static int node_match_buffer(const RAnal *anal, const RFlirtNode *node, ut8 *b, 
 	return false;
 }
 
-static int node_match_functions(const RAnal *anal, const RFlirtNode *root_node) {
+static int node_match_functions(RAnal *anal, const RFlirtNode *root_node) {
 	/* Tries to find matching functions between the signature infos in root_node
 	* and the analyzed functions in anal
 	* Returns false on error. */
@@ -1457,7 +1457,7 @@ R_API void r_sign_flirt_dump(const RAnal *anal, const char *flirt_file) {
 	}
 }
 
-R_API void r_sign_flirt_scan(const RAnal *anal, const char *flirt_file) {
+R_API void r_sign_flirt_scan(RAnal *anal, const char *flirt_file) {
 	/*parses a flirt signature file and scan the currently opened file against it.*/
 	RBuffer *flirt_buf;
 	RFlirtNode *node;

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -627,7 +627,7 @@ static int java_analyze_fns_from_buffer( RAnal *anal, ut64 start, ut64 end, int 
 			break;
 		}
 		//r_listrange_add (anal->fcnstore, fcn);
-		r_anal_fcn_tree_insert (&anal->fcn_tree, fcn);
+		r_anal_fcn_tree_insert (anal, fcn);
 		r_list_append (anal->fcns, fcn);
 		offset += r_anal_fcn_size (fcn);
 		if (!analyze_all) {
@@ -679,7 +679,7 @@ static int java_analyze_fns( RAnal *anal, ut64 start, ut64 end, int reftype, int
 				}
 				//r_listrange_add (anal->fcnstore, fcn);
 				r_anal_fcn_update_tinyrange_bbs (fcn);
-				r_anal_fcn_tree_insert (&anal->fcn_tree, fcn);
+				r_anal_fcn_tree_insert (anal, fcn);
 				r_list_append (anal->fcns, fcn);
 			}
 		} // End of methods loop

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1695,7 +1695,7 @@ R_API int r_core_anal_fcn_clean(RCore *core, ut64 addr) {
 	} else {
 		r_list_foreach_safe (core->anal->fcns, iter, iter_tmp, fcni) {
 			if (r_anal_fcn_in (fcni, addr)) {
-				r_anal_fcn_tree_delete (&core->anal->fcn_tree, fcni);
+				r_anal_fcn_tree_delete (core->anal, fcni);
 				r_list_delete (core->anal->fcns, iter);
 			}
 		}
@@ -4026,7 +4026,7 @@ R_API void r_core_anal_fcn_merge(RCore *core, ut64 addr, ut64 addr2) {
 	r_anal_fcn_set_size (core->anal, f1, max - min);
 	// resize
 	f2->bbs = NULL;
-	r_anal_fcn_tree_delete (&core->anal->fcn_tree, f2);
+	r_anal_fcn_tree_delete (core->anal, f2);
 	r_list_foreach (core->anal->fcns, iter, f2) {
 		if (f2 == f3) {
 			r_list_delete (core->anal->fcns, iter);

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -47,7 +47,7 @@ R_API int r_core_gdiff(RCore *c, RCore *c2) {
 		/* remove strings */
 		r_list_foreach_safe (cores[i]->anal->fcns, iter, iter2, fcn) {
 			if (!strncmp (fcn->name, "str.", 4)) {
-				r_anal_fcn_tree_delete (&cores[i]->anal->fcn_tree, fcn);
+				r_anal_fcn_tree_delete (cores[i]->anal, fcn);
 				r_list_delete (cores[i]->anal->fcns, iter);
 			}
 		}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1422,8 +1422,8 @@ R_API void r_anal_pin_list(RAnal *a);
 
 /* fcn.c */
 R_API ut32 r_anal_fcn_cost(RAnal *anal, RAnalFunction *fcn);
-R_API bool r_anal_fcn_tree_delete(RBNode **root, RAnalFunction *data);
-R_API void r_anal_fcn_tree_insert(RBNode **root, RAnalFunction *fcn);
+R_API bool r_anal_fcn_tree_delete(RAnal *anal, RAnalFunction *data);
+R_API void r_anal_fcn_tree_insert(RAnal *anal, RAnalFunction *fcn);
 R_API int r_anal_fcn_count_edges(RAnalFunction *fcn, int *ebbs);
 R_API RAnalFunction *r_anal_fcn_new(void);
 R_API int r_anal_fcn_is_in_offset (RAnalFunction *fcn, ut64 addr);
@@ -1472,7 +1472,7 @@ R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind, int type);
 /* vars // globals. not here  */
 R_API bool r_anal_var_display(RAnal *anal, int delta, char kind, const char *type);
 R_API ut32 r_anal_fcn_size(const RAnalFunction *fcn);
-R_API void r_anal_fcn_set_size(const RAnal *anal, RAnalFunction *fcn, ut32 size);
+R_API void r_anal_fcn_set_size(RAnal *anal, RAnalFunction *fcn, ut32 size);
 R_API ut32 r_anal_fcn_contsize(const RAnalFunction *fcn);
 R_API ut32 r_anal_fcn_realsize(const RAnalFunction *fcn);
 R_API int r_anal_fcn_cc(RAnalFunction *fcn);
@@ -1491,7 +1491,7 @@ R_API RAnalBlock *r_anal_fcn_bbget_in(const RAnal *anal, RAnalFunction *fcn, ut6
 R_API RAnalBlock *r_anal_fcn_bbget_at(RAnalFunction *fcn, ut64 addr);
 R_API bool r_anal_fcn_contains(RAnalFunction *fcn, ut64 addr);
 R_API bool r_anal_fcn_bbadd(RAnalFunction *fcn, RAnalBlock *bb);
-R_API int r_anal_fcn_resize (const RAnal *anal, RAnalFunction *fcn, int newsize);
+R_API int r_anal_fcn_resize (RAnal *anal, RAnalFunction *fcn, int newsize);
 R_API bool r_anal_fcn_get_purity(RAnal *anal, RAnalFunction *fcn);
 
 typedef bool (* RAnalRefCmp)(RAnalRef *ref, void *data);

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -112,7 +112,7 @@ R_API RList *r_sign_fcn_vars(RAnal *a, RAnalFunction *fcn);
 // TODO
 R_API int r_sign_is_flirt(RBuffer *buf);
 R_API void r_sign_flirt_dump(const RAnal *anal, const char *flirt_file);
-R_API void r_sign_flirt_scan(const RAnal *anal, const char *flirt_file);
+R_API void r_sign_flirt_scan(RAnal *anal, const char *flirt_file);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
For #13193 and also for greater flexibility in implementing the fcn rbtree.