### PR TITLE
Add chip8 pseudo support

### DIFF
--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -74,6 +74,7 @@ extern RParsePlugin r_parse_plugin_6502_pseudo;
 extern RParsePlugin r_parse_plugin_arm_pseudo;
 extern RParsePlugin r_parse_plugin_att2intel;
 extern RParsePlugin r_parse_plugin_avr_pseudo;
+extern RParsePlugin r_parse_plugin_chip8_pseudo;
 extern RParsePlugin r_parse_plugin_dalvik_pseudo;
 extern RParsePlugin r_parse_plugin_dummy;
 extern RParsePlugin r_parse_plugin_m68k_pseudo;

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -300,6 +300,7 @@ parse_plugins = [
   'arm_pseudo',
   'att2intel',
   'avr_pseudo',
+  'chip8_pseudo',
   'dalvik_pseudo',
   'm68k_pseudo',
   'mips_pseudo',

--- a/libr/parse/meson.build
+++ b/libr/parse/meson.build
@@ -5,6 +5,7 @@ r_parse_sources = [
   'p/parse_arm_pseudo.c',
   'p/parse_att2intel.c',
   'p/parse_avr_pseudo.c',
+  'p/parse_chip8_pseudo.c',
   'p/parse_dalvik_pseudo.c',
   'p/parse_m68k_pseudo.c',
   'p/parse_mips_pseudo.c',

--- a/libr/parse/p/Makefile
+++ b/libr/parse/p/Makefile
@@ -11,7 +11,7 @@ ifeq ($(WITHPIC),1)
 all: ${ALL_TARGETS}
 
 ALL_TARGETS=
-ARCHS=att2intel.mk x86_pseudo.mk mreplace.mk
+ARCHS=att2intel.mk x86_pseudo.mk mreplace.mk chip8_pseudo.mk
 ARCHS+=arm_pseudo.mk z80_pseudo.mk ppc_pseudo.mk 6502_pseudo.mk
 ARCHS+=m68k_pseudo.mk sh_pseudo.mk avr_pseudo.mk wasm_pseudo.mk
 include $(ARCHS)

--- a/libr/parse/p/chip8_pseudo.mk
+++ b/libr/parse/p/chip8_pseudo.mk
@@ -1,0 +1,18 @@
+OBJ_CHIP8PSEUDO+=parse_chip8_pseudo.o
+
+TARGET_CHIP8PSEUDO=parse_chip8_pseudo.${EXT_SO}
+STATIC_OBJ+=${OBJ_CHIP8PSEUDO}
+ifeq ($(CC),cccl)
+LIBDEPS=-L../../util -llibr_util
+LIBDEPS+=-L../../flag -llibr_flag
+else
+LIBDEPS=-L../../util -lr_util
+LIBDEPS+=-L../../flag -lr_flag
+endif
+
+ifeq ($(WITHPIC),1)
+ALL_TARGETS+=${TARGET_CHIP8PSEUDO}
+${TARGET_CHIP8PSEUDO}: ${OBJ_CHIP8PSEUDO}
+	${CC} $(call libname,parse_chip8_pseudo) ${LIBDEPS} $(LDFLAGS) \
+		$(LDFLAGS_SHARED) ${CFLAGS} -o ${TARGET_CHIP8PSEUDO} ${OBJ_CHIP8PSEUDO}
+endif

--- a/libr/parse/p/parse_chip8_pseudo.c
+++ b/libr/parse/p/parse_chip8_pseudo.c
@@ -1,0 +1,118 @@
+/* radare - LGPL - Copyright 2019 - Vasilij Schneidermann <mail@vasilij.de> */
+
+#include <r_lib.h>
+#include <r_util.h>
+#include <r_flag.h>
+#include <r_anal.h>
+#include <r_parse.h>
+
+#define MAXARGS 4
+#define BUFSIZE 64
+
+static void concat(char *buf, size_t len, char** args) {
+	char *arg;
+	char *dest = buf;
+	int arg_len;
+
+	while ((arg = *args++)) {
+		if (snprintf (dest, len, "%s", arg) >= len) {
+			break;
+		}
+		arg_len = strlen (arg);
+		dest += arg_len;
+		len -= arg_len;
+	}
+}
+
+static int replace(int argc, char *argv[], char *newstr, size_t len) {
+	int i;
+	struct {
+		char *op;
+		char **res;
+	} ops[] = {
+		{ "add",  (char*[]){ argv[1], " += ", argv[2], NULL } },
+		{ "and",  (char*[]){ argv[1], " &= ", argv[2], NULL } },
+		{ "cls",  (char*[]){ "clear_screen()", NULL } },
+		{ "drw",  (char*[]){ "draw(", argv[1], ", ", argv[2], ", ", argv[3], ")", NULL } },
+		{ "exit", (char*[]){ "exit()", NULL } },
+		{ "high", (char*[]){ "high_res()", NULL } },
+		{ "jp",   (char*[]){ "goto ", argv[1], NULL } },
+		{ "ld",   (char*[]){ argv[1], " = ", argv[2], NULL } },
+		{ "low",  (char*[]){ "low_res()", NULL } },
+		{ "or",   (char*[]){ argv[1], " |= ", argv[2], NULL } },
+		{ "rnd",  (char*[]){ argv[1], " = random(256) & ", argv[2], NULL } },
+		{ "scd",  (char*[]){ "scroll_down(", argv[1], ")", NULL } },
+		{ "scl",  (char*[]){ "scroll_left()", NULL } },
+		{ "scr",  (char*[]){ "scroll_right()", NULL } },
+		{ "se",   (char*[]){ "skip_next_instr if ", argv[1], " == ", argv[2], NULL } },
+		{ "shl",  (char*[]){ argv[1], " <<= 1", NULL } },
+		{ "shr",  (char*[]){ argv[1], " >>= 1", NULL } },
+		{ "sknp", (char*[]){ "skip_next_instr if !key_pressed(", argv[1], ")", NULL } },
+		{ "skp",  (char*[]){ "skip_next_instr if key_pressed(", argv[1], "))", NULL } },
+		{ "sne",  (char*[]){ "skip_next_instr if ", argv[1], " != ", argv[2], NULL } },
+		{ "sub",  (char*[]){ argv[1], " -= ", argv[2], NULL } },
+		{ "subn", (char*[]){ argv[1], " = ", argv[1], " - ", argv[2], NULL } },
+		{ "xor",  (char*[]){ argv[1], " ^= ", argv[2], NULL } },
+		{ NULL }
+	};
+
+	for (i = 0; ops[i].op; i++) {
+		if (!strcmp (ops[i].op, argv[0]) && newstr) {
+			concat (newstr, len, ops[i].res);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static int tokenize(const char* in, char* out[]) {
+	int len = strlen (in), count = 0, i = 0, tokenlen = 0, seplen = 0;
+	char *token, *buf = (char*) in;
+
+	while (i < len) {
+		tokenlen = strcspn (buf, ", ");
+		token = calloc (tokenlen + 1, sizeof(char));
+		memcpy (token, buf, tokenlen);
+		out[count] = token;
+		i += tokenlen;
+		buf += tokenlen;
+		count++;
+
+		seplen = strspn (buf, ", ");
+		i += seplen;
+		buf += seplen;
+	}
+
+	return count;
+}
+
+static int parse(RParse *p, const char *data, char *str) {
+	int i;
+	char *argv[MAXARGS] = { NULL, NULL, NULL, NULL };
+	int argc = tokenize (data, argv);
+
+	if (!replace (argc, argv, str, BUFSIZE)) {
+		strcpy (str, data);
+	}
+
+	for (i = 0; i < MAXARGS; i++) {
+		free (argv[i]);
+	}
+
+	return true;
+}
+
+RParsePlugin r_parse_plugin_chip8_pseudo = {
+	.name = "chip8.pseudo",
+	.desc = "chip8 pseudo syntax",
+	.parse = parse,
+};
+
+#ifndef CORELIB
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_PARSE,
+	.data = &r_parse_plugin_chip8_pseudo,
+	.version = R2_VERSION
+};
+#endif

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -250,6 +250,7 @@ lang.vala
 parse.6502_pseudo
 parse.arm_pseudo
 parse.att2intel
+parse.chip8_pseudo
 parse.dalvik_pseudo
 parse.m68k_pseudo
 parse.mips_pseudo

--- a/plugins.static.cfg
+++ b/plugins.static.cfg
@@ -213,6 +213,7 @@ parse.6502_pseudo
 parse.arm_pseudo
 parse.att2intel
 parse.avr_pseudo
+parse.chip8_pseudo
 parse.dalvik_pseudo
 parse.m68k_pseudo
 parse.mips_pseudo


### PR DESCRIPTION
I have a few questions:

- Any preferences for the copyright line?
- How exactly is memory management done here? I've compared with other parse functions and found a lot of heap-allocated memory that is neither used nor freed afterwards...
- Any other files I need to edit to include the plugin properly?
- How can this kind of plugin be tested?
- Does the logic look good to you? If yes, the same kind of changes can be done to the other parse plugins as well.