### PR TITLE
Make flag comments base64-compatible

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -560,15 +560,19 @@ rep:
 	case '+': // "f+'
 	case ' ': {
 		const char *cstr = r_str_trim_ro (str);
-		char* eq = strchr (cstr, '=');
 		char* s = strchr (cstr, ' ');
-		char* s2 = NULL;
+		char* s2 = NULL, *s3 = NULL;
+		char* comment = NULL;
+		bool comment_needs_free = false;
 		ut32 bsze = 1; //core->blocksize;
-		if (eq) {
-			// TODO: add support for '=' char in flag comments
-			*eq = 0;
-			off = r_num_math (core->num, eq + 1);
+
+		// Get outta here as fast as we can so we can make sure that the comment
+		// buffer used on later code can be freed properly if necessary.
+		if (*cstr == '.') {
+			input++;
+			goto rep;
 		}
+
 		if (s) {
 			*s = '\0';
 			s2 = strchr (s + 1, ' ');
@@ -577,21 +581,34 @@ rep:
 				if (s2[1] && s2[2]) {
 					off = r_num_math (core->num, s2 + 1);
 				}
-			}
-			bsze = r_num_math (core->num, s + 1);
-		}
-		if (*cstr == '.') {
-			input++;
-			goto rep;
-		} else {
-			bool addFlag = true;
-			if (input[0] == '+') {
-				if (r_flag_get_at (core->flags, off, false)) {
-					addFlag = false;
+				s3 = strchr (s2 + 1, ' ');
+				if (s3) {
+					*s3 = '\0';
+					if (!strncmp (s3+1, "base64:", 7)) {
+						comment = (char *) sdb_decode (s3+8, NULL);
+						comment_needs_free = true;
+					} else if (s3[1]) {
+						comment = s3 + 1;
+					}
 				}
 			}
-			if (addFlag) {
-				r_flag_set (core->flags, cstr, off, bsze);
+
+			bsze = s[1] == '=' ? 1 : r_num_math (core->num, s + 1);
+		}
+
+		bool addFlag = true;
+		if (input[0] == '+') {
+			if ((item = r_flag_get_at (core->flags, off, false))) {
+				addFlag = false;
+			}
+		}
+		if (addFlag) {
+			item = r_flag_set (core->flags, cstr, off, bsze);
+		}
+		if (item && comment) {
+			r_flag_item_set_comment (item, comment);
+			if (comment_needs_free) {
+				free(comment);
 			}
 		}
 		}

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -559,6 +559,8 @@ rep:
 	case '+': // "f+'
 	case ' ': {
 		const char *cstr = r_str_trim_ro (str);
+		char* eq = strchr (cstr, '=');
+		char* b64 = strstr (cstr, "base64:");
 		char* s = strchr (cstr, ' ');
 		char* s2 = NULL, *s3 = NULL;
 		char* comment = NULL;
@@ -571,7 +573,12 @@ rep:
 			input++;
 			goto rep;
 		}
-
+		// Check base64 padding
+		if (eq && !(b64 && eq > b64 && (eq[1] == '\0' || (eq[1] == '=' && eq[2] == '\0')))) {
+			// TODO: add support for '=' char in non-base64 flag comments
+			*eq = 0;
+			off = r_num_math (core->num, eq + 1);
+		}
 		if (s) {
 			*s = '\0';
 			s2 = strchr (s + 1, ' ');

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -3,7 +3,6 @@
 #include <stddef.h>
 #include "r_cons.h"
 #include "r_core.h"
-#include "sdb/sdb.h"
 
 static const char *help_msg_f[] = {
 	"Usage: f","[?] [flagname]", " # Manage offset-name flags",
@@ -585,7 +584,7 @@ rep:
 				if (s3) {
 					*s3 = '\0';
 					if (!strncmp (s3+1, "base64:", 7)) {
-						comment = (char *) sdb_decode (s3+8, NULL);
+						comment = (char *) r_base64_decode_dyn (s3+8, -1);
 						comment_needs_free = true;
 					} else if (s3[1]) {
 						comment = s3 + 1;
@@ -859,7 +858,7 @@ rep:
 				item = r_flag_get (core->flags, p);
 				if (item) {
 					if (!strncmp (q+1, "base64:", 7)) {
-						dec = (char *) sdb_decode (q+8, NULL);
+						dec = (char *) r_base64_decode_dyn (q+8, -1);
 						if (dec) {
 							r_flag_item_set_comment (item, dec);
 							free (dec);

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -590,8 +590,8 @@ rep:
 				s3 = strchr (s2 + 1, ' ');
 				if (s3) {
 					*s3 = '\0';
-					if (!strncmp (s3+1, "base64:", 7)) {
-						comment = (char *) r_base64_decode_dyn (s3+8, -1);
+					if (!strncmp (s3 + 1, "base64:", 7)) {
+						comment = (char *) r_base64_decode_dyn (s3 + 8, -1);
 						comment_needs_free = true;
 					} else if (s3[1]) {
 						comment = s3 + 1;
@@ -614,7 +614,7 @@ rep:
 		if (item && comment) {
 			r_flag_item_set_comment (item, comment);
 			if (comment_needs_free) {
-				free(comment);
+				free (comment);
 			}
 		}
 		}
@@ -864,8 +864,8 @@ rep:
 				*q = 0;
 				item = r_flag_get (core->flags, p);
 				if (item) {
-					if (!strncmp (q+1, "base64:", 7)) {
-						dec = (char *) r_base64_decode_dyn (q+8, -1);
+					if (!strncmp (q + 1, "base64:", 7)) {
+						dec = (char *) r_base64_decode_dyn (q + 8, -1);
 						if (dec) {
 							r_flag_item_set_comment (item, dec);
 							free (dec);
@@ -873,7 +873,7 @@ rep:
 							eprintf ("Failed to decode base64-encoded string\n");
 						}
 					} else {
-						r_flag_item_set_comment (item, q+1);
+						r_flag_item_set_comment (item, q + 1);
 					}
 				} else {
 					eprintf ("Cannot find flag with name '%s'\n", p);

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -340,19 +340,12 @@ static bool print_flag_rad(RFlagItem *flag, void *user) {
 		u->f->cb_printf ("fs %s\n", u->fs? u->fs->name: "*");
 	}
 	if (flag->comment && *flag->comment) {
-		comment_b64 = r_base64_encode_dyn(flag->comment, -1);
+		comment_b64 = r_base64_encode_dyn (flag->comment, -1);
 		// prefix the armored string with "base64:"
 		if (comment_b64) {
-			tmp = malloc(strlen(comment_b64) + 8);
-			if (tmp) {
-				memcpy(tmp, "base64:", 7);
-				strcpy(tmp+7, comment_b64);
-				free(comment_b64);
-				comment_b64 = tmp;
-			} else {
-				free(comment_b64);
-				comment_b64 = NULL;
-			}
+			tmp = r_str_newf ("base64:%s", comment_b64);
+			free (comment_b64);
+			comment_b64 = tmp;
 		}
 	}
 	if (flag->alias) {
@@ -367,9 +360,8 @@ static bool print_flag_rad(RFlagItem *flag, void *user) {
 			u->pfx? "+": "", u->pfx? u->pfx: "",
 			comment_b64? comment_b64: "");
 	}
-	if (comment_b64) {
-		free(comment_b64);
-	}
+
+	free (comment_b64);
 	return true;
 }
 

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -331,7 +331,7 @@ static bool print_flag_json(RFlagItem *flag, void *user) {
 
 static bool print_flag_rad(RFlagItem *flag, void *user) {
 	struct print_flag_t *u = (struct print_flag_t *)user;
-	char *comment_b64 = NULL;
+	char *comment_b64 = NULL, *tmp = NULL;
 	if (u->in_range && (flag->offset < u->range_from || flag->offset >= u->range_to)) {
 		return true;
 	}
@@ -340,22 +340,35 @@ static bool print_flag_rad(RFlagItem *flag, void *user) {
 		u->f->cb_printf ("fs %s\n", u->fs? u->fs->name: "*");
 	}
 	if (flag->comment && *flag->comment) {
-	    comment_b64 = r_base64_encode_dyn(flag->comment, -1);
+		comment_b64 = r_base64_encode_dyn(flag->comment, -1);
+		// prefix the armored string with "base64:"
+		if (comment_b64) {
+			tmp = malloc(strlen(comment_b64) + 8);
+			if (tmp) {
+				memcpy(tmp, "base64:", 7);
+				strcpy(tmp+7, comment_b64);
+				free(comment_b64);
+				comment_b64 = tmp;
+			} else {
+				free(comment_b64);
+				comment_b64 = NULL;
+			}
+		}
 	}
 	if (flag->alias) {
 		u->f->cb_printf ("fa %s %s\n", flag->name, flag->alias);
 		if (comment_b64) {
-			u->f->cb_printf ("\"fC %s base64:%s\"\n",
-				flag->name, comment_b64);
+			u->f->cb_printf ("\"fC %s %s\"\n",
+				flag->name, comment_b64? comment_b64: "");
 		}
 	} else {
-		u->f->cb_printf ("f %s %" PFMT64d " 0x%08" PFMT64x "%s%s base64:%s\n",
+		u->f->cb_printf ("f %s %" PFMT64d " 0x%08" PFMT64x "%s%s %s\n",
 			flag->name, flag->size, flag->offset,
 			u->pfx? "+": "", u->pfx? u->pfx: "",
 			comment_b64? comment_b64: "");
 	}
 	if (comment_b64) {
-	    free(comment_b64);
+		free(comment_b64);
 	}
 	return true;
 }

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -331,6 +331,7 @@ static bool print_flag_json(RFlagItem *flag, void *user) {
 
 static bool print_flag_rad(RFlagItem *flag, void *user) {
 	struct print_flag_t *u = (struct print_flag_t *)user;
+	char *comment_b64 = NULL;
 	if (u->in_range && (flag->offset < u->range_from || flag->offset >= u->range_to)) {
 		return true;
 	}
@@ -338,17 +339,23 @@ static bool print_flag_rad(RFlagItem *flag, void *user) {
 		u->fs = flag->space;
 		u->f->cb_printf ("fs %s\n", u->fs? u->fs->name: "*");
 	}
+	if (flag->comment && *flag->comment) {
+	    comment_b64 = r_base64_encode_dyn(flag->comment, -1);
+	}
 	if (flag->alias) {
 		u->f->cb_printf ("fa %s %s\n", flag->name, flag->alias);
-		if (flag->comment && *flag->comment) {
-			u->f->cb_printf ("\"fC %s %s\"\n",
-				flag->name, flag->comment);
+		if (comment_b64) {
+			u->f->cb_printf ("\"fC %s base64:%s\"\n",
+				flag->name, comment_b64);
 		}
 	} else {
-		u->f->cb_printf ("f %s %" PFMT64d " 0x%08" PFMT64x "%s%s %s\n",
+		u->f->cb_printf ("f %s %" PFMT64d " 0x%08" PFMT64x "%s%s base64:%s\n",
 			flag->name, flag->size, flag->offset,
 			u->pfx? "+": "", u->pfx? u->pfx: "",
-			flag->comment? flag->comment: "");
+			comment_b64? comment_b64: "");
+	}
+	if (comment_b64) {
+	    free(comment_b64);
 	}
 	return true;
 }


### PR DESCRIPTION
`fC` (and `f`) command now accepts base64 encoded strings prefixed with `base64:` similar to `CC`. In addition, `f*` now automatically armors the comment string with base64 before printing.

This PR also fixes the issue of optional comment in `f` being ignored when the command executes.