### PR TITLE
cfg.contaftererr: Continue after error when using -i

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2934,6 +2934,7 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* cfg */
 	SETPREF ("cfg.r2wars", "false", "Enable some tweaks for the r2wars game");
+	SETPREF ("cfg.contaftererr", "false", "Continue after error when using -i");
 	SETPREF ("cfg.plugins", "true", "Load plugins at startup");
 	SETCB ("time.fmt", "%Y-%m-%d %H:%M:%S %z", &cb_cfgdatefmt, "Date format (%Y-%m-%d %H:%M:%S %z)");
 	SETICB ("time.zone", 0, &cb_timezone, "Time zone, in hours relative to GMT: +2, -1,..");

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4014,6 +4014,7 @@ R_API int r_core_cmd_lines(RCore *core, const char *lines) {
 	if (!odata) {
 		return false;
 	}
+	bool cont_after_err = r_config_get_i (core->config, "cfg.contaftererr");
 	nl = strchr (odata, '\n');
 	if (nl) {
 		r_cons_break_push (NULL, NULL);
@@ -4025,7 +4026,7 @@ R_API int r_core_cmd_lines(RCore *core, const char *lines) {
 			}
 			*nl = '\0';
 			r = r_core_cmd (core, data, 0);
-			if (r < 0) { //== -1) {
+			if (r < 0 && !cont_after_err) { //== -1) {
 				data = nl + 1;
 				ret = -1; //r; //false;
 				break;


### PR DESCRIPTION
This is mainly for r2r.