### PR TITLE
Assume filetype is unknown if `core->bin->cur` is null

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7856,7 +7856,7 @@ static bool is_unknown_file(RCore *core) {
 	if (core->bin->cur && core->bin->cur->o) {
 		return (r_list_empty (core->bin->cur->o->sections));
 	}
-	return false;
+	return true;
 }
 
 static int cmd_anal_all(RCore *core, const char *input) {


### PR DESCRIPTION
Fix for comment at https://github.com/radare/radare2/issues/13825#issuecomment-485068356.

Previously, the method `is_unknown_file` used to return `false` if `core->bin->cur` or `core->bin->cur->o` are null. By changing that assumption this works for r2 -n as well.
