### PR TITLE
Fixes pipes implementation on windows

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -71,7 +71,7 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 #define r_sys_conv_win_to_utf8_l(buf, len) r_acp_to_utf8_l (buf, len)
 #endif
 R_API int r_sys_get_src_dir_w32(char *buf);
-R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **output, char **sterr);
+R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **output, int *outlen, char **sterr);
 R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE in, HANDLE out, HANDLE err);
 #endif
 R_API int r_sys_truncate(const char *file, int sz);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -642,14 +642,7 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 #elif __WINDOWS__
 // TODO: fully implement the rest
 R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, int *len, char **sterr) {
-	bool result = r_sys_cmd_str_full_w32 (cmd, input, output, sterr);
-	if (len) {
-		*len = 0;
-		if (output && result) {
-			*len = strlen (*output);
-		}
-	}
-
+	bool result = r_sys_cmd_str_full_w32 (cmd, input, output, len, sterr);
 	return result;
 }
 #else

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -640,10 +640,8 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 	return false;
 }
 #elif __WINDOWS__
-// TODO: fully implement the rest
 R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, int *len, char **sterr) {
-	bool result = r_sys_cmd_str_full_w32 (cmd, input, output, len, sterr);
-	return result;
+	return r_sys_cmd_str_full_w32 (cmd, input, output, len, sterr);
 }
 #else
 R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, int *len, char **sterr) {

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -184,6 +184,9 @@ char *ReadFromPipe(HANDLE fh, int *outlen) {
 	int strl = 0;
 	int strsz = BUFSIZE+1;
 
+	if (outlen) {
+		*outlen = 0;
+	}
 	str = malloc (strsz);
 	if (!str) {
 		return NULL;

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -10,7 +10,7 @@
 void r_sys_perror_str(const char *fun);
 
 #define ErrorExit(x) { r_sys_perror(x); return NULL; }
-char *ReadFromPipe(HANDLE fh);
+char *ReadFromPipe(HANDLE fh, int *outlen);
 
 // HACKY
 static char *getexe(const char *str) {
@@ -51,7 +51,7 @@ R_API int r_sys_get_src_dir_w32(char *buf) {
 	return true;
 }
 
-R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **output, char **sterr) {
+R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **output, int *outlen, char **sterr) {
 	HANDLE in = NULL;
 	HANDLE out = NULL;
 	HANDLE err = NULL;
@@ -113,11 +113,11 @@ R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **out
 	}
 
 	if (output) {
-		*output = ReadFromPipe (fo);
+		*output = ReadFromPipe (fo, outlen);
 	}
 
 	if (sterr) {
-		*sterr = ReadFromPipe (fe);
+		*sterr = ReadFromPipe (fe, NULL);
 	}
 	
 	if (fi && !CloseHandle (fi)) {
@@ -176,7 +176,7 @@ R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE in, HANDLE ou
 	return ret;
 }
 
-char *ReadFromPipe(HANDLE fh) {
+char *ReadFromPipe(HANDLE fh, int *outlen) {
 	DWORD dwRead;
 	CHAR chBuf[BUFSIZE];
 	BOOL bSuccess = FALSE;
@@ -206,6 +206,9 @@ char *ReadFromPipe(HANDLE fh) {
 		strl += dwRead;
 	}
 	str[strl] = 0;
+	if (outlen) {
+		*outlen = strl;
+	}
 	return str;
 }
 #endif


### PR DESCRIPTION
- pipe data is being treated as a string instead of binary data so first \0 truncates it

Fixes the following bug from regression tests:

```
[00:08:39] [XX] db\tools\radiff2 radiff2 -B (GDIFF support) #1  788
[00:08:39] $ r2 -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Q -i C:\Users\appveyor\AppData\Local\Temp\1\tmp-2356IRggMMYPaNOb.tmp -
[00:08:39] !!radiff2 -B ../bins/other/radiff2/radiff2_c_1 ../bins/other/radiff2/radiff2_c_2 | rax2 -S
[00:08:39] 
[00:08:39] -d1ffd1ff04019000
[00:08:39] +d1ffd1ff040190
[00:08:39] 
[00:08:39] EXPECT=<<RUN
[00:08:39] d1ffd1ff040190
```

Related to #13441