### PR TITLE
Fix integer overflow that leads to a crash in the DEX parser ##bin

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -1528,9 +1528,10 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 	if (!c || !c->class_data_offset) {
 		if (dexdump) {
 			rbin->cb_printf (
-				"  Static fields     -\n  Instance fields   "
-				"-\n  Direct methods    -\n  Virtual methods   "
-				"-\n");
+				"  Static fields     -\n"
+				"  Instance fields   -\n"
+				"  Direct methods    -\n"
+				"  Virtual methods   -\n");
 		}
 	} else {
 		// TODO: move to func, def or inline
@@ -1553,23 +1554,31 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 		//XXX check for NULL!!
 		c->class_data = (struct dex_class_data_item_t *)malloc (
 			sizeof (struct dex_class_data_item_t));
+		if (!p->class_data) {
+			return;
+		}
 		if (p >= p_end) {
+			free (c->class_data);
 			return;
 		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->static_fields_size);
 		if (p >= p_end) {
+			free (c->class_data);
 			return;
 		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->instance_fields_size);
 		if (p >= p_end) {
+			free (c->class_data);
 			return;
 		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->direct_methods_size);
 		if (p >= p_end) {
+			free (c->class_data);
 			return;
 		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->virtual_methods_size);
 		if (p >= p_end) {
+			free (c->class_data);
 			return;
 		}
 
@@ -1613,8 +1622,7 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 					 c->source_file, source_file);
 		}
 	}
-	// TODO:!!!!
-	// FIX: FREE BEFORE ALLOCATE!!!
+	// TODO: fix memleaks
 	//free (class_name);
 }
 

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -1544,15 +1544,34 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 
 		const ut8 *bufbuf = r_buf_buffer (binfile->buf);
 		p = bufbuf + c->class_data_offset;
-		// runtime error: pointer index expression with base 0x000000004402 overflowed to 0xfffffffffffffd46
-		p_end = p + (r_buf_size (binfile->buf) - c->class_data_offset);
+		// XXX may overflow
+		if (r_buf_size (binfile->buf) < c->class_data_offset) {
+			return;
+		}
+		ut32 p_size = (r_buf_size (binfile->buf) - c->class_data_offset);
+		p_end = p + p_size;
 		//XXX check for NULL!!
 		c->class_data = (struct dex_class_data_item_t *)malloc (
 			sizeof (struct dex_class_data_item_t));
+		if (p >= p_end) {
+			return;
+		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->static_fields_size);
+		if (p >= p_end) {
+			return;
+		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->instance_fields_size);
+		if (p >= p_end) {
+			return;
+		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->direct_methods_size);
+		if (p >= p_end) {
+			return;
+		}
 		p = r_uleb128 (p, p_end - p, &c->class_data->virtual_methods_size);
+		if (p >= p_end) {
+			return;
+		}
 
 		if (dexdump) {
 			rbin->cb_printf ("  Static fields     -\n");


### PR DESCRIPTION
clusterfuzz-testcase-minimized-ia_fuzz-5651766995058688.dms