### PR TITLE
dm= now honors theme (eco) settings + wx sections are highlighted ##cons

### DIFF
--- a/libr/debug/map.c
+++ b/libr/debug/map.c
@@ -205,10 +205,12 @@ static void print_debug_maps_ascii_art(RDebug *dbg, RList *maps, ut64 addr, int 
 			r_num_units (humansz, sizeof (humansz), map->size); // Convert map size to human readable string
 			if (colors) {
 				color_suffix = Color_RESET;
-				if (map->perm & 2) { // Writable maps are red
-					color_prefix = Color_RED;
-				} else if (map->perm & 1) { // Executable maps are green
-					color_prefix = Color_GREEN;
+				if ((map->perm & 2) && (map->perm & 1)) { // Writable & Executable
+					color_prefix = r_cons_singleton()->context->pal.widget_sel;
+				} else if (map->perm & 2) { // Writable
+					color_prefix = r_cons_singleton()->context->pal.graph_false;
+				} else if (map->perm & 1) { // Executable
+					color_prefix = r_cons_singleton()->context->pal.graph_true;
 				} else {
 					color_prefix = "";
 					color_suffix = "";


### PR DESCRIPTION
eco twilight

Before:
![dmeq_before](https://user-images.githubusercontent.com/25580985/54885084-c8000f80-4e78-11e9-853b-65035862df80.png)

After (**w/x** mem regions [execstack]):
![dmeq_after_wx_highlight](https://user-images.githubusercontent.com/25580985/54885091-d4846800-4e78-11e9-8b31-a888735acc78.png)

After: (**no w/x** mem regions/desired state):
![dmeq_after_no_wx](https://user-images.githubusercontent.com/25580985/54885094-e239ed80-4e78-11e9-8e4d-9aad0a34a341.png)
