### PR TITLE
Honor asm.jmpsub in pdj output

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5580,9 +5580,11 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			char *buf = malloc (strlen (aop) + 128);
 			if (buf) {
 				strcpy (buf, aop);
+				buf = ds_sub_jumps (ds, buf);
 				r_parse_filter (core->parser, ds->vat, core->flags, buf,
 					str, sizeof (str), core->print->big_endian);
 				r_asm_op_set_asm (&asmop, buf);
+				
 				free (buf);
 			}
 		}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5584,7 +5584,6 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 				r_parse_filter (core->parser, ds->vat, core->flags, buf,
 					str, sizeof (str), core->print->big_endian);
 				r_asm_op_set_asm (&asmop, buf);
-				
 				free (buf);
 			}
 		}


### PR DESCRIPTION
This to continue the PR by @sivaramaaa https://github.com/radare/radare2/pull/13524.


Before:

```
[0x08000034]> pdj 1 @ 0x0800132c ~{}
[
  {
    "offset": 134222636,
...
    "opcode": "call 0x800132d",
    "disasm": "call reloc.png_crc_read_45",
    "bytes": "e8fcffffff",
    "family": "cpu",
...

```

After ("_45" is removed from "disasm"):

```
[0x08000034]> pdj 1 @ 0x0800132c ~{}
[
  {
    "offset": 134222636,
...
...
    "opcode": "call 0x800132d",
    "disasm": "call png_crc_read",
    "bytes": "e8fcffffff",
    "family": "cpu",
...
...