### PR TITLE
Add eval for refptr #asm

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2747,6 +2747,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.nodup", "false", "Do not show dupped instructions (collapse disasm)");
 	SETPREF ("asm.emu", "false", "Run ESIL emulation analysis on disasm");
 	SETPREF ("emu.pre", "false", "Run ESIL emulation starting at the closest flag in pd");
+	SETPREF ("asm.refptr", "false", "Show refpointer information in disasm");
 	SETPREF ("emu.lazy", "false", "Do not emulate all instructions with aae (optimization)");
 	SETPREF ("emu.stack", "false", "Create a temporary fake stack when emulating in disasm (asm.emu)");
 	SETCB ("emu.str", "false", &cb_emustr, "Show only strings if any in the asm.emu output");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2747,7 +2747,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.nodup", "false", "Do not show dupped instructions (collapse disasm)");
 	SETPREF ("asm.emu", "false", "Run ESIL emulation analysis on disasm");
 	SETPREF ("emu.pre", "false", "Run ESIL emulation starting at the closest flag in pd");
-	SETPREF ("asm.refptr", "false", "Show refpointer information in disasm");
+	SETPREF ("asm.refptr", "true", "Show refpointer information in disasm");
 	SETPREF ("emu.lazy", "false", "Do not emulate all instructions with aae (optimization)");
 	SETPREF ("emu.stack", "false", "Create a temporary fake stack when emulating in disasm (asm.emu)");
 	SETCB ("emu.str", "false", &cb_emustr, "Show only strings if any in the asm.emu output");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -151,6 +151,7 @@ typedef struct {
 	bool show_calls;
 	bool show_cmtflgrefs;
 	bool show_cycles;
+	bool show_refptr;
 	bool show_stackptr;
 	int stackFd;
 	bool show_xrefs;
@@ -674,6 +675,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->asm_hint_pos = r_config_get_i (core->config, "asm.hint.pos");
 	ds->asm_hints = r_config_get_i (core->config, "asm.hints"); // only for cdiv wtf
 	ds->show_slow = r_config_get_i (core->config, "asm.slow");
+	ds->show_refptr = r_config_get_i (core->config, "asm.refptr");
 	ds->show_calls = r_config_get_i (core->config, "asm.calls");
 	ds->show_family = r_config_get_i (core->config, "asm.family");
 	ds->cmtcol = r_config_get_i (core->config, "asm.cmt.col");
@@ -3588,7 +3590,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			}
 		}
 		r_io_read_at (core->io, refaddr, (ut8*)msg, len - 1);
-		if (refptr) {
+		if (refptr && ds->show_refptr) {
 			ut64 num = r_read_ble (msg, core->print->big_endian, refptr * 8);
 			st64 n = (st64)num;
 			st32 n32 = (st32)(n & UT32_MAX);


### PR DESCRIPTION
Add eval for refptr and disable it by default, should reduce the volume of output in disassembly while leaving the user able to show this information back

```
Default Before:
0x100001237      c7058f420000.  mov dword [0x1000054d0], 0x50    ; 'P' ; section.10.__DATA.__data ; [0x1000054d0:4]=80 ; U"P."

Default After:
0x100001237      c7058f420000.  mov dword [0x1000054d0], 0x50    ; 'P' ; section.10.__DATA.__data ; U"P."
```