### PR TITLE
bin_art: avoid double free

### DIFF
--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -83,7 +83,6 @@ static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
 
 static int destroy(RBinFile *bf) {
 	ArtObj *obj = bf->o->bin_obj;
-	sdb_free (obj->kv);
 	r_buf_free (obj->buf);
 	free (obj);
 	return true;


### PR DESCRIPTION
ao->kv's ownership is moved to RBin through the get_sdb method of
RBinPlugin, thus the plugins should not free it themselves.