### PR TITLE
Fixed help text for 'Z' in visual graph mode

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -4296,7 +4296,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 				" x/X          - jump to xref/ref\n"
 				" Y            - toggle tiny graph\n"
 				" z            - toggle node folding\n"
-				" Z            - follow parent node");
+				" Z            - toggle basic block folding");
 			r_cons_less ();
 			r_cons_any_key (NULL);
 			break;


### PR DESCRIPTION
fbe251a759a767f2ac3206dfd7edeb748bf6da56 changed the function of the Z key in visual graph mode but did not update the help text. This commit fixes the help text.