### PR TITLE
Move RAnalOpMask into parameter

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -160,7 +160,6 @@ R_API RAnal *r_anal_new() {
 	anal->limit = NULL;
 	anal->opt.nopskip = true; // skip nops in code analysis
 	anal->opt.hpskip = false; // skip `mov reg,reg` and `lea reg,[reg]`
-	anal->decode = true; // slow slow if not used
 	anal->gp = 0LL;
 	anal->sdb = sdb_new0 ();
 	anal->cpp_abi = R_ANAL_CPP_ABI_ITANIUM;

--- a/libr/anal/anal_ex.c
+++ b/libr/anal/anal_ex.c
@@ -125,7 +125,7 @@ R_API void r_anal_ex_clone_op_switch_to_bb (RAnalBlock *bb, RAnalOp *op) {
 	}
 }
 
-R_API RAnalOp * r_anal_ex_get_op(RAnal *anal, RAnalState *state, ut64 addr) {
+R_API RAnalOp * r_anal_ex_get_op(RAnal *anal, RAnalState *state, ut64 addr, RAnalOpMask mask) {
 	RAnalOp *current_op = state->current_op;
 	const ut8 * data;
 	// current_op set in a prior stage
@@ -145,7 +145,7 @@ R_API RAnalOp * r_anal_ex_get_op(RAnal *anal, RAnalState *state, ut64 addr) {
 		current_op = anal->cur->op_from_buffer (anal, addr, data,  r_anal_state_get_len (state, addr));
 	} else {
 		current_op = r_anal_op_new();
-		anal->cur->op (anal, current_op, addr, data,  r_anal_state_get_len (state, addr));
+		anal->cur->op (anal, current_op, addr, data,  r_anal_state_get_len (state, addr), mask);
 	}
 	state->current_op = current_op;
 	return current_op;
@@ -159,7 +159,7 @@ R_API RAnalBlock * r_anal_ex_get_bb(RAnal *anal, RAnalState *state, ut64 addr) {
 		return current_bb;
 	}
 	if (r_anal_state_addr_is_valid (state, addr) && !op) {
-		op = r_anal_ex_get_op (anal, state, addr);
+		op = r_anal_ex_get_op (anal, state, addr, R_ANAL_OP_MASK_ALL);
 	}
 	if (!op || !r_anal_state_addr_is_valid (state, addr)) {
 		return NULL;
@@ -255,7 +255,7 @@ R_API RList* r_anal_ex_analysis_driver(RAnal *anal, RAnalState *state, ut64 addr
 		if (state->done) {
 			break;
 		}
-	   	r_anal_ex_get_op (anal, state, state->current_addr);
+	   	r_anal_ex_get_op (anal, state, state->current_addr, R_ANAL_OP_MASK_ALL);
 		r_anal_ex_perform_post_anal_op_cb (anal, state, state->current_addr);
 		if (state->done) {
 			break;

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -131,12 +131,10 @@ static int defaultCycles(RAnalOp *op) {
 	}
 }
 
-R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, int mask) {
+R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	r_anal_op_init (op);
 	r_return_val_if_fail (anal && op && len > 0, -1);
 
-	anal->decode = (bool)(mask & R_ANAL_OP_MASK_ESIL);
-	anal->fillval = (bool)(mask & R_ANAL_OP_MASK_VAL);
 	if (anal->pcalign && addr % anal->pcalign) {
 		op->type = R_ANAL_OP_TYPE_ILL;
 		op->addr = addr;
@@ -151,7 +149,7 @@ R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 		if (anal && anal->coreb.archbits) {
 			anal->coreb.archbits (anal->coreb.core, addr);
 		}
-		ret = anal->cur->op (anal, op, addr, data, len);
+		ret = anal->cur->op (anal, op, addr, data, len, mask);
 		if (ret < 1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		}

--- a/libr/anal/p/anal_6502.c
+++ b/libr/anal/p/anal_6502.c
@@ -305,7 +305,7 @@ static void _6502_anal_esil_flags(RAnalOp *op, ut8 data0) {
 	r_strbuf_setf (&op->esil, "%d,%c,=", enabled, flag);
 }
 
-static int _6502_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int _6502_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	char addrbuf[64];
 	const int buffsize = sizeof (addrbuf) - 1;
 	if (len < 1) {

--- a/libr/anal/p/anal_6502_cs.c
+++ b/libr/anal/p/anal_6502_cs.c
@@ -18,7 +18,7 @@
 
 static csh handle = 0;
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	static int omode = 0;
 #if USE_ITER_API
 	static

--- a/libr/anal/p/anal_8051.c
+++ b/libr/anal/p/anal_8051.c
@@ -875,7 +875,7 @@ static ut32 map_direct_addr(RAnal *anal, ut8 addr) {
 	}
 }
 
-static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	set_cpu_model (anal, false);
 
 	op->delay = 0;
@@ -1035,7 +1035,7 @@ static int i8051_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		op->refptr = 1;
 	}
 
-	if (anal->decode) {
+	if (mask & R_ANAL_OP_MASK_ESIL) {
 		ut8 copy[3] = {0, 0, 0};
 		memcpy (copy, buf, len >= 3 ? 3 : len);
 		analop_esil (anal, op, addr, copy);

--- a/libr/anal/p/anal_arc.c
+++ b/libr/anal/p/anal_arc.c
@@ -1013,7 +1013,7 @@ static int arcompact_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, in
 	return op->size;
 }
 
-static int arc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int arc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	const ut8 *b = (ut8 *)data;
 	memset (op, '\0', sizeof (RAnalOp));
 

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -3023,7 +3023,7 @@ static void op_fillval(RAnalOp *op , csh handle, cs_insn *insn, int bits) {
 	}
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	static csh handle = 0;
 	static int omode = -1;
 	static int obits = 32;
@@ -3074,17 +3074,17 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		op->id = insn->id;
 		if (a->bits == 64) {
 			anop64 (handle, op, insn);
-			if (a->decode) {
+			if (mask & R_ANAL_OP_MASK_ESIL) {
 				analop64_esil (a, op, addr, buf, len, &handle, insn);
 			}
 		} else {
 			anop32 (a, handle, op, insn, thumb, (ut8*)buf, len);
-			if (a->decode) {
+			if (mask & R_ANAL_OP_MASK_ESIL) {
 				analop_esil (a, op, addr, buf, len, &handle, insn, thumb);
 			}
 		}
 		set_opdir (op);
-		if (a->fillval) {
+		if (mask & R_ANAL_OP_MASK_VAL) {
 			op_fillval (op, handle, insn, a->bits);
 		}
 		cs_free (insn, n);
@@ -3439,7 +3439,7 @@ static ut8 *anal_mask(RAnal *anal, int size, const ut8 *data, ut64 at) {
 			free (hint);
 		}
 
-		if ((oplen = analop (anal, op, at + idx, data + idx, size - idx)) < 1) {
+		if ((oplen = analop (anal, op, at + idx, data + idx, size - idx, R_ANAL_OP_MASK_BASIC)) < 1) {
 			break;
 		}
 		if (op->ptr != UT64_MAX || op->jump != UT64_MAX) {

--- a/libr/anal/p/anal_arm_gnu.c
+++ b/libr/anal/p/anal_arm_gnu.c
@@ -407,7 +407,7 @@ static int arm_op64(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *d, int len) 
 	return op->size;
 }
 
-static int arm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int arm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	if (anal->bits == 64) {
 		return arm_op64 (anal, op, addr, data, len);
 	}

--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -1772,7 +1772,7 @@ INVALID_OP:
 	return NULL;
 }
 
-static int avr_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int avr_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	CPU_MODEL *cpu;
 	ut64 offset;
 

--- a/libr/anal/p/anal_bf.c
+++ b/libr/anal/p/anal_bf.c
@@ -23,7 +23,7 @@ static int getid (char ch) {
 }
 
 #define BUFSIZE_INC 32
-static int bf_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int bf_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	ut64 dst = 0LL;
 	if (!op) {
 		return 1;

--- a/libr/anal/p/anal_chip8.c
+++ b/libr/anal/p/anal_chip8.c
@@ -6,7 +6,7 @@
 #include <r_asm.h>
 #include <r_anal.h>
 
-static int chip8_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int chip8_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	memset (op, '\0', sizeof (RAnalOp));
 	ut16 opcode = r_read_be16 (data);
 //	uint8_t x = (opcode >> 8) & 0x0F;

--- a/libr/anal/p/anal_cr16.c
+++ b/libr/anal/p/anal_cr16.c
@@ -11,7 +11,7 @@
 #include <cr16_disas.h>
 
 static int cr16_op(RAnal *anal, RAnalOp *op, ut64 addr,
-		const ut8 *buf, int len)
+		const ut8 *buf, int len, RAnalOpMask mask)
 {
 	int ret;
 	struct cr16_cmd cmd;

--- a/libr/anal/p/anal_cris.c
+++ b/libr/anal/p/anal_cris.c
@@ -3,7 +3,7 @@
 #include <r_asm.h>
 #include <r_lib.h>
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int opsize = -1;
         op->type = -1;
 	opsize = 2;

--- a/libr/anal/p/anal_dalvik.c
+++ b/libr/anal/p/anal_dalvik.c
@@ -44,7 +44,7 @@ static const char *getCondz(ut8 cond) {
 	return "";
 }
 
-static int dalvik_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int dalvik_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	int sz = dalvik_opcodes[data[0]].len;
 	if (!op || sz >= len) {
 		return sz;

--- a/libr/anal/p/anal_ebc.c
+++ b/libr/anal/p/anal_ebc.c
@@ -57,7 +57,7 @@ static void ebc_anal_call(RAnalOp *op, ut64 addr, const ut8 *buf) {
 	}
 }
 
-static int ebc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int ebc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int ret;
 	ebc_command_t cmd;
 	ut8 opcode = buf[0] & EBC_OPCODE_MASK;

--- a/libr/anal/p/anal_gb.c
+++ b/libr/anal/p/anal_gb.c
@@ -713,7 +713,7 @@ static int gb_custom_daa (RAnalEsil *esil) {
 	return true;
 }
 
-static int gb_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len){
+static int gb_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	int ilen = gbOpLength (gb_op[data[0]].type);
 	if (ilen > len) {
 		ilen = 0;

--- a/libr/anal/p/anal_h8300.c
+++ b/libr/anal/p/anal_h8300.c
@@ -538,7 +538,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf) {
 }
 
 static int h8300_op(RAnal *anal, RAnalOp *op, ut64 addr,
-		const ut8 *buf, int len)
+		const ut8 *buf, int len, RAnalOpMask mask)
 {
 	int ret;
 	ut8 opcode = buf[0];
@@ -678,7 +678,7 @@ static int h8300_op(RAnal *anal, RAnalOp *op, ut64 addr,
 		op->type = R_ANAL_OP_TYPE_UNK;
 		break;
 	};
-	if (anal->decode) {
+	if (mask & R_ANAL_OP_MASK_ESIL) {
 		analop_esil(anal, op, addr, buf);
 	}
 	return ret;

--- a/libr/anal/p/anal_hexagon.c
+++ b/libr/anal/p/anal_hexagon.c
@@ -9,7 +9,7 @@
 #include "hexagon_insn.h"
 #include "hexagon_anal.h"
 
-static int hexagon_v6_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int hexagon_v6_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	HexInsn hi = {0};;
 	ut32 data = 0;
 	memset (op, 0, sizeof (RAnalOp));

--- a/libr/anal/p/anal_i4004.c
+++ b/libr/anal/p/anal_i4004.c
@@ -97,7 +97,7 @@ static int i4004_get_ins_len (ut8 hex) {
 	return ret;
 }
 
-static int i4004_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int i4004_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	char basm[128];
 	const size_t basz = sizeof (basm)-1;
 	int rlen = i4004_get_ins_len (*buf);

--- a/libr/anal/p/anal_i8080.c
+++ b/libr/anal/p/anal_i8080.c
@@ -11,7 +11,7 @@
 // hack
 #include "../../asm/arch/i8080/i8080dis.c"
 
-static int i8080_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int i8080_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	char out[32];
 	int ilen = i8080_disasm (data, out, len);
 	memset (op, '\0', sizeof (RAnalOp));

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -62,7 +62,7 @@ static int analyze_from_code_buffer (RAnal *anal, RAnalFunction *fcn, ut64 addr,
 static int analyze_from_code_attr (RAnal *anal, RAnalFunction *fcn, RBinJavaField *method, ut64 loadaddr);
 static int analyze_method(RAnal *anal, RAnalFunction *fcn, RAnalState *state);
 
-static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len);
+static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask);
 //static int java_bb(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 len, int reftype);
 //static int java_fn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 len, int reftype);
 
@@ -742,7 +742,7 @@ static int java_switch_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, 
 	return op->size;
 }
 
-static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	/* get opcode size */
 	//ut8 op_byte = data[0];
 	ut8 op_byte = data[0];

--- a/libr/anal/p/anal_m680x_cs.c
+++ b/libr/anal/p/anal_m680x_cs.c
@@ -56,7 +56,7 @@ static int m680xmode(const char *str) {
 	return CS_MODE_M680X_6800;
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int n, ret, opsize = -1;
 	static csh handle = 0;
 	static int omode = -1;

--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -124,7 +124,7 @@ static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	}
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int n, ret, opsize = -1;
 	static csh handle = 0;
 	static int omode = -1;
@@ -675,7 +675,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		op->stackptr = 0;
 		break;
 	}
-	if (a->fillval) {
+	if (mask & R_ANAL_OP_MASK_VAL) {
 		op_fillval (op, handle, insn);
 	}
 beach:

--- a/libr/anal/p/anal_malbolge.c
+++ b/libr/anal/p/anal_malbolge.c
@@ -4,7 +4,7 @@
 #include <r_types.h>
 #include <r_lib.h>
 
-static int mal_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int mal_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	memset (op, '\0', sizeof (RAnalOp));
 	if (len) {
 		switch ((data[0] + addr) % 94) {

--- a/libr/anal/p/anal_mcore.c
+++ b/libr/anal/p/anal_mcore.c
@@ -5,7 +5,7 @@
 #include <r_lib.h>
 #include "../../asm/arch/mcore/mcore.h"
 
-static int mcore_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int mcore_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	mcore_handle handle = {0};
 	mcore_t* instr = NULL;
 

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -703,7 +703,7 @@ static void set_opdir(RAnalOp *op) {
         }
 }
 
-static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int n, ret, opsize = -1;
 	static csh hndl = 0;
 	static int omode = -1;
@@ -1034,12 +1034,12 @@ static int analop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) 
 	}
 beach:
 	set_opdir (op);
-	if (anal->decode) {
+	if (mask & R_ANAL_OP_MASK_ESIL) {
 		if (analop_esil (anal, op, addr, buf, len, &hndl, insn) != 0) {
 			r_strbuf_fini (&op->esil);
 		}
 	}
-	if (anal->fillval) {
+	if (mask & R_ANAL_OP_MASK_VAL) {
 		op_fillval (anal, op, &hndl, insn);
 	}
 	cs_free (insn, n);

--- a/libr/anal/p/anal_mips_gnu.c
+++ b/libr/anal/p/anal_mips_gnu.c
@@ -21,7 +21,7 @@ static const char* mips_reg_decode(unsigned reg_num) {
 	return NULL;
 }
 
-static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
+static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RAnalOpMask mask) {
 	ut32 opcode;
 	// WIP char buf[10]; int reg; int family;
 	int optype, oplen = (anal->bits==16)?2:4;

--- a/libr/anal/p/anal_msp430.c
+++ b/libr/anal/p/anal_msp430.c
@@ -7,7 +7,7 @@
 
 #include <msp430_disas.h>
 
-static int msp430_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int msp430_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int ret;
 	struct msp430_cmd cmd;
 

--- a/libr/anal/p/anal_nios2.c
+++ b/libr/anal/p/anal_nios2.c
@@ -6,7 +6,7 @@
 #include <r_asm.h>
 #include <r_anal.h>
 
-static int nios2_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
+static int nios2_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RAnalOpMask mask) {
 	if (!op) {
 		return 1;
 	}

--- a/libr/anal/p/anal_null.c
+++ b/libr/anal/p/anal_null.c
@@ -4,7 +4,7 @@
 #include <r_types.h>
 #include <r_lib.h>
 
-static int null_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int null_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	memset (op, '\0', sizeof(RAnalOp));
 	/* This should better follow the disassembler */
 	return op->size = 1;

--- a/libr/anal/p/anal_pic.c
+++ b/libr/anal/p/anal_pic.c
@@ -1153,7 +1153,7 @@ static int anal_pic_pic18_set_reg_profile(RAnal *esil) {
 }
 
 
-static int anal_pic_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int anal_pic_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	if (anal->cpu && strcasecmp (anal->cpu, "baseline") == 0) {
 		// TODO: implement
 		return -1;

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -534,7 +534,7 @@ static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	}
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	static csh handle = 0;
 	static int omode = -1, obits = -1;
 	int n, ret;
@@ -1147,7 +1147,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			esilprintf (op, "%s,%s,<<<,%s,&,%s,=", ARG (2), ARG (1), cmask64 (0, ARG (3)), ARG (0));
 			break;
 		}
-		if (a->fillval) {
+		if (mask & R_ANAL_OP_MASK_VAL) {
 			op_fillval (op, handle, insn);
 		}
 		r_strbuf_fini (&op->esil);

--- a/libr/anal/p/anal_ppc_gnu.c
+++ b/libr/anal/p/anal_ppc_gnu.c
@@ -7,7 +7,7 @@
 
 // NOTE: buf should be at least 16 bytes!
 // XXX addr should be off_t for 64 love
-static int ppc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *bytes, int len) {
+static int ppc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *bytes, int len, RAnalOpMask mask) {
 //int arch_ppc_op(ut64 addr, const u8 *bytes, struct op_t *op)
 	// XXX hack
 	int opcode = (bytes[0] & 0xf8) >> 3; // bytes 0-5

--- a/libr/anal/p/anal_propeller.c
+++ b/libr/anal/p/anal_propeller.c
@@ -10,7 +10,7 @@
 
 #include <propeller_disas.h>
 
-static int propeller_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int propeller_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int ret;
 	struct propeller_cmd cmd;
 

--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -50,7 +50,7 @@ static struct riscv_opcode *get_opcode (insn_t word) {
 	return (struct riscv_opcode *)riscv_hash[OP_HASH_IDX (word)];
 }
 
-static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	const int no_alias = 1;
 	struct riscv_opcode *o = NULL;
 	ut64 word = 0;

--- a/libr/anal/p/anal_rsp.c
+++ b/libr/anal/p/anal_rsp.c
@@ -13,7 +13,7 @@
 #include <r_anal.h>
 #include "rsp_idec.h"
 
-static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
+static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RAnalOpMask mask) {
 	int i;
 	typedef struct {
 		RAnalValue* value;

--- a/libr/anal/p/anal_sh.c
+++ b/libr/anal/p/anal_sh.c
@@ -1061,7 +1061,7 @@ static int (*first_nibble_decode[])(RAnal*,RAnalOp*,ut16) = {
 /* This is the basic operation analysis. Just initialize and jump to
  * routines defined in first_nibble_decode table
  */
-static int sh_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int sh_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	ut8 op_MSB, op_LSB;
 	int ret;
 	if (!data || len < 2) {

--- a/libr/anal/p/anal_snes.c
+++ b/libr/anal/p/anal_snes.c
@@ -10,7 +10,7 @@
 
 static struct snes_asm_flags* snesflags = NULL;
 
-static int snes_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int snes_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	memset (op, '\0', sizeof (RAnalOp));
 	op->size = snes_op_get_size(snesflags->M, snesflags->X, &snes_op[data[0]]);
 	if (op->size > len) {

--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -94,7 +94,7 @@ static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	}
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	static csh handle = 0;
 	static int omode;
 	cs_insn *insn;
@@ -316,7 +316,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 			op->type = R_ANAL_OP_TYPE_DIV;
 			break;
 		}
-		if (a->fillval) {
+		if (mask & R_ANAL_OP_MASK_VAL) {
 			op_fillval (op, handle, insn);
 		}
 		cs_free (insn, n);

--- a/libr/anal/p/anal_sparc_gnu.c
+++ b/libr/anal/p/anal_sparc_gnu.c
@@ -369,7 +369,7 @@ static void anal_branch(RAnalOp *op, const ut32 insn, const ut64 addr) {
 }
 
 // TODO: this implementation is just a fast hack. needs to be rewritten and completed
-static int sparc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int sparc_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	int sz = 4;
 	ut32 insn;
 

--- a/libr/anal/p/anal_sysz.c
+++ b/libr/anal/p/anal_sysz.c
@@ -50,7 +50,7 @@ static void opex(RStrBuf *buf, csh handle, cs_insn *insn) {
 	r_strbuf_append (buf, "]}");
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	csh handle;
 	cs_insn *insn;
 	int mode, n, ret;

--- a/libr/anal/p/anal_tms320.c
+++ b/libr/anal/p/anal_tms320.c
@@ -80,7 +80,7 @@ int tms320_c55x_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len)
 	return op->size;
 }
 
-int tms320_op(RAnal * anal, RAnalOp * op, ut64 addr, const ut8 * buf, int len) {
+int tms320_op(RAnal * anal, RAnalOp * op, ut64 addr, const ut8 * buf, int len, RAnalOpMask mask) {
 	TMS_ANAL_OP_FN aop = tms320_c55x_op;
 
 	if (anal->cpu && r_str_casecmp(anal->cpu, "c64x") == 0) {

--- a/libr/anal/p/anal_v810.c
+++ b/libr/anal/p/anal_v810.c
@@ -46,7 +46,7 @@ static void clear_flags(RAnalOp *op, int flags) {
 	}
 }
 
-static int v810_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int v810_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int ret;
 	ut8 opcode, reg1, reg2, imm5, cond;
 	ut16 word1, word2 = 0;

--- a/libr/anal/p/anal_v850.c
+++ b/libr/anal/p/anal_v850.c
@@ -164,7 +164,7 @@ static void clear_flags(RAnalOp *op, int flags) {
 	}
 }
 
-static int v850_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int v850_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	int ret = 0;
 	ut8 opcode = 0;
 	const char *reg1 = NULL;

--- a/libr/anal/p/anal_vax.c
+++ b/libr/anal/p/anal_vax.c
@@ -11,7 +11,7 @@
 // XXX: do not hardcode size/type here, use proper decoding table
 // http://hotkosc.ru:8080/method-vax.doc
 
-static int vax_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int vax_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	op->size = 1;
 	if (len < 1) {
 		return -1;

--- a/libr/anal/p/anal_wasm.c
+++ b/libr/anal/p/anal_wasm.c
@@ -71,7 +71,7 @@ static bool advance_till_scope_end(RAnal* anal, RAnalOp *op, ut64 address, ut32 
 }
 
 // analyzes the wasm opcode.
-static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	WasmOp wop = {{0}};
 	RAnalHint *hint = NULL;
 	memset (op, '\0', sizeof (RAnalOp));

--- a/libr/anal/p/anal_ws.c
+++ b/libr/anal/p/anal_ws.c
@@ -26,7 +26,7 @@ static ut64 ws_find_label(int l, RIOBind iob) {
 	return 0;
 }
 
-static int ws_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int ws_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	memset (op, '\0', sizeof (RAnalOp));
 	op->addr = addr;
 	op->type = R_ANAL_OP_TYPE_UNK;

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1204,19 +1204,17 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 		// TODO: what if UJMP?
 		switch (INSOP(0).type) {
 		case X86_OP_IMM:
-			if (a->decode) {
-				if (INSOP(1).type == X86_OP_IMM) {
-					ut64 seg = INSOP(0).imm;
-					ut64 off = INSOP(1).imm;
-					esilprintf (
-						op,
-						"0x%"PFMT64x",cs,=,"
-						"0x%"PFMT64x",%s,=",
-						seg, off, pc);
-				} else {
-					ut64 dst = INSOP(0).imm;
-					esilprintf (op, "0x%"PFMT64x",%s,=", dst, pc);
-				}
+			if (INSOP(1).type == X86_OP_IMM) {
+				ut64 seg = INSOP(0).imm;
+				ut64 off = INSOP(1).imm;
+				esilprintf (
+					op,
+					"0x%"PFMT64x",cs,=,"
+					"0x%"PFMT64x",%s,=",
+					seg, off, pc);
+			} else {
+				ut64 dst = INSOP(0).imm;
+				esilprintf (op, "0x%"PFMT64x",%s,=", dst, pc);
 			}
 			break;
 		case X86_OP_MEM:
@@ -1225,26 +1223,24 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 			} else {
 				cs_x86_op in = INSOP (0);
 				if (in.mem.index == 0 && in.mem.base == 0 && in.mem.scale == 1) {
-					if (a->decode) {
-						if (in.mem.segment != X86_REG_INVALID) {
-							esilprintf (
-								op,
-								"4,%s,<<,0x%"PFMT64x",+,[],%s,=",
-								INSOP(0).mem.segment == X86_REG_ES ? "es"
-								: INSOP(0).mem.segment == X86_REG_CS ? "cs"
-								: INSOP(0).mem.segment == X86_REG_DS ? "ds"
-								: INSOP(0).mem.segment == X86_REG_FS ? "fs"
-								: INSOP(0).mem.segment == X86_REG_GS ? "gs"
-								: INSOP(0).mem.segment == X86_REG_SS ? "ss"
-								: "unknown_segment_register",
-								INSOP(0).mem.disp,
-								pc);
-						} else {
-							esilprintf (
-								op,
-								"0x%"PFMT64x",[],%s,=",
-								INSOP(0).mem.disp, pc);
-						}
+					if (in.mem.segment != X86_REG_INVALID) {
+						esilprintf (
+							op,
+							"4,%s,<<,0x%"PFMT64x",+,[],%s,=",
+							INSOP(0).mem.segment == X86_REG_ES ? "es"
+							: INSOP(0).mem.segment == X86_REG_CS ? "cs"
+							: INSOP(0).mem.segment == X86_REG_DS ? "ds"
+							: INSOP(0).mem.segment == X86_REG_FS ? "fs"
+							: INSOP(0).mem.segment == X86_REG_GS ? "gs"
+							: INSOP(0).mem.segment == X86_REG_SS ? "ss"
+							: "unknown_segment_register",
+							INSOP(0).mem.disp,
+							pc);
+					} else {
+						esilprintf (
+							op,
+							"0x%"PFMT64x",[],%s,=",
+							INSOP(0).mem.disp, pc);
 					}
 				}
 			}
@@ -2731,7 +2727,7 @@ static int cs_len_prefix_opcode(uint8_t *item) {
 	return len;
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	static int omode = 0;
 #if USE_ITER_API
 	static
@@ -2808,10 +2804,10 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 		}
 		anop (a, op, addr, buf, len, &handle, insn);
 		set_opdir (op, insn);
-		if (a->decode) {
+		if (mask & R_ANAL_OP_MASK_ESIL) {
 			anop_esil (a, op, addr, buf, len, &handle, insn);
 		}
-		if (a->fillval) {
+		if (mask & R_ANAL_OP_MASK_VAL) {
 			op_fillval (a, op, &handle, insn);
 		}
 	}

--- a/libr/anal/p/anal_xap.c
+++ b/libr/anal/p/anal_xap.c
@@ -37,7 +37,7 @@ static inline ut16 i2ut16(struct instruction *in) {
 	return *((uint16_t*)in);
 }
 
-static int xap_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *bytes, int len) {
+static int xap_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *bytes, int len, RAnalOpMask mask) {
 	struct instruction *in = (struct instruction *)bytes;
 	ut16 lol, ins;
 	struct directive d = {{0}};

--- a/libr/anal/p/anal_xcore_cs.c
+++ b/libr/anal/p/anal_xcore_cs.c
@@ -50,7 +50,7 @@ static void opex(RStrBuf *buf, csh handle, cs_insn *insn) {
 	r_strbuf_append (buf, "}");
 }
 
-static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
 	static csh handle = 0;
 	static int omode = 0;
 	cs_insn *insn;

--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -1908,7 +1908,7 @@ static void analop_esil (xtensa_isa isa, xtensa_opcode opcode, xtensa_format for
 	}
 }
 
-static int xtensa_op (RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf_original, int len_original) {
+static int xtensa_op (RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf_original, int len_original, RAnalOpMask mask) {
 	if (!op) {
 		return 1;
 	}
@@ -1921,9 +1921,6 @@ static int xtensa_op (RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf_origin
 	}
 
 	xtensa_op0_fns[(buf_original[0] & 0xf)] (anal, op, addr, buf_original);
-
-	if (anal->decode) {
-	}
 
 	ut8 buffer[XTENSA_MAX_LENGTH] = { 0 };
 	int len = R_MIN(op->size, XTENSA_MAX_LENGTH);
@@ -1972,7 +1969,7 @@ static int xtensa_op (RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf_origin
 			xtensa_check_stack_op (isa, opcode, format, i, slot_buffer, op);
 		}
 
-		if (anal->decode) {
+		if (mask & R_ANAL_OP_MASK_ESIL) {
 			analop_esil (isa, opcode, format, i, slot_buffer, op);
 		}
 	}

--- a/libr/anal/p/anal_z80.c
+++ b/libr/anal/p/anal_z80.c
@@ -55,7 +55,7 @@ static void z80_op_size(const ut8 *data, int len, int *size, int *size_prefix) {
 	}
 }
 
-static int z80_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len) {
+static int z80_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	int ilen = 0;
 	z80_op_size (data, len, &ilen, &op->nopcode);
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -657,7 +657,6 @@ typedef struct r_anal_t {
 	RFlagSet flg_fcn_set;
 	RBinBind binb; // Set only from core when an analysis plugin is called.
 	RCoreBind coreb;
-	int decode;
 	int maxreflines;
 	int trace;
 	int esil_goto_limit;
@@ -704,7 +703,6 @@ typedef struct r_anal_t {
 	bool merge_hints;
 	RListComparator columnSort;
 	int stackptr;
-	bool fillval;
 	bool (*log)(struct r_anal_t *anal, const char *msg);
 	bool (*read_at)(struct r_anal_t *anal, ut64 addr, ut8 *buf, int len);
 	bool verbose;
@@ -1185,7 +1183,7 @@ typedef RAnalOp * (*RAnalOpFromBuffer)      (RAnal *a, ut64 addr, const ut8* buf
 typedef RAnalBlock * (*RAnalBbFromBuffer)   (RAnal *a, ut64 addr, const ut8* buf, ut64 len);
 typedef RAnalFunction * (*RAnalFnFromBuffer)(RAnal *a, ut64 addr, const ut8* buf, ut64 len);
 
-typedef int (*RAnalOpCallback)(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *data, int len);
+typedef int (*RAnalOpCallback)(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask);
 typedef int (*RAnalBbCallback)(RAnal *a, RAnalBlock *bb, ut64 addr, const ut8 *data, int len);
 typedef int (*RAnalFnCallback)(RAnal *a, RAnalFunction *fcn, ut64 addr, const ut8 *data, int len, int reftype);
 
@@ -1368,7 +1366,7 @@ R_API RAnalVar *get_link_var(RAnal *anal, ut64 faddr, RAnalVar *var);
 R_API bool r_anal_op_is_eob(RAnalOp *op);
 R_API RList *r_anal_op_list_new(void);
 R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr,
-		const ut8 *data, int len, int mask);
+		const ut8 *data, int len, RAnalOpMask mask);
 R_API RAnalOp *r_anal_op_hexstr(RAnal *anal, ut64 addr,
 		const char *hexstr);
 R_API char *r_anal_op_to_string(RAnal *anal, RAnalOp *op);

--- a/libr/include/r_anal_ex.h
+++ b/libr/include/r_anal_ex.h
@@ -314,7 +314,7 @@ R_API RList * r_anal_ex_perform_analysis( RAnal *anal, RAnalState *state, ut64 a
 
 // BB and OP handling
 R_API void r_anal_ex_update_bb_cfg_head_tail( RAnalBlock *start, RAnalBlock * head, RAnalBlock * tail );
-R_API RAnalOp * r_anal_ex_get_op(RAnal *anal, RAnalState *state, ut64 addr);
+R_API RAnalOp * r_anal_ex_get_op(RAnal *anal, RAnalState *state, ut64 addr, RAnalOpMask mask);
 R_API RAnalBlock * r_anal_ex_get_bb(RAnal *anal, RAnalState *state, ut64 addr);
 R_API void r_anal_ex_clone_op_switch_to_bb (RAnalBlock *bb, RAnalOp *op);
 


### PR DESCRIPTION
These options are misplaced in the global RAnal instance.