### PR TITLE
Remove RParse.hint to fix Segfaults ##parse

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1546,7 +1546,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			// 0x33->sym.xx
 			char *p = strdup (strsub);
 			if (p) {
-				r_parse_filter (core->parser, addr, core->flags, p,
+				r_parse_filter (core->parser, addr, core->flags, hint, p,
 						strsub, sizeof (strsub), be);
 				free (p);
 			}
@@ -6047,8 +6047,10 @@ static char *get_buf_asm(RCore *core, ut64 from, ut64 addr, RAnalFunction *fcn, 
 		r_parse_varsub (core->parser, fcn, addr, asmop.size,
 				ba, ba, sizeof (asmop.buf_asm));
 	}
-	r_parse_filter (core->parser, addr, core->flags,
+	RAnalHint *hint = r_anal_hint_get (core->anal, addr);
+	r_parse_filter (core->parser, addr, core->flags, hint,
 			ba, str, sizeof (str), core->print->big_endian);
+	r_anal_hint_free (hint);
 	r_asm_op_set_asm (&asmop, ba);
 	free (ba);
 	if (color && has_color) {
@@ -6403,8 +6405,10 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 							r_io_read_at (core->io, ref->addr, buf, sizeof (buf));
 							r_asm_set_pc (core->assembler, ref->addr);
 							r_asm_disassemble (core->assembler, &asmop, buf, sizeof(buf));
-							r_parse_filter (core->parser, ref->addr, core->flags, r_asm_op_get_asm (&asmop),
+							RAnalHint *hint = r_anal_hint_get (core->anal, ref->addr);
+							r_parse_filter (core->parser, ref->addr, core->flags, hint, r_asm_op_get_asm (&asmop),
 									str, sizeof (str), core->print->big_endian);
+							r_anal_hint_free (hint);
 							if (has_color) {
 								desc = desc_to_free = r_print_colorize_opcode (core->print, str,
 										core->cons->context->pal.reg, core->cons->context->pal.num, false, fcn ? fcn->addr : 0);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1864,8 +1864,10 @@ static void do_ref_search(RCore *core, ut64 addr,ut64 from, ut64 to, struct sear
 			r_asm_set_pc (core->assembler, ref->addr);
 			r_asm_disassemble (core->assembler, &asmop, buf, size);
 			fcn = r_anal_get_fcn_in (core->anal, ref->addr, 0);
-			r_parse_filter (core->parser, ref->addr, core->flags, r_strbuf_get (&asmop.buf_asm),
+			RAnalHint *hint = r_anal_hint_get (core->anal, ref->addr);
+			r_parse_filter (core->parser, ref->addr, core->flags, hint, r_strbuf_get (&asmop.buf_asm),
 				str, sizeof (str), core->print->big_endian);
+			r_anal_hint_free (hint);
 			comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ref->addr);
 			char *buf_fcn = comment
 				? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", strtok (comment, "\n"))
@@ -2223,8 +2225,10 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 						char tmp[128] = {
 							0
 						};
-						r_parse_filter (core->parser, hit->addr, core->flags, hit->code, tmp, sizeof (tmp),
+						RAnalHint *hint = r_anal_hint_get (core->anal, hit->addr);
+						r_parse_filter (core->parser, hit->addr, core->flags, hint, hit->code, tmp, sizeof (tmp),
 								core->print->big_endian);
+						r_anal_hint_free (hint);
 						r_cons_printf ("0x%08"PFMT64x "   # %i: %s\n",
 							hit->addr, hit->len, tmp);
 					} else {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1684,8 +1684,6 @@ R_API void r_anal_merge_hint_ranges(RAnal *a);
 R_API void r_anal_hint_del (RAnal *anal, ut64 addr, int size);
 R_API void r_anal_hint_clear (RAnal *a);
 R_API RAnalHint *r_anal_hint_from_string(RAnal *a, ut64 addr, const char *str);
-R_API RAnalHint *r_anal_hint_at (RAnal *a, ut64 from);
-R_API RAnalHint *r_anal_hint_add (RAnal *a, ut64 from, int size);
 R_API void r_anal_hint_free (RAnalHint *h);
 R_API RAnalHint *r_anal_hint_get(RAnal *anal, ut64 addr);
 R_API void r_anal_hint_set_syntax (RAnal *a, ut64 addr, const char *syn);

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -32,7 +32,6 @@ typedef struct r_parse_t {
 	char *retleave_asm;
 	struct r_parse_plugin_t *cur;
 	RAnal *anal; // weak anal ref
-	RAnalHint *hint; // weak anal ref
 	RList *parsers;
 	RAnalVarList varlist;
 	char* (*get_op_ireg)(void *user, ut64 addr);
@@ -61,7 +60,7 @@ R_API int r_parse_list(RParse *p);
 R_API int r_parse_use(RParse *p, const char *name);
 R_API int r_parse_parse(RParse *p, const char *data, char *str);
 R_API int r_parse_assemble(RParse *p, char *data, char *str);
-R_API int r_parse_filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len, bool big_endian);
+R_API int r_parse_filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, char *str, int len, bool big_endian);
 R_API bool r_parse_varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len);
 R_API char *r_parse_c_string(RAnal *anal, const char *code, char **error_msg);
 R_API char *r_parse_c_file(RAnal *anal, const char *path, char **error_msg);

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -225,7 +225,7 @@ static void replaceRegisters (RReg *reg, char *s, bool x86) {
 	}
 }
 
-static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len, bool big_endian) {
+static int filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, char *str, int len, bool big_endian) {
 	char *ptr = data, *ptr2, *ptr_backup;
 	RAnalFunction *fcn;
 	RFlagItem *flag;
@@ -410,19 +410,19 @@ static int filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len
 				}
 			}
 		}
-		if (p->hint) {
-			const int nw = p->hint->nword;
+		if (hint) {
+			const int nw = hint->nword;
 			if (count != nw) {
 				ptr = ptr2;
 				continue;
 			}
-			int pnumleft, immbase = p->hint->immbase;
+			int pnumleft, immbase = hint->immbase;
 			char num[256] = {0}, *pnum, *tmp;
 			bool is_hex = false;
 			int tmp_count;
-			if (p->hint->offset) {
+			if (hint->offset) {
 				*ptr = 0;
-				snprintf (str, len, "%s%s%s", data, p->hint->offset, (ptr != ptr2)? ptr2: "");
+				snprintf (str, len, "%s%s%s", data, hint->offset, (ptr != ptr2)? ptr2: "");
 				return true;
 			}
 			strncpy (num, ptr, sizeof (num)-2);
@@ -591,8 +591,8 @@ R_API char *r_parse_immtrim(char *opstr) {
 	return opstr;
 }
 
-R_API int r_parse_filter(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len, bool big_endian) {
-	filter (p, addr, f, data, str, len, big_endian);
+R_API int r_parse_filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, char *str, int len, bool big_endian) {
+	filter (p, addr, f, hint, data, str, len, big_endian);
 	if (p->cur && p->cur->filter) {
 		return p->cur->filter (p, addr, f, data, str, len, big_endian);
 	}


### PR DESCRIPTION
It's a miracle this didn't show up breaking everything before.
Disassembly code was setting `core->parse->hint` to an instance it allocated itself, then freed this instance, but never reset `core->parse->hint`, which led to uaf or in my case use of completely unrelated data allocated by Qt. Best solution was to just kill this scary global state.