### PR TITLE
Fix simple typo that generates a compilation error

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -1554,7 +1554,7 @@ static void parse_class(RBinFile *binfile, RBinDexObj *bin, RBinDexClass *c,
 		//XXX check for NULL!!
 		c->class_data = (struct dex_class_data_item_t *)malloc (
 			sizeof (struct dex_class_data_item_t));
-		if (!p->class_data) {
+		if (!c->class_data) {
 			return;
 		}
 		if (p >= p_end) {


### PR DESCRIPTION
However, r2 still segfaults:
```
[----------------------------------registers-----------------------------------]
RAX: 0x0
RBX: 0x0
RCX: 0x58 ('X')
RDX: 0x0
RSI: 0xc ('\x0c')
RDI: 0x58 ('X')
RBP: 0x7fffffffb970 --> 0x7fffffffba00 --> 0x7fffffffba70 --> 0x7fffffffbeb0 --> 0x7fffffffbfa0 --> 0x7fffffffc0d0 (--> ...)
RSP: 0x7fffffffb970 --> 0x7fffffffba00 --> 0x7fffffffba70 --> 0x7fffffffbeb0 --> 0x7fffffffbfa0 --> 0x7fffffffc0d0 (--> ...)
RIP: 0x7ffff70809fa (<cs_len_prefix_opcode+42>: )
R8 : 0x2
R9 : 0x202c5d7861725b20 (' [rax], ')
R10: 0x1
R11: 0x7ffff6979460 --> 0x200000395
R12: 0x555555555040 (<_start>:  endbr64)
R13: 0x7fffffffe550 --> 0x2
R14: 0x0
R15: 0x0
EFLAGS: 0x10246 (carry PARITY adjust ZERO sign trap INTERRUPT direction overflow)
[-------------------------------------code-------------------------------------]
   0x7ffff70809f0 <cs_len_prefix_opcode+32>:
    xor    eax,eax
   0x7ffff70809f2 <cs_len_prefix_opcode+34>:
    mov    rcx,QWORD PTR [rbp-0x8]
   0x7ffff70809f6 <cs_len_prefix_opcode+38>:
    movsxd rdx,DWORD PTR [rbp-0xc]
=> 0x7ffff70809fa <cs_len_prefix_opcode+42>:
    movzx  esi,BYTE PTR [rcx+rdx*1]
   0x7ffff70809fe <cs_len_prefix_opcode+46>:
    cmp    esi,0x0
   0x7ffff7080a01 <cs_len_prefix_opcode+49>:
    mov    esi,0x1
   0x7ffff7080a06 <cs_len_prefix_opcode+54>:
    cmovne eax,esi
   0x7ffff7080a09 <cs_len_prefix_opcode+57>:
    add    eax,DWORD PTR [rbp-0x10]
[------------------------------------stack-------------------------------------]
0000| 0x7fffffffb970 --> 0x7fffffffba00 --> 0x7fffffffba70 --> 0x7fffffffbeb0 --> 0x7fffffffbfa0 --> 0x7fffffffc0d0 (--> ...)
0008| 0x7fffffffb978 --> 0x7ffff7080674 (<analop+580>: )
0016| 0x7fffffffb980 --> 0x7fffffffb9e0 --> 0x555555576020 --> 0x5555556189a0 --> 0x555500363878 ('x86')
0024| 0x7fffffffb988 --> 0x7ffff754a55a (<r_core_seek_archbits+202>:    )
0032| 0x7fffffffb990 --> 0x0
0040| 0x7fffffffb998 --> 0x0
0048| 0x7fffffffb9a0 --> 0x0
0056| 0x7fffffffb9a8 --> 0x0
[------------------------------------------------------------------------------]
Legend: code, data, rodata, value
Stopped reason: SIGSEGV
0x00007ffff70809fa in cs_len_prefix_opcode (
    item=0x58 <error: Cannot access memory at address 0x58>)
    at XXX/radare2/libr/..//libr/anal/p/anal_x86_cs.c:2792
2792                    len += (item[i] != 0) ? 1 : 0;
```
_EDIT: I use capstone 4.0, may be this is the problem._