### PR TITLE
Improve Makefile on macOS

### DIFF
--- a/shlr/sdb/config.mk
+++ b/shlr/sdb/config.mk
@@ -52,7 +52,7 @@ HAVE_VALA=#$(shell valac --version 2> /dev/null)
 # This is hacky
 HOST_CC?=gcc
 RANLIB?=ranlib
-OS?=$(shell uname)
+OS=$(shell uname)
 OSTYPE?=$(shell uname -s)
 ARCH?=$(shell uname -m)
 


### PR DESCRIPTION
`OS`  can have already be set to other values on user machines, `OS=` fits better here.