### PR TITLE
Add more function sorting methods and reduce unnecessary resorts ##anal

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2812,7 +2812,7 @@ R_API int r_core_anal_fcn_list(RCore *core, const char *input, const char *rad) 
 		addr = r_num_math (core->num, name);
 	}
 
-	RList *fcns = r_list_new ();
+	RList *fcns = r_list_newf (NULL);
 	if (!fcns) {
 		return -1;
 	}
@@ -2824,7 +2824,7 @@ R_API int r_core_anal_fcn_list(RCore *core, const char *input, const char *rad) 
 		}
 	}
 
-	r_list_sort (fcns, &cmpfcn);
+	// r_list_sort (fcns, &cmpfcn);
 	if (!rad) {
 		fcn_list_default (core, fcns, false);
 		r_list_free (fcns);

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -2947,8 +2947,13 @@ R_API void r_core_visual_anal(RCore *core, const char *input) {
 			}
 			break;
 		case ':':
-			r_core_visual_prompt (core);
-			r_cons_any_key (NULL);
+			{
+				ut64 orig = core->offset;
+				r_core_seek (core, addr, 0);
+				r_core_visual_prompt (core);
+				r_cons_any_key (NULL);
+				r_core_seek (core, orig, 0);
+			}
 			continue;
 		case 'a':
 			switch (level) {
@@ -3095,7 +3100,13 @@ R_API void r_core_visual_anal(RCore *core, const char *input) {
 			}
 			break;
 		case '!':
-			r_core_cmd0 (core, "afls");
+			// TODO: use aflsn/aflsb/aflss/...
+			{
+			static int sortMode = 0;
+			const char *sortModes[4] = { "aflsa", "aflss", "aflsb", "aflsn" };
+			r_core_cmd0 (core, sortModes[sortMode%4]);
+			sortMode++;
+			}
 			break;
 		case 'k':
 			if (selectPanel) {


### PR DESCRIPTION
* aflsa, aflsb, aflsn, aflss - sort by addr, bbs, name or size