### PR TITLE
Fixes #1179 - `itj` hashes calculation command has fixed

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -886,7 +886,7 @@ R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file, RList/*<RBin
 		*old_file_hashes = NULL;
 	}
 	if (!r_list_empty (o->info->file_hashes)) {
-		if (old_file_hashes) {
+		if (old_file_hashes && o->info->file_hashes) {
 			*old_file_hashes = o->info->file_hashes;
 		} else {
 			r_list_free (o->info->file_hashes);
@@ -914,7 +914,7 @@ R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file, RList/*<RBin
 	}
 	r_hash_do_end (ctx, R_HASH_MD5);
 	r_hex_bin2str (ctx->digest, R_HASH_SIZE_MD5, hash);
-	
+
 	o->info->file_hashes = r_list_newf (r_bin_file_hash_free);
 	RBinFileHash *md5h = R_NEW0 (RBinFileHash);
 	if (md5h) {
@@ -924,7 +924,7 @@ R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file, RList/*<RBin
 	}
 	r_hash_do_end (ctx, R_HASH_SHA1);
 	r_hex_bin2str (ctx->digest, R_HASH_SIZE_SHA1, hash);
-	
+
 	RBinFileHash *sha1h = R_NEW0 (RBinFileHash);
 	if (sha1h) {
 		sha1h->type = strdup ("sha1");

--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -847,7 +847,7 @@ R_API bool r_bin_file_close(RBin *bin, int bd) {
 	return false;
 }
 
-R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file) {
+R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file, RList/*<RBinFileHash>*/ **old_file_hashes) {
 	r_return_val_if_fail (bin, false);
 
 	char hash[128], *p;
@@ -882,6 +882,17 @@ R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file) {
 		eprintf ("Cannot allocate computation buffer\n");
 		return false;
 	}
+	if (old_file_hashes) {
+		*old_file_hashes = NULL;
+	}
+	if (!r_list_empty (o->info->file_hashes)) {
+		if (old_file_hashes) {
+			*old_file_hashes = o->info->file_hashes;
+		} else {
+			r_list_free (o->info->file_hashes);
+		}
+		o->info->file_hashes = NULL;
+	}
 	ctx = r_hash_new (false, R_HASH_MD5 | R_HASH_SHA1);
 	while (r + blocksize < buf_len) {
 		r_io_desc_seek (iod, r, R_IO_SEEK_SET);
@@ -902,18 +913,26 @@ R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file) {
 		}
 	}
 	r_hash_do_end (ctx, R_HASH_MD5);
-	p = hash;
-	r_hex_bin2str (ctx->digest, R_HASH_SIZE_MD5, p);
-	RStrBuf *sbuf = r_strbuf_new ("");
-	r_strbuf_appendf (sbuf, "md5 %s", hash);
-
+	r_hex_bin2str (ctx->digest, R_HASH_SIZE_MD5, hash);
+	
+	o->info->file_hashes = r_list_newf (r_bin_file_hash_free);
+	RBinFileHash *md5h = R_NEW0 (RBinFileHash);
+	if (md5h) {
+		md5h->type = strdup ("md5");
+		md5h->hex = strdup (hash);
+		r_list_push (o->info->file_hashes, md5h);
+	}
 	r_hash_do_end (ctx, R_HASH_SHA1);
-	p = hash;
-	r_hex_bin2str (ctx->digest, R_HASH_SIZE_SHA1, p);
-	r_strbuf_appendf (sbuf, "\nsha1 %s", hash);
+	r_hex_bin2str (ctx->digest, R_HASH_SIZE_SHA1, hash);
+	
+	RBinFileHash *sha1h = R_NEW0 (RBinFileHash);
+	if (sha1h) {
+		sha1h->type = strdup ("sha1");
+		sha1h->hex = strdup (hash);
+		r_list_push (o->info->file_hashes, sha1h);
+	}
 	// TODO: add here more rows
 
-	o->info->hashes = r_strbuf_drain (sbuf);
 	free (buf);
 	r_hash_free (ctx);
 	return true;

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -120,11 +120,22 @@ R_API void r_bin_arch_options_init(RBinArchOptions *opt, const char *arch, int b
 	opt->bits = bits? bits: R_SYS_BITS;
 }
 
+R_API void r_bin_file_hash_free(RBinFileHash *fhash) {
+	if (!fhash) {
+		return;
+	}
+
+	R_FREE (fhash->type);
+	R_FREE (fhash->hex);
+	free (fhash);
+}
+
 R_API void r_bin_info_free(RBinInfo *rb) {
 	if (!rb) {
 		return;
 	}
-	free (rb->hashes);
+
+	r_list_free (rb->file_hashes);
 	free (rb->intrp);
 	free (rb->file);
 	free (rb->type);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3618,31 +3618,6 @@ static int bin_header(RCore *r, int mode) {
 	return false;
 }
 
-static int bin_hashes(RCore *r, int mode) {
-	ut64 lim = r_config_get_i (r->config, "bin.hashlimit");
-	RIODesc *iod = r_io_desc_get (r->io, r->file->fd);
-	if (iod) {
-		// recompute again
-		r_bin_file_hash (r->bin, lim, iod->name);
-		char *hashes = (r->bin && r->bin->cur && r->bin->cur->o && r->bin->cur->o->info)? r->bin->cur->o->info->hashes: NULL;
-		if (IS_MODE_JSON (mode)) {
-			PJ *pj = pj_new ();
-			if (!pj) {
-				return false;
-			}
-			pj_o (pj);
-			pj_ks (pj, "values", hashes);
-			pj_end (pj);
-			r_cons_printf ("%s", pj_string (pj));
-			pj_free (pj);
-		} else {
-			r_cons_printf ("%s\n", hashes);
-		}
-		return true;
-	}
-	return false;
-}
-
 R_API int r_core_bin_info(RCore *core, int action, int mode, int va, RCoreBinFilter *filter, const char *chksum) {
 	int ret = true;
 	const char *name = NULL;
@@ -3745,12 +3720,6 @@ R_API int r_core_bin_info(RCore *core, int action, int mode, int va, RCoreBinFil
 			}
 		}
 	}
-#if 0
-	// only compute when requested
-	if ((action & R_CORE_BIN_ACC_HASHES)) {
-		ret &= bin_hashes (core, mode);
-	}
-#endif
 	return ret;
 }
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3335,7 +3335,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("file.offset", "", "Offset where the file will be mapped at");
 	SETCB ("file.path", "", &cb_filepath, "Path of current file");
 	SETPREF ("file.lastpath", "", "Path of current file");
-	SETPREF ("file.sha1", "", "SHA1 hash of current file");
 	SETPREF ("file.type", "", "Type of current file");
 	SETI ("file.loadalign", 1024, "Alignment of load addresses");
 	SETI ("file.openmany", 1, "Maximum number of files opened at once");

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -511,7 +511,7 @@ static int cmd_info(void *data, const char *input) {
 					if (!r_list_empty (old_file_hashes)) {
 						r_list_free (old_file_hashes);
 					}
-					if (r_list_empty (info->file_hashes)) {
+					if (differs || r_list_empty (info->file_hashes)) {
 						break;
 					}
 				}

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -184,6 +184,11 @@ typedef struct r_bin_hash_t {
 	const char *cmd;
 } RBinHash;
 
+typedef struct r_bin_file_hash_t {
+	const char *type;
+	const char *hex;
+} RBinFileHash;
+
 typedef struct r_bin_info_t {
 	char *file;
 	char *type;
@@ -198,7 +203,7 @@ typedef struct r_bin_info_t {
 	char *guid;
 	char *debug_file_name;
 	const char *lang;
-	char *hashes;
+	RList/*<RBinFileHash>*/ *file_hashes;
 	int bits;
 	int has_va;
 	int has_pi; // pic/pie
@@ -346,6 +351,7 @@ typedef struct r_bin_xtr_extract_t {
 
 R_API RBinXtrData *r_bin_xtrdata_new(RBuffer *buf, ut64 offset, ut64 size, ut32 file_count, RBinXtrMetadata *metadata);
 R_API void r_bin_xtrdata_free(void /*RBinXtrData*/ *data);
+R_API void r_bin_file_hash_free(RBinFileHash *fhash);
 R_API void r_bin_info_free(RBinInfo *rb);
 R_API void r_bin_import_free(void *_imp);
 R_API void r_bin_symbol_free(void *_sym);
@@ -703,7 +709,7 @@ R_API bool r_bin_file_set_cur_by_name(RBin *bin, const char *name);
 R_API bool r_bin_file_close(RBin *bin, int bd);
 R_API int r_bin_file_delete_all(RBin *bin);
 R_API int r_bin_file_delete(RBin *bin, ut32 bin_fd);
-R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file);
+R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file, RList/*<RBinFileHash>*/ **old_file_hashes);
 
 // binobject functions
 R_API int r_bin_object_set_items(RBinFile *binfile, RBinObject *o);

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1291,12 +1291,10 @@ R_API int r_main_radare2(int argc, char **argv) {
 
 		r_core_seek (&r, r.offset, 1); // read current block
 
-		/* check if file.sha1 has changed */
+		/* check if file.path has changed */
 		if (iod && !strstr (iod->uri, "://")) {
 			const char *npath, *nsha1;
 			char *path = strdup (r_config_get (r.config, "file.path"));
-			char *sha1 = strdup (r_config_get (r.config, "file.sha1"));
-			ut64 limit = r_config_get_i (r.config, "bin.hashlimit");
 			has_project = r_core_project_open (&r, r_config_get (r.config, "prj.name"), threaded);
 			iod = r.io ? r_io_desc_get (r.io, fh->fd) : NULL;
 			if (has_project) {
@@ -1304,18 +1302,14 @@ R_API int r_main_radare2(int argc, char **argv) {
 			}
 			if (compute_hashes && iod) {
 				// TODO: recall with limit=0 ?
-				(void)r_bin_file_hash (r.bin, limit, iod->name);
+				ut64 limit = r_config_get_i (r.config, "bin.hashlimit");
+				(void)r_bin_file_hash (r.bin, limit, iod->name, NULL);
 				//eprintf ("WARNING: File hash not calculated\n");
 			}
-			nsha1 = r_config_get (r.config, "file.sha1");
 			npath = r_config_get (r.config, "file.path");
-			if (!quiet && sha1 && *sha1 && nsha1 && strcmp (sha1, nsha1)) {
-				eprintf ("WARNING: file.sha1 change: %s => %s\n", sha1, nsha1);
-			}
 			if (!quiet && path && *path && npath && strcmp (path, npath)) {
 				eprintf ("WARNING: file.path change: %s => %s\n", path, npath);
 			}
-			free (sha1);
 			free (path);
 		}
 

--- a/libr/util/pj.c
+++ b/libr/util/pj.c
@@ -82,30 +82,26 @@ R_API PJ *pj_a(PJ *j) {
 }
 
 R_API PJ *pj_end(PJ *j) {
-	if (j) {
-		r_return_val_if_fail (j && j->level > 0, NULL);
-		if (--j->level < 1) {
-			char msg[2] = { j->braces[j->level], 0 };
-			pj_raw (j, msg);
-			j->level = 0;
-			return j;
-		}
-		j->is_first = false;
+	r_return_val_if_fail (j && j->level > 0, NULL);
+	if (--j->level < 1) {
 		char msg[2] = { j->braces[j->level], 0 };
 		pj_raw (j, msg);
+		j->level = 0;
+		return j;
 	}
+	j->is_first = false;
+	char msg[2] = { j->braces[j->level], 0 };
+	pj_raw (j, msg);
 	return j;
 }
 
 R_API PJ *pj_k(PJ *j, const char *k) {
-	if (j && k) {
-		r_return_val_if_fail (j && k, NULL);
-		j->is_key = false;
-		pj_s (j, k);
-		pj_raw (j, ":");
-		j->is_first = false;
-		j->is_key = true;
-	}
+	r_return_val_if_fail (j && k, j);
+	j->is_key = false;
+	pj_s (j, k);
+	pj_raw (j, ":");
+	j->is_first = false;
+	j->is_key = true;
 	return j;
 }
 
@@ -149,7 +145,7 @@ R_API PJ *pj_ki(PJ *j, const char *k, int i) {
 }
 
 R_API PJ *pj_ks(PJ *j, const char *k, const char *v) {
-	if (j && v && *v) {
+	if (j && k && v && *v) {
 		pj_k (j, k);
 		pj_s (j, v);
 	}


### PR DESCRIPTION
- changed the output json keys, now there will be `md5` and `sha1` instead of `values`
- small refactoring on hashes storage
- removed obsolete `file.sha1` usage

![image](https://user-images.githubusercontent.com/14978853/54650318-fd92aa80-4abe-11e9-8d6a-a59022bb1ea1.png)

Related to radareorg/cutter#1179
