### PR TITLE
Use r_buf_size to get the size of a buffer, not the private field

### DIFF
--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -1385,7 +1385,7 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	}
 	r_buf = r_buf_new_with_pointers (buf, size);
 #if DEBUG
-	r_file_dump ("sig_dump", r_buf->buf, r_buf_size(r_buf));
+	r_file_dump ("sig_dump", r_buf->buf, r_buf_size (r_buf));
 #endif
 	if (parse_tree (anal, r_buf, node)) {
 		ret = node;

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -1225,37 +1225,37 @@ static int parse_header(RBuffer *buf, idasig_v5_t *header) {
 	if (r_buf_read_at (buf, 0, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), &header->version, sizeof(header->version)) != sizeof(header->version)) {
+	if (r_buf_read(buf, &header->version, sizeof(header->version)) != sizeof(header->version)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), &header->arch, sizeof(header->arch)) != sizeof(header->arch)) {
+	if (r_buf_read(buf, &header->arch, sizeof(header->arch)) != sizeof(header->arch)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->file_types, sizeof(header->file_types)) != sizeof(header->file_types)) {
+	if (r_buf_read(buf, (unsigned char *)&header->file_types, sizeof(header->file_types)) != sizeof(header->file_types)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->os_types, sizeof(header->os_types)) != sizeof(header->os_types)) {
+	if (r_buf_read(buf, (unsigned char *)&header->os_types, sizeof(header->os_types)) != sizeof(header->os_types)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->app_types, sizeof(header->app_types)) != sizeof(header->app_types)) {
+	if (r_buf_read(buf, (unsigned char *)&header->app_types, sizeof(header->app_types)) != sizeof(header->app_types)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->features, sizeof(header->features)) != sizeof(header->features)) {
+	if (r_buf_read(buf, (unsigned char *)&header->features, sizeof(header->features)) != sizeof(header->features)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->old_n_functions, sizeof(header->old_n_functions)) != sizeof(header->old_n_functions)) {
+	if (r_buf_read(buf, (unsigned char *)&header->old_n_functions, sizeof(header->old_n_functions)) != sizeof(header->old_n_functions)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->crc16, sizeof(header->crc16)) != sizeof(header->crc16)) {
+	if (r_buf_read(buf, (unsigned char *)&header->crc16, sizeof(header->crc16)) != sizeof(header->crc16)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), header->ctype, sizeof(header->ctype)) != sizeof(header->ctype)) {
+	if (r_buf_read(buf, header->ctype, sizeof(header->ctype)) != sizeof(header->ctype)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->library_name_len, sizeof(header->library_name_len)) != sizeof(header->library_name_len)) {
+	if (r_buf_read(buf, (unsigned char *)&header->library_name_len, sizeof(header->library_name_len)) != sizeof(header->library_name_len)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->ctypes_crc16, sizeof(header->ctypes_crc16)) != sizeof(header->ctypes_crc16)) {
+	if (r_buf_read(buf, (unsigned char *)&header->ctypes_crc16, sizeof(header->ctypes_crc16)) != sizeof(header->ctypes_crc16)) {
 		return false;
 	}
 
@@ -1263,8 +1263,7 @@ static int parse_header(RBuffer *buf, idasig_v5_t *header) {
 }
 
 static int parse_v6_v7_header(RBuffer *buf, idasig_v6_v7_t *header) {
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->n_functions, sizeof(header->n_functions))
-	    != sizeof(header->n_functions)) {
+	if (r_buf_read (buf, (unsigned char *)&header->n_functions, sizeof (header->n_functions)) != sizeof (header->n_functions)) {
 		return false;
 	}
 
@@ -1272,7 +1271,7 @@ static int parse_v6_v7_header(RBuffer *buf, idasig_v6_v7_t *header) {
 }
 
 static int parse_v8_v9_header(RBuffer *buf, idasig_v8_v9_t *header) {
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->pattern_size, sizeof(header->pattern_size)) != sizeof(header->pattern_size)) {
+	if (r_buf_read (buf, (unsigned char *)&header->pattern_size, sizeof (header->pattern_size)) != sizeof (header->pattern_size)) {
 		return false;
 	}
 
@@ -1280,7 +1279,7 @@ static int parse_v8_v9_header(RBuffer *buf, idasig_v8_v9_t *header) {
 }
 
 static int parse_v10_header(RBuffer *buf, idasig_v10_t *header) {
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->unknown, sizeof(header->unknown)) != sizeof(header->unknown)) {
+	if (r_buf_read (buf, (unsigned char *)&header->unknown, sizeof (header->unknown)) != sizeof (header->unknown)) {
 		return false;
 	}
 
@@ -1416,8 +1415,7 @@ R_API int r_sign_is_flirt(RBuffer *buf) {
 	int ret = false;
 
 	idasig_v5_t *header = R_NEW0 (idasig_v5_t);
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), header->magic,\
-		sizeof(header->magic)) != sizeof(header->magic)) {
+	if (r_buf_read(buf, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
 		goto exit;
 	}
 
@@ -1425,7 +1423,7 @@ R_API int r_sign_is_flirt(RBuffer *buf) {
 		goto exit;
 	}
 
-	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), &header->version, sizeof(header->version)) != sizeof(header->version)) {
+	if (r_buf_read(buf, &header->version, sizeof(header->version)) != sizeof(header->version)) {
 		goto exit;
 	}
 

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -389,8 +389,8 @@ static ut32 read_word(RBuffer *b) {
 static ut16 read_max_2_bytes(RBuffer *b) {
 	ut16 r = read_byte (b);
 	return (r & 0x80)
-	? ((r & 0x7f) << 8) + read_byte (b)
-	: r;
+		? ((r & 0x7f) << 8) + read_byte (b)
+		: r;
 }
 
 static ut32 read_multiple_bytes(RBuffer *b) {
@@ -435,7 +435,7 @@ static void node_free(RFlirtNode *node) {
 	free (node->variant_bool_array);
 	free (node->pattern_bytes);
 	if (node->module_list) {
-		node->module_list->free = (RListFree) module_free;
+		node->module_list->free = (RListFree)module_free;
 		r_list_free (node->module_list);
 	}
 	if (node->child_list) {
@@ -863,7 +863,7 @@ static ut8 read_module_public_functions(RFlirtModule *module, RBuffer *b, ut8 *f
 #if DEBUG
 				// XXX investigate
 				eprintf ("INVESTIGATE PUBLIC NAME FLAG: %02X @ %04X\n", current_byte,
-					 r_buf_seek(b, 0, 1) + header_size);
+					r_buf_seek (b, 0, 1) + header_size);
 #endif
 			}
 			current_byte = read_byte (b);
@@ -923,7 +923,7 @@ static ut8 parse_leaf(const RAnal *anal, RBuffer *b, RFlirtNode *node) {
 #if DEBUG
 		if (crc_length == 0x00 && crc16 != 0x0000) {
 			eprintf ("WARNING non zero crc of zero length @ %04X\n",
-				 r_buf_seek(b, 0, 1) + header_size);
+				r_buf_seek (b, 0, 1) + header_size);
 		}
 		eprintf ("crc_len: %02X crc16: %04X\n", crc_length, crc16);
 #endif
@@ -1005,8 +1005,7 @@ static ut8 read_node_variant_mask(RFlirtNode *node, RBuffer *b) {
 			return false;
 		}
 	} else if (node->length <= 0x40) { // it shouldn't be more than 64 bytes
-		node->variant_mask = ((ut64) read_multiple_bytes (b) << 32)
-		+ read_multiple_bytes (b);
+		node->variant_mask = ((ut64)read_multiple_bytes (b) << 32) + read_multiple_bytes (b);
 		if (buf_eof || buf_err) {
 			return false;
 		}
@@ -1360,7 +1359,7 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	header_size = r_buf_seek (flirt_buf, 0, 1);
 #endif
 
-	size = r_buf_size (flirt_buf) - r_buf_seek(flirt_buf, 0, 1);
+	size = r_buf_size (flirt_buf) - r_buf_seek (flirt_buf, 0, 1);
 	buf = malloc (size);
 	if (r_buf_read (flirt_buf, buf, size) != size) {
 		goto exit;

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -362,7 +362,7 @@ static ut8 read_byte(RBuffer *b) {
 	if (buf_eof || buf_err) {
 		return 0;
 	}
-	if ((length = r_buf_read(b, &r, 1)) != 1) {
+	if ((length = r_buf_read (b, &r, 1)) != 1) {
 		if (length == -1) {
 			buf_err = true;
 		}
@@ -1224,37 +1224,37 @@ static int parse_header(RBuffer *buf, idasig_v5_t *header) {
 	if (r_buf_read_at (buf, 0, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
 		return false;
 	}
-	if (r_buf_read(buf, &header->version, sizeof(header->version)) != sizeof(header->version)) {
+	if (r_buf_read (buf, &header->version, sizeof(header->version)) != sizeof(header->version)) {
 		return false;
 	}
-	if (r_buf_read(buf, &header->arch, sizeof(header->arch)) != sizeof(header->arch)) {
+	if (r_buf_read (buf, &header->arch, sizeof(header->arch)) != sizeof(header->arch)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->file_types, sizeof(header->file_types)) != sizeof(header->file_types)) {
+	if (r_buf_read (buf, (unsigned char *)&header->file_types, sizeof(header->file_types)) != sizeof(header->file_types)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->os_types, sizeof(header->os_types)) != sizeof(header->os_types)) {
+	if (r_buf_read (buf, (unsigned char *)&header->os_types, sizeof(header->os_types)) != sizeof(header->os_types)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->app_types, sizeof(header->app_types)) != sizeof(header->app_types)) {
+	if (r_buf_read (buf, (unsigned char *)&header->app_types, sizeof(header->app_types)) != sizeof(header->app_types)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->features, sizeof(header->features)) != sizeof(header->features)) {
+	if (r_buf_read (buf, (unsigned char *)&header->features, sizeof(header->features)) != sizeof(header->features)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->old_n_functions, sizeof(header->old_n_functions)) != sizeof(header->old_n_functions)) {
+	if (r_buf_read (buf, (unsigned char *)&header->old_n_functions, sizeof(header->old_n_functions)) != sizeof(header->old_n_functions)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->crc16, sizeof(header->crc16)) != sizeof(header->crc16)) {
+	if (r_buf_read (buf, (unsigned char *)&header->crc16, sizeof(header->crc16)) != sizeof(header->crc16)) {
 		return false;
 	}
-	if (r_buf_read(buf, header->ctype, sizeof(header->ctype)) != sizeof(header->ctype)) {
+	if (r_buf_read (buf, header->ctype, sizeof(header->ctype)) != sizeof(header->ctype)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->library_name_len, sizeof(header->library_name_len)) != sizeof(header->library_name_len)) {
+	if (r_buf_read (buf, (unsigned char *)&header->library_name_len, sizeof(header->library_name_len)) != sizeof(header->library_name_len)) {
 		return false;
 	}
-	if (r_buf_read(buf, (unsigned char *)&header->ctypes_crc16, sizeof(header->ctypes_crc16)) != sizeof(header->ctypes_crc16)) {
+	if (r_buf_read (buf, (unsigned char *)&header->ctypes_crc16, sizeof(header->ctypes_crc16)) != sizeof(header->ctypes_crc16)) {
 		return false;
 	}
 
@@ -1408,7 +1408,7 @@ R_API int r_sign_is_flirt(RBuffer *buf) {
 	int ret = false;
 
 	idasig_v5_t *header = R_NEW0 (idasig_v5_t);
-	if (r_buf_read(buf, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
+	if (r_buf_read (buf, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
 		goto exit;
 	}
 
@@ -1416,7 +1416,7 @@ R_API int r_sign_is_flirt(RBuffer *buf) {
 		goto exit;
 	}
 
-	if (r_buf_read(buf, &header->version, sizeof(header->version)) != sizeof(header->version)) {
+	if (r_buf_read (buf, &header->version, sizeof(header->version)) != sizeof(header->version)) {
 		goto exit;
 	}
 

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -1386,9 +1386,9 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	}
 	r_buf = r_buf_new ();
 	r_buf->buf = buf;
-	r_buf->length = size;
+	r_buf_resize(r_buf, size);
 #if DEBUG
-	r_file_dump ("sig_dump", r_buf->buf, r_buf->length);
+	r_file_dump ("sig_dump", r_buf->buf, r_buf_size(r_buf));
 #endif
 	if (parse_tree (anal, r_buf, node)) {
 		ret = node;

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -362,7 +362,7 @@ static ut8 read_byte(RBuffer *b) {
 	if (buf_eof || buf_err) {
 		return 0;
 	}
-	if ((length = r_buf_read_at (b, r_buf_seek(b, 0, 1), &r, 1)) != 1) {
+	if ((length = r_buf_read(b, &r, 1)) != 1) {
 		if (length == -1) {
 			buf_err = true;
 		}
@@ -1348,8 +1348,7 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 		goto exit;
 	}
 
-	if (r_buf_read_at (flirt_buf, r_buf_seek(flirt_buf, 0, 1), name, header->library_name_len)
-	    != header->library_name_len) {
+	if (r_buf_read (flirt_buf, name, header->library_name_len) != header->library_name_len) {
 		goto exit;
 	}
 
@@ -1358,12 +1357,12 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	// anal->cb_printf  ("Loading: %s\n", name);
 #if DEBUG
 	print_header (header);
-	header_size = r_buf_seek(flirt_buf, 0, 1);
+	header_size = r_buf_seek (flirt_buf, 0, 1);
 #endif
 
 	size = r_buf_size (flirt_buf) - r_buf_seek(flirt_buf, 0, 1);
 	buf = malloc (size);
-	if (r_buf_read_at (flirt_buf, r_buf_seek(flirt_buf, 0, 1), buf, size) != size) {
+	if (r_buf_read (flirt_buf, buf, size) != size) {
 		goto exit;
 	}
 

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -362,7 +362,7 @@ static ut8 read_byte(RBuffer *b) {
 	if (buf_eof || buf_err) {
 		return 0;
 	}
-	if ((length = r_buf_read_at (b, b->cur, &r, 1)) != 1) {
+	if ((length = r_buf_read_at (b, r_buf_seek(b, 0, 1), &r, 1)) != 1) {
 		if (length == -1) {
 			buf_err = true;
 		}
@@ -862,7 +862,8 @@ static ut8 read_module_public_functions(RFlirtModule *module, RBuffer *b, ut8 *f
 			if (current_byte & 0x01 || current_byte & 0x04) { // appears as 'd' or '?' in dumpsig
 #if DEBUG
 				// XXX investigate
-				eprintf ("INVESTIGATE PUBLIC NAME FLAG: %02X @ %04X\n", current_byte, b->cur + header_size);
+				eprintf ("INVESTIGATE PUBLIC NAME FLAG: %02X @ %04X\n", current_byte,
+					 r_buf_seek(b, 0, 1) + header_size);
 #endif
 			}
 			current_byte = read_byte (b);
@@ -921,7 +922,8 @@ static ut8 parse_leaf(const RAnal *anal, RBuffer *b, RFlirtNode *node) {
 		}
 #if DEBUG
 		if (crc_length == 0x00 && crc16 != 0x0000) {
-			eprintf ("WARNING non zero crc of zero length @ %04X\n", b->cur + header_size);
+			eprintf ("WARNING non zero crc of zero length @ %04X\n",
+				 r_buf_seek(b, 0, 1) + header_size);
 		}
 		eprintf ("crc_len: %02X crc16: %04X\n", crc_length, crc16);
 #endif
@@ -1223,37 +1225,37 @@ static int parse_header(RBuffer *buf, idasig_v5_t *header) {
 	if (r_buf_read_at (buf, 0, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, &header->version, sizeof(header->version)) != sizeof(header->version)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), &header->version, sizeof(header->version)) != sizeof(header->version)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, &header->arch, sizeof(header->arch)) != sizeof(header->arch)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), &header->arch, sizeof(header->arch)) != sizeof(header->arch)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->file_types, sizeof(header->file_types)) != sizeof(header->file_types)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->file_types, sizeof(header->file_types)) != sizeof(header->file_types)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->os_types, sizeof(header->os_types)) != sizeof(header->os_types)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->os_types, sizeof(header->os_types)) != sizeof(header->os_types)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->app_types, sizeof(header->app_types)) != sizeof(header->app_types)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->app_types, sizeof(header->app_types)) != sizeof(header->app_types)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->features, sizeof(header->features)) != sizeof(header->features)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->features, sizeof(header->features)) != sizeof(header->features)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->old_n_functions, sizeof(header->old_n_functions)) != sizeof(header->old_n_functions)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->old_n_functions, sizeof(header->old_n_functions)) != sizeof(header->old_n_functions)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->crc16, sizeof(header->crc16)) != sizeof(header->crc16)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->crc16, sizeof(header->crc16)) != sizeof(header->crc16)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, header->ctype, sizeof(header->ctype)) != sizeof(header->ctype)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), header->ctype, sizeof(header->ctype)) != sizeof(header->ctype)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->library_name_len, sizeof(header->library_name_len)) != sizeof(header->library_name_len)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->library_name_len, sizeof(header->library_name_len)) != sizeof(header->library_name_len)) {
 		return false;
 	}
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->ctypes_crc16, sizeof(header->ctypes_crc16)) != sizeof(header->ctypes_crc16)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->ctypes_crc16, sizeof(header->ctypes_crc16)) != sizeof(header->ctypes_crc16)) {
 		return false;
 	}
 
@@ -1261,8 +1263,8 @@ static int parse_header(RBuffer *buf, idasig_v5_t *header) {
 }
 
 static int parse_v6_v7_header(RBuffer *buf, idasig_v6_v7_t *header) {
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->n_functions, sizeof(header->n_functions))
-	!= sizeof(header->n_functions)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->n_functions, sizeof(header->n_functions))
+	    != sizeof(header->n_functions)) {
 		return false;
 	}
 
@@ -1270,7 +1272,7 @@ static int parse_v6_v7_header(RBuffer *buf, idasig_v6_v7_t *header) {
 }
 
 static int parse_v8_v9_header(RBuffer *buf, idasig_v8_v9_t *header) {
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->pattern_size, sizeof(header->pattern_size)) != sizeof(header->pattern_size)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->pattern_size, sizeof(header->pattern_size)) != sizeof(header->pattern_size)) {
 		return false;
 	}
 
@@ -1278,7 +1280,7 @@ static int parse_v8_v9_header(RBuffer *buf, idasig_v8_v9_t *header) {
 }
 
 static int parse_v10_header(RBuffer *buf, idasig_v10_t *header) {
-	if (r_buf_read_at (buf, buf->cur, (unsigned char *) &header->unknown, sizeof(header->unknown)) != sizeof(header->unknown)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), (unsigned char *) &header->unknown, sizeof(header->unknown)) != sizeof(header->unknown)) {
 		return false;
 	}
 
@@ -1347,8 +1349,8 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 		goto exit;
 	}
 
-	if (r_buf_read_at (flirt_buf, flirt_buf->cur, name, header->library_name_len)
-	!= header->library_name_len) {
+	if (r_buf_read_at (flirt_buf, r_buf_seek(flirt_buf, 0, 1), name, header->library_name_len)
+	    != header->library_name_len) {
 		goto exit;
 	}
 
@@ -1357,12 +1359,12 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	// anal->cb_printf  ("Loading: %s\n", name);
 #if DEBUG
 	print_header (header);
-	header_size = flirt_buf->cur;
+	header_size = r_buf_seek(flirt_buf, 0, 1);
 #endif
 
-	size = r_buf_size (flirt_buf) - flirt_buf->cur;
+	size = r_buf_size (flirt_buf) - r_buf_seek(flirt_buf, 0, 1);
 	buf = malloc (size);
-	if (r_buf_read_at (flirt_buf, flirt_buf->cur, buf, size) != size) {
+	if (r_buf_read_at (flirt_buf, r_buf_seek(flirt_buf, 0, 1), buf, size) != size) {
 		goto exit;
 	}
 
@@ -1414,7 +1416,7 @@ R_API int r_sign_is_flirt(RBuffer *buf) {
 	int ret = false;
 
 	idasig_v5_t *header = R_NEW0 (idasig_v5_t);
-	if (r_buf_read_at (buf, buf->cur, header->magic,\
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), header->magic,\
 		sizeof(header->magic)) != sizeof(header->magic)) {
 		goto exit;
 	}
@@ -1423,7 +1425,7 @@ R_API int r_sign_is_flirt(RBuffer *buf) {
 		goto exit;
 	}
 
-	if (r_buf_read_at (buf, buf->cur, &header->version, sizeof(header->version)) != sizeof(header->version)) {
+	if (r_buf_read_at (buf, r_buf_seek(buf, 0, 1), &header->version, sizeof(header->version)) != sizeof(header->version)) {
 		goto exit;
 	}
 

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -863,7 +863,7 @@ static ut8 read_module_public_functions(RFlirtModule *module, RBuffer *b, ut8 *f
 #if DEBUG
 				// XXX investigate
 				eprintf ("INVESTIGATE PUBLIC NAME FLAG: %02X @ %04X\n", current_byte,
-					r_buf_seek (b, 0, 1) + header_size);
+					r_buf_tell (b) + header_size);
 #endif
 			}
 			current_byte = read_byte (b);
@@ -923,7 +923,7 @@ static ut8 parse_leaf(const RAnal *anal, RBuffer *b, RFlirtNode *node) {
 #if DEBUG
 		if (crc_length == 0x00 && crc16 != 0x0000) {
 			eprintf ("WARNING non zero crc of zero length @ %04X\n",
-				r_buf_seek (b, 0, 1) + header_size);
+				r_buf_tell (b) + header_size);
 		}
 		eprintf ("crc_len: %02X crc16: %04X\n", crc_length, crc16);
 #endif
@@ -1356,10 +1356,10 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	// anal->cb_printf  ("Loading: %s\n", name);
 #if DEBUG
 	print_header (header);
-	header_size = r_buf_seek (flirt_buf, 0, 1);
+	header_size = r_buf_tell (flirt_buf);
 #endif
 
-	size = r_buf_size (flirt_buf) - r_buf_seek (flirt_buf, 0, 1);
+	size = r_buf_size (flirt_buf) - r_buf_tell (flirt_buf);
 	buf = malloc (size);
 	if (r_buf_read (flirt_buf, buf, size) != size) {
 		goto exit;

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -1384,9 +1384,7 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	if (!(node = R_NEW0 (RFlirtNode))) {
 		goto exit;
 	}
-	r_buf = r_buf_new ();
-	r_buf->buf = buf;
-	r_buf_resize(r_buf, size);
+	r_buf = r_buf_new_with_pointers (buf, size);
 #if DEBUG
 	r_file_dump ("sig_dump", r_buf->buf, r_buf_size(r_buf));
 #endif
@@ -1397,9 +1395,6 @@ static RFlirtNode *flirt_parse(const RAnal *anal, RBuffer *flirt_buf) {
 	}
 exit:
 	free (buf);
-	if (r_buf && buf == r_buf->buf) {
-		r_buf->buf = NULL;
-	}
 	r_buf_free (r_buf);
 	free (header);
 	free (v6_v7);

--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -305,7 +305,7 @@ static void get_strings_range(RBinFile *bf, RList *list, int min, int raw, ut64 
 	if (min < 0) {
 		return;
 	}
-	if (!to || to > bf->buf->length) {
+	if (!to || to > r_buf_size(bf->buf)) {
 		to = r_buf_size (bf->buf);
 	}
 	if (!to) {

--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -305,7 +305,7 @@ static void get_strings_range(RBinFile *bf, RList *list, int min, int raw, ut64 
 	if (min < 0) {
 		return;
 	}
-	if (!to || to > r_buf_size(bf->buf)) {
+	if (!to || to > r_buf_size (bf->buf)) {
 		to = r_buf_size (bf->buf);
 	}
 	if (!to) {

--- a/libr/bin/bin_write.c
+++ b/libr/bin/bin_write.c
@@ -37,8 +37,7 @@ R_API bool r_bin_wr_output(RBin *bin, const char *filename) {
 	if (!filename || !binfile || !binfile->buf) {
 		return false;
 	}
-	return r_file_dump (filename, binfile->buf->buf,
-			binfile->buf->length, 0);
+	return r_file_dump (filename, binfile->buf->buf, r_buf_size (binfile->buf), 0);
 }
 
 R_API bool r_bin_wr_entry(RBin *bin, ut64 addr) {

--- a/libr/bin/format/bflt/bflt.c
+++ b/libr/bin/format/bflt/bflt.c
@@ -61,7 +61,7 @@ fail:
 
 static int r_bin_bflt_init(struct r_bin_bflt_obj *obj, RBuffer *buf) {
 	obj->b = r_buf_ref (buf);
-	obj->size = r_buf_size(buf);
+	obj->size = r_buf_size (buf);
 	obj->endian = false;
 	obj->reloc_table = NULL;
 	obj->got_table = NULL;

--- a/libr/bin/format/bflt/bflt.c
+++ b/libr/bin/format/bflt/bflt.c
@@ -61,7 +61,7 @@ fail:
 
 static int r_bin_bflt_init(struct r_bin_bflt_obj *obj, RBuffer *buf) {
 	obj->b = r_buf_ref (buf);
-	obj->size = buf->length;
+	obj->size = r_buf_size(buf);
 	obj->endian = false;
 	obj->reloc_table = NULL;
 	obj->got_table = NULL;
@@ -73,7 +73,7 @@ static int r_bin_bflt_init(struct r_bin_bflt_obj *obj, RBuffer *buf) {
 	return true;
 }
 
-struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf) {
+struct r_bin_bflt_obj *r_bin_bflt_new_buf(RBuffer *buf) {
 	struct r_bin_bflt_obj *bin = R_NEW0 (struct r_bin_bflt_obj);
 	if (bin && r_bin_bflt_init (bin, buf)) {
 		return bin;

--- a/libr/bin/format/bflt/bflt.h
+++ b/libr/bin/format/bflt/bflt.h
@@ -52,7 +52,7 @@ struct r_bin_bflt_obj {
 #define VALID_GOT_ENTRY(x)	(x != 0xFFFFFFFF)
 
 RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin);
-struct r_bin_bflt_obj *r_bin_bflt_new_buf(struct r_buf_t *buf);
+struct r_bin_bflt_obj *r_bin_bflt_new_buf(RBuffer *buf);
 void r_bin_bflt_free(struct r_bin_bflt_obj *obj);
 
 #endif

--- a/libr/bin/format/bflt/bflt.h
+++ b/libr/bin/format/bflt/bflt.h
@@ -53,6 +53,6 @@ struct r_bin_bflt_obj {
 
 RBinAddr *r_bflt_get_entry(struct r_bin_bflt_obj *bin);
 struct r_bin_bflt_obj *r_bin_bflt_new_buf(RBuffer *buf);
-void r_bin_bflt_free(struct r_bin_bflt_obj *obj);
+void r_bin_bflt_free (struct r_bin_bflt_obj *obj);
 
 #endif

--- a/libr/bin/format/coff/coff.c
+++ b/libr/bin/format/coff/coff.c
@@ -185,7 +185,7 @@ static bool r_bin_coff_init_symtable(struct r_bin_coff_obj *obj) {
 
 static int r_bin_coff_init(struct r_bin_coff_obj *obj, RBuffer *buf, bool verbose) {
 	obj->b = r_buf_ref (buf);
-	obj->size = buf->length;
+	obj->size = r_buf_size(buf);
 	obj->verbose = verbose;
 	if (!r_bin_coff_init_hdr (obj)) {
 		bprintf ("Warning: failed to init hdr\n");

--- a/libr/bin/format/coff/coff.c
+++ b/libr/bin/format/coff/coff.c
@@ -185,7 +185,7 @@ static bool r_bin_coff_init_symtable(struct r_bin_coff_obj *obj) {
 
 static int r_bin_coff_init(struct r_bin_coff_obj *obj, RBuffer *buf, bool verbose) {
 	obj->b = r_buf_ref (buf);
-	obj->size = r_buf_size(buf);
+	obj->size = r_buf_size (buf);
 	obj->verbose = verbose;
 	if (!r_bin_coff_init_hdr (obj)) {
 		bprintf ("Warning: failed to init hdr\n");

--- a/libr/bin/format/coff/coff.h
+++ b/libr/bin/format/coff/coff.h
@@ -18,7 +18,7 @@ struct r_bin_coff_obj {
 
 	ut16 target_id; /* TI COFF specific */
 
-	struct r_buf_t *b;
+	RBuffer *b;
 	size_t size;
 	ut8 endian;
 	Sdb *kv;

--- a/libr/bin/format/dex/dex.c
+++ b/libr/bin/format/dex/dex.c
@@ -25,7 +25,7 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	if (!bin) {
 		goto fail;
 	}
-	bin->size = buf->length;
+	bin->size = r_buf_size(buf);
 	bin->b = r_buf_ref (buf);
 	/* header */
 	if (bin->size < sizeof (struct dex_header_t)) {

--- a/libr/bin/format/dex/dex.c
+++ b/libr/bin/format/dex/dex.c
@@ -25,7 +25,7 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	if (!bin) {
 		goto fail;
 	}
-	bin->size = r_buf_size(buf);
+	bin->size = r_buf_size (buf);
 	bin->b = r_buf_ref (buf);
 	/* header */
 	if (bin->size < sizeof (struct dex_header_t)) {

--- a/libr/bin/format/dex/dex.h
+++ b/libr/bin/format/dex/dex.h
@@ -137,7 +137,7 @@ struct dex_debug_local_t {
 
 char* r_bin_dex_get_version(struct r_bin_dex_obj_t* bin);
 struct r_bin_dex_obj_t *r_bin_dex_new_buf(RBuffer *buf);
-struct r_bin_dex_str_t *r_bin_dex_get_strings (struct r_bin_dex_obj_t* bin);
+struct r_bin_dex_str_t *r_bin_dex_get_strings (struct r_bin_dex_obj_t *bin);
 
 int dex_read_uleb128 (const ut8 *ptr, int size);
 int dex_read_sleb128 (const char *ptr, int size);

--- a/libr/bin/format/dex/dex.h
+++ b/libr/bin/format/dex/dex.h
@@ -136,7 +136,7 @@ struct dex_debug_local_t {
 };
 
 char* r_bin_dex_get_version(struct r_bin_dex_obj_t* bin);
-struct r_bin_dex_obj_t *r_bin_dex_new_buf(struct r_buf_t *buf);
+struct r_bin_dex_obj_t *r_bin_dex_new_buf(RBuffer *buf);
 struct r_bin_dex_str_t *r_bin_dex_get_strings (struct r_bin_dex_obj_t* bin);
 
 int dex_read_uleb128 (const ut8 *ptr, int size);

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -269,7 +269,7 @@ static int init_phdr(ELFOBJ *bin) {
 	bool linux_kern_hack = false;
 	/* Enable this hack only for the X86 64bit ELFs */
 	const int _128K = 1024 * 128;
-	if (r_buf_size(bin->b) > _128K && (bin->ehdr.e_machine == EM_X86_64 || bin->ehdr.e_machine == EM_386)) {
+	if (r_buf_size (bin->b) > _128K && (bin->ehdr.e_machine == EM_X86_64 || bin->ehdr.e_machine == EM_386)) {
 		linux_kern_hack = true;
 	}
 	if (!read_phdr (bin, linux_kern_hack)) {
@@ -2345,7 +2345,7 @@ int Elf_(r_bin_elf_get_bits)(ELFOBJ *bin) {
 
 static inline int noodle(ELFOBJ *bin, const char *s) {
 	const ut8 *p = bin->b->buf;
-	if (r_buf_size(bin->b) > 64)  {
+	if (r_buf_size (bin->b) > 64)  {
 		p += r_buf_size (bin->b) - 64;
 	} else {
 		return 0;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -279,8 +279,9 @@ static int init_phdr(ELFOBJ *bin) {
 	sdb_num_set (bin->kv, "elf_phdr.offset", bin->ehdr.e_phoff, 0);
 	sdb_num_set (bin->kv, "elf_phdr.size", sizeof (Elf_(Phdr)), 0);
 	sdb_set (bin->kv, "elf_p_type.cparse", "enum elf_p_type {PT_NULL=0,PT_LOAD=1,PT_DYNAMIC=2,"
-			"PT_INTERP=3,PT_NOTE=4,PT_SHLIB=5,PT_PHDR=6,PT_LOOS=0x60000000,"
-			"PT_HIOS=0x6fffffff,PT_LOPROC=0x70000000,PT_HIPROC=0x7fffffff};", 0);
+		"PT_INTERP=3,PT_NOTE=4,PT_SHLIB=5,PT_PHDR=6,PT_LOOS=0x60000000,"
+		"PT_HIOS=0x6fffffff,PT_LOPROC=0x70000000,PT_HIPROC=0x7fffffff};",
+		0);
 	sdb_set (bin->kv, "elf_p_flags.cparse", "enum elf_p_flags {PF_None=0,PF_Exec=1,"
 			"PF_Write=2,PF_Write_Exec=3,PF_Read=4,PF_Read_Exec=5,PF_Read_Write=6,"
 			"PF_Read_Write_Exec=7};", 0);
@@ -296,7 +297,6 @@ static int init_phdr(ELFOBJ *bin) {
 	// > td `k bin/cur/info/elf_p_type.cparse`; td `k bin/cur/info/elf_p_flags.cparse`
 	// > pf `k bin/cur/info/elf_phdr.format` @ `k bin/cur/info/elf_phdr.offset`
 }
-
 
 static int init_shdr(ELFOBJ *bin) {
 	ut32 shdr_size;
@@ -2346,7 +2346,7 @@ int Elf_(r_bin_elf_get_bits)(ELFOBJ *bin) {
 static inline int noodle(ELFOBJ *bin, const char *s) {
 	const ut8 *p = bin->b->buf;
 	if (r_buf_size(bin->b) > 64)  {
-		p += r_buf_size(bin->b) - 64;
+		p += r_buf_size (bin->b) - 64;
 	} else {
 		return 0;
 	}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -269,7 +269,7 @@ static int init_phdr(ELFOBJ *bin) {
 	bool linux_kern_hack = false;
 	/* Enable this hack only for the X86 64bit ELFs */
 	const int _128K = 1024 * 128;
-	if (bin->b->length > _128K && (bin->ehdr.e_machine == EM_X86_64 || bin->ehdr.e_machine == EM_386)) {
+	if (r_buf_size(bin->b) > _128K && (bin->ehdr.e_machine == EM_X86_64 || bin->ehdr.e_machine == EM_386)) {
 		linux_kern_hack = true;
 	}
 	if (!read_phdr (bin, linux_kern_hack)) {
@@ -2345,8 +2345,8 @@ int Elf_(r_bin_elf_get_bits)(ELFOBJ *bin) {
 
 static inline int noodle(ELFOBJ *bin, const char *s) {
 	const ut8 *p = bin->b->buf;
-	if (bin->b->length > 64)  {
-		p += bin->b->length - 64;
+	if (r_buf_size(bin->b) > 64)  {
+		p += r_buf_size(bin->b) - 64;
 	} else {
 		return 0;
 	}
@@ -3421,7 +3421,7 @@ static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type
 				{
 					int rest = ELF_STRING_LENGTH - 1;
 					int st_name = sym[k].st_name;
-					int maxsize = R_MIN (bin->b->length, strtab_section->sh_size);
+					int maxsize = R_MIN (r_buf_size (bin->b), strtab_section->sh_size);
 					if (is_section_local_sym (bin, &sym[k])) {
 						const char *shname = &bin->shstrtab[bin->shdr[sym[k].st_shndx].sh_name];
 						r_str_ncpy (ret[ret_ctr].name, shname, ELF_STRING_LENGTH);
@@ -3628,7 +3628,7 @@ ELFOBJ* Elf_(r_bin_elf_new)(const char* file, bool verbose) {
 ELFOBJ* Elf_(r_bin_elf_new_buf)(RBuffer *buf, bool verbose) {
 	ELFOBJ *bin = R_NEW0 (ELFOBJ);
 	bin->kv = sdb_new0 ();
-	bin->size = (ut32)buf->length;
+	bin->size = (ut32)r_buf_size (buf);
 	bin->verbose = verbose;
 	bin->b = r_buf_ref (buf);
 	if (!elf_init (bin)) {

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -155,7 +155,7 @@ struct r_bin_elf_field_t* Elf_(r_bin_elf_get_fields)(struct Elf_(r_bin_elf_obj_t
 char *Elf_(r_bin_elf_get_rpath)(struct Elf_(r_bin_elf_obj_t) *bin);
 void* Elf_(r_bin_elf_free)(struct Elf_(r_bin_elf_obj_t)* bin);
 struct Elf_(r_bin_elf_obj_t)* Elf_(r_bin_elf_new)(const char* file, bool verbose);
-struct Elf_(r_bin_elf_obj_t)* Elf_(r_bin_elf_new_buf)(struct r_buf_t *buf, bool verbose);
+struct Elf_(r_bin_elf_obj_t)* Elf_(r_bin_elf_new_buf)(RBuffer *buf, bool verbose);
 ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const char *name, ut64 size);
 bool Elf_(r_bin_elf_section_perms)(struct Elf_(r_bin_elf_obj_t) *bin, const char *name, int perms);
 bool Elf_(r_bin_elf_entry_write)(struct Elf_(r_bin_elf_obj_t) *bin, ut64 addr);

--- a/libr/bin/format/elf/elf_write.c
+++ b/libr/bin/format/elf/elf_write.c
@@ -179,7 +179,7 @@ ut64 Elf_(r_bin_elf_resize_section)(struct Elf_(r_bin_elf_obj_t) *bin, const cha
 	r_buf_write_at (bin->b, rsz_offset + rsz_size, (ut8*)buf, rest_size);
 	printf ("Shifted %d byte(s)\n", (int)delta);
 	free (buf);
-	bin->size = bin->b->length;
+	bin->size = r_buf_size (bin->b);
 
 	return delta;
 }

--- a/libr/bin/format/mach0/dyldcache.c
+++ b/libr/bin/format/mach0/dyldcache.c
@@ -148,7 +148,7 @@ struct r_bin_dyldcache_lib_t *r_bin_dyldcache_extract(struct r_bin_dyldcache_obj
 				(ut64) ((size_t)&seg->fileoff - (size_t)data));
 			/* Patch section offsets */
 			int sect_offset = seg->fileoff - libsz;
-			libsz = r_buf_size(dbuf);
+			libsz = r_buf_size (dbuf);
 			if (!strcmp (seg->segname, "__LINKEDIT")) {
 				linkedit_offset = sect_offset;
 			}

--- a/libr/bin/format/mach0/dyldcache.c
+++ b/libr/bin/format/mach0/dyldcache.c
@@ -15,20 +15,20 @@ static int r_bin_dyldcache_init(struct r_bin_dyldcache_obj_t* bin) {
 	return true;
 }
 
-static int r_bin_dyldcache_apply_patch (RBuffer* buf, ut32 data, ut64 offset) {
-	return r_buf_write_at (buf, offset, (ut8*)&data, sizeof (data));
+static int r_bin_dyldcache_apply_patch(RBuffer* buf, ut32 data, ut64 offset) {
+	return r_buf_write_at (buf, offset, (ut8 *)&data, sizeof (data));
 }
 
 #define NZ_OFFSET(x) if((x) > 0) r_bin_dyldcache_apply_patch (dbuf, (x) - linkedit_offset, (ut64)((size_t)&(x) - (size_t)data))
 
 // make it public in util/buf.c ?
-static ut64 r_buf_read64le (RBuffer *buf, ut64 off) {
+static ut64 r_buf_read64le(RBuffer *buf, ut64 off) {
 	ut8 data[8] = {0};
 	r_buf_read_at (buf, off, data, 8);
 	return r_read_le64 (data);
 }
 
-static char *r_buf_read_string (RBuffer *buf, ut64 addr, int len) {
+static char *r_buf_read_string(RBuffer *buf, ut64 addr, int len) {
 	ut8 *data = malloc (len);
 	if (data) {
 		r_buf_read_at (buf, addr, data, len);
@@ -144,8 +144,8 @@ struct r_bin_dyldcache_lib_t *r_bin_dyldcache_extract(struct r_bin_dyldcache_obj
 				return NULL;
 			}
 			r_buf_append_bytes (dbuf, bin->b->buf+seg->fileoff, t);
-			r_bin_dyldcache_apply_patch (dbuf, r_buf_size(dbuf),
-						     (ut64)((size_t)&seg->fileoff - (size_t)data));
+			r_bin_dyldcache_apply_patch (dbuf, r_buf_size (dbuf),
+				(ut64) ((size_t)&seg->fileoff - (size_t)data));
 			/* Patch section offsets */
 			int sect_offset = seg->fileoff - libsz;
 			libsz = r_buf_size(dbuf);

--- a/libr/bin/format/mach0/dyldcache.c
+++ b/libr/bin/format/mach0/dyldcache.c
@@ -15,7 +15,7 @@ static int r_bin_dyldcache_init(struct r_bin_dyldcache_obj_t* bin) {
 	return true;
 }
 
-static int r_bin_dyldcache_apply_patch (struct r_buf_t* buf, ut32 data, ut64 offset) {
+static int r_bin_dyldcache_apply_patch (RBuffer* buf, ut32 data, ut64 offset) {
 	return r_buf_write_at (buf, offset, (ut8*)&data, sizeof (data));
 }
 
@@ -144,10 +144,11 @@ struct r_bin_dyldcache_lib_t *r_bin_dyldcache_extract(struct r_bin_dyldcache_obj
 				return NULL;
 			}
 			r_buf_append_bytes (dbuf, bin->b->buf+seg->fileoff, t);
-			r_bin_dyldcache_apply_patch (dbuf, dbuf->length, (ut64)((size_t)&seg->fileoff - (size_t)data));
+			r_bin_dyldcache_apply_patch (dbuf, r_buf_size(dbuf),
+						     (ut64)((size_t)&seg->fileoff - (size_t)data));
 			/* Patch section offsets */
 			int sect_offset = seg->fileoff - libsz;
-			libsz = dbuf->length;
+			libsz = r_buf_size(dbuf);
 			if (!strcmp (seg->segname, "__LINKEDIT")) {
 				linkedit_offset = sect_offset;
 			}

--- a/libr/bin/format/mach0/fatmach0.h
+++ b/libr/bin/format/mach0/fatmach0.h
@@ -12,13 +12,13 @@ struct r_bin_fatmach0_obj_t {
 	int nfat_arch;
 	struct fat_header hdr;
 	struct fat_arch *archs;
-	struct r_buf_t* b;
+	RBuffer* b;
 };
 
 struct r_bin_fatmach0_arch_t {
 	int size;
 	int offset;
-	struct r_buf_t *b; 
+	RBuffer *b; 
 	int last;
 };
 

--- a/libr/bin/format/mach0/fatmach0.h
+++ b/libr/bin/format/mach0/fatmach0.h
@@ -18,7 +18,7 @@ struct r_bin_fatmach0_obj_t {
 struct r_bin_fatmach0_arch_t {
 	int size;
 	int offset;
-	RBuffer *b; 
+	RBuffer *b;
 	int last;
 };
 

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -757,7 +757,7 @@ static bool parse_signature(struct MACH0_(obj_t) *bin, ut64 off) {
 					break;
 				}
 				ut8 *src = bin->b->buf + off + sizeof (struct blob_t);
-				if (off + sizeof (struct blob_t) + len < bin->b->length) {
+				if (off + sizeof (struct blob_t) + len < r_buf_size (bin->b)) {
 					memcpy (bin->signature, src, len);
 					bin->signature[len] = '\0';
 				} else {

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -460,8 +460,7 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 			ut64 start_offset = (ut64)entry->location.rva
 			                + r_offsetof (struct minidump_memory_list, memory_ranges);
 			ut64 needed_space = (i + 1) * sizeof (memories[0]);
-			if (start_offset + needed_space > r_buf_size(obj->b)
-			    || start_offset + needed_space < start_offset) {
+			if (start_offset + needed_space > r_buf_size (obj->b) || start_offset + needed_space < start_offset) {
 				break;
 			}
 			r_list_append (obj->streams.memories, &(memories[i]));
@@ -475,17 +474,19 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		}
 
 		sdb_set (obj->kv, "mdmp_exception.format", "[4]E[4]Eqqdd[15]q "
-			"(mdmp_exception_code)ExceptionCode "
-			"(mdmp_exception_flags)ExceptionFlags "
-			"ExceptionRecord ExceptionAddress "
-			"NumberParameters __UnusedAlignment "
-			"ExceptionInformation", 0);
+							   "(mdmp_exception_code)ExceptionCode "
+							   "(mdmp_exception_flags)ExceptionFlags "
+							   "ExceptionRecord ExceptionAddress "
+							   "NumberParameters __UnusedAlignment "
+							   "ExceptionInformation",
+			0);
 		sdb_num_set (obj->kv, "mdmp_exception_stream.offset",
 			entry->location.rva, 0);
 		sdb_set (obj->kv, "mdmp_exception_stream.format", "dd?? "
-			"ThreadId __Alignment "
-			"(mdmp_exception)ExceptionRecord "
-			"(mdmp_location_descriptor)ThreadContext", 0);
+								  "ThreadId __Alignment "
+								  "(mdmp_exception)ExceptionRecord "
+								  "(mdmp_location_descriptor)ThreadContext",
+			0);
 
 		break;
 	case SYSTEM_INFO_STREAM:

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -370,7 +370,7 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 
 	/* We could confirm data sizes but a malcious MDMP will always get around
 	** this! But we can ensure that the data is not outside of the file */
-	if ((ut64)entry->location.rva + entry->location.data_size > r_buf_size(obj->b)) {
+	if ((ut64)entry->location.rva + entry->location.data_size > r_buf_size (obj->b)) {
 		eprintf ("[ERROR] Size Mismatch - Stream data is larger than file size!\n");
 		return false;
 	}
@@ -911,7 +911,7 @@ struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(RBuffer *buf) {
 	}
 	obj->kv = sdb_new0 ();
 	obj->b = r_buf_new ();
-	obj->size = (ut32) r_buf_size(buf);
+	obj->size = (ut32) r_buf_size (buf);
 
 	fail |= (!(obj->streams.ex_threads = r_list_new ()));
 	fail |= (!(obj->streams.memories = r_list_new ()));
@@ -932,7 +932,7 @@ struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(RBuffer *buf) {
 		return NULL;
 	}
 
-	if (!r_buf_set_bytes (obj->b, buf->buf, r_buf_size(buf))) {
+	if (!r_buf_set_bytes (obj->b, buf->buf, r_buf_size (buf))) {
 		r_bin_mdmp_free (obj);
 		return NULL;
 	}

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -370,7 +370,7 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 
 	/* We could confirm data sizes but a malcious MDMP will always get around
 	** this! But we can ensure that the data is not outside of the file */
-	if ((ut64)entry->location.rva + entry->location.data_size > obj->b->length) {
+	if ((ut64)entry->location.rva + entry->location.data_size > r_buf_size(obj->b)) {
 		eprintf ("[ERROR] Size Mismatch - Stream data is larger than file size!\n");
 		return false;
 	}
@@ -460,7 +460,7 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 			ut64 start_offset = (ut64)entry->location.rva
 			                + r_offsetof (struct minidump_memory_list, memory_ranges);
 			ut64 needed_space = (i + 1) * sizeof (memories[0]);
-			if (start_offset + needed_space > obj->b->length
+			if (start_offset + needed_space > r_buf_size(obj->b)
 			    || start_offset + needed_space < start_offset) {
 				break;
 			}
@@ -902,7 +902,7 @@ static int r_bin_mdmp_init(struct r_bin_mdmp_obj *obj) {
 	return true;
 }
 
-struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(struct r_buf_t *buf) {
+struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(RBuffer *buf) {
 	bool fail = false;
 	struct r_bin_mdmp_obj *obj = R_NEW0 (struct r_bin_mdmp_obj);
 	if (!obj) {
@@ -910,7 +910,7 @@ struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(struct r_buf_t *buf) {
 	}
 	obj->kv = sdb_new0 ();
 	obj->b = r_buf_new ();
-	obj->size = (ut32)buf->length;
+	obj->size = (ut32) r_buf_size(buf);
 
 	fail |= (!(obj->streams.ex_threads = r_list_new ()));
 	fail |= (!(obj->streams.memories = r_list_new ()));
@@ -931,7 +931,7 @@ struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(struct r_buf_t *buf) {
 		return NULL;
 	}
 
-	if (!r_buf_set_bytes (obj->b, buf->buf, buf->length)) {
+	if (!r_buf_set_bytes (obj->b, buf->buf, r_buf_size(buf))) {
 		r_bin_mdmp_free (obj);
 		return NULL;
 	}

--- a/libr/bin/format/mdmp/mdmp.h
+++ b/libr/bin/format/mdmp/mdmp.h
@@ -50,13 +50,13 @@ struct r_bin_mdmp_obj {
 	RList *pe32_bins;
 	RList *pe64_bins;
 
-	struct r_buf_t *b;
+	RBuffer *b;
 	size_t size;
 	ut8 endian;
 	Sdb *kv;
 };
 
-struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(struct r_buf_t *buf);
+struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(RBuffer *buf);
 void r_bin_mdmp_free(struct r_bin_mdmp_obj *obj);
 ut64 r_bin_mdmp_get_paddr(struct r_bin_mdmp_obj *obj, ut64 vaddr);
 ut32 r_bin_mdmp_get_perm(struct r_bin_mdmp_obj *obj, ut64 vaddr);

--- a/libr/bin/format/mz/mz.c
+++ b/libr/bin/format/mz/mz.c
@@ -303,13 +303,13 @@ struct r_bin_mz_obj_t *r_bin_mz_new (const char *file) {
 	return bin;
 }
 
-struct r_bin_mz_obj_t *r_bin_mz_new_buf (const struct r_buf_t *buf) {
+struct r_bin_mz_obj_t *r_bin_mz_new_buf (const RBuffer *buf) {
 	struct r_bin_mz_obj_t *bin = R_NEW0 (struct r_bin_mz_obj_t);
 	if (!bin) {
 		return NULL;
 	}
 	bin->b = r_buf_new ();
-	bin->size = buf->length;
+	bin->size = r_buf_size(buf);
 	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)) {
 		return r_bin_mz_free (bin);
 	}

--- a/libr/bin/format/mz/mz.c
+++ b/libr/bin/format/mz/mz.c
@@ -309,7 +309,7 @@ struct r_bin_mz_obj_t *r_bin_mz_new_buf (const RBuffer *buf) {
 		return NULL;
 	}
 	bin->b = r_buf_new ();
-	bin->size = r_buf_size(buf);
+	bin->size = r_buf_size (buf);
 	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)) {
 		return r_bin_mz_free (bin);
 	}

--- a/libr/bin/format/mz/mz.c
+++ b/libr/bin/format/mz/mz.c
@@ -314,7 +314,7 @@ struct r_bin_mz_obj_t *r_bin_mz_new_buf (const RBuffer *buf) {
 		return r_bin_mz_free (bin);
 	}
 
-	return r_bin_mz_init (bin) ? bin : r_bin_mz_free (bin);
+	return r_bin_mz_init (bin)? bin: r_bin_mz_free (bin);
 }
 
 RBinAddr *r_bin_mz_get_main_vaddr (struct r_bin_mz_obj_t *bin) {

--- a/libr/bin/format/mz/mz.h
+++ b/libr/bin/format/mz/mz.h
@@ -30,7 +30,7 @@ struct r_bin_mz_obj_t {
 	int dos_file_size; /* Size of dos file from dos executable header */
 	int load_module_size; /* Size of load module: dos_file_size - header size */
 	const char *file;
-	struct r_buf_t *b;
+	RBuffer *b;
 	Sdb *kv;
 };
 
@@ -39,5 +39,5 @@ RList *r_bin_mz_get_segments (const struct r_bin_mz_obj_t *bin);
 struct r_bin_mz_reloc_t *r_bin_mz_get_relocs (const struct r_bin_mz_obj_t *bin);
 void *r_bin_mz_free (struct r_bin_mz_obj_t *bin);
 struct r_bin_mz_obj_t *r_bin_mz_new (const char *file);
-struct r_bin_mz_obj_t *r_bin_mz_new_buf (const struct r_buf_t *buf);
+struct r_bin_mz_obj_t *r_bin_mz_new_buf (const RBuffer *buf);
 RBinAddr *r_bin_mz_get_main_vaddr (struct r_bin_mz_obj_t *bin);

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -1153,7 +1153,7 @@ static int bin_pe_init_imports(struct PE_(r_bin_pe_obj_t)* bin) {
 
 	indx = 0;
 	if (r_buf_size (bin->b) > 0) {
-		if ((delay_import_dir_offset != 0) && (delay_import_dir_offset < (ut32) r_buf_size (bin->b))) {
+		if ((delay_import_dir_offset != 0) && (delay_import_dir_offset < (ut32)r_buf_size (bin->b))) {
 			ut64 off;
 			bin->delay_import_directory_offset = delay_import_dir_offset;
 			do {
@@ -1173,7 +1173,7 @@ static int bin_pe_init_imports(struct PE_(r_bin_pe_obj_t)* bin) {
 				delay_import_dir = new_delay_import_dir;
 				curr_delay_import_dir = delay_import_dir + (indx - 1);
 				rr = r_buf_read_at (bin->b, delay_import_dir_offset + (indx - 1) * delay_import_size,
-					(ut8*) (curr_delay_import_dir), dir_size);
+					(ut8 *)(curr_delay_import_dir), dir_size);
 				if (rr != dir_size) {
 					bprintf ("Warning: read (delay import directory)\n");
 					goto fail;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -1152,14 +1152,14 @@ static int bin_pe_init_imports(struct PE_(r_bin_pe_obj_t)* bin) {
 	}
 
 	indx = 0;
-	if (bin->b->length > 0) {
-		if ((delay_import_dir_offset != 0) && (delay_import_dir_offset < (ut32) bin->b->length)) {
+	if (r_buf_size (bin->b) > 0) {
+		if ((delay_import_dir_offset != 0) && (delay_import_dir_offset < (ut32) r_buf_size (bin->b))) {
 			ut64 off;
 			bin->delay_import_directory_offset = delay_import_dir_offset;
 			do {
 				indx++;
 				off = indx * delay_import_size;
-				if (off >= bin->b->length) {
+				if (off >= r_buf_size (bin->b)) {
 					bprintf ("Warning: Cannot find end of import symbols\n");
 					break;
 				}
@@ -2880,16 +2880,16 @@ int PE_(r_bin_pe_get_debug_data)(struct PE_(r_bin_pe_obj_t)* bin, SDebugInfo* re
 	if ((int) dbg_dir_offset < 0 || dbg_dir_offset >= bin->size) {
 		return false;
 	}
-	if (dbg_dir_offset >= bin->b->length) {
+	if (dbg_dir_offset >= r_buf_size (bin->b)) {
 		return false;
 	}
 	img_dbg_dir_entry = (PE_(image_debug_directory_entry)*)(bin->b->buf + dbg_dir_offset);
-	if ((bin->b->length - dbg_dir_offset) < sizeof (PE_(image_debug_directory_entry))) {
+	if ((r_buf_size (bin->b) - dbg_dir_offset) < sizeof (PE_(image_debug_directory_entry))) {
 		return false;
 	}
 	if (img_dbg_dir_entry) {
-		ut32 dbg_data_poff = R_MIN (img_dbg_dir_entry->PointerToRawData, bin->b->length);
-		int dbg_data_len = R_MIN (img_dbg_dir_entry->SizeOfData, bin->b->length - dbg_data_poff);
+		ut32 dbg_data_poff = R_MIN (img_dbg_dir_entry->PointerToRawData, r_buf_size (bin->b));
+		int dbg_data_len = R_MIN (img_dbg_dir_entry->SizeOfData, r_buf_size (bin->b) - dbg_data_poff);
 		if (dbg_data_len < 1) {
 			return false;
 		}
@@ -3571,7 +3571,7 @@ struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new_buf)(RBuffer * buf, bool verbose) {
 	bin->kv = sdb_new0 ();
 	bin->b = r_buf_new ();
 	bin->verbose = verbose;
-	bin->size = buf->length;
+	bin->size = r_buf_size (buf);
 	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)) {
 		return PE_(r_bin_pe_free)(bin);
 	}

--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -120,7 +120,7 @@ struct PE_(r_bin_pe_obj_t) {
 	RList* relocs;
 	RList* resources; //RList of r_pe_resources
 	const char* file;
-	struct r_buf_t* b;
+	RBuffer* b;
 	Sdb *kv;
 	RCMS* cms;
 	bool is_signed;
@@ -150,7 +150,7 @@ int PE_(r_bin_pe_is_stripped_local_syms)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(r_bin_pe_is_stripped_debug)(struct PE_(r_bin_pe_obj_t)* bin);
 void* PE_(r_bin_pe_free)(struct PE_(r_bin_pe_obj_t)* bin);
 struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new)(const char* file, bool verbose);
-struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new_buf)(struct r_buf_t* buf, bool verbose);
+struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new_buf)(RBuffer* buf, bool verbose);
 int PE_(r_bin_pe_get_debug_data)(struct PE_(r_bin_pe_obj_t)* bin, struct SDebugInfo* res);
 int PE_(bin_pe_get_claimed_checksum)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(bin_pe_get_actual_checksum)(struct PE_(r_bin_pe_obj_t)* bin);

--- a/libr/bin/format/pe/pemixed.c
+++ b/libr/bin/format/pe/pemixed.c
@@ -62,7 +62,7 @@ struct PE_(r_bin_pe_obj_t)* r_bin_pemixed_init_native(struct PE_(r_bin_pe_obj_t)
 	struct PE_(r_bin_pe_obj_t)* sub_bin_native = R_NEW0 (struct PE_(r_bin_pe_obj_t));
 	memcpy (sub_bin_native, pe_bin, sizeof(struct PE_(r_bin_pe_obj_t)));
 
-	b_size = pe_bin->b->length;
+	b_size = r_buf_size (pe_bin->b);
 
 	//copy pe_bin->b and assign to sub_bin_native
 

--- a/libr/bin/format/pe/pemixed.h
+++ b/libr/bin/format/pe/pemixed.h
@@ -15,7 +15,7 @@ struct r_bin_pemixed_obj_t {
 	struct PE_(r_bin_pe_obj_t)* sub_bin_native;
 	struct PE_(r_bin_pe_obj_t)* sub_bin_net;
 	
-	struct r_buf_t* b;
+	RBuffer* b;
 };
 
 // static int r_bin_pemixed_init(struct r_bin_pemixed_obj_t* bin, struct PE_(r_bin_pe_obj_t)* pe_bin);

--- a/libr/bin/format/te/te.c
+++ b/libr/bin/format/te/te.c
@@ -443,7 +443,7 @@ struct r_bin_te_obj_t* r_bin_te_new_buf(RBuffer *buf) {
 	bin->kv = sdb_new0 ();
 	bin->b = r_buf_new ();
 	bin->size = r_buf_size(buf);
-	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)){
+	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)) {
 		return r_bin_te_free (bin);
 	}
 	if (!r_bin_te_init (bin)) {

--- a/libr/bin/format/te/te.c
+++ b/libr/bin/format/te/te.c
@@ -435,14 +435,14 @@ struct r_bin_te_obj_t* r_bin_te_new(const char* file) {
 	return bin;
 }
 
-struct r_bin_te_obj_t* r_bin_te_new_buf(struct r_buf_t *buf) {
+struct r_bin_te_obj_t* r_bin_te_new_buf(RBuffer *buf) {
 	struct r_bin_te_obj_t *bin = R_NEW0 (struct r_bin_te_obj_t);
 	if (!bin) {
 		return NULL;
 	}
 	bin->kv = sdb_new0 ();
 	bin->b = r_buf_new ();
-	bin->size = buf->length;
+	bin->size = r_buf_size(buf);
 	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)){
 		return r_bin_te_free (bin);
 	}

--- a/libr/bin/format/te/te.c
+++ b/libr/bin/format/te/te.c
@@ -441,9 +441,9 @@ struct r_bin_te_obj_t* r_bin_te_new_buf(RBuffer *buf) {
 		return NULL;
 	}
 	bin->kv = sdb_new0 ();
-	bin->b = r_buf_new ();
 	bin->size = r_buf_size (buf);
-	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)) {
+	bin->b = r_buf_new_with_buf (buf);
+	if (!bin->b) {
 		return r_bin_te_free (bin);
 	}
 	if (!r_bin_te_init (bin)) {

--- a/libr/bin/format/te/te.c
+++ b/libr/bin/format/te/te.c
@@ -442,7 +442,7 @@ struct r_bin_te_obj_t* r_bin_te_new_buf(RBuffer *buf) {
 	}
 	bin->kv = sdb_new0 ();
 	bin->b = r_buf_new ();
-	bin->size = r_buf_size(buf);
+	bin->size = r_buf_size (buf);
 	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)) {
 		return r_bin_te_free (bin);
 	}

--- a/libr/bin/format/te/te.h
+++ b/libr/bin/format/te/te.h
@@ -39,7 +39,7 @@ struct r_bin_te_obj_t {
 	int size;
 	int endian;
 	const char* file;
-	struct r_buf_t* b;
+	RBuffer* b;
 	Sdb *kv;
 };
 
@@ -55,6 +55,6 @@ struct r_bin_te_section_t* r_bin_te_get_sections(struct r_bin_te_obj_t* bin);
 char* r_bin_te_get_subsystem(struct r_bin_te_obj_t* bin);
 void* r_bin_te_free(struct r_bin_te_obj_t* bin);
 struct r_bin_te_obj_t* r_bin_te_new(const char* file);
-struct r_bin_te_obj_t* r_bin_te_new_buf(struct r_buf_t *buf);
+struct r_bin_te_obj_t* r_bin_te_new_buf(RBuffer *buf);
 
 #endif

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -11,7 +11,7 @@
 static size_t consume_u32_r(RBuffer *b, ut64 max, ut32 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_tell (b) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
 		return 0;
 	}
 	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp))) {
@@ -61,7 +61,7 @@ static size_t consume_u7_r(RBuffer *b, ut64 max, ut8 *out) {
 static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
 	size_t n;
 	ut32 tmp = 0;
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_tell (b) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
 		return 0;
 	}
 	if (!(n = read_i32_leb128 (&b->buf[r_buf_tell (b)], (ut8 *)&b->buf[max + 1], (int *)&tmp)) || n > 2) {
@@ -77,7 +77,7 @@ static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
 static size_t consume_u1_r(RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_tell (b) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
 		return 0;
 	}
 	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp)) || n > 1) {
@@ -799,7 +799,7 @@ RBinWasmObj *r_bin_wasm_init (RBinFile *bf) {
 		free (bin);
 		return NULL;
 	}
-	bin->size = (ut32) r_buf_size(bf->buf);
+	bin->size = (ut32) r_buf_size (bf->buf);
 	if (!r_buf_set_bytes (bin->buf, bf->buf->buf, bin->size)) {
 		r_bin_wasm_destroy (bf);
 		free (bin);
@@ -866,7 +866,7 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 		return NULL;
 	}
 	RBuffer *b = bin->buf;
-	ut64 max = r_buf_size(b) - 1;
+	ut64 max = r_buf_size (b) - 1;
 	r_buf_seek (b, 8, R_IO_SEEK_SET);
 	while (r_buf_tell (b) <= max) {
 		if (!(ptr = R_NEW0 (RBinWasmSection))) {

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -11,7 +11,7 @@
 static size_t consume_u32_r (RBuffer *b, ut64 max, ut32 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
 		return 0;
 	}
 	if (!(n = read_u32_leb128 (&b->buf[b->cur], &b->buf[max + 1], &tmp))) {
@@ -45,7 +45,7 @@ static size_t consume_s32_r (RBuffer *b, ut64 max, st32 *out) {
 static size_t consume_u7_r (RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
 		return 0;
 	}
 	if (!(n = read_u32_leb128 (&b->buf[b->cur], &b->buf[max + 1], &tmp))) {
@@ -61,7 +61,7 @@ static size_t consume_u7_r (RBuffer *b, ut64 max, ut8 *out) {
 static size_t consume_s7_r (RBuffer *b, ut64 max, st8 *out) {
 	size_t n;
 	ut32 tmp = 0;
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
 		return 0;
 	}
 	if (!(n = read_i32_leb128 (&b->buf[b->cur], (ut8*)&b->buf[max + 1], (int*)&tmp)) || n > 2) {
@@ -77,7 +77,7 @@ static size_t consume_s7_r (RBuffer *b, ut64 max, st8 *out) {
 static size_t consume_u1_r (RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
 		return 0;
 	}
 	if (!(n = read_u32_leb128 (&b->buf[b->cur], &b->buf[max + 1], &tmp)) || n > 1) {
@@ -91,7 +91,7 @@ static size_t consume_u1_r (RBuffer *b, ut64 max, ut8 *out) {
 }
 
 static size_t consume_str_r (RBuffer *b, ut64 max, size_t sz, char *out) {
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
 		return 0;
 	}
 	if (!(b->cur + sz - 1 <= max)) {
@@ -107,7 +107,7 @@ static size_t consume_str_r (RBuffer *b, ut64 max, size_t sz, char *out) {
 }
 
 static size_t consume_init_expr_r (RBuffer *b, ut64 max, ut8 eoc, void *out) {
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
 		return 0;
 	}
 	ut32 i = 0;
@@ -123,7 +123,7 @@ static size_t consume_init_expr_r (RBuffer *b, ut64 max, ut8 eoc, void *out) {
 }
 
 static size_t consume_locals_r (RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
 		return 0;
 	}
 	ut32 count = out ? out->local_count : 0;
@@ -155,7 +155,7 @@ beach:
 }
 
 static size_t consume_limits_r (RBuffer *b, ut64 max, struct r_bin_wasm_resizable_limits_t *out) {
-	if (!b || !b->buf || max >= b->length || b->cur > max || !out) {
+	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max || !out) {
 		return 0;
 	}
 	ut32 i = b->cur;
@@ -261,7 +261,7 @@ static RList *r_bin_wasm_get_type_entries (RBinWasmObj *bin, RBinWasmSection *se
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut32 r = 0;
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	while (b->cur <= max && r < sec->count) {
@@ -330,7 +330,7 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -407,7 +407,7 @@ static RList *r_bin_wasm_get_export_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -451,7 +451,7 @@ static RList *r_bin_wasm_get_code_entries (RBinWasmObj *bin, RBinWasmSection *se
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -509,7 +509,7 @@ static RList *r_bin_wasm_get_data_entries (RBinWasmObj *bin, RBinWasmSection *se
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -556,7 +556,7 @@ static RList *r_bin_wasm_get_symtab_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data + 3, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 4;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	while (b->cur <= max) {
@@ -597,7 +597,7 @@ static RBinWasmStartEntry *r_bin_wasm_get_start (RBinWasmObj *bin, RBinWasmSecti
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	if (!(consume_u32_r (b, max, &ptr->index))) {
@@ -624,7 +624,7 @@ static RList *r_bin_wasm_get_memory_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max =  b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -663,7 +663,7 @@ static RList *r_bin_wasm_get_table_entries (RBinWasmObj *bin, RBinWasmSection *s
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -705,7 +705,7 @@ static RList *r_bin_wasm_get_global_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -750,7 +750,7 @@ static RList *r_bin_wasm_get_element_entries (RBinWasmObj *bin, RBinWasmSection 
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = b->cur + sec->payload_len - 1;
-	if (!(max < b->length)) {
+	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -798,7 +798,7 @@ RBinWasmObj *r_bin_wasm_init (RBinFile *bf) {
 		free (bin);
 		return NULL;
 	}
-	bin->size = (ut32)bf->buf->length;
+	bin->size = (ut32) r_buf_size(bf->buf);
 	if (!r_buf_set_bytes (bin->buf, bf->buf->buf, bin->size)) {
 		r_bin_wasm_destroy (bf);
 		free (bin);
@@ -865,7 +865,7 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 		return NULL;
 	}
 	RBuffer *b = bin->buf;
-	ut64 max = b->length - 1;
+	ut64 max = r_buf_size(b) - 1;
 	r_buf_seek (b, 8, R_IO_SEEK_SET);
 	while (b->cur <= max) {
 		if (!(ptr = R_NEW0 (RBinWasmSection))) {

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -11,10 +11,10 @@
 static size_t consume_u32_r(RBuffer *b, ut64 max, ut32 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_tell (b) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], &b->buf[max + 1], &tmp))) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp))) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -45,10 +45,10 @@ static size_t consume_s32_r(RBuffer *b, ut64 max, st32 *out) {
 static size_t consume_u7_r(RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek (b, 0, 1)], &b->buf[max + 1], &tmp))) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp))) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -61,10 +61,10 @@ static size_t consume_u7_r(RBuffer *b, ut64 max, ut8 *out) {
 static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
 	size_t n;
 	ut32 tmp = 0;
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_tell (b) > max) {
 		return 0;
 	}
-	if (!(n = read_i32_leb128 (&b->buf[r_buf_seek (b, 0, 1)], (ut8 *)&b->buf[max + 1], (int *)&tmp)) || n > 2) {
+	if (!(n = read_i32_leb128 (&b->buf[r_buf_tell (b)], (ut8 *)&b->buf[max + 1], (int *)&tmp)) || n > 2) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -77,10 +77,10 @@ static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
 static size_t consume_u1_r(RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_tell (b) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek (b, 0, 1)], &b->buf[max + 1], &tmp)) || n > 1) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp)) || n > 1) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -91,14 +91,14 @@ static size_t consume_u1_r(RBuffer *b, ut64 max, ut8 *out) {
 }
 
 static size_t consume_str_r(RBuffer *b, ut64 max, size_t sz, char *out) {
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
 		return 0;
 	}
-	if (!(r_buf_seek(b, 0, 1) + sz - 1 <= max)) {
+	if (!(r_buf_tell (b) + sz - 1 <= max)) {
 		return 0;
 	}
 	if (sz > 0) {
-		strncpy (out, (char *)&b->buf[r_buf_seek (b, 0, 1)],
+		strncpy (out, (char *)&b->buf[r_buf_tell (b)],
 			R_MIN (R_BIN_WASM_STRING_LENGTH - 1, sz));
 	} else {
 		*out = 0;
@@ -108,15 +108,15 @@ static size_t consume_str_r(RBuffer *b, ut64 max, size_t sz, char *out) {
 }
 
 static size_t consume_init_expr_r(RBuffer *b, ut64 max, ut8 eoc, void *out) {
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
 		return 0;
 	}
 	ut32 i = 0;
-	while (r_buf_seek (b, 0, 1) + i <= max && b->buf[r_buf_seek (b, 0, 1) + i] != eoc) {
+	while (r_buf_tell (b) + i <= max && b->buf[r_buf_tell (b) + i] != eoc) {
 		// TODO: calc the expresion with the bytcode (ESIL?)
 		i++;
 	}
-	if (*(ut8 *)(&b->buf[r_buf_seek (b, 0, 1) + i]) != eoc) {
+	if (*(ut8 *)(&b->buf[r_buf_tell (b) + i]) != eoc) {
 		return 0;
 	}
 	r_buf_seek (b, i + 1, R_IO_SEEK_CUR);
@@ -124,11 +124,11 @@ static size_t consume_init_expr_r(RBuffer *b, ut64 max, ut8 eoc, void *out) {
 }
 
 static size_t consume_locals_r(RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
 		return 0;
 	}
 	ut32 count = out? out->local_count: 0;
-	if (!(r_buf_seek (b, 0, 1) + (count * 7) <= max)) { // worst case 7 bytes
+	if (!(r_buf_tell (b) + (count * 7) <= max)) { // worst case 7 bytes
 		return 0;
 	}
 	if (count > 0) {
@@ -137,7 +137,7 @@ static size_t consume_locals_r(RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
 		}
 	}
 	ut32 j = 0;
-	while (r_buf_seek (b, 0, 1) <= max && j < count) {
+	while (r_buf_tell (b) <= max && j < count) {
 		if (!(consume_u32_r (b, max, (out? &out->locals[j].count: NULL)))) {
 			goto beach;
 		}
@@ -156,10 +156,10 @@ beach:
 }
 
 static size_t consume_limits_r(RBuffer *b, ut64 max, struct r_bin_wasm_resizable_limits_t *out) {
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max || !out) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max || !out) {
 		return 0;
 	}
-	ut32 i = r_buf_seek (b, 0, 1);
+	ut32 i = r_buf_tell (b);
 	if (!(consume_u7_r (b, max, &out->flags))) {
 		return 0;
 	}
@@ -169,7 +169,7 @@ static size_t consume_limits_r(RBuffer *b, ut64 max, struct r_bin_wasm_resizable
 	if (out->flags && (!(consume_u32_r (b, max, &out->maximum)))) {
 		return 0;
 	}
-	return (size_t)R_ABS (r_buf_seek (b, 0, 1) - i);
+	return (size_t)R_ABS (r_buf_tell (b) - i);
 }
 
 // Utils
@@ -261,11 +261,11 @@ static RList *r_bin_wasm_get_type_entries(RBinWasmObj *bin, RBinWasmSection *sec
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut32 r = 0;
-	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
-	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmTypeEntry))) {
 			return ret;
 		}
@@ -277,7 +277,7 @@ static RList *r_bin_wasm_get_type_entries(RBinWasmObj *bin, RBinWasmSection *sec
 			goto beach;
 		}
 		ut32 count = ptr? ptr->param_count: 0;
-		if (!(r_buf_seek (b, 0, 1) + count <= max)) {
+		if (!(r_buf_tell (b) + count <= max)) {
 			goto beach;
 		}
 		if (count > 0) {
@@ -330,12 +330,12 @@ static RList *r_bin_wasm_get_import_entries(RBinWasmObj *bin, RBinWasmSection *s
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmImportEntry))) {
 			return ret;
 		}
@@ -407,12 +407,12 @@ static RList *r_bin_wasm_get_export_entries(RBinWasmObj *bin, RBinWasmSection *s
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmExportEntry))) {
 			return ret;
 		}
@@ -451,20 +451,20 @@ static RList *r_bin_wasm_get_code_entries(RBinWasmObj *bin, RBinWasmSection *sec
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmCodeEntry))) {
 			return ret;
 		}
 		if (!(consume_u32_r (b, max, &ptr->body_size))) {
 			goto beach;
 		}
-		ut32 j = r_buf_seek (b, 0, 1);
-		if (!(r_buf_seek (b, 0, 1) + ptr->body_size - 1 <= max)) {
+		ut32 j = r_buf_tell (b);
+		if (!(r_buf_tell (b) + ptr->body_size - 1 <= max)) {
 			goto beach;
 		}
 		if (!(consume_u32_r (b, max, &ptr->local_count))) {
@@ -473,7 +473,7 @@ static RList *r_bin_wasm_get_code_entries(RBinWasmObj *bin, RBinWasmSection *sec
 		if (consume_locals_r (b, max, ptr) < ptr->local_count) {
 			goto beach;
 		}
-		ptr->code = r_buf_seek (b, 0, 1);
+		ptr->code = r_buf_tell (b);
 		ptr->len = ptr->body_size - ptr->code + j;
 		r_buf_seek (b, ptr->len - 1, R_IO_SEEK_CUR); // consume bytecode
 		r_buf_read (b, &ptr->byte, 1);
@@ -509,12 +509,12 @@ static RList *r_bin_wasm_get_data_entries(RBinWasmObj *bin, RBinWasmSection *sec
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmDataEntry))) {
 			return ret;
 		}
@@ -527,7 +527,7 @@ static RList *r_bin_wasm_get_data_entries(RBinWasmObj *bin, RBinWasmSection *sec
 		if (!(consume_u32_r (b, max, &ptr->size))) {
 			goto beach;
 		}
-		ptr->data = r_buf_seek(b, 0, 1);
+		ptr->data = r_buf_tell (b);
 		r_buf_seek (b, ptr->size, R_IO_SEEK_CUR);
 		if (!r_list_append (ret, ptr)) {
 			free (ptr);
@@ -556,11 +556,11 @@ static RList *r_bin_wasm_get_symtab_entries(RBinWasmObj *bin, RBinWasmSection *s
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data + 3, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 4;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 4;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
-	while (r_buf_seek (b, 0, 1) <= max) {
+	while (r_buf_tell (b) <= max) {
 		if (!(ptr = R_NEW0 (RBinWasmSymbol))) {
 			return ret;
 		}
@@ -597,7 +597,7 @@ static RBinWasmStartEntry *r_bin_wasm_get_start(RBinWasmObj *bin, RBinWasmSectio
 
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
@@ -624,12 +624,12 @@ static RList *r_bin_wasm_get_memory_entries(RBinWasmObj *bin, RBinWasmSection *s
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max =  r_buf_seek(b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmMemoryEntry))) {
 			return ret;
 		}
@@ -663,12 +663,12 @@ static RList *r_bin_wasm_get_table_entries(RBinWasmObj *bin, RBinWasmSection *se
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmTableEntry))) {
 			return ret;
 		}
@@ -705,12 +705,12 @@ static RList *r_bin_wasm_get_global_entries(RBinWasmObj *bin, RBinWasmSection *s
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmGlobalEntry))) {
 			return ret;
 		}
@@ -750,12 +750,12 @@ static RList *r_bin_wasm_get_element_entries(RBinWasmObj *bin, RBinWasmSection *
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
 	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_tell (b) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmElementEntry))) {
 			return ret;
 		}
@@ -769,7 +769,7 @@ static RList *r_bin_wasm_get_element_entries(RBinWasmObj *bin, RBinWasmSection *
 			goto beach;
 		}
 		ut32 j = 0;
-		while (r_buf_seek(b, 0, 1) <= max && j < ptr->num_elem) {
+		while (r_buf_tell (b) <= max && j < ptr->num_elem) {
 			// TODO: allocate space and fill entry
 			if (!(consume_u32_r (b, max, NULL))) {
 				goto beach;
@@ -868,7 +868,7 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 	RBuffer *b = bin->buf;
 	ut64 max = r_buf_size(b) - 1;
 	r_buf_seek (b, 8, R_IO_SEEK_SET);
-	while (r_buf_seek(b, 0, 1) <= max) {
+	while (r_buf_tell (b) <= max) {
 		if (!(ptr = R_NEW0 (RBinWasmSection))) {
 			return ret;
 		}
@@ -884,11 +884,11 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 			// free (ptr);
 			// continue;
 		}
-		if (!(r_buf_seek(b, 0, 1) + (ut64)ptr->size - 1 <= max)) {
+		if (!(r_buf_tell (b) + (ut64)ptr->size - 1 <= max)) {
 			goto beach;
 		}
 		ptr->count = 0;
-		ptr->offset = r_buf_seek(b, 0, 1);
+		ptr->offset = r_buf_tell (b);
 		switch (ptr->id) {
 		case R_BIN_WASM_SECTION_CUSTOM:
 			// eprintf("custom section: 0x%x, ", (ut32)b->cur);
@@ -967,7 +967,7 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 			}
 			// eprintf("count %d\n", ptr->count);
 		}
-		ptr->payload_data = r_buf_seek(b, 0, 1);
+		ptr->payload_data = r_buf_tell (b);
 		ptr->payload_len = ptr->size - (ptr->payload_data - ptr->offset);
 		if (ptr->payload_len > ptr->size) {
 			goto beach;

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -8,7 +8,7 @@
 #include "wasm.h"
 
 // RBuffer consume functions
-static size_t consume_u32_r (RBuffer *b, ut64 max, ut32 *out) {
+static size_t consume_u32_r(RBuffer *b, ut64 max, ut32 *out) {
 	size_t n;
 	ut32 tmp;
 	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
@@ -25,7 +25,7 @@ static size_t consume_u32_r (RBuffer *b, ut64 max, ut32 *out) {
 }
 
 #if 0
-static size_t consume_s32_r (RBuffer *b, ut64 max, st32 *out) {
+static size_t consume_s32_r(RBuffer *b, ut64 max, st32 *out) {
 	size_t n;
 	st32 tmp;
 	if (!b || !b->buf || max >= b->length || b->cur > max) {
@@ -42,13 +42,13 @@ static size_t consume_s32_r (RBuffer *b, ut64 max, st32 *out) {
 }
 #endif
 
-static size_t consume_u7_r (RBuffer *b, ut64 max, ut8 *out) {
+static size_t consume_u7_r(RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], &b->buf[max + 1], &tmp))) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek (b, 0, 1)], &b->buf[max + 1], &tmp))) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -58,13 +58,13 @@ static size_t consume_u7_r (RBuffer *b, ut64 max, ut8 *out) {
 	return n;
 }
 
-static size_t consume_s7_r (RBuffer *b, ut64 max, st8 *out) {
+static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
 	size_t n;
 	ut32 tmp = 0;
 	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(n = read_i32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], (ut8*)&b->buf[max + 1], (int*)&tmp)) || n > 2) {
+	if (!(n = read_i32_leb128 (&b->buf[r_buf_seek (b, 0, 1)], (ut8 *)&b->buf[max + 1], (int *)&tmp)) || n > 2) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -74,13 +74,13 @@ static size_t consume_s7_r (RBuffer *b, ut64 max, st8 *out) {
 	return n;
 }
 
-static size_t consume_u1_r (RBuffer *b, ut64 max, ut8 *out) {
+static size_t consume_u1_r(RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
 	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], &b->buf[max + 1], &tmp)) || n > 1) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek (b, 0, 1)], &b->buf[max + 1], &tmp)) || n > 1) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -90,16 +90,16 @@ static size_t consume_u1_r (RBuffer *b, ut64 max, ut8 *out) {
 	return n;
 }
 
-static size_t consume_str_r (RBuffer *b, ut64 max, size_t sz, char *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
+static size_t consume_str_r(RBuffer *b, ut64 max, size_t sz, char *out) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
 		return 0;
 	}
 	if (!(r_buf_seek(b, 0, 1) + sz - 1 <= max)) {
 		return 0;
 	}
 	if (sz > 0) {
-		strncpy (out, (char*)&b->buf[r_buf_seek(b, 0, 1)],
-			 R_MIN (R_BIN_WASM_STRING_LENGTH - 1, sz));
+		strncpy (out, (char *)&b->buf[r_buf_seek (b, 0, 1)],
+			R_MIN (R_BIN_WASM_STRING_LENGTH - 1, sz));
 	} else {
 		*out = 0;
 	}
@@ -107,28 +107,28 @@ static size_t consume_str_r (RBuffer *b, ut64 max, size_t sz, char *out) {
 	return sz;
 }
 
-static size_t consume_init_expr_r (RBuffer *b, ut64 max, ut8 eoc, void *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
+static size_t consume_init_expr_r(RBuffer *b, ut64 max, ut8 eoc, void *out) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
 		return 0;
 	}
 	ut32 i = 0;
-	while (r_buf_seek(b, 0, 1) + i <= max && b->buf[r_buf_seek(b, 0, 1) + i] != eoc) {
+	while (r_buf_seek (b, 0, 1) + i <= max && b->buf[r_buf_seek (b, 0, 1) + i] != eoc) {
 		// TODO: calc the expresion with the bytcode (ESIL?)
 		i++;
 	}
-	if (*(ut8*)(&b->buf[r_buf_seek(b, 0, 1) + i]) != eoc) {
+	if (*(ut8 *)(&b->buf[r_buf_seek (b, 0, 1) + i]) != eoc) {
 		return 0;
 	}
 	r_buf_seek (b, i + 1, R_IO_SEEK_CUR);
 	return i + 1;
 }
 
-static size_t consume_locals_r (RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
+static size_t consume_locals_r(RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max) {
 		return 0;
 	}
-	ut32 count = out ? out->local_count : 0;
-	if (!(r_buf_seek(b, 0, 1) + (count * 7) <= max)) { // worst case 7 bytes
+	ut32 count = out? out->local_count: 0;
+	if (!(r_buf_seek (b, 0, 1) + (count * 7) <= max)) { // worst case 7 bytes
 		return 0;
 	}
 	if (count > 0) {
@@ -137,11 +137,11 @@ static size_t consume_locals_r (RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
 		}
 	}
 	ut32 j = 0;
-	while (r_buf_seek(b, 0, 1) <= max && j < count) {
+	while (r_buf_seek (b, 0, 1) <= max && j < count) {
 		if (!(consume_u32_r (b, max, (out? &out->locals[j].count: NULL)))) {
 			goto beach;
 		}
-		if (!(consume_s7_r (b, max, (out? (st8*)&out->locals[j].type: NULL)))) {
+		if (!(consume_s7_r (b, max, (out? (st8 *)&out->locals[j].type: NULL)))) {
 			goto beach;
 		}
 		j++;
@@ -155,11 +155,11 @@ beach:
 	return 0;
 }
 
-static size_t consume_limits_r (RBuffer *b, ut64 max, struct r_bin_wasm_resizable_limits_t *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max || !out) {
+static size_t consume_limits_r(RBuffer *b, ut64 max, struct r_bin_wasm_resizable_limits_t *out) {
+	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_seek (b, 0, 1) > max || !out) {
 		return 0;
 	}
-	ut32 i = r_buf_seek(b, 0, 1);
+	ut32 i = r_buf_seek (b, 0, 1);
 	if (!(consume_u7_r (b, max, &out->flags))) {
 		return 0;
 	}
@@ -169,11 +169,11 @@ static size_t consume_limits_r (RBuffer *b, ut64 max, struct r_bin_wasm_resizabl
 	if (out->flags && (!(consume_u32_r (b, max, &out->maximum)))) {
 		return 0;
 	}
-	return (size_t)R_ABS (r_buf_seek(b, 0, 1) - i);
+	return (size_t)R_ABS (r_buf_seek (b, 0, 1) - i);
 }
 
 // Utils
-static RList *r_bin_wasm_get_sections_by_id (RList *sections, ut8 id) {
+static RList *r_bin_wasm_get_sections_by_id(RList *sections, ut8 id) {
 	RBinWasmSection *sec = NULL;
 	RList *ret = r_list_newf (NULL);
 	if (!ret) {
@@ -182,13 +182,13 @@ static RList *r_bin_wasm_get_sections_by_id (RList *sections, ut8 id) {
 	RListIter *iter;
 	r_list_foreach (sections, iter, sec) {
 		if (sec->id == id) {
-			r_list_append(ret, sec);
+			r_list_append (ret, sec);
 		}
 	}
 	return ret;
 }
 
-# if 0
+#if 0
 const char *r_bin_wasm_valuetype_to_string (r_bin_wasm_value_type_t type) {
 	switch (type) {
 	case R_BIN_WASM_VALUETYPE_i32:
@@ -208,7 +208,7 @@ const char *r_bin_wasm_valuetype_to_string (r_bin_wasm_value_type_t type) {
 	}
 }
 
-static char *r_bin_wasm_type_entry_to_string (RBinWasmTypeEntry *ptr) {
+static char *r_bin_wasm_type_entry_to_string(RBinWasmTypeEntry *ptr) {
 	if (!ptr) {
 		return NULL;
 	}
@@ -232,14 +232,14 @@ static char *r_bin_wasm_type_entry_to_string (RBinWasmTypeEntry *ptr) {
 #endif
 
 // Free
-static void r_bin_wasm_free_types (RBinWasmTypeEntry *ptr) {
+static void r_bin_wasm_free_types(RBinWasmTypeEntry *ptr) {
 	if (ptr) {
 		free (ptr->param_types);
 	}
 	free (ptr);
 }
 
-static void r_bin_wasm_free_codes (RBinWasmCodeEntry *ptr) {
+static void r_bin_wasm_free_codes(RBinWasmCodeEntry *ptr) {
 	if (ptr) {
 		free (ptr->locals);
 	}
@@ -247,7 +247,7 @@ static void r_bin_wasm_free_codes (RBinWasmCodeEntry *ptr) {
 }
 
 // Parsing
-static RList *r_bin_wasm_get_type_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_type_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmTypeEntry *ptr = NULL;
 
@@ -261,11 +261,11 @@ static RList *r_bin_wasm_get_type_entries (RBinWasmObj *bin, RBinWasmSection *se
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut32 r = 0;
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmTypeEntry))) {
 			return ret;
 		}
@@ -276,8 +276,8 @@ static RList *r_bin_wasm_get_type_entries (RBinWasmObj *bin, RBinWasmSection *se
 		if (!(consume_u32_r (b, max, &ptr->param_count))) {
 			goto beach;
 		}
-		ut32 count = ptr ? ptr->param_count : 0;
-		if (!(r_buf_seek(b, 0, 1) + count <= max)) {
+		ut32 count = ptr? ptr->param_count: 0;
+		if (!(r_buf_seek (b, 0, 1) + count <= max)) {
 			goto beach;
 		}
 		if (count > 0) {
@@ -287,18 +287,18 @@ static RList *r_bin_wasm_get_type_entries (RBinWasmObj *bin, RBinWasmSection *se
 		}
 		int j;
 		for (j = 0; j < count; j++) {
-			if (!(consume_s7_r (b, max, (st8*)&ptr->param_types[j]))) {
+			if (!(consume_s7_r (b, max, (st8 *)&ptr->param_types[j]))) {
 				goto beach;
 			}
 		}
-		if (!(consume_u1_r (b, max, (ut8*)&ptr->return_count))) {
+		if (!(consume_u1_r (b, max, (ut8 *)&ptr->return_count))) {
 			goto beach;
 		}
 		if (ptr->return_count > 1) {
 			goto beach;
 		}
 		if (ptr->return_count == 1) {
-			if (!(consume_s7_r (b, max, (st8*)&ptr->return_type))) {
+			if (!(consume_s7_r (b, max, (st8 *)&ptr->return_type))) {
 				goto beach;
 			}
 		}
@@ -317,7 +317,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_import_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmImportEntry *ptr = NULL;
 
@@ -331,11 +331,11 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmImportEntry))) {
 			return ret;
 		}
@@ -361,7 +361,7 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 			}
 			break;
 		case 1: // Table
-			if (!(consume_s7_r (b, max, (st8*)&ptr->type_t.elem_type))) {
+			if (!(consume_s7_r (b, max, (st8 *)&ptr->type_t.elem_type))) {
 				goto beach;
 			}
 			if (!(consume_limits_r (b, max, &ptr->type_t.limits))) {
@@ -374,10 +374,10 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 			}
 			break;
 		case 3: // Global
-			if (!(consume_s7_r (b, max, (st8*)&ptr->type_g.content_type))) {
+			if (!(consume_s7_r (b, max, (st8 *)&ptr->type_g.content_type))) {
 				goto beach;
 			}
-			if (!(consume_u1_r (b, max, (ut8*)&ptr->type_g.mutability))) {
+			if (!(consume_u1_r (b, max, (ut8 *)&ptr->type_g.mutability))) {
 				goto beach;
 			}
 			break;
@@ -394,7 +394,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_export_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_export_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmExportEntry *ptr = NULL;
 
@@ -407,8 +407,8 @@ static RList *r_bin_wasm_get_export_entries (RBinWasmObj *bin, RBinWasmSection *
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -438,7 +438,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_code_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_code_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmCodeEntry *ptr = NULL;
 
@@ -451,8 +451,8 @@ static RList *r_bin_wasm_get_code_entries (RBinWasmObj *bin, RBinWasmSection *se
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -463,8 +463,8 @@ static RList *r_bin_wasm_get_code_entries (RBinWasmObj *bin, RBinWasmSection *se
 		if (!(consume_u32_r (b, max, &ptr->body_size))) {
 			goto beach;
 		}
-		ut32 j = r_buf_seek(b, 0, 1);
-		if (!(r_buf_seek(b, 0, 1) + ptr->body_size - 1 <= max)) {
+		ut32 j = r_buf_seek (b, 0, 1);
+		if (!(r_buf_seek (b, 0, 1) + ptr->body_size - 1 <= max)) {
 			goto beach;
 		}
 		if (!(consume_u32_r (b, max, &ptr->local_count))) {
@@ -473,9 +473,9 @@ static RList *r_bin_wasm_get_code_entries (RBinWasmObj *bin, RBinWasmSection *se
 		if (consume_locals_r (b, max, ptr) < ptr->local_count) {
 			goto beach;
 		}
-		ptr->code = r_buf_seek(b, 0, 1);
+		ptr->code = r_buf_seek (b, 0, 1);
 		ptr->len = ptr->body_size - ptr->code + j;
-		r_buf_seek(b, ptr->len - 1, R_IO_SEEK_CUR); // consume bytecode
+		r_buf_seek (b, ptr->len - 1, R_IO_SEEK_CUR); // consume bytecode
 		r_buf_read (b, &ptr->byte, 1);
 		if (ptr->byte != R_BIN_WASM_END_OF_CODE) {
 			goto beach;
@@ -496,7 +496,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_data_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_data_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmDataEntry *ptr = NULL;
 
@@ -510,11 +510,11 @@ static RList *r_bin_wasm_get_data_entries (RBinWasmObj *bin, RBinWasmSection *se
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmDataEntry))) {
 			return ret;
 		}
@@ -543,7 +543,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_symtab_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_symtab_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmSymbol *ptr = NULL;
 	size_t read = 0;
@@ -557,10 +557,10 @@ static RList *r_bin_wasm_get_symtab_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data + 3, R_IO_SEEK_SET);
 	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 4;
-	if (!(max < r_buf_size(b))) {
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
-	while (r_buf_seek(b, 0, 1) <= max) {
+	while (r_buf_seek (b, 0, 1) <= max) {
 		if (!(ptr = R_NEW0 (RBinWasmSymbol))) {
 			return ret;
 		}
@@ -588,7 +588,7 @@ beach:
 	return ret;
 }
 
-static RBinWasmStartEntry *r_bin_wasm_get_start (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RBinWasmStartEntry *r_bin_wasm_get_start(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RBinWasmStartEntry *ptr;
 
 	if (!(ptr = R_NEW0 (RBinWasmStartEntry))) {
@@ -597,8 +597,8 @@ static RBinWasmStartEntry *r_bin_wasm_get_start (RBinWasmObj *bin, RBinWasmSecti
 
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	if (!(consume_u32_r (b, max, &ptr->index))) {
@@ -611,7 +611,7 @@ beach:
 	return NULL;
 }
 
-static RList *r_bin_wasm_get_memory_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_memory_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmMemoryEntry *ptr = NULL;
 
@@ -625,7 +625,7 @@ static RList *r_bin_wasm_get_memory_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max =  r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -650,7 +650,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_table_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_table_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmTableEntry *ptr = NULL;
 
@@ -664,11 +664,11 @@ static RList *r_bin_wasm_get_table_entries (RBinWasmObj *bin, RBinWasmSection *s
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
+	while (r_buf_seek (b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmTableEntry))) {
 			return ret;
 		}
@@ -692,7 +692,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_global_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_global_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmGlobalEntry *ptr = NULL;
 
@@ -706,7 +706,7 @@ static RList *r_bin_wasm_get_global_entries (RBinWasmObj *bin, RBinWasmSection *
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;
@@ -737,7 +737,7 @@ beach:
 	return ret;
 }
 
-static RList *r_bin_wasm_get_element_entries (RBinWasmObj *bin, RBinWasmSection *sec) {
+static RList *r_bin_wasm_get_element_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RList *ret = NULL;
 	RBinWasmElementEntry *ptr = NULL;
 
@@ -750,8 +750,8 @@ static RList *r_bin_wasm_get_element_entries (RBinWasmObj *bin, RBinWasmSection 
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
-	if (!(max < r_buf_size(b))) {
+	ut64 max = r_buf_seek (b, 0, 1) + sec->payload_len - 1;
+	if (!(max < r_buf_size (b))) {
 		goto beach;
 	}
 	ut32 r = 0;

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -11,10 +11,10 @@
 static size_t consume_u32_r (RBuffer *b, ut64 max, ut32 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[b->cur], &b->buf[max + 1], &tmp))) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], &b->buf[max + 1], &tmp))) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -45,10 +45,10 @@ static size_t consume_s32_r (RBuffer *b, ut64 max, st32 *out) {
 static size_t consume_u7_r (RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[b->cur], &b->buf[max + 1], &tmp))) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], &b->buf[max + 1], &tmp))) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -61,10 +61,10 @@ static size_t consume_u7_r (RBuffer *b, ut64 max, ut8 *out) {
 static size_t consume_s7_r (RBuffer *b, ut64 max, st8 *out) {
 	size_t n;
 	ut32 tmp = 0;
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(n = read_i32_leb128 (&b->buf[b->cur], (ut8*)&b->buf[max + 1], (int*)&tmp)) || n > 2) {
+	if (!(n = read_i32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], (ut8*)&b->buf[max + 1], (int*)&tmp)) || n > 2) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -77,10 +77,10 @@ static size_t consume_s7_r (RBuffer *b, ut64 max, st8 *out) {
 static size_t consume_u1_r (RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[b->cur], &b->buf[max + 1], &tmp)) || n > 1) {
+	if (!(n = read_u32_leb128 (&b->buf[r_buf_seek(b, 0, 1)], &b->buf[max + 1], &tmp)) || n > 1) {
 		return 0;
 	}
 	r_buf_seek (b, n, R_IO_SEEK_CUR);
@@ -91,14 +91,15 @@ static size_t consume_u1_r (RBuffer *b, ut64 max, ut8 *out) {
 }
 
 static size_t consume_str_r (RBuffer *b, ut64 max, size_t sz, char *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
-	if (!(b->cur + sz - 1 <= max)) {
+	if (!(r_buf_seek(b, 0, 1) + sz - 1 <= max)) {
 		return 0;
 	}
 	if (sz > 0) {
-		strncpy (out, (char*)&b->buf[b->cur], R_MIN (R_BIN_WASM_STRING_LENGTH - 1, sz));
+		strncpy (out, (char*)&b->buf[r_buf_seek(b, 0, 1)],
+			 R_MIN (R_BIN_WASM_STRING_LENGTH - 1, sz));
 	} else {
 		*out = 0;
 	}
@@ -107,15 +108,15 @@ static size_t consume_str_r (RBuffer *b, ut64 max, size_t sz, char *out) {
 }
 
 static size_t consume_init_expr_r (RBuffer *b, ut64 max, ut8 eoc, void *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
 	ut32 i = 0;
-	while (b->cur + i <= max && b->buf[b->cur + i] != eoc) {
+	while (r_buf_seek(b, 0, 1) + i <= max && b->buf[r_buf_seek(b, 0, 1) + i] != eoc) {
 		// TODO: calc the expresion with the bytcode (ESIL?)
 		i++;
 	}
-	if (*(ut8*)(&b->buf[b->cur + i]) != eoc) {
+	if (*(ut8*)(&b->buf[r_buf_seek(b, 0, 1) + i]) != eoc) {
 		return 0;
 	}
 	r_buf_seek (b, i + 1, R_IO_SEEK_CUR);
@@ -123,11 +124,11 @@ static size_t consume_init_expr_r (RBuffer *b, ut64 max, ut8 eoc, void *out) {
 }
 
 static size_t consume_locals_r (RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max) {
 		return 0;
 	}
 	ut32 count = out ? out->local_count : 0;
-	if (!(b->cur + (count * 7) <= max)) { // worst case 7 bytes
+	if (!(r_buf_seek(b, 0, 1) + (count * 7) <= max)) { // worst case 7 bytes
 		return 0;
 	}
 	if (count > 0) {
@@ -136,7 +137,7 @@ static size_t consume_locals_r (RBuffer *b, ut64 max, RBinWasmCodeEntry *out) {
 		}
 	}
 	ut32 j = 0;
-	while (b->cur <= max && j < count) {
+	while (r_buf_seek(b, 0, 1) <= max && j < count) {
 		if (!(consume_u32_r (b, max, (out? &out->locals[j].count: NULL)))) {
 			goto beach;
 		}
@@ -155,10 +156,10 @@ beach:
 }
 
 static size_t consume_limits_r (RBuffer *b, ut64 max, struct r_bin_wasm_resizable_limits_t *out) {
-	if (!b || !b->buf || max >= r_buf_size(b) || b->cur > max || !out) {
+	if (!b || !b->buf || max >= r_buf_size(b) || r_buf_seek(b, 0, 1) > max || !out) {
 		return 0;
 	}
-	ut32 i = b->cur;
+	ut32 i = r_buf_seek(b, 0, 1);
 	if (!(consume_u7_r (b, max, &out->flags))) {
 		return 0;
 	}
@@ -168,7 +169,7 @@ static size_t consume_limits_r (RBuffer *b, ut64 max, struct r_bin_wasm_resizabl
 	if (out->flags && (!(consume_u32_r (b, max, &out->maximum)))) {
 		return 0;
 	}
-	return (size_t)R_ABS (b->cur - i);
+	return (size_t)R_ABS (r_buf_seek(b, 0, 1) - i);
 }
 
 // Utils
@@ -260,11 +261,11 @@ static RList *r_bin_wasm_get_type_entries (RBinWasmObj *bin, RBinWasmSection *se
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
 	ut32 r = 0;
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmTypeEntry))) {
 			return ret;
 		}
@@ -276,7 +277,7 @@ static RList *r_bin_wasm_get_type_entries (RBinWasmObj *bin, RBinWasmSection *se
 			goto beach;
 		}
 		ut32 count = ptr ? ptr->param_count : 0;
-		if (!(b->cur + count <= max)) {
+		if (!(r_buf_seek(b, 0, 1) + count <= max)) {
 			goto beach;
 		}
 		if (count > 0) {
@@ -329,12 +330,12 @@ static RList *r_bin_wasm_get_import_entries (RBinWasmObj *bin, RBinWasmSection *
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmImportEntry))) {
 			return ret;
 		}
@@ -406,12 +407,12 @@ static RList *r_bin_wasm_get_export_entries (RBinWasmObj *bin, RBinWasmSection *
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmExportEntry))) {
 			return ret;
 		}
@@ -450,20 +451,20 @@ static RList *r_bin_wasm_get_code_entries (RBinWasmObj *bin, RBinWasmSection *se
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmCodeEntry))) {
 			return ret;
 		}
 		if (!(consume_u32_r (b, max, &ptr->body_size))) {
 			goto beach;
 		}
-		ut32 j = b->cur;
-		if (!(b->cur + ptr->body_size - 1 <= max)) {
+		ut32 j = r_buf_seek(b, 0, 1);
+		if (!(r_buf_seek(b, 0, 1) + ptr->body_size - 1 <= max)) {
 			goto beach;
 		}
 		if (!(consume_u32_r (b, max, &ptr->local_count))) {
@@ -472,7 +473,7 @@ static RList *r_bin_wasm_get_code_entries (RBinWasmObj *bin, RBinWasmSection *se
 		if (consume_locals_r (b, max, ptr) < ptr->local_count) {
 			goto beach;
 		}
-		ptr->code = b->cur;
+		ptr->code = r_buf_seek(b, 0, 1);
 		ptr->len = ptr->body_size - ptr->code + j;
 		r_buf_seek(b, ptr->len - 1, R_IO_SEEK_CUR); // consume bytecode
 		r_buf_read (b, &ptr->byte, 1);
@@ -508,12 +509,12 @@ static RList *r_bin_wasm_get_data_entries (RBinWasmObj *bin, RBinWasmSection *se
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmDataEntry))) {
 			return ret;
 		}
@@ -526,7 +527,7 @@ static RList *r_bin_wasm_get_data_entries (RBinWasmObj *bin, RBinWasmSection *se
 		if (!(consume_u32_r (b, max, &ptr->size))) {
 			goto beach;
 		}
-		ptr->data = b->cur;
+		ptr->data = r_buf_seek(b, 0, 1);
 		r_buf_seek (b, ptr->size, R_IO_SEEK_CUR);
 		if (!r_list_append (ret, ptr)) {
 			free (ptr);
@@ -555,11 +556,11 @@ static RList *r_bin_wasm_get_symtab_entries (RBinWasmObj *bin, RBinWasmSection *
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data + 3, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 4;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 4;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
-	while (b->cur <= max) {
+	while (r_buf_seek(b, 0, 1) <= max) {
 		if (!(ptr = R_NEW0 (RBinWasmSymbol))) {
 			return ret;
 		}
@@ -596,7 +597,7 @@ static RBinWasmStartEntry *r_bin_wasm_get_start (RBinWasmObj *bin, RBinWasmSecti
 
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
@@ -623,12 +624,12 @@ static RList *r_bin_wasm_get_memory_entries (RBinWasmObj *bin, RBinWasmSection *
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max =  b->cur + sec->payload_len - 1;
+	ut64 max =  r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmMemoryEntry))) {
 			return ret;
 		}
@@ -662,12 +663,12 @@ static RList *r_bin_wasm_get_table_entries (RBinWasmObj *bin, RBinWasmSection *s
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmTableEntry))) {
 			return ret;
 		}
@@ -704,12 +705,12 @@ static RList *r_bin_wasm_get_global_entries (RBinWasmObj *bin, RBinWasmSection *
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmGlobalEntry))) {
 			return ret;
 		}
@@ -749,12 +750,12 @@ static RList *r_bin_wasm_get_element_entries (RBinWasmObj *bin, RBinWasmSection 
 	}
 	RBuffer *b = bin->buf;
 	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = b->cur + sec->payload_len - 1;
+	ut64 max = r_buf_seek(b, 0, 1) + sec->payload_len - 1;
 	if (!(max < r_buf_size(b))) {
 		goto beach;
 	}
 	ut32 r = 0;
-	while (b->cur <= max && r < sec->count) {
+	while (r_buf_seek(b, 0, 1) <= max && r < sec->count) {
 		if (!(ptr = R_NEW0 (RBinWasmElementEntry))) {
 			return ret;
 		}
@@ -768,7 +769,7 @@ static RList *r_bin_wasm_get_element_entries (RBinWasmObj *bin, RBinWasmSection 
 			goto beach;
 		}
 		ut32 j = 0;
-		while (b->cur <= max && j < ptr->num_elem) {
+		while (r_buf_seek(b, 0, 1) <= max && j < ptr->num_elem) {
 			// TODO: allocate space and fill entry
 			if (!(consume_u32_r (b, max, NULL))) {
 				goto beach;
@@ -867,7 +868,7 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 	RBuffer *b = bin->buf;
 	ut64 max = r_buf_size(b) - 1;
 	r_buf_seek (b, 8, R_IO_SEEK_SET);
-	while (b->cur <= max) {
+	while (r_buf_seek(b, 0, 1) <= max) {
 		if (!(ptr = R_NEW0 (RBinWasmSection))) {
 			return ret;
 		}
@@ -883,11 +884,11 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 			// free (ptr);
 			// continue;
 		}
-		if (!(b->cur + (ut64)ptr->size - 1 <= max)) {
+		if (!(r_buf_seek(b, 0, 1) + (ut64)ptr->size - 1 <= max)) {
 			goto beach;
 		}
 		ptr->count = 0;
-		ptr->offset = b->cur;
+		ptr->offset = r_buf_seek(b, 0, 1);
 		switch (ptr->id) {
 		case R_BIN_WASM_SECTION_CUSTOM:
 			// eprintf("custom section: 0x%x, ", (ut32)b->cur);
@@ -966,7 +967,7 @@ RList *r_bin_wasm_get_sections (RBinWasmObj *bin) {
 			}
 			// eprintf("count %d\n", ptr->count);
 		}
-		ptr->payload_data = b->cur;
+		ptr->payload_data = r_buf_seek(b, 0, 1);
 		ptr->payload_len = ptr->size - (ptr->payload_data - ptr->offset);
 		if (ptr->payload_len > ptr->size) {
 			goto beach;

--- a/libr/bin/format/zimg/zimg.c
+++ b/libr/bin/format/zimg/zimg.c
@@ -10,7 +10,7 @@ struct r_bin_zimg_obj_t* r_bin_zimg_new_buf(RBuffer *buf) {
 	if (!bin) {
 		goto fail;
 	}
-	bin->size = r_buf_size(buf);
+	bin->size = r_buf_size (buf);
 	bin->b = r_buf_new ();
 	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)){
 		goto fail;

--- a/libr/bin/format/zimg/zimg.c
+++ b/libr/bin/format/zimg/zimg.c
@@ -10,7 +10,7 @@ struct r_bin_zimg_obj_t* r_bin_zimg_new_buf(RBuffer *buf) {
 	if (!bin) {
 		goto fail;
 	}
-	bin->size = buf->length;
+	bin->size = r_buf_size(buf);
 	bin->b = r_buf_new ();
 	if (!r_buf_set_bytes (bin->b, buf->buf, bin->size)){
 		goto fail;

--- a/libr/bin/format/zimg/zimg.h
+++ b/libr/bin/format/zimg/zimg.h
@@ -35,4 +35,4 @@ struct r_bin_zimg_str_t {
 };
 
 struct r_bin_zimg_obj_t *r_bin_zimg_new_buf(RBuffer *buf);
-struct r_bin_zimg_str_t *r_bin_zimg_get_strings (struct r_bin_zimg_obj_t* bin);
+struct r_bin_zimg_str_t *r_bin_zimg_get_strings (struct r_bin_zimg_obj_t *bin);

--- a/libr/bin/format/zimg/zimg.h
+++ b/libr/bin/format/zimg/zimg.h
@@ -16,7 +16,7 @@ struct zimg_header_t {
 typedef struct r_bin_zimg_obj_t {
 	int size;
 	const char *file;
-	struct r_buf_t *b;
+	RBuffer *b;
 	struct zimg_header_t header;
 	ut32 *strings;
 	RList *methods_list;
@@ -34,5 +34,5 @@ struct r_bin_zimg_str_t {
 	int last;
 };
 
-struct r_bin_zimg_obj_t *r_bin_zimg_new_buf(struct r_buf_t *buf);
+struct r_bin_zimg_obj_t *r_bin_zimg_new_buf(RBuffer *buf);
 struct r_bin_zimg_str_t *r_bin_zimg_get_strings (struct r_bin_zimg_obj_t* bin);

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -177,7 +177,7 @@ static RList *sections(RBinFile *bf) {
 		return ret;
 	}
 	ptr->name = strdup ("load");
-	ptr->size = r_buf_size(bf->buf);
+	ptr->size = r_buf_size (bf->buf);
 	ptr->vsize = art.image_size; // TODO: align?
 	ptr->paddr = 0;
 	ptr->vaddr = art.image_base;

--- a/libr/bin/p/bin_art.c
+++ b/libr/bin/p/bin_art.c
@@ -177,7 +177,7 @@ static RList *sections(RBinFile *bf) {
 		return ret;
 	}
 	ptr->name = strdup ("load");
-	ptr->size = bf->buf->length;
+	ptr->size = r_buf_size(bf->buf);
 	ptr->vsize = art.image_size; // TODO: align?
 	ptr->paddr = 0;
 	ptr->vaddr = art.image_base;

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -110,7 +110,7 @@ static RList *patch_relocs(RBin *b) {
 		}
 		R_FREE (bin->reloc_table);
 	}
-	b->iob.write_at (b->iob.io, bin->b->base, bin->b->buf, bin->b->length);
+	b->iob.write_at (b->iob.io, bin->b->base, bin->b->buf, r_buf_size (bin->b));
 	return list;
 }
 

--- a/libr/bin/p/bin_cgc.c
+++ b/libr/bin/p/bin_cgc.c
@@ -33,7 +33,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 #define H(x) r_buf_append_ut16(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=buf->length;Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
 
 	B ("\x7F" "CGC" "\x01\x01\x01\x43", 8);
 	Z (8);
@@ -41,38 +41,38 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	H (3); // e_machne = EM_I386
 
 	D (1);
-	p_start = buf->length;
+	p_start = r_buf_size(buf);
 	D (-1); // _start
-	p_phoff = buf->length;
+	p_phoff = r_buf_size(buf);
 	D (-1); // phoff -- program headers offset
 	D (0);  // shoff -- section headers offset
 	D (0);  // flags
-	p_ehdrsz = buf->length;
+	p_ehdrsz = r_buf_size(buf);
 	H (-1); // ehdrsz
-	p_phdrsz = buf->length;
+	p_phdrsz = r_buf_size(buf);
 	H (-1); // phdrsz
 	H (1);
 	H (0);
 	H (0);
 	H (0);
 	// phdr:
-	p_phdr = buf->length;
+	p_phdr = r_buf_size(buf);
 	D (1);
 	D (0);
-	p_vaddr = buf->length;
+	p_vaddr = r_buf_size(buf);
 	D (-1); // vaddr = $$
-	p_paddr = buf->length;
+	p_paddr = r_buf_size(buf);
 	D (-1); // paddr = $$
-	p_fs = buf->length;
+	p_fs = r_buf_size(buf);
 	D (-1); // filesize
-	p_fs2 = buf->length;
+	p_fs2 = r_buf_size(buf);
 	D (-1); // filesize
 	D (5); // flags
 	D (0x1000); // align
 
 	ehdrsz = p_phdr;
-	phdrsz = buf->length - p_phdr;
-	code_pa = buf->length;
+	phdrsz = r_buf_size(buf) - p_phdr;
+	code_pa = r_buf_size(buf);
 	code_va = code_pa + baddr;
 	phoff = 0x34;//p_phdr ;
 	filesize = code_pa + codelen + datalen;

--- a/libr/bin/p/bin_cgc.c
+++ b/libr/bin/p/bin_cgc.c
@@ -33,7 +33,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 #define H(x) r_buf_append_ut16(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size (buf);Z(x);W(p_tmp,y,strlen(y))
 
 	B ("\x7F" "CGC" "\x01\x01\x01\x43", 8);
 	Z (8);
@@ -41,37 +41,37 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	H (3); // e_machne = EM_I386
 
 	D (1);
-	p_start = r_buf_size(buf);
+	p_start = r_buf_size (buf);
 	D (-1); // _start
-	p_phoff = r_buf_size(buf);
+	p_phoff = r_buf_size (buf);
 	D (-1); // phoff -- program headers offset
 	D (0);  // shoff -- section headers offset
 	D (0);  // flags
-	p_ehdrsz = r_buf_size(buf);
+	p_ehdrsz = r_buf_size (buf);
 	H (-1); // ehdrsz
-	p_phdrsz = r_buf_size(buf);
+	p_phdrsz = r_buf_size (buf);
 	H (-1); // phdrsz
 	H (1);
 	H (0);
 	H (0);
 	H (0);
 	// phdr:
-	p_phdr = r_buf_size(buf);
+	p_phdr = r_buf_size (buf);
 	D (1);
 	D (0);
-	p_vaddr = r_buf_size(buf);
+	p_vaddr = r_buf_size (buf);
 	D (-1); // vaddr = $$
-	p_paddr = r_buf_size(buf);
+	p_paddr = r_buf_size (buf);
 	D (-1); // paddr = $$
-	p_fs = r_buf_size(buf);
+	p_fs = r_buf_size (buf);
 	D (-1); // filesize
-	p_fs2 = r_buf_size(buf);
+	p_fs2 = r_buf_size (buf);
 	D (-1); // filesize
 	D (5); // flags
 	D (0x1000); // align
 
 	ehdrsz = p_phdr;
-	phdrsz = r_buf_size(buf) - p_phdr;
+	phdrsz = r_buf_size (buf) - p_phdr;
 	code_pa = r_buf_size (buf);
 	code_va = code_pa + baddr;
 	phoff = 0x34;//p_phdr ;

--- a/libr/bin/p/bin_cgc.c
+++ b/libr/bin/p/bin_cgc.c
@@ -72,7 +72,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 
 	ehdrsz = p_phdr;
 	phdrsz = r_buf_size(buf) - p_phdr;
-	code_pa = r_buf_size(buf);
+	code_pa = r_buf_size (buf);
 	code_va = code_pa + baddr;
 	phoff = 0x34;//p_phdr ;
 	filesize = code_pa + codelen + datalen;

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -800,7 +800,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->rclass = strdup ("class");
 	ret->os = strdup ("linux");
 	const char *kw = "Landroid/support/wearable/view";
-	if (r_mem_mem (bf->buf->buf, r_buf_size(bf->buf), (const ut8*)kw, strlen (kw))) {
+	if (r_mem_mem (bf->buf->buf, r_buf_size (bf->buf), (const ut8*)kw, strlen (kw))) {
 		ret->subsystem = strdup ("android-wear");
 	} else {
 		ret->subsystem = strdup ("android");
@@ -811,14 +811,14 @@ static RBinInfo *info(RBinFile *bf) {
 	h->len = 20;
 	h->addr = 12;
 	h->from = 12;
-	h->to = r_buf_size(bf->buf)-32;
+	h->to = r_buf_size (bf->buf)-32;
 	memcpy (h->buf, bf->buf->buf + 12, 20);
 	h = &ret->sum[1];
 	h->type = "adler32";
 	h->len = 4;
 	h->addr = 0x8;
 	h->from = 12;
-	h->to = r_buf_size(bf->buf)-h->from;
+	h->to = r_buf_size (bf->buf)-h->from;
 	h = &ret->sum[2];
 	h->type = 0;
 	memcpy (h->buf, bf->buf->buf + 8, 4);
@@ -1233,7 +1233,7 @@ static const ut8 *parse_dex_class_method(RBinFile *binfile, RBinDexObj *bin,
 					}
 					// TODO: catch left instead of null
 					const ut8 *p3 = r_buf_get_at (binfile->buf, off, NULL);
-					const ut8 *p3_end = p3 + r_buf_size(binfile->buf) - off;
+					const ut8 *p3_end = p3 + r_buf_size (binfile->buf) - off;
 					st64 size = r_sleb128 (&p3, p3_end);
 
 					if (size <= 0) {
@@ -1545,7 +1545,7 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 
 		p = r_buf_get_at (binfile->buf, c->class_data_offset, NULL);
 		// runtime error: pointer index expression with base 0x000000004402 overflowed to 0xfffffffffffffd46
-		p_end = p + (r_buf_size(binfile->buf) - c->class_data_offset);
+		p_end = p + (r_buf_size (binfile->buf) - c->class_data_offset);
 		//XXX check for NULL!!
 		c->class_data = (struct dex_class_data_item_t *)malloc (
 			sizeof (struct dex_class_data_item_t));
@@ -1914,7 +1914,7 @@ static RList *sections(RBinFile *bf) {
 			fsym = m->paddr;
 		}
 		ns = m->paddr + m->size;
-		if (ns > r_buf_size(bf->buf)) {
+		if (ns > r_buf_size (bf->buf)) {
 			continue;
 		}
 		if (ns > fsymsz) {
@@ -1960,11 +1960,11 @@ static RList *sections(RBinFile *bf) {
 		//ut64 sz = bf ? r_buf_size (bf->buf): 0;
 		ptr->name = strdup ("data");
 		ptr->paddr = ptr->vaddr = fsymsz+fsym;
-		if (ptr->vaddr > r_buf_size(bf->buf)) {
+		if (ptr->vaddr > r_buf_size (bf->buf)) {
 			ptr->paddr = ptr->vaddr = bin->code_to;
-			ptr->size = ptr->vsize = r_buf_size(bf->buf) - ptr->vaddr;
+			ptr->size = ptr->vsize = r_buf_size (bf->buf) - ptr->vaddr;
 		} else {
-			ptr->size = ptr->vsize = r_buf_size(bf->buf) - ptr->vaddr;
+			ptr->size = ptr->vsize = r_buf_size (bf->buf) - ptr->vaddr;
 			// hacky workaround
 			//ptr->size = ptr->vsize = 1024;
 		}

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -86,77 +86,77 @@ static int countOnes(ut32 val) {
 }
 
 typedef enum {
-	kAccessForClass  = 0,
+	kAccessForClass = 0,
 	kAccessForMethod = 1,
-	kAccessForField  = 2,
+	kAccessForField = 2,
 	kAccessForMAX
 } AccessFor;
 
 static char *createAccessFlagStr(ut32 flags, AccessFor forWhat) {
 	#define NUM_FLAGS 18
-	static const char* kAccessStrings[kAccessForMAX][NUM_FLAGS] = {
+	static const char *kAccessStrings[kAccessForMAX][NUM_FLAGS] = {
 		{
 			/* class, inner class */
-			"PUBLIC",           /* 0x0001 */
-			"PRIVATE",          /* 0x0002 */
-			"PROTECTED",        /* 0x0004 */
-			"STATIC",           /* 0x0008 */
-			"FINAL",            /* 0x0010 */
-			"?",                /* 0x0020 */
-			"?",                /* 0x0040 */
-			"?",                /* 0x0080 */
-			"?",                /* 0x0100 */
-			"INTERFACE",        /* 0x0200 */
-			"ABSTRACT",         /* 0x0400 */
-			"?",                /* 0x0800 */
-			"SYNTHETIC",        /* 0x1000 */
-			"ANNOTATION",       /* 0x2000 */
-			"ENUM",             /* 0x4000 */
-			"?",                /* 0x8000 */
-			"VERIFIED",         /* 0x10000 */
-			"OPTIMIZED",        /* 0x20000 */
+			"PUBLIC", /* 0x0001 */
+			"PRIVATE", /* 0x0002 */
+			"PROTECTED", /* 0x0004 */
+			"STATIC", /* 0x0008 */
+			"FINAL", /* 0x0010 */
+			"?", /* 0x0020 */
+			"?", /* 0x0040 */
+			"?", /* 0x0080 */
+			"?", /* 0x0100 */
+			"INTERFACE", /* 0x0200 */
+			"ABSTRACT", /* 0x0400 */
+			"?", /* 0x0800 */
+			"SYNTHETIC", /* 0x1000 */
+			"ANNOTATION", /* 0x2000 */
+			"ENUM", /* 0x4000 */
+			"?", /* 0x8000 */
+			"VERIFIED", /* 0x10000 */
+			"OPTIMIZED", /* 0x20000 */
 		},
 		{
 			/* method */
-			"PUBLIC",           /* 0x0001 */
-			"PRIVATE",          /* 0x0002 */
-			"PROTECTED",        /* 0x0004 */
-			"STATIC",           /* 0x0008 */
-			"FINAL",            /* 0x0010 */
-			"SYNCHRONIZED",     /* 0x0020 */
-			"BRIDGE",           /* 0x0040 */
-			"VARARGS",          /* 0x0080 */
-			"NATIVE",           /* 0x0100 */
-			"?",                /* 0x0200 */
-			"ABSTRACT",         /* 0x0400 */
-			"STRICT",           /* 0x0800 */
-			"SYNTHETIC",        /* 0x1000 */
-			"?",                /* 0x2000 */
-			"?",                /* 0x4000 */
-			"MIRANDA",          /* 0x8000 */
-			"CONSTRUCTOR",      /* 0x10000 */
+			"PUBLIC", /* 0x0001 */
+			"PRIVATE", /* 0x0002 */
+			"PROTECTED", /* 0x0004 */
+			"STATIC", /* 0x0008 */
+			"FINAL", /* 0x0010 */
+			"SYNCHRONIZED", /* 0x0020 */
+			"BRIDGE", /* 0x0040 */
+			"VARARGS", /* 0x0080 */
+			"NATIVE", /* 0x0100 */
+			"?", /* 0x0200 */
+			"ABSTRACT", /* 0x0400 */
+			"STRICT", /* 0x0800 */
+			"SYNTHETIC", /* 0x1000 */
+			"?", /* 0x2000 */
+			"?", /* 0x4000 */
+			"MIRANDA", /* 0x8000 */
+			"CONSTRUCTOR", /* 0x10000 */
 			"DECLARED_SYNCHRONIZED", /* 0x20000 */
 		},
 		{
 			/* field */
-			"PUBLIC",           /* 0x0001 */
-			"PRIVATE",          /* 0x0002 */
-			"PROTECTED",        /* 0x0004 */
-			"STATIC",           /* 0x0008 */
-			"FINAL",            /* 0x0010 */
-			"?",                /* 0x0020 */
-			"VOLATILE",         /* 0x0040 */
-			"TRANSIENT",        /* 0x0080 */
-			"?",                /* 0x0100 */
-			"?",                /* 0x0200 */
-			"?",                /* 0x0400 */
-			"?",                /* 0x0800 */
-			"SYNTHETIC",        /* 0x1000 */
-			"?",                /* 0x2000 */
-			"ENUM",             /* 0x4000 */
-			"?",                /* 0x8000 */
-			"?",                /* 0x10000 */
-			"?",                /* 0x20000 */
+			"PUBLIC", /* 0x0001 */
+			"PRIVATE", /* 0x0002 */
+			"PROTECTED", /* 0x0004 */
+			"STATIC", /* 0x0008 */
+			"FINAL", /* 0x0010 */
+			"?", /* 0x0020 */
+			"VOLATILE", /* 0x0040 */
+			"TRANSIENT", /* 0x0080 */
+			"?", /* 0x0100 */
+			"?", /* 0x0200 */
+			"?", /* 0x0400 */
+			"?", /* 0x0800 */
+			"SYNTHETIC", /* 0x1000 */
+			"?", /* 0x2000 */
+			"ENUM", /* 0x4000 */
+			"?", /* 0x8000 */
+			"?", /* 0x10000 */
+			"?", /* 0x20000 */
 		},
 	};
 	int i, count = countOnes (flags);
@@ -824,8 +824,8 @@ static RBinInfo *info(RBinFile *bf) {
 	memcpy (h->buf, bf->buf->buf + 8, 4);
 	{
 		ut32 *fc = (ut32 *)(bf->buf->buf + 8);
-		ut32  cc = __adler32 (bf->buf->buf + 12,
-				      r_buf_size(bf->buf) - 12);
+		ut32 cc = __adler32 (bf->buf->buf + 12,
+			r_buf_size (bf->buf) - 12);
 		if (*fc != cc) {
 			eprintf ("# adler32 checksum doesn't match. Type this to fix it:\n");
 			eprintf ("wx `ph sha1 $s-32 @32` @12 ; wx `ph adler32 $s-12 @12` @8\n");

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -49,7 +49,7 @@ static char *getstr(RBinDexObj *bin, int idx) {
 	if (r_buf_read_at (bin->b, bin->strings[idx], buf, sizeof (buf)) < 1) {
 		return NULL;
 	}
-	bin->b->buf[bin->b->length - 1] = 0;
+	bin->b->buf[r_buf_size (bin->b) - 1] = 0;
 	uleblen = r_uleb128 (buf, sizeof (buf), &len) - buf;
 	if (!uleblen || uleblen >= bin->size) {
 		return NULL;
@@ -800,7 +800,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->rclass = strdup ("class");
 	ret->os = strdup ("linux");
 	const char *kw = "Landroid/support/wearable/view";
-	if (r_mem_mem (bf->buf->buf, bf->buf->length, (const ut8*)kw, strlen (kw))) {
+	if (r_mem_mem (bf->buf->buf, r_buf_size(bf->buf), (const ut8*)kw, strlen (kw))) {
 		ret->subsystem = strdup ("android-wear");
 	} else {
 		ret->subsystem = strdup ("android");
@@ -811,20 +811,21 @@ static RBinInfo *info(RBinFile *bf) {
 	h->len = 20;
 	h->addr = 12;
 	h->from = 12;
-	h->to = bf->buf->length-32;
+	h->to = r_buf_size(bf->buf)-32;
 	memcpy (h->buf, bf->buf->buf + 12, 20);
 	h = &ret->sum[1];
 	h->type = "adler32";
 	h->len = 4;
 	h->addr = 0x8;
 	h->from = 12;
-	h->to = bf->buf->length-h->from;
+	h->to = r_buf_size(bf->buf)-h->from;
 	h = &ret->sum[2];
 	h->type = 0;
 	memcpy (h->buf, bf->buf->buf + 8, 4);
 	{
 		ut32 *fc = (ut32 *)(bf->buf->buf + 8);
-		ut32  cc = __adler32 (bf->buf->buf + 12, bf->buf->length - 12);
+		ut32  cc = __adler32 (bf->buf->buf + 12,
+				      r_buf_size(bf->buf) - 12);
 		if (*fc != cc) {
 			eprintf ("# adler32 checksum doesn't match. Type this to fix it:\n");
 			eprintf ("wx `ph sha1 $s-32 @32` @12 ; wx `ph adler32 $s-12 @12` @8\n");
@@ -1232,7 +1233,7 @@ static const ut8 *parse_dex_class_method(RBinFile *binfile, RBinDexObj *bin,
 					}
 					// TODO: catch left instead of null
 					const ut8 *p3 = r_buf_get_at (binfile->buf, off, NULL);
-					const ut8 *p3_end = p3 + binfile->buf->length - off;
+					const ut8 *p3_end = p3 + r_buf_size(binfile->buf) - off;
 					st64 size = r_sleb128 (&p3, p3_end);
 
 					if (size <= 0) {
@@ -1544,7 +1545,7 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 
 		p = r_buf_get_at (binfile->buf, c->class_data_offset, NULL);
 		// runtime error: pointer index expression with base 0x000000004402 overflowed to 0xfffffffffffffd46
-		p_end = p + (binfile->buf->length - c->class_data_offset);
+		p_end = p + (r_buf_size(binfile->buf) - c->class_data_offset);
 		//XXX check for NULL!!
 		c->class_data = (struct dex_class_data_item_t *)malloc (
 			sizeof (struct dex_class_data_item_t));
@@ -1913,7 +1914,7 @@ static RList *sections(RBinFile *bf) {
 			fsym = m->paddr;
 		}
 		ns = m->paddr + m->size;
-		if (ns > bf->buf->length) {
+		if (ns > r_buf_size(bf->buf)) {
 			continue;
 		}
 		if (ns > fsymsz) {
@@ -1959,11 +1960,11 @@ static RList *sections(RBinFile *bf) {
 		//ut64 sz = bf ? r_buf_size (bf->buf): 0;
 		ptr->name = strdup ("data");
 		ptr->paddr = ptr->vaddr = fsymsz+fsym;
-		if (ptr->vaddr > bf->buf->length) {
+		if (ptr->vaddr > r_buf_size(bf->buf)) {
 			ptr->paddr = ptr->vaddr = bin->code_to;
-			ptr->size = ptr->vsize = bf->buf->length - ptr->vaddr;
+			ptr->size = ptr->vsize = r_buf_size(bf->buf) - ptr->vaddr;
 		} else {
-			ptr->size = ptr->vsize = bf->buf->length - ptr->vaddr;
+			ptr->size = ptr->vsize = r_buf_size(bf->buf) - ptr->vaddr;
 			// hacky workaround
 			//ptr->size = ptr->vsize = 1024;
 		}

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -44,7 +44,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 #define H(x) r_buf_append_ut16(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=buf->length;Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
 
 	B ("\x7F" "ELF" "\x01\x01\x01\x00", 8);
 	Z (8);
@@ -56,38 +56,38 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	}
 
 	D (1);
-	p_start = buf->length;
+	p_start = r_buf_size(buf);
 	D (-1); // _start
-	p_phoff = buf->length;
+	p_phoff = r_buf_size(buf);
 	D (-1); // phoff -- program headers offset
 	D (0);  // shoff -- section headers offset
 	D (0);  // flags
-	p_ehdrsz = buf->length;
+	p_ehdrsz = r_buf_size(buf);
 	H (-1); // ehdrsz
-	p_phdrsz = buf->length;
+	p_phdrsz = r_buf_size(buf);
 	H (-1); // phdrsz
 	H (1);
 	H (0);
 	H (0);
 	H (0);
 	// phdr:
-	p_phdr = buf->length;
+	p_phdr = r_buf_size(buf);
 	D (1);
 	D (0);
-	p_vaddr = buf->length;
+	p_vaddr = r_buf_size(buf);
 	D (-1); // vaddr = $$
-	p_paddr = buf->length;
+	p_paddr = r_buf_size(buf);
 	D (-1); // paddr = $$
-	p_fs = buf->length;
+	p_fs = r_buf_size(buf);
 	D (-1); // filesize
-	p_fs2 = buf->length;
+	p_fs2 = r_buf_size(buf);
 	D (-1); // filesize
 	D (5); // flags
 	D (0x1000); // align
 
 	ehdrsz = p_phdr;
-	phdrsz = buf->length - p_phdr;
-	code_pa = buf->length;
+	phdrsz = r_buf_size(buf) - p_phdr;
+	code_pa = r_buf_size(buf);
 	code_va = code_pa + baddr;
 	phoff = 0x34;//p_phdr ;
 	filesize = code_pa + codelen + datalen;

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -44,7 +44,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 #define H(x) r_buf_append_ut16(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size (buf);Z(x);W(p_tmp,y,strlen(y))
 
 	B ("\x7F" "ELF" "\x01\x01\x01\x00", 8);
 	Z (8);
@@ -56,15 +56,15 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	}
 
 	D (1);
-	p_start = r_buf_size(buf);
+	p_start = r_buf_size (buf);
 	D (-1); // _start
-	p_phoff = r_buf_size(buf);
+	p_phoff = r_buf_size (buf);
 	D (-1); // phoff -- program headers offset
 	D (0);  // shoff -- section headers offset
 	D (0); // flags
-	p_ehdrsz = r_buf_size(buf);
+	p_ehdrsz = r_buf_size (buf);
 	H (-1); // ehdrsz
-	p_phdrsz = r_buf_size(buf);
+	p_phdrsz = r_buf_size (buf);
 	H (-1); // phdrsz
 	H (1);
 	H (0);
@@ -74,19 +74,19 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	p_phdr = r_buf_size (buf);
 	D (1);
 	D (0);
-	p_vaddr = r_buf_size(buf);
+	p_vaddr = r_buf_size (buf);
 	D (-1); // vaddr = $$
-	p_paddr = r_buf_size(buf);
+	p_paddr = r_buf_size (buf);
 	D (-1); // paddr = $$
-	p_fs = r_buf_size(buf);
+	p_fs = r_buf_size (buf);
 	D (-1); // filesize
-	p_fs2 = r_buf_size(buf);
+	p_fs2 = r_buf_size (buf);
 	D (-1); // filesize
 	D (5); // flags
 	D (0x1000); // align
 
 	ehdrsz = p_phdr;
-	phdrsz = r_buf_size(buf) - p_phdr;
+	phdrsz = r_buf_size (buf) - p_phdr;
 	code_pa = r_buf_size (buf);
 	code_va = code_pa + baddr;
 	phoff = 0x34;//p_phdr ;

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -61,7 +61,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	p_phoff = r_buf_size(buf);
 	D (-1); // phoff -- program headers offset
 	D (0);  // shoff -- section headers offset
-	D (0);  // flags
+	D (0); // flags
 	p_ehdrsz = r_buf_size(buf);
 	H (-1); // ehdrsz
 	p_phdrsz = r_buf_size(buf);
@@ -71,7 +71,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	H (0);
 	H (0);
 	// phdr:
-	p_phdr = r_buf_size(buf);
+	p_phdr = r_buf_size (buf);
 	D (1);
 	D (0);
 	p_vaddr = r_buf_size(buf);
@@ -87,7 +87,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 
 	ehdrsz = p_phdr;
 	phdrsz = r_buf_size(buf) - p_phdr;
-	code_pa = r_buf_size(buf);
+	code_pa = r_buf_size (buf);
 	code_va = code_pa + baddr;
 	phoff = 0x34;//p_phdr ;
 	filesize = code_pa + codelen + datalen;

--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -55,15 +55,15 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	H (2); // e_type = ET_EXEC
 	H (62); // e_machine = EM_X86_64
 	D (1); // e_version = EV_CURRENT
-	p_start = buf->length;
+	p_start = r_buf_size(buf);
 	Q (-1); // e_entry = 0xFFFFFFFF
-	p_phoff = buf->length;
+	p_phoff = r_buf_size(buf);
 	Q (-1); // e_phoff = 0xFFFFFFFF
 	Q (0);  // e_shoff = 0xFFFFFFFF
 	D (0);  // e_flags
-	p_ehdrsz = buf->length;
+	p_ehdrsz = r_buf_size(buf);
 	H (-1); // e_ehsize = 0xFFFFFFFF
-	p_phdrsz = buf->length;
+	p_phdrsz = r_buf_size(buf);
 	H (-1); // e_phentsize = 0xFFFFFFFF
 	H (1);  // e_phnum
 	H (0);  // e_shentsize
@@ -71,24 +71,24 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	H (0);  // e_shstrndx
 
 	/* Phdr */
-	p_phdr = buf->length;
+	p_phdr = r_buf_size(buf);
 	D (1);  // p_type
 	D (5);  // p_flags = PF_R | PF_X
 	Q (0);  // p_offset
-	p_vaddr = buf->length;
+	p_vaddr = r_buf_size(buf);
 	Q (-1); // p_vaddr = 0xFFFFFFFF
-	p_paddr = buf->length;
+	p_paddr = r_buf_size(buf);
 	Q (-1); // p_paddr = 0xFFFFFFFF
-	p_fs = buf->length;
+	p_fs = r_buf_size(buf);
 	Q (-1); // p_filesz
-	p_fs2 = buf->length;
+	p_fs2 = r_buf_size(buf);
 	Q (-1); // p_memsz
 	Q (0x200000); // p_align
 
 	/* Calc fields */
 	ehdrsz = p_phdr;
-	phdrsz = buf->length - p_phdr;
-	code_pa = buf->length;
+	phdrsz = r_buf_size(buf) - p_phdr;
+	code_pa = r_buf_size(buf);
 	code_va = code_pa + baddr;
 	phoff = p_phdr;
 	filesize = code_pa + codelen + datalen;

--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -55,15 +55,15 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	H (2); // e_type = ET_EXEC
 	H (62); // e_machine = EM_X86_64
 	D (1); // e_version = EV_CURRENT
-	p_start = r_buf_size(buf);
+	p_start = r_buf_size (buf);
 	Q (-1); // e_entry = 0xFFFFFFFF
-	p_phoff = r_buf_size(buf);
+	p_phoff = r_buf_size (buf);
 	Q (-1); // e_phoff = 0xFFFFFFFF
 	Q (0);  // e_shoff = 0xFFFFFFFF
 	D (0);  // e_flags
-	p_ehdrsz = r_buf_size(buf);
+	p_ehdrsz = r_buf_size (buf);
 	H (-1); // e_ehsize = 0xFFFFFFFF
-	p_phdrsz = r_buf_size(buf);
+	p_phdrsz = r_buf_size (buf);
 	H (-1); // e_phentsize = 0xFFFFFFFF
 	H (1);  // e_phnum
 	H (0);  // e_shentsize
@@ -71,23 +71,23 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	H (0);  // e_shstrndx
 
 	/* Phdr */
-	p_phdr = r_buf_size(buf);
+	p_phdr = r_buf_size (buf);
 	D (1); // p_type
 	D (5);  // p_flags = PF_R | PF_X
 	Q (0);  // p_offset
-	p_vaddr = r_buf_size(buf);
+	p_vaddr = r_buf_size (buf);
 	Q (-1); // p_vaddr = 0xFFFFFFFF
-	p_paddr = r_buf_size(buf);
+	p_paddr = r_buf_size (buf);
 	Q (-1); // p_paddr = 0xFFFFFFFF
-	p_fs = r_buf_size(buf);
+	p_fs = r_buf_size (buf);
 	Q (-1); // p_filesz
-	p_fs2 = r_buf_size(buf);
+	p_fs2 = r_buf_size (buf);
 	Q (-1); // p_memsz
 	Q (0x200000); // p_align
 
 	/* Calc fields */
 	ehdrsz = p_phdr;
-	phdrsz = r_buf_size(buf) - p_phdr;
+	phdrsz = r_buf_size (buf) - p_phdr;
 	code_pa = r_buf_size (buf);
 	code_va = code_pa + baddr;
 	phoff = p_phdr;

--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -72,7 +72,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 
 	/* Phdr */
 	p_phdr = r_buf_size(buf);
-	D (1);  // p_type
+	D (1); // p_type
 	D (5);  // p_flags = PF_R | PF_X
 	Q (0);  // p_offset
 	p_vaddr = r_buf_size(buf);
@@ -88,7 +88,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	/* Calc fields */
 	ehdrsz = p_phdr;
 	phdrsz = r_buf_size(buf) - p_phdr;
-	code_pa = r_buf_size(buf);
+	code_pa = r_buf_size (buf);
 	code_va = code_pa + baddr;
 	phoff = p_phdr;
 	filesize = code_pa + codelen + datalen;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -635,7 +635,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 #define D(x) r_buf_append_ut32(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size (buf);Z(x);W(p_tmp,y,strlen(y))
 
 	/* MACH0 HEADER */
 	B ("\xce\xfa\xed\xfe", 4); // header
@@ -673,11 +673,11 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 
 	/* COMMANDS */
 	D (ncmds); // ncmds
-	p_cmdsize = r_buf_size(buf);
+	p_cmdsize = r_buf_size (buf);
 	D (-1); // cmdsize
 	D (0); // flags
 	// D (0x01200085); // alternative flags found in some a.out..
-	magiclen = r_buf_size(buf);
+	magiclen = r_buf_size (buf);
 
 	if (use_pagezero) {
 		/* PAGEZERO */
@@ -701,7 +701,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 	D (baddr); // vmaddr
 	D (0x1000); // vmsize XXX
 	D (0); // fileoff
-	p_codefsz = r_buf_size(buf);
+	p_codefsz = r_buf_size (buf);
 	D (-1); // filesize
 	D (7); // maxprot
 	D (5); // initprot
@@ -711,9 +711,9 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 	WZ (16, "__TEXT");
 	p_codeva = r_buf_size (buf); // virtual address
 	D (-1);
-	p_codesz = r_buf_size(buf); // size of code (end-start)
+	p_codesz = r_buf_size (buf); // size of code (end-start)
 	D (-1);
-	p_codepa = r_buf_size(buf); // code - baddr
+	p_codepa = r_buf_size (buf); // code - baddr
 	D (-1); //_start-0x1000);
 	D (0); // align // should be 2 for 64bit
 	D (0); // reloff
@@ -726,7 +726,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 		/* DATA SEGMENT */
 		D (1); // cmd.LC_SEGMENT
 		D (124); // sizeof (cmd)
-		p_tmp = r_buf_size(buf);
+		p_tmp = r_buf_size (buf);
 		Z (16);
 		W (p_tmp, "__TEXT", 6); // segment name
 		D (0x2000); // vmaddr
@@ -742,9 +742,9 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 		WZ (16, "__data");
 		WZ (16, "__DATA");
 
-		p_datava = r_buf_size(buf);
+		p_datava = r_buf_size (buf);
 		D (-1);
-		p_datasz = r_buf_size(buf);
+		p_datasz = r_buf_size (buf);
 		D (-1);
 		p_datapa = r_buf_size (buf);
 		D (-1); //_start-0x1000);
@@ -822,23 +822,23 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 			/* arm */
 			D (1); // i386-thread-state
 			D (17); // thread-state-count
-			p_entry = r_buf_size(buf) + (16 * sizeof (ut32));
+			p_entry = r_buf_size (buf) + (16 * sizeof (ut32));
 			Z (17 * sizeof (ut32));
 			// mach0-arm has one byte more
 		} else {
 			/* x86-32 */
 			D (1); // i386-thread-state
 			D (16); // thread-state-count
-			p_entry = r_buf_size(buf) + (10 * sizeof (ut32));
+			p_entry = r_buf_size (buf) + (10 * sizeof (ut32));
 			Z (16 * sizeof (ut32));
 		}
 	}
 
 	/* padding to make mach_loader checks happy */
 	/* binaries must be at least of 4KB :( not tiny anymore */
-	WZ (4096 - r_buf_size(buf), "");
+	WZ (4096 - r_buf_size (buf), "");
 
-	cmdsize = r_buf_size(buf) - magiclen;
+	cmdsize = r_buf_size (buf) - magiclen;
 	codeva = r_buf_size (buf) + baddr;
 	datava = r_buf_size (buf) + clen + baddr;
 	if (p_entry != 0) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -709,7 +709,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 	D (0); // flags
 	WZ (16, "__text");
 	WZ (16, "__TEXT");
-	p_codeva = r_buf_size(buf); // virtual address
+	p_codeva = r_buf_size (buf); // virtual address
 	D (-1);
 	p_codesz = r_buf_size(buf); // size of code (end-start)
 	D (-1);
@@ -724,7 +724,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 
 	if (data && dlen > 0) {
 		/* DATA SEGMENT */
-		D (1);   // cmd.LC_SEGMENT
+		D (1); // cmd.LC_SEGMENT
 		D (124); // sizeof (cmd)
 		p_tmp = r_buf_size(buf);
 		Z (16);
@@ -732,7 +732,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 		D (0x2000); // vmaddr
 		D (0x1000); // vmsize
 		D (0); // fileoff
-		p_datafsz = r_buf_size(buf);
+		p_datafsz = r_buf_size (buf);
 		D (-1); // filesize
 		D (6); // maxprot
 		D (6); // initprot
@@ -746,7 +746,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 		D (-1);
 		p_datasz = r_buf_size(buf);
 		D (-1);
-		p_datapa = r_buf_size(buf);
+		p_datapa = r_buf_size (buf);
 		D (-1); //_start-0x1000);
 		D (2); // align
 		D (0); // reloff
@@ -839,8 +839,8 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 	WZ (4096 - r_buf_size(buf), "");
 
 	cmdsize = r_buf_size(buf) - magiclen;
-	codeva = r_buf_size(buf) + baddr;
-	datava = r_buf_size(buf) + clen + baddr;
+	codeva = r_buf_size (buf) + baddr;
+	datava = r_buf_size (buf) + clen + baddr;
 	if (p_entry != 0) {
 		W (p_entry, &codeva, 4); // set PC
 	}

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -635,7 +635,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 #define D(x) r_buf_append_ut32(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=buf->length;Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
 
 	/* MACH0 HEADER */
 	B ("\xce\xfa\xed\xfe", 4); // header
@@ -673,11 +673,11 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 
 	/* COMMANDS */
 	D (ncmds); // ncmds
-	p_cmdsize = buf->length;
+	p_cmdsize = r_buf_size(buf);
 	D (-1); // cmdsize
 	D (0); // flags
 	// D (0x01200085); // alternative flags found in some a.out..
-	magiclen = buf->length;
+	magiclen = r_buf_size(buf);
 
 	if (use_pagezero) {
 		/* PAGEZERO */
@@ -701,7 +701,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 	D (baddr); // vmaddr
 	D (0x1000); // vmsize XXX
 	D (0); // fileoff
-	p_codefsz = buf->length;
+	p_codefsz = r_buf_size(buf);
 	D (-1); // filesize
 	D (7); // maxprot
 	D (5); // initprot
@@ -709,11 +709,11 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 	D (0); // flags
 	WZ (16, "__text");
 	WZ (16, "__TEXT");
-	p_codeva = buf->length; // virtual address
+	p_codeva = r_buf_size(buf); // virtual address
 	D (-1);
-	p_codesz = buf->length; // size of code (end-start)
+	p_codesz = r_buf_size(buf); // size of code (end-start)
 	D (-1);
-	p_codepa = buf->length; // code - baddr
+	p_codepa = r_buf_size(buf); // code - baddr
 	D (-1); //_start-0x1000);
 	D (0); // align // should be 2 for 64bit
 	D (0); // reloff
@@ -726,13 +726,13 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 		/* DATA SEGMENT */
 		D (1);   // cmd.LC_SEGMENT
 		D (124); // sizeof (cmd)
-		p_tmp = buf->length;
+		p_tmp = r_buf_size(buf);
 		Z (16);
 		W (p_tmp, "__TEXT", 6); // segment name
 		D (0x2000); // vmaddr
 		D (0x1000); // vmsize
 		D (0); // fileoff
-		p_datafsz = buf->length;
+		p_datafsz = r_buf_size(buf);
 		D (-1); // filesize
 		D (6); // maxprot
 		D (6); // initprot
@@ -742,11 +742,11 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 		WZ (16, "__data");
 		WZ (16, "__DATA");
 
-		p_datava = buf->length;
+		p_datava = r_buf_size(buf);
 		D (-1);
-		p_datasz = buf->length;
+		p_datasz = r_buf_size(buf);
 		D (-1);
-		p_datapa = buf->length;
+		p_datapa = r_buf_size(buf);
 		D (-1); //_start-0x1000);
 		D (2); // align
 		D (0); // reloff
@@ -822,25 +822,25 @@ static RBuffer *create(RBin *bin, const ut8 *code, int clen, const ut8 *data, in
 			/* arm */
 			D (1); // i386-thread-state
 			D (17); // thread-state-count
-			p_entry = buf->length + (16 * sizeof (ut32));
+			p_entry = r_buf_size(buf) + (16 * sizeof (ut32));
 			Z (17 * sizeof (ut32));
 			// mach0-arm has one byte more
 		} else {
 			/* x86-32 */
 			D (1); // i386-thread-state
 			D (16); // thread-state-count
-			p_entry = buf->length + (10 * sizeof (ut32));
+			p_entry = r_buf_size(buf) + (10 * sizeof (ut32));
 			Z (16 * sizeof (ut32));
 		}
 	}
 
 	/* padding to make mach_loader checks happy */
 	/* binaries must be at least of 4KB :( not tiny anymore */
-	WZ (4096 - buf->length, "");
+	WZ (4096 - r_buf_size(buf), "");
 
-	cmdsize = buf->length - magiclen;
-	codeva = buf->length + baddr;
-	datava = buf->length + clen + baddr;
+	cmdsize = r_buf_size(buf) - magiclen;
+	codeva = r_buf_size(buf) + baddr;
+	datava = r_buf_size(buf) + clen + baddr;
 	if (p_entry != 0) {
 		W (p_entry, &codeva, 4); // set PC
 	}

--- a/libr/bin/p/bin_mach064.c
+++ b/libr/bin/p/bin_mach064.c
@@ -117,11 +117,11 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	// define section
 	WZ (16, "__text");
 	WZ (16, "__TEXT");
-	p_codeva = r_buf_size(buf); // virtual address
+	p_codeva = r_buf_size (buf); // virtual address
 	Q (-1);
-	p_codesz = r_buf_size(buf); // size of code (end-start)
+	p_codesz = r_buf_size (buf); // size of code (end-start)
 	Q (-1);
-	p_codepa = r_buf_size(buf); // code - baddr
+	p_codepa = r_buf_size (buf); // code - baddr
 	D (-1); // offset, _start-0x1000);
 	D (2); // align
 	D (0); // reloff
@@ -131,19 +131,19 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	D (0); // reserved2
 	D (0); // reserved3
 
-	if (data && datalen>0) {
+	if (data && datalen > 0) {
 		/* DATA SEGMENT */
 		D (0x19);   // cmd.LC_SEGMENT_64
 		D (124+28); // sizeof (cmd)
 		p_tmp = r_buf_size(buf);
 		Z (16);
 		W (p_tmp, "__TEXT", 6); // segment name
-//XXX must be vmaddr+baddr
+		//XXX must be vmaddr+baddr
 		Q (0x2000); // vmaddr
-//XXX must be vmaddr+baddr
+		//XXX must be vmaddr+baddr
 		Q (0x1000); // vmsize
 		Q (0); // fileoff
-		p_datafsz = r_buf_size(buf);
+		p_datafsz = r_buf_size (buf);
 		Q (-1); // filesize
 		D (6); // maxprot
 		D (6); // initprot
@@ -157,7 +157,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 		Q (-1);
 		p_datasz = r_buf_size(buf);
 		Q (-1);
-		p_datapa = r_buf_size(buf);
+		p_datapa = r_buf_size (buf);
 		D (-1); //_start-0x1000);
 		D (2); // align
 		D (0); // reloff
@@ -171,7 +171,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	if (use_dylinker) {
 		if (use_linkedit) {
 			/* LINKEDIT */
-			D (0x19);   // cmd.LC_SEGMENT
+			D (0x19); // cmd.LC_SEGMENT
 			D (72); // sizeof (cmd)
 			WZ (16, "__LINKEDIT");
 			Q (0x3000); // vmaddr
@@ -237,10 +237,10 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	}
 
 	WZ (4096 - r_buf_size(buf), "");
-	headerlen = r_buf_size(buf) - magiclen;
+	headerlen = r_buf_size (buf) - magiclen;
 
 	codeva = r_buf_size(buf) + baddr;
-	datava = r_buf_size(buf) + codelen + baddr;
+	datava = r_buf_size (buf) + codelen + baddr;
 
 	if (p_entry != 0) {
 		W (p_entry, &codeva, 8); // set PC

--- a/libr/bin/p/bin_mach064.c
+++ b/libr/bin/p/bin_mach064.c
@@ -51,7 +51,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 #define Q(x) r_buf_append_ut64(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size (buf);Z(x);W(p_tmp,y,strlen(y))
 
 	/* MACH0 HEADER */
 	// 32bit B ("\xce\xfa\xed\xfe", 4); // header
@@ -77,12 +77,12 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 
 	/* COMMANDS */
 	D (ncmds); // ncmds
-	p_cmdsize = r_buf_size(buf);
+	p_cmdsize = r_buf_size (buf);
 	D (-1); // headsize // cmdsize?
 	D (0);//0x85); // flags
 	D (0); // reserved -- only found in x86-64
 
-	magiclen = r_buf_size(buf);
+	magiclen = r_buf_size (buf);
 
 	if (use_pagezero) {
 		/* PAGEZERO */
@@ -108,7 +108,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	Q (0x1000); // vmsize XXX
 
 	Q (0); // fileoff
-	p_codefsz = r_buf_size(buf);
+	p_codefsz = r_buf_size (buf);
 	Q (-1); // filesize
 	D (7); // maxprot
 	D (5); // initprot
@@ -135,7 +135,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 		/* DATA SEGMENT */
 		D (0x19);   // cmd.LC_SEGMENT_64
 		D (124+28); // sizeof (cmd)
-		p_tmp = r_buf_size(buf);
+		p_tmp = r_buf_size (buf);
 		Z (16);
 		W (p_tmp, "__TEXT", 6); // segment name
 		//XXX must be vmaddr+baddr
@@ -153,9 +153,9 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 		WZ (16, "__data");
 		WZ (16, "__DATA");
 
-		p_datava = r_buf_size(buf);
+		p_datava = r_buf_size (buf);
 		Q (-1);
-		p_datasz = r_buf_size(buf);
+		p_datasz = r_buf_size (buf);
 		Q (-1);
 		p_datapa = r_buf_size (buf);
 		D (-1); //_start-0x1000);
@@ -232,14 +232,14 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 		D (184); // sizeof (cmd)
 		D (4); // 1=i386, 4=x86_64
 		D (42); // thread-state-count
-		p_entry = r_buf_size(buf) + (16*sizeof (ut64));
+		p_entry = r_buf_size (buf) + (16*sizeof (ut64));
 		Z (STATESIZE);
 	}
 
-	WZ (4096 - r_buf_size(buf), "");
+	WZ (4096 - r_buf_size (buf), "");
 	headerlen = r_buf_size (buf) - magiclen;
 
-	codeva = r_buf_size(buf) + baddr;
+	codeva = r_buf_size (buf) + baddr;
 	datava = r_buf_size (buf) + codelen + baddr;
 
 	if (p_entry != 0) {

--- a/libr/bin/p/bin_nes.c
+++ b/libr/bin/p/bin_nes.c
@@ -16,7 +16,7 @@ static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut
 }
 
 static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
-	if (!check_bytes (r_buf_get_at (buf, 0, NULL), r_buf_size(buf))) {
+	if (!check_bytes (r_buf_get_at (buf, 0, NULL), r_buf_size (buf))) {
 		return NULL;
 	}
 	return r_buf_new ();

--- a/libr/bin/p/bin_nes.c
+++ b/libr/bin/p/bin_nes.c
@@ -16,7 +16,7 @@ static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut
 }
 
 static void *load_buffer(RBinFile *bf, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
-	if (!check_bytes (r_buf_get_at (buf, 0, NULL), buf->length)) {
+	if (!check_bytes (r_buf_get_at (buf, 0, NULL), r_buf_size(buf))) {
 		return NULL;
 	}
 	return r_buf_new ();

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -39,7 +39,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 #define D(x) r_buf_append_ut32(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=buf->length;Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
 
 	B ("MZ\x00\x00", 4); // MZ Header
 	B ("PE\x00\x00", 4); // PE Signature
@@ -48,16 +48,16 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	D (0); // Timestamp (Unused)
 	D (0); // PointerToSymbolTable (Unused)
 	D (0); // NumberOfSymbols (Unused)
-	p_lsrlc = buf->length;
+	p_lsrlc = r_buf_size(buf);
 	H (-1); // SizeOfOptionalHeader
 	H (0x103); // Characteristics
 
 	/* Optional Header */
-	p_opthdr = buf->length;
+	p_opthdr = r_buf_size(buf);
 	H (0x10b); // Magic
 	B ("\x08\x00", 2); // (Major/Minor)LinkerVersion (Unused)
 
-	p_sections = buf->length;
+	p_sections = r_buf_size(buf);
 	n = p_sections-p_opthdr;
 	W (p_lsrlc, &n, 2); // Fix SizeOfOptionalHeader
 

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -39,7 +39,7 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 #define D(x) r_buf_append_ut32(buf,x)
 #define Z(x) r_buf_append_nbytes(buf,x)
 #define W(x,y,z) r_buf_write_at(buf,x,(const ut8*)(y),z)
-#define WZ(x,y) p_tmp=r_buf_size(buf);Z(x);W(p_tmp,y,strlen(y))
+#define WZ(x,y) p_tmp=r_buf_size (buf);Z(x);W(p_tmp,y,strlen(y))
 
 	B ("MZ\x00\x00", 4); // MZ Header
 	B ("PE\x00\x00", 4); // PE Signature

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -48,17 +48,17 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	D (0); // Timestamp (Unused)
 	D (0); // PointerToSymbolTable (Unused)
 	D (0); // NumberOfSymbols (Unused)
-	p_lsrlc = r_buf_size(buf);
+	p_lsrlc = r_buf_size (buf);
 	H (-1); // SizeOfOptionalHeader
 	H (0x103); // Characteristics
 
 	/* Optional Header */
-	p_opthdr = r_buf_size(buf);
+	p_opthdr = r_buf_size (buf);
 	H (0x10b); // Magic
 	B ("\x08\x00", 2); // (Major/Minor)LinkerVersion (Unused)
 
-	p_sections = r_buf_size(buf);
-	n = p_sections-p_opthdr;
+	p_sections = r_buf_size (buf);
+	n = p_sections - p_opthdr;
 	W (p_lsrlc, &n, 2); // Fix SizeOfOptionalHeader
 
 	/* Sections */

--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -284,7 +284,7 @@ static RList *sections(RBinFile *bf) {
 		ut64 baddr = r_read_be32 (&hdr.RomStart);
 		ptr->vaddr += baddr;
 	}
-	ptr->size = ptr->vsize = r_buf_size(bf->buf) - ptr->paddr;
+	ptr->size = ptr->vsize = r_buf_size (bf->buf) - ptr->paddr;
 	ptr->perm = R_PERM_RX;
 	ptr->add = true;
 	r_list_append (ret, ptr);

--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -284,7 +284,7 @@ static RList *sections(RBinFile *bf) {
 		ut64 baddr = r_read_be32 (&hdr.RomStart);
 		ptr->vaddr += baddr;
 	}
-	ptr->size = ptr->vsize = bf->buf->length - ptr->paddr;
+	ptr->size = ptr->vsize = r_buf_size(bf->buf) - ptr->paddr;
 	ptr->perm = R_PERM_RX;
 	ptr->add = true;
 	r_list_append (ret, ptr);

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -15,7 +15,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 
 static bool check_bytes_buf(RBuffer* rbuf) {
 	ut8 buf[4] = {0};
-	return rbuf && r_buf_read(rbuf, buf, 4) == 4 && !memcmp (buf, R_BIN_WASM_MAGIC_BYTES, 4);
+	return rbuf && r_buf_read (rbuf, buf, 4) == 4 && !memcmp (buf, R_BIN_WASM_MAGIC_BYTES, 4);
 }
 
 static bool find_symbol(const ut32 *p, const RBinWasmSymbol* q) {

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -312,7 +312,7 @@ static ut64 size(RBinFile *bf) {
 	if (!bf || !bf->buf) {
 		return 0;
 	}
-	return r_buf_size(bf->buf);
+	return r_buf_size (bf->buf);
 }
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -15,7 +15,7 @@ static bool check_bytes(const ut8 *buf, ut64 length) {
 
 static bool check_bytes_buf(RBuffer* rbuf) {
 	ut8 buf[4] = {0};
-	return rbuf && r_buf_read_at (rbuf, R_BUF_CUR, buf, 4) == 4 && !memcmp (buf, R_BIN_WASM_MAGIC_BYTES, 4);
+	return rbuf && r_buf_read(rbuf, buf, 4) == 4 && !memcmp (buf, R_BIN_WASM_MAGIC_BYTES, 4);
 }
 
 static bool find_symbol(const ut32 *p, const RBinWasmSymbol* q) {

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -312,7 +312,7 @@ static ut64 size(RBinFile *bf) {
 	if (!bf || !bf->buf) {
 		return 0;
 	}
-	return bf->buf->length;
+	return r_buf_size(bf->buf);
 }
 
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */

--- a/libr/bin/p/bin_xtr_dyldcache.c
+++ b/libr/bin/p/bin_xtr_dyldcache.c
@@ -136,7 +136,7 @@ static RBinXtrData *oneshot(RBin *bin, const ut8* buf, ut64 size, int idx) {
 	r_bin_dydlcache_get_libname (lib, &libname);
 	metadata->libname = strdup (libname);
 
-	res = r_bin_xtrdata_new (lib->b, lib->offset, r_buf_size(lib->b), nlib, metadata);
+	res = r_bin_xtrdata_new (lib->b, lib->offset, r_buf_size (lib->b), nlib, metadata);
 	r_buf_free (lib->b);
 	free (hdr);
 	free (lib);

--- a/libr/bin/p/bin_xtr_dyldcache.c
+++ b/libr/bin/p/bin_xtr_dyldcache.c
@@ -136,7 +136,7 @@ static RBinXtrData *oneshot(RBin *bin, const ut8* buf, ut64 size, int idx) {
 	r_bin_dydlcache_get_libname (lib, &libname);
 	metadata->libname = strdup (libname);
 
-	res = r_bin_xtrdata_new (lib->b, lib->offset, lib->b->length, nlib, metadata);
+	res = r_bin_xtrdata_new (lib->b, lib->offset, r_buf_size(lib->b), nlib, metadata);
 	r_buf_free (lib->b);
 	free (hdr);
 	free (lib);

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -124,7 +124,7 @@ static RList *sections(RBinFile *bf) {
 		return NULL;
 	}
 	text->name = strdup ("text");
-	text->size = bf->buf->length - N64_ROM_START;
+	text->size = r_buf_size(bf->buf) - N64_ROM_START;
 	text->vsize = text->size;
 	text->paddr = N64_ROM_START;
 	text->vaddr = baddr (bf);

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -124,7 +124,7 @@ static RList *sections(RBinFile *bf) {
 		return NULL;
 	}
 	text->name = strdup ("text");
-	text->size = r_buf_size(bf->buf) - N64_ROM_START;
+	text->size = r_buf_size (bf->buf) - N64_ROM_START;
 	text->vsize = text->size;
 	text->paddr = N64_ROM_START;
 	text->vaddr = baddr (bf);

--- a/libr/bin/pdb/stream_file.c
+++ b/libr/bin/pdb/stream_file.c
@@ -35,7 +35,7 @@ static void stream_file_read_pages(R_STREAM_FILE *stream_file, int start_indx, i
 		if (page_offset < 1) {
 			return;
 		}
-		stream_file->buf->cur = page_offset;
+		r_buf_seek(stream_file->buf, page_offset, 0);
 		r_buf_read_at (stream_file->buf, page_offset,
 			(ut8*)res, stream_file->page_size);
 		res += stream_file->page_size;

--- a/libr/bin/pdb/stream_file.c
+++ b/libr/bin/pdb/stream_file.c
@@ -35,7 +35,7 @@ static void stream_file_read_pages(R_STREAM_FILE *stream_file, int start_indx, i
 		if (page_offset < 1) {
 			return;
 		}
-		r_buf_seek(stream_file->buf, page_offset, 0);
+		r_buf_seek (stream_file->buf, page_offset, 0);
 		r_buf_read_at (stream_file->buf, page_offset,
 			(ut8 *)res, stream_file->page_size);
 		res += stream_file->page_size;

--- a/libr/bin/pdb/stream_file.c
+++ b/libr/bin/pdb/stream_file.c
@@ -37,7 +37,7 @@ static void stream_file_read_pages(R_STREAM_FILE *stream_file, int start_indx, i
 		}
 		r_buf_seek(stream_file->buf, page_offset, 0);
 		r_buf_read_at (stream_file->buf, page_offset,
-			(ut8*)res, stream_file->page_size);
+			(ut8 *)res, stream_file->page_size);
 		res += stream_file->page_size;
 	}
 }

--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -134,7 +134,7 @@ R_API int r_core_write_op(RCore *core, const char *arg, char op) {
 				goto beach;
 			}
 		} else {  // use clipboard as key
-			len = core->yank_buf->length;
+			len = r_buf_size (core->yank_buf);
 			if (len <= 0) {
 				eprintf ("Clipboard is empty and no value argument(s) given\n");
 				goto beach;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -337,7 +337,7 @@ R_API RAsmOp *r_core_disassemble (RCore *core, ut64 addr) {
 		b->base = addr;
 		r_buf_set_bytes (b, buf, sizeof (buf));
 	} else {
-		if ((addr < b->base) || addr > (b->base + r_buf_size(b) - 32)) {
+		if ((addr < b->base) || addr > (b->base + r_buf_size (b) - 32)) {
 			if (!r_io_read_at (core->io, addr, buf, sizeof (buf))) {
 				return NULL;
 			}
@@ -348,7 +348,7 @@ R_API RAsmOp *r_core_disassemble (RCore *core, ut64 addr) {
 	delta = addr - b->base;
 	op = R_NEW0 (RAsmOp);
 	r_asm_set_pc (core->assembler, addr);
-	if (r_asm_disassemble (core->assembler, op, b->buf + delta, r_buf_size(b)) < 1) {
+	if (r_asm_disassemble (core->assembler, op, b->buf + delta, r_buf_size (b)) < 1) {
 		free (op);
 		return NULL;
 	}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -337,7 +337,7 @@ R_API RAsmOp *r_core_disassemble (RCore *core, ut64 addr) {
 		b->base = addr;
 		r_buf_set_bytes (b, buf, sizeof (buf));
 	} else {
-		if ((addr < b->base) || addr > (b->base + b->length - 32)) {
+		if ((addr < b->base) || addr > (b->base + r_buf_size(b) - 32)) {
 			if (!r_io_read_at (core->io, addr, buf, sizeof (buf))) {
 				return NULL;
 			}
@@ -348,7 +348,7 @@ R_API RAsmOp *r_core_disassemble (RCore *core, ut64 addr) {
 	delta = addr - b->base;
 	op = R_NEW0 (RAsmOp);
 	r_asm_set_pc (core->assembler, addr);
-	if (r_asm_disassemble (core->assembler, op, b->buf + delta, b->length) < 1) {
+	if (r_asm_disassemble (core->assembler, op, b->buf + delta, r_buf_size(b)) < 1) {
 		free (op);
 		return NULL;
 	}
@@ -629,7 +629,7 @@ static int cmd_yank(void *data, const char *input) {
 		r_core_yank (core, core->offset, r_num_math (core->num, input + 1));
 		break;
 	case 'l': // "yl"
-		core->num->value = core->yank_buf->length;
+		core->num->value = r_buf_size (core->yank_buf);
 		break;
 	case 'y': // "yy"
 		while (input[1] == ' ') {
@@ -678,7 +678,7 @@ static int cmd_yank(void *data, const char *input) {
 	case 't': // "wt"
 		if (input[1] == 'f') { // "wtf"
 			const char *file = r_str_trim_ro (input + 2);
-			if (!r_file_dump (file, core->yank_buf->buf, core->yank_buf->length, false)) {
+			if (!r_file_dump (file, core->yank_buf->buf, r_buf_size (core->yank_buf), false)) {
 				eprintf ("Cannot dump to '%s'\n", file);
 			}
 		} else if (input[1] == ' ') {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4408,7 +4408,7 @@ static void consumeBuffer(RBuffer *buf, const char *cmd, const char *errmsg) {
 		r_cons_printf ("%s", cmd);
 	}
 	int i;
-	for (i = 0; i < buf->length; i++) {
+	for (i = 0; i < r_buf_size(buf); i++) {
 		r_cons_printf ("%02x", buf->buf[i]);
 	}
 	r_cons_printf ("\n");
@@ -4991,7 +4991,7 @@ static int cmd_debug(void *data, const char *input) {
 			b = r_egg_get_bin (egg);
 			r_asm_set_pc (core->assembler, core->offset);
 			r_reg_arena_push (core->dbg->reg);
-			r_debug_execute (core->dbg, b->buf, b->length, 0);
+			r_debug_execute (core->dbg, b->buf, r_buf_size(b), 0);
 			r_reg_arena_pop (core->dbg->reg);
 			break;
 		}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4408,7 +4408,7 @@ static void consumeBuffer(RBuffer *buf, const char *cmd, const char *errmsg) {
 		r_cons_printf ("%s", cmd);
 	}
 	int i;
-	for (i = 0; i < r_buf_size(buf); i++) {
+	for (i = 0; i < r_buf_size (buf); i++) {
 		r_cons_printf ("%02x", buf->buf[i]);
 	}
 	r_cons_printf ("\n");
@@ -4991,7 +4991,7 @@ static int cmd_debug(void *data, const char *input) {
 			b = r_egg_get_bin (egg);
 			r_asm_set_pc (core->assembler, core->offset);
 			r_reg_arena_push (core->dbg->reg);
-			r_debug_execute (core->dbg, b->buf, r_buf_size(b), 0);
+			r_debug_execute (core->dbg, b->buf, r_buf_size (b), 0);
 			r_reg_arena_pop (core->dbg->reg);
 			break;
 		}

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -43,8 +43,8 @@ static void cmd_egg_option(REgg *egg, const char *key, const char *input) {
 
 static void showBuffer(RBuffer *b) {
 	int i;
-	if (b && b->length > 0) {
-		for (i = 0; i < b->length; i++) {
+	if (b && r_buf_size(b) > 0) {
+		for (i = 0; i < r_buf_size(b); i++) {
 			r_cons_printf ("%02x", b->buf[i]);
 		}
 		r_cons_newline ();

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -43,7 +43,7 @@ static void cmd_egg_option(REgg *egg, const char *key, const char *input) {
 
 static void showBuffer(RBuffer *b) {
 	int i;
-	if (b && r_buf_size(b) > 0) {
+	if (b && r_buf_size (b) > 0) {
 		for (i = 0; i < r_buf_size (b); i++) {
 			r_cons_printf ("%02x", b->buf[i]);
 		}

--- a/libr/core/cmd_egg.c
+++ b/libr/core/cmd_egg.c
@@ -44,7 +44,7 @@ static void cmd_egg_option(REgg *egg, const char *key, const char *input) {
 static void showBuffer(RBuffer *b) {
 	int i;
 	if (b && r_buf_size(b) > 0) {
-		for (i = 0; i < r_buf_size(b); i++) {
+		for (i = 0; i < r_buf_size (b); i++) {
 			r_cons_printf ("%02x", b->buf[i]);
 		}
 		r_cons_newline ();

--- a/libr/core/patch.c
+++ b/libr/core/patch.c
@@ -98,8 +98,8 @@ static int __core_patch_bracket(RCore *core, const char *str, ut64 *noff) {
 	if (strcmp (off, "+")) {
 		*noff = r_num_math (core->num, off);
 	}
-	r_core_write_at (core, *noff, b->buf, b->length);
-	*noff += b->length;
+	r_core_write_at (core, *noff, b->buf, r_buf_size(b));
+	*noff += r_buf_size(b);
 	free (off);
 	return 1;
 }

--- a/libr/core/patch.c
+++ b/libr/core/patch.c
@@ -99,12 +99,12 @@ static int __core_patch_bracket(RCore *core, const char *str, ut64 *noff) {
 		*noff = r_num_math (core->num, off);
 	}
 	r_core_write_at (core, *noff, b->buf, r_buf_size(b));
-	*noff += r_buf_size(b);
+	*noff += r_buf_size (b);
 	free (off);
 	return 1;
 }
 
-R_API int r_core_patch (RCore *core, const char *patch) {
+R_API int r_core_patch(RCore *core, const char *patch) {
 	char *p, *p0, *str;
 	ut64 noff = 0LL;
 

--- a/libr/core/patch.c
+++ b/libr/core/patch.c
@@ -98,7 +98,7 @@ static int __core_patch_bracket(RCore *core, const char *str, ut64 *noff) {
 	if (strcmp (off, "+")) {
 		*noff = r_num_math (core->num, off);
 	}
-	r_core_write_at (core, *noff, b->buf, r_buf_size(b));
+	r_core_write_at (core, *noff, b->buf, r_buf_size (b));
 	*noff += r_buf_size (b);
 	free (off);
 	return 1;

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -189,7 +189,7 @@ R_API int r_core_yank_paste(RCore *core, ut64 addr, int len) {
 		return false;
 	}
 	if (len == 0 || len >= r_buf_size(core->yank_buf)) {
-		len = r_buf_size(core->yank_buf);
+		len = r_buf_size (core->yank_buf);
 	}
 	r_core_write_at (core, addr, core->yank_buf->buf, len);
 	return true;
@@ -236,7 +236,7 @@ R_API int r_core_yank_dump(RCore *core, ut64 pos) {
 			r_cons_printf ("0x%08"PFMT64x " %d ",
 				core->yank_buf->base + pos,
 				r_buf_size(core->yank_buf) - pos);
-			for (i = pos; i < r_buf_size(core->yank_buf); i++) {
+			for (i = pos; i < r_buf_size (core->yank_buf); i++) {
 				r_cons_printf ("%02x",
 					core->yank_buf->buf[i]);
 			}
@@ -253,7 +253,7 @@ R_API int r_core_yank_dump(RCore *core, ut64 pos) {
 
 R_API int r_core_yank_hexdump(RCore *core, ut64 pos) {
 	int res = false;
-	int ybl = r_buf_size(core->yank_buf);
+	int ybl = r_buf_size (core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			r_print_hexdump (core->print, pos,
@@ -273,8 +273,8 @@ R_API int r_core_yank_cat(RCore *core, ut64 pos) {
 	int ybl = r_buf_size(core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
-			r_cons_memcat ((const char *) core->yank_buf->buf + pos,
-				r_buf_size(core->yank_buf) - pos);
+			r_cons_memcat ((const char *)core->yank_buf->buf + pos,
+				r_buf_size (core->yank_buf) - pos);
 			r_cons_newline ();
 			return true;
 		}

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -188,7 +188,7 @@ R_API int r_core_yank_paste(RCore *core, ut64 addr, int len) {
 	if (len < 0) {
 		return false;
 	}
-	if (len == 0 || len >= r_buf_size(core->yank_buf)) {
+	if (len == 0 || len >= r_buf_size (core->yank_buf)) {
 		len = r_buf_size (core->yank_buf);
 	}
 	r_core_write_at (core, addr, core->yank_buf->buf, len);
@@ -230,12 +230,12 @@ R_API int r_core_yank_to(RCore *core, const char *_arg) {
 
 R_API int r_core_yank_dump(RCore *core, ut64 pos) {
 	int res = false, i = 0;
-	int ybl = r_buf_size(core->yank_buf);
+	int ybl = r_buf_size (core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			r_cons_printf ("0x%08"PFMT64x " %d ",
 				core->yank_buf->base + pos,
-				r_buf_size(core->yank_buf) - pos);
+				r_buf_size (core->yank_buf) - pos);
 			for (i = pos; i < r_buf_size (core->yank_buf); i++) {
 				r_cons_printf ("%02x",
 					core->yank_buf->buf[i]);
@@ -270,7 +270,7 @@ R_API int r_core_yank_hexdump(RCore *core, ut64 pos) {
 }
 
 R_API int r_core_yank_cat(RCore *core, ut64 pos) {
-	int ybl = r_buf_size(core->yank_buf);
+	int ybl = r_buf_size (core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			r_cons_memcat ((const char *)core->yank_buf->buf + pos,
@@ -286,7 +286,7 @@ R_API int r_core_yank_cat(RCore *core, ut64 pos) {
 }
 
 R_API int r_core_yank_cat_string(RCore *core, ut64 pos) {
-	int ybl = r_buf_size(core->yank_buf);
+	int ybl = r_buf_size (core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			int len = r_str_nlen ((const char *) core->yank_buf->buf + pos, ybl - pos);

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -188,8 +188,8 @@ R_API int r_core_yank_paste(RCore *core, ut64 addr, int len) {
 	if (len < 0) {
 		return false;
 	}
-	if (len == 0 || len >= core->yank_buf->length) {
-		len = core->yank_buf->length;
+	if (len == 0 || len >= r_buf_size(core->yank_buf)) {
+		len = r_buf_size(core->yank_buf);
 	}
 	r_core_write_at (core, addr, core->yank_buf->buf, len);
 	return true;
@@ -230,13 +230,13 @@ R_API int r_core_yank_to(RCore *core, const char *_arg) {
 
 R_API int r_core_yank_dump(RCore *core, ut64 pos) {
 	int res = false, i = 0;
-	int ybl = core->yank_buf->length;
+	int ybl = r_buf_size(core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			r_cons_printf ("0x%08"PFMT64x " %d ",
 				core->yank_buf->base + pos,
-				core->yank_buf->length - pos);
-			for (i = pos; i < core->yank_buf->length; i++) {
+				r_buf_size(core->yank_buf) - pos);
+			for (i = pos; i < r_buf_size(core->yank_buf); i++) {
 				r_cons_printf ("%02x",
 					core->yank_buf->buf[i]);
 			}
@@ -253,7 +253,7 @@ R_API int r_core_yank_dump(RCore *core, ut64 pos) {
 
 R_API int r_core_yank_hexdump(RCore *core, ut64 pos) {
 	int res = false;
-	int ybl = core->yank_buf->length;
+	int ybl = r_buf_size(core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			r_print_hexdump (core->print, pos,
@@ -270,11 +270,11 @@ R_API int r_core_yank_hexdump(RCore *core, ut64 pos) {
 }
 
 R_API int r_core_yank_cat(RCore *core, ut64 pos) {
-	int ybl = core->yank_buf->length;
+	int ybl = r_buf_size(core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			r_cons_memcat ((const char *) core->yank_buf->buf + pos,
-				core->yank_buf->length - pos);
+				r_buf_size(core->yank_buf) - pos);
 			r_cons_newline ();
 			return true;
 		}
@@ -286,7 +286,7 @@ R_API int r_core_yank_cat(RCore *core, ut64 pos) {
 }
 
 R_API int r_core_yank_cat_string(RCore *core, ut64 pos) {
-	int ybl = core->yank_buf->length;
+	int ybl = r_buf_size(core->yank_buf);
 	if (ybl > 0) {
 		if (pos < ybl) {
 			int len = r_str_nlen ((const char *) core->yank_buf->buf + pos, ybl - pos);

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1121,7 +1121,7 @@ static RDebugMap* linux_map_alloc (RDebug *dbg, ut64 addr, int size) {
 		ut64 map_addr;
 
 		r_reg_arena_push (dbg->reg);
-		map_addr = r_debug_execute (dbg, buf->buf, buf->length, 1);
+		map_addr = r_debug_execute (dbg, buf->buf, r_buf_size(buf), 1);
 		r_reg_arena_pop (dbg->reg);
 		if (map_addr != (ut64)-1) {
 			r_debug_map_sync (dbg);
@@ -1160,7 +1160,7 @@ static int linux_map_dealloc (RDebug *dbg, ut64 addr, int size) {
 	buf = r_egg_get_bin (dbg->egg);
 	if (buf) {
 		r_reg_arena_push (dbg->reg);
-		ret = r_debug_execute (dbg, buf->buf, buf->length, 1) == 0;
+		ret = r_debug_execute (dbg, buf->buf, r_buf_size(buf), 1) == 0;
 		r_reg_arena_pop (dbg->reg);
 	}
 err_linux_map_dealloc:
@@ -2007,7 +2007,7 @@ static int r_debug_native_map_protect (RDebug *dbg, ut64 addr, int size, int per
 	buf = r_egg_get_bin (dbg->egg);
 	if (buf) {
 		r_reg_arena_push (dbg->reg);
-		r_debug_execute (dbg, buf->buf, buf->length , 1);
+		r_debug_execute (dbg, buf->buf, r_buf_size(buf), 1);
 		r_reg_arena_pop (dbg->reg);
 		return true;
 	}

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1121,7 +1121,7 @@ static RDebugMap* linux_map_alloc (RDebug *dbg, ut64 addr, int size) {
 		ut64 map_addr;
 
 		r_reg_arena_push (dbg->reg);
-		map_addr = r_debug_execute (dbg, buf->buf, r_buf_size(buf), 1);
+		map_addr = r_debug_execute (dbg, buf->buf, r_buf_size (buf), 1);
 		r_reg_arena_pop (dbg->reg);
 		if (map_addr != (ut64)-1) {
 			r_debug_map_sync (dbg);
@@ -1161,7 +1161,7 @@ static int linux_map_dealloc(RDebug *dbg, ut64 addr, int size) {
 	buf = r_egg_get_bin (dbg->egg);
 	if (buf) {
 		r_reg_arena_push (dbg->reg);
-		ret = r_debug_execute (dbg, buf->buf, r_buf_size(buf), 1) == 0;
+		ret = r_debug_execute (dbg, buf->buf, r_buf_size (buf), 1) == 0;
 		r_reg_arena_pop (dbg->reg);
 	}
 err_linux_map_dealloc:
@@ -2008,7 +2008,7 @@ static int r_debug_native_map_protect (RDebug *dbg, ut64 addr, int size, int per
 	buf = r_egg_get_bin (dbg->egg);
 	if (buf) {
 		r_reg_arena_push (dbg->reg);
-		r_debug_execute (dbg, buf->buf, r_buf_size(buf), 1);
+		r_debug_execute (dbg, buf->buf, r_buf_size (buf), 1);
 		r_reg_arena_pop (dbg->reg);
 		return true;
 	}

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1132,14 +1132,15 @@ err_linux_map_alloc:
 	return map;
 }
 
-static int linux_map_dealloc (RDebug *dbg, ut64 addr, int size) {
+static int linux_map_dealloc(RDebug *dbg, ut64 addr, int size) {
 	RBuffer *buf = NULL;
 	char code[1024];
 	int ret = 0;
 	char *asm_list[] = {
-			"x86", "x86.as",
-			"x64", "x86.as",
-			NULL};
+		"x86", "x86.as",
+		"x64", "x86.as",
+		NULL
+	};
 	int num = r_syscall_get_num (dbg->anal->syscall, "munmap");
 
 	snprintf (code, sizeof (code),
@@ -1167,7 +1168,7 @@ err_linux_map_dealloc:
 	return ret;
 }
 #elif __WINDOWS__
-static int io_perms_to_prot (int io_perms) {
+static int io_perms_to_prot(int io_perms) {
 	int prot_perms;
 
 	if ((io_perms & R_PERM_RWX) == R_PERM_RWX) {

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -373,7 +373,7 @@ R_API void r_egg_append(REgg *egg, const char *src) {
 
 /* JIT : TODO: accept arguments here */
 R_API int r_egg_run(REgg *egg) {
-	return r_sys_run (egg->bin->buf, egg->bin->length);
+	return r_sys_run (egg->bin->buf, r_buf_size (egg->bin));
 }
 
 #define R_EGG_FILL_TYPE_TRAP
@@ -465,7 +465,7 @@ R_API int r_egg_shellcode(REgg *egg, const char *name) {
 				eprintf ("%s Shellcode has failed\n", p->name);
 				return false;
 			}
-			r_egg_raw (egg, b->buf, b->length);
+			r_egg_raw (egg, b->buf, r_buf_size(b));
 			r_buf_free (b);
 			return true;
 		}
@@ -514,14 +514,14 @@ R_API void r_egg_finalize(REgg *egg) {
 	}
 	r_list_foreach (egg->patches, iter, b) {
 		if (b->cur < 0) {
-			r_egg_append_bytes (egg, b->buf, b->length);
+			r_egg_append_bytes (egg, b->buf, r_buf_size(b));
 		} else {
 			// TODO: use r_buf_cpy_buf or what
-			if (b->length + b->cur > egg->bin->length) {
+			if (r_buf_size(b) + b->cur > r_buf_size (egg->bin)) {
 				eprintf ("Cannot patch outside\n");
 				return;
 			}
-			memcpy (egg->bin->buf + b->cur, b->buf, b->length);
+			memcpy (egg->bin->buf + b->cur, b->buf, r_buf_size(b));
 		}
 	}
 }

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -500,7 +500,7 @@ R_API int r_egg_patch(REgg *egg, int off, const ut8 *buf, int len) {
 		r_buf_free (b);
 		return false;
 	}
-	b->cur = off;
+	r_buf_seek(b, off, 0);
 	r_list_append (egg->patches, b);
 	return true;
 }
@@ -513,15 +513,16 @@ R_API void r_egg_finalize(REgg *egg) {
 		egg->bin = r_buf_new ();
 	}
 	r_list_foreach (egg->patches, iter, b) {
-		if (b->cur < 0) {
+		if (r_buf_seek(b, 0, 1) < 0) {
 			r_egg_append_bytes (egg, b->buf, r_buf_size(b));
 		} else {
 			// TODO: use r_buf_cpy_buf or what
-			if (r_buf_size(b) + b->cur > r_buf_size (egg->bin)) {
+			if (r_buf_size(b) + r_buf_seek(b, 0, 1) > r_buf_size (egg->bin)) {
 				eprintf ("Cannot patch outside\n");
 				return;
 			}
-			memcpy (egg->bin->buf + b->cur, b->buf, r_buf_size(b));
+			memcpy (egg->bin->buf + r_buf_seek(b, 0, 1), b->buf,
+				r_buf_size(b));
 		}
 	}
 }

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -533,7 +533,7 @@ R_API void r_egg_finalize(REgg *egg) {
 			const ut8 *buf = r_buf_buffer (ep->b);
 			int r = r_buf_write_at (egg->bin, ep->off, buf, sz);
 			if (r < sz) {
-				eprintf ("Cannot patch\n");
+				eprintf ("Cannot patch outside\n");
 				return;
 			}
 		}

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -400,14 +400,14 @@ static inline char *eon(char *n) {
 /* padding looks like:
   ([snatSNAT][0-9]+)*
 */
-R_API int r_egg_padding (REgg *egg, const char *pad) {
+R_API int r_egg_padding(REgg *egg, const char *pad) {
 	int number;
-	ut8* buf, padding_byte;
+	ut8 *buf, padding_byte;
 	char *p, *o = strdup (pad);
 
 	for (p = o; *p; ) { // parse pad string
 		const char f = *p++;
-		number = strtol(p, NULL, 10);
+		number = strtol (p, NULL, 10);
 
 		if (number < 1) {
 			eprintf ("Invalid padding length at %d\n", number);
@@ -419,8 +419,10 @@ R_API int r_egg_padding (REgg *egg, const char *pad) {
 		switch (f) {
 		case 's': case 'S': padding_byte = 0; break;
 		case 'n': case 'N': padding_byte = 0x90; break;
-		case 'a': case 'A': padding_byte = 'A'; break;
-		case 't': case 'T': padding_byte = 0xcc; break;
+		case 'a':
+		case 'A': padding_byte = 'A'; break;
+		case 't':
+		case 'T': padding_byte = 0xcc; break;
 		default:
 			eprintf ("Invalid padding format (%c)\n", *p);
 			eprintf ("Valid ones are:\n");

--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -475,7 +475,7 @@ R_API int r_egg_shellcode(REgg *egg, const char *name) {
 				eprintf ("%s Shellcode has failed\n", p->name);
 				return false;
 			}
-			r_egg_raw (egg, b->buf, r_buf_size(b));
+			r_egg_raw (egg, b->buf, r_buf_size (b));
 			r_buf_free (b);
 			return true;
 		}

--- a/libr/egg/p/egg_xor.c
+++ b/libr/egg/p/egg_xor.c
@@ -77,7 +77,7 @@ static RBuffer *build (REgg *egg) {
 		r_buf_append_bytes (buf, stub, STUBLEN);
 
 		for (i = 0; i<r_buf_size(sc); i++) {
-//			 eprintf ("%02x -> %02x\n", sc->buf[i], sc->buf[i] ^nkey);
+			//			 eprintf ("%02x -> %02x\n", sc->buf[i], sc->buf[i] ^nkey);
 			sc->buf[i]^=nkey;
 		}
 		r_buf_append_buf (buf, sc);

--- a/libr/egg/p/egg_xor.c
+++ b/libr/egg/p/egg_xor.c
@@ -27,19 +27,19 @@ static RBuffer *build (REgg *egg) {
 		nkey &= 0xff;
 		eprintf ("xor key wrapped to (%d)\n", nkey);
 	}
-	if (egg->bin->length > 240) { // XXX
+	if (r_buf_size (egg->bin) > 240) { // XXX
 		eprintf ("shellcode is too long :(\n");
 		free (key);
 		return NULL;
 	}
 	sc = egg->bin; // hack
-	if (!sc->length) {
+	if (!r_buf_size(sc)) {
 		eprintf ("No shellcode found!\n");
 		free (key);
 		return NULL;
 	}
 
-	for (i = 0; i<sc->length; i++) {
+	for (i = 0; i<r_buf_size(sc); i++) {
 		// eprintf ("%02x -> %02x\n", sc->buf[i], sc->buf[i] ^nkey);
 		if ((sc->buf[i]^nkey)==0) {
 			eprintf ("This xor key generates null bytes. Try again.\n");
@@ -66,7 +66,7 @@ static RBuffer *build (REgg *egg) {
 			"\xe2\xf9"; // loop loop0
 		// ecx = length
 		aux[0] = 0x6a; // push length
-		aux[1] = sc->length;
+		aux[1] = r_buf_size(sc);
 		aux[2] = 0x59; // pop ecx
 		// ebx = key
 		aux[3] = 0x6a; // push key
@@ -76,7 +76,7 @@ static RBuffer *build (REgg *egg) {
 
 		r_buf_append_bytes (buf, stub, STUBLEN);
 
-		for (i = 0; i<sc->length; i++) {
+		for (i = 0; i<r_buf_size(sc); i++) {
 //			 eprintf ("%02x -> %02x\n", sc->buf[i], sc->buf[i] ^nkey);
 			sc->buf[i]^=nkey;
 		}

--- a/libr/egg/p/egg_xor.c
+++ b/libr/egg/p/egg_xor.c
@@ -33,13 +33,13 @@ static RBuffer *build (REgg *egg) {
 		return NULL;
 	}
 	sc = egg->bin; // hack
-	if (!r_buf_size(sc)) {
+	if (!r_buf_size (sc)) {
 		eprintf ("No shellcode found!\n");
 		free (key);
 		return NULL;
 	}
 
-	for (i = 0; i<r_buf_size(sc); i++) {
+	for (i = 0; i<r_buf_size (sc); i++) {
 		// eprintf ("%02x -> %02x\n", sc->buf[i], sc->buf[i] ^nkey);
 		if ((sc->buf[i]^nkey)==0) {
 			eprintf ("This xor key generates null bytes. Try again.\n");
@@ -66,7 +66,7 @@ static RBuffer *build (REgg *egg) {
 			"\xe2\xf9"; // loop loop0
 		// ecx = length
 		aux[0] = 0x6a; // push length
-		aux[1] = r_buf_size(sc);
+		aux[1] = r_buf_size (sc);
 		aux[2] = 0x59; // pop ecx
 		// ebx = key
 		aux[3] = 0x6a; // push key
@@ -76,7 +76,7 @@ static RBuffer *build (REgg *egg) {
 
 		r_buf_append_bytes (buf, stub, STUBLEN);
 
-		for (i = 0; i<r_buf_size(sc); i++) {
+		for (i = 0; i<r_buf_size (sc); i++) {
 			//			 eprintf ("%02x -> %02x\n", sc->buf[i], sc->buf[i] ^nkey);
 			sc->buf[i]^=nkey;
 		}

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -10,7 +10,7 @@ extern "C" {
 
 typedef struct r_buf_t {
 	ut8 *buf;
-	ut64 length;
+	ut64 length_priv;
 	st64 cur;
 	ut64 base;
 	RMmap *mmap;
@@ -25,7 +25,7 @@ typedef struct r_buf_t {
 	void *iob;
 	ut64 offset;
 	ut64 limit;
-	struct r_buf_t * parent;
+	struct r_buf_t *parent;
 } RBuffer;
 
 typedef struct r_buf_cache_t {

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -29,7 +29,7 @@ typedef struct r_buf_t {
 } RBuffer;
 
 typedef struct r_buf_cache_t {
-        ut64 from;
+	ut64 from;
         ut64 to;
         int size;
         ut8 *data;
@@ -40,7 +40,7 @@ typedef struct r_buf_cache_t {
 R_API RBuffer *r_buf_new(void);
 R_API RBuffer *r_buf_new_with_io(void *iob, int fd);
 R_API RBuffer *r_buf_new_with_bytes(const ut8* bytes, ut64 len);
-R_API RBuffer *r_buf_new_with_string (const char *msg);
+R_API RBuffer *r_buf_new_with_string(const char *msg);
 R_API RBuffer *r_buf_new_with_pointers(const ut8 *bytes, ut64 len);
 R_API RBuffer *r_buf_new_with_buf(RBuffer *b);
 R_API RBuffer *r_buf_new_with_bufref(RBuffer *b);

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -11,7 +11,7 @@ extern "C" {
 typedef struct r_buf_t {
 	ut8 *buf;
 	ut64 length_priv;
-	st64 cur;
+	st64 cur_priv;
 	ut64 base;
 	RMmap *mmap;
 	bool empty;

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -78,6 +78,7 @@ R_API void r_buf_free(RBuffer *b);
 R_API bool r_buf_fini(RBuffer *b);
 R_API char *r_buf_free_to_string(RBuffer *b);
 R_API const ut8 *r_buf_buffer(RBuffer *b);
+R_API ut8 *r_buf_reserve(RBuffer *b, ut64 addr, ut64 len);
 R_API ut64 r_buf_size(RBuffer *b);
 R_API bool r_buf_resize(RBuffer *b, ut64 newsize);
 

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -79,7 +79,6 @@ R_API void r_buf_free(RBuffer *b);
 R_API bool r_buf_fini(RBuffer *b);
 R_API char *r_buf_free_to_string(RBuffer *b);
 R_API const ut8 *r_buf_buffer(RBuffer *b);
-R_API ut8 *r_buf_reserve(RBuffer *b, ut64 addr, ut64 len);
 R_API ut64 r_buf_size(RBuffer *b);
 R_API bool r_buf_resize(RBuffer *b, ut64 newsize);
 

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -70,6 +70,7 @@ R_API ut8 *r_buf_get_at(RBuffer *b, ut64 addr, int *len);
 #define r_buf_write(a,b,c) r_buf_write_at(a,R_BUF_CUR,b,c)
 R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, int len);
 R_API ut8 r_buf_read8_at(RBuffer *b, ut64 addr);
+R_API ut64 r_buf_tell(RBuffer *b);
 R_API int r_buf_seek(RBuffer *b, st64 addr, int whence);
 R_API int r_buf_fread_at(RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n);
 R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -112,21 +112,6 @@ R_API RIO* r_io_init(RIO* io) {
 	return io;
 }
 
-R_API RBuffer *r_io_read_buf(RIO *io, ut64 addr, int len) {
-	RBuffer *b = r_buf_new ();
-	if (!b) {
-		return NULL;
-	}
-	ut8 *buftmp = r_buf_reserve (b, addr, len);
-	len = r_io_read_at (io, addr, buftmp, len);
-	r_buf_resize (b, len);
-	return b;
-}
-
-R_API int r_io_write_buf(RIO *io, RBuffer *b) {
-	return r_io_write_at (io, b->base, b->buf, r_buf_size (b));
-}
-
 R_API void r_io_free(RIO *io) {
 	if (!io) {
 		return;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -123,12 +123,12 @@ R_API RBuffer *r_io_read_buf(RIO *io, ut64 addr, int len) {
 		return NULL;
 	}
 	len = r_io_read_at (io, addr, b->buf, len);
-	b->length = (len < 0)? 0: len;
+	r_buf_resize(b, (len < 0) ? 0 : len);
 	return b;
 }
 
-R_API int r_io_write_buf(RIO *io, struct r_buf_t *b) {
-	return r_io_write_at (io, b->base, b->buf, b->length);
+R_API int r_io_write_buf(RIO *io, RBuffer *b) {
+	return r_io_write_at (io, b->base, b->buf, r_buf_size (b));
 }
 
 R_API void r_io_free(RIO *io) {

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -113,17 +113,13 @@ R_API RIO* r_io_init(RIO* io) {
 }
 
 R_API RBuffer *r_io_read_buf(RIO *io, ut64 addr, int len) {
-	RBuffer *b = R_NEW0 (RBuffer);
+	RBuffer *b = r_buf_new ();
 	if (!b) {
 		return NULL;
 	}
-	b->buf = malloc (len);
-	if (!b->buf) {
-		free (b);
-		return NULL;
-	}
-	len = r_io_read_at (io, addr, b->buf, len);
-	r_buf_resize(b, (len < 0) ? 0 : len);
+	ut8 *buftmp = r_buf_reserve (b, addr, len);
+	len = r_io_read_at (io, addr, buftmp, len);
+	r_buf_resize (b, len);
 	return b;
 }
 

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -48,17 +48,17 @@ static ut64 r_io_ar_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	case SEEK_SET:
 		seek_val = (r_buf_size (b) < offset)? r_buf_size (b) : offset;
 		io->off = seek_val;
-		r_buf_seek(b, b->base + seek_val, 0);
+		r_buf_seek (b, b->base + seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
 		seek_val = (r_buf_size (b) < offset)? r_buf_size (b) : offset;
 		io->off = seek_val;
-		r_buf_seek(b, b->base + seek_val, 0);
+		r_buf_seek (b, b->base + seek_val, 0);
 		return seek_val;
 	case SEEK_END:
 		seek_val = r_buf_size (b);
 		io->off = seek_val;
-		r_buf_seek(b, b->base + seek_val, 0);
+		r_buf_seek (b, b->base + seek_val, 0);
 		return seek_val;
 	}
 	return seek_val;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -46,17 +46,17 @@ static ut64 r_io_ar_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 
 	switch (whence) {
 	case SEEK_SET:
-		seek_val = (b->length < offset)? b->length: offset;
+		seek_val = (r_buf_size(b) < offset)? r_buf_size(b) : offset;
 		io->off = seek_val;
 		b->cur = b->base + seek_val;
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (b->length < offset)? b->length: offset;
+		seek_val = (r_buf_size(b) < offset)? r_buf_size(b) : offset;
 		io->off = seek_val;
 		b->cur = b->base + seek_val;
 		return seek_val;
 	case SEEK_END:
-		seek_val = b->length;
+		seek_val = r_buf_size(b);
 		io->off = seek_val;
 		b->cur = b->base + seek_val;
 		return seek_val;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -42,7 +42,7 @@ static ut64 r_io_ar_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	}
 
 	b = fd->data;
-	seek_val = r_buf_seek(b, 0, 1);
+	seek_val = r_buf_tell (b);
 
 	switch (whence) {
 	case SEEK_SET:

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -42,23 +42,23 @@ static ut64 r_io_ar_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	}
 
 	b = fd->data;
-	seek_val = b->cur;
+	seek_val = r_buf_seek(b, 0, 1);
 
 	switch (whence) {
 	case SEEK_SET:
 		seek_val = (r_buf_size(b) < offset)? r_buf_size(b) : offset;
 		io->off = seek_val;
-		b->cur = b->base + seek_val;
+		r_buf_seek(b, b->base + seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
 		seek_val = (r_buf_size(b) < offset)? r_buf_size(b) : offset;
 		io->off = seek_val;
-		b->cur = b->base + seek_val;
+		r_buf_seek(b, b->base + seek_val, 0);
 		return seek_val;
 	case SEEK_END:
 		seek_val = r_buf_size(b);
 		io->off = seek_val;
-		b->cur = b->base + seek_val;
+		r_buf_seek(b, b->base + seek_val, 0);
 		return seek_val;
 	}
 	return seek_val;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -46,17 +46,17 @@ static ut64 r_io_ar_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 
 	switch (whence) {
 	case SEEK_SET:
-		seek_val = (r_buf_size(b) < offset)? r_buf_size(b) : offset;
+		seek_val = (r_buf_size (b) < offset)? r_buf_size (b) : offset;
 		io->off = seek_val;
 		r_buf_seek(b, b->base + seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (r_buf_size(b) < offset)? r_buf_size(b) : offset;
+		seek_val = (r_buf_size (b) < offset)? r_buf_size (b) : offset;
 		io->off = seek_val;
 		r_buf_seek(b, b->base + seek_val, 0);
 		return seek_val;
 	case SEEK_END:
-		seek_val = r_buf_size(b);
+		seek_val = r_buf_size (b);
 		io->off = seek_val;
 		r_buf_seek(b, b->base + seek_val, 0);
 		return seek_val;

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -58,20 +58,20 @@ static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int wh
 		return UT64_MAX;
 	}
 
-	seek_val = mmo->buf->cur;
+	seek_val = r_buf_seek(mmo->buf, 0, 1);
 	switch (whence) {
 	case SEEK_SET:
 		seek_val = R_MIN (r_buf_size(mmo->buf), offset);
 		break;
 	case SEEK_CUR:
 		seek_val = R_MIN (r_buf_size(mmo->buf),
-				  (offset + mmo->buf->cur));
+				  (offset + r_buf_seek(mmo->buf, 0, 1)));
 		break;
 	case SEEK_END:
 		seek_val = r_buf_size(mmo->buf);
 		break;
 	}
-	mmo->buf->cur = io->off = seek_val;
+	r_buf_seek(mmo->buf, io->off = seek_val, 0);
 	return seek_val;
 }
 
@@ -79,7 +79,7 @@ static int r_io_def_mmap_refresh_def_mmap_buf(RIOMMapFileObj *mmo) {
 	RIO* io = mmo->io_backref;
 	ut64 cur;
 	if (mmo->buf) {
-		cur = mmo->buf->cur;
+		cur = r_buf_seek(mmo->buf, 0, 1);
 		r_buf_free (mmo->buf);
 		mmo->buf = NULL;
 	} else {

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -61,14 +61,14 @@ static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int wh
 	seek_val = r_buf_tell (mmo->buf);
 	switch (whence) {
 	case SEEK_SET:
-		seek_val = R_MIN (r_buf_size(mmo->buf), offset);
+		seek_val = R_MIN (r_buf_size (mmo->buf), offset);
 		break;
 	case SEEK_CUR:
 		seek_val = R_MIN (r_buf_size (mmo->buf),
 			(offset + r_buf_tell (mmo->buf)));
 		break;
 	case SEEK_END:
-		seek_val = r_buf_size(mmo->buf);
+		seek_val = r_buf_size (mmo->buf);
 		break;
 	}
 	r_buf_seek(mmo->buf, io->off = seek_val, 0);
@@ -233,7 +233,7 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		}
 		return read (mmo->fd, buf, count);
 	}
-	if (r_buf_size(mmo->buf) < io->off) {
+	if (r_buf_size (mmo->buf) < io->off) {
 		io->off = r_buf_size (mmo->buf);
 	}
 	return r_buf_read_at (mmo->buf, io->off, buf, count);
@@ -296,7 +296,7 @@ static int r_io_def_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) 
 		if (!(mmo->perm & R_PERM_W)) {
 			return -1;
 		}
-		if ( (count + addr > r_buf_size(mmo->buf)) || mmo->buf->empty) {
+		if ( (count + addr > r_buf_size (mmo->buf)) || mmo->buf->empty) {
 			ut64 sz = count + addr;
 			r_file_truncate (mmo->filename, sz);
 		}

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -61,13 +61,14 @@ static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int wh
 	seek_val = mmo->buf->cur;
 	switch (whence) {
 	case SEEK_SET:
-		seek_val = R_MIN (mmo->buf->length, offset);
+		seek_val = R_MIN (r_buf_size(mmo->buf), offset);
 		break;
 	case SEEK_CUR:
-		seek_val = R_MIN (mmo->buf->length, (offset + mmo->buf->cur));
+		seek_val = R_MIN (r_buf_size(mmo->buf),
+				  (offset + mmo->buf->cur));
 		break;
 	case SEEK_END:
-		seek_val = mmo->buf->length;
+		seek_val = r_buf_size(mmo->buf);
 		break;
 	}
 	mmo->buf->cur = io->off = seek_val;
@@ -232,8 +233,8 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		}
 		return read (mmo->fd, buf, count);
 	}
-	if (mmo->buf->length < io->off) {
-		io->off = mmo->buf->length;
+	if (r_buf_size(mmo->buf) < io->off) {
+		io->off = r_buf_size(mmo->buf);
 	}
 	return r_buf_read_at (mmo->buf, io->off, buf, count);
 }
@@ -295,7 +296,7 @@ static int r_io_def_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) 
 		if (!(mmo->perm & R_PERM_W)) {
 			return -1;
 		}
-		if ( (count + addr > mmo->buf->length) || mmo->buf->empty) {
+		if ( (count + addr > r_buf_size(mmo->buf)) || mmo->buf->empty) {
 			ut64 sz = count + addr;
 			r_file_truncate (mmo->filename, sz);
 		}

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -64,8 +64,8 @@ static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int wh
 		seek_val = R_MIN (r_buf_size(mmo->buf), offset);
 		break;
 	case SEEK_CUR:
-		seek_val = R_MIN (r_buf_size(mmo->buf),
-				  (offset + r_buf_seek(mmo->buf, 0, 1)));
+		seek_val = R_MIN (r_buf_size (mmo->buf),
+			(offset + r_buf_seek (mmo->buf, 0, 1)));
 		break;
 	case SEEK_END:
 		seek_val = r_buf_size(mmo->buf);
@@ -234,7 +234,7 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		return read (mmo->fd, buf, count);
 	}
 	if (r_buf_size(mmo->buf) < io->off) {
-		io->off = r_buf_size(mmo->buf);
+		io->off = r_buf_size (mmo->buf);
 	}
 	return r_buf_read_at (mmo->buf, io->off, buf, count);
 }

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -71,7 +71,7 @@ static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int wh
 		seek_val = r_buf_size (mmo->buf);
 		break;
 	}
-	r_buf_seek(mmo->buf, io->off = seek_val, 0);
+	r_buf_seek (mmo->buf, io->off = seek_val, 0);
 	return seek_val;
 }
 

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -58,14 +58,14 @@ static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int wh
 		return UT64_MAX;
 	}
 
-	seek_val = r_buf_seek(mmo->buf, 0, 1);
+	seek_val = r_buf_tell (mmo->buf);
 	switch (whence) {
 	case SEEK_SET:
 		seek_val = R_MIN (r_buf_size(mmo->buf), offset);
 		break;
 	case SEEK_CUR:
 		seek_val = R_MIN (r_buf_size (mmo->buf),
-			(offset + r_buf_seek (mmo->buf, 0, 1)));
+			(offset + r_buf_tell (mmo->buf)));
 		break;
 	case SEEK_END:
 		seek_val = r_buf_size(mmo->buf);
@@ -79,7 +79,7 @@ static int r_io_def_mmap_refresh_def_mmap_buf(RIOMMapFileObj *mmo) {
 	RIO* io = mmo->io_backref;
 	ut64 cur;
 	if (mmo->buf) {
-		cur = r_buf_seek(mmo->buf, 0, 1);
+		cur = r_buf_tell (mmo->buf);
 		r_buf_free (mmo->buf);
 		mmo->buf = NULL;
 	} else {

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -27,7 +27,7 @@ static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence
 		r_buf_seek (mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_END:
-		seek_val = r_buf_size(mmo->buf);
+		seek_val = r_buf_size (mmo->buf);
 		r_buf_seek (mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	}
@@ -36,7 +36,7 @@ static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence
 
 static bool r_io_mmap_refresh_buf(RIOMMapFileObj *mmo) {
 	RIO* io = mmo->io_backref;
-	ut64 cur = mmo->buf? r_buf_tell (mmo->buf) : 0;
+	ut64 cur = mmo->buf? r_buf_tell (mmo->buf): 0;
 	if (mmo->buf) {
 		r_buf_free (mmo->buf);
 		mmo->buf = NULL;
@@ -95,7 +95,7 @@ static int r_io_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		return -1;
 	}
 	mmo = fd->data;
-	if (r_buf_size(mmo->buf) < io->off) {
+	if (r_buf_size (mmo->buf) < io->off) {
 		io->off = r_buf_size (mmo->buf);
 	}
 	return r_buf_read_at (mmo->buf, io->off, buf, count);
@@ -114,7 +114,7 @@ static int r_io_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	if ( !(mmo->flags & R_PERM_W)) {
 		return -1;
 	}
-	if ( (count + addr > r_buf_size(mmo->buf)) || mmo->buf->empty) {
+	if ( (count + addr > r_buf_size (mmo->buf)) || mmo->buf->empty) {
 		ut64 sz = count + addr;
 		r_file_truncate (mmo->filename, sz);
 	}

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -19,17 +19,17 @@ static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence
 	ut64 seek_val = mmo->buf->cur;
 	switch (whence) {
 	case SEEK_SET:
-		seek_val = (mmo->buf->length < offset) ?
-			mmo->buf->length : offset;
+		seek_val = (r_buf_size(mmo->buf) < offset) ?
+			r_buf_size(mmo->buf) : offset;
 		mmo->buf->cur = io->off = seek_val;
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (mmo->buf->length < (offset + mmo->buf->cur)) ?
-			mmo->buf->length : offset + mmo->buf->cur;
+		seek_val = (r_buf_size(mmo->buf) < (offset + mmo->buf->cur)) ?
+			r_buf_size(mmo->buf) : offset + mmo->buf->cur;
 		mmo->buf->cur = io->off = seek_val;
 		return seek_val;
 	case SEEK_END:
-		seek_val = mmo->buf->length;
+		seek_val = r_buf_size(mmo->buf);
 		mmo->buf->cur = io->off = seek_val;
 		return seek_val;
 	}
@@ -97,8 +97,8 @@ static int r_io_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		return -1;
 	}
 	mmo = fd->data;
-	if (mmo->buf->length < io->off) {
-		io->off = mmo->buf->length;
+	if (r_buf_size(mmo->buf) < io->off) {
+		io->off = r_buf_size(mmo->buf);
 	}
 	return r_buf_read_at (mmo->buf, io->off, buf, count);
 }
@@ -116,7 +116,7 @@ static int r_io_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	if ( !(mmo->flags & R_PERM_W)) {
 		return -1;
 	}
-	if ( (count + addr > mmo->buf->length) || mmo->buf->empty) {
+	if ( (count + addr > r_buf_size(mmo->buf)) || mmo->buf->empty) {
 		ut64 sz = count + addr;
 		r_file_truncate (mmo->filename, sz);
 	}

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -19,19 +19,16 @@ static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence
 	ut64 seek_val = r_buf_seek(mmo->buf, 0, 1);
 	switch (whence) {
 	case SEEK_SET:
-		seek_val = (r_buf_size(mmo->buf) < offset) ?
-			r_buf_size(mmo->buf) : offset;
-		r_buf_seek(mmo->buf, io->off = seek_val, 0);
+		seek_val = (r_buf_size (mmo->buf) < offset)? r_buf_size (mmo->buf): offset;
+		r_buf_seek (mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (r_buf_size(mmo->buf) < (offset + r_buf_seek(mmo->buf, 0, 1))) ?
-			r_buf_size(mmo->buf) : offset + r_buf_seek(mmo->buf,
-								   0, 1);
-		r_buf_seek(mmo->buf, io->off = seek_val, 0);
+		seek_val = (r_buf_size (mmo->buf) < (offset + r_buf_seek (mmo->buf, 0, 1)))? r_buf_size (mmo->buf): offset + r_buf_seek (mmo->buf, 0, 1);
+		r_buf_seek (mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_END:
 		seek_val = r_buf_size(mmo->buf);
-		r_buf_seek(mmo->buf, io->off = seek_val, 0);
+		r_buf_seek (mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	}
 	return seek_val;
@@ -39,7 +36,7 @@ static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence
 
 static bool r_io_mmap_refresh_buf(RIOMMapFileObj *mmo) {
 	RIO* io = mmo->io_backref;
-	ut64 cur = mmo->buf ? r_buf_seek(mmo->buf, 0, 1) : 0;
+	ut64 cur = mmo->buf? r_buf_seek(mmo->buf, 0, 1): 0;
 	if (mmo->buf) {
 		r_buf_free (mmo->buf);
 		mmo->buf = NULL;
@@ -51,7 +48,7 @@ static bool r_io_mmap_refresh_buf(RIOMMapFileObj *mmo) {
 	return mmo->buf != NULL;
 }
 
-static void r_io_mmap_free (RIOMMapFileObj *mmo) {
+static void r_io_mmap_free(RIOMMapFileObj *mmo) {
 	free (mmo->filename);
 	r_buf_free (mmo->buf);
 	memset (mmo, 0, sizeof (RIOMMapFileObj));
@@ -99,7 +96,7 @@ static int r_io_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	}
 	mmo = fd->data;
 	if (r_buf_size(mmo->buf) < io->off) {
-		io->off = r_buf_size(mmo->buf);
+		io->off = r_buf_size (mmo->buf);
 	}
 	return r_buf_read_at (mmo->buf, io->off, buf, count);
 }

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -16,14 +16,14 @@ typedef struct r_io_mmo_t {
 } RIOMMapFileObj;
 
 static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence) {
-	ut64 seek_val = r_buf_seek(mmo->buf, 0, 1);
+	ut64 seek_val = r_buf_tell (mmo->buf);
 	switch (whence) {
 	case SEEK_SET:
 		seek_val = (r_buf_size (mmo->buf) < offset)? r_buf_size (mmo->buf): offset;
 		r_buf_seek (mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (r_buf_size (mmo->buf) < (offset + r_buf_seek (mmo->buf, 0, 1)))? r_buf_size (mmo->buf): offset + r_buf_seek (mmo->buf, 0, 1);
+		seek_val = (r_buf_size (mmo->buf) < (offset + r_buf_tell (mmo->buf)))? r_buf_size (mmo->buf): offset + r_buf_tell (mmo->buf);
 		r_buf_seek (mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_END:
@@ -36,7 +36,7 @@ static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence
 
 static bool r_io_mmap_refresh_buf(RIOMMapFileObj *mmo) {
 	RIO* io = mmo->io_backref;
-	ut64 cur = mmo->buf? r_buf_seek(mmo->buf, 0, 1): 0;
+	ut64 cur = mmo->buf? r_buf_tell (mmo->buf) : 0;
 	if (mmo->buf) {
 		r_buf_free (mmo->buf);
 		mmo->buf = NULL;

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -16,21 +16,22 @@ typedef struct r_io_mmo_t {
 } RIOMMapFileObj;
 
 static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence) {
-	ut64 seek_val = mmo->buf->cur;
+	ut64 seek_val = r_buf_seek(mmo->buf, 0, 1);
 	switch (whence) {
 	case SEEK_SET:
 		seek_val = (r_buf_size(mmo->buf) < offset) ?
 			r_buf_size(mmo->buf) : offset;
-		mmo->buf->cur = io->off = seek_val;
+		r_buf_seek(mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (r_buf_size(mmo->buf) < (offset + mmo->buf->cur)) ?
-			r_buf_size(mmo->buf) : offset + mmo->buf->cur;
-		mmo->buf->cur = io->off = seek_val;
+		seek_val = (r_buf_size(mmo->buf) < (offset + r_buf_seek(mmo->buf, 0, 1))) ?
+			r_buf_size(mmo->buf) : offset + r_buf_seek(mmo->buf,
+								   0, 1);
+		r_buf_seek(mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_END:
 		seek_val = r_buf_size(mmo->buf);
-		mmo->buf->cur = io->off = seek_val;
+		r_buf_seek(mmo->buf, io->off = seek_val, 0);
 		return seek_val;
 	}
 	return seek_val;
@@ -38,7 +39,7 @@ static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence
 
 static bool r_io_mmap_refresh_buf(RIOMMapFileObj *mmo) {
 	RIO* io = mmo->io_backref;
-	ut64 cur = mmo->buf ? mmo->buf->cur : 0;
+	ut64 cur = mmo->buf ? r_buf_seek(mmo->buf, 0, 1) : 0;
 	if (mmo->buf) {
 		r_buf_free (mmo->buf);
 		mmo->buf = NULL;

--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -17,7 +17,7 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	RBuffer *b = fd->data;
-	return r_buf_read(b, buf, count);
+	return r_buf_read (b, buf, count);
 }
 
 static int __close(RIODesc *fd) {

--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -12,12 +12,12 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 		return -1;
 	}
 	RBuffer *b = fd->data;
-	return r_buf_write_at (b, b->cur, buf, count);
+	return r_buf_write_at (b, r_buf_seek(b, 0, 1), buf, count);
 }
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	RBuffer *b = fd->data;
-	return r_buf_read_at (b, b->cur, buf, count);
+	return r_buf_read_at (b, r_buf_seek(b, 0, 1), buf, count);
 }
 
 static int __close(RIODesc *fd) {

--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -17,7 +17,7 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	RBuffer *b = fd->data;
-	return r_buf_read_at (b, r_buf_seek(b, 0, 1), buf, count);
+	return r_buf_read(b, buf, count);
 }
 
 static int __close(RIODesc *fd) {

--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -12,7 +12,7 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 		return -1;
 	}
 	RBuffer *b = fd->data;
-	return r_buf_write_at (b, r_buf_seek(b, 0, 1), buf, count);
+	return r_buf_write_at (b, r_buf_tell (b), buf, count);
 }
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {

--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -12,7 +12,7 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 		return -1;
 	}
 	RBuffer *b = fd->data;
-	return r_buf_write_at (b, r_buf_tell (b), buf, count);
+	return r_buf_write (b, buf, count);
 }
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -197,7 +197,7 @@ int r_io_zip_flush_file(RIOZipFileObj *zfo) {
 	}
 
 	struct zip_source *s = zip_source_buffer (zipArch, zfo->b->buf,
-						  r_buf_size(zfo->b), 0);
+		r_buf_size (zfo->b), 0);
 	if (s && zfo->entry != -1) {
 		if (zip_replace(zipArch, zfo->entry, s) == 0) {
 			res = true;
@@ -229,13 +229,13 @@ static void r_io_zip_free_zipfileobj(RIOZipFileObj *zfo) {
 	free (zfo);
 }
 
-RIOZipFileObj *r_io_zip_create_new_file(const char *archivename, const char *filename, struct zip_stat *sb, ut32 perm, int mode, int rw) {
+RIOZipFileObj *r_io_zip_create_new_file (const char *archivename, const char *filename, struct zip_stat *sb, ut32 perm, int mode, int rw) {
 	RIOZipFileObj *zfo = R_NEW0 (RIOZipFileObj);
 	if (zfo) {
 		zfo->b = r_buf_new ();
 		zfo->archivename = strdup (archivename);
 		zfo->name = strdup (sb? sb->name: filename);
-		zfo->entry = !sb ? -1 : sb->index;
+		zfo->entry = !sb? -1: sb->index;
 		zfo->fd = r_num_rand (0xFFFF); // XXX: Use r_io_fd api
 		zfo->perm = perm;
 		zfo->mode = mode;
@@ -528,18 +528,16 @@ static ut64 r_io_zip_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 
 	switch (whence) {
 	case SEEK_SET:
-		seek_val = (r_buf_size(zfo->b) < offset) ?
-			r_buf_size(zfo->b) : offset;
-		r_buf_seek(zfo->b, io->off = seek_val, 0);
+		seek_val = (r_buf_size (zfo->b) < offset)? r_buf_size (zfo->b): offset;
+		r_buf_seek (zfo->b, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (r_buf_size(zfo->b) < (offset + r_buf_seek(zfo->b, 0, 1))) ?
-			r_buf_size(zfo->b) : offset + r_buf_seek(zfo->b, 0, 1);
-		r_buf_seek(zfo->b, io->off = seek_val, 0);
+		seek_val = (r_buf_size (zfo->b) < (offset + r_buf_seek (zfo->b, 0, 1)))? r_buf_size (zfo->b): offset + r_buf_seek (zfo->b, 0, 1);
+		r_buf_seek (zfo->b, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_END:
 		seek_val = r_buf_size(zfo->b);
-		r_buf_seek(zfo->b, io->off = seek_val, 0);
+		r_buf_seek (zfo->b, io->off = seek_val, 0);
 		return seek_val;
 	}
 	return seek_val;
@@ -552,7 +550,7 @@ static int r_io_zip_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	}
 	zfo = fd->data;
 	if (r_buf_size(zfo->b) < io->off) {
-		io->off = r_buf_size(zfo->b);
+		io->off = r_buf_size (zfo->b);
 	}
 	return r_buf_read_at (zfo->b, io->off, buf, count);
 }
@@ -593,7 +591,7 @@ static int r_io_zip_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 		r_io_zip_realloc_buf (zfo, count);
 	}
 	if (r_buf_size(zfo->b) < io->off) {
-		io->off = r_buf_size(zfo->b);
+		io->off = r_buf_size (zfo->b);
 	}
 	zfo->modified = 1;
 	ret = r_buf_write_at (zfo->b, io->off, buf, count);

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -524,7 +524,7 @@ static ut64 r_io_zip_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	}
 
 	zfo = fd->data;
-	seek_val = r_buf_seek(zfo->b, 0, 1);
+	seek_val = r_buf_tell (zfo->b);
 
 	switch (whence) {
 	case SEEK_SET:
@@ -532,7 +532,7 @@ static ut64 r_io_zip_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		r_buf_seek (zfo->b, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
-		seek_val = (r_buf_size (zfo->b) < (offset + r_buf_seek (zfo->b, 0, 1)))? r_buf_size (zfo->b): offset + r_buf_seek (zfo->b, 0, 1);
+		seek_val = (r_buf_size (zfo->b) < (offset + r_buf_tell (zfo->b)))? r_buf_size (zfo->b): offset + r_buf_tell (zfo->b);
 		r_buf_seek (zfo->b, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_END:
@@ -549,14 +549,14 @@ static int r_io_zip_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		return -1;
 	}
 	zfo = fd->data;
-	if (r_buf_size(zfo->b) < io->off) {
+	if (r_buf_size (zfo->b) < io->off) {
 		io->off = r_buf_size (zfo->b);
 	}
 	return r_buf_read_at (zfo->b, io->off, buf, count);
 }
 
 static int r_io_zip_realloc_buf(RIOZipFileObj *zfo, int count) {
-	return r_buf_resize (zfo->b, r_buf_seek (zfo->b, 0, 1) + count);
+	return r_buf_resize (zfo->b, r_buf_tell (zfo->b) + count);
 }
 
 static bool r_io_zip_truncate_buf(RIOZipFileObj *zfo, int size) {
@@ -587,7 +587,7 @@ static int r_io_zip_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	if (!(zfo->perm & R_PERM_W)) {
 		return -1;
 	}
-	if (r_buf_seek(zfo->b, 0, 1) + count >= r_buf_size(zfo->b)) {
+	if (r_buf_tell (zfo->b) + count >= r_buf_size(zfo->b)) {
 		r_io_zip_realloc_buf (zfo, count);
 	}
 	if (r_buf_size(zfo->b) < io->off) {

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -558,46 +558,11 @@ static int r_io_zip_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 }
 
 static int r_io_zip_realloc_buf(RIOZipFileObj *zfo, int count) {
-	int res = false;
-	if (count >= 0 && r_buf_seek(zfo->b, 0, 1) + count > r_buf_size(zfo->b)) {
-		RBuffer *buffer = r_buf_new ();
-		if (!buffer) {
-			return false;
-		}
-		buffer->buf = malloc (r_buf_seek(zfo->b, 0, 1) + count );
-		if (!buffer->buf) {
-			r_buf_free (buffer);
-			return false;
-		}
-		r_buf_resize(buffer, r_buf_seek(zfo->b, 0, 1) + count);
-		memcpy (buffer->buf, zfo->b->buf, r_buf_size(zfo->b));
-		memset (buffer->buf + r_buf_size(zfo->b), 0, count);
-		r_buf_seek(buffer, r_buf_seek(zfo->b, 0, 1), 0);
-		r_buf_free (zfo->b);
-		zfo->b = buffer;
-		res = true;
-	}
-	return res;
+	return r_buf_resize (zfo->b, r_buf_seek (zfo->b, 0, 1) + count);
 }
 
 static bool r_io_zip_truncate_buf(RIOZipFileObj *zfo, int size) {
-	if (r_buf_size(zfo->b) < size) {
-		return r_io_zip_realloc_buf (zfo, size - r_buf_size(zfo->b));
-	}
-	if (size > 0) {
-		ut8 *buf = malloc (size);
-		if (!buf) {
-			return false;
-		}
-		memcpy (buf, zfo->b->buf, size);
-		free (zfo->b->buf);
-		zfo->b->buf = buf;
-		r_buf_resize(zfo->b, size);
-	} else {
-		memset (zfo->b->buf, 0, r_buf_size(zfo->b));
-		r_buf_resize(zfo->b, 0);
-	}
-	return true;
+	return r_buf_resize (zfo->b, size);
 }
 
 static bool r_io_zip_resize(RIO *io, RIODesc *fd, ut64 size) {

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -536,7 +536,7 @@ static ut64 r_io_zip_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		r_buf_seek (zfo->b, io->off = seek_val, 0);
 		return seek_val;
 	case SEEK_END:
-		seek_val = r_buf_size(zfo->b);
+		seek_val = r_buf_size (zfo->b);
 		r_buf_seek (zfo->b, io->off = seek_val, 0);
 		return seek_val;
 	}
@@ -587,10 +587,10 @@ static int r_io_zip_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	if (!(zfo->perm & R_PERM_W)) {
 		return -1;
 	}
-	if (r_buf_tell (zfo->b) + count >= r_buf_size(zfo->b)) {
+	if (r_buf_tell (zfo->b) + count >= r_buf_size (zfo->b)) {
 		r_io_zip_realloc_buf (zfo, count);
 	}
-	if (r_buf_size(zfo->b) < io->off) {
+	if (r_buf_size (zfo->b) < io->off) {
 		io->off = r_buf_size (zfo->b);
 	}
 	zfo->modified = 1;

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -229,7 +229,7 @@ static void r_io_zip_free_zipfileobj(RIOZipFileObj *zfo) {
 	free (zfo);
 }
 
-RIOZipFileObj *r_io_zip_create_new_file (const char *archivename, const char *filename, struct zip_stat *sb, ut32 perm, int mode, int rw) {
+RIOZipFileObj *r_io_zip_create_new_file(const char *archivename, const char *filename, struct zip_stat *sb, ut32 perm, int mode, int rw) {
 	RIOZipFileObj *zfo = R_NEW0 (RIOZipFileObj);
 	if (zfo) {
 		zfo->b = r_buf_new ();
@@ -529,15 +529,18 @@ static ut64 r_io_zip_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	switch (whence) {
 	case SEEK_SET:
 		seek_val = (r_buf_size (zfo->b) < offset)? r_buf_size (zfo->b): offset;
-		r_buf_seek (zfo->b, io->off = seek_val, 0);
+		io->off = seek_val;
+		r_buf_seek (zfo->b, seek_val, 0);
 		return seek_val;
 	case SEEK_CUR:
 		seek_val = (r_buf_size (zfo->b) < (offset + r_buf_tell (zfo->b)))? r_buf_size (zfo->b): offset + r_buf_tell (zfo->b);
-		r_buf_seek (zfo->b, io->off = seek_val, 0);
+		io->off = seek_val;
+		r_buf_seek (zfo->b, seek_val, 0);
 		return seek_val;
 	case SEEK_END:
 		seek_val = r_buf_size (zfo->b);
-		r_buf_seek (zfo->b, io->off = seek_val, 0);
+		io->off = seek_val;
+		r_buf_seek (zfo->b, seek_val, 0);
 		return seek_val;
 	}
 	return seek_val;
@@ -560,7 +563,7 @@ static int r_io_zip_realloc_buf(RIOZipFileObj *zfo, int count) {
 }
 
 static bool r_io_zip_truncate_buf(RIOZipFileObj *zfo, int size) {
-	return r_buf_resize (zfo->b, size);
+	return r_buf_resize (zfo->b, size > 0? size: 0);
 }
 
 static bool r_io_zip_resize(RIO *io, RIODesc *fd, ut64 size) {

--- a/libr/main/rabin2.c
+++ b/libr/main/rabin2.c
@@ -308,7 +308,7 @@ static int rabin_dump_sections(char *scnname) {
 				return false;
 			}
 			if (section->paddr > r_buf_size (bin->cur->buf) ||
-			    section->paddr + section->size > r_buf_size (bin->cur->buf)) {
+				section->paddr + section->size > r_buf_size (bin->cur->buf)) {
 				free (buf);
 				free (ret);
 				return false;
@@ -908,8 +908,8 @@ R_API int r_main_rabin2(int argc, char **argv) {
 		b = r_bin_create (bin, create, code, codelen, data, datalen, &opts);
 		if (b) {
 			if (r_file_dump (file, b->buf, r_buf_size(b), 0)) {
-				eprintf ("Dumped %"PFMT64d" bytes in '%s'\n",
-					 r_buf_size(b), file);
+				eprintf ("Dumped %" PFMT64d " bytes in '%s'\n",
+					r_buf_size (b), file);
 				r_file_chmod (file, "+x", 0);
 			} else {
 				eprintf ("Error dumping into a.out\n");

--- a/libr/main/rabin2.c
+++ b/libr/main/rabin2.c
@@ -307,8 +307,8 @@ static int rabin_dump_sections(char *scnname) {
 				free (buf);
 				return false;
 			}
-			if (section->paddr > bin->cur->buf->length ||
-			  section->paddr + section->size > bin->cur->buf->length) {
+			if (section->paddr > r_buf_size (bin->cur->buf) ||
+			    section->paddr + section->size > r_buf_size (bin->cur->buf)) {
 				free (buf);
 				free (ret);
 				return false;
@@ -907,8 +907,9 @@ R_API int r_main_rabin2(int argc, char **argv) {
 		r_bin_arch_options_init (&opts, arch, bits);
 		b = r_bin_create (bin, create, code, codelen, data, datalen, &opts);
 		if (b) {
-			if (r_file_dump (file, b->buf, b->length, 0)) {
-				eprintf ("Dumped %"PFMT64d" bytes in '%s'\n", b->length, file);
+			if (r_file_dump (file, b->buf, r_buf_size(b), 0)) {
+				eprintf ("Dumped %"PFMT64d" bytes in '%s'\n",
+					 r_buf_size(b), file);
 				r_file_chmod (file, "+x", 0);
 			} else {
 				eprintf ("Error dumping into a.out\n");

--- a/libr/main/rabin2.c
+++ b/libr/main/rabin2.c
@@ -907,7 +907,7 @@ R_API int r_main_rabin2(int argc, char **argv) {
 		r_bin_arch_options_init (&opts, arch, bits);
 		b = r_bin_create (bin, create, code, codelen, data, datalen, &opts);
 		if (b) {
-			if (r_file_dump (file, b->buf, r_buf_size(b), 0)) {
+			if (r_file_dump (file, b->buf, r_buf_size (b), 0)) {
 				eprintf ("Dumped %" PFMT64d " bytes in '%s'\n",
 					r_buf_size (b), file);
 				r_file_chmod (file, "+x", 0);

--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -72,7 +72,7 @@ static int create(const char *format, const char *arch, int bits, const ut8 *cod
 	r_bin_arch_options_init (&opts, arch, bits);
 	b = r_bin_create (bin, format, code, codelen, NULL, 0, &opts);
 	if (b) {
-		size_t blen = r_buf_size(b);
+		size_t blen = r_buf_size (b);
 		if (write (1, b->buf, blen) != blen) {
 			eprintf ("Failed to write buffer\n");
 		}
@@ -525,7 +525,7 @@ R_API int r_main_ragg2(int argc, char **argv) {
 		}
 		b = r_egg_get_bin (egg);
 		if (show_raw) {
-			size_t blen = r_buf_size(b);
+			size_t blen = r_buf_size (b);
 			if (write (1, b->buf, blen) != blen) {
 				eprintf ("Failed to write buffer\n");
 				goto fail;
@@ -548,12 +548,12 @@ R_API int r_main_ragg2(int argc, char **argv) {
 			case 'r':
 				if (show_str) {
 					printf ("\"");
-					for (i = 0; i < r_buf_size(b); i++) {
+					for (i = 0; i < r_buf_size (b); i++) {
 						printf ("\\x%02x", b->buf[i]);
 					}
 					printf ("\"\n");
 				} else if (show_hex) {
-					for (i = 0; i < r_buf_size(b); i++) {
+					for (i = 0; i < r_buf_size (b); i++) {
 						printf ("%02x", b->buf[i]);
 					}
 					printf ("\n");

--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -111,7 +111,6 @@ static int openfile(const char *f, int x) {
 }
 #define ISEXEC (fmt!='r')
 
-
 R_API int r_main_ragg2(int argc, char **argv) {
 	const char *file = NULL;
 	const char *padding = NULL;
@@ -539,12 +538,12 @@ R_API int r_main_ragg2(int argc, char **argv) {
 			RPrint *p = r_print_new ();
 			switch (*format) {
 			case 'c':
-				r_print_code (p, 0, b->buf, r_buf_size(b),
-					      'c');
+				r_print_code (p, 0, b->buf, r_buf_size (b),
+					'c');
 				break;
 			case 'j': // JavaScript
-				r_print_code (p, 0, b->buf, r_buf_size(b),
-					      'j');
+				r_print_code (p, 0, b->buf, r_buf_size (b),
+					'j');
 				break;
 			case 'r':
 				if (show_str) {
@@ -563,13 +562,13 @@ R_API int r_main_ragg2(int argc, char **argv) {
 			case 'p': // PE
 				if (strlen(format) >= 2 && format[1] == 'y') { // Python
 					r_print_code (p, 0, b->buf,
-						      r_buf_size(b), 'p');
+						r_buf_size (b), 'p');
 				}
 				break;
 			case 'e': // ELF
 			case 'm': // MACH0
 				create (format, arch, bits, b->buf,
-					r_buf_size(b));
+					r_buf_size (b));
 				break;
 			default:
 				eprintf ("unknown executable format (%s)\n", format);

--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -72,7 +72,7 @@ static int create(const char *format, const char *arch, int bits, const ut8 *cod
 	r_bin_arch_options_init (&opts, arch, bits);
 	b = r_bin_create (bin, format, code, codelen, NULL, 0, &opts);
 	if (b) {
-		size_t blen = b->length;
+		size_t blen = r_buf_size(b);
 		if (write (1, b->buf, blen) != blen) {
 			eprintf ("Failed to write buffer\n");
 		}
@@ -526,7 +526,7 @@ R_API int r_main_ragg2(int argc, char **argv) {
 		}
 		b = r_egg_get_bin (egg);
 		if (show_raw) {
-			size_t blen = b->length;
+			size_t blen = r_buf_size(b);
 			if (write (1, b->buf, blen) != blen) {
 				eprintf ("Failed to write buffer\n");
 				goto fail;
@@ -539,20 +539,22 @@ R_API int r_main_ragg2(int argc, char **argv) {
 			RPrint *p = r_print_new ();
 			switch (*format) {
 			case 'c':
-				r_print_code (p, 0, b->buf, b->length, 'c');
+				r_print_code (p, 0, b->buf, r_buf_size(b),
+					      'c');
 				break;
 			case 'j': // JavaScript
-				r_print_code (p, 0, b->buf, b->length, 'j');
+				r_print_code (p, 0, b->buf, r_buf_size(b),
+					      'j');
 				break;
 			case 'r':
 				if (show_str) {
 					printf ("\"");
-					for (i = 0; i < b->length; i++) {
+					for (i = 0; i < r_buf_size(b); i++) {
 						printf ("\\x%02x", b->buf[i]);
 					}
 					printf ("\"\n");
 				} else if (show_hex) {
-					for (i = 0; i < b->length; i++) {
+					for (i = 0; i < r_buf_size(b); i++) {
 						printf ("%02x", b->buf[i]);
 					}
 					printf ("\n");
@@ -560,12 +562,14 @@ R_API int r_main_ragg2(int argc, char **argv) {
 				break;
 			case 'p': // PE
 				if (strlen(format) >= 2 && format[1] == 'y') { // Python
-					r_print_code (p, 0, b->buf, b->length, 'p');
+					r_print_code (p, 0, b->buf,
+						      r_buf_size(b), 'p');
 				}
 				break;
 			case 'e': // ELF
 			case 'm': // MACH0
-				create (format, arch, bits, b->buf, b->length);
+				create (format, arch, bits, b->buf,
+					r_buf_size(b));
 				break;
 			default:
 				eprintf ("unknown executable format (%s)\n", format);

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -406,14 +406,25 @@ R_API RBuffer *r_buf_new() {
 	return b;
 }
 
-R_API const ut8 *r_buf_buffer (RBuffer *b) {
+R_API const ut8 *r_buf_buffer(RBuffer *b) {
 	if (b && !b->sparse && b->fd == -1 && !b->mmap) {
 		return b->buf;
 	}
 	r_return_val_if_fail (false, NULL);
 }
 
-R_API ut64 r_buf_size (RBuffer *b) {
+R_API ut8 *r_buf_reserve(RBuffer *b, ut64 addr, ut64 len) {
+	if (b && !b->sparse && b->fd == -1 && !b->mmap) {
+		if (addr + len > r_buf_size (b)) {
+			r_buf_resize (b, addr + len);
+		}
+
+		return b->buf + addr - b->base;
+	}
+	r_return_val_if_fail (false, NULL);
+}
+
+R_API ut64 r_buf_size(RBuffer *b) {
 	r_return_val_if_fail (b, 0);
 	if (b->iob) {
 		RIOBind *iob = b->iob;

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -164,7 +164,7 @@ static int r_buf_cpy(RBuffer *b, ut64 addr, ut8 *dst, const ut8 *src, int len, i
 		}
 		return real_len;
 	}
-	addr = (addr == R_BUF_CUR) ? b->cur_priv : start;
+	addr = (addr == R_BUF_CUR)? b->cur_priv: start;
 	if (len < 1 || !dst || addr - b->offset > effective_size) {
 		return -1;
 	}
@@ -178,7 +178,7 @@ static int r_buf_cpy(RBuffer *b, ut64 addr, ut8 *dst, const ut8 *src, int len, i
 	return real_len;
 }
 
-static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n, int write) {
+static int r_buf_fcpy_at(RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n, int write) {
 	ut64 len, check_len;
 	int i, j, k, tsize = 2, m = 1;
 	bool bigendian = true;
@@ -205,17 +205,23 @@ static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 		#ifdef _MSC_VER
 		case'0':case'1':case'2':case'3':case'4':case'5':case'6':case'7':case'8':case'9':
 		#else
-		case '0'...'9':
-		#endif
+			case '0' ... '9':
+#endif
 			if (m == 1) {
 				m = r_num_get (NULL, &fmt[j]);
 			}
 			continue;
 		case 's': tsize = 2; bigendian = false; break;
 		case 'S': tsize = 2; bigendian = true; break;
-		case 'i': tsize = 4; bigendian = false; break;
+		case 'i':
+			tsize = 4;
+			bigendian = false;
+			break;
 		case 'I': tsize = 4; bigendian = true; break;
-		case 'l': tsize = 8; bigendian = false; break;
+		case 'l':
+			tsize = 8;
+			bigendian = false;
+			break;
 		case 'L': tsize = 8; bigendian = true; break;
 		case 'c': tsize = 1; bigendian = false; break;
 		default: return -1;
@@ -236,12 +242,12 @@ static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 		}
 
 		for (k = 0; k < m; k++) {
-			ut8 _dest1[sizeof (ut64)] = {0};
-			ut8 _dest2[sizeof (ut64)] = {0};
+			ut8 _dest1[sizeof (ut64)] = { 0 };
+			ut8 _dest2[sizeof (ut64)] = { 0 };
 			int left1, left2;
 			ut64 addr1 = len + (k * tsize);
 			ut64 addr2 = vaddr + addr1;
-			ut8 *src1=NULL, *src2=NULL;
+			ut8 *src1 = NULL, *src2 = NULL;
 			if (b->fd == -1) {
 				src1 = r_buf_get_at (b, addr1, &left1);
 				src2 = r_buf_get_at (b, addr2, &left2);
@@ -252,11 +258,11 @@ static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 				src1 = _dest1;
 				src2 = _dest2;
 			}
-			void* dest1 = buf + addr + addr1; // shouldn't this be an address in b ?
-			void* dest2 = buf + addr1;
-			ut8* dest1_8 = (ut8*)dest1;
-			ut16* dest1_16 = (ut16*)dest1;
-			ut32* dest1_32 = (ut32*)dest1;
+			void *dest1 = buf + addr + addr1; // shouldn't this be an address in b ?
+			void *dest2 = buf + addr1;
+			ut8 *dest1_8 = (ut8 *)dest1;
+			ut16 *dest1_16 = (ut16 *)dest1;
+			ut32 *dest1_32 = (ut32 *)dest1;
 			ut64* dest1_64 = (ut64*)dest1;
 			ut8* dest2_8 = (ut8*)dest2;
 			ut16* dest2_16 = (ut16*)dest2;
@@ -311,7 +317,7 @@ R_API RBuffer *r_buf_new_with_io(void *iob, int fd) {
 	return b;
 }
 
-R_API RBuffer *r_buf_new_with_pointers (const ut8 *bytes, ut64 len) {
+R_API RBuffer *r_buf_new_with_pointers(const ut8 *bytes, ut64 len) {
 	RBuffer *b = r_buf_new ();
 	if (b && bytes && len > 0 && len != UT64_MAX) {
 		b->buf = (ut8*)bytes;
@@ -322,7 +328,7 @@ R_API RBuffer *r_buf_new_with_pointers (const ut8 *bytes, ut64 len) {
 	return b;
 }
 
-R_API RBuffer *r_buf_new_empty (ut64 len) {
+R_API RBuffer *r_buf_new_empty(ut64 len) {
 	RBuffer *b = r_buf_new ();
 	if (!b) {
 		return NULL;
@@ -336,7 +342,7 @@ R_API RBuffer *r_buf_new_empty (ut64 len) {
 	return b;
 }
 
-R_API RBuffer *r_buf_new_with_bytes (const ut8 *bytes, ut64 len) {
+R_API RBuffer *r_buf_new_with_bytes(const ut8 *bytes, ut64 len) {
 	RBuffer *b = r_buf_new ();
 	if (b && bytes && (len > 0 && len != UT64_MAX)) {
 		r_buf_set_bytes (b, bytes, len);
@@ -344,8 +350,8 @@ R_API RBuffer *r_buf_new_with_bytes (const ut8 *bytes, ut64 len) {
 	return b;
 }
 
-R_API RBuffer *r_buf_new_with_string (const char *msg) {
-	return r_buf_new_with_bytes ((const ut8*)msg, (ut64) strlen (msg));
+R_API RBuffer *r_buf_new_with_string(const char *msg) {
+	return r_buf_new_with_bytes ((const ut8 *)msg, (ut64)strlen (msg));
 }
 
 R_API RBuffer *r_buf_new_with_bufref(RBuffer *b) {
@@ -441,13 +447,12 @@ R_API ut64 r_buf_size(RBuffer *b) {
 		}
 		return 0LL;
 	}
-	return b->empty? 0: remainingBytes (b->limit, b->length_priv,
-					    b->offset);
+	return b->empty? 0: remainingBytes (b->limit, b->length_priv, b->offset);
 }
 
 // rename to new?
-R_API RBuffer *r_buf_mmap (const char *file, int perm) {
-	int rw = perm & R_PERM_W? true : false;
+R_API RBuffer *r_buf_mmap(const char *file, int perm) {
+	int rw = perm & R_PERM_W? true: false;
 	RBuffer *b = r_buf_new ();
 	if (!b) {
 		return NULL;
@@ -467,7 +472,7 @@ R_API RBuffer *r_buf_mmap (const char *file, int perm) {
 
 R_API RBuffer *r_buf_new_file(const char *file, bool newFile) {
 	const int mode = 0644;
-	const int perm = newFile? O_RDWR|O_CREAT: O_RDWR;
+	const int perm = newFile? O_RDWR | O_CREAT: O_RDWR;
 	int fd = r_sandbox_open (file, perm, mode);
 	if (fd != -1) {
 		RBuffer *b = r_buf_new ();
@@ -488,7 +493,7 @@ R_API RBuffer *r_buf_new_slurp(const char *file) {
 	if (!b) {
 		return NULL;
 	}
-	b->buf = (ut8*)r_file_slurp (file, &len);
+	b->buf = (ut8 *)r_file_slurp (file, &len);
 	b->length_priv = len;
 	if (b->buf) {
 		return b;
@@ -504,7 +509,7 @@ R_API bool r_buf_dump(RBuffer *b, const char *file) {
 	return r_file_dump (file, r_buf_get_at (b, 0, NULL), r_buf_size (b), 0);
 }
 
-R_API int r_buf_seek (RBuffer *b, st64 addr, int whence) {
+R_API int r_buf_seek(RBuffer *b, st64 addr, int whence) {
 	ut64 min = 0LL, max = 0LL;
 	ut64 pa = addr - b->base + b->offset;
 	if (b->fd != -1) {
@@ -518,10 +523,11 @@ R_API int r_buf_seek (RBuffer *b, st64 addr, int whence) {
 		case R_IO_SEEK_SET: b->cur_priv = pa; break;
 		case R_IO_SEEK_CUR: b->cur_priv = b->cur_priv + addr; break;
 		case R_IO_SEEK_END:
-			    if (sparse_limits (b->sparse, NULL, &max)) {
-				    return max; // -min
-			    }
-			    b->cur_priv = max + addr; break; //b->base + b->length + addr; break;
+			if (sparse_limits (b->sparse, NULL, &max)) {
+				return max; // -min
+			}
+			b->cur_priv = max + addr;
+			break; //b->base + b->length + addr; break;
 		}
 	} else {
 		ut64 effective_size = r_buf_size (b);
@@ -544,7 +550,7 @@ R_API int r_buf_seek (RBuffer *b, st64 addr, int whence) {
 	return (int)b->cur_priv;
 }
 
-R_API bool r_buf_set_bits(RBuffer *b, ut64 at, const ut8* buf, int bitoff, int count) {
+R_API bool r_buf_set_bits(RBuffer *b, ut64 at, const ut8 *buf, int bitoff, int count) {
 	r_mem_copybits_delta (b->buf, at * 8, buf, bitoff, count);
 	// TODO: implement r_buf_set_bits
 	// TODO: get the implementation from reg/value.c ?
@@ -578,8 +584,8 @@ R_API int r_buf_set_bytes_steal(RBuffer *b, const ut8 *buf, ut64 length) {
 }
 
 R_API bool r_buf_prepend_bytes(RBuffer *b, const ut8 *buf, int length) {
-	if ((b->buf = realloc (b->buf, b->length_priv+length))) {
-		memmove (b->buf+length, b->buf, b->length_priv);
+	if ((b->buf = realloc (b->buf, b->length_priv + length))) {
+		memmove (b->buf + length, b->buf, b->length_priv);
 		memmove (b->buf, buf, length);
 		b->length_priv += length;
 		b->empty = 0;
@@ -619,8 +625,8 @@ R_API bool r_buf_append_bytes(RBuffer *b, const ut8 *buf, int length) {
 	if (!(b->buf = realloc (b->buf, 1 + b->length_priv + length))) {
 		return false;
 	}
-	memmove (b->buf+b->length_priv, buf, length);
-	b->buf[b->length_priv+length] = 0;
+	memmove (b->buf + b->length_priv, buf, length);
+	b->buf[b->length_priv + length] = 0;
 	b->length_priv += length;
 	return true;
 }
@@ -645,7 +651,7 @@ R_API bool r_buf_append_nbytes(RBuffer *b, int length) {
 	if (!(b->buf = realloc (b->buf, b->length_priv + length))) {
 		return false;
 	}
-	memset (b->buf+b->length_priv, 0, length);
+	memset (b->buf + b->length_priv, 0, length);
 	b->length_priv += length;
 	return true;
 }
@@ -655,7 +661,7 @@ R_API bool r_buf_append_ut16(RBuffer *b, ut16 n) {
 		return false;
 	}
 	if (b->fd != -1) {
-		return r_buf_append_bytes (b, (const ut8*)&n, sizeof (n));
+		return r_buf_append_bytes (b, (const ut8 *)&n, sizeof (n));
 	}
 	if (b->empty) {
 		b->length_priv = b->empty = 0;
@@ -663,7 +669,7 @@ R_API bool r_buf_append_ut16(RBuffer *b, ut16 n) {
 	if (!(b->buf = realloc (b->buf, b->length_priv + sizeof (n)))) {
 		return false;
 	}
-	memmove (b->buf+b->length_priv, &n, sizeof (n));
+	memmove (b->buf + b->length_priv, &n, sizeof (n));
 	b->length_priv += sizeof (n);
 	return true;
 }
@@ -676,9 +682,9 @@ R_API bool r_buf_append_ut32(RBuffer *b, ut32 n) {
 		b->length_priv = b->empty = 0;
 	}
 	if (b->fd != -1) {
-		return r_buf_append_bytes (b, (const ut8*)&n, sizeof (n));
+		return r_buf_append_bytes (b, (const ut8 *)&n, sizeof (n));
 	}
-	if (!(b->buf = realloc (b->buf, b->length_priv+sizeof (n)))) {
+	if (!(b->buf = realloc (b->buf, b->length_priv + sizeof (n)))) {
 		return false;
 	}
 	memmove (b->buf + b->length_priv, &n, sizeof (n));
@@ -691,7 +697,7 @@ R_API bool r_buf_append_ut64(RBuffer *b, ut64 n) {
 		return false;
 	}
 	if (b->fd != -1) {
-		return r_buf_append_bytes (b, (const ut8*)&n, sizeof (n));
+		return r_buf_append_bytes (b, (const ut8 *)&n, sizeof (n));
 	}
 	if (b->empty) {
 		b->length_priv = b->empty = 0;
@@ -699,7 +705,7 @@ R_API bool r_buf_append_ut64(RBuffer *b, ut64 n) {
 	if (!(b->buf = realloc (b->buf, b->length_priv + sizeof (n)))) {
 		return false;
 	}
-	memmove (b->buf+b->length_priv, &n, sizeof (n));
+	memmove (b->buf + b->length_priv, &n, sizeof (n));
 	b->length_priv += sizeof (n);
 	return true;
 }
@@ -717,7 +723,7 @@ R_API bool r_buf_append_buf(RBuffer *b, RBuffer *a) {
 		b->empty = 0;
 	}
 	if ((b->buf = realloc (b->buf, b->length_priv + a->length_priv))) {
-		memmove (b->buf+b->length_priv, a->buf, a->length_priv);
+		memmove (b->buf + b->length_priv, a->buf, a->length_priv);
 		b->length_priv += a->length_priv;
 		return true;
 	}
@@ -857,7 +863,7 @@ R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len) {
 		return r_sandbox_write (b->fd, buf, len);
 	}
 	if (b->sparse) {
-		return (sparse_write (b->sparse, addr, buf, len) < 0) ? -1 : len;
+		return (sparse_write (b->sparse, addr, buf, len) < 0)? -1: len;
 	}
 	if (b->empty) {
 		if (b->ro) {
@@ -870,7 +876,7 @@ R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len) {
 	return r_buf_cpy (b, addr, b->buf, buf, len, true);
 }
 
-R_API int r_buf_fwrite_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n) {
+R_API int r_buf_fwrite_at(RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n) {
 	return r_buf_fcpy_at (b, addr, buf, fmt, n, true);
 }
 
@@ -915,7 +921,7 @@ R_API void r_buf_free(RBuffer *b) {
 	}
 }
 
-R_API int r_buf_append_string (RBuffer *b, const char *str) {
+R_API int r_buf_append_string(RBuffer *b, const char *str) {
 	return r_buf_append_bytes (b, (const ut8*)str, strlen (str));
 }
 
@@ -937,7 +943,7 @@ R_API char *r_buf_free_to_string(RBuffer *b) {
 	return p;
 }
 
-R_API bool r_buf_resize (RBuffer *b, ut64 newsize) {
+R_API bool r_buf_resize(RBuffer *b, ut64 newsize) {
 	if (!b || b->ro) {
 		return false;
 	}

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -509,6 +509,10 @@ R_API bool r_buf_dump(RBuffer *b, const char *file) {
 	return r_file_dump (file, r_buf_get_at (b, 0, NULL), r_buf_size (b), 0);
 }
 
+R_API ut64 r_buf_tell(RBuffer *b) {
+	return r_buf_get_cur (b);
+}
+
 R_API int r_buf_seek(RBuffer *b, st64 addr, int whence) {
 	ut64 min = 0LL, max = 0LL;
 	ut64 pa = addr - b->base + b->offset;

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -419,17 +419,6 @@ R_API const ut8 *r_buf_buffer(RBuffer *b) {
 	r_return_val_if_fail (false, NULL);
 }
 
-R_API ut8 *r_buf_reserve(RBuffer *b, ut64 addr, ut64 len) {
-	if (b && !b->sparse && b->fd == -1 && !b->mmap) {
-		if (addr + len > r_buf_size (b)) {
-			r_buf_resize (b, addr + len);
-		}
-
-		return b->buf + addr - b->base;
-	}
-	r_return_val_if_fail (false, NULL);
-}
-
 R_API ut64 r_buf_size(RBuffer *b) {
 	r_return_val_if_fail (b, 0);
 	if (b->iob) {
@@ -510,7 +499,7 @@ R_API bool r_buf_dump(RBuffer *b, const char *file) {
 }
 
 R_API ut64 r_buf_tell(RBuffer *b) {
-	return r_buf_get_cur (b);
+	return r_buf_seek (b, 0, 1);
 }
 
 R_API int r_buf_seek(RBuffer *b, st64 addr, int whence) {

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -84,7 +84,7 @@ int ar_read(RBuffer *b, void *dest, int len) {
 	if (!r) {
 		return 0;
 	}
-	r_buf_seek(b, r, 1);
+	r_buf_seek (b, r, 1);
 	return r;
 }
 
@@ -129,7 +129,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 		/* Fix padding issues */
 		if (*buffer == '\n') {
 			buffer[0] = buffer[1];
-			r_buf_seek(b, -1, 1);
+			r_buf_seek (b, -1, 1);
 			ar_read (b, buffer, 2);
 		}
 		ar_read (b, buffer + 2, AR_FILENAME_LEN - 2);
@@ -145,7 +145,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 		int dif = (int) (tmp - buffer);
 		dif = 31 - dif;
 		// Re-read the whole filename
-		r_buf_seek(b, -dif, 1);
+		r_buf_seek (b, -dif, 1);
 		r = ar_read (b, buffer, AR_FILENAME_LEN);
 		if (r != AR_FILENAME_LEN) {
 			goto fail;
@@ -200,7 +200,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 	}
 	(void)ar_read (b, buffer, 1);
 
-	r_buf_seek(b, filesize - 1, 1);
+	r_buf_seek (b, filesize - 1, 1);
 	free (curfile);
 	return filesize;
 fail:
@@ -215,12 +215,12 @@ int ar_read_filename_table(RBuffer *b, char *buffer, RList *files, const char *f
 	}
 	if (strncmp (buffer, "//", 2)) {
 		// What we read was not a filename table, just go back
-		r_buf_seek(b, -AR_FILENAME_LEN, 1);
+		r_buf_seek (b, -AR_FILENAME_LEN, 1);
 		return 0;
 	}
 
 	/* Read table size */
-	r_buf_seek(b, 32, 1);
+	r_buf_seek (b, 32, 1);
 	r = ar_read (b, buffer, 10);
 	if (r != 10) {
 		return 0;
@@ -248,7 +248,7 @@ int ar_read_filename_table(RBuffer *b, char *buffer, RList *files, const char *f
 		/* End slash plus separation character ("/\n") */
 		len += r + 2;
 		/* Separation character (not always '\n') */
-		r_buf_seek(b, 1, 1);
+		r_buf_seek (b, 1, 1);
 		index++;
 	}
 	return len;

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -84,7 +84,7 @@ int ar_read(RBuffer *b, void *dest, int len) {
 	if (!r) {
 		return 0;
 	}
-	b->cur += r;
+	r_buf_seek(b, r, 1);
 	return r;
 }
 
@@ -129,7 +129,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 		/* Fix padding issues */
 		if (*buffer == '\n') {
 			buffer[0] = buffer[1];
-			b->cur--;
+			r_buf_seek(b, -1, 1);
 			ar_read (b, buffer, 2);
 		}
 		ar_read (b, buffer + 2, AR_FILENAME_LEN - 2);
@@ -145,7 +145,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 		int dif = (int) (tmp - buffer);
 		dif = 31 - dif;
 		// Re-read the whole filename
-		b->cur -= dif;
+		r_buf_seek(b, -dif, 1);
 		r = ar_read (b, buffer, AR_FILENAME_LEN);
 		if (r != AR_FILENAME_LEN) {
 			goto fail;
@@ -193,14 +193,14 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 		/* Check filename */
 		if (index == index_filename || !strcmp (curfile, filename)) {
 			r_buf_resize(b, filesize);
-			b->base = b->cur;
+			b->base = r_buf_seek(b, 0, 1);
 			free (curfile);
 			return r_buf_size(b);
 		}
 	}
 	(void)ar_read (b, buffer, 1);
 
-	b->cur += filesize - 1;
+	r_buf_seek(b, filesize - 1, 1);
 	free (curfile);
 	return filesize;
 fail:
@@ -215,12 +215,12 @@ int ar_read_filename_table(RBuffer *b, char *buffer, RList *files, const char *f
 	}
 	if (strncmp (buffer, "//", 2)) {
 		// What we read was not a filename table, just go back
-		b->cur -= AR_FILENAME_LEN;
+		r_buf_seek(b, -AR_FILENAME_LEN, 1);
 		return 0;
 	}
 
 	/* Read table size */
-	b->cur += 32;
+	r_buf_seek(b, 32, 1);
 	r = ar_read (b, buffer, 10);
 	if (r != 10) {
 		return 0;
@@ -248,7 +248,7 @@ int ar_read_filename_table(RBuffer *b, char *buffer, RList *files, const char *f
 		/* End slash plus separation character ("/\n") */
 		len += r + 2;
 		/* Separation character (not always '\n') */
-		b->cur += 1;
+		r_buf_seek(b, 1, 1);
 		index++;
 	}
 	return len;

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -195,7 +195,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 			r_buf_resize(b, filesize);
 			b->base = r_buf_tell (b);
 			free (curfile);
-			return r_buf_size(b);
+			return r_buf_size (b);
 		}
 	}
 	(void)ar_read (b, buffer, 1);

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -192,10 +192,10 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 	if (!lookup && filename) {
 		/* Check filename */
 		if (index == index_filename || !strcmp (curfile, filename)) {
-			b->length = filesize;
+			r_buf_resize(b, filesize);
 			b->base = b->cur;
 			free (curfile);
-			return b->length;
+			return r_buf_size(b);
 		}
 	}
 	(void)ar_read (b, buffer, 1);

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -193,7 +193,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 		/* Check filename */
 		if (index == index_filename || !strcmp (curfile, filename)) {
 			r_buf_resize(b, filesize);
-			b->base = r_buf_seek(b, 0, 1);
+			b->base = r_buf_seek (b, 0, 1);
 			free (curfile);
 			return r_buf_size(b);
 		}

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -80,7 +80,7 @@ R_API int ar_write_at(RBuffer *b, ut64 off, void *buf, int count) {
 }
 
 int ar_read(RBuffer *b, void *dest, int len) {
-	int r = r_buf_read(b, dest, len);
+	int r = r_buf_read (b, dest, len);
 	if (!r) {
 		return 0;
 	}

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -80,7 +80,7 @@ R_API int ar_write_at(RBuffer *b, ut64 off, void *buf, int count) {
 }
 
 int ar_read(RBuffer *b, void *dest, int len) {
-	int r = r_buf_read_at (b, R_BUF_CUR, dest, len);
+	int r = r_buf_read(b, dest, len);
 	if (!r) {
 		return 0;
 	}

--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -193,7 +193,7 @@ int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char
 		/* Check filename */
 		if (index == index_filename || !strcmp (curfile, filename)) {
 			r_buf_resize(b, filesize);
-			b->base = r_buf_seek (b, 0, 1);
+			b->base = r_buf_tell (b);
 			free (curfile);
 			return r_buf_size(b);
 		}

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -3111,7 +3111,7 @@ R_API RBinJavaObj *r_bin_java_new_buf(RBuffer *buf, ut64 loadaddr, Sdb *kv) {
 	if (!bin) {
 		return NULL;
 	}
-	if (!r_bin_java_new_bin (bin, loadaddr, kv, buf->buf, buf->length)) {
+	if (!r_bin_java_new_bin (bin, loadaddr, kv, buf->buf, r_buf_size(buf))) {
 		return r_bin_java_free (bin);
 	}
 	return bin;

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -3111,7 +3111,7 @@ R_API RBinJavaObj *r_bin_java_new_buf(RBuffer *buf, ut64 loadaddr, Sdb *kv) {
 	if (!bin) {
 		return NULL;
 	}
-	if (!r_bin_java_new_bin (bin, loadaddr, kv, buf->buf, r_buf_size(buf))) {
+	if (!r_bin_java_new_bin (bin, loadaddr, kv, buf->buf, r_buf_size (buf))) {
 		return r_bin_java_free (bin);
 	}
 	return bin;

--- a/shlr/java/class.h
+++ b/shlr/java/class.h
@@ -782,7 +782,7 @@ R_API RList* r_bin_java_get_symbols(RBinJavaObj* bin);
 R_API RList* r_bin_java_get_strings(RBinJavaObj* bin);
 R_API void* r_bin_java_free(RBinJavaObj* bin);
 R_API RBinJavaObj* r_bin_java_new(const char* file, ut64 baddr, Sdb * kv);
-R_API RBinJavaObj* r_bin_java_new_buf(struct r_buf_t* buf, ut64 baddr, Sdb * kv);
+R_API RBinJavaObj* r_bin_java_new_buf(RBuffer* buf, ut64 baddr, Sdb * kv);
 R_API int r_bin_java_valid_class (const ut8 * buf, ut64 buf_sz);
 
 // Stuff used to manage Java Class File Constant Information

--- a/shlr/java/class.h
+++ b/shlr/java/class.h
@@ -783,7 +783,7 @@ R_API RList* r_bin_java_get_strings(RBinJavaObj* bin);
 R_API void* r_bin_java_free(RBinJavaObj* bin);
 R_API RBinJavaObj* r_bin_java_new(const char* file, ut64 baddr, Sdb * kv);
 R_API RBinJavaObj* r_bin_java_new_buf(RBuffer* buf, ut64 baddr, Sdb * kv);
-R_API int r_bin_java_valid_class (const ut8 * buf, ut64 buf_sz);
+R_API int r_bin_java_valid_class(const ut8 *buf, ut64 buf_sz);
 
 // Stuff used to manage Java Class File Constant Information
 typedef struct r_bin_java_object_allocs_t {


### PR DESCRIPTION
A bit of coccinelle magic. And this is just to "hide" one field... Why so many places directly work with the private field? It makes the abstraction of RBuffer (which can come from IO/file/mmap/whatever) almost useless... :( 