### PR TITLE
Fix bug when quoting a comment ##core

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2005,7 +2005,7 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	if (!icmd || (cmd[0] == '#' && cmd[1] != '!' && cmd[1] != '?')) {
 		goto beach;
 	}
-	cmt = *icmd ? (char *)r_str_firstbut (icmd + 1, '#', "\""): NULL;
+	cmt = *icmd ? (char *)r_str_firstbut (icmd, '#', "\""): NULL;
 	if (cmt && (cmt[1] == ' ' || cmt[1] == '\t')) {
 		*cmt = 0;
 	}


### PR DESCRIPTION
$ r2 -c '"w hello # world"' -qcps -