### PR TITLE
Improve visual mark  ##visual

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -526,9 +526,12 @@ rep:
 			break;
 		case ' ':
 			{
-			const char *arg = strchr (input+2, ' ');
-			ut64 addr = arg? r_num_math (core->num, arg): core->offset;
-			r_core_visual_mark_set (core, atoi (input+1), addr);
+				const int ASCII_MAX = 127;
+				if (atoi (input+1) + ASCII_MAX + 1 < UT8_MAX) {
+					const char *arg = strchr (input+2, ' ');
+					ut64 addr = arg? r_num_math (core->num, arg): core->offset;
+					r_core_visual_mark_set (core, atoi (input+1) + ASCII_MAX + 1, addr);
+				}
 			}
 			break;
 		case '?':

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3076,19 +3076,31 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 		case 'm':
 			{
 				r_cons_gotoxy (0, 0);
-				r_cons_printf (R_CONS_CLEAR_LINE"set shortcut key for 0x%"PFMT64x"\n", core->offset);
+				r_cons_printf (R_CONS_CLEAR_LINE"Set shortcut key for 0x%"PFMT64x"\n", core->offset);
 				r_cons_flush ();
 				int ch = r_cons_readchar ();
 				r_core_visual_mark (core, ch);
 			}
 			break;
+		case 'M':
+			{
+				r_cons_gotoxy (0, 0);
+				if (r_core_visual_mark_dump (core)) {
+					r_cons_printf (R_CONS_CLEAR_LINE"Remove a shortcut key from the list\n");
+					r_cons_flush ();
+					int ch = r_cons_readchar ();
+					r_core_visual_mark_del (core, ch);
+				}
+			}
+			break;
 		case '\'':
 			{
 				r_cons_gotoxy (0, 0);
-				r_core_visual_mark_dump (core);
-				r_cons_flush ();
-				int ch = r_cons_readchar ();
-				r_core_visual_mark_seek (core, ch);
+				if (r_core_visual_mark_dump (core)) {
+					r_cons_flush ();
+					int ch = r_cons_readchar ();
+					r_core_visual_mark_seek (core, ch);
+				}
 			}
 			break;
 		case 'y':

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3074,10 +3074,22 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			//r_core_cmd0 (core, "=H");
 			break;
 		case 'm':
-			r_core_visual_mark (core, r_cons_readchar ());
+			{
+				r_cons_gotoxy (0, 0);
+				r_cons_printf (R_CONS_CLEAR_LINE"set shortcut key for 0x%"PFMT64x"\n", core->offset);
+				r_cons_flush ();
+				int ch = r_cons_readchar ();
+				r_core_visual_mark (core, ch);
+			}
 			break;
 		case '\'':
-			r_core_visual_mark_seek (core, r_cons_readchar ());
+			{
+				r_cons_gotoxy (0, 0);
+				r_core_visual_mark_dump (core);
+				r_cons_flush ();
+				int ch = r_cons_readchar ();
+				r_core_visual_mark_seek (core, ch);
+			}
 			break;
 		case 'y':
 			if (core->print->ocur == -1) {

--- a/libr/core/vmarks.c
+++ b/libr/core/vmarks.c
@@ -14,16 +14,19 @@ R_API void r_core_visual_mark_reset(RCore *core) {
 	}
 }
 
-R_API void r_core_visual_mark_dump(RCore *core) {
+R_API bool r_core_visual_mark_dump(RCore *core) {
 	int i;
+	bool out = false;
 	if (!marks_init) {
-		return;
+		return out;
 	}
 	for (i = 0; i < UT8_MAX; i++) {
 		if (marks[i] != UT64_MAX) {
 			r_cons_printf (R_CONS_CLEAR_LINE"fV %c 0x%"PFMT64x"\n", i, marks[i]);
+			out = true;
 		}
 	}
+	return out;
 }
 
 R_API void r_core_visual_mark_set(RCore *core, ut8 ch, ut64 addr) {
@@ -31,6 +34,13 @@ R_API void r_core_visual_mark_set(RCore *core, ut8 ch, ut64 addr) {
 		r_core_visual_mark_reset (core);
 	}
 	marks[ch] = addr;
+}
+
+R_API void r_core_visual_mark_del(RCore *core, ut8 ch) {
+	if (!marks_init) {
+		return;
+	}
+	marks[ch] = UT64_MAX;
 }
 
 R_API void r_core_visual_mark(RCore *core, ut8 ch) {

--- a/libr/core/vmarks.c
+++ b/libr/core/vmarks.c
@@ -21,7 +21,7 @@ R_API void r_core_visual_mark_dump(RCore *core) {
 	}
 	for (i = 0; i < UT8_MAX; i++) {
 		if (marks[i] != UT64_MAX) {
-			r_cons_printf ("fV %d 0x%"PFMT64x"\n", i, marks[i]);
+			r_cons_printf (R_CONS_CLEAR_LINE"fV %c 0x%"PFMT64x"\n", i, marks[i]);
 		}
 	}
 }

--- a/libr/core/vmarks.c
+++ b/libr/core/vmarks.c
@@ -2,6 +2,8 @@
 
 #include <r_core.h>
 
+#define ASCII_MAX 127
+
 /* maybe move this into RCore */
 static bool marks_init = false;
 static ut64 marks[UT8_MAX + 1];
@@ -22,7 +24,11 @@ R_API bool r_core_visual_mark_dump(RCore *core) {
 	}
 	for (i = 0; i < UT8_MAX; i++) {
 		if (marks[i] != UT64_MAX) {
-			r_cons_printf (R_CONS_CLEAR_LINE"fV %c 0x%"PFMT64x"\n", i, marks[i]);
+			if (i > ASCII_MAX) {
+				r_cons_printf (R_CONS_CLEAR_LINE"fV %d 0x%"PFMT64x"\n", i - ASCII_MAX - 1, marks[i]);
+			} else {
+				r_cons_printf (R_CONS_CLEAR_LINE"fV %c 0x%"PFMT64x"\n", i, marks[i]);
+			}
 			out = true;
 		}
 	}
@@ -44,6 +50,9 @@ R_API void r_core_visual_mark_del(RCore *core, ut8 ch) {
 }
 
 R_API void r_core_visual_mark(RCore *core, ut8 ch) {
+	if (IS_DIGIT (ch)) {
+		ch += ASCII_MAX + 1;
+	}
 	r_core_visual_mark_set (core, ch, core->offset);
 }
 

--- a/libr/core/vmarks.c
+++ b/libr/core/vmarks.c
@@ -25,9 +25,9 @@ R_API bool r_core_visual_mark_dump(RCore *core) {
 	for (i = 0; i < UT8_MAX; i++) {
 		if (marks[i] != UT64_MAX) {
 			if (i > ASCII_MAX) {
-				r_cons_printf (R_CONS_CLEAR_LINE"fV %d 0x%"PFMT64x"\n", i - ASCII_MAX - 1, marks[i]);
+				r_cons_printf ("fV %d 0x%"PFMT64x"\n", i - ASCII_MAX - 1, marks[i]);
 			} else {
-				r_cons_printf (R_CONS_CLEAR_LINE"fV %c 0x%"PFMT64x"\n", i, marks[i]);
+				r_cons_printf ("fV %c 0x%"PFMT64x"\n", i, marks[i]);
 			}
 			out = true;
 		}

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -442,7 +442,8 @@ R_API void r_core_visual_list(RCore *core, RList* list, ut64 seek, ut64 len, int
 R_API void r_core_visual_mark_seek(RCore *core, ut8 ch);
 R_API void r_core_visual_mark(RCore *core, ut8 ch);
 R_API void r_core_visual_mark_set(RCore *core, ut8 ch, ut64 addr);
-R_API void r_core_visual_mark_dump(RCore *core);
+R_API void r_core_visual_mark_del(RCore *core, ut8 ch);
+R_API bool r_core_visual_mark_dump(RCore *core);
 R_API void r_core_visual_mark_reset(RCore *core);
 
 R_API int r_core_search_cb(RCore *core, ut64 from, ut64 to, RCoreSearchCallback cb);


### PR DESCRIPTION
![GIFrecord_2019-05-08_035708](https://user-images.githubusercontent.com/29271244/57325889-1bd36900-7146-11e9-8c58-f9e9cab68ab8.gif)

I'm not sure if you like this, but i thought it would make visual mark more usable this way, so...