### PR TITLE
Remove extraneous space for scd instruction

### DIFF
--- a/libr/asm/p/asm_chip8.c
+++ b/libr/asm/p/asm_chip8.c
@@ -18,7 +18,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *b, int l) {
 		} else if (opcode == 0x00EE) {
 			buf_asm = "ret";
 		} else if ((opcode & 0xFFF0) == 0x00C0) {
-			buf_asm = sdb_fmt ("scd  0x%01x", nibble);
+			buf_asm = sdb_fmt ("scd 0x%01x", nibble);
 		} else if (opcode == 0x00FB) {
 			buf_asm = "scr";
 		} else if (opcode == 0x00FC) {


### PR DESCRIPTION
See also https://github.com/radare/radare2-regressions/pull/1736