### PR TITLE
Fix a bug

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -889,6 +889,7 @@ static void activateCursor(RCore *core) {
 				(void)r_cons_any_key ("Cache is off and cursor is on");
 				setCursor (core, !core->print->cur_enabled);
 				cur->view->refresh = true;
+				resetScrollPos (cur);
 			} else {
 				(void)r_cons_any_key ("You can always toggle cache by \'&\' key");
 			}


### PR DESCRIPTION
Repro

1. Open hexdump
2. Turn cache on
3. Scroll down a bit
4. Turn on cursor by answering y to all the question you will get
5. Cursor isn't gonna be there

Now it's fixed with this.