### PR TITLE
Fix `ft` command crash on Windows

### DIFF
--- a/libr/flag/tags.c
+++ b/libr/flag/tags.c
@@ -53,11 +53,14 @@ static bool iter_glob_flag(RFlagItem *fi, void *user) {
 R_API RList *r_flag_tags_get(RFlag *f, const char *name) {
 	r_return_val_if_fail (f && name, NULL);
 	const char *k = sdb_fmt ("tag.%s", name);
-	char *words = sdb_get (f->tags, k, NULL);
 	RList *res = r_list_newf (NULL);
-	RList *list = r_str_split_list (words, " ");
-	struct iter_glob_flag_t u = { .res = res, .words = list };
-	r_flag_foreach (f, iter_glob_flag, &u);
-	r_list_free (list);
+	char *words = sdb_get (f->tags, k, NULL);
+	if (words) {
+		RList *list = r_str_split_list (words, " ");
+		struct iter_glob_flag_t u = { .res = res, .words = list };
+		r_flag_foreach (f, iter_glob_flag, &u);
+		r_list_free (list);
+		free (words);
+	}
 	return res;
 }

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3053,6 +3053,8 @@ R_API bool r_str_endswith(const char *str, const char *needle) {
 // Splits the string <str> by string <c> and returns the result in a list.
 R_API RList *r_str_split_list(char *str, const char *c)  {
 	RList *lst = r_list_new ();
+	r_return_val_if_fail (str && c, lst);
+
 	char *aux;
 	bool first_loop = true;
 


### PR DESCRIPTION
- chash fixed when tag is not found (on Windows)
- memory leak fixed (`words`)

The crash reason is because the following line of code can return NULL when tag is not found:

```c
char *words = sdb_get (f->tags, k, NULL);
```

then this NULL will go to `r_str_split_list`  which uses `strtok` (unsafe func) and passes NULL as first argument on the **first**  iteration so this forces strtok algorithm to utilize static variable which caches tokenizing status, which can be NULL or already freed memory.