### PR TITLE
Enable asm.jmpsub by default

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2732,7 +2732,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.calls", "true", "Show callee function related info as comments in disasm");
 	SETPREF ("asm.comments", "true", "Show comments in disassembly view");
 	SETPREF ("asm.usercomments", "false", "Show user comments even if asm.comments is false");
-	SETPREF ("asm.jmpsub", "false", "Always substitute jump, call and branch targets in disassembly");
+	SETPREF ("asm.jmpsub", "true", "Always substitute jump, call and branch targets in disassembly");
 	SETPREF ("asm.hints", "true", "Disable all asm.hint* if false");
 	SETPREF ("asm.hint.jmp", "true", "Show jump hints [numbers] in disasm");
 	SETPREF ("asm.hint.lea", "false", "Show LEA hints [numbers] in disasm");


### PR DESCRIPTION
This PR wishes to enable `asm.jmpsub` by default. This is as a continue to the conversation on Telegram and on PR #13524.

Please notice the calls in these two outputs:

![image](https://user-images.githubusercontent.com/20182642/55685356-ba10bb00-595d-11e9-82d4-0a32995e72b3.png)
