### PR TITLE
meson: Fix deprecation warning in libcore

### DIFF
--- a/libr/core/meson.build
+++ b/libr/core/meson.build
@@ -117,7 +117,7 @@ r_core_dep = declare_dependency(link_with: r_core,
                                 include_directories: r_core_inc)
 
 pkgconfig_mod.generate(
-  libraries: [r_core],
+  r_core,
   subdirs: 'libr',
   version: r2_version,
   name: 'r_core',


### PR DESCRIPTION
Description of the warning:
```meson
libr/core/meson.build:118: DEPRECATION: Library r_core was passed to the "libraries" keyword argument of a previous call to generate() method instead of first positional a
rgument. Adding r_core to "Requires" field, but this is a deprecated behaviour that will change in a future version of Meson. Please report the issue if this warning canno
t be avoided in your case.
```