### PR TITLE
Simplify WASM code by avoiding duplications

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -7,51 +7,45 @@
 
 #include "wasm.h"
 
+typedef size_t (*ConsumeFcn)(const ut8 *p, const ut8 *max, ut32 *out_value);
+typedef void *(*ParseEntryFcn)(RBuffer *b, ut64 max);
+
 // RBuffer consume functions
-static size_t consume_u32_r(RBuffer *b, ut64 max, ut32 *out) {
+static ut32 consume_r(RBuffer *b, ut64 max, size_t *n_out, ConsumeFcn consume_fcn) {
 	size_t n;
 	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
+	ut64 cur = r_buf_tell (b);
+	if (!b || max >= r_buf_size (b) || cur > max) {
 		return 0;
 	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp))) {
+	// 16 bytes are enough to store 128bits values
+	ut8 *buf = R_NEWS (ut8, 16);
+	if (!buf) {
 		return 0;
 	}
-	r_buf_seek (b, n, R_IO_SEEK_CUR);
-	if (out) {
-		*out = tmp;
+	r_buf_read (b, buf, 16);
+	if (!(n = consume_fcn (buf, buf + max + 1, &tmp))) {
+		free (buf);
+		return 0;
 	}
-	return n;
+	r_buf_seek (b, cur + n, R_IO_SEEK_SET);
+	*n_out = n;
+	free (buf);
+	return tmp;
 }
 
-#if 0
-static size_t consume_s32_r(RBuffer *b, ut64 max, st32 *out) {
+static size_t consume_u32_r(RBuffer *b, ut64 max, ut32 *out) {
 	size_t n;
-	st32 tmp;
-	if (!b || !b->buf || max >= b->length || b->cur > max) {
-		return 0;
-	}
-	if (!(n = read_i32_leb128 (&b->buf[b->cur], &b->buf[max + 1], &tmp))) {
-		return 0;
-	}
-	r_buf_seek (b, n, R_IO_SEEK_CUR);
+	ut32 tmp = consume_r (b, max, &n, read_u32_leb128);
 	if (out) {
 		*out = tmp;
 	}
 	return n;
 }
-#endif
 
 static size_t consume_u7_r(RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
-	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
-		return 0;
-	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp))) {
-		return 0;
-	}
-	r_buf_seek (b, n, R_IO_SEEK_CUR);
+	ut32 tmp = consume_r (b, max, &n, read_u32_leb128);
 	if (out) {
 		*out = (ut8)(tmp & 0x7f);
 	}
@@ -60,14 +54,7 @@ static size_t consume_u7_r(RBuffer *b, ut64 max, ut8 *out) {
 
 static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
 	size_t n;
-	ut32 tmp = 0;
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
-		return 0;
-	}
-	if (!(n = read_i32_leb128 (&b->buf[r_buf_tell (b)], (ut8 *)&b->buf[max + 1], (int *)&tmp)) || n > 2) {
-		return 0;
-	}
-	r_buf_seek (b, n, R_IO_SEEK_CUR);
+	ut32 tmp = consume_r (b, max, &n, (ConsumeFcn)read_i32_leb128);
 	if (out) {
 		*out = (st8)(((tmp & 0x10000000) << 7) | (tmp & 0x7f));
 	}
@@ -76,14 +63,7 @@ static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
 
 static size_t consume_u1_r(RBuffer *b, ut64 max, ut8 *out) {
 	size_t n;
-	ut32 tmp;
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
-		return 0;
-	}
-	if (!(n = read_u32_leb128 (&b->buf[r_buf_tell (b)], &b->buf[max + 1], &tmp)) || n > 1) {
-		return 0;
-	}
-	r_buf_seek (b, n, R_IO_SEEK_CUR);
+	ut32 tmp = consume_r (b, max, &n, read_u32_leb128);
 	if (out) {
 		*out = (ut8)(tmp & 0x1);
 	}
@@ -91,14 +71,15 @@ static size_t consume_u1_r(RBuffer *b, ut64 max, ut8 *out) {
 }
 
 static size_t consume_str_r(RBuffer *b, ut64 max, size_t sz, char *out) {
-	if (!b || !b->buf || max >= r_buf_size (b) || r_buf_tell (b) > max) {
+	ut64 cur = r_buf_tell (b);
+	if (!b || max >= r_buf_size (b) || cur > max) {
 		return 0;
 	}
-	if (!(r_buf_tell (b) + sz - 1 <= max)) {
+	if (!(cur + sz - 1 <= max)) {
 		return 0;
 	}
 	if (sz > 0) {
-		strncpy (out, (char *)&b->buf[r_buf_tell (b)],
+		strncpy (out, (char *)&b->buf[cur],
 			R_MIN (R_BIN_WASM_STRING_LENGTH - 1, sz));
 	} else {
 		*out = 0;
@@ -247,15 +228,11 @@ static void r_bin_wasm_free_codes(RBinWasmCodeEntry *ptr) {
 }
 
 // Parsing
-static RList *r_bin_wasm_get_type_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmTypeEntry *ptr = NULL;
+static RList *get_entries_from_section(RBinWasmObj *bin, RBinWasmSection *sec, ParseEntryFcn parse_entry, RListFree free_entry) {
+	r_return_val_if_fail (sec && bin, NULL);
 
-	if (!(ret = r_list_newf ((RListFree)r_bin_wasm_free_types))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
+	RList *ret = r_list_newf (free_entry);
+	if (!ret) {
 		return NULL;
 	}
 	RBuffer *b = bin->buf;
@@ -266,326 +243,329 @@ static RList *r_bin_wasm_get_type_entries(RBinWasmObj *bin, RBinWasmSection *sec
 		goto beach;
 	}
 	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmTypeEntry))) {
-			return ret;
-		}
-		if (!(consume_u7_r (b, max, &ptr->form))) {
+		void *entry = parse_entry (b, max);
+		if (!entry) {
 			goto beach;
 		}
-		// check valid type?
-		if (!(consume_u32_r (b, max, &ptr->param_count))) {
-			goto beach;
-		}
-		ut32 count = ptr? ptr->param_count: 0;
-		if (!(r_buf_tell (b) + count <= max)) {
-			goto beach;
-		}
-		if (count > 0) {
-			if (!(ptr->param_types = R_NEWS0 (r_bin_wasm_value_type_t, count))) {
-				goto beach;
-			}
-		}
-		int j;
-		for (j = 0; j < count; j++) {
-			if (!(consume_s7_r (b, max, (st8 *)&ptr->param_types[j]))) {
-				goto beach;
-			}
-		}
-		if (!(consume_u1_r (b, max, (ut8 *)&ptr->return_count))) {
-			goto beach;
-		}
-		if (ptr->return_count > 1) {
-			goto beach;
-		}
-		if (ptr->return_count == 1) {
-			if (!(consume_s7_r (b, max, (st8 *)&ptr->return_type))) {
-				goto beach;
-			}
-		}
-		// r_bin_wasm_type_entry_to_string (ptr);
-		if (!r_list_append (ret, ptr)) {
-			r_bin_wasm_free_types (ptr);
+
+		if (!r_list_append (ret, entry)) {
+			free_entry (entry);
 			// should this jump to beach?
 		}
-		ptr = NULL;
 		r++;
 	}
 	return ret;
 beach:
-	eprintf ("[wasm] error: beach type entries\n");
-	r_bin_wasm_free_types (ptr);
+	eprintf ("[wasm] error: beach reading entries for section %s\n", sec->name);
 	return ret;
+}
+
+static void *parse_type_entry(RBuffer *b, ut64 max) {
+	RBinWasmTypeEntry *ptr = R_NEW0 (RBinWasmTypeEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_u7_r (b, max, &ptr->form))) {
+		goto beach;
+	}
+	// check valid type?
+	if (!(consume_u32_r (b, max, &ptr->param_count))) {
+		goto beach;
+	}
+	ut32 count = ptr? ptr->param_count: 0;
+	if (!(r_buf_tell (b) + count <= max)) {
+		goto beach;
+	}
+	if (count > 0) {
+		if (!(ptr->param_types = R_NEWS0 (r_bin_wasm_value_type_t, count))) {
+			goto beach;
+		}
+	}
+	int j;
+	for (j = 0; j < count; j++) {
+		if (!(consume_s7_r (b, max, (st8 *)&ptr->param_types[j]))) {
+			goto beach;
+		}
+	}
+	if (!(consume_u1_r (b, max, (ut8 *)&ptr->return_count))) {
+		goto beach;
+	}
+	if (ptr->return_count > 1) {
+		goto beach;
+	}
+	if (ptr->return_count == 1) {
+		if (!(consume_s7_r (b, max, (st8 *)&ptr->return_type))) {
+			goto beach;
+		}
+	}
+	return ptr;
+
+beach:
+	r_bin_wasm_free_types (ptr);
+	return NULL;
+}
+static void *parse_import_entry(RBuffer *b, ut64 max) {
+	RBinWasmImportEntry *ptr = R_NEW0 (RBinWasmImportEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_u32_r (b, max, &ptr->module_len))) {
+		goto beach;
+	}
+	if (consume_str_r (b, max, ptr->module_len, ptr->module_str) < ptr->module_len) {
+		goto beach;
+	}
+	if (!(consume_u32_r (b, max, &ptr->field_len))) {
+		goto beach;
+	}
+	if (consume_str_r (b, max, ptr->field_len, ptr->field_str) < ptr->field_len) {
+		goto beach;
+	}
+	if (!(consume_u7_r (b, max, &ptr->kind))) {
+		goto beach;
+	}
+	switch (ptr->kind) {
+	case 0: // Function
+		if (!(consume_u32_r (b, max, &ptr->type_f))) {
+			goto beach;
+		}
+		break;
+	case 1: // Table
+		if (!(consume_s7_r (b, max, (st8 *)&ptr->type_t.elem_type))) {
+			goto beach;
+		}
+		if (!(consume_limits_r (b, max, &ptr->type_t.limits))) {
+			goto beach;
+		}
+		break;
+	case 2: // Memory
+		if (!(consume_limits_r (b, max, &ptr->type_m.limits))) {
+			goto beach;
+		}
+		break;
+	case 3: // Global
+		if (!(consume_s7_r (b, max, (st8 *)&ptr->type_g.content_type))) {
+			goto beach;
+		}
+		if (!(consume_u1_r (b, max, (ut8 *)&ptr->type_g.mutability))) {
+			goto beach;
+		}
+		break;
+	default:
+		goto beach;
+	}
+	return ptr;
+
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static void *parse_export_entry(RBuffer *b, ut64 max) {
+	RBinWasmExportEntry *ptr = R_NEW0 (RBinWasmExportEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_u32_r (b, max, &ptr->field_len))) {
+		goto beach;
+	}
+	if (consume_str_r (b, max, ptr->field_len, ptr->field_str) < ptr->field_len) {
+		goto beach;
+	}
+	if (!(consume_u7_r (b, max, &ptr->kind))) {
+		goto beach;
+	}
+	if (!(consume_u32_r (b, max, &ptr->index))) {
+		goto beach;
+	}
+	return ptr;
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static void *parse_code_entry(RBuffer *b, ut64 max) {
+	RBinWasmCodeEntry *ptr = R_NEW0 (RBinWasmCodeEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_u32_r (b, max, &ptr->body_size))) {
+		goto beach;
+	}
+	ut32 j = r_buf_tell (b);
+	if (!(r_buf_tell (b) + ptr->body_size - 1 <= max)) {
+		goto beach;
+	}
+	if (!(consume_u32_r (b, max, &ptr->local_count))) {
+		goto beach;
+	}
+	if (consume_locals_r (b, max, ptr) < ptr->local_count) {
+		goto beach;
+	}
+	ptr->code = r_buf_tell (b);
+	ptr->len = ptr->body_size - ptr->code + j;
+	r_buf_seek (b, ptr->len - 1, R_IO_SEEK_CUR); // consume bytecode
+	r_buf_read (b, &ptr->byte, 1);
+	if (ptr->byte != R_BIN_WASM_END_OF_CODE) {
+		goto beach;
+	}
+	return ptr;
+
+beach:
+	r_bin_wasm_free_codes (ptr);
+	return NULL;
+}
+
+static void *parse_data_entry(RBuffer *b, ut64 max) {
+	RBinWasmDataEntry *ptr = R_NEW0 (RBinWasmDataEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_u32_r (b, max, &ptr->index))) {
+		goto beach;
+	}
+	if (!(ptr->offset.len = consume_init_expr_r (b, max, R_BIN_WASM_END_OF_CODE, NULL))) {
+		goto beach;
+	}
+	if (!(consume_u32_r (b, max, &ptr->size))) {
+		goto beach;
+	}
+	ptr->data = r_buf_tell (b);
+	r_buf_seek (b, ptr->size, R_IO_SEEK_CUR);
+	return ptr;
+
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static void *parse_symbol_entry(RBuffer *b, ut64 max) {
+	RBinWasmSymbol *ptr = R_NEW0 (RBinWasmSymbol);
+	if (!ptr) {
+		return NULL;
+	}
+	ut32 tmp = 0;
+	size_t read = consume_u32_r (b, max, &ptr->id);
+	consume_u32_r (b, max - read, &tmp);
+	if (tmp == R_BIN_WASM_STRING_LENGTH) {
+		tmp = R_BIN_WASM_STRING_LENGTH - 1;
+	}
+	ptr->name_len = tmp;
+	if (!(consume_str_r (b, max, tmp, ptr->name))) {
+		goto beach;
+	}
+	ptr->name[tmp] = 0;
+	return ptr;
+
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static void *parse_memory_entry(RBuffer *b, ut64 max) {
+	RBinWasmMemoryEntry *ptr = R_NEW0 (RBinWasmMemoryEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_limits_r (b, max, &ptr->limits))) {
+		goto beach;
+	}
+	return ptr;
+
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static void *parse_table_entry(RBuffer *b, ut64 max) {
+	RBinWasmTableEntry *ptr = R_NEW0 (RBinWasmTableEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_s7_r (b, max, (st8 *)&ptr->element_type))) {
+		goto beach;
+	}
+	if (!(consume_limits_r (b, max, &ptr->limits))) {
+		goto beach;
+	}
+	return ptr;
+
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static void *parse_global_entry(RBuffer *b, ut64 max) {
+	RBinWasmGlobalEntry *ptr = R_NEW0 (RBinWasmGlobalEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_u7_r (b, max, (ut8 *)&ptr->content_type))) {
+		goto beach;
+	}
+	if (!(consume_u1_r (b, max, &ptr->mutability))) {
+		goto beach;
+	}
+	if (!(consume_init_expr_r (b, max, R_BIN_WASM_END_OF_CODE, NULL))) {
+		goto beach;
+	}
+	return ptr;
+
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static void *parse_element_entry(RBuffer *b, ut64 max) {
+	RBinWasmElementEntry *ptr = R_NEW0 (RBinWasmElementEntry);
+	if (!ptr) {
+		return NULL;
+	}
+	if (!(consume_u32_r (b, max, &ptr->index))) {
+		goto beach;
+	}
+	if (!(consume_init_expr_r (b, max, R_BIN_WASM_END_OF_CODE, NULL))) {
+		goto beach;
+	}
+	if (!(consume_u32_r (b, max, &ptr->num_elem))) {
+		goto beach;
+	}
+	ut32 j = 0;
+	while (r_buf_tell (b) <= max && j < ptr->num_elem) {
+		// TODO: allocate space and fill entry
+		if (!(consume_u32_r (b, max, NULL))) {
+			goto beach;
+		}
+	}
+	return ptr;
+
+beach:
+	free (ptr);
+	return NULL;
+}
+
+static RList *r_bin_wasm_get_type_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
+	return get_entries_from_section (bin, sec, parse_type_entry, (RListFree)r_bin_wasm_free_types);
 }
 
 static RList *r_bin_wasm_get_import_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmImportEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmImportEntry))) {
-			return ret;
-		}
-		if (!(consume_u32_r (b, max, &ptr->module_len))) {
-			goto beach;
-		}
-		if (consume_str_r (b, max, ptr->module_len, ptr->module_str) < ptr->module_len) {
-			goto beach;
-		}
-		if (!(consume_u32_r (b, max, &ptr->field_len))) {
-			goto beach;
-		}
-		if (consume_str_r (b, max, ptr->field_len, ptr->field_str) < ptr->field_len) {
-			goto beach;
-		}
-		if (!(consume_u7_r (b, max, &ptr->kind))) {
-			goto beach;
-		}
-		switch (ptr->kind) {
-		case 0: // Function
-			if (!(consume_u32_r (b, max, &ptr->type_f))) {
-				goto beach;
-			}
-			break;
-		case 1: // Table
-			if (!(consume_s7_r (b, max, (st8 *)&ptr->type_t.elem_type))) {
-				goto beach;
-			}
-			if (!(consume_limits_r (b, max, &ptr->type_t.limits))) {
-				goto beach;
-			}
-			break;
-		case 2: // Memory
-			if (!(consume_limits_r (b, max, &ptr->type_m.limits))) {
-				goto beach;
-			}
-			break;
-		case 3: // Global
-			if (!(consume_s7_r (b, max, (st8 *)&ptr->type_g.content_type))) {
-				goto beach;
-			}
-			if (!(consume_u1_r (b, max, (ut8 *)&ptr->type_g.mutability))) {
-				goto beach;
-			}
-			break;
-		default:
-			goto beach;
-		}
-		r_list_append (ret, ptr);
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach import entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_import_entry, (RListFree)free);
 }
 
 static RList *r_bin_wasm_get_export_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmExportEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmExportEntry))) {
-			return ret;
-		}
-		if (!(consume_u32_r (b, max, &ptr->field_len))) {
-			goto beach;
-		}
-		if (consume_str_r (b, max, ptr->field_len, ptr->field_str) < ptr->field_len) {
-			goto beach;
-		}
-		if (!(consume_u7_r (b, max, &ptr->kind))) {
-			goto beach;
-		}
-		if (!(consume_u32_r (b, max, &ptr->index))) {
-			goto beach;
-		}
-		r_list_append (ret, ptr);
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach export entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_export_entry, (RListFree)free);
 }
 
 static RList *r_bin_wasm_get_code_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmCodeEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)r_bin_wasm_free_codes))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmCodeEntry))) {
-			return ret;
-		}
-		if (!(consume_u32_r (b, max, &ptr->body_size))) {
-			goto beach;
-		}
-		ut32 j = r_buf_tell (b);
-		if (!(r_buf_tell (b) + ptr->body_size - 1 <= max)) {
-			goto beach;
-		}
-		if (!(consume_u32_r (b, max, &ptr->local_count))) {
-			goto beach;
-		}
-		if (consume_locals_r (b, max, ptr) < ptr->local_count) {
-			goto beach;
-		}
-		ptr->code = r_buf_tell (b);
-		ptr->len = ptr->body_size - ptr->code + j;
-		r_buf_seek (b, ptr->len - 1, R_IO_SEEK_CUR); // consume bytecode
-		r_buf_read (b, &ptr->byte, 1);
-		if (ptr->byte != R_BIN_WASM_END_OF_CODE) {
-			goto beach;
-		}
-		// search 'r' in function_space, if present get signature from types
-		// if export get name
-		if (!r_list_append (ret, ptr)) {
-			r_bin_wasm_free_codes (ptr);
-			// should it jump to beach?
-		}
-		ptr = NULL;
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach code entries\n");
-	r_bin_wasm_free_codes (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_code_entry, (RListFree)r_bin_wasm_free_codes);
 }
 
 static RList *r_bin_wasm_get_data_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmDataEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmDataEntry))) {
-			return ret;
-		}
-		if (!(consume_u32_r (b, max, &ptr->index))) {
-			goto beach;
-		}
-		if (!(ptr->offset.len = consume_init_expr_r (b, max, R_BIN_WASM_END_OF_CODE, NULL))) {
-			goto beach;
-		}
-		if (!(consume_u32_r (b, max, &ptr->size))) {
-			goto beach;
-		}
-		ptr->data = r_buf_tell (b);
-		r_buf_seek (b, ptr->size, R_IO_SEEK_CUR);
-		if (!r_list_append (ret, ptr)) {
-			free (ptr);
-			// should it jump to beach?
-		}
-		ptr = NULL;
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach data entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_data_entry, (RListFree)free);
 }
 
 static RList *r_bin_wasm_get_symtab_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmSymbol *ptr = NULL;
-	size_t read = 0;
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data + 3, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 4;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	while (r_buf_tell (b) <= max) {
-		if (!(ptr = R_NEW0 (RBinWasmSymbol))) {
-			return ret;
-		}
-		ut32 tmp = 0;
-		read = consume_u32_r (b, max, &ptr->id);
-		consume_u32_r (b, max - read, &tmp);
-		if (tmp == R_BIN_WASM_STRING_LENGTH) {
-			tmp = R_BIN_WASM_STRING_LENGTH - 1;
-		}
-		ptr->name_len = tmp;
-		if (!(consume_str_r (b, max, tmp, ptr->name))) {
-			goto beach;
-		}
-		ptr->name[tmp] = 0;
-		if (!r_list_append (ret, ptr)) {
-			free (ptr);
-			// should it jump to beach?
-		}
-		ptr = NULL;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach symtab entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_symbol_entry, (RListFree)free);
 }
 
 static RBinWasmStartEntry *r_bin_wasm_get_start(RBinWasmObj *bin, RBinWasmSection *sec) {
@@ -612,181 +592,19 @@ beach:
 }
 
 static RList *r_bin_wasm_get_memory_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmMemoryEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmMemoryEntry))) {
-			return ret;
-		}
-		if (!(consume_limits_r (b, max, &ptr->limits))) {
-			goto beach;
-		}
-		if (!r_list_append (ret, ptr)) {
-			free (ptr);
-			// should it jump to beach?
-		}
-		ptr = NULL;
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach memory entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_memory_entry, (RListFree)free);
 }
 
 static RList *r_bin_wasm_get_table_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmTableEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmTableEntry))) {
-			return ret;
-		}
-		if (!(consume_s7_r (b, max, (st8*)&ptr->element_type))) {
-			goto beach;
-		}
-		if (!(consume_limits_r (b, max, &ptr->limits))) {
-			goto beach;
-		}
-		if (!r_list_append (ret, ptr)) {
-			free (ptr);
-			// should it jump to beach?
-		}
-		ptr = NULL;
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach table entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_table_entry, (RListFree)free);
 }
 
 static RList *r_bin_wasm_get_global_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmGlobalEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmGlobalEntry))) {
-			return ret;
-		}
-		if (!(consume_u7_r (b, max, (ut8*)&ptr->content_type))) {
-			goto beach;
-		}
-		if (!(consume_u1_r (b, max, &ptr->mutability))) {
-			goto beach;
-		}
-		if (!(consume_init_expr_r (b, max, R_BIN_WASM_END_OF_CODE, NULL))) {
-			goto beach;
-		}
-		if (!r_list_append (ret, ptr)) {
-			free (ptr);
-			// should it jump to beach?
-		}
-		ptr = NULL;
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach global entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_global_entry, (RListFree)free);
 }
 
 static RList *r_bin_wasm_get_element_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = NULL;
-	RBinWasmElementEntry *ptr = NULL;
-
-	if (!(ret = r_list_newf ((RListFree)free))) {
-		return NULL;
-	}
-	if (!sec) {
-		r_list_free (ret);
-		return NULL;
-	}
-	RBuffer *b = bin->buf;
-	r_buf_seek (b, sec->payload_data, R_IO_SEEK_SET);
-	ut64 max = r_buf_tell (b) + sec->payload_len - 1;
-	if (!(max < r_buf_size (b))) {
-		goto beach;
-	}
-	ut32 r = 0;
-	while (r_buf_tell (b) <= max && r < sec->count) {
-		if (!(ptr = R_NEW0 (RBinWasmElementEntry))) {
-			return ret;
-		}
-		if (!(consume_u32_r (b, max, &ptr->index))) {
-			goto beach;
-		}
-		if (!(consume_init_expr_r (b, max, R_BIN_WASM_END_OF_CODE, NULL))) {
-			goto beach;
-		}
-		if (!(consume_u32_r (b, max, &ptr->num_elem))) {
-			goto beach;
-		}
-		ut32 j = 0;
-		while (r_buf_tell (b) <= max && j < ptr->num_elem) {
-			// TODO: allocate space and fill entry
-			if (!(consume_u32_r (b, max, NULL))) {
-				goto beach;
-			}
-		}
-		if (!r_list_append (ret, ptr)) {
-			free (ptr);
-			// should it jump to beach?
-		}
-		ptr = NULL;
-		r++;
-	}
-	return ret;
-beach:
-	eprintf ("[wasm] error: beach element entries\n");
-	free (ptr);
-	return ret;
+	return get_entries_from_section (bin, sec, parse_element_entry, (RListFree)free);
 }
 
 // Public functions

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -12,10 +12,12 @@ typedef void *(*ParseEntryFcn)(RBuffer *b, ut64 max);
 
 // RBuffer consume functions
 static ut32 consume_r(RBuffer *b, ut64 max, size_t *n_out, ConsumeFcn consume_fcn) {
+	r_return_val_if_fail (b && n_out && consume_fcn, 0);
+
 	size_t n;
 	ut32 tmp;
 	ut64 cur = r_buf_tell (b);
-	if (!b || max >= r_buf_size (b) || cur > max) {
+	if (max >= r_buf_size (b) || cur > max) {
 		return 0;
 	}
 	// 16 bytes are enough to store 128bits values


### PR DESCRIPTION
I was doing another refactoring for RBuf and this wasm code was using it sooo much, so I ended up simplifying it a bit to avoid duplicated code.