### PR TITLE
Build arch detection for RISC-V

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -491,6 +491,14 @@ static inline void *r_new_copy(int size, void *data) {
 /* we should default to wasm when ready */
 #define R_SYS_ARCH "x86"
 #define R_SYS_BITS R_SYS_BITS_32
+#elif __riscv__ || __riscv
+# define R_SYS_ARCH "riscv"
+# define R_SYS_ENDIAN 0
+# if __riscv_xlen == 32
+#  define R_SYS_BITS R_SYS_BITS_32
+# else
+#  define R_SYS_BITS (R_SYS_BITS_32 | R_SYS_BITS_64)
+# endif
 #else
 #ifdef _MSC_VER
 #ifdef _WIN64


### PR DESCRIPTION
Make sure that `asm.arch` and `anal.arch` is set correctly when starting radare on RISC-V.
(tested on SiFive Unleashed board w/ `gcc 9.0.1`)