### PR TITLE
Fix #13596 - Implement afb= and afl= and and refactor

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2248,93 +2248,6 @@ static char *build_hash_string(int mode, const char *chksum, ut8 *data, ut32 dat
 	return ret;
 }
 
-#define PRINT_CURRENT_SEEK \
-        if (i > 0 && len != 0) { \
-                if (seek == UT64_MAX) seek = 0; \
-                io->cb_printf ("=>  0x%08"PFMT64x" |", seek); \
-                for (j = 0; j < width; j++) { \
-                        io->cb_printf ( \
-                                ((j*mul) + min >= seek && \
-                                (j*mul) + min <= seek + len) \
-                                ? "^" : "-"); \
-                } \
-                io->cb_printf ("| 0x%08"PFMT64x"\n", seek+len); \
-        }
-
-static void list_section_visual(RIO *io, RList *sections, ut64 seek, ut64 len, int use_color, int cols) {
-	ut64 mul, min = -1, max = -1;
-	RListIter *iter;
-	RBinSection *s;
-	int j, i = 0;
-	int width = cols - 70;
-	if (width < 1) {
-		width = 30;
-	}
-	ls_foreach (sections, iter, s) {
-		if (min == -1 || s->paddr < min) {
-			min = s->paddr;
-		}
-		if (max == -1 || s->paddr+s->size > max) {
-			max = s->paddr + s->size;
-		}
-	}
-	mul = (max-min) / width;
-	if (min != -1 && mul != 0) {
-		const char * color = "", *color_end = "";
-		char humansz[8];
-		i = 0;
-		ls_foreach (sections, iter, s) {
-			char *r_sname = r_str_escape (s->name);
-			r_num_units (humansz, sizeof (humansz), s->size);
-			if (use_color) {
-				color_end = Color_RESET;
-				if ((s->perm & R_PERM_X) && (s->perm & R_PERM_W)) { // exec & write bits
-					color = r_cons_singleton()->context->pal.widget_sel;
-				} else if (s->perm & R_PERM_X) { // exec bit
-					color = r_cons_singleton()->context->pal.graph_true;
-				} else if (s->perm & R_PERM_W) { // write bit
-					color = r_cons_singleton()->context->pal.graph_false;
-				} else {
-					color = "";
-					color_end = "";
-				}
-			} else {
-				color = "";
-				color_end = "";
-			}
-			if (io->va) {
-				io->cb_printf ("%02d%c %s0x%08"PFMT64x"%s |", i,
-						(seek >= s->vaddr && seek < s->vaddr + s->vsize) ? '*' : ' ',
-						color, s->vaddr, color_end);
-			} else {
-				io->cb_printf ("%02d%c %s0x%08"PFMT64x"%s |", i,
-						(seek >= s->paddr && seek < s->paddr + s->size) ? '*' : ' ',
-						color, s->paddr, color_end);
-			}
-			for (j = 0; j < width; j++) {
-				ut64 pos = min + (j * mul);
-				ut64 npos = min + ((j + 1) * mul);
-				if (s->paddr < npos && (s->paddr + s->size) > pos)
-					io->cb_printf ("#");
-				else io->cb_printf ("-");
-			}
-			if (io->va) {
-				io->cb_printf ("| %s0x%08"PFMT64x"%s %5s %s  %04s\n",
-						color, s->vaddr + s->vsize, color_end, humansz,
-						r_str_rwx_i (s->perm), r_sname);
-			} else {
-				io->cb_printf ("| %s0x%08"PFMT64x"%s %5s %s  %04s\n",
-						color, s->paddr+s->size, color_end, humansz,
-						r_str_rwx_i (s->perm), r_sname);
-			}
-
-			i++;
-			free (r_sname);
-		}
-		PRINT_CURRENT_SEEK;
-	}
-}
-
 typedef struct {
 	const char *uri;
 	int perm;
@@ -2469,7 +2382,28 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 	}
 	if (IS_MODE_EQUAL (mode)) {
 		int cols = r_cons_get_size (NULL);
-		list_section_visual (r->io, sections, r->offset, -1, r->print->flags & R_PRINT_FLAGS_COLOR, cols);
+		RList *list = r_list_new ();
+		if (!list) {
+			return false;
+		}
+		SdbListIter *iter;
+		RBinSection *s;
+		r_list_foreach (sections, iter, s) {
+			char humansz[8];
+			ListInfo *info = R_NEW (ListInfo);
+			if (!info) {
+				return false;
+			}
+			info->name = s->name;
+			info->pitv = (RInterval){s->paddr, s->size};
+			info->vitv = (RInterval){s->vaddr, s->vsize};
+			info->perm = s->perm;
+			r_num_units (humansz, sizeof (humansz), s->size);
+			info->extra = strdup (humansz);
+			r_list_append (list, info);
+		}
+		r_core_visual_list (r, list, r->offset, -1, cols, r->print->flags & R_PRINT_FLAGS_COLOR);
+		r_list_free (list);
 		goto out;
 	}
 	if (IS_MODE_JSON (mode) && !printHere) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1803,8 +1803,14 @@ static bool anal_fcn_list_bb(RCore *core, const char *input, bool one) {
 	r_list_sort (fcn->bbs, bb_cmp);
 	if (mode == '=') { // afb
 		RList *flist = r_list_new ();
+		if (!flist) {
+			return false;
+		}
 		ls_foreach (fcn->bbs, iter, b) {
 			ListInfo *info = R_NEW (ListInfo);
+			if (!info) {
+				return false;
+			}
 			info->name = b->label;
 			info->pitv = (RInterval) {b->addr, b->size};
 			info->vitv = info->pitv;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1801,6 +1801,22 @@ static bool anal_fcn_list_bb(RCore *core, const char *input, bool one) {
 		r_cons_printf ("fs blocks\n");
 	}
 	r_list_sort (fcn->bbs, bb_cmp);
+	if (mode == '=') { // afb
+		RList *flist = r_list_new ();
+		ls_foreach (fcn->bbs, iter, b) {
+			ListInfo *info = R_NEW (ListInfo);
+			info->name = b->label;
+			info->pitv = (RInterval) {b->addr, b->size};
+			info->vitv = info->pitv;
+			info->perm = -1;
+			info->extra = NULL;
+			r_list_append (flist, info);
+		}
+		r_core_visual_list (core, flist, core->offset, core->blocksize,
+			r_cons_get_size (NULL), r_config_get_i (core->config, "scr.color"));
+		r_list_free (flist);
+		return true;
+	}
 	r_list_foreach (fcn->bbs, iter, b) {
 		if (one) {
 			if (bbaddr != UT64_MAX && (bbaddr < b->addr || bbaddr >= (b->addr + b->size))) {
@@ -2640,6 +2656,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		case 'q': // "aflq"
 		case 'm': // "aflm"
 		case '+': // "afl+"
+		case '=': // "afl="
 		case '*': // "afl*"
 			r_core_anal_fcn_list (core, NULL, input + 2);
 			break;
@@ -2898,6 +2915,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		case ' ': // "afb "
 		case 'q': // "afbq"
 		case 'r': // "afbr"
+		case '=': // "afb="
 		case '*': // "afb*"
 		case 'j': // "afbj"
 			anal_fcn_list_bb (core, input + 2, false);

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -733,11 +733,17 @@ static void cmd_open_map(RCore *core, const char *input) {
 	case '=': // "om=" 
 		{
 		RList *list = r_list_new ();
+		if (!list) {
+			return;
+		}
 		SdbListIter *iter;
 		RIOMap *map;
 		ls_foreach_prev (core->io->maps, iter, map) {
 			char temp[4];
 			ListInfo *info = R_NEW (ListInfo);
+			if (!info) {
+				return;
+			}
 			info->name = map->name;
 			info->pitv = map->itv;
 			info->vitv = map->itv;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4147,8 +4147,8 @@ R_API void r_core_visual_list(RCore *core, RList *list, ut64 seek, ut64 len, int
 				io->cb_printf ("| %s0x%08"PFMT64x"%s %s %6s %s\n",
 					color, r_itv_end (info->pitv), color_end,
 					(info->perm != -1)? r_str_rwx_i (info->perm) : "   ",
-					(info->extra)?info->extra : "    ",
-					(info->name)?info->name : " ");
+					(info->extra)?info->extra : "      ",
+					(info->name)?info->name : "");
 			}
 			i++;
 		}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4077,3 +4077,94 @@ dodo:
 	r_cons_show_cursor (true);
 	return 0;
 }
+
+// TODO: move this to the table api
+R_API void r_core_visual_list(RCore *core, RList *list, ut64 seek, ut64 len, int width, int use_color) {
+	ut64 mul, min = -1, max = -1;
+	RListIter *iter;
+	ListInfo *info;
+	int j, i;
+	RIO *io = core->io;
+	width -= 80;
+	if (width < 1) {
+		width = 30;
+	}
+
+	r_list_foreach (list, iter, info) {
+		if (min == -1 || info->pitv.addr < min) {
+			min = info->pitv.addr;
+		}
+		if (max == -1 || info->pitv.addr + info->pitv.size > max) {
+			max = info->pitv.addr + info->pitv.size;
+		}
+	}
+	mul = (max - min) / width;
+	if (min != -1 && mul > 0) {
+		const char * color = "", *color_end = "";
+		i = 0;
+		r_list_foreach (list, iter, info) {
+			if (use_color && info->perm != -1) {
+				color_end = Color_RESET;
+				if ((info->perm & R_PERM_X) && (info->perm & R_PERM_W)) { // exec & write bits
+					color = r_cons_singleton ()->context->pal.graph_trufae;
+				} else if ((info->perm & R_PERM_X)) { // exec bit
+					color = r_cons_singleton ()->context->pal.graph_true;
+				} else if ((info->perm & R_PERM_W)) { // write bit
+					color = r_cons_singleton ()->context->pal.graph_false;
+				} else {
+					color = "";
+					color_end = "";
+				}
+			} else {
+				color = "";
+				color_end = "";
+			}
+			if (io->va) {
+				io->cb_printf ("%03d%c %s0x%08"PFMT64x"%s |", i,
+						r_itv_contain (info->vitv, seek) ? '*' : ' ',
+						color, info->vitv.addr, color_end);
+			} else {
+				io->cb_printf ("%03d%c %s0x%08"PFMT64x"%s |", i,
+						r_itv_contain (info->pitv, seek) ? '*' : ' ',
+						color, info->pitv.addr, color_end);
+			}
+			for (j = 0; j < width; j++) {
+				ut64 pos = min + j * mul;
+				ut64 npos = min + (j + 1) * mul;
+				if (info->pitv.addr < npos && (info->pitv.addr + info->pitv.size) > pos) {
+					io->cb_printf ("#");
+				} else {
+					io->cb_printf ("-");
+				}
+			}
+			if (io->va) {
+				io->cb_printf ("| %s0x%08"PFMT64x"%s %s %6s %s\n",
+					color, r_itv_end (info->vitv), color_end,
+					(info->perm != -1)? r_str_rwx_i (info->perm) : "   ",
+					(info->extra)?info->extra : "    ",
+					(info->name)?info->name : " ");
+			} else {
+				io->cb_printf ("| %s0x%08"PFMT64x"%s %s %6s %s\n",
+					color, r_itv_end (info->pitv), color_end,
+					(info->perm != -1)? r_str_rwx_i (info->perm) : "   ",
+					(info->extra)?info->extra : "    ",
+					(info->name)?info->name : " ");
+			}
+			i++;
+		}
+		/* current seek */
+		if (i > 0 && len != 0) {
+			if (seek == UT64_MAX) {
+				seek = 0;
+			}
+			io->cb_printf ("=>   0x%08"PFMT64x" |", seek);
+			for (j = 0; j < width; j++) {
+				io->cb_printf (
+					((j * mul) + min >= seek &&
+					 (j * mul) + min <= seek+len)
+					?"^" : "-");
+			}
+			io->cb_printf ("| 0x%08"PFMT64x"\n", seek+len);
+		}
+	}
+}

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -333,7 +333,6 @@ typedef struct r_core_cmpwatch_t {
 
 typedef int (*RCoreSearchCallback)(RCore *core, ut64 from, ut8 *buf, int len);
 
-
 typedef struct {
 	char *name;
 	RInterval pitv;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -333,6 +333,15 @@ typedef struct r_core_cmpwatch_t {
 
 typedef int (*RCoreSearchCallback)(RCore *core, ut64 from, ut8 *buf, int len);
 
+
+typedef struct {
+	char *name;
+	RInterval pitv;
+	RInterval vitv;
+	int perm;
+	char *extra;
+} ListInfo;
+
 #ifdef R_API
 //#define r_core_ncast(x) (RCore*)(size_t)(x)
 R_API RList *r_core_list_themes(RCore *core);
@@ -428,6 +437,7 @@ R_API void r_core_anal_cc_init(RCore *core);
 R_API void r_core_anal_paths(RCore *core, ut64 from, ut64 to, bool followCalls, int followDepth, bool is_json);
 
 R_API void r_core_list_io(RCore *core);
+R_API void r_core_visual_list(RCore *core, RList* list, ut64 seek, ut64 len, int width, int use_color);
 /* visual marks */
 R_API void r_core_visual_mark_seek(RCore *core, ut8 ch);
 R_API void r_core_visual_mark(RCore *core, ut8 ch);


### PR DESCRIPTION
Closes #13596
* One obvious blunder is the location of the code, I know it's wrong the place but I kept it there until the table API is written.
* I will add more fields for afb= or afl= as per direction, right now they have very less number

Screenshots after the change:

<img width="1632" alt="Screen Shot 2019-04-08 at 11 29 49 PM" src="https://user-images.githubusercontent.com/20895544/55746060-66ce6380-5a56-11e9-93b0-e34b4123b310.png">
<img width="1635" alt="Screen Shot 2019-04-08 at 11 30 16 PM" src="https://user-images.githubusercontent.com/20895544/55746069-6afa8100-5a56-11e9-8952-7a5f56b31801.png">
<img width="1408" alt="Screen Shot 2019-04-08 at 11 30 32 PM" src="https://user-images.githubusercontent.com/20895544/55746075-6e8e0800-5a56-11e9-8e96-ff45a5f921cd.png">
