### PR TITLE
Fix #13672: Display variables value in the disasm view

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1512,6 +1512,7 @@ static void ds_show_functions_argvar(RDisasmState *ds, RAnalVar *var, const char
 		if (val) {
 			r_str_replace_char (val, '\n', '\0');
 			r_cons_printf (" = %s", val);
+			free (val);
 		}
 	}
 	r_strbuf_free (constr_buf);
@@ -1757,6 +1758,7 @@ static void ds_show_functions(RDisasmState *ds) {
 					if (val) {
 						r_str_replace_char (val, '\n', '\0');
 						r_cons_printf ("%s", val);
+						free (val);
 					}
 				}
 				}


### PR DESCRIPTION
`asm.var.summary` must equal -1 for the values to be displayed


<img width="501" alt="Screen Shot 2019-04-21 at 5 05 29 PM" src="https://user-images.githubusercontent.com/20895544/56469674-62447a80-645a-11e9-9b9f-a194c8ec6e6b.png">
