### PR TITLE
Implement /am and add initial support for PAC instructions ##anal

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2018 - pancake, nibble */
+/* radare - LGPL - Copyright 2009-2019 - pancake, nibble */
 
 #include <r_anal.h>
 #include <r_util.h>

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -687,6 +687,7 @@ R_API const char *r_anal_op_family_to_string(int n) {
 	switch (n) {
 	case R_ANAL_OP_FAMILY_UNKNOWN: return "unk";
 	case R_ANAL_OP_FAMILY_CPU: return "cpu";
+	case R_ANAL_OP_FAMILY_PAC: return "pac";
 	case R_ANAL_OP_FAMILY_FPU: return "fpu";
 	case R_ANAL_OP_FAMILY_MMX: return "mmx";
 	case R_ANAL_OP_FAMILY_SSE: return "sse";
@@ -713,6 +714,7 @@ R_API int r_anal_op_family_from_string(const char *f) {
 		{"virt", R_ANAL_OP_FAMILY_VIRT},
 		{"crpt", R_ANAL_OP_FAMILY_CRYPTO},
 		{"io", R_ANAL_OP_FAMILY_IO},
+		{"pac", R_ANAL_OP_FAMILY_PAC},
 		{"thread", R_ANAL_OP_FAMILY_THREAD},
 	};
 

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2013-2018 - pancake */
+/* radare2 - LGPL - Copyright 2013-2019 - pancake */
 
 #include <r_anal.h>
 #include <r_lib.h>

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -89,8 +89,8 @@ static const char *help_msg_slash_a[] = {
 	"/ai", "", "Search for infinite loop instructions (jmp $$)",
 	"/at", " type", "Search for instructions of given type",
 	"/af", " family", "Search for instruction of specific family",
+	"/am", " opcode", "Search for specific instructions of specific mnemonic",
 	"/as", "", "Search for syscalls (See /at swi and /af priv)",
-
 	"/al", "", "Same as aoml, list all opcodes",
 	"/asl", "", "Same as asl, list all syscalls",
 	"/atl", "", "List all instruction types",
@@ -1934,6 +1934,7 @@ static bool do_anal_search(RCore *core, struct search_parameters *param, const c
 		case 'f': // "/af"
 		case 's': // "/as"
 		case 't': // "/at"
+		case 'm': // "/am"
 		case ' ':
 			type = *input;
 			break;
@@ -1946,7 +1947,7 @@ static bool do_anal_search(RCore *core, struct search_parameters *param, const c
 		input++;
 	}
 	if (type == 's') {
-		eprintf ("Shouldnt reach\n");
+		eprintf ("Shouldn't reach\n");
 // ??
 #if 0
 	case 's': // "/s"
@@ -1960,39 +1961,31 @@ static bool do_anal_search(RCore *core, struct search_parameters *param, const c
 		r_cons_printf ("[");
 	}
 	input = r_str_trim_ro (input);
-	buf = malloc (bsize);
-	if (!buf) {
-		eprintf ("Cannot allocate %d byte(s)\n", bsize);
-		return false;
-	}
 	r_cons_break_push (NULL, NULL);
 	RIOMap* map;
 	RListIter *iter;
 	r_list_foreach (param->boundaries, iter, map) {
 		ut64 from = map->itv.addr;
 		ut64 to = r_itv_end (map->itv);
-		for (i = 0, at = from; at < to; at++, i++) {
+		for (i = 0, at = from; at < to; i++, at++) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-			if (i >= (bsize - 32)) {
-				i = 0;
-			}
-			if (!i) {
-				r_io_read_at (core->io, at, buf, bsize);
-			}
-			ret = r_anal_op (core->anal, &aop, at, buf + i, bsize - i, R_ANAL_OP_MASK_BASIC);
+			at = from + i;
+			ut8 bufop[32];
+			r_io_read_at (core->io, at, bufop, sizeof(bufop));
+			ret = r_anal_op (core->anal, &aop, at, bufop, sizeof(bufop), R_ANAL_OP_MASK_BASIC | R_ANAL_OP_MASK_DISASM);
 			if (ret) {
 				bool match = false;
-				if (type == 'f') {
+				if (type == 'm') {
+					const char *fam = aop.mnemonic;
+					if (fam && (!*input || r_str_startswith (fam, input))) {
+						match = true;
+					}
+				} else if (type == 'f') {
 					const char *fam = r_anal_op_family_to_string (aop.family);
-					if (fam) {
-						if (!*input || !strcmp (input, fam)) {
-							match = true;
-							if (mode == 0) {
-								r_cons_printf ("0x%08"PFMT64x " - %d %s\n", at, ret, fam);
-							}
-						}
+					if (fam && (!*input || !strcmp (input, fam))) {
+						match = true;
 					}
 				} else {
 					const char *type = r_anal_optype_to_string (aop.type);
@@ -2033,7 +2026,12 @@ static bool do_anal_search(RCore *core, struct search_parameters *param, const c
 						r_cons_printf ("0x%08"PFMT64x "\n", at);
 						break;
 					default:
-						r_cons_printf ("0x%08"PFMT64x " %d %s\n", at, ret, opstr);
+						if (type == 'f') {
+							const char *fam = r_anal_op_family_to_string (aop.family);
+							r_cons_printf ("0x%08"PFMT64x " %d %s %s\n", at, ret, fam, opstr);
+						} else {
+							r_cons_printf ("0x%08"PFMT64x " %d %s\n", at, ret, opstr);
+						}
 						break;
 					}
 					R_FREE (opstr);
@@ -2069,7 +2067,6 @@ done:
 		r_cons_println ("]\n");
 	}
 	r_cons_break_pop ();
-	free (buf);
 	return false;
 }
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -348,6 +348,7 @@ enum {
 	R_ANAL_OP_FAMILY_CRYPTO, /* cryptographic instructions */
 	R_ANAL_OP_FAMILY_THREAD, /* thread/lock/sync instructions */
 	R_ANAL_OP_FAMILY_VIRT,   /* virtualization instructions */
+	R_ANAL_OP_FAMILY_PAC,    /* pointer authentication instructions */
 	R_ANAL_OP_FAMILY_IO,     /* IO instructions (i.e. IN/OUT) */
 	R_ANAL_OP_FAMILY_LAST
 };
@@ -809,7 +810,7 @@ typedef enum r_anal_data_type_t {
 } RAnalDataType;
 
 typedef struct r_anal_op_t {
-	char *mnemonic; /* mnemonic */
+	char *mnemonic; /* mnemonic.. it actually contains the args too, we should replace rasm with this */
 	ut64 addr;      /* address */
 	ut32 type;      /* type of opcode */
 	ut64 prefix;    /* type of opcode prefix (rep,lock,..) */


### PR DESCRIPTION
* /am is like /c but only search for instructions and uses R_ANAL_MASK_DISASM
* Added new op family: R_ANAL_OP_FAMILY_PAC; (see /af)