### PR TITLE
[13363] Remove URI handler before looking for auxillary script

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1328,8 +1328,14 @@ R_API int r_main_radare2(int argc, char **argv) {
 		r_flag_space_set (r.flags, NULL);
 		/* load <file>.r2 */
 		{
-			char f[128];
+			char f[256];
 			snprintf (f, sizeof (f), "%s.r2", pfile);
+			if(strncmp(f, "dbg://", 6) == 0) {
+				// cut out the uri handler part of the path
+				char tmp[256];
+				strncpy (tmp, f + 6, 250);
+				strncpy (f, tmp, 250);
+			}
 			if (r_file_exists (f)) {
 				// TODO: should 'q' unset the interactive bit?
 				bool isInteractive = r_cons_is_interactive ();

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1329,20 +1329,16 @@ R_API int r_main_radare2(int argc, char **argv) {
 		/* load <file>.r2 */
 		{
 			char* f = r_str_newf ("%s.r2", pfile);
-			const int f_len = strlen (f);
-			const char *prefix = "dbg://";
-			const int prefix_len = strlen (prefix);
-			if (r_str_startswith (f, prefix)) {
-				memmove (f, f + prefix_len, f_len - prefix_len + 1);
-			}
-			if (r_file_exists (f)) {
+			const char *uri_splitter = strstr (f, "://");
+			const char *path = uri_splitter? uri_splitter + 3: f;
+			if (r_file_exists (path)) {
 				// TODO: should 'q' unset the interactive bit?
 				bool isInteractive = r_cons_is_interactive ();
-				if (isInteractive && r_cons_yesno ('n', "Do you want to run the '%s' script? (y/N) ", f)) {
-					r_core_cmd_file (&r, f);
+				if (isInteractive && r_cons_yesno ('n', "Do you want to run the '%s' script? (y/N) ", path)) {
+					r_core_cmd_file (&r, path);
 				}
 			}
-			free(f);
+			free (f);
 		}
 	} else {
 		r_core_block_read (&r);

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1328,13 +1328,13 @@ R_API int r_main_radare2(int argc, char **argv) {
 		r_flag_space_set (r.flags, NULL);
 		/* load <file>.r2 */
 		{
-			char f[256];
-			snprintf (f, sizeof (f), "%s.r2", pfile);
-			if(strncmp(f, "dbg://", 6) == 0) {
-				// cut out the uri handler part of the path
-				char tmp[256];
-				strncpy (tmp, f + 6, 250);
-				strncpy (f, tmp, 250);
+			char* f = r_str_newf("%s.r2", pfile);
+			int f_len = strlen (f);
+			const char* prefix = "dbg://";
+			int prefix_len = strlen (prefix);
+			if (r_str_startswith (f, prefix)) {
+				memmove (f, f + prefix_len, f_len - prefix_len);
+				f[f_len - prefix_len] = '\0';
 			}
 			if (r_file_exists (f)) {
 				// TODO: should 'q' unset the interactive bit?

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1328,13 +1328,12 @@ R_API int r_main_radare2(int argc, char **argv) {
 		r_flag_space_set (r.flags, NULL);
 		/* load <file>.r2 */
 		{
-			char* f = r_str_newf("%s.r2", pfile);
-			int f_len = strlen (f);
-			const char* prefix = "dbg://";
-			int prefix_len = strlen (prefix);
+			char* f = r_str_newf ("%s.r2", pfile);
+			const int f_len = strlen (f);
+			const char *prefix = "dbg://";
+			const int prefix_len = strlen (prefix);
 			if (r_str_startswith (f, prefix)) {
-				memmove (f, f + prefix_len, f_len - prefix_len);
-				f[f_len - prefix_len] = '\0';
+				memmove (f, f + prefix_len, f_len - prefix_len + 1);
 			}
 			if (r_file_exists (f)) {
 				// TODO: should 'q' unset the interactive bit?
@@ -1343,6 +1342,7 @@ R_API int r_main_radare2(int argc, char **argv) {
 					r_core_cmd_file (&r, f);
 				}
 			}
+			free(f);
 		}
 	} else {
 		r_core_block_read (&r);


### PR DESCRIPTION
When using debugger the file assumed path for the auxillary script
was dbg://...binary path.r2, without debugger it's just ...binary path.r2.

This patch cuts out the 'dbg://' prefix, if found, before looking for the
auxillary script.

Fix for https://github.com/radare/radare2/issues/13363