### PR TITLE
Displaying chunk flags as bits

### DIFF
--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -341,9 +341,9 @@ void GH(print_heap_chunk)(RCore *core) {
 	PRINT_GA (",\n  size = ");
 	PRINTF_BA ("0x%"PFMT64x, (ut64)cnk->size & ~(NON_MAIN_ARENA | IS_MMAPPED | PREV_INUSE));
 	PRINT_GA(",\n  flags: |N:");
-	PRINTF_BA("%1d", cnk->size & NON_MAIN_ARENA);
+	PRINTF_BA("%1d", (cnk->size & NON_MAIN_ARENA ) >> 2);
 	PRINT_GA(" |M:");
-	PRINTF_BA("%1d", cnk->size & IS_MMAPPED);
+	PRINTF_BA("%1d", (cnk->size & IS_MMAPPED) >> 1);
 	PRINT_GA(" |P:");
 	PRINTF_BA("%1d", cnk->size & PREV_INUSE);
 


### PR DESCRIPTION
The 'display' routine of the malloc_chunk should display each field of
flag field as bits.

So prior to this proposal, `dmhc` could yield following information:

```
struct malloc_chunk @ 0x7f5462ed4000 {
  prev_size = 0x0,
  size = 0x1112000,
  flags: |N:4 |M:2 |P:1,
```

The flags should be displayed as: `flags: |N:1 |M:1 |P:1`