### PR TITLE
sys/meson.py: Create r2.bat as alias to radare2.exe on Windows

### DIFF
--- a/sys/meson.py
+++ b/sys/meson.py
@@ -165,6 +165,12 @@ def win_dist(args):
 
     makedirs(r'{DIST}')
     copy(r'{BUILDDIR}\binr\*\*.exe', r'{DIST}')
+
+    r2_bat_fname = args.install + r'\r2.bat'
+    log.debug('create "%s"', r2_bat_fname)
+    with open(r2_bat_fname, 'w') as r2_bat:
+        r2_bat.write('@"%s\\radare2" %%*\n' % os.path.abspath(args.install))
+
     copy(r'{BUILDDIR}\libr\*\*.dll', r'{DIST}')
     makedirs(r'{DIST}\{R2_LIBDIR}')
     if args.shared:


### PR DESCRIPTION
So that one just needs to type in r-2 instead of r-a-d-a-r-e-2 on Windows.