### PR TITLE
Fix coredump PC not being considered

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -663,7 +663,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 			r_config_set (r->config, "asm.arch", inf->arch);
 			r_config_set_i (r->config, "asm.bits", inf->bits);
 			r_bin_info_free (inf);
-                }
+		}
 		if (binfile->o->regstate) {
 			if (r_reg_arena_set_bytes (r->anal->reg, binfile->o->regstate)) {
 				eprintf ("Setting up coredump: Problem while setting the registers\n");
@@ -677,8 +677,16 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 						stack_map = r_io_map_get (r->io, sp_addr);
 					}
 				}
+				regname = r_reg_get_name (r->anal->reg, R_REG_NAME_PC);
+				if (regname) {
+					RRegItem *reg = r_reg_get (r->anal->reg, regname, -1);
+					if (reg) {
+						ut64 seek = r_reg_get_value (r->anal->reg, reg);
+						r_core_cmdf (r, "s 0x%x", seek);
+					}
+				}
 			}
-                }
+		}
 
 		RBinObject *o = binfile->o;
 		int map = 0;

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -682,7 +682,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 					RRegItem *reg = r_reg_get (r->anal->reg, regname, -1);
 					if (reg) {
 						ut64 seek = r_reg_get_value (r->anal->reg, reg);
-						r_core_cmdf (r, "s 0x%x", seek);
+						r_core_seek (r, seek, 1);
 					}
 				}
 			}

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1276,7 +1276,7 @@ R_API int r_main_radare2(int argc, char **argv) {
 		if (debug) {
 			r_core_setup_debugger (&r, debugbackend, baddr == UT64_MAX);
 		}
-		if (!debug && r_flag_get (r.flags, "entry0")) {
+		if (!debug && r_flag_get (r.flags, "entry0") && !r_bin_cur_object (r.bin)->regstate) {
 			r_core_cmd0 (&r, "s entry0");
 		}
 		if (s_seek) {


### PR DESCRIPTION
Before ESIL would overwrite the PC to be on the entry0