### PR TITLE
Update anal_m68k_cs.c

### DIFF
--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -318,6 +318,8 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		op->type = R_ANAL_OP_TYPE_XOR;
 		break;
 	case M68K_INS_EXG:
+		op->type = R_ANAL_OP_TYPE_MOV;
+		break;
 	case M68K_INS_EXT:
 	case M68K_INS_EXTB:
 		break;


### PR DESCRIPTION
EXG (EXchanGe register) is an valid instruction for R_ANAL_OP_TYPE_MOV because it only moves from RegN to RegN.