### PR TITLE
added an early-out optimization for r_isprint. 

### DIFF
--- a/libr/util/utf8.c
+++ b/libr/util/utf8.c
@@ -585,8 +585,8 @@ R_API int r_utf8_strlen(const ut8 *str) {
 }
 
 R_API int r_isprint(const RRune c) {
-	//RRunes are most commonly single byte... We can early out with this common case.
-	if(c < 0x34F){
+	// RRunes are most commonly single byte... We can early out with this common case.
+	if (c < 0x34F){
 		/*
 		manually copied from top, please update if this ever changes
 		{ 0x0000, 0x001F }, { 0x007F, 0x009F }, { 0x034F, 0x034F },
@@ -594,8 +594,6 @@ R_API int r_isprint(const RRune c) {
 		*/
 		return !( c <= 0x1F || ( c >= 0x7F && c <= 0x9F) );
 	}
-
-
 
 	const int last = nonprintable_ranges_count;
 

--- a/libr/util/utf8.c
+++ b/libr/util/utf8.c
@@ -585,6 +585,18 @@ R_API int r_utf8_strlen(const ut8 *str) {
 }
 
 R_API int r_isprint(const RRune c) {
+	//RRunes are most commonly single byte... We can early out with this common case.
+	if(c < 0x34F){
+		/*
+		manually copied from top, please update if this ever changes
+		{ 0x0000, 0x001F }, { 0x007F, 0x009F }, { 0x034F, 0x034F },
+		could do a linear search, but thats a lot slower than a few compare
+		*/
+		return !( c <= 0x1F || ( c >= 0x7F && c <= 0x9F) );
+	}
+
+
+
 	const int last = nonprintable_ranges_count;
 
 	int low = 0;

--- a/libr/util/utf8.c
+++ b/libr/util/utf8.c
@@ -586,13 +586,13 @@ R_API int r_utf8_strlen(const ut8 *str) {
 
 R_API int r_isprint(const RRune c) {
 	// RRunes are most commonly single byte... We can early out with this common case.
-	if (c < 0x34F){
+	if (c < 0x34F) {
 		/*
 		manually copied from top, please update if this ever changes
 		{ 0x0000, 0x001F }, { 0x007F, 0x009F }, { 0x034F, 0x034F },
 		could do a linear search, but thats a lot slower than a few compare
 		*/
-		return !( c <= 0x1F || ( c >= 0x7F && c <= 0x9F) );
+		return !( c <= 0x1F || ( c >= 0x7F && c <= 0x9F));
 	}
 
 	const int last = nonprintable_ranges_count;


### PR DESCRIPTION
 Reduces time spent in r_isprint from ~30% to ~2% in my tests.


Measured with valgrind cachegrind.
Appears to have minor real-world performance improvements (2% less time spent with a long r2pipe script).