### PR TITLE
Make -x behave like /x unless mask is provided

### DIFF
--- a/binr/rafind2/rafind2.c
+++ b/binr/rafind2/rafind2.c
@@ -197,7 +197,11 @@ static int rafind_open_file(char *file) {
 	if (mode == R_SEARCH_KEYWORD) {
 		r_list_foreach (keywords, iter, kw) {
 			if (hexstr) {
-				r_search_kw_add (rs, r_search_keyword_new_hex (kw, mask, NULL));
+				if (mask) {
+					r_search_kw_add (rs, r_search_keyword_new_hex (kw, mask, NULL));
+				} else {
+					r_search_kw_add (rs, r_search_keyword_new_hexmask (kw, NULL));
+				}
 			} else if (widestr) {
 				r_search_kw_add (rs, r_search_keyword_new_wide (kw, mask, NULL, 0));
 			} else {


### PR DESCRIPTION
`rafind2 -x f.f.` doesn't behave like `/x f.f.` in r2. This patch adjusts this behavior unless a mask is provided.

Please let me know if you consider this change to warrant mention in the manual or usage help.