### PR TITLE
arm improvements/refactoring

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -951,7 +951,6 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		break;
 	}
 	case ARM64_INS_ADR:
-		op->type = R_ANAL_OP_TYPE_LEA;
 		// TODO: must be 21bit signed
 		r_strbuf_setf (&op->esil,
 			"%"PFMT64d",%s,=", IMM64(1), REG64(0));
@@ -960,87 +959,46 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 	case ARM64_INS_SMADDL:
 	case ARM64_INS_FMADD:
 	case ARM64_INS_MADD:
-		op->type = R_ANAL_OP_TYPE_ADD;
 		r_strbuf_setf (&op->esil, "%s,%s,*,%s,+,%s,=",
 			REG64 (2), REG64 (1), REG64 (3), REG64 (0));
 		break;
 	case ARM64_INS_MSUB:
-		op->type = R_ANAL_OP_TYPE_SUB;
 		r_strbuf_setf (&op->esil, "%s,%s,*,%s,-,%s,=",
 			REG64 (2), REG64 (1), REG64 (3), REG64 (0));
 		break;
-	case ARM64_INS_UBFX: // Unsigned bitfield extract.
-	case ARM64_INS_UXTW:
-	case ARM64_INS_UBFM:
-	case ARM64_INS_SBFIZ:
-	case ARM64_INS_UBFIZ:
-		op->type = R_ANAL_OP_TYPE_MOV;
-		break;
-	case ARM64_INS_DMB:
-	case ARM64_INS_DSB:
-	case ARM64_INS_ISB:
-		op->family = R_ANAL_OP_FAMILY_THREAD;
-		// intentional fallthrough
-	case ARM64_INS_IC: // instruction cache invalidate
-	case ARM64_INS_DC: // data cache invalidate
-		op->type = R_ANAL_OP_TYPE_SYNC; // or cache
-		break;
-	case ARM64_INS_CLS: // Count leading sign bits.
-	case ARM64_INS_CLZ: // Count leading zero bits.
-		op->type = R_ANAL_OP_TYPE_MOV; // XXX
-		break;
-	case ARM64_INS_BIC:
-		op->type = R_ANAL_OP_TYPE_MOV;
-		break;
 	case ARM64_INS_ADD:
 	case ARM64_INS_ADC: // Add with carry.
-		op->cycles = 2;
-		op->type = R_ANAL_OP_TYPE_ADD;
 		OPCALL("+");
 		break;
 	case ARM64_INS_SUB:
-		op->cycles = 2;
-		op->type = R_ANAL_OP_TYPE_SUB;
 		OPCALL("-");
 		break;
 	case ARM64_INS_SMULL:
 	case ARM64_INS_MUL:
-		op->type = R_ANAL_OP_TYPE_MUL;
 		OPCALL("*");
 		break;
 	case ARM64_INS_AND:
-		op->type = R_ANAL_OP_TYPE_AND;
 		OPCALL("&");
 		break;
 	case ARM64_INS_ORR:
-		op->type = R_ANAL_OP_TYPE_OR;
 		OPCALL("|");
 		break;
 	case ARM64_INS_EOR:
-		op->type = R_ANAL_OP_TYPE_XOR;
 		OPCALL("^");
 		break;
 	case ARM64_INS_ORN:
-		op->type = R_ANAL_OP_TYPE_OR;
 		OPCALL_NEG("|");
 		break;
 	case ARM64_INS_EON:
-		op->type = R_ANAL_OP_TYPE_NOT;
 		OPCALL_NEG("^");
 		break;
 	case ARM64_INS_LSR:
-		op->cycles = 1;
-		op->type = R_ANAL_OP_TYPE_SHR;
 		OPCALL(">>");
 		break;
 	case ARM64_INS_LSL:
-		op->cycles = 1;
-		op->type = R_ANAL_OP_TYPE_SHL;
 		OPCALL("<<");
 		break;
 	case ARM64_INS_ROR:
-		op->cycles = 1;
-		op->type = R_ANAL_OP_TYPE_ROR;
 		OPCALL(">>>");
 		break;
 	case ARM64_INS_STURB: // sturb wzr, [x9, 0xffffffffffffffff]
@@ -1048,7 +1006,6 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		break;
 	case ARM64_INS_NOP:
 		r_strbuf_setf (&op->esil, ",");
-		op->cycles = 1;
 		break;
 	case ARM64_INS_FDIV:
 	case ARM64_INS_SDIV:
@@ -1147,7 +1104,6 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 	case ARM64_INS_TST: // cmp w8, 0xd
 	case ARM64_INS_CMP: // cmp w8, 0xd
 	case ARM64_INS_CMN: // cmp w8, 0xd
-		op->type = R_ANAL_OP_TYPE_CMP;
 		// update esil, cpu flags
 		if (ISIMM64(1)) {
 			r_strbuf_setf (&op->esil, "%"PFMT64d",%s,-,$z,zf,=,$s,nf,=,$b%d,!,cf,=,$o,vf,=", IMM64(1), REG64(0), arm64_reg_width(REGID64(0)));
@@ -1158,18 +1114,14 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		break;
 	case ARM64_INS_FCSEL:
 	case ARM64_INS_CSEL: // CSEL w8, w13, w14, eq
-		op->type = R_ANAL_OP_TYPE_MOV;
 		r_strbuf_appendf (&op->esil, "%s,%s,=,BREAK", REG64(1), REG64(0));
 		r_strbuf_appendf (&op->esil, "%s,%s,%s,=", postfix, REG64(2), REG64(0));
 		break;
 	case ARM64_INS_CSET: // cset w8, eq
-		op->type = R_ANAL_OP_TYPE_MOV;
 		r_strbuf_appendf (&op->esil, "1,%s,=,BREAK", REG64(0));
 		r_strbuf_appendf (&op->esil, "%s,0,%s,=", postfix, REG64(0));
 		break;
 	case ARM64_INS_CINC: // cinc w10, w20, eq
-		op->type = R_ANAL_OP_TYPE_ADD;
-		op->val = 1;
 		r_strbuf_appendf (&op->esil, "1,%s,+,%s,=,BREAK", REG64(1), REG64(0));
 		r_strbuf_appendf (&op->esil, "%s,%s,%s,=", postfix, REG64(1), REG64(0));
 		break;
@@ -1364,8 +1316,6 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		break;
 	/* ASR, SXTB, SXTH and SXTW are alias for SBFM */
 	case ARM64_INS_ASR:
-		op->cycles = 1;
-		op->type = R_ANAL_OP_TYPE_SHR;
 		OPCALL(">>>>");
 		break;
 	case ARM64_INS_SXTB:
@@ -1391,7 +1341,6 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		}
 		break;
 	case ARM64_INS_SXTW: /* word */
-		op->type = R_ANAL_OP_TYPE_AND;
 		r_strbuf_setf (&op->esil, "%s,%s,=,32,%s,>>,%s,%s,=,%s,%s,&=,$c,?{,0xffffffffffffff00,%s,|=}",
 				REG64(1), REG64(0), REG64(1), REG64(1), REG64(0),
 				"0xffffffff", REG64(0), REG64(0));
@@ -1403,17 +1352,14 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		r_strbuf_setf (&op->esil, "%s,0xffff,&,%s,=", REG64(1),REG64(0));
 		break;
 	case ARM64_INS_RET:
-		op->type = R_ANAL_OP_TYPE_RET;
 		r_strbuf_setf (&op->esil, "lr,pc,=");
 		break;
 	case ARM64_INS_ERET:
-		op->type = R_ANAL_OP_TYPE_RET;
 		r_strbuf_setf (&op->esil, "lr,pc,=");
 		break;
 	case ARM64_INS_BFI: // bfi w8, w8, 2, 1
 	case ARM64_INS_BFXIL:
 	{
-		op->type = R_ANAL_OP_TYPE_MOV;
 		if (OPCOUNT64() >= 3 && ISIMM64 (3) && IMM64 (3) > 0) {
 			ut64 mask = bitmask_by_width[IMM64 (3) - 1];
 			ut64 shift = IMM64 (2);
@@ -1428,7 +1374,6 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 #if CS_API_MAJOR > 3
 	case ARM64_INS_NEGS:
 #endif
-		op->type = R_ANAL_OP_TYPE_NOT;
 		if (LSHIFT2_64 (1)) {
 			SHIFTED_REG64_APPEND (&op->esil, 1);
 		} else {
@@ -1437,7 +1382,6 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		r_strbuf_appendf (&op->esil, ",0,-,%s,=", REG64 (0));
 		break;
 	case ARM64_INS_SVC:
-		op->type = R_ANAL_OP_TYPE_SWI;
 		r_strbuf_setf (&op->esil, "%u,$", IMM64 (0));
 		break;
 	}
@@ -1541,58 +1485,39 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case ARM_INS_SADD16:
 	case ARM_INS_SADD8:
-		op->type = R_ANAL_OP_TYPE_ADD;
-		if (REGID(0) == ARM_REG_PC && insn->detail->arm.cc != ARM_CC_AL) {
-			//op->type = R_ANAL_OP_TYPE_RCJMP;
-			op->type = R_ANAL_OP_TYPE_UCJMP;
-		}
 		MATH32AS("+");
 		break;
 	case ARM_INS_ADDW:
 	case ARM_INS_ADD:
-		op->type = R_ANAL_OP_TYPE_ADD;
-		if (REGID(0) == ARM_REG_PC && insn->detail->arm.cc != ARM_CC_AL) {
-			//op->type = R_ANAL_OP_TYPE_RCJMP;
-			op->type = R_ANAL_OP_TYPE_UCJMP;
-		}
 		MATH32("+");
 		break;
 	case ARM_INS_SSUB16:
 	case ARM_INS_SSUB8:
-		op->type = R_ANAL_OP_TYPE_SUB;
 		MATH32AS("-");
 		break;
 	case ARM_INS_SUBW:
 	case ARM_INS_SUB:
-		op->type = R_ANAL_OP_TYPE_SUB;
 		MATH32("-");
 		break;
 	case ARM_INS_MUL:
-		op->type = R_ANAL_OP_TYPE_MUL;
 		MATH32("*");
 		break;
 	case ARM_INS_AND:
-		op->type = R_ANAL_OP_TYPE_AND;
 		MATH32("&");
 		break;
 	case ARM_INS_ORR:
-		op->type = R_ANAL_OP_TYPE_OR;
 		MATH32("|");
 		break;
 	case ARM_INS_EOR:
-		op->type = R_ANAL_OP_TYPE_XOR;
 		MATH32("^");
 		break;
 	case ARM_INS_ORN:
-		op->type = R_ANAL_OP_TYPE_OR;
 		MATH32_NEG("|");
 		break;
 	case ARM_INS_LSR:
-		op->type = R_ANAL_OP_TYPE_SHR;
 		MATH32(">>");
 		break;
 	case ARM_INS_LSL:
-		op->type = R_ANAL_OP_TYPE_SHL;
 		MATH32("<<");
 		break;
 	case ARM_INS_SVC:
@@ -1657,7 +1582,6 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 		}
 		break;
 	case ARM_INS_CMP:
-		op->type = R_ANAL_OP_TYPE_CMP;
 		r_strbuf_appendf (&op->esil, "%s,%s,==,$z,zf,=,$s,nf,=,$b32,!,cf,=,$o,vf,=", ARG(1), ARG(0));
 		break;
 	case ARM_INS_CMN:
@@ -2041,6 +1965,7 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 		r_strbuf_appendf (&op->esil, "%s,%d,+,[1],%s,=",
 			MEMBASE(1), MEMDISP(1), REG(0));
 		break;
+	case ARM_INS_LDREX:
 	case ARM_INS_LDREXB:
 	case ARM_INS_LDREXD:
 	case ARM_INS_LDREXH:
@@ -2135,20 +2060,11 @@ r4,r5,r6,3,sp,[*],12,sp,+=
 				}
 			}
 		}
-		if (REGBASE(0) == ARM_REG_PC) {
-			op->type = R_ANAL_OP_TYPE_UJMP;
-			if (insn->detail->arm.cc != ARM_CC_AL) {
-				//op->type = R_ANAL_OP_TYPE_MCJMP;
-				op->type = R_ANAL_OP_TYPE_UCJMP;
-			}
-		}
 		break;
 	case ARM_INS_MRS:
-		op->family = R_ANAL_OP_FAMILY_PRIV;
 		// TODO: esil for MRS
 		break;
 	case ARM_INS_MSR:
-		op->family = R_ANAL_OP_FAMILY_PRIV;
 		msr_flags = insn->detail->arm.operands[0].reg >> 4;
 		r_strbuf_appendf (&op->esil, "0,",REG(1));
 		if (msr_flags & 1) {
@@ -2332,10 +2248,9 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 		break;
 	case ARM64_INS_NOP:
 		op->type = R_ANAL_OP_TYPE_NOP;
+		op->cycles = 1;
 		break;
 	case ARM64_INS_SUB:
-		op->cycles = 1;
-		op->type = R_ANAL_OP_TYPE_SUB;
 		if (ISREG64(0) && REGID64(0) == ARM64_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			if (ISIMM64(1)) {
@@ -2350,6 +2265,10 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 			op->stackop = R_ANAL_STACK_RESET;
 			op->stackptr = 0;
 		}
+		op->cycles = 1;
+		/* fallthru */
+	case ARM64_INS_MSUB:
+		op->type = R_ANAL_OP_TYPE_SUB;
 		break;
 	case ARM64_INS_FDIV:
 	case ARM64_INS_SDIV:
@@ -2358,6 +2277,7 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 		op->type = R_ANAL_OP_TYPE_DIV;
 		break;
 	case ARM64_INS_MUL:
+	case ARM64_INS_SMULL:
 	case ARM64_INS_FMUL:
 	case ARM64_INS_UMULL:
 		/* TODO: if next instruction is also a MUL, cycles are /=2 */
@@ -2367,10 +2287,18 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 		break;
 	case ARM64_INS_ADD:
 		op->cycles = 1;
+		/* fallthru */
+	case ARM64_INS_ADC:
+	case ARM64_INS_UMADDL:
+	case ARM64_INS_SMADDL:
+	case ARM64_INS_FMADD:
+	case ARM64_INS_MADD:
 		op->type = R_ANAL_OP_TYPE_ADD;
 		break;
 	case ARM64_INS_CSEL:
 	case ARM64_INS_FCSEL:
+	case ARM64_INS_CSET:
+	case ARM64_INS_CINC:
 		op->type = R_ANAL_OP_TYPE_CMOV;
 		break;
 	case ARM64_INS_MOV:
@@ -2378,6 +2306,7 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 			op->stackop = R_ANAL_STACK_RESET;
 			op->stackptr = 0;
 		}
+		op->cycles = 1;
 		/* fallthru */
 	case ARM64_INS_MOVI:
 	case ARM64_INS_MOVK:
@@ -2385,6 +2314,14 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 	case ARM64_INS_SMOV:
 	case ARM64_INS_UMOV:
 	case ARM64_INS_FMOV:
+	case ARM64_INS_SBFX:
+	case ARM64_INS_UBFX:
+	case ARM64_INS_UBFM:
+	case ARM64_INS_SBFIZ:
+	case ARM64_INS_UBFIZ:
+	case ARM64_INS_BIC:
+	case ARM64_INS_BFI:
+	case ARM64_INS_BFXIL:
 		op->type = R_ANAL_OP_TYPE_MOV;
 		break;
 	case ARM64_INS_MOVZ:
@@ -2394,21 +2331,36 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 		op->val = IMM64(1);
 		break;
 	case ARM64_INS_UXTB:
+	case ARM64_INS_SXTB:
 		op->type = R_ANAL_OP_TYPE_MOV;
 		op->ptr = 0LL;
-		op->ptrsize = 4;
+		op->ptrsize = 1;
 		break;
 	case ARM64_INS_UXTH:
+	case ARM64_INS_SXTH:
 		op->type = R_ANAL_OP_TYPE_MOV;
 		op->ptr = 0LL;
 		op->ptrsize = 2;
 		break;
-	case ARM64_INS_BRK:
-		op->type = R_ANAL_OP_TYPE_TRAP;
+	case ARM64_INS_UXTW:
+	case ARM64_INS_SXTW:
+		op->type = R_ANAL_OP_TYPE_MOV;
+		op->ptr = 0LL;
+		op->ptrsize = 4;
 		break;
+	case ARM64_INS_BRK:
 	case ARM64_INS_HLT:
 		op->type = R_ANAL_OP_TYPE_TRAP;
 		// hlt stops the process, not skips some cycles like in x86
+		break;
+	case ARM64_INS_DMB:
+	case ARM64_INS_DSB:
+	case ARM64_INS_ISB:
+		op->family = R_ANAL_OP_FAMILY_THREAD;
+		// intentional fallthrough
+	case ARM64_INS_IC: // instruction cache invalidate
+	case ARM64_INS_DC: // data cache invalidate
+		op->type = R_ANAL_OP_TYPE_SYNC; // or cache
 		break;
 	//  XXX unimplemented instructions
 	case ARM64_INS_DUP:
@@ -2419,12 +2371,26 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 	case ARM64_INS_INS:
 		op->type = R_ANAL_OP_TYPE_MOV;
 		break;
-	case ARM64_INS_USHLL:
+	case ARM64_INS_LSL:
+		op->cycles = 1;
+		/* fallthru */
 	case ARM64_INS_SHL:
+	case ARM64_INS_USHLL:
 		op->type = R_ANAL_OP_TYPE_SHL;
 		break;
-	case ARM64_INS_LSL:
-		op->type = R_ANAL_OP_TYPE_SHL;
+	case ARM64_INS_LSR:
+		op->cycles = 1;
+		op->type = R_ANAL_OP_TYPE_SHR;
+		break;
+	case ARM64_INS_ASR:
+		op->cycles = 1;
+		op->type = R_ANAL_OP_TYPE_SAR;
+		break;
+	case ARM64_INS_NEG:
+#if CS_API_MAJOR > 3
+	case ARM64_INS_NEGS:
+#endif
+		op->type = R_ANAL_OP_TYPE_NOT;
 		break;
 	case ARM64_INS_FCMP:
 	case ARM64_INS_CCMP:
@@ -2435,18 +2401,19 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 		op->type = R_ANAL_OP_TYPE_CMP;
 		break;
 	case ARM64_INS_ROR:
+		op->cycles = 1;
 		op->type = R_ANAL_OP_TYPE_ROR;
+		break;
+	case ARM64_INS_AND:
+		op->type = R_ANAL_OP_TYPE_AND;
 		break;
 	case ARM64_INS_ORR:
 	case ARM64_INS_ORN:
 		op->type = R_ANAL_OP_TYPE_OR;
 		break;
 	case ARM64_INS_EOR:
+	case ARM64_INS_EON:
 		op->type = R_ANAL_OP_TYPE_XOR;
-		break;
-	case ARM64_INS_ASR:
-	case ARM64_INS_LSR:
-		op->type = R_ANAL_OP_TYPE_SHR;
 		break;
 	case ARM64_INS_STRB:
 	case ARM64_INS_STURB:
@@ -2476,7 +2443,15 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 	case ARM64_INS_LDPSW:
 	case ARM64_INS_LDRH:
 	case ARM64_INS_LDRB:
-		op->type = R_ANAL_OP_TYPE_LOAD;
+		if (REGID(0) == ARM_REG_PC) {
+			op->type = R_ANAL_OP_TYPE_UJMP;
+			if (insn->detail->arm.cc != ARM_CC_AL) {
+				//op->type = R_ANAL_OP_TYPE_MCJMP;
+				op->type = R_ANAL_OP_TYPE_UCJMP;
+			}
+		} else {
+			op->type = R_ANAL_OP_TYPE_LOAD;
+		}
 		switch (insn->id) {
 		case ARM64_INS_LDPSW:
 		case ARM64_INS_LDRSW:
@@ -2502,9 +2477,8 @@ static void anop64 (csh handle, RAnalOp *op, cs_insn *insn) {
 		}
 		break;
 	case ARM64_INS_ERET:
-		op->type = R_ANAL_OP_TYPE_RET;
 		op->family = R_ANAL_OP_FAMILY_PRIV;
-		break;
+		/* fallthru */
 	case ARM64_INS_RET:
 		op->type = R_ANAL_OP_TYPE_RET;
 		break;
@@ -2687,7 +2661,6 @@ jmp $$ + 4 + ( [delta] * 2 )
 		}
 		break;
 	case ARM_INS_SUB:
-		op->type = R_ANAL_OP_TYPE_SUB;
 		if (ISREG(0) && REGID(0) == ARM_REG_SP) {
 				op->stackop = R_ANAL_STACK_INC;
 				if (ISIMM(1)) {
@@ -2699,6 +2672,12 @@ jmp $$ + 4 + ( [delta] * 2 )
 				}
 				op->val = op->stackptr;
 		}
+		op->cycles = 1;
+		/* fall-thru */
+	case ARM_INS_SUBW:
+	case ARM_INS_SSUB8:
+	case ARM_INS_SSUB16:
+		op->type = R_ANAL_OP_TYPE_SUB;
 		break;
 	case ARM_INS_ADD:
 		op->type = R_ANAL_OP_TYPE_ADD;
@@ -2715,23 +2694,36 @@ jmp $$ + 4 + ( [delta] * 2 )
 				break;
 			}
 		}
+		op->cycles = 1;
 		break;
-	case ARM_INS_VMOV:
-		op->type = R_ANAL_OP_TYPE_MOV;
-		op->family = R_ANAL_OP_FAMILY_FPU;
+		/* fall-thru */
+	case ARM_INS_ADDW:
+	case ARM_INS_SADD8:
+	case ARM_INS_SADD16:
+		op->type = R_ANAL_OP_TYPE_ADD;
+		break;
+	case ARM_INS_SDIV:
+	case ARM_INS_UDIV:
+		op->cycles = 4;
+		/* fall-thru */
+	case ARM_INS_VDIV:
+		op->type = R_ANAL_OP_TYPE_DIV;
+		break;
+	case ARM_INS_MUL:
+	case ARM_INS_SMULL:
+	case ARM_INS_UMULL:
+		/* TODO: if next instruction is also a MUL, cycles are /=2 */
+		/* also known as Register Indexing Addressing */
+		op->cycles = 4;
+		/* fall-thru */
+	case ARM_INS_VMUL:
+		op->type = R_ANAL_OP_TYPE_MUL;
 		break;
 	case ARM_INS_TRAP:
 		op->type = R_ANAL_OP_TYPE_TRAP;
 		op->cycles = 2;
 		break;
 	case ARM_INS_MOV:
-	case ARM_INS_MOVT:
-	case ARM_INS_MOVW:
-	case ARM_INS_VMOVL:
-	case ARM_INS_VMOVN:
-	case ARM_INS_VQMOVUN:
-	case ARM_INS_VQMOVN:
-		op->type = R_ANAL_OP_TYPE_MOV;
 		if (REGID(0) == ARM_REG_PC) {
 			if (REGID(1) == ARM_REG_LR) {
 				op->type = R_ANAL_OP_TYPE_RET;
@@ -2742,6 +2734,22 @@ jmp $$ + 4 + ( [delta] * 2 )
 		if (ISIMM (1)) {
 			op->val = IMM(1);
 		}
+		/* fall-thru */
+	case ARM_INS_MOVT:
+	case ARM_INS_MOVW:
+	case ARM_INS_VMOVL:
+	case ARM_INS_VMOVN:
+	case ARM_INS_VQMOVUN:
+	case ARM_INS_VQMOVN:
+	case ARM_INS_SBFX:
+	case ARM_INS_UBFX:
+	case ARM_INS_BIC:
+	case ARM_INS_BFI:
+		op->type = R_ANAL_OP_TYPE_MOV;
+		break;
+	case ARM_INS_VMOV:
+		op->type = R_ANAL_OP_TYPE_MOV;
+		op->family = R_ANAL_OP_FAMILY_FPU;
 		break;
 	case ARM_INS_UDF:
 		op->type = R_ANAL_OP_TYPE_TRAP;
@@ -2750,24 +2758,44 @@ jmp $$ + 4 + ( [delta] * 2 )
 		op->type = R_ANAL_OP_TYPE_SWI;
 		op->val = IMM(0);
 		break;
+	case ARM_INS_ROR:
+	case ARM_INS_RRX:
+		op->cycles = 1;
+		op->type = R_ANAL_OP_TYPE_ROR;
+		break;
 	case ARM_INS_AND:
 		op->type = R_ANAL_OP_TYPE_AND;
+		break;
+	case ARM_INS_ORR:
+	case ARM_INS_ORN:
+		op->type = R_ANAL_OP_TYPE_OR;
+		break;
+	case ARM_INS_EOR:
+		op->type = R_ANAL_OP_TYPE_XOR;
 		break;
 	case ARM_INS_CMP:
 	case ARM_INS_CMN:
 	case ARM_INS_TST:
-		op->type = R_ANAL_OP_TYPE_CMP;
 		if (ISIMM(1)) {
 			op->ptr = IMM(1);
 		}
 		op->reg = r_str_get (cs_reg_name (handle, INSOP (0).reg));
+		/* fall-thru */
+	case ARM_INS_VCMP:
+		op->type = R_ANAL_OP_TYPE_CMP;
 		break;
-	case ARM_INS_ROR:
-	case ARM_INS_ORN:
 	case ARM_INS_LSL:
-	case ARM_INS_LSR:
+		op->cycles = 1;
+		op->type = R_ANAL_OP_TYPE_SHL;
 		break;
-		//case ARM_INS_POP:
+	case ARM_INS_LSR:
+		op->cycles = 1;
+		op->type = R_ANAL_OP_TYPE_SHR;
+		break;
+	case ARM_INS_ASR:
+		op->cycles = 1;
+		op->type = R_ANAL_OP_TYPE_SAR;
+		break;
 	case ARM_INS_PUSH:
 	case ARM_INS_STM:
 	case ARM_INS_STMDB:
@@ -2780,6 +2808,12 @@ jmp $$ + 4 + ( [delta] * 2 )
 			op->ptr = MEMDISP(1);
 		}
 		break;
+	case ARM_INS_STREX:
+	case ARM_INS_STREXB:
+	case ARM_INS_STREXD:
+	case ARM_INS_STREXH:
+		op->family = R_ANAL_OP_FAMILY_THREAD;
+		/* fall-thru */
 	case ARM_INS_STR:
 	case ARM_INS_STRB:
 	case ARM_INS_STRD:
@@ -2795,14 +2829,16 @@ jmp $$ + 4 + ( [delta] * 2 )
 			op->ptr = -MEMDISP(1);
 		}
 		break;
-	case ARM_INS_LDR:
-	case ARM_INS_LDRD:
-	case ARM_INS_LDRB:
-	case ARM_INS_LDRBT:
 	case ARM_INS_LDREX:
 	case ARM_INS_LDREXB:
 	case ARM_INS_LDREXD:
 	case ARM_INS_LDREXH:
+		op->family = R_ANAL_OP_FAMILY_THREAD;
+		/* fall-thru */
+	case ARM_INS_LDR:
+	case ARM_INS_LDRD:
+	case ARM_INS_LDRB:
+	case ARM_INS_LDRBT:
 	case ARM_INS_LDRH:
 	case ARM_INS_LDRHT:
 	case ARM_INS_LDRSB:
@@ -2814,6 +2850,10 @@ jmp $$ + 4 + ( [delta] * 2 )
 // 0x000082a8    28301be5     ldr r3, [fp, -0x28]
 		if (REGID(0) == ARM_REG_PC) {
 			op->type = R_ANAL_OP_TYPE_UJMP;
+			if (insn->detail->arm.cc != ARM_CC_AL) {
+				//op->type = R_ANAL_OP_TYPE_MCJMP;
+				op->type = R_ANAL_OP_TYPE_UCJMP;
+			}
 		} else {
 			op->type = R_ANAL_OP_TYPE_LOAD;
 		}
@@ -2842,6 +2882,11 @@ jmp $$ + 4 + ( [delta] * 2 )
 				break;
 			}
 		}
+		break;
+	case ARM_INS_MRS:
+	case ARM_INS_MSR:
+		op->type = R_ANAL_OP_TYPE_MOV;
+		op->family = R_ANAL_OP_FAMILY_PRIV;
 		break;
 	case ARM_INS_BLX:
 		op->cycles = 4;


### PR DESCRIPTION
My goal was to add a new glibc signature (so "s main" would work), and I ended up fixing other issues as well.

[gcc-linaro-arm-linux-gnueabi-2012.01-20120125_linux](https://releases.linaro.org/archive/12.01/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabi-2012.01-20120125_linux.tar.xz) (GCC 4.6.3, glibc 2.13) produces binaries with the following entry point that require the new signature:

```
[0x000082bc]> pd20
            ;-- entry0:
            ;-- section..text:
            ;-- pc:
            ;-- r15:
            0x000082bc      4ff0000b       mov.w fp, 0                 ; [13] -r-x section size 220 named .text
            0x000082c0      4ff0000e       mov.w lr, 0
            0x000082c4      5df8041b       ldr r1, [sp], 4
            0x000082c8      6a46           mov r2, sp
            0x000082ca      4df8042d       str r2, [sp, -0x4]!
            0x000082ce      4df8040d       str r0, [sp, -0x4]!
            0x000082d2      dff814c0       ldr.w ip, [0x000082e8]      ; [0x82e8:4]=0x8395
            0x000082d6      4df804cd       str ip, [sp, -0x4]!
            0x000082da      0448           ldr r0, [0x000082ec]        ; [0x82ec:4]=0x8334
            0x000082dc      044b           ldr r3, [0x000082f0]        ; [0x82f0:4]=0x8351
            0x000082de      fff7daef       blx sym.imp.__libc_start_main
            0x000082e2      fff7e6ef       blx sym.imp.abort
            0x000082e6      0000           movs r0, r0
            0x000082e8      9583           strh r5, [r2, 0x1c]
            0x000082ea      0000           movs r0, r0
            0x000082ec      3483           strh r4, [r6, 0x18]
            0x000082ee      0000           movs r0, r0
            0x000082f0      5183           strh r1, [r2, 0x1a]
            0x000082f2      0000           movs r0, r0
            0x000082f4      034b           ldr r3, [0x00008304]        ; [0x8304:4]=0x81a8
```