### PR TITLE
asm.var.summary should be on if the screen is too small ##visual

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1687,8 +1687,9 @@ static void ds_show_functions(RDisasmState *ds) {
 	r_anal_fcn_vars_cache_init (core->anal, &vars_cache, f);
 
 	int o_varsum = ds->show_varsum;
-	if (!ds->show_varsum) {
-		int numvars = vars_cache.bvars->length + vars_cache.rvars->length + vars_cache.svars->length;
+	if (ds->interactive && !o_varsum) {
+		int padding = 10;
+		int numvars = vars_cache.bvars->length + vars_cache.rvars->length + vars_cache.svars->length + padding;
 		if (numvars > ds->l) {
 			ds->show_varsum = 1;
 		} else {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1685,6 +1685,17 @@ static void ds_show_functions(RDisasmState *ds) {
 	ds->stackptr = core->anal->stackptr;
 	RAnalFcnVarsCache vars_cache;
 	r_anal_fcn_vars_cache_init (core->anal, &vars_cache, f);
+
+	int o_varsum = ds->show_varsum;
+	if (!ds->show_varsum) {
+		int numvars = vars_cache.bvars->length + vars_cache.rvars->length + vars_cache.svars->length;
+		if (numvars > ds->l) {
+			ds->show_varsum = 1;
+		} else {
+			ds->show_varsum = 0;
+		}
+	}
+
 	if (ds->show_vars && ds->show_varsum) {
 		RList *all_vars = vars_cache.bvars;
 		r_list_join (all_vars, vars_cache.svars);
@@ -1762,6 +1773,7 @@ static void ds_show_functions(RDisasmState *ds) {
 			ds_newline (ds);
 		}
 	}
+	ds->show_varsum = o_varsum;
 	r_anal_fcn_vars_cache_fini (&vars_cache);
 	if (fcn_name_alloc) {
 		free (fcn_name);


### PR DESCRIPTION
about this #13259

but still not thoroughly done probably and so much room to improve so you'd better keep this issue open just yet.


![Screenshot from 2019-03-29 02-32-38](https://user-images.githubusercontent.com/29271244/55179565-17bd3e80-51cb-11e9-81ac-a46b21d80514.png)

![Screenshot from 2019-03-29 02-33-15](https://user-images.githubusercontent.com/29271244/55179564-17bd3e80-51cb-11e9-99ec-0740e4179d75.png)
