### PR TITLE
Fix reverse i search

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1746,16 +1746,20 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		if (I.echo) {
 			if (gcomp) {
 				gcomp_line = "";
+				int counter = 0;
 				if (I.history.data != NULL) {
-					for (i = 0; i < I.history.size; i++) {
+					for (i = I.history.size-1; i >= 0; i--) {
 						if (!I.history.data[i]) {
-							break;
+							continue;
 						}
 						if (strstr (I.history.data[i], I.buffer.data)) {
 							gcomp_line = I.history.data[i];
-							if (!gcomp_idx--) {
+							if (++counter > gcomp_idx) {
 								break;
 							}
+						}
+						if (i == 0) {
+							gcomp_idx--;
 						}
 					}
 				}

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1350,6 +1350,9 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 			fflush (stdout);
 			break;
 		case 18:// ^R -- autocompletion
+			if (gcomp) {
+				gcomp_idx++;
+			}
 			gcomp = 1;
 			break;
 		case 19:// ^S -- backspace


### PR DESCRIPTION
For me the nice reverse-i-search feature was broken (it did only find the last occurrence of the command in search). Also I think it's nice to be able to just press CTRL+R again to continue searching in history so I don't have to reach the arrow keys. 