### PR TITLE
Fail kernelcache check for non-arm64 kernels

### DIFF
--- a/libr/bin/format/mach0/mach064_is_kernelcache.c
+++ b/libr/bin/format/mach0/mach064_is_kernelcache.c
@@ -2,6 +2,10 @@ static bool is_kernelcache(const ut8 *buf, ut64 length) {
 	if (length < sizeof (struct MACH0_(mach_header))) {
 		return false;
 	}
+	ut32 cputype = r_read_le32 (buf + 4);
+	if (cputype != CPU_TYPE_ARM64) {
+		return false;
+	}
 
 	const ut8 *end = buf + length;
 	const ut8 *cursor = buf + sizeof (struct MACH0_(mach_header));


### PR DESCRIPTION
Since for now only arm64 kernels are supported.