### PR TITLE
m68k register fixes

### DIFF
--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -708,7 +708,8 @@ fin:
 static int set_reg_profile(RAnal *anal) {
 	const char *p = \
 		"=PC    pc\n"
-		"=SP    sp\n"
+		"=SP    a7\n"
+		"=BP    a6\n"
 		"=A0    a0\n"
 		"=A1    a1\n"
 		"=A2    a2\n"
@@ -769,7 +770,7 @@ RAnalPlugin r_anal_plugin_m68k_cs = {
 	.esil = false,
 	.arch = "m68k",
 	.set_reg_profile = &set_reg_profile,
-	.bits = 16 | 32,
+	.bits = 32,
 	.op = &analop,
 };
 #else

--- a/libr/asm/p/asm_m68k_cs.c
+++ b/libr/asm/p/asm_m68k_cs.c
@@ -130,8 +130,8 @@ RAsmPlugin r_asm_plugin_m68k_cs = {
 	.cpus = "68000,68010,68020,68030,68040,68060",
 	.license = "BSD",
 	.arch = "m68k",
-	.bits = 16 | 32,
-	.endian = R_SYS_ENDIAN_LITTLE | R_SYS_ENDIAN_BIG,
+	.bits = 32,
+	.endian = R_SYS_ENDIAN_BIG,
 	.disassemble = &disassemble,
 	.mnemonics = &mnemonics,
 };
@@ -156,8 +156,8 @@ RAsmPlugin r_asm_plugin_m68k_cs = {
 	.license = "BSD",
 	.author = "pancake",
 	.arch = "m68k",
-	.bits = 16 | 32,
-	.endian = R_SYS_ENDIAN_LITTLE | R_SYS_ENDIAN_BIG,
+	.bits = 32,
+	.endian = R_SYS_ENDIAN_BIG,
 };
 
 #ifndef CORELIB


### PR DESCRIPTION
* m68k architecture is always 32 bits and big endian
* SP was declared as 'sp' in the register profile which doesn't exist. Stack pointer is a7.
* Most C compilers for m68k (e.g. LatticeC) use a6 as stack frame pointer via LINK and UNLK instructions, declare a6 as BP