### PR TITLE
Sign hash, possible mem leak fix.

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -616,6 +616,7 @@ R_API bool r_sign_add_hash(RAnal *a, const char *name, int type, const char *val
 	r_return_val_if_fail (a && name && type && val && len > 0, false);
 	if (type != R_SIGN_BBHASH) {
 		eprintf ("error: hash type unknown");
+		return false;
 	}
 	int digestsize = r_hash_size (R_ZIGN_HASH) * 2;
 	if (len != digestsize) {


### PR DESCRIPTION
Avoiding creating an entry if the type is not known (at the moment).