### PR TITLE
Rewrite kernelcache check_bytes

### DIFF
--- a/libr/bin/format/mach0/mach064_is_kernelcache.c
+++ b/libr/bin/format/mach0/mach064_is_kernelcache.c
@@ -1,0 +1,42 @@
+static bool is_kernelcache(const ut8 *buf, ut64 length) {
+	r_return_val_if_fail (length >= sizeof (struct MACH0_(mach_header)), false);
+
+	const ut8 *end = buf + length;
+	const ut8 *cursor = buf + sizeof (struct MACH0_(mach_header));
+	int ncmds = r_read_le32 (buf + 16);
+	bool has_unixthread = false;
+	bool has_negative_vaddr = false;
+
+	for (int i = 0; i < ncmds; i++) {
+		if (cursor >= end) {
+			return false;
+		}
+
+		ut32 cmdtype = r_read_le32 (cursor);
+		ut32 cmdsize = r_read_le32 (cursor + 4);
+
+		switch (cmdtype) {
+		case LC_UNIXTHREAD:
+			has_unixthread = true;
+			break;
+		case LC_LOAD_DYLIB:
+		case LC_LOAD_WEAK_DYLIB:
+		case LC_LAZY_LOAD_DYLIB:
+			return false;
+		case LC_SEGMENT_64: {
+			if (has_negative_vaddr) {
+				break;
+			}
+			st64 vmaddr = r_read_le64 (cursor + 24);
+			if (vmaddr < 0) {
+				has_negative_vaddr = true;
+			}
+			break;
+		}
+		}
+
+		cursor += cmdsize;
+	}
+
+	return has_unixthread && has_negative_vaddr;
+}

--- a/libr/bin/format/mach0/mach064_is_kernelcache.c
+++ b/libr/bin/format/mach0/mach064_is_kernelcache.c
@@ -1,5 +1,7 @@
 static bool is_kernelcache(const ut8 *buf, ut64 length) {
-	r_return_val_if_fail (length >= sizeof (struct MACH0_(mach_header)), false);
+	if (length < sizeof (struct MACH0_(mach_header))) {
+		return false;
+	}
 
 	const ut8 *end = buf + length;
 	const ut8 *cursor = buf + sizeof (struct MACH0_(mach_header));

--- a/libr/bin/p/bin_mach064.c
+++ b/libr/bin/p/bin_mach064.c
@@ -4,28 +4,15 @@
 #include "bin_mach0.c"
 
 #include "objc/mach064_classes.h"
+#include "../format/mach0/mach064_is_kernelcache.c"
 
 static bool check_bytes(const ut8 *buf, ut64 length) {
 	if (buf && length > 4) {
-		if (!memcmp (buf, "\xfe\xed\xfa\xcf", 4) ||
-			!memcmp (buf, "\xcf\xfa\xed\xfe", 4)) {
-			if (length >= 4096) {
-				const char *features[] = {
-					"__PRELINK_INFO",
-					"__PRELINK_DATA",
-					"__PRELINK_TEXT",
-					"__KLD"
-				};
-				int i;
-				for (i = 0; i < 4; i++) {
-					const ut8 *needle = (const ut8 *) features[i];
-					if (!r_mem_mem (buf, 4096, needle, strlen ((char *)needle))) {
-						break;
-					}
-				}
-				return i == 0;
-			}
+		if (!memcmp (buf, "\xfe\xed\xfa\xcf", 4)) {
 			return true;
+		}
+		if (!memcmp (buf, "\xcf\xfa\xed\xfe", 4)) {
+			return !is_kernelcache (buf, length);
 		}
 	}
 	return false;

--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -12,6 +12,7 @@
 
 #include "../format/xnu/r_cf_dict.h"
 #include "../format/xnu/mig_index.h"
+#include "../format/mach0/mach064_is_kernelcache.c"
 
 typedef bool (*ROnRebaseFunc) (ut64 offset, ut64 decorated_addr, void *user_data);
 
@@ -905,26 +906,10 @@ static RBinAddr *newEntry(ut64 haddr, ut64 vaddr, int type) {
 
 static bool check_bytes(const ut8 *buf, ut64 length) {
 	if (buf && length > 4) {
-		if (memcmp (buf, "\xfe\xed\xfa\xcf", 4) &&
-			memcmp (buf, "\xcf\xfa\xed\xfe", 4)) {
+		if (memcmp (buf, "\xcf\xfa\xed\xfe", 4)) {
 			return false;
 		}
-		if (length >= 4096) {
-			const char *features[] = {
-				"__PRELINK_INFO",
-				"__PRELINK_DATA",
-				"__PRELINK_TEXT",
-				"__KLD"
-			};
-			int i;
-			for (i = 0; i < 4; i++) {
-				const ut8 *needle = (const ut8 *) features[i];
-				if (!r_mem_mem (buf, 4096, needle, strlen ((const char *)needle))) {
-					break;
-				}
-			}
-			return i == 4;
-		}
+		return is_kernelcache (buf, length);
 	}
 	return false;
 }


### PR DESCRIPTION
Parse load commands to extract 3 metrics (kudos to @Siguza for suggesting):
- use of LC_UNIXTHREAD
- absence of any library linked against
- addresses in the upper half of the address space

If those are met, then it’s a kernelcache. This just needs to parse all load commands types and vmaddr from LC_SEGMENT_64 (but nothing more) from the bytes.

Plus: no big endian kernelcaches so far.