### PR TITLE
Add unsigned decimal output to ? command

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -544,7 +544,9 @@ static int cmd_help(void *data, const char *input) {
 				r_num_units (unit, sizeof (unit), n);
 				if (*input ==  'j') {
 					pj_ks (pj, "int32", sdb_fmt ("%d", (st32)(n & UT32_MAX)));
+					pj_ks (pj, "uint32", sdb_fmt ("%u", (ut32)n));
 					pj_ks (pj, "int64", sdb_fmt ("%"PFMT64d, (st64)n));
+					pj_ks (pj, "uint64", sdb_fmt ("%"PFMT64u, (ut64)n));
 					pj_ks (pj, "hex", sdb_fmt ("0x%08"PFMT64x, n));
 					pj_ks (pj, "octal", sdb_fmt ("0%"PFMT64o, n));
 					pj_ks (pj, "unit", unit);

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -553,8 +553,10 @@ static int cmd_help(void *data, const char *input) {
 				} else {
 					if (n >> 32) {
 						r_cons_printf ("int64   %"PFMT64d"\n", (st64)n);
+						r_cons_printf ("uint64  %"PFMT64u"\n", (ut64)n);
 					} else {
 						r_cons_printf ("int32   %d\n", (st32)n);
+						r_cons_printf ("uint32  %u\n", (ut32)n);
 					}
 					r_cons_printf ("hex     0x%"PFMT64x"\n", n);
 					r_cons_printf ("octal   0%"PFMT64o"\n", n);


### PR DESCRIPTION
The non-JSON version of the command still differentiates between inputs greater/less than 32 bits and includes only the appropriate output.