### PR TITLE
Add support to multiline assembly patching

### DIFF
--- a/libr/core/patch.c
+++ b/libr/core/patch.c
@@ -24,7 +24,7 @@ R_API int r_core_patch_line (RCore *core, char *str) {
 		  break;
 	case ':':
 		  r_core_cmdf (core, "s %s", str);
-		  r_core_cmdf (core, "wa %s", p);
+		  r_core_cmdf (core, "\"wa %s\"", p);
 		  break;
 	case 'v':
 		q = strchr (p + 1,' ');


### PR DESCRIPTION
For example, this line 'OFFSET : nop;nop;nop' (provided in the example patchfile at binr/rabin2/patch.txt) now actually works