### PR TITLE
Improve aav ##anal

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7483,15 +7483,6 @@ static void cmd_anal_aad(RCore *core, const char *input) {
 	r_list_free (list);
 }
 
-#if 0
-static bool archIsMips(RCore *core) {
-	RAsm *as = core ? core->assembler : NULL;
-	if (as && as->cur && as->cur->name) {
-		return strstr (as->cur->name, "mips");
-	}
-	return false;
-}
-#endif
 static bool archIsThumbable(RCore *core) {
 	RAsm *as = core ? core->assembler : NULL;
 	if (as && as->cur && as->bits <= 32 && as->cur->name) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7501,7 +7501,15 @@ static void _CbInRangeAav(RCore *core, ut64 from, ut64 to, int vsize, bool aster
 			if (core->anal->verbose) {
 				eprintf ("Warning: aav: false positive in 0x%08"PFMT64x"\n", from);
 			}
-			return;
+			bool itsFine = false;
+			if (core->assembler->bits == 16) {
+				if ((from & 1) || (to & 1)) {
+					itsFine = true;
+				}
+			}
+			if (!itsFine) {
+				return;
+			}
 		}
 	}
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, from, -1);

--- a/libr/core/cmd_mount.c
+++ b/libr/core/cmd_mount.c
@@ -323,7 +323,7 @@ static int cmd_mount(void *data, const char *_input) {
 		file = r_fs_open (core->fs, input);
 		if (file) {
 			char *localFile = strdup (input);
-			char *slash = r_str_rchr (localFile, NULL, '/');
+			char *slash = (char *)r_str_rchr (localFile, NULL, '/');
 			if (slash) {
 				memmove (localFile, slash + 1, strlen (slash));
 			}


### PR DESCRIPTION
* Do not take as valid hits the words found inside a function (considered code)
* Honor anal.arch.align
* Call it after aac in aaa