### PR TITLE
Consider the map sorting when two map_events are the same.

### DIFF
--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -29,9 +29,12 @@ static int _cmp_map_event(const void *a_, const void *b_) {
 		return addr0 < addr1? -1: 1;
 	}
 	if (a->is_to != b->is_to) {
-		return a->is_to - b->is_to;
+		return !a->is_to? -1: 1;
 	}
-	return a->id - b->id;
+	if (a->id != b->id) {
+		return a->id < b->id? -1: 1;
+	}
+	return 0;
 }
 
 static int _cmp_map_event_by_id(const void *a_, const void *b_) {

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -26,9 +26,12 @@ static int _cmp_map_event(const void *a_, const void *b_) {
 	struct map_event_t *a = (void *)a_, *b = (void *)b_;
 	ut64 addr0 = a->addr - a->is_to, addr1 = b->addr - b->is_to;
 	if (addr0 != addr1) {
-		return addr0 < addr1 ? -1 : 1;
+		return addr0 < addr1? -1: 1;
 	}
-	return a->is_to - b->is_to;
+	if (a->is_to != b->is_to) {
+		return a->is_to - b->is_to;
+	}
+	return a->id - b->id;
 }
 
 static int _cmp_map_event_by_id(const void *a_, const void *b_) {


### PR DESCRIPTION
When two maps start at the same address, it's important to consider the
initial priority of the maps, which is given by the `id` field.

r2r PR: https://github.com/radare/radare2-regressions/pull/1745