### PR TITLE
Implement the missing bits in the triple-at ##core

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -152,11 +152,20 @@ static const char *help_msg_at_at[] = {
 
 static const char *help_msg_at_at_at[] = {
 	"@@@", "", " # foreach offset+size iterator command:",
+	"x", " @@@=", "[addr] [size] ([addr] [size] ...)",
+	"x", " @@@b", "basic blocks of current function",
+	"x", " @@@c:cmd", "Same as @@@=`cmd`, without the backticks",
+	"x", " @@@C:cmd", "comments matching",
 	"x", " @@@i", "imports",
+	"x", " @@@r", "registers",
 	"x", " @@@s", "symbols",
 	"x", " @@@S", "sections",
+	"x", " @@@m", "io.maps",
+	"x", " @@@M", "dbg.maps (See ?$?~size)",
 	"x", " @@@f", "flags",
-	"x", " @@@F", "functions",
+	"x", " @@@f:hit*", "flags matching glob expression",
+	"x", " @@@F", "functions (set fcn size which may be incorrect if not linear)",
+	"x", " @@@F:glob", "functions matching glob expression",
 	"x", " @@@t", "threads",
 	"x", " @@@r", "regs",
 	// TODO: Add @@k sdb-query-expression-here

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -244,10 +244,9 @@ R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr) {
 }
 
 R_API bool r_io_map_remap_fd (RIO *io, int fd, ut64 addr) {
-	RList *maps;
 	RIOMap *map;
 	bool retval = false;
-	maps = r_io_map_get_for_fd (io, fd);
+	RList *maps = r_io_map_get_for_fd (io, fd);
 	if (maps) {
 		map = r_list_get_n (maps, 0);
 		if (map) {


### PR DESCRIPTION
```
@@@           # foreach offset+size iterator command:
x @@@=       [addr] [size] ([addr] [size] ...)
x @@@b       basic blocks of current function
x @@@c:cmd   Same as @@@=`cmd`, without the backticks
x @@@C:cmd   comments matching
x @@@i       imports
x @@@r       registers
x @@@s       symbols
x @@@S       sections
x @@@m       io.maps
x @@@M       dbg.maps (See ?$?~size)
x @@@f       flags
x @@@f:hit*  flags matching glob expression
x @@@F       functions (set fcn size which may be incorrect if not linear)
x @@@F:glob  functions matching glob expression
x @@@t       threads
x @@@r       regs
```