### PR TITLE
WIP: Support asm.pseudo=1 in pad command

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -640,7 +640,7 @@ R_API RAsmCode* r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len) {
 	return acode;
 }
 
-R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, const char *hexstr) {
+R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, RParse *p, const char *hexstr) {
 	ut8 *buf = malloc (strlen (hexstr) + 1);
 	if (!buf) {
 		return NULL;
@@ -651,8 +651,8 @@ R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, const char *hexstr) {
 		return NULL;
 	}
 	RAsmCode *ret = r_asm_mdisassemble (a, buf, (ut64)len);
-	if (ret && a->ofilter) {
-		r_parse_parse (a->ofilter, ret->buf_asm, ret->buf_asm);
+	if (ret && p) {
+		r_parse_parse (p, ret->buf_asm, ret->buf_asm);
 	}
 	free (buf);
 	return ret;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4371,7 +4371,8 @@ static int cmd_print(void *data, const char *input) {
 			case ' ': // "pad"
 			{
 				r_asm_set_pc (core->assembler, core->offset);
-				RAsmCode *c = r_asm_mdisassemble_hexstr (core->assembler, arg);
+				bool is_pseudo = r_config_get_i (core->config, "asm.pseudo");
+				RAsmCode *c = r_asm_mdisassemble_hexstr (core->assembler, is_pseudo ? core->parser : NULL, arg);
 				if (c) {
 					r_cons_print (c->buf_asm);
 					r_asm_code_free (c);

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -165,7 +165,7 @@ R_API int r_asm_set_pc(RAsm *a, ut64 pc);
 R_API int r_asm_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len);
 R_API int r_asm_assemble(RAsm *a, RAsmOp *op, const char *buf);
 R_API RAsmCode* r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len);
-R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, const char *hexstr);
+R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, RParse *p, const char *hexstr);
 R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf);
 R_API RAsmCode* r_asm_rasm_assemble(RAsm *a, const char *buf, bool use_spp);
 R_API RAsmCode* r_asm_assemble_file(RAsm *a, const char *file);


### PR DESCRIPTION
WIP because actually using this in an ASan build triggers crashes. This can be reproduced using any of these, showing that it's not the fault of the newly added chip8-parse plugin.  The `ASAN_OPTIONS` setting is to supress false positives for memory leaks.

```
ASAN_OPTIONS=detect_leaks=0 r2 -a x86 -b 32 -e asm.pseudo=1 -q -c 'pad 7400' -
ASAN_OPTIONS=detect_leaks=0 r2 -a chip8 -q -e asm.pseudo=1 -c 'pad c97f' -
```

See also https://github.com/radare/radare2/issues/13429