### PR TITLE
Remove CYGWIN & MINGW remnants

### DIFF
--- a/libr/bin/pdb/pdb_downloader.c
+++ b/libr/bin/pdb/pdb_downloader.c
@@ -6,7 +6,7 @@
 #include "pdb_downloader.h"
 
 static bool checkExtract() {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	if (r_sys_cmd ("expand -? >nul") != 0) {
 		return false;
 	}
@@ -79,7 +79,7 @@ static int download(struct SPDBDownloader *pd) {
 							   guid,
 		                       archive_name_escaped,
 		                       abspath_to_archive);
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 		const char *cabextractor = "expand";
 		const char *format = "%s %s %s";
 		char *abspath_to_file = strdup (abspath_to_archive);

--- a/libr/config.mk.tail
+++ b/libr/config.mk.tail
@@ -92,20 +92,6 @@ EXT_SO=dll
 EXT_EXE=.exe
 TH_LIBS=
 endif
-ifneq (,$(findstring cygwin,${OSTYPE}))
-CFLAGS+=-D__CYGWIN__=1
-EXT_AR=lib
-EXT_SO=dll
-EXT_EXE=.exe
-TH_LIBS=
-endif
-ifneq (,$(findstring mingw32,${OSTYPE})$(findstring mingw64,${OSTYPE})$(findstring msys,${OSTYPE}))
-CFLAGS+=-DMINGW32=1
-EXT_AR=lib
-EXT_SO=dll
-EXT_EXE=.exe
-TH_LIBS=
-endif
 ifeq (${OSTYPE},bsd)
 CFLAGS+=-D__UNIX__=1
 EXT_AR=a

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 #include <signal.h>
 #endif
 
@@ -134,7 +134,7 @@ static void break_signal(int sig) {
 }
 
 static inline void __cons_write(const char *buf, int len) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	if (I.ansicon) {
 		(void) write (I.fdout, buf, len);
 	} else {
@@ -290,7 +290,7 @@ R_API void r_cons_context_break_push(RConsContext *context, RConsBreak cb, void 
 		return;
 	}
 	if (r_stack_is_empty (context->break_stack)) {
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 		if (sig && r_cons_context_is_main ()) {
 			signal (SIGINT, break_signal);
 		}
@@ -319,7 +319,7 @@ R_API void r_cons_context_break_pop(RConsContext *context, bool sig) {
 		break_stack_free (b);
 	} else {
 		//there is not more elements in the stack
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 		if (sig && r_cons_context_is_main ()) {
 			signal (SIGINT, SIG_IGN);
 		}
@@ -369,7 +369,7 @@ R_API void r_cons_break_timeout(int timeout) {
 R_API void r_cons_break_end() {
 	I.context->breaked = false;
 	I.timeout = 0;
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 	signal (SIGINT, SIG_IGN);
 #endif
 	if (!r_stack_is_empty (I.context->break_stack)) {
@@ -396,7 +396,7 @@ R_API void r_cons_sleep_end(void *user) {
 	I.cb_sleep_end (I.user, user);
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static HANDLE h;
 static BOOL __w32_control(DWORD type) {
 	if (type == CTRL_C_EVENT) {
@@ -406,7 +406,7 @@ static BOOL __w32_control(DWORD type) {
 	}
 	return false;
 }
-#elif __UNIX__ || __CYGWIN__
+#elif __UNIX__
 volatile sig_atomic_t sigwinchFlag;
 static void resize(int sig) {
 	sigwinchFlag = 1;
@@ -420,7 +420,7 @@ void resizeWin(void) {
 #endif
 
 R_API bool r_cons_enable_mouse(const bool enable) {
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 	const char *code = enable
 		? "\x1b[?1001s" "\x1b[?1000h"
 		: "\x1b[?1001r" "\x1b[?1000l";
@@ -467,12 +467,12 @@ R_API RCons *r_cons_new() {
 	r_cons_get_size (&I.pagesize);
 	I.num = NULL;
 	I.null = 0;
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	I.ansicon = r_sys_getenv ("ANSICON");
 #endif
 #if EMSCRIPTEN
 	/* do nothing here :? */
-#elif __UNIX__ || __CYGWIN__
+#elif __UNIX__
 	tcgetattr (0, &I.term_buf);
 	memcpy (&I.term_raw, &I.term_buf, sizeof (I.term_raw));
 	I.term_raw.c_iflag &= ~(BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL|IXON);
@@ -891,7 +891,7 @@ R_API void r_cons_visual_flush() {
 	r_cons_highlight (I.highlight);
 	if (!I.null) {
 /* TODO: this ifdef must go in the function body */
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 		if (I.ansicon) {
 			r_cons_visual_write (I.context->buffer);
 		} else {
@@ -1157,7 +1157,7 @@ R_API int r_cons_get_cursor(int *rows) {
 }
 
 R_API bool r_cons_isatty() {
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 	struct winsize win = { 0 };
 	const char *tty;
 	struct stat sb;
@@ -1186,7 +1186,7 @@ R_API bool r_cons_isatty() {
 
 // XXX: if this function returns <0 in rows or cols expect MAYHEM
 R_API int r_cons_get_size(int *rows) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 	GetConsoleScreenBufferInfo (GetStdHandle (STD_OUTPUT_HANDLE), &csbi);
 	I.columns = (csbi.srWindow.Right - csbi.srWindow.Left) - 1;
@@ -1199,7 +1199,7 @@ R_API int r_cons_get_size(int *rows) {
 #elif EMSCRIPTEN
 	I.columns = 80;
 	I.rows = 23;
-#elif __UNIX__ || __CYGWIN__
+#elif __UNIX__
 	struct winsize win = { 0 };
 	if (isatty (0) && !ioctl (0, TIOCGWINSZ, &win)) {
 		if ((!win.ws_col) || (!win.ws_row)) {
@@ -1266,7 +1266,7 @@ R_API int r_cons_get_size(int *rows) {
 }
 
 R_API void r_cons_show_cursor(int cursor) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	// TODO
 #else
 	if (cursor) {
@@ -1298,7 +1298,7 @@ R_API void r_cons_set_raw(bool is_raw) {
 	}
 #if EMSCRIPTEN
 	/* do nothing here */
-#elif __UNIX__ || __CYGWIN__
+#elif __UNIX__
 	// enforce echo off
 	if (is_raw) {
 		I.term_raw.c_lflag &= ~(ECHO|ECHONL|ICANON|ISIG|IEXTEN);
@@ -1330,13 +1330,13 @@ R_API void r_cons_invert(int set, int color) {
   rmcup: enable terminal scrolling (normal mode)
 */
 R_API void r_cons_set_cup(int enable) {
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 	const char *code = enable
 		? "\x1b[?1049h" "\x1b" "7\x1b[?47h"
 		: "\x1b[?1049l" "\x1b[?47l" "\x1b" "8";
 	write (2, code, strlen (code));
 	fflush (stdout);
-#elif __WINDOWS__ && !__CYGWIN__
+#elif __WINDOWS__
 	if (I.ansicon) {
 		if (enable) {
 			const char *code =
@@ -1620,7 +1620,7 @@ R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 }
 
 R_API void r_cons_clear_buffer(void) {
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 	write (1, "\x1b" "c\x1b[3J",  6);
 #endif
 }

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 #include <windows.h>
 #define USE_UTF8 0
 #else
@@ -186,7 +186,7 @@ static int r_line_readchar_utf8(ut8 *s, int slen) {
 }
 #endif
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static int r_line_readchar_win(int *vch) { // this function handle the input in console mode
 	INPUT_RECORD irInBuf;
 	BOOL ret, bCtrl = FALSE;
@@ -694,7 +694,7 @@ R_API const char *r_line_readline() {
 	return r_line_readline_cb (NULL, NULL);
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 	int columns = r_cons_get_size (NULL) - 2;
 	const char *gcomp_line = "";
@@ -1126,7 +1126,7 @@ _end:
 #endif
 
 R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	// new implementation for read input at windows by skuater. If something fail set this to 0
 	return r_line_readline_cb_win (cb, user);
 #endif
@@ -1200,7 +1200,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		if (columns < 1) {
 			columns = 40;
 		}
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 		if (I.echo) {
 			printf ("\r%*c\r", columns, ' ');
 		}

--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -83,7 +83,7 @@ static int parseMouseEvent() {
 }
 
 R_API int r_cons_arrow_to_hjkl(int ch) {
-#if __WINDOWS_ && !__CYGWIN__
+#if __WINDOWS__
 	return ch;
 #endif
 	I->mouse_event = 0;
@@ -293,7 +293,7 @@ R_API int r_cons_any_key(const char *msg) {
 	//r_cons_strcat ("\x1b[2J\x1b[0;0H"); // wtf?
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static int readchar_win(ut32 usec) {
 	int ch = 0;
 	BOOL ret;
@@ -473,7 +473,7 @@ R_API void r_cons_switchbuf(bool active) {
 	bufactive = active;
 }
 
-#if !(__WINDOWS__ && !__CYGWIN__)
+#if !__WINDOWS__
 extern volatile sig_atomic_t sigwinchFlag;
 extern void resizeWin(void);
 #endif
@@ -488,7 +488,7 @@ R_API int r_cons_readchar() {
 		memmove (readbuffer, readbuffer + 1, readbuffer_length);
 		return ch;
 	}
-#if __WINDOWS__ && !__CYGWIN__ //&& !MINGW32
+#if __WINDOWS__
 	#if 1   // if something goes wrong set this to 0. skuater.....
 	return readchar_win(0);
 	#endif

--- a/libr/cons/line.c
+++ b/libr/cons/line.c
@@ -14,7 +14,7 @@ R_API RLine *r_line_new() {
 	I.hist_down = NULL;
 	I.prompt = strdup ("> ");
 	I.contents = NULL;
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	I.ansicon = r_sys_getenv ("ANSICON");
 #endif
 	if (!r_line_dietline_init ()) {

--- a/libr/cons/pipe.c
+++ b/libr/cons/pipe.c
@@ -34,7 +34,7 @@ R_API int r_cons_pipe_open(const char *file, int fdn, int append) {
 		close (backup_fd);
 	}
 	backup_fdn = fdn;
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	backup_fd = 2002-(fd-2); // windows xp has 2048 as limit fd
 	if (_dup2 (fdn, backup_fd) == -1) {
 #else

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1889,7 +1889,7 @@ static int cb_scrhighlight(void *user, void *data) {
 	return true;
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static int scr_ansicon(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *) data;
 	r_cons_singleton ()->ansicon = node->i_value;
@@ -2906,7 +2906,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("cfg.newtab", "false", "Show descriptions in command completion");
 	SETCB ("cfg.debug", "false", &cb_cfgdebug, "Debugger mode");
 	p = r_sys_getenv ("EDITOR");
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	r_config_set (cfg, "cfg.editor", p? p: "notepad");
 #else
 	r_config_set (cfg, "cfg.editor", p? p: "vi");
@@ -3219,7 +3219,7 @@ R_API int r_core_config_init(RCore *core) {
 	/* TODO: rename to asm.color.ops ? */
 	SETPREF ("scr.zoneflags", "true", "Show zoneflags in visual mode before the title (see fz?)");
 	SETPREF ("scr.slow", "true", "Do slow stuff on visual mode like RFlag.get_at(true)");
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	SETCB ("scr.ansicon", r_str_bool (r_cons_singleton ()->ansicon),
 		&scr_ansicon, "Use ANSICON mode or not on Windows");
 #endif

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1757,7 +1757,7 @@ static int cmd_system(void *data, const char *input) {
 	return ret;
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static void r_w32_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
 	STARTUPINFO si = {0};
 	PROCESS_INFORMATION pi = {0};
@@ -1832,7 +1832,7 @@ err_r_w32_cmd_pipe:
 #endif
 
 R_API int r_core_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 	int stdout_fd, fds[2];
 	int child;
 #endif
@@ -1861,7 +1861,7 @@ R_API int r_core_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
 		free (out);
 		ret = 0;
 	}
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 	radare_cmd = (char*)r_str_trim_head (radare_cmd);
 	shell_cmd = (char*)r_str_trim_head (shell_cmd);
 

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -109,7 +109,7 @@ static const char *help_msg_dc[] = {
 	"dcb", "", "Continue back until breakpoint",
 	"dcc", "", "Continue until call (use step into)",
 	"dccu", "", "Continue until unknown call (call reg)",
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	"dce", "", "Continue execution (pass exception to program)",
 #endif
 	"dcf", "", "Continue until fork (TODO)",
@@ -4108,7 +4108,7 @@ static int cmd_debug_continue (RCore *core, const char *input) {
 			}
 			break;
 		}
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	case 'e': // "dce"
 		r_reg_arena_swap (core->dbg->reg, true);
 		r_debug_continue_pass_exception (core->dbg);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1515,7 +1515,7 @@ repeat:
 	return ret;
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 void SetWindow(int Width, int Height) {
 	COORD coord;
 	coord.X = Width;
@@ -2154,7 +2154,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 		}
 	} else {
 		switch (ch) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 		case 0xf5:
 			SetWindow (81, 25);
 			break;

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1237,7 +1237,7 @@ R_API int r_debug_continue(RDebug *dbg) {
 	return r_debug_continue_kill (dbg, 0); //dbg->reason.signum);
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 R_API int r_debug_continue_pass_exception(RDebug *dbg) {
 	return r_debug_continue_kill (dbg, DBG_EXCEPTION_NOT_HANDLED);
 }

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -21,9 +21,9 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 
 #include "native/bt.c"
 
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 # include <errno.h>
-# if !defined (__HAIKU__) && !defined (__CYGWIN__) && !defined (__sun)
+# if !defined (__HAIKU__) && !defined (__sun)
 #  include <sys/ptrace.h>
 # endif
 # include <sys/wait.h>
@@ -127,7 +127,7 @@ static char *r_debug_native_reg_profile (RDebug *dbg) {
 #include "native/reg.c" // x86 specific
 
 #endif
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static int windows_step (RDebug *dbg) {
 	/* set TRAP flag */
 #if _MSC_VER
@@ -144,7 +144,7 @@ static int windows_step (RDebug *dbg) {
 }
 #endif
 static int r_debug_native_step (RDebug *dbg) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return windows_step (dbg);
 #elif __APPLE__
 	return xnu_step (dbg);
@@ -155,9 +155,6 @@ static int r_debug_native_step (RDebug *dbg) {
 		return false;
 	}
 	return true;
-#elif __CYGWIN__
-	#warning "r_debug_native_step not supported on this platform"
-	return false;
 #else // linux
 	return linux_step (dbg);
 #endif
@@ -171,7 +168,7 @@ static int r_debug_native_attach (RDebug *dbg, int pid) {
 #endif
 #if __linux__ || __ANDROID__
 	return linux_attach (dbg, pid);
-#elif __WINDOWS__ && !__CYGWIN__
+#elif __WINDOWS__
 	int ret;
 	HANDLE process = w32_OpenProcess (PROCESS_ALL_ACCESS, FALSE, pid);
 	if (process != (HANDLE)NULL && DebugActiveProcess (pid)) {
@@ -183,9 +180,6 @@ static int r_debug_native_attach (RDebug *dbg, int pid) {
 	ret = w32_first_thread (pid);
 	CloseHandle (process);
 	return ret;
-#elif __CYGWIN__
-	#warning "r_debug_native_attach not supported on this platform"
-	return -1;
 #elif __APPLE__
 	return xnu_attach (dbg, pid);
 #elif __KFBSD__
@@ -204,11 +198,8 @@ static int r_debug_native_attach (RDebug *dbg, int pid) {
 }
 
 static int r_debug_native_detach (RDebug *dbg, int pid) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return w32_DebugActiveProcessStop (pid)? 0 : -1;
-#elif __CYGWIN__
-	#warning "r_debug_native_detach not supported on this platform"
-	return -1;
 #elif __APPLE__
 	return xnu_detach (dbg, pid);
 #elif __BSD__
@@ -233,7 +224,7 @@ static int r_debug_native_continue_syscall (RDebug *dbg, int pid, int num) {
 #endif
 }
 
-#if !__WINDOWS__ && !__CYGWIN__ && !__APPLE__ && !__BSD__
+#if !__WINDOWS__ && !__APPLE__ && !__BSD__
 /* Callback to trigger SIGINT signal */
 static void r_debug_native_stop(RDebug *dbg) {
 	r_debug_kill (dbg, dbg->pid, dbg->tid, SIGINT);
@@ -244,7 +235,7 @@ static void r_debug_native_stop(RDebug *dbg) {
 /* TODO: specify thread? */
 /* TODO: must return true/false */
 static int r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	/* Honor the Windows-specific signal that instructs threads to process exceptions */
 	DWORD continue_status = (sig == DBG_EXCEPTION_NOT_HANDLED)
 		? DBG_EXCEPTION_NOT_HANDLED : DBG_CONTINUE;
@@ -264,9 +255,6 @@ static int r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
 	void *data = (void*)(size_t)((sig != -1) ? sig : dbg->reason.signum);
 	ut64 pc = r_debug_reg_get (dbg, "PC");
 	return ptrace (PTRACE_CONT, pid, (void*)(size_t)pc, (int)(size_t)data) == 0;
-#elif __CYGWIN__
-	#warning "r_debug_native_continue not supported on this platform"
-	return -1;
 #else
 	int contsig = dbg->reason.signum;
 
@@ -392,7 +380,7 @@ static RDebugInfo* r_debug_native_info (RDebug *dbg, const char *arg) {
 #endif
 }
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static bool tracelib(RDebug *dbg, const char *mode, PLIB_ITEM item) {
 	const char *needle = NULL;
 	int tmp = 0;
@@ -422,7 +410,7 @@ static bool tracelib(RDebug *dbg, const char *mode, PLIB_ITEM item) {
 static RDebugReasonType r_debug_native_wait (RDebug *dbg, int pid) {
 	RDebugReasonType reason = R_DEBUG_REASON_UNKNOWN;
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	reason = w32_dbg_wait (dbg, pid);
 	if (reason == R_DEBUG_REASON_NEW_LIB) {
 		RDebugInfo *r = r_debug_native_info (dbg, "");
@@ -665,7 +653,7 @@ reason:
 	}
 #endif // __linux__ && !defined (WAIT_ON_ALL_CHILDREN)
 #endif // __APPLE__
-#endif // __WINDOWS__ && !__CYGWIN__
+#endif // __WINDOWS__
 	dbg->reason.tid = pid;
 	dbg->reason.type = reason;
 	return reason;
@@ -685,7 +673,7 @@ static RList *r_debug_native_pids (RDebug *dbg, int pid) {
 	if (!list) {
 		return NULL;
 	}
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return w32_pids (pid, list);
 #elif __APPLE__
 	if (pid) {
@@ -852,7 +840,7 @@ static RList *r_debug_native_threads (RDebug *dbg, int pid) {
 		eprintf ("No list?\n");
 		return NULL;
 	}
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return w32_thread_list (pid, list);
 #elif __APPLE__
 	return xnu_thread_list (dbg, pid, list);
@@ -933,7 +921,7 @@ static int r_debug_native_reg_read (RDebug *dbg, int type, ut8 *buf, int size) {
 	if (size < 1) {
 		return false;
 	}
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return w32_reg_read (dbg, type, buf, size);
 #elif __APPLE__
 	return xnu_reg_read (dbg, type, buf, size);
@@ -960,7 +948,7 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 		return xnu_reg_write (dbg, type, buf, size);
 #else
 		//eprintf ("TODO: No support for write DRX registers\n");
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 		return w32_reg_write (dbg, type, buf, size);
 #endif
 		return false;
@@ -969,7 +957,7 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 		return false;
 #endif
 	} else if (type == R_REG_TYPE_GPR) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 		return w32_reg_write(dbg, type, buf, size);
 #elif __linux__
 		return linux_reg_write (dbg, type, buf, size);
@@ -1178,7 +1166,7 @@ static int linux_map_dealloc (RDebug *dbg, ut64 addr, int size) {
 err_linux_map_dealloc:
 	return ret;
 }
-#elif __WINDOWS__ && !__CYGWIN__
+#elif __WINDOWS__
 static int io_perms_to_prot (int io_perms) {
 	int prot_perms;
 
@@ -1209,7 +1197,7 @@ static RDebugMap* r_debug_native_map_alloc (RDebug *dbg, ut64 addr, int size) {
 
 	return xnu_map_alloc (dbg, addr, size);
 
-#elif __WINDOWS__ && !__CYGWIN__
+#elif __WINDOWS__
 	RDebugMap *map = NULL;
 	LPVOID base = NULL;
 	HANDLE process = w32_OpenProcess (PROCESS_ALL_ACCESS, FALSE, dbg->pid);
@@ -1239,7 +1227,7 @@ static int r_debug_native_map_dealloc (RDebug *dbg, ut64 addr, int size) {
 
 	return xnu_map_dealloc (dbg, addr, size);
 
-#elif __WINDOWS__ && !__CYGWIN__
+#elif __WINDOWS__
 	HANDLE process = w32_OpenProcess (PROCESS_ALL_ACCESS, FALSE, dbg->tid);
 	if (process == INVALID_HANDLE_VALUE) {
 		return false;
@@ -1279,7 +1267,7 @@ static RList *r_debug_native_map_get (RDebug *dbg) {
 #endif
 #if __APPLE__
 	list = xnu_dbg_maps (dbg, 0);
-#elif __WINDOWS__ && !__CYGWIN__
+#elif __WINDOWS__
 	list = w32_dbg_maps (dbg); // TODO: moar?
 #else
 #if __sun
@@ -1475,7 +1463,7 @@ static bool r_debug_native_kill (RDebug *dbg, int pid, int tid, int sig) {
 	if (pid == 0) {
 		pid = dbg->pid;
 	}
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	if (sig==0)
 		ret = true;
 	else
@@ -1510,7 +1498,7 @@ static bool r_debug_native_kill (RDebug *dbg, int pid, int tid, int sig) {
 struct r_debug_desc_plugin_t r_debug_desc_plugin_native;
 static int r_debug_native_init (RDebug *dbg) {
 	dbg->h->desc = r_debug_desc_plugin_native;
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return w32_dbg_init ();
 #else
 	return true;
@@ -1980,7 +1968,7 @@ static RList *r_debug_desc_native_list (int pid) {
 }
 
 static int r_debug_native_map_protect (RDebug *dbg, ut64 addr, int size, int perms) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	DWORD old;
 	BOOL ret = FALSE;
 	HANDLE h_proc = w32_OpenProcess (PROCESS_ALL_ACCESS, FALSE, dbg->pid);

--- a/libr/fs/p/fs_posix.c
+++ b/libr/fs/p/fs_posix.c
@@ -42,7 +42,7 @@ static RList *fs_posix_dir(RFSRoot *root, const char *path, int view /*ignored*/
 	RList *list;
 	char fullpath[4096];
 	struct stat st;
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	WIN32_FIND_DATAW entry;
 	HANDLE fh;
 	wchar_t *wcpath;
@@ -56,7 +56,7 @@ static RList *fs_posix_dir(RFSRoot *root, const char *path, int view /*ignored*/
 	if (!list) {
 		return NULL;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	wcpath = r_utf8_to_utf16 (path);
 	if (!wcpath) {
 		return NULL;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -24,13 +24,13 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#if __UNIX__
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
 #endif
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 #include <windows.h>
 #include <wincon.h>
 #endif
@@ -452,7 +452,7 @@ typedef struct r_cons_t {
 	RConsQueueTaskOneshot cb_task_oneshot;
 
 	void *user; // Used by <RCore*>
-#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#if __UNIX__
 	struct termios term_raw, term_buf;
 #elif __WINDOWS__
 	DWORD term_raw, term_buf;
@@ -470,7 +470,7 @@ typedef struct r_cons_t {
 	const char **vline;
 	int refcnt;
 	bool newline;
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	bool ansicon;
 #endif
 	bool flush;
@@ -911,7 +911,7 @@ struct r_line_t {
 	int file_hist_index;
 	RList *sdbshell_hist;
 	RListIter *sdbshell_hist_iter;
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	bool ansicon;
 #endif
 }; /* RLine */

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -446,7 +446,7 @@ R_API int r_debug_continue_syscall(RDebug *dbg, int sc);
 R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc);
 R_API int r_debug_continue(RDebug *dbg);
 R_API int r_debug_continue_kill(RDebug *dbg, int signal);
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 R_API int r_debug_continue_pass_exception(RDebug *dbg);
 #endif
 

--- a/libr/include/r_socket.h
+++ b/libr/include/r_socket.h
@@ -2,7 +2,7 @@
 #define R2_SOCKET_H
 
 /* Must be included before windows.h (r_types) */
-#if defined(__WINDOWS__) && !defined(__CYGWIN__) && !defined(MINGW32) && !defined(__MINGW64__)
+#if defined(__WINDOWS__)
 #include <ws2tcpip.h>
 #endif
 
@@ -16,7 +16,7 @@ extern "C" {
 
 R_LIB_VERSION_HEADER (r_socket);
 
-#if __UNIX__ || __CYGWIN__ || __MINGW64__ && !defined(MINGW32)
+#if __UNIX__
 #include <netinet/in.h>
 #include <sys/un.h>
 #include <poll.h>
@@ -31,7 +31,7 @@ R_LIB_VERSION_HEADER (r_socket);
 #include <openssl/err.h>
 #endif
 
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 #include <netinet/tcp.h>
 #endif
 

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -143,7 +143,7 @@
   #define __BSD__ 1
   #define __UNIX__ 1
 #endif
-#if __WINDOWS__ || _WIN32 || MINGW32 && !(__MINGW64__ || __CYGWIN__)
+#if __WINDOWS__ || _WIN32
   #ifdef _MSC_VER
   /* Must be included before windows.h */
   #include <winsock2.h>
@@ -155,7 +155,7 @@
   #undef __UNIX__
   #undef __BSD__
 #endif
-#if __WINDOWS__ || _WIN32 || __CYGWIN__ || MINGW32
+#if __WINDOWS__ || _WIN32
   #define __addr_t_defined
   #include <windows.h>
 #endif
@@ -362,7 +362,7 @@ static inline void *r_new_copy(int size, void *data) {
 #if 1
 #define r_offsetof(type, member) offsetof(type, member)
 #else
-#if __SDB_WINDOWS__ && !__CYGWIN__
+#if __SDB_WINDOWS__
 #define r_offsetof(type, member) ((unsigned long) (ut64)&((type*)0)->member)
 #else
 #define r_offsetof(type, member) ((unsigned long) &((type*)0)->member)
@@ -391,7 +391,7 @@ static inline void *r_new_copy(int size, void *data) {
 #define HAVE_REGEXP 1
 #endif
 
-#if (__WINDOWS__ || MINGW32) && !__CYGWIN__
+#if __WINDOWS__
 #define PFMT64x "I64x"
 #define PFMT64d "I64d"
 #define PFMT64u "I64u"
@@ -567,7 +567,7 @@ enum {
 #define R_SYS_OS "darwin"
 #elif defined (__linux__)
 #define R_SYS_OS "linux"
-#elif defined (__WINDOWS__) || defined (__CYGWIN__) || defined (MINGW32)
+#elif defined (__WINDOWS__)
 #define R_SYS_OS "windows"
 #elif defined (__NetBSD__ )
 #define R_SYS_OS "netbsd"

--- a/libr/include/r_userconf.h.acr
+++ b/libr/include/r_userconf.h.acr
@@ -28,7 +28,7 @@
 #define R2_FLAGS "@FLAGS@"
 #define R2_HUD "@HUD@"
 #else
-#if __WINDOWS__ || __CYGWIN__ || MINGW32 || _MSC_VER || CUTTER
+#if __WINDOWS__ || _MSC_VER || CUTTER
 #define R2_PREFIX "."
 #define R2_LIBDIR "lib"
 #define R2_INCDIR "include\\libr"

--- a/libr/include/r_util/r_sandbox.h
+++ b/libr/include/r_util/r_sandbox.h
@@ -22,7 +22,7 @@ extern "C" {
  * Paths pointing into the webroot are an exception: For reaching the webroot, .. and absolute
  * path are ok.
  */
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 R_API HANDLE r_sandbox_opendir(const char *path, WIN32_FIND_DATAW *entry);
 #else
 R_API DIR* r_sandbox_opendir(const char *path);

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -3,7 +3,7 @@
 
 #include <r_list.h>
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 #define R_SYS_DEVNULL "nul"
 #else
 #define R_SYS_DEVNULL "/dev/null"
@@ -36,7 +36,7 @@ R_API int r_sys_arch_id(const char *arch);
 R_API bool r_sys_arch_match(const char *archstr, const char *arch);
 R_API RList *r_sys_dir(const char *path);
 R_API void r_sys_perror_str(const char *fun);
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 #define r_sys_mkdir_failed() (GetLastError () != ERROR_ALREADY_EXISTS)
 #else
 #define r_sys_mkdir_failed() (errno != EEXIST)

--- a/libr/include/sdb/sdb.h
+++ b/libr/include/sdb/sdb.h
@@ -28,7 +28,7 @@ extern "C" {
 #define SZT_ADD_OVFCHK(x, y) ((SIZE_MAX - (x)) <= (y))
 #endif
 
-#if __SDB_WINDOWS__ && !__CYGWIN__
+#if __SDB_WINDOWS__
 #include <windows.h>
 #include <fcntl.h>
 #include <stdbool.h>

--- a/libr/include/sdb/types.h
+++ b/libr/include/sdb/types.h
@@ -36,13 +36,13 @@
 #include <windows.h>
 #define DIRSEP '\\'
 #else
-// CYGWIN AND UNIX
+// UNIX
 #define __SDB_WINDOWS__ 0
 #define DIRSEP '/'
 #endif
 
 #include <inttypes.h>
-#if __SDB_WINDOWS__ && !__CYGWIN__
+#if __SDB_WINDOWS__
 #define HAVE_MMAN 0
 #define ULLFMT "I64"
 #else

--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -231,7 +231,7 @@ static int __close(RIODesc *fd) {
 }
 
 static void got_alarm(int sig) {
-#if (!defined(__WINDOWS__)) || defined(__CYGWIN__)
+#if !defined(__WINDOWS__)
 	// !!! may die if not running from r2preload !!! //
 	kill (getpid (), SIGUSR1);
 #endif
@@ -242,7 +242,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 		return r_str_newf ("%d", fd->fd);
 	} else if (!strncmp (cmd, "pid", 3)) {
 		/* do nothing here */
-#if (!defined(__WINDOWS__)) || defined(__CYGWIN__)
+#if !defined(__WINDOWS__)
 	} else if (!strncmp (cmd, "kill", 4)) {
 		if (r_sandbox_enable (false)) {
 			eprintf ("This is unsafe, so disabled by the sandbox\n");
@@ -342,7 +342,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 		}
 		eprintf ("RES %"PFMT64d"\n", result);
 		free (argv);
-#if (!defined(__WINDOWS__)) || defined(__CYGWIN__)
+#if !defined(__WINDOWS__)
 	} else if (!strncmp (cmd, "alarm ", 6)) {
 		signal (SIGALRM, got_alarm);
 		// TODO: use setitimer
@@ -386,7 +386,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 		eprintf ("| =!pid               show getpid()\n");
 		eprintf ("| =!maps              show map regions\n");
 		eprintf ("| =!kill              commit suicide\n");
-#if (!defined(__WINDOWS__)) || defined(__CYGWIN__)
+#if !defined(__WINDOWS__)
 		eprintf ("| =!alarm [secs]      setup alarm signal to raise r2 prompt\n");
 #endif
 		eprintf ("| =!dlsym [sym]       dlopen\n");

--- a/libr/reg/double.c
+++ b/libr/reg/double.c
@@ -3,7 +3,7 @@
 #include <r_reg.h>
 #include <r_util.h>
 
-#if __SDB_WINDOWS__ && !__CYGWIN__
+#if __SDB_WINDOWS__
 #define CASTLDBL (double)
 #else
 #define CASTLDBL

--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -45,7 +45,7 @@ R_API int r2pipe_write(R2Pipe *r2pipe, const char *str) {
 	}
 	memcpy (cmd, str, len - 1);
 	strcpy (cmd + len - 2, "\n");
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	DWORD dwWritten = -1;
 	WriteFile (r2pipe->pipe, cmd, len, &dwWritten, NULL);
 	ret = (dwWritten == len);
@@ -68,7 +68,7 @@ R_API char *r2pipe_read(R2Pipe *r2pipe) {
 	if (!buf) {
 		return NULL;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	BOOL bSuccess = FALSE;
 	DWORD dwRead = 0;
 	// TODO: handle > 4096 buffers here
@@ -110,7 +110,7 @@ R_API int r2pipe_close(R2Pipe *r2pipe) {
 	if (!r2pipe) {
 		return 0;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	if (r2pipe->pipe) {
 		CloseHandle (r2pipe->pipe);
 		r2pipe->pipe = NULL;
@@ -142,7 +142,7 @@ R_API int r2pipe_close(R2Pipe *r2pipe) {
 	return 0;
 }
 
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 static int w32_createPipe(R2Pipe *r2pipe, const char *cmd) {
 	CHAR buf[1024];
 	r2pipe->pipe = CreateNamedPipe (TEXT ("\\\\.\\pipe\\R2PIPE_IN"),
@@ -160,7 +160,7 @@ static int w32_createPipe(R2Pipe *r2pipe, const char *cmd) {
 #endif
 
 static R2Pipe* r2pipe_open_spawn(R2Pipe* r2pipe) {
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 	char *out = r_sys_getenv ("R2PIPE_IN");
 	char *in = r_sys_getenv ("R2PIPE_OUT");
 	int done = false;
@@ -189,7 +189,7 @@ static R2Pipe* r2pipe_open_spawn(R2Pipe* r2pipe) {
 static R2Pipe *r2pipe_new() {
 	R2Pipe *r2pipe = R_NEW0 (R2Pipe);
 	if (r2pipe) {
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 		r2pipe->input[0] = r2pipe->input[1] = -1;
 		r2pipe->output[0] = r2pipe->output[1] = -1;
 #endif
@@ -215,7 +215,7 @@ R_API R2Pipe *r2pipe_open(const char *cmd) {
 		r2pipe->child = -1;
 		return r2pipe_open_spawn (r2pipe);
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	w32_createPipe (r2pipe, cmd);
 	r2pipe->child = (int)(r2pipe->pipe);
 #else

--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -111,7 +111,7 @@ WSACleanup: closes all network connections
 #define BUFFER_SIZE 4096
 
 R_API bool r_socket_is_connected(RSocket *s) {
-#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#if __WINDOWS__
 	char buf[2];
 	r_socket_block_time (s, 0, 0);
 #ifdef _MSC_VER
@@ -128,7 +128,7 @@ R_API bool r_socket_is_connected(RSocket *s) {
 #endif
 }
 
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 static int r_socket_unix_connect(RSocket *s, const char *file) {
 	struct sockaddr_un addr;
 	int sock = socket (PF_UNIX, SOCK_STREAM, 0);
@@ -266,7 +266,7 @@ R_API bool r_socket_spawn(RSocket *s, const char *cmd, unsigned int timeout) {
 }
 
 R_API bool r_socket_connect(RSocket *s, const char *host, const char *port, int proto, unsigned int timeout) {
-#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#if __WINDOWS__
 	struct sockaddr_in sa;
 	struct hostent *he;
 	WSADATA wsadata;
@@ -332,7 +332,7 @@ R_API bool r_socket_connect(RSocket *s, const char *host, const char *port, int 
 		return true;
 	}
 	return false;
-#elif __UNIX__ || defined(__CYGWIN__)
+#elif __UNIX__
 	int ret;
 	struct addrinfo hints = {0};
 	struct addrinfo *res, *rp;
@@ -447,10 +447,10 @@ R_API int r_socket_close(RSocket *s) {
 		return false;
 	}
 	if (s->fd != -1) {
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 		shutdown (s->fd, SHUT_RDWR);
 #endif
-#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#if __WINDOWS__
 		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms740481(v=vs.85).aspx
 		shutdown (s->fd, SD_SEND);
 		if (r_socket_ready (s, 0, 250)) {
@@ -503,7 +503,7 @@ R_API bool r_socket_listen(RSocket *s, const char *port, const char *certfile) {
 	if (r_sandbox_enable (0)) {
 		return false;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#if __WINDOWS__
 	WSADATA wsadata;
 	if (WSAStartup (MAKEWORD (1, 1), &wsadata) == SOCKET_ERROR) {
 		eprintf ("Error creating socket.");
@@ -549,7 +549,7 @@ R_API bool r_socket_listen(RSocket *s, const char *port, const char *certfile) {
 #endif
 		return false;
 	}
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 	signal (SIGPIPE, SIG_IGN);
 #endif
 	if (listen (s->fd, 32) < 0) {
@@ -650,13 +650,13 @@ R_API RSocket *r_socket_accept_timeout(RSocket *s, unsigned int timeout) {
 }
 
 R_API int r_socket_block_time(RSocket *s, int block, int sec) {
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 	int ret, flags;
 #endif
 	if (!s) {
 		return false;
 	}
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 	flags = fcntl (s->fd, F_GETFL, 0);
 	if (flags < 0) {
 		return false;
@@ -667,7 +667,7 @@ R_API int r_socket_block_time(RSocket *s, int block, int sec) {
 	if (ret < 0) {
 		return false;
 	}
-#elif __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#elif __WINDOWS__
 	ioctlsocket (s->fd, FIONBIO, (u_long FAR*)&block);
 #endif
 	if (sec > 0) {
@@ -695,7 +695,7 @@ R_API int r_socket_flush(RSocket *s) {
 /* waits secs until new data is received.	  */
 /* returns -1 on error, 0 is false, 1 is true */
 R_API int r_socket_ready(RSocket *s, int secs, int usecs) {
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 	//int msecs = (1000 * secs) + (usecs / 1000);
 	int msecs = (usecs / 1000);
 	struct pollfd fds[1];
@@ -703,7 +703,7 @@ R_API int r_socket_ready(RSocket *s, int secs, int usecs) {
 	fds[0].events = POLLIN | POLLPRI;
 	fds[0].revents = POLLNVAL | POLLHUP | POLLERR;
 	return poll ((struct pollfd *)&fds, 1, msecs);
-#elif __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#elif __WINDOWS__
 	fd_set rfds;
 	struct timeval tv;
 	if (s->fd == -1) {
@@ -720,9 +720,9 @@ R_API int r_socket_ready(RSocket *s, int secs, int usecs) {
 }
 
 R_API char *r_socket_to_string(RSocket *s) {
-#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#if __WINDOWS__
 	return r_str_newf ("fd%d", (int)(size_t)s->fd);
-#elif __UNIX__ || defined(__CYGWIN__)
+#elif __UNIX__
 	char *str = NULL;
 	struct sockaddr sa;
 	socklen_t sl = sizeof (sa);
@@ -746,7 +746,7 @@ R_API char *r_socket_to_string(RSocket *s) {
 /* Read/Write functions */
 R_API int r_socket_write(RSocket *s, void *buf, int len) {
 	int ret, delta = 0;
-#if __UNIX__ || defined(__CYGWIN__)
+#if __UNIX__
 	signal (SIGPIPE, SIG_IGN);
 #endif
 	for (;;) {
@@ -809,7 +809,7 @@ R_API int r_socket_read(RSocket *s, unsigned char *buf, int len) {
 		return SSL_read (s->sfd, buf, len);
 	}
 #endif
-#if __WINDOWS__ && !defined(__CYGWIN__) //&& !defined(__MINGW64__)
+#if __WINDOWS__
 rep:
 	{
 	int ret = recv (s->fd, (void *)buf, len, 0);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -201,11 +201,11 @@ R_API char *r_file_abspath(const char *file) {
 	if (!strncmp (file, "~/", 2) || !strncmp (file, "~\\", 2)) {
 		ret = r_str_home (file + 2);
 	} else {
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 		if (cwd && *file != '/') {
 			ret = r_str_newf ("%s" R_SYS_DIR "%s", cwd, file);
 		}
-#elif __WINDOWS__ && !__CYGWIN__
+#elif __WINDOWS__
 		// Network path
 		if (!strncmp (file, "\\\\", 2)) {
 			return strdup (file);

--- a/libr/util/idpool.c
+++ b/libr/util/idpool.c
@@ -4,7 +4,7 @@
 #include <r_types.h>
 #include <string.h>
 #include <stdlib.h>
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 #include <search.h>
 #endif
 

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -347,7 +347,7 @@ R_API int r_lib_open_ptr (RLib *lib, const char *file, void *handler, RLibStruct
 }
 
 R_API int r_lib_opendir(RLib *lib, const char *path) {
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	wchar_t file[1024];
 	WIN32_FIND_DATAW dir;
 	HANDLE fh;
@@ -367,10 +367,10 @@ R_API int r_lib_opendir(RLib *lib, const char *path) {
 	if (!path) {
 		return false;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	wcpath = r_utf8_to_utf16 (path);
 	if (!wcpath) {
-		return false;	
+		return false;
 
 	}
 #if __MINGW32__

--- a/libr/util/mem.c
+++ b/libr/util/mem.c
@@ -255,7 +255,7 @@ R_API int r_mem_protect(void *ptr, int size, const char *prot) {
 	if (mprotect (ptr, size, p) == -1) {
 		return false;
 	}
-#elif __WINDOWS__ || __CYGWIN__
+#elif __WINDOWS__
 	int r, w, x;
 	DWORD p = PAGE_NOACCESS;
 	r = strchr (prot, 'r')? 1: 0;

--- a/libr/util/sandbox.c
+++ b/libr/util/sandbox.c
@@ -348,7 +348,7 @@ R_API int r_sandbox_kill(int pid, int sig) {
 #endif
 	return -1;
 }
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 R_API HANDLE r_sandbox_opendir (const char *path, WIN32_FIND_DATAW *entry) {
 	wchar_t dir[MAX_PATH];
 	wchar_t *wcpath = 0;

--- a/libr/util/signal.c
+++ b/libr/util/signal.c
@@ -20,7 +20,7 @@ static struct {
 	{ "SIGPWR", SIGPWR },
 	{ "SIGPOLL", SIGPOLL },
 #endif
-#if !__WINDOWS__ || __CYGWIN__
+#if !__WINDOWS__
 	{ "SIGHUP", SIGHUP },
 	{ "SIGQUIT", SIGQUIT },
 	{ "SIGTRAP", SIGTRAP },

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -16,7 +16,7 @@
 #if defined(__FreeBSD__)
 # include <sys/param.h>
 # include <sys/sysctl.h>
-# if __FreeBSD_version >= 1000000 
+# if __FreeBSD_version >= 1000000
 #  define FREEBSD_WITH_BACKTRACE
 # endif
 #endif
@@ -51,7 +51,7 @@ int proc_pidpath(int pid, void * buffer, ut32 buffersize);
 //#  include <libproc.h>
 # endif
 #endif
-#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#if __UNIX__
 # include <sys/wait.h>
 # include <sys/stat.h>
 # include <errno.h>
@@ -63,7 +63,7 @@ extern char **environ;
 # define Sleep sleep
 #endif
 #endif
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 # include <io.h>
 # include <winbase.h>
 #define TMP_BUFSIZE	4096
@@ -113,7 +113,7 @@ static const struct {const char* name; ut64 bit;} arch_bit_array[] = {
 
 R_API int r_sys_fork() {
 #if HAVE_FORK
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return -1;
 #else
 	return fork ();
@@ -137,7 +137,7 @@ R_API ut64 r_sys_now(void) {
 }
 
 R_API int r_sys_truncate(const char *file, int sz) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	int fd = r_sandbox_open (file, O_RDWR, 0644);
 	if (fd == -1) {
 		return false;
@@ -164,7 +164,7 @@ R_API int r_sys_truncate(const char *file, int sz) {
 
 R_API RList *r_sys_dir(const char *path) {
 	RList *list = NULL;
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	WIN32_FIND_DATAW entry;
 	char *cfname;
 	HANDLE fh = r_sandbox_opendir (path, &entry);
@@ -274,7 +274,7 @@ R_API int r_sys_usleep(int usecs) {
 	rqtp.tv_sec = usecs / 1000000;
 	rqtp.tv_nsec = (usecs - (rqtp.tv_sec * 1000000)) * 1000;
 	return clock_nanosleep (CLOCK_MONOTONIC, 0, &rqtp, NULL);
-#elif __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#elif __UNIX__
 	return usleep (usecs);
 #else
 	// w32 api uses milliseconds
@@ -285,7 +285,7 @@ R_API int r_sys_usleep(int usecs) {
 }
 
 R_API int r_sys_clearenv(void) {
-#if __UNIX__ || (__CYGWIN__ && !defined(MINGW32))
+#if __UNIX__
 #if __APPLE__ && !HAVE_ENVIRON
 	/* do nothing */
 	if (!env) {
@@ -318,7 +318,7 @@ R_API int r_sys_clearenv(void) {
 }
 
 R_API int r_sys_setenv(const char *key, const char *value) {
-#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#if __UNIX__
 	if (!key) {
 		return 0;
 	}
@@ -403,7 +403,7 @@ R_API int r_sys_crash_handler(const char *cmd) {
 }
 
 R_API char *r_sys_getenv(const char *key) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	DWORD dwRet;
 	LPTSTR envbuf = NULL, key_ = NULL, tmp_ptr;
 	char *val = NULL;
@@ -448,7 +448,7 @@ err_r_sys_get_env:
 }
 
 R_API char *r_sys_getdir(void) {
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 	return _getcwd (NULL, 0);
 #else
 	return getcwd (NULL, 0);
@@ -490,7 +490,7 @@ R_API bool r_sys_aslr(int val) {
 	return ret;
 }
 
-#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#if __UNIX__
 R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, int *len, char **sterr) {
 	char *mysterr = NULL;
 	if (!sterr) {
@@ -672,7 +672,7 @@ R_API int r_sys_cmdf (const char *fmt, ...) {
 }
 
 R_API int r_sys_cmdbg (const char *str) {
-#if __UNIX__ || __CYGWIN && !defined(MINGW32)
+#if __UNIX__
 	int ret, pid = r_sys_fork ();
 	if (pid == -1) {
 		return -1;
@@ -739,7 +739,7 @@ R_API bool r_sys_mkdir(const char *dir) {
 	if (r_sandbox_enable (0)) {
 		return false;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	LPTSTR dir_ = r_sys_conv_utf8_to_utf16 (dir);
 
 	ret = CreateDirectory (dir_, NULL) != 0;
@@ -761,7 +761,7 @@ R_API bool r_sys_mkdirp(const char *dir) {
 	if (*ptr == slash) {
 		ptr++;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	{
 		char *p = strstr (ptr, ":\\");
 		if (p) {
@@ -797,7 +797,7 @@ R_API bool r_sys_mkdirp(const char *dir) {
 }
 
 R_API void r_sys_perror_str(const char *fun) {
-#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#if __UNIX__
 #pragma push_macro("perror")
 #undef perror
 	perror (fun);
@@ -886,7 +886,7 @@ R_API int r_sys_run(const ut8 *buf, int len) {
 	//r_mem_protect (ptr, sz, "rwx"); // try, ignore if fail
 	cb = (int (*)())ptr;
 #if USE_FORK
-#if __UNIX__ || __CYGWIN__ && !defined(MINGW32)
+#if __UNIX__
 	pid = r_sys_fork ();
 #else
 	pid = -1;
@@ -1060,7 +1060,7 @@ R_API char *r_sys_whoami (char *buf) {
 R_API int r_sys_getpid() {
 #if __UNIX__
 	return getpid ();
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	return GetCurrentProcessId();
 #else
 #warning r_sys_getpid not implemented for this platform

--- a/libr/util/thread.c
+++ b/libr/util/thread.c
@@ -2,7 +2,7 @@
 
 #include <r_th.h>
 
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 static DWORD WINAPI _r_th_launcher(void *_th) {
 #else
 static void *_r_th_launcher(void *_th) {
@@ -118,7 +118,7 @@ R_API RThread *r_th_new(R_TH_FUNCTION(fun), void *user, int delay) {
 		pthread_cond_init (&th->_cond, NULL);
 		pthread_mutex_init (&th->_mutex, NULL);
 		pthread_create (&th->tid, NULL, _r_th_launcher, th);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 		th->tid = CreateThread (NULL, 0, _r_th_launcher, th, 0, 0);
 #endif
 	}
@@ -142,7 +142,7 @@ R_API bool r_th_kill(RThread *th, bool force) {
 #else
 	pthread_cancel (th->tid);
 #endif
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	TerminateThread (th->tid, -1);
 #endif
 	return 0;
@@ -217,7 +217,7 @@ R_API int r_th_wait(struct r_th_t *th) {
 	if (th) {
 #if HAVE_PTHREAD
 		ret = pthread_join (th->tid, &thret);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 		ret = WaitForSingleObject (th->tid, INFINITE);
 #endif
 		th->running = false;
@@ -233,7 +233,7 @@ R_API void *r_th_free(struct r_th_t *th) {
 	if (!th) {
 		return NULL;
 	}
-#if __WINDOWS__ && !defined(__CYGWIN__)
+#if __WINDOWS__
 	CloseHandle (th->tid);
 #endif
 	r_th_lock_free (th->lock);

--- a/libr/util/thread_cond.c
+++ b/libr/util/thread_cond.c
@@ -12,7 +12,7 @@ R_API RThreadCond *r_th_cond_new() {
 		free (cond);
 		return NULL;
 	}
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	InitializeConditionVariable (&cond->cond);
 #endif
 	return cond;
@@ -21,7 +21,7 @@ R_API RThreadCond *r_th_cond_new() {
 R_API void r_th_cond_signal(RThreadCond *cond) {
 #if HAVE_PTHREAD
 	pthread_cond_signal (&cond->cond);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	WakeConditionVariable (&cond->cond);
 #endif
 }
@@ -29,7 +29,7 @@ R_API void r_th_cond_signal(RThreadCond *cond) {
 R_API void r_th_cond_signal_all(RThreadCond *cond) {
 #if HAVE_PTHREAD
 	pthread_cond_broadcast (&cond->cond);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	WakeAllConditionVariable (&cond->cond);
 #endif
 }
@@ -37,7 +37,7 @@ R_API void r_th_cond_signal_all(RThreadCond *cond) {
 R_API void r_th_cond_wait(RThreadCond *cond, RThreadLock *lock) {
 #if HAVE_PTHREAD
 	pthread_cond_wait (&cond->cond, &lock->lock);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	SleepConditionVariableCS (&cond->cond, &lock->lock, INFINITE);
 #endif
 }

--- a/libr/util/thread_lock.c
+++ b/libr/util/thread_lock.c
@@ -22,7 +22,7 @@ R_API RThreadLock *r_th_lock_new(bool recursive) {
 		} else {
 			pthread_mutex_init (&thl->lock, NULL);
 		}
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 		// TODO: obey `recursive` (currently it is always recursive)
 		InitializeCriticalSection (&thl->lock);
 #endif
@@ -39,7 +39,7 @@ R_API int r_th_lock_wait(RThreadLock *thl) {
 R_API int r_th_lock_enter(RThreadLock *thl) {
 #if HAVE_PTHREAD
 	pthread_mutex_lock (&thl->lock);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	EnterCriticalSection (&thl->lock);
 #endif
 	return ++thl->refs;
@@ -48,7 +48,7 @@ R_API int r_th_lock_enter(RThreadLock *thl) {
 R_API int r_th_lock_leave(RThreadLock *thl) {
 #if HAVE_PTHREAD
 	pthread_mutex_unlock (&thl->lock);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	LeaveCriticalSection (&thl->lock);
 #endif
 	if (thl->refs > 0) {
@@ -65,7 +65,7 @@ R_API void *r_th_lock_free(RThreadLock *thl) {
 	if (thl) {
 #if HAVE_PTHREAD
 		pthread_mutex_destroy (&thl->lock);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 		DeleteCriticalSection (&thl->lock);
 #endif
 		free (thl);

--- a/libr/util/thread_sem.c
+++ b/libr/util/thread_sem.c
@@ -46,7 +46,7 @@ R_API RThreadSemaphore *r_th_sem_new(unsigned int initial) {
 		return NULL;
 	}
 #  endif
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	sem->sem = CreateSemaphore (NULL, (LONG)initial, ST32_MAX, NULL);
 	if (!sem->sem) {
 		free (sem);
@@ -69,7 +69,7 @@ R_API void r_th_sem_free(RThreadSemaphore *sem) {
 		free (sem->sem);
 #  endif
 	}
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	CloseHandle (sem->sem);
 #endif
 	free (sem);
@@ -78,7 +78,7 @@ R_API void r_th_sem_free(RThreadSemaphore *sem) {
 R_API void r_th_sem_post(RThreadSemaphore *sem) {
 #if HAVE_PTHREAD
 	sem_post (sem->sem);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	ReleaseSemaphore (sem->sem, 1, NULL);
 #endif
 }
@@ -86,7 +86,7 @@ R_API void r_th_sem_post(RThreadSemaphore *sem) {
 R_API void r_th_sem_wait(RThreadSemaphore *sem) {
 #if HAVE_PTHREAD
 	sem_wait (sem->sem);
-#elif __WINDOWS__ && !defined(__CYGWIN__)
+#elif __WINDOWS__
 	WaitForSingleObject (sem->sem, INFINITE);
 #endif
 }

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -1,6 +1,6 @@
 /* radare - LGPL - Copyright 2007-2018 - pancake */
 
-#if __WINDOWS__ && MINGW32 && !__CYGWIN__
+#if __WINDOWS__
 #include <stdlib.h>
 #endif
 
@@ -349,7 +349,7 @@ R_API ut64 r_num_get(RNum *num, const char *str) {
 #if 0
 			//sscanf (str, "%"PFMT64d"%n", &ret, &chars_read);
 // 32bit chop
-#if __WINDOWS__ && MINGW32 && !__CYGWIN__
+#if __WINDOWS__
 			ret = _strtoui64 (str, &endptr, 10);
 #endif
 #endif

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -4,9 +4,7 @@
 #if __WINDOWS__
 #include <windows.h>
 #include <stdio.h>
-#ifndef __CYGWIN__
 #include <tchar.h>
-#endif
 
 #define BUFSIZE 1024
 void r_sys_perror_str(const char *fun);

--- a/shlr/gdb/include/packet.h
+++ b/shlr/gdb/include/packet.h
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #if __WINDOWS__
 #include <windows.h>
-#if !__CYGWIN__ && !defined(_MSC_VER)
+#if !defined(_MSC_VER)
 #include <winsock.h>
 #endif
 #endif

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -17,7 +17,7 @@
 #include <termios.h>
 #endif
 
-#if __UNIX__ || __CYGWIN__
+#if __UNIX__
 #include <signal.h>
 #endif
 
@@ -870,7 +870,7 @@ int test_command(libgdbr_t *g, const char *command) {
 
 static bool _isbreaked = false;
 
-#if __WINDOWS__ && !__CYGWIN__
+#if __WINDOWS__
 static HANDLE h;
 static BOOL __w32_signal(DWORD type) {
 	if (type == CTRL_C_EVENT) {
@@ -883,7 +883,7 @@ static BOOL __w32_signal(DWORD type) {
 #define SET_SIGINT_HANDLER(g,x)
 #define UNSET_SIGINT_HANDLER()
 
-#elif __UNIX__ || __CYGWIN__
+#elif __UNIX__
 static void _sigint_handler(int signo) {
 	_isbreaked = true;
 }

--- a/shlr/tcc/Makefile
+++ b/shlr/tcc/Makefile
@@ -5,22 +5,6 @@ OFILES=libtcc.o tccgen.o tccpp.o
 
 CFLAGS+=${PIC_CFLAGS}
 
-ifneq (,$(findstring cygwin,${OSTYPE}))
-CFLAGS+=-D__CYGWIN__=1
-EXT_SO=dll
-SOVER=${EXT_SO}
-LDFLAGS+=-shared
-LDFLAGS_SHARED?=-shared
-else
-ifneq (,$(findstring mingw32,${OSTYPE}))
-CFLAGS+=-DMINGW32=1
-EXT_SO=dll
-SOVER=${EXT_SO}
-LDFLAGS+=-shared
-LDFLAGS_SHARED?=-shared
-endif
-endif
-
 LDFLAGS+=-L../../libr/util
 LIBS+=-lr_util
 CFLAGS+=-I../../libr/include

--- a/shlr/windbg/Makefile
+++ b/shlr/windbg/Makefile
@@ -5,27 +5,6 @@ include ../../mk/${COMPILER}.mk
 
 CFLAGS+=${PIC_CFLAGS}
 
-ifneq (,$(findstring cygwin,${OSTYPE}))
-CFLAGS+=-D__CYGWIN__=1
-EXT_SO=dll
-SOVER=${EXT_SO}
-LDFLAGS+=-shared
-LDFLAGS_SHARED?=-shared
-else
-ifneq (,$(findstring mingw32,${OSTYPE}))
-CFLAGS+=-DMINGW32=1
-EXT_SO=dll
-SOVER=${EXT_SO}
-LDFLAGS+=-shared
-LDFLAGS_SHARED?=-shared
-else
-ifneq (,$(findstring mingw64,${OSTYPE})$(findstring msys,${OSTYPE}))
-LDFLAGS+=-shared
-LFDLAGS_SHARE?=-shared
-endif
-endif
-endif
-
 CFLAGS+=-I../../libr/include
 LIBAR=libr_windbg.${EXT_AR}
 LDFLAGS+=-L../../libr/util

--- a/shlr/windbg/iob_pipe.c
+++ b/shlr/windbg/iob_pipe.c
@@ -6,7 +6,7 @@
 #include <r_util.h>
 #include "transport.h"
 
-#if __WINDOWS__ || __CYGWIN__ || MINGW32
+#if __WINDOWS__
 #include <windows.h>
 
 static void *iob_pipe_open(const char *path) {

--- a/shlr/windbg/transport.c
+++ b/shlr/windbg/transport.c
@@ -5,7 +5,7 @@
 extern io_backend_t iob_pipe;
 
 static io_backend_t *io_backends[] = {
-// #if __WINDOWS__ || __CYGWIN__ || MINGW32
+// #if __WINDOWS__
 // #warning TODO: add proper IO backend for windows here
 // #else
 	&iob_pipe,


### PR DESCRIPTION
To address this https://github.com/radare/radare2/issues/9973

So far Cygwin wasn't working properly for quite some time. Same applies to MinGW and MSYS2/MinGW-W64 targets. So lets remove various quirks to support them.