### PR TITLE
Replace pointer with an array of variable size

### DIFF
--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -423,6 +423,9 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		offset = entry->location.rva + sizeof (module_list);
 		for (i = 0; i < module_list.number_of_modules; i++) {
 			struct minidump_module *module = R_NEW (struct minidump_module);
+			if (!module) {
+				break;
+			}
 			r = r_buf_read_at (obj->b, offset, (ut8 *)module, sizeof (*module));
 			if (r != sizeof (*module)) {
 				break;

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -3,6 +3,8 @@
 #include <r_util.h>
 
 #include "mdmp.h"
+// XXX: this is a random number, no idea how long it should be.
+#define COMMENTS_SIZE 32
 
 ut64 r_bin_mdmp_get_paddr(struct r_bin_mdmp_obj *obj, ut64 vaddr) {
 	/* FIXME: Will only resolve exact matches, probably no need to fix as
@@ -105,6 +107,13 @@ void r_bin_mdmp_free(struct r_bin_mdmp_obj *obj) {
 	r_list_free (obj->streams.threads);
 	r_list_free (obj->streams.token_infos);
 	r_list_free (obj->streams.unloaded_modules);
+	free (obj->streams.exception);
+	free (obj->streams.system_info);
+	free (obj->streams.comments_a);
+	free (obj->streams.comments_w);
+	free (obj->streams.handle_data);
+	free (obj->streams.function_table);
+	free (obj->streams.misc_info.misc_info_1);
 
 	r_list_free (obj->pe32_bins);
 	r_list_free (obj->pe64_bins);
@@ -348,30 +357,18 @@ static bool r_bin_mdmp_init_hdr(struct r_bin_mdmp_obj *obj) {
 }
 
 static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct minidump_directory *entry) {
-	int i;
-
-	struct minidump_handle_operation_list *handle_operation_list;
-	struct minidump_memory_list *memory_list;
-	struct minidump_memory64_list *memory64_list;
-	struct minidump_memory_info_list *memory_info_list;
-	struct minidump_module_list *module_list;
-	struct minidump_thread_list *thread_list;
-	struct minidump_thread_ex_list *thread_ex_list;
-	struct minidump_thread_info_list *thread_info_list;
-	struct minidump_token_info_list *token_info_list;
-	struct minidump_unloaded_module_list *unloaded_module_list;
-
-	struct avrf_handle_operation *handle_operations;
-	struct minidump_memory_descriptor *memories;
-	struct minidump_memory_descriptor64 *memories64;
-	struct minidump_memory_info *memory_infos;
-	struct minidump_module *modules;
-	struct minidump_thread *threads;
-	struct minidump_thread_ex *ex_threads;
-	struct minidump_thread_info *thread_infos;
-	struct minidump_token_info *token_infos;
-	struct minidump_unloaded_module *unloaded_modules;
-	int left;
+	struct minidump_handle_operation_list handle_operation_list;
+	struct minidump_memory_list memory_list;
+	struct minidump_memory64_list memory64_list;
+	struct minidump_memory_info_list memory_info_list;
+	struct minidump_module_list module_list;
+	struct minidump_thread_list thread_list;
+	struct minidump_thread_ex_list thread_ex_list;
+	struct minidump_thread_info_list thread_info_list;
+	struct minidump_token_info_list token_info_list;
+	struct minidump_unloaded_module_list unloaded_module_list;
+	ut64 offset;
+	int i, r;
 
 	/* We could confirm data sizes but a malcious MDMP will always get around
 	** this! But we can ensure that the data is not outside of the file */
@@ -382,8 +379,8 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 
 	switch (entry->stream_type) {
 	case THREAD_LIST_STREAM:
-		thread_list = (struct minidump_thread_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!thread_list || left < sizeof (struct minidump_thread_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&thread_list, sizeof (thread_list));
+		if (r != sizeof (thread_list)) {
 			break;
 		}
 
@@ -396,19 +393,14 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_thread_list.format",
 			sdb_fmt ("d[%i]? "
 				"NumberOfThreads (mdmp_thread)Threads",
-				thread_list->number_of_threads),
+				thread_list.number_of_threads),
 			0);
 
 		/* TODO: Not yet fully parsed or utilised */
-		for (i = 0; i < thread_list->number_of_threads; i++) {
-			threads = (struct minidump_thread *)(&(thread_list->threads));
-			r_list_append (obj->streams.threads, &(threads[i]));
-		}
 		break;
 	case MODULE_LIST_STREAM:
-		module_list = (struct minidump_module_list *)
-			r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!module_list || left < sizeof (struct minidump_module_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&module_list, sizeof (module_list));
+		if (r != sizeof (module_list)) {
 			break;
 		}
 
@@ -424,29 +416,24 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_module_list.format",
 			sdb_fmt ("d[%i]? "
 				"NumberOfModule (mdmp_module)Modules",
-				module_list->number_of_modules,
+				module_list.number_of_modules,
 				0),
 			0);
 
-		const int sizeOfModule = sizeof (struct minidump_module);
-		int endOffset = sizeOfModule * module_list->number_of_modules;
-		ut64 nextOffset = 0;
-		if (endOffset >= left) {
-			endOffset = left;
-		}
-		modules = (struct minidump_module *)(&(module_list->modules));
-		for (i = 0; i < module_list->number_of_modules; i++) {
-			nextOffset += sizeOfModule;
-			if (nextOffset > endOffset) {
-				eprintf ("[INFO] Invalid number of modules or truncated file\n");
+		offset = entry->location.rva + sizeof (module_list);
+		for (i = 0; i < module_list.number_of_modules; i++) {
+			struct minidump_module *module = R_NEW (struct minidump_module);
+			r = r_buf_read_at (obj->b, offset, (ut8 *)module, sizeof (*module));
+			if (r != sizeof (*module)) {
 				break;
 			}
-			r_list_append (obj->streams.modules, &(modules[i]));
+			r_list_append (obj->streams.modules, module);
+			offset += sizeof (*module);
 		}
 		break;
 	case MEMORY_LIST_STREAM:
-		memory_list = (struct minidump_memory_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!memory_list || left < sizeof (struct minidump_memory_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&memory_list, sizeof (memory_list));
+		if (r != sizeof (memory_list)) {
 			break;
 		}
 
@@ -456,25 +443,33 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 			sdb_fmt ("d[%i]? "
 				"NumberOfMemoryRanges "
 				"(mdmp_memory_descriptor)MemoryRanges ",
-				memory_list->number_of_memory_ranges,
+				memory_list.number_of_memory_ranges,
 				0),
 			0);
 
-		for (i = 0; i < memory_list->number_of_memory_ranges; i++) {
-			memories = (struct minidump_memory_descriptor *)(&(memory_list->memory_ranges));
-			ut64 start_offset = (ut64)entry->location.rva
-			                + r_offsetof (struct minidump_memory_list, memory_ranges);
-			ut64 needed_space = (i + 1) * sizeof (memories[0]);
-			if (start_offset + needed_space > r_buf_size (obj->b) || start_offset + needed_space < start_offset) {
+		offset = entry->location.rva + sizeof (memory_list);
+		for (i = 0; i < memory_list.number_of_memory_ranges; i++) {
+			struct minidump_memory_descriptor *desc = R_NEW (struct minidump_memory_descriptor);
+			if (!desc) {
 				break;
 			}
-			r_list_append (obj->streams.memories, &(memories[i]));
+			r = r_buf_read_at (obj->b, offset, (ut8 *)desc, sizeof (*desc));
+			if (r != sizeof (*desc)) {
+				break;
+			}
+			r_list_append (obj->streams.memories, desc);
+			offset += sizeof (*desc);
 		}
 		break;
 	case EXCEPTION_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		obj->streams.exception = (struct minidump_exception_stream *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!obj->streams.exception || left < sizeof (struct minidump_exception_stream)) {
+		obj->streams.exception = R_NEW (struct minidump_exception_stream);
+		if (!obj->streams.exception) {
+			break;
+		}
+
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)obj->streams.exception, sizeof (*obj->streams.exception));
+		if (r != sizeof (*obj->streams.exception)) {
 			break;
 		}
 
@@ -495,8 +490,12 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 
 		break;
 	case SYSTEM_INFO_STREAM:
-		obj->streams.system_info = (struct minidump_system_info *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!obj->streams.system_info || left < sizeof (struct minidump_system_info)) {
+		obj->streams.system_info = R_NEW (struct minidump_system_info);
+		if (!obj->streams.system_info) {
+			break;
+		}
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)obj->streams.system_info, sizeof (*obj->streams.system_info));
+		if (r != sizeof (*obj->streams.system_info)) {
 			break;
 		}
 
@@ -513,8 +512,8 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		break;
 	case THREAD_EX_LIST_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		thread_ex_list = (struct minidump_thread_ex_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!thread_ex_list || left < sizeof (struct minidump_thread_ex_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&thread_ex_list, sizeof (thread_ex_list));
+		if (r != sizeof (thread_ex_list)) {
 			break;
 		}
 
@@ -528,17 +527,26 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_thread_ex_list.format",
 			sdb_fmt ("d[%i]? NumberOfThreads "
 				"(mdmp_thread_ex)Threads",
-				thread_ex_list->number_of_threads, 0),
+				thread_ex_list.number_of_threads, 0),
 			0);
 
-		for (i = 0; i < thread_ex_list->number_of_threads; i++) {
-			ex_threads = (struct minidump_thread_ex *)(&(thread_ex_list->threads));
-			r_list_append (obj->streams.ex_threads, &(ex_threads[i]));
+		offset = entry->location.rva + sizeof (thread_ex_list);
+		for (i = 0; i < thread_ex_list.number_of_threads; i++) {
+			struct minidump_thread_ex *thread = R_NEW (struct minidump_thread_ex);
+			if (!thread) {
+				break;
+			}
+			r = r_buf_read_at (obj->b, offset, (ut8 *)thread, sizeof (*thread));
+			if (r != sizeof (*thread)) {
+				break;
+			}
+			r_list_append (obj->streams.ex_threads, thread);
+			offset += sizeof (*thread);
 		}
 		break;
 	case MEMORY_64_LIST_STREAM:
-		memory64_list = (struct minidump_memory64_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!memory64_list || left < sizeof (struct minidump_memory64_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&memory64_list, sizeof (memory64_list));
+		if (r != sizeof (memory64_list)) {
 			break;
 		}
 
@@ -548,19 +556,32 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 			sdb_fmt ("qq[%i]? NumberOfMemoryRanges "
 				"BaseRva "
 				"(mdmp_memory_descriptor64)MemoryRanges",
-				memory64_list->number_of_memory_ranges),
+				memory64_list.number_of_memory_ranges),
 			0);
 
-		obj->streams.memories64.base_rva = memory64_list->base_rva;
-		for (i = 0; i < memory64_list->number_of_memory_ranges; i++) {
-			memories64 = (struct minidump_memory_descriptor64 *)(&(memory64_list->memory_ranges));
-			r_list_append (obj->streams.memories64.memories, &(memories64[i]));
+		obj->streams.memories64.base_rva = memory64_list.base_rva;
+		offset = entry->location.rva + sizeof (memory64_list);
+		for (i = 0; i < memory64_list.number_of_memory_ranges; i++) {
+			struct minidump_memory_descriptor64 *desc = R_NEW (struct minidump_memory_descriptor64);
+			if (!desc) {
+				break;
+			}
+			r = r_buf_read_at (obj->b, offset, (ut8 *)desc, sizeof (*desc));
+			if (r != sizeof (*desc)) {
+				break;
+			}
+			r_list_append (obj->streams.memories64.memories, desc);
+			offset += sizeof (*desc);
 		}
 		break;
 	case COMMENT_STREAM_A:
 		/* TODO: Not yet fully parsed or utilised */
-		obj->streams.comments_a = r_buf_get_at (obj->b, entry->location.rva, NULL);
+		obj->streams.comments_a = R_NEWS (ut8, COMMENTS_SIZE);
 		if (!obj->streams.comments_a) {
+			break;
+		}
+		r = r_buf_read_at (obj->b, entry->location.rva, obj->streams.comments_a, COMMENTS_SIZE);
+		if (r != COMMENTS_SIZE) {
 			break;
 		}
 
@@ -572,8 +593,12 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		break;
 	case COMMENT_STREAM_W:
 		/* TODO: Not yet fully parsed or utilised */
-		obj->streams.comments_w = r_buf_get_at (obj->b, entry->location.rva, NULL);
+		obj->streams.comments_w = R_NEWS (ut8, COMMENTS_SIZE);
 		if (!obj->streams.comments_w) {
+			break;
+		}
+		r = r_buf_read_at (obj->b, entry->location.rva, obj->streams.comments_w, COMMENTS_SIZE);
+		if (r != COMMENTS_SIZE) {
 			break;
 		}
 
@@ -585,8 +610,12 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		break;
 	case HANDLE_DATA_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		obj->streams.handle_data = (struct minidump_handle_data_stream *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!obj->streams.handle_data || left < sizeof (struct minidump_handle_data_stream)) {
+		obj->streams.handle_data = R_NEW (struct minidump_handle_data_stream);
+		if (!obj->streams.handle_data) {
+			break;
+		}
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)obj->streams.handle_data, sizeof (*obj->streams.handle_data));
+		if (r != sizeof (*obj->streams.handle_data)) {
 			break;
 		}
 
@@ -598,8 +627,12 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		break;
 	case FUNCTION_TABLE_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		obj->streams.function_table = (struct minidump_function_table_stream *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!obj->streams.function_table || left < sizeof (struct minidump_function_table_stream)) {
+		obj->streams.function_table = R_NEW (struct minidump_function_table_stream);
+		if (!obj->streams.function_table) {
+			break;
+		}
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)obj->streams.function_table, sizeof (*obj->streams.function_table));
+		if (r != sizeof (*obj->streams.function_table)) {
 			break;
 		}
 
@@ -612,8 +645,8 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		break;
 	case UNLOADED_MODULE_LIST_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		unloaded_module_list = (struct minidump_unloaded_module_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!unloaded_module_list || left < sizeof (struct minidump_unloaded_module_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&unloaded_module_list, sizeof (unloaded_module_list));
+		if (r != sizeof (unloaded_module_list)) {
 			break;
 		}
 
@@ -625,15 +658,28 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_unloaded_module_list.format", "ddd "
 			"SizeOfHeader SizeOfEntry NumberOfEntries", 0);
 
-		for (i = 0; i < unloaded_module_list->number_of_entries; i++) {
-			unloaded_modules = (struct minidump_unloaded_module *)((ut8 *)&unloaded_module_list + sizeof (struct minidump_unloaded_module_list));
-			r_list_append (obj->streams.unloaded_modules, &(unloaded_modules[i]));
+		offset = entry->location.rva + sizeof (unloaded_module_list);
+		for (i = 0; i < unloaded_module_list.number_of_entries; i++) {
+			struct minidump_unloaded_module *module = R_NEW (struct minidump_unloaded_module);
+			if (!module) {
+				break;
+			}
+			r = r_buf_read_at (obj->b, offset, (ut8 *)module, sizeof (*module));
+			if (r != sizeof (*module)) {
+				break;
+			}
+			r_list_append (obj->streams.unloaded_modules, module);
+			offset += sizeof (*module);
 		}
 		break;
 	case MISC_INFO_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		obj->streams.misc_info.misc_info_1 = (struct minidump_misc_info *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!obj->streams.misc_info.misc_info_1 || left < sizeof (struct minidump_misc_info)) {
+		obj->streams.misc_info.misc_info_1 = R_NEW (struct minidump_misc_info);
+		if (!obj->streams.misc_info.misc_info_1) {
+			break;
+		}
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)obj->streams.misc_info.misc_info_1, sizeof (*obj->streams.misc_info.misc_info_1));
+		if (r != sizeof (*obj->streams.misc_info.misc_info_1)) {
 			break;
 		}
 
@@ -649,8 +695,8 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 
 		break;
 	case MEMORY_INFO_LIST_STREAM:
-		memory_info_list = (struct minidump_memory_info_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!memory_info_list || left < sizeof (struct minidump_memory_info_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&memory_info_list, sizeof (memory_info_list));
+		if (r != sizeof (memory_info_list)) {
 			break;
 		}
 
@@ -664,18 +710,27 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_memory_info_list.format",
 			sdb_fmt ("ddq[%i]? SizeOfHeader SizeOfEntry "
 				"NumberOfEntries (mdmp_memory_info)MemoryInfo",
-				memory_info_list->number_of_entries),
+				memory_info_list.number_of_entries),
 			0);
 
-		for (i = 0; i < memory_info_list->number_of_entries; i++) {
-			memory_infos = (struct minidump_memory_info *)((ut8 *)memory_info_list + sizeof (struct minidump_memory_info_list));
-			r_list_append (obj->streams.memory_infos, &(memory_infos[i]));
+		offset = entry->location.rva + sizeof (memory_info_list);
+		for (i = 0; i < memory_info_list.number_of_entries; i++) {
+			struct minidump_memory_info *info = R_NEW (struct minidump_memory_info);
+			if (!info) {
+				break;
+			}
+			r = r_buf_read_at (obj->b, offset, (ut8 *)info, sizeof (*info));
+			if (r != sizeof (*info)) {
+				break;
+			}
+			r_list_append (obj->streams.memory_infos, info);
+			offset += sizeof (*info);
 		}
 		break;
 	case THREAD_INFO_LIST_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		thread_info_list = (struct minidump_thread_info_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!thread_info_list || left < sizeof (struct minidump_thread_info_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&thread_info_list, sizeof (thread_info_list));
+		if (r != sizeof (thread_info_list)) {
 			break;
 		}
 
@@ -688,15 +743,24 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_thread_info_list.format", "ddd "
 			"SizeOfHeader SizeOfEntry NumberOfEntries", 0);
 
-		for (i = 0; i < thread_info_list->number_of_entries; i++) {
-			thread_infos = (struct minidump_thread_info *)((ut8 *)thread_info_list + sizeof (struct minidump_thread_info_list));
-			r_list_append (obj->streams.thread_infos, &(thread_infos[i]));
+		offset = entry->location.rva + sizeof (thread_info_list);
+		for (i = 0; i < thread_info_list.number_of_entries; i++) {
+			struct minidump_thread_info *info = R_NEW (struct minidump_thread_info);
+			if (!info) {
+				break;
+			}
+			r = r_buf_read_at (obj->b, offset, (ut8 *)info, sizeof (*info));
+			if (r != sizeof (*info)) {
+				break;
+			}
+			r_list_append (obj->streams.thread_infos, info);
+			offset += sizeof (*info);
 		}
 		break;
 	case HANDLE_OPERATION_LIST_STREAM:
 		/* TODO: Not yet fully parsed or utilised */
-		handle_operation_list = (struct minidump_handle_operation_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!handle_operation_list || left < sizeof (struct minidump_handle_operation_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&handle_operation_list, sizeof (handle_operation_list));
+		if (r != sizeof (handle_operation_list)) {
 			break;
 		}
 
@@ -705,16 +769,25 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_handle_operation_list.format", "dddd "
 			"SizeOfHeader SizeOfEntry NumberOfEntries Reserved", 0);
 
-		for (i = 0; i < handle_operation_list->number_of_entries; i++) {
-			handle_operations = (struct avrf_handle_operation *)((ut8 *)handle_operation_list + sizeof (struct minidump_handle_operation_list));
-			r_list_append (obj->streams.operations, &(handle_operations[i]));
+		offset = entry->location.rva + sizeof (handle_operation_list);
+		for (i = 0; i < handle_operation_list.number_of_entries; i++) {
+			struct avrf_handle_operation *op = R_NEW (struct avrf_handle_operation);
+			if (!op) {
+				break;
+			}
+			r = r_buf_read_at (obj->b, offset, (ut8 *)op, sizeof (*op));
+			if (r != sizeof (*op)) {
+				break;
+			}
+			r_list_append (obj->streams.operations, op);
+			offset += sizeof (*op);
 		}
 
 		break;
 	case TOKEN_STREAM:
 		/* TODO: Not fully parsed or utilised */
-		token_info_list = (struct minidump_token_info_list *)r_buf_get_at (obj->b, entry->location.rva, &left);
-		if (!token_info_list || left < sizeof (struct minidump_token_info_list)) {
+		r = r_buf_read_at (obj->b, entry->location.rva, (ut8 *)&token_info_list, sizeof (token_info_list));
+		if (r != sizeof (token_info_list)) {
 			break;
 		}
 
@@ -726,9 +799,18 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		sdb_set (obj->kv, "mdmp_token_info_list.format", "dddd "
 			"TokenListSize TokenListEntries ListHeaderSize ElementHeaderSize", 0);
 
-		for (i = 0; i < token_info_list->number_of_entries; i++) {
-			token_infos = (struct minidump_token_info *)((ut8 *)token_info_list + sizeof (struct minidump_token_info_list));
-			r_list_append (obj->streams.token_infos, &(token_infos[i]));
+		offset = entry->location.rva + sizeof (token_info_list);
+		for (i = 0; i < token_info_list.number_of_entries; i++) {
+			struct minidump_token_info *info = R_NEW (struct minidump_token_info);
+			if (!info) {
+				break;
+			}
+			r = r_buf_read_at (obj->b, offset, (ut8 *)info, sizeof (*info));
+			if (r != sizeof (*info)) {
+				break;
+			}
+			r_list_append (obj->streams.token_infos, info);
+			offset += sizeof (*info);
 		}
 		break;
 
@@ -928,15 +1010,15 @@ struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(RBuffer *buf) {
 	obj->size = (ut32) r_buf_size (buf);
 
 	fail |= (!(obj->streams.ex_threads = r_list_new ()));
-	fail |= (!(obj->streams.memories = r_list_new ()));
+	fail |= (!(obj->streams.memories = r_list_newf ((RListFree)free)));
 	fail |= (!(obj->streams.memories64.memories = r_list_new ()));
-	fail |= (!(obj->streams.memory_infos = r_list_new ()));
-	fail |= (!(obj->streams.modules = r_list_new ()));
-	fail |= (!(obj->streams.operations = r_list_new ()));
-	fail |= (!(obj->streams.thread_infos = r_list_new ()));
-	fail |= (!(obj->streams.token_infos = r_list_new ()));
+	fail |= (!(obj->streams.memory_infos = r_list_newf ((RListFree)free)));
+	fail |= (!(obj->streams.modules = r_list_newf ((RListFree)free)));
+	fail |= (!(obj->streams.operations = r_list_newf ((RListFree)free)));
+	fail |= (!(obj->streams.thread_infos = r_list_newf ((RListFree)free)));
+	fail |= (!(obj->streams.token_infos = r_list_newf ((RListFree)free)));
 	fail |= (!(obj->streams.threads = r_list_new ()));
-	fail |= (!(obj->streams.unloaded_modules = r_list_new ()));
+	fail |= (!(obj->streams.unloaded_modules = r_list_newf ((RListFree)free)));
 
 	fail |= (!(obj->pe32_bins = r_list_newf (r_bin_mdmp_free_pe32_bin)));
 	fail |= (!(obj->pe64_bins = r_list_newf (r_bin_mdmp_free_pe64_bin)));

--- a/libr/bin/format/mdmp/mdmp_specs.h
+++ b/libr/bin/format/mdmp/mdmp_specs.h
@@ -369,20 +369,11 @@ struct minidump_handle_object_information {
 	ut32	size_of_info;
 });
 
-/* Contains a list of handle operations. */
-R_PACKED (
-struct minidump_handle_operation_list {
-	ut32	size_of_header;
-	ut32	size_of_entry;
-	ut32	number_of_entries;
-	ut32	reserved;
-});
-
 /* Contains a list of memory ranges. */
 R_PACKED (
 struct minidump_memory_list {
 	ut32	number_of_memory_ranges;
-	struct minidump_memory_descriptor *memory_ranges;
+	struct minidump_memory_descriptor memory_ranges[];
 });
 
 /* Contains a list of memory ranges. */
@@ -390,7 +381,7 @@ R_PACKED (
 struct minidump_memory64_list {
 	ut64	number_of_memory_ranges;
 	rva64_t	base_rva;
-	struct minidump_memory_descriptor64 *memory_ranges;
+	struct minidump_memory_descriptor64 memory_ranges[];
 });
 
 /* Describes a region of memory. */
@@ -413,6 +404,7 @@ struct minidump_memory_info_list {
 	ut32	size_of_header;
 	ut32	size_of_entry;
 	ut64	number_of_entries;
+	struct minidump_memory_info entries[];
 });
 
 /* Contains a variety of information. */
@@ -482,7 +474,7 @@ struct minidump_module {
 R_PACKED (
 struct minidump_module_list {
 	ut32 number_of_modules;
-	struct minidump_module *modules;
+	struct minidump_module modules[];
 });
 
 /* Describes a string. */
@@ -550,7 +542,7 @@ struct minidump_thread {
 R_PACKED (
 struct minidump_thread_list {
 	ut32 number_of_threads;
-	struct minidump_thread *threads;
+	struct minidump_thread threads[0];
 });
 
 /* Contains extended information for a specific thread. */
@@ -571,8 +563,7 @@ struct minidump_thread_ex {
 R_PACKED (
 struct minidump_thread_ex_list {
 	ut32	number_of_threads;
-
-	struct minidump_thread_ex *threads;
+	struct minidump_thread_ex threads[];
 });
 
 /* Contains thread state information. */
@@ -596,6 +587,7 @@ struct minidump_thread_info_list {
 	ut32	size_of_header;
 	ut32	size_of_entry;
 	ut32	number_of_entries;
+	struct minidump_thread_info entries[];
 });
 
 /* Contains a token information. */
@@ -613,6 +605,7 @@ struct minidump_token_info_list {
 	ut32	number_of_entries;
 	ut32	list_header_size;
 	ut32	element_header_size;
+	struct minidump_token_info entries[];
 });
 
 /* Contains information about a module that has been unloaded. This information
@@ -632,6 +625,7 @@ struct minidump_unloaded_module_list {
 	ut32	size_of_header;
 	ut32	size_of_entry;
 	ut32	number_of_entries;
+	struct minidump_unloaded_module entries[];
 });
 
 /* Contains user-defined information stored in a data stream. */
@@ -745,6 +739,16 @@ struct avrf_handle_operation {
 	ut32	spare_0;
 
 	struct avrf_backtrace_information back_trace_information;
+});
+
+/* Contains a list of handle operations. */
+R_PACKED (
+struct minidump_handle_operation_list {
+	ut32 size_of_header;
+	ut32 size_of_entry;
+	ut32 number_of_entries;
+	ut32 reserved;
+	struct avrf_handle_operation entries[];
 });
 
 #endif /* MDMP_SPECS_H */


### PR DESCRIPTION
The elements are directly after the headers, there is no pointer
involved.

Also, use r_buf_read_at instead of r_buf_get_at in mdmp.