### PR TITLE
Fix esil negative numbers

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1583,11 +1583,9 @@ static int esil_add(RAnalEsil *esil) {
 	ut64 s, d;
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
-	if (src && r_anal_esil_get_parm (esil, src, &s)) {
-		if (dst && r_anal_esil_get_parm (esil, dst, &d)) {
+	if ((src && r_anal_esil_get_parm (esil, src, &s)) && (dst && r_anal_esil_get_parm (esil, dst, &d))) {
 			r_anal_esil_pushnum (esil, s + d);
 			ret = true;
-		}
 	} else {
 		ERR ("esil_add: invalid parameters");
 	}

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1656,6 +1656,11 @@ static int esil_sub(RAnalEsil *esil) {
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if ((src && r_anal_esil_get_parm (esil, src, &s)) && (dst && r_anal_esil_get_parm (esil, dst, &d))) {
+		if (r_anal_esil_get_parm_type (esil, src) != R_ANAL_ESIL_PARM_INTERNAL) {
+			esil->old = d;
+			esil->cur = d - s;
+			esil->lastsz = esil_internal_sizeof_reg (esil, dst);
+		}
 		r_anal_esil_pushnum (esil, d - s);
 		ret = true;
 	} else {

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1584,8 +1584,8 @@ static int esil_add(RAnalEsil *esil) {
 	char *dst = r_anal_esil_pop (esil);
 	char *src = r_anal_esil_pop (esil);
 	if ((src && r_anal_esil_get_parm (esil, src, &s)) && (dst && r_anal_esil_get_parm (esil, dst, &d))) {
-			r_anal_esil_pushnum (esil, s + d);
-			ret = true;
+		r_anal_esil_pushnum (esil, s + d);
+		ret = true;
 	} else {
 		ERR ("esil_add: invalid parameters");
 	}
@@ -1651,34 +1651,19 @@ static int esil_inceq(RAnalEsil *esil) {
 }
 
 static int esil_sub(RAnalEsil *esil) {
-	ut64 s = 0, d = 0;
-	char * dst = r_anal_esil_pop (esil);
-	if (!dst) {
-		goto dst_broken;
-	}
-	if (r_anal_esil_reg_read (esil, dst, &d, NULL)) {
-		esil->lastsz = esil_internal_sizeof_reg (esil, dst);
+	int ret = 0;
+	ut64 s, d;
+	char *dst = r_anal_esil_pop (esil);
+	char *src = r_anal_esil_pop (esil);
+	if ((src && r_anal_esil_get_parm (esil, src, &s)) && (dst && r_anal_esil_get_parm (esil, dst, &d))) {
+		r_anal_esil_pushnum (esil, d - s);
+		ret = true;
 	} else {
-		if (!isnum (esil, dst, &d)) {
-			free (dst);
-			goto dst_broken;
-		}
-		esil->lastsz = 64;
+		ERR ("esil_sub: invalid parameters");
 	}
+	free (src);
 	free (dst);
-
-	if (!popRN (esil, &s)) {
-		ERR ("esil_sub: src is broken");
-		return false;
-	}
-	esil->old = d;
-	esil->cur = d - s;
-	r_anal_esil_pushnum (esil, esil->cur);
-	return true;
-
-dst_broken:
-	ERR ("esil_sub: dst is broken");
-	return false;
+	return ret;
 }
 
 static int esil_subeq(RAnalEsil *esil) {


### PR DESCRIPTION
esil's handling of negative numbers isn't perfect, but when subtraction is involved, it's basically non-existant.

For example, `ae 3,-4,+` results in `0xffffffffffffffff` (since esil treats all numbers as `ut64`, and it's tricky to know when to treat it as signed/unsigned). So, a bummer, but at least it works.

However, `ae 3,-4,-` returns nothing (as opposed to the expected `0xfffffffffffffff9`). Reason: the current implementation of `esil_sub` reads the parameters directly, and validates that they are numbers only by checking for digits (instead of using the more generic `r_anal_esil_get_parm`, used in `esil_add`, `esil_mul`, and `esil_div`, that supports negative numbers as well).

This PR fixes the issue - the code for `esil_sub` is copied from `esil_add`, with the actual operation, `s + d` replaced with `d - s`.