### PR TITLE
Fixes `wcr` command

### DIFF
--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -1086,7 +1086,7 @@ static int cmd_write(void *data, const char *input) {
 			break;
 		case '+': // "wc+"
 			if (input[2]=='*') { // "wc+*"
-				//r_io_cache_reset (core->io, true);
+				//r_io_cache_reset (core->io, core->io->cached);
 				eprintf ("TODO\n");
 			} else if (input[2]==' ') { // "wc+ "
 				char *p = strchr (input+3, ' ');
@@ -1110,7 +1110,7 @@ static int cmd_write(void *data, const char *input) {
 			break;
 		case '-': { // "wc-"
 			if (input[2]=='*') { // "wc-*"
-				r_io_cache_reset (core->io, true);
+				r_io_cache_reset (core->io, core->io->cached);
 				break;
 			}
 			ut64 from, to;
@@ -1149,7 +1149,7 @@ static int cmd_write(void *data, const char *input) {
 			cmd_write_pcache (core, &input[2]);
 			break;
 		case 'r': // "wcr"
-			r_io_cache_reset (core->io, true);
+			r_io_cache_reset (core->io, core->io->cached);
 			/* Before loading the core block we have to make sure that if
 			 * the cache wrote past the original EOF these changes are no
 			 * longer displayed. */


### PR DESCRIPTION
`wcr` command fixed. Now it will preserves cache permissions

**Before:**
![image](https://user-images.githubusercontent.com/14978853/54824997-87a86200-4cbd-11e9-9f1c-44be48d37abd.png)


**After:**
![image](https://user-images.githubusercontent.com/14978853/54824875-3ef0a900-4cbd-11e9-81b8-c2fb5885524f.png)
