### PR TITLE
added a call to r_search_kw_reset in r_search_prelude to fix arbitrary heap oob write

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -329,7 +329,7 @@ R_API int r_core_search_prelude(RCore *core, ut64 from, ut64 to, const ut8 *buf,
 	// r_search_reset might also benifet from having an if(s->data) R_FREE(s->data), but im not sure.
 	//add a commit that puts it in there to this PR if it wouldnt break anything. (dont have to worry about this happening again, since all searches start by resetting core->search)
 	//For now we will just use r_search_kw_reset
-	r_search_kw_reset(core->search);
+	r_search_kw_reset (core->search);
 	free (b);
 	return preludecnt;
 }

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -326,6 +326,10 @@ R_API int r_core_search_prelude(RCore *core, ut64 from, ut64 to, const ut8 *buf,
 			break;
 		}
 	}
+	// r_search_reset might also benifet from having an if(s->data) R_FREE(s->data), but im not sure.
+	//add a commit that puts it in there to this PR if it wouldnt break anything. (dont have to worry about this happening again, since all searches start by resetting core->search)
+	//For now we will just use r_search_kw_reset
+	r_search_kw_reset(core->search);
 	free (b);
 	return preludecnt;
 }


### PR DESCRIPTION
https://asciinema.org/a/0LnnzCR0ohoZdCnG17E34vcDI


search->data is only allocated on the first time it is used... aap will do a search, allocate it to fit 4 bytes of search data, and then never R_FREE it. The next time a search is done, it wont re-allocate, and wont have enough size for the search string.

see r_search_mybinparse_update() for more info.

All the other searches (that i can tell) use r_search_kw_reset to properly free seach->data when they are done with it.

