### PR TITLE
Added missing c2 command + theme support for comparison commands ##cons

### DIFF
--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -7,6 +7,7 @@ static const char *help_msg_c[] = {
 	"c", " [string]", "Compare a plain with escaped chars string",
 	"c*", " [string]", "Same as above, but printing r2 commands instead",
 	"c1", " [addr]", "Compare 8 bits from current offset",
+	"c2", " [value]", "Compare a word from a math expression",
 	"c4", " [value]", "Compare a doubleword from a math expression",
 	"c8", " [value]", "Compare a quadword from a math expression",
 	"cat", " [file]", "Show contents of file (see pwd, ls)",
@@ -161,11 +162,11 @@ static int radare_compare_words(RCore *core, ut64 of, ut64 od, int len, int ws) 
 		r_io_read_at (core->io, of + i, (ut8*)&v0, ws);
 		r_io_read_at (core->io, od + i, (ut8*)&v1, ws);
 		char ch = (v0.v64 == v1.v64)? '=': '!';
-		const char *color = useColor? ch == '='? "": Color_RED: "";
+		const char *color = useColor? ch == '='? "": r_cons_singleton()->context->pal.graph_false: "";
 		const char *colorEnd = useColor? Color_RESET: "";
 
 		if (useColor) {
-			r_cons_printf (Color_YELLOW"0x%08" PFMT64x"  "Color_RESET, of + i);
+			r_cons_printf ("%s0x%08" PFMT64x"  "Color_RESET, r_cons_singleton()->context->pal.offset, of + i);
 		} else {
 			r_cons_printf ("0x%08" PFMT64x"  ", of + i);
 		}
@@ -359,7 +360,7 @@ static int cmd_cmp_disasm(RCore *core, const char *input, int mode) {
 				colpad[pos] = 0;
 			}
 			if (hascolor) {
-				r_cons_printf (iseq? Color_GREEN: Color_RED);
+				r_cons_printf (iseq? r_cons_singleton()->context->pal.graph_true: r_cons_singleton()->context->pal.graph_false);
 			}
 			r_cons_printf (" 0x%08"PFMT64x "  %s %s",
 				core->offset + i, r_strbuf_get (&op.buf_asm), colpad);
@@ -397,12 +398,12 @@ static int cmd_cmp_disasm(RCore *core, const char *input, int mode) {
 					core->offset + i, r_strbuf_get (&op.buf_asm));
 			} else {
 				if (hascolor) {
-					r_cons_printf (Color_RED);
+					r_cons_printf (r_cons_singleton()->context->pal.graph_false);
 				}
 				r_cons_printf ("-0x%08"PFMT64x "  %s\n",
 					core->offset + i, r_strbuf_get (&op.buf_asm));
 				if (hascolor) {
-					r_cons_printf (Color_GREEN);
+					r_cons_printf (r_cons_singleton()->context->pal.graph_true);
 				}
 				r_cons_printf ("+0x%08"PFMT64x "  %s\n",
 					off + j, r_strbuf_get (&op2.buf_asm));
@@ -461,7 +462,7 @@ static void __core_cmp_bits (RCore *core, ut64 addr) {
 	ut8 a, b;
 	r_io_read_at (core->io, core->offset, &a, 1);
 	r_io_read_at (core->io, addr, &b, 1);
-	const char *color = scr_color? Color_CYAN: "";
+	const char *color = scr_color? r_cons_singleton()->context->pal.offset: "";
 	const char *color_end = scr_color? Color_RESET: "";
 	if (r_config_get_i (core->config, "hex.header")) {
 		char *n = r_str_newf ("0x%08"PFMT64x, core->offset);
@@ -469,24 +470,24 @@ static void __core_cmp_bits (RCore *core, ut64 addr) {
 		free (n);
 		r_cons_printf ("%s- offset -%s  7 6 5 4 3 2 1 0%s\n", color, extra, color_end);
 	}
-	color = scr_color? Color_RED: "";
+	color = scr_color? r_cons_singleton()->context->pal.graph_false: "";
 	color_end = scr_color? Color_RESET: "";
 
 	r_cons_printf ("%s0x%08"PFMT64x"%s  ", color, core->offset, color_end);
 	for (i = 7; i >= 0; i--) {
 		bool b0 = (a & 1<<i)? 1: 0;
 		bool b1 = (b & 1<<i)? 1: 0;
-		color = scr_color? (b0 == b1)? "": b0? Color_GREEN:Color_RED: "";
+		color = scr_color? (b0 == b1)? "": b0? r_cons_singleton()->context->pal.graph_true:r_cons_singleton()->context->pal.graph_false: "";
 		color_end = scr_color ? Color_RESET: "";
 		r_cons_printf ("%s%d%s ", color, b0, color_end);
 	}
-	color = scr_color? Color_GREEN: "";
+	color = scr_color? r_cons_singleton()->context->pal.graph_true: "";
 	color_end = scr_color? Color_RESET: "";
 	r_cons_printf ("\n%s0x%08"PFMT64x"%s  ", color, addr, color_end);
 	for (i = 7; i >= 0; i--) {
 		bool b0 = (a & 1<<i)? 1: 0;
 		bool b1 = (b & 1<<i)? 1: 0;
-		color = scr_color? (b0 == b1)? "": b1? Color_GREEN: Color_RED: "";
+		color = scr_color? (b0 == b1)? "": b1? r_cons_singleton()->context->pal.graph_true: r_cons_singleton()->context->pal.graph_false: "";
 		color_end = scr_color ? Color_RESET: "";
 		r_cons_printf ("%s%d%s ", color, b1, color_end);
 	}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -872,7 +872,7 @@ static const char *radare_argv[] = {
 	"ax?", "ax", "ax*", "ax-", "ax-*", "axc", "axC", "axg", "axg*", "axgj", "axd", "axw", "axj", "axF",
 	"axt", "axf", "ax.", "axff", "axffj", "axs",
 	"b?", "b", "b+", "b-", "bf", "bm",
-	"c?", "c", "c1", "c4", "c8", "cc", "ccd", "cf", "cg?", "cg", "cgf", "cgff", "cgfc", "cgfn", "cgo",
+	"c?", "c", "c1", "c2", "c4", "c8", "cc", "ccd", "cf", "cg?", "cg", "cgf", "cgff", "cgfc", "cgfn", "cgo",
 	"cu?", "cu", "cu1", "cu2", "cu4", "cu8", "cud",
 	"cv", "cv1", "cv2", "cv4", "cv8",
 	"cV", "cV1", "cV2", "cV4", "cV8",

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1292,12 +1292,12 @@ R_API void r_print_hexdump_simple(const ut8 *buf, int len) {
 	r_print_hexdump (NULL, 0, buf, len, 16, 16, 0);
 }
 
-static const char* getbytediff(char *fmt, ut8 a, ut8 b) {
+static const char* getbytediff(RPrint *p, char *fmt, ut8 a, ut8 b) {
 	if (*fmt) {
 		if (a == b) {
-			sprintf (fmt, Color_GREEN "%02x" Color_RESET, a);
+			sprintf (fmt, "%s%02x" Color_RESET, p->cons->context->pal.graph_true, a);
 		} else {
-			sprintf (fmt, Color_RED "%02x" Color_RESET, a);
+			sprintf (fmt, "%s%02x" Color_RESET, p->cons->context->pal.graph_false, a);
 		}
 	} else {
 		sprintf (fmt, "%02x", a);
@@ -1305,13 +1305,13 @@ static const char* getbytediff(char *fmt, ut8 a, ut8 b) {
 	return fmt;
 }
 
-static const char* getchardiff(char *fmt, ut8 a, ut8 b) {
+static const char* getchardiff(RPrint *p, char *fmt, ut8 a, ut8 b) {
 	char ch = IS_PRINTABLE (a)? a: '.';
 	if (*fmt) {
 		if (a == b) {
-			sprintf (fmt, Color_GREEN "%c" Color_RESET, ch);
+			sprintf (fmt, "%s%c" Color_RESET, p->cons->context->pal.graph_true, ch);
 		} else {
-			sprintf (fmt, Color_RED "%c" Color_RESET, ch);
+			sprintf (fmt, "%s%c" Color_RESET, p->cons->context->pal.graph_false, ch);
 		}
 	} else {
 		sprintf (fmt, "%c", ch);
@@ -1320,8 +1320,8 @@ static const char* getchardiff(char *fmt, ut8 a, ut8 b) {
 	return fmt;
 }
 
-#define BD(a, b) getbytediff (fmt, (a)[i + j], (b)[i + j])
-#define CD(a, b) getchardiff (fmt, (a)[i + j], (b)[i + j])
+#define BD(a, b) getbytediff (p, fmt, (a)[i + j], (b)[i + j])
+#define CD(a, b) getchardiff (p, fmt, (a)[i + j], (b)[i + j])
 
 static ut8* M(const ut8 *b, int len) {
 	ut8 *r = malloc (len + 16);


### PR DESCRIPTION
I'm considering #defining _r_cons_singleton()->context->pal.x_ in _r_core.h_ , to not obscure the code further with such long statements, and do refactor for this piece of code and the previous changes.
If it does make sense for you, then I will propose the change via subsequent PR