### PR TITLE
Fixes #13713: vr rotates between JMP, CALL and DATA reference hints

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2760,6 +2760,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.jmpsub", "true", "Always substitute jump, call and branch targets in disassembly");
 	SETPREF ("asm.hints", "true", "Disable all asm.hint* if false");
 	SETPREF ("asm.hint.jmp", "true", "Show jump hints [numbers] in disasm");
+	SETPREF ("asm.hint.call", "false", "Show call hints [numbers] in disarm");
 	SETPREF ("asm.hint.lea", "false", "Show LEA hints [numbers] in disasm");
 	SETPREF ("asm.hint.cdiv", "false", "Show CDIV hints optimization hint");
 	SETI ("asm.hint.pos", 1, "Shortcut hint position (-1, 0, 1)");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2759,8 +2759,8 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.usercomments", "false", "Show user comments even if asm.comments is false");
 	SETPREF ("asm.jmpsub", "true", "Always substitute jump, call and branch targets in disassembly");
 	SETPREF ("asm.hints", "true", "Disable all asm.hint* if false");
-	SETPREF ("asm.hint.jmp", "true", "Show jump hints [numbers] in disasm");
-	SETPREF ("asm.hint.call", "false", "Show call hints [numbers] in disarm");
+	SETPREF ("asm.hint.jmp", "false", "Show jump hints [numbers] in disasm");
+	SETPREF ("asm.hint.call", "true", "Show call hints [numbers] in disarm");
 	SETPREF ("asm.hint.lea", "false", "Show LEA hints [numbers] in disasm");
 	SETPREF ("asm.hint.cdiv", "false", "Show CDIV hints optimization hint");
 	SETI ("asm.hint.pos", 1, "Shortcut hint position (-1, 0, 1)");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -143,6 +143,7 @@ typedef struct {
 	bool asm_hints;
 	bool asm_hint_jmp;
 	bool asm_hint_cdiv;
+	bool asm_hint_call;
 	bool asm_hint_lea;
 	int  asm_hint_pos;
 	bool show_slow;
@@ -676,6 +677,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->show_comments = r_config_get_i (core->config, "asm.comments");
 	ds->show_usercomments = r_config_get_i (core->config, "asm.usercomments");
 	ds->asm_hint_jmp = r_config_get_i (core->config, "asm.hint.jmp");
+	ds->asm_hint_call = r_config_get_i (core->config, "asm.hint.call");
 	ds->asm_hint_lea = r_config_get_i (core->config, "asm.hint.lea");
 	ds->asm_hint_cdiv = r_config_get_i (core->config, "asm.hint.cdiv");
 	ds->asm_hint_pos = r_config_get_i (core->config, "asm.hint.pos");
@@ -3233,7 +3235,7 @@ static void ds_print_core_vmode(RDisasmState *ds, int pos) {
 			ds_print_shortcut (ds, ds->analop.ptr, pos);
 		}
 #endif
-		if (ds->asm_hint_jmp) {
+		if (ds->asm_hint_call) {
 			if (ds->analop.jump != UT64_MAX) {
 				slen = ds_print_shortcut (ds, ds->analop.jump, pos);
 			} else {
@@ -3246,9 +3248,14 @@ static void ds_print_core_vmode(RDisasmState *ds, int pos) {
 		break;
 	case R_ANAL_OP_TYPE_JMP:
 	case R_ANAL_OP_TYPE_CJMP:
+		if (ds->asm_hint_jmp) {
+			slen = ds_print_shortcut (ds, ds->analop.jump, pos);
+			gotShortcut = true;
+		}
+		break;
 	case R_ANAL_OP_TYPE_CALL:
 	case R_ANAL_OP_TYPE_COND | R_ANAL_OP_TYPE_CALL:
-		if (ds->asm_hint_jmp) {
+		if (ds->asm_hint_call) {
 			slen = ds_print_shortcut (ds, ds->analop.jump, pos);
 			gotShortcut = true;
 		}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2187,7 +2187,8 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 	if (isNumber (core, ch)) {
 		// only in disasm and debug prints..
 		if (isDisasmPrint (core->printidx)) {
-			if (r_config_get_i (core->config, "asm.hints") && (r_config_get_i (core->config, "asm.hint.jmp") || r_config_get_i (core->config, "asm.hint.lea"))) {
+			if (r_config_get_i (core->config, "asm.hints") && (r_config_get_i (core->config, "asm.hint.jmp")
+			|| r_config_get_i (core->config, "asm.hint.lea") || r_config_get_i (core->config, "asm.hint.call"))) {
 				r_core_visual_jump (core, ch);
 			} else {
 				numbuf_append (ch);
@@ -2680,8 +2681,16 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			break;
 		case 'r':
 			// TODO: toggle shortcut hotkeys
-			r_core_cmd0 (core, "e!asm.hint.jmp");
-			r_core_cmd0 (core, "e!asm.hint.lea");
+			if (r_config_get_i (core->config, "asm.hint.jmp")) {
+				r_core_cmd0 (core, "e!asm.hint.jmp");
+				r_core_cmd0 (core, "e!asm.hint.call");
+			} else if (r_config_get_i (core->config, "asm.hint.call")) {
+				r_core_cmd0 (core, "e!asm.hint.call");
+				r_core_cmd0 (core, "e!asm.hint.lea");
+			} else if (r_config_get_i (core->config, "asm.hint.lea")) {
+				r_core_cmd0 (core, "e!asm.hint.lea");
+				r_core_cmd0 (core, "e!asm.hint.jmp");
+			}
 			visual_refresh (core);
 			break;
 		case ' ':


### PR DESCRIPTION
## After Images:

### jmp hints
<img width="837" alt="Screen Shot 2019-04-15 at 11 43 35 PM" src="https://user-images.githubusercontent.com/20895544/56156249-790e4b80-5fda-11e9-9fc0-ed1e6cd5a8a3.png">

### call hints
<img width="891" alt="Screen Shot 2019-04-15 at 11 43 47 PM" src="https://user-images.githubusercontent.com/20895544/56156251-79a6e200-5fda-11e9-8366-f5b00b8db9f2.png">

### LEA hints
<img width="1148" alt="Screen Shot 2019-04-15 at 11 43 57 PM" src="https://user-images.githubusercontent.com/20895544/56156252-79a6e200-5fda-11e9-83bc-d55a6f4b8395.png">
