### PR TITLE
t key instead of tab key is supported in Disassembly panel ##panels

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -111,7 +111,7 @@ R_API void r_core_visual_toggle_decompiler_disasm(RCore *core, bool for_graph, b
 	r_config_set (core->config, "asm.instr", "false");
 }
 
-static void applyDisMode(RCore *core, int disMode) {
+R_API void r_core_visual_applyDisMode(RCore *core, int disMode) {
 	switch (disMode % 5) {
 	case 0:
 		r_config_set (core->config, "asm.pseudo", "false");

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2249,11 +2249,11 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 					printfmtSingle[0] = printHexFormats[R_ABS(hexMode) % PRINT_HEX_FORMATS];
 					break;
 				case R_CORE_VISUAL_MODE_PD: // pd
-					applyDisMode (core, --disMode);
+					r_core_visual_applyDisMode (core, --disMode);
 					printfmtSingle[1] = rotateAsmemu (core);
 					break;
 				case R_CORE_VISUAL_MODE_DB: // debugger
-					applyDisMode (core, --disMode);
+					r_core_visual_applyDisMode (core, --disMode);
 					printfmtSingle[1] = rotateAsmemu (core);
 					current3format = current3format + 1;
 					printfmtSingle[2] = print3Formats[R_ABS(current3format) % PRINT_3_FORMATS];
@@ -2313,11 +2313,11 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 						printfmtSingle[0] = printHexFormats[R_ABS(hexMode) % PRINT_HEX_FORMATS];
 						break;
 					case R_CORE_VISUAL_MODE_PD: // pd
-						applyDisMode (core, ++disMode);
+						r_core_visual_applyDisMode (core, ++disMode);
 						printfmtSingle[1] = rotateAsmemu (core);
 						break;
 					case R_CORE_VISUAL_MODE_DB: // debugger
-						applyDisMode (core, ++disMode);
+						r_core_visual_applyDisMode (core, ++disMode);
 						printfmtSingle[1] = rotateAsmemu (core);
 						current3format = current3format + 1;
 						printfmtSingle[2] = print3Formats[R_ABS(current3format) % PRINT_3_FORMATS];
@@ -3397,13 +3397,13 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 							break;
 						case R_CORE_VISUAL_MODE_PD: // pd
 							printfmtSingle[1] = rotateAsmemu (core);
-							applyDisMode (core, --disMode);
+							r_core_visual_applyDisMode (core, --disMode);
 							break;
 						case R_CORE_VISUAL_MODE_DB: // debugger
 							//printfmtSingle[1] = rotateAsmemu (core);
 							current3format = current3format - 1;
 							printfmtSingle[2] = print3Formats[R_ABS(current3format) % PRINT_3_FORMATS];
-							applyDisMode (core, --disMode);
+							r_core_visual_applyDisMode (core, --disMode);
 							break;
 						case R_CORE_VISUAL_MODE_OV: // overview
 							current4format = current4format-1;

--- a/libr/core/visual_tabs.inc
+++ b/libr/core/visual_tabs.inc
@@ -71,7 +71,7 @@ static void visual_tabset(RCore *core, RCoreVisualTab *tab) {
 	current3format = tab->current3format;
 	current4format = tab->current4format;
 	current5format = tab->current5format;
-	applyDisMode (core, disMode);
+	r_core_visual_applyDisMode (core, disMode);
 	applyHexMode (core, hexMode);
 	r_config_set_i (core->config, "asm.offset", tab->asm_offset);
 	r_config_set_i (core->config, "asm.instr", tab->asm_instr);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -1090,6 +1090,7 @@ typedef struct r_panels_t {
 	int n_panels;
 	int columnWidth;
 	int curnode;
+	int disMode;
 	bool isResizing;
 	bool autoUpdate;
 	RPanelsMenu *panelsMenu;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -396,6 +396,7 @@ R_API void r_core_print_scrollbar(RCore *core);
 R_API void r_core_print_scrollbar_bottom(RCore *core);
 R_API void r_core_visual_prompt_input (RCore *core);
 R_API void r_core_visual_toggle_decompiler_disasm(RCore *core, bool for_graph, bool reset);
+R_API void r_core_visual_applyDisMode(RCore *core, int disMode);
 R_API int r_core_visual_refs(RCore *core, bool xref, bool fcnInsteadOfAddr);
 R_API void r_core_visual_append_help(RStrBuf *p, const char *title, const char **help);
 R_API bool r_core_prevop_addr(RCore* core, ut64 start_addr, int numinstrs, ut64* prev_addr);

--- a/libr/include/r_util/r_panels.h
+++ b/libr/include/r_util/r_panels.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 typedef void (*RPanelDirectionCallback)(void *user, int direction);
+typedef void (*RPanelRotateCallback)(void *user, bool rev);
 
 typedef enum {
 	PANEL_TYPE_DEFAULT = 0,
@@ -27,6 +28,7 @@ typedef enum {
 
 typedef struct r_panel_model_t {
 	RPanelDirectionCallback directionCb;
+	RPanelRotateCallback rotateCb;
 	RPanelType type;
 	char *cmd;
 	char *title;


### PR DESCRIPTION
Initial support for tab key, but just not tab key, 't' instead, because people already got used to using tab key as a key to move around tabs, so. 