### PR TITLE
#include sdb/ht_uu.h after r_types.h

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1,11 +1,11 @@
 /* radare - LGPL - Copyright 2009-2019 - pancake, nibble */
 
-#include <sdb/ht_uu.h>
 #include <r_types.h>
 #include <r_list.h>
 #include <r_flag.h>
 #include <r_core.h>
 #include <r_bin.h>
+#include <sdb/ht_uu.h>
 
 #include <string.h>
 


### PR DESCRIPTION
Reason: https://stackoverflow.com/questions/1372480/c-redefinition-header-files-winsock2-h.
Fixes the AppVeyor build.