### PR TITLE
Make p= bars dont use the background color ##cons

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1987,6 +1987,18 @@ static int cb_iotrap(void *user, void *data) {
 	return true;
 }
 
+static int cb_scr_bgfill(void *user, void *data) {
+	RCore *core = (RCore*) user;
+	RConfigNode *node = (RConfigNode *) data;
+	if (node->i_value) {
+		core->print->flags |= R_PRINT_FLAGS_BGFILL;
+	} else {
+		core->print->flags &= (~R_PRINT_FLAGS_BGFILL);
+	}
+	r_print_set_flags (core->print, core->print->flags);
+	return true;
+}
+
 static int cb_scrint(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *) data;
 	if (node->i_value && r_sandbox_enable (0)) {
@@ -3279,6 +3291,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETICB ("scr.fix.columns", 0, &cb_fixcolumns, "Workaround for Prompt iOS SSH client");
 	SETCB ("scr.highlight", "", &cb_scrhighlight, "Highlight that word at RCons level");
 	SETCB ("scr.interactive", "true", &cb_scrint, "Start in interactive mode");
+	SETCB ("scr.bgfill", "false", &cb_scr_bgfill, "Fill background for ascii art when possible");
 	SETI ("scr.feedback", 1, "Set visual feedback level (1=arrow on jump, 2=every key (useful for videos))");
 	SETCB ("scr.html", "false", &cb_scrhtml, "Disassembly uses HTML syntax");
 	n = NODECB ("scr.nkey", "flag", &cb_scrnkey);

--- a/libr/include/r_util/r_print.h
+++ b/libr/include/r_util/r_print.h
@@ -31,6 +31,7 @@ extern "C" {
 #define R_PRINT_FLAGS_NONASCII 0x00020000
 #define R_PRINT_FLAGS_ALIGN    0x00040000
 #define R_PRINT_FLAGS_UNALLOC  0x00080000
+#define R_PRINT_FLAGS_BGFILL   0x00100000
 
 typedef int (*RPrintZoomCallback)(void *user, int mode, ut64 addr, ut8 *bufz, ut64 size);
 typedef const char *(*RPrintNameCallback)(void *user, ut64 addr);

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1615,11 +1615,12 @@ R_API void r_print_zoom(RPrint *p, void *user, RPrintZoomCallback cb, ut64 from,
 R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step) {
 	r_return_if_fail (p && arr);
 	const bool show_colors = (p && (p->flags & R_PRINT_FLAGS_COLOR));
+	const bool bgFill = (p && (p->flags & R_PRINT_FLAGS_BGFILL));
 	char *firebow[6];
 	int i = 0, j;
 
 	for (i = 0; i < 6; i++) {
-		firebow[i] = p->cb_color (i, 6, false);
+		firebow[i] = p->cb_color (i, 6, bgFill);
 	}
 #define INC 5
 #if TOPLINE
@@ -1668,7 +1669,11 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step
 		if (next < arr[i]) {
 			if (arr[i] > INC) {
 				for (j = 0; j < next + base; j += INC) {
-					p->cb_printf (i ? "." : "'");
+					if (bgFill) {
+						p->cb_printf (i ? " " : "'");
+					} else {
+						p->cb_printf (i ? "." : "'");
+					}
 				}
 			}
 			for (j = next + INC; j + base < arr[i]; j += INC) {

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1619,7 +1619,7 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step
 	int i = 0, j;
 
 	for (i = 0; i < 6; i++) {
-		firebow[i] = p->cb_color (i, 6, true);
+		firebow[i] = p->cb_color (i, 6, false);
 	}
 #define INC 5
 #if TOPLINE
@@ -1666,10 +1666,9 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step
 			base = 1;
 		}
 		if (next < arr[i]) {
-			//if (arr[i]>0 && i>0) p->cb_printf ("  ");
 			if (arr[i] > INC) {
 				for (j = 0; j < next + base; j += INC) {
-					p->cb_printf (i ? " " : "'");
+					p->cb_printf (i ? "." : "'");
 				}
 			}
 			for (j = next + INC; j + base < arr[i]; j += INC) {
@@ -1682,11 +1681,10 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step
 				}
 			} else {
 				for (j = INC; j < arr[i] + base; j += INC) {
-					p->cb_printf (" ");
+					p->cb_printf (".");
 				}
 			}
 		}
-		//for (j=1;j<arr[i]; j+=INC) p->cb_printf (under);
 		if (show_colors) {
 			p->cb_printf ("|" Color_RESET);
 		} else {


### PR DESCRIPTION
the reason to not use the bg is beacuse it conflicts with Cons_INVERT if we want to highlight a row and also because it will look bad in panels.

before:

<img width="496" alt="Screenshot 2019-04-21 at 01 27 41" src="https://user-images.githubusercontent.com/917142/56463446-aa20be80-63d4-11e9-8549-4e75871fcbf2.png">

after: 
<img width="495" alt="Screenshot 2019-04-21 at 01 25 36" src="https://user-images.githubusercontent.com/917142/56463433-61690580-63d4-11e9-9d1e-9e76bdb9fab3.png">
