### PR TITLE
Fix build on newer RISC-V compilers

### DIFF
--- a/shlr/heap/include/r_jemalloc/internal/jemalloc_internal.h
+++ b/shlr/heap/include/r_jemalloc/internal/jemalloc_internal.h
@@ -268,7 +268,7 @@ typedef unsigned szind_t;
 #  ifdef __powerpc__
 #    define LG_QUANTUM		4
 #  endif
-#  ifdef __riscv__
+#  if defined(__riscv) || defined(__riscv__)
 #    define LG_QUANTUM		4
 #  endif
 #  ifdef __s390__


### PR DESCRIPTION
On gcc 9.x, `__riscv__` is no longer defined but `__riscv` is.

This is documented under C/C++ preprocessor definitions on
https://github.com/riscv/riscv-toolchain-conventions

edit: Might be that this needs to be sent to `jemalloc` upstream, but I wasn't able to find where