### PR TITLE
Call to same relocs must have same name instead of appending number

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4610,16 +4610,17 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 		name = fcn->name;
 	} else if (f) {
 		flag = r_core_flag_get_by_spaces (f, addr);
-		if (flag) {
-			name = flag->name;
-		} else {
-			RBinReloc *rel = getreloc (ds->core, addr, ds->analop.size);
+		RBinReloc *rel = getreloc (ds->core, addr, ds->analop.size);
+		if (rel) {
 			if (rel && rel->import && rel->import->name) {
 				name = rel->import->name;
+			} else if (rel && rel->symbol && rel->symbol->name) {
+				name = rel->symbol->name;
 			}
+		} else if (flag) {
+			name = flag->name;
 		}
-	}
-	if (name) {
+	} if (name) {
 		char *nptr, *ptr;
 		ut64 numval;
 		ptr = str;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4593,7 +4593,6 @@ static char *_find_next_number(char *op) {
 static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 	RAnal *anal = ds->core->anal;
 	RFlag *f = ds->core->flags;
-	RFlagItem *flag;
 	const char *name = NULL;
 
 	if (!ds->jmpsub || !anal) {
@@ -4609,7 +4608,6 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 	if (fcn) {
 		name = fcn->name;
 	} else if (f) {
-		flag = r_core_flag_get_by_spaces (f, addr);
 		RBinReloc *rel = getreloc (ds->core, addr, ds->analop.size);
 		if (rel) {
 			if (rel && rel->import && rel->import->name) {
@@ -4617,10 +4615,14 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 			} else if (rel && rel->symbol && rel->symbol->name) {
 				name = rel->symbol->name;
 			}
-		} else if (flag) {
-			name = flag->name;
+		} else {
+			RFlagItem *flag = r_core_flag_get_by_spaces (f, addr);
+			if (flag) {
+				name = flag->name;
+			}
 		}
-	} if (name) {
+	}
+	if (name) {
 		char *nptr, *ptr;
 		ut64 numval;
 		ptr = str;


### PR DESCRIPTION
### * Before

```
$ r2 -A ~/dev/karta/pngrutil.o 

[0x0800132c]> pdfs
0x0800132c call reloc.png_crc_read_45
0x0800133b call reloc.png_get_uint_32_60
0x08001352 call reloc.png_crc_read_83
0x08001361 call reloc.png_get_uint_32_98
0x0800138d:
0x08001398 call 0x8001399
0x080013a8 call reloc.png_crc_finish_169
0x080013b5:
0x080013cd call reloc.png_crc_read_206
0x080013dc call reloc.png_get_uint_32_221
0x080013f3 call reloc.png_crc_read_244
0x08001402 call reloc.png_get_uint_32_3
0x08001427 call 0x8001428
0x08001437 call reloc.png_crc_finish_56
0x08001444:
0x0800145c call reloc.png_crc_read_93
```

### * After 

```
$ r2 -A ~/dev/karta/pngrutil.o 

[0x0800132c]> pdfs
0x0800132c call png_crc_read
0x0800133b call png_get_uint_32
0x08001352 call png_crc_read
0x08001361 call png_get_uint_32
0x0800138d:
0x08001398 call png_warning
0x080013a8 call png_crc_finish
0x080013b5:
0x080013cd call png_crc_read
0x080013dc call png_get_uint_32
0x080013f3 call png_crc_read
0x08001402 call png_get_uint_32
0x0800141a cjmp 0x08001444
0x08001427 call png_warning
0x08001437 call png_crc_finish
0x08001444:
0x0800145c call png_crc_read

```