### PR TITLE
meson: Change completions installation directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -195,7 +195,7 @@ else
   r2_bindings = join_paths(r2_libdir, 'radare2-bindings', r2_version)
 endif
 
-r2_zsh_compdir = join_paths(r2_datdir, 'zsh', 'vendor-completions')
+r2_zsh_compdir = join_paths(r2_datdir, 'zsh', 'site-functions')
 
 # load plugin configuration
 subdir('libr')


### PR DESCRIPTION
To be able to use completion with zsh, completion script must be in
the `fpath` variable. On Ubuntu, these paths are:
```console
% print -ln $fpath
/usr/local/share/zsh/site-functions
/usr/share/zsh/vendor-functions
/usr/share/zsh/vendor-completions
/usr/share/zsh/functions/Calendar
/usr/share/zsh/functions/Chpwd
/usr/share/zsh/functions/<.. redacted ..>                               
```
On Arch Linux, these paths are:
```console
% print -ln $fpath
/usr/local/share/zsh/site-functions
/usr/share/zsh/site-functions
/usr/share/zsh/functions/Calendar
/usr/share/zsh/functions/Chpwd
/usr/share/zsh/functions/<.. redacted ..>              
```

So if r2 users install radare2 with `prefix=/usr/local`, completion will **not work** 
on both Ubuntu and Arch Linux. In this case, users have to [edit fpath](https://unix.stackexchange.com/a/26558/178265) or link them to 
`/usr/local/share/zsh/site-functions`. In case of users install radare2 with `prefix=/usr`, 
completion will work on Arch Linux.

With this PR, users on both distro could use completion when installing with
`prefix=/usr/local`. However, Ubuntu users might need to manually edit 
`fpath` themselves.