### PR TITLE
Initial implementation of alias files ##core

### DIFF
--- a/libr/cons/pipe.c
+++ b/libr/cons/pipe.c
@@ -34,10 +34,10 @@ R_API int r_cons_pipe_open(const char *file, int fdn, int append) {
 	}
 	backup_fdn = fdn;
 #if __WINDOWS__
-	backup_fd = 2002-(fd-2); // windows xp has 2048 as limit fd
+	backup_fd = 2002 - (fd - 2); // windows xp has 2048 as limit fd
 	if (_dup2 (fdn, backup_fd) == -1) {
 #else
-	backup_fd = sysconf (_SC_OPEN_MAX)-(fd-2); // portable getdtablesize()
+	backup_fd = sysconf (_SC_OPEN_MAX) - (fd - 2); // portable getdtablesize()
 	if (backup_fd < 2) {
 		backup_fd = 2002 - (fd - 2); // fallback
 	}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -99,10 +99,13 @@ static void cmd_debug_reg(RCore *core, const char *str);
 #include "cmd_colon.c"
 
 static const char *help_msg_dollar[] = {
-	"Usage:", "$alias[=cmd] [args...]", "Alias commands",
+	"Usage:", "$alias[=cmd] [args...]", "Alias commands and strings (See ?$? for help on $variables)",
 	"$", "", "list all defined aliases",
-	"$*", "", "same as above, but using r2 commands",
-	"$", "dis='af;pdf'", "create command - analyze to show function",
+	"$*", "", "list all the aliases as r2 commands in base64",
+	"$**", "", "same as above, but using plain text",
+	"$", "dis=base64:AAA==", "alias this base64 encoded text to be printed when $dis is called",
+	"$", "dis=$hello world", "alias this text to be printed when $dis is called",
+	"$", "dis=af;pdf", "create command - analyze to show function",
 	"$", "test=#!pipe node /tmp/test.js", "create command - rlangpipe script",
 	"$", "dis=", "undefine alias",
 	"$", "dis", "execute the previously defined alias",
@@ -401,7 +404,7 @@ static int cmd_alias(void *data, const char *input) {
 	if (!buf) {
 		return 0;
 	}
-	*buf = '$'; // prefix aliases with a dash
+	*buf = '$'; // prefix aliases with a dollar
 	memcpy (buf + 1, input, i + 1);
 	char *q = strchr (buf, ' ');
 	char *def = strchr (buf, '=');
@@ -439,8 +442,14 @@ static int cmd_alias(void *data, const char *input) {
 		int i, count = 0;
 		char **keys = r_cmd_alias_keys (core->rcmd, &count);
 		for (i = 0; i < count; i++) {
-			const char *v = r_cmd_alias_get (core->rcmd, keys[i], 0);
-			r_cons_printf ("%s=%s\n", keys[i], v);
+			char *v = r_cmd_alias_get (core->rcmd, keys[i], 0);
+			char *q = r_base64_encode_dyn (v, -1);
+			if (buf[2] == '*') {
+				r_cons_printf ("%s=%s\n", keys[i], v);
+			} else {
+				r_cons_printf ("%s=base64:%s\n", keys[i], q);
+			}
+			free (q);
 		}
 	} else if (!buf[1]) {
 		int i, count = 0;
@@ -455,18 +464,13 @@ static int cmd_alias(void *data, const char *input) {
 		}
 		char *v = r_cmd_alias_get (core->rcmd, buf, 0);
 		if (v) {
-			if (q) {
-				char *out, *args = q + 1;
-				out = malloc (strlen (v) + strlen (args) + 2);
-				if (out) { //XXX slow
-					strcpy (out, v);
-					strcat (out, " ");
-					strcat (out, args);
-					r_core_cmd0 (core, out);
-					free (out);
-				} else {
-					eprintf ("Cannot malloc\n");
-				}
+			if (*v == '$') {
+				r_cons_strcat (v + 1);
+				r_cons_newline ();
+			} else if (q) {
+				char *out = r_str_newf ("%s %s", v, q + 1);
+				r_core_cmd0 (core, out);
+				free (out);
 			} else {
 				r_core_cmd0 (core, v);
 			}
@@ -1925,6 +1929,7 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	const char *cmdrep = NULL;
 	bool tmpseek = false;
 	bool original_tmpseek = core->tmpseek;
+
 	/* must store a local orig_offset because there can be
 	 * nested call of this function */
 	ut64 orig_offset = core->offset;
@@ -2190,11 +2195,10 @@ static int r_core_cmd_subst_i(RCore *core, char *cmd, char *colon, bool *tmpseek
 					while (*str == '>') {
 						str++;
 					}
-					while (IS_WHITESPACE (*str)) {
-						str++;
-					}
+					str = (char *)r_str_trim_ro (str);
 					r_cons_flush ();
-					pipefd = r_cons_pipe_open (str, 1, p[2] == '>');
+					const bool append = p[2] == '>';
+					pipefd = r_cons_pipe_open (str, 1, append);
 				}
 			}
 			line = strdup (cmd);
@@ -2506,8 +2510,34 @@ next:
 			str = r_file_temp ("dumpedit");
 			r_config_set_i (core->config, "scr.color", COLOR_MODE_DISABLED);
 		}
-		if (fdn > 0) {
-			pipefd = r_cons_pipe_open (str, fdn, ptr[1] == '>');
+		const bool appendResult = (ptr[1] == '>');
+		if (*str == '$') {
+			// pipe to alias variable
+			// register output of command as an alias
+			char *o = r_core_cmd_str (core, cmd);
+			if (appendResult) {
+				char *oldText = r_cmd_alias_get (core->rcmd, str, 1);
+				if (oldText) {
+					char *two = r_str_newf ("%s%s", oldText, o);
+					if (two) {
+						r_cmd_alias_set (core->rcmd, str, two, 1);
+						free (two);
+					}
+				} else {
+					char *n = r_str_newf ("$%s", o);
+					r_cmd_alias_set (core->rcmd, str, n, 1);
+					free (n);
+				}
+			} else {
+				char *n = r_str_newf ("$%s", o);
+				r_cmd_alias_set (core->rcmd, str, n, 1);
+				free (n);
+			}
+			ret = 0;
+			free (o);
+		} else if (fdn > 0) {
+			// pipe to file (or append)
+			pipefd = r_cons_pipe_open (str, fdn, appendResult);
 			if (pipefd != -1) {
 				if (!pipecolor) {
 					r_config_set_i (core->config, "scr.color", COLOR_MODE_DISABLED);
@@ -2848,9 +2878,7 @@ repeat_arroba:
 			goto next_arroba; //ignore; //return ret;
 		}
 ignore:
-		ptr = r_str_trim_head (ptr + 1);
-		ptr--;
-
+		ptr = r_str_trim_head (ptr + 1) - 1;
 		cmd = r_str_trim_nc (cmd);
 		if (ptr2) {
 			if (strlen (ptr + 1) == 13 && strlen (ptr2 + 1) == 6 &&
@@ -4090,7 +4118,7 @@ R_API void r_core_cmd_init(RCore *core) {
 	struct {
 		const char *cmd;
 		const char *description;
-		r_cmd_callback(cb);
+		r_cmd_callback (cb);
 		void (*descriptor_init)(RCore *core);
 	} cmds[] = {
 		{"!",        "run system command", cmd_system},

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2016 - pancake */
+/* radare - LGPL - Copyright 2009-2019 - pancake */
 
 #include <r_cmd.h>
 #include <r_util.h>
@@ -100,39 +100,47 @@ R_API bool r_cmd_alias_del (RCmd *cmd, const char *k) {
 	return false;
 }
 
+// XXX: use a hashtable or any other standard data structure
 R_API int r_cmd_alias_set (RCmd *cmd, const char *k, const char *v, int remote) {
-	int i; // find
+	void *tofree = NULL;
+	if (!strncmp (v, "base64:", 7)) {
+		ut8 *s = r_base64_decode_dyn (v + 7, -1);
+		if (s) {
+			tofree = s;
+			v = (const char *)s;
+		}
+	}
+	int i;
 	for (i = 0; i < cmd->aliases.count; i++) {
 		int matches = !strcmp (k, cmd->aliases.keys[i]);
 		if (matches) {
 			free (cmd->aliases.values[i]);
 			cmd->aliases.values[i] = strdup (v);
+			free (tofree);
 			return 1;
 		}
 	}
-	// new
+	
 	i = cmd->aliases.count++;
 	char **K = (char **)realloc (cmd->aliases.keys,
 				     sizeof (char *) * cmd->aliases.count);
-	if (!K) {
-		return 0;
+	if (K) {
+		cmd->aliases.keys = K;
+		int *R = (int *)realloc (cmd->aliases.remote,
+				sizeof (int) * cmd->aliases.count);
+		if (R) {
+			cmd->aliases.remote = R;
+			char **V = (char **)realloc (cmd->aliases.values,
+					sizeof (char *) * cmd->aliases.count);
+			if (V) {
+				cmd->aliases.values = V;
+				cmd->aliases.keys[i] = strdup (k);
+				cmd->aliases.values[i] = strdup (v);
+				cmd->aliases.remote[i] = remote;
+			}
+		}
 	}
-	cmd->aliases.keys = K;
-	int *R = (int *)realloc (cmd->aliases.remote,
-				 sizeof (int) * cmd->aliases.count);
-	if (!R) {
-		return 0;
-	}
-	cmd->aliases.remote = R;
-	char **V = (char **)realloc (cmd->aliases.values,
-				     sizeof (char *) * cmd->aliases.count);
-	if (!V) {
-		return 0;
-	}
-	cmd->aliases.values = V;
-	cmd->aliases.keys[i] = strdup (k);
-	cmd->aliases.values[i] = strdup (v);
-	cmd->aliases.remote[i] = remote;
+	free (tofree);
 	return 0;
 }
 
@@ -141,7 +149,7 @@ R_API char *r_cmd_alias_get (RCmd *cmd, const char *k, int remote) {
 	if (!cmd || !k) {
 		return NULL;
 	}
-	for (i=0; i < cmd->aliases.count; i++) {
+	for (i = 0; i < cmd->aliases.count; i++) {
 		matches = 0;
 		if (remote) {
 			if (cmd->aliases.remote[i]) {
@@ -205,10 +213,8 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 	int ret = -1;
 	RListIter *iter;
 	RCorePlugin *cp;
-	if (!cmd || !input) {
-		return -1;
-	}
-	if (!input || !*input) {
+	r_return_val_if_fail (cmd && input, -1);
+	if (!*input) {
 		if (cmd->nullcallback) {
 			ret = cmd->nullcallback (cmd->data);
 		}
@@ -216,8 +222,13 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 		char *nstr = NULL;
 		const char *ji = r_cmd_alias_get (cmd, input, 1);
 		if (ji) {
-			nstr = r_str_newf ("=!%s", input);
-			input = nstr;
+			if (*ji == '$') {
+				r_cons_strcat (ji + 1);
+				return true;
+			} else {
+				nstr = r_str_newf ("=!%s", input);
+				input = nstr;
+			}
 		}
 		r_list_foreach (cmd->plist, iter, cp) {
 			if (cp->call (cmd->data, input)) {

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -230,6 +230,7 @@ static const char *help_msg_question_V[] = {
 static const char *help_msg_greater_sign[] = {
 	"Usage:", "[cmd]>[file]", "redirects console from 'cmd' output to 'file'",
 	"[cmd] > [file]", "", "redirect STDOUT of 'cmd' to 'file'",
+	"[cmd] > $alias", "", "save the output of the command as an alias (see $?)",
 	"[cmd] H> [file]", "", "redirect html output of 'cmd' to 'file'",
 	"[cmd] 2> [file]", "", "redirect STDERR of 'cmd' to 'file'",
 	"[cmd] 2> /dev/null", "", "omit the STDERR output of 'cmd'",


### PR DESCRIPTION
pd 10 > $foo  # save the output of pd 10 into $foo
$foo          # print the contents of $foo (the output)
$*            # values are now printed in base64
$foo=base64:  # is now supported