### PR TITLE
Code cleanup for anal.ex, make java work without it.

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1768,7 +1768,7 @@ R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int r
 	}
 	if (anal->cur && anal->cur->fcn) {
 		int result = anal->cur->fcn (anal, fcn, addr, reftype);
-		if (anal->cur->custom_fn_anal) {
+		if (anal->use_ex && anal->cur->custom_fn_anal) {
 			return result;
 		}
 	}

--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2017 - pancake, nibble, Adam Pridgen <dso@rice.edu || adam.pridgen@thecoverofnight.com> */
+/* radare - LGPL - Copyright 2009-2019 - pancake, nibble, Adam Pridgen <dso@rice.edu || adam.pridgen@thecoverofnight.com> */
 
 #include <r_types.h>
 #include <r_util.h>

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1610,10 +1610,13 @@ R_API int r_core_anal_esil_fcn(RCore *core, ut64 at, ut64 from, int reftype, int
  * reference to that fcn */
 R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth) {
 	if (from == UT64_MAX && r_anal_get_fcn_in (core->anal, at, 0)) {
+		if (core->anal->verbose) {
+			eprintf ("Message: Invalid address for function 0x%08"PFMT64x"\n", at);
+		}
 		return 0;
 	}
 
-	bool use_esil = r_config_get_i (core->config, "anal.esil");
+	const bool use_esil = r_config_get_i (core->config, "anal.esil");
 	RAnalFunction *fcn;
 	RListIter *iter;
 
@@ -1636,7 +1639,7 @@ R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dept
 
 	/* if there is an anal plugin and it wants to analyze the function itself,
 	 * run it instead of the normal analysis */
-	if (core->anal->cur && core->anal->cur->analyze_fns) {
+	if (core->anal->use_ex && core->anal->cur && core->anal->cur->analyze_fns) {
 		int result = R_ANAL_RET_ERROR;
 		result = core->anal->cur->analyze_fns (core->anal, at, from, reftype, depth);
 		/* update the flags after running the analysis function of the plugin */
@@ -1648,9 +1651,11 @@ R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dept
 		return result;
 	}
 	if (from != UT64_MAX && !at) {
+		eprintf ("invalid address\n");
 		return false;
 	}
 	if (at == UT64_MAX || depth < 0) {
+		eprintf ("err dp\n");
 		return false;
 	}
 	if (r_cons_is_breaked ()) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2151,6 +2151,13 @@ static bool cb_zoombyte(void *user, void *data) {
 	return true;
 }
 
+static bool cb_analex(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	core->anal->use_ex = node->i_value;
+	return true;
+}
+
 static bool cb_analverbose(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -2650,6 +2657,7 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* anal */
 	SETPREF ("anal.fcnprefix", "fcn",  "Prefix new function names with this");
+	SETCB ("anal.ex", "true", &cb_analex, "Use the anal extension methods from the selected plugin if available");
 	SETCB ("anal.verbose", "false", &cb_analverbose, "Show RAnal warnings when analyzing code");
 	SETPREF ("anal.a2f", "false",  "Use the new WIP analysis algorithm (core/p/a2f), anal.depth ignored atm");
 	SETCB ("anal.roregs", "gp,zero", (RConfigCallback)&cb_anal_roregs, "Comma separated list of register names to be readonly");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1694,11 +1694,8 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			if (op.failcycles) {
 				printline ("failcycles", "%d\n", op.failcycles);
 			}
-			{
-				const char *t2 = r_anal_optype_to_string (op.type2);
-				if (t2 && strcmp (t2, "null")) {
-					printline ("type2", "%s\n", t2);
-				}
+			if (op.type2) {
+				printline ("type2", "0x%x\n", op.type2);
 			}
 			if (op.reg) {
 				printline ("reg", "%s\n", op.reg);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4753,7 +4753,7 @@ R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int l
 	{ /* used by asm.emu */
 		r_reg_arena_push (core->anal->reg);
 	}
-	if (core->anal->cur && core->anal->cur->reset_counter) {
+	if (core->anal->use_ex && core->anal->cur && core->anal->cur->reset_counter) {
 		core->anal->cur->reset_counter (core->anal, addr);
 	}
 

--- a/libr/core/p/core_java.c
+++ b/libr/core/p/core_java.c
@@ -1,4 +1,4 @@
-/* radare - Apache - Copyright 2014-2016 - dso, pancake */
+/* radare - Apache - Copyright 2014-2019 - dso, pancake */
 
 #include <r_types.h>
 #include <r_lib.h>
@@ -9,11 +9,6 @@
 #include <r_anal.h>
 #include <r_anal_ex.h>
 
-#if 0
-#include "../../../shlr/java/ops.c"
-#include "../../../shlr/java/code.c"
-#include "../../../shlr/java/class.c"
-#endif
 #include "../../../shlr/java/class.h"
 #include "../../../shlr/java/code.h"
 #include "../../../shlr/java/dsojson.h"
@@ -985,23 +980,22 @@ static int r_cmd_java_handle_find_cp_const (RCore *core, const char *cmd) {
 			char op = bb->op_bytes[0];
 			cp_res = NULL;
 			switch (op) {
-				case 0x12:
-					cp_res = (idx == (ut16) -1) || (bb->op_bytes[1] == idx) ?
-								R_NEW0(RCmdJavaCPResult) : NULL;
-					if (cp_res) {
-						cp_res->idx = bb->op_bytes[1];
-					}
-					break;
-				case 0x13:
-				case 0x14:
-					cp_res = (idx == (ut16) -1) || (R_BIN_JAVA_USHORT (bb->op_bytes, 1) == idx) ?
-								R_NEW0(RCmdJavaCPResult) : NULL;
-					if (cp_res) {
-						cp_res->idx = R_BIN_JAVA_USHORT (bb->op_bytes, 1);
-					}
-					break;
+			case 0x12:
+				cp_res = (idx == (ut16) -1) || (bb->op_bytes[1] == idx) ?
+							R_NEW0(RCmdJavaCPResult) : NULL;
+				if (cp_res) {
+					cp_res->idx = bb->op_bytes[1];
+				}
+				break;
+			case 0x13:
+			case 0x14:
+				cp_res = (idx == (ut16) -1) || (R_BIN_JAVA_USHORT (bb->op_bytes, 1) == idx) ?
+							R_NEW0(RCmdJavaCPResult) : NULL;
+				if (cp_res) {
+					cp_res->idx = R_BIN_JAVA_USHORT (bb->op_bytes, 1);
+				}
+				break;
 			}
-
 			if (cp_res) {
 				cp_res->addr = bb->addr;
 				cp_res->obj = r_bin_java_get_item_from_cp (obj, cp_res->idx);
@@ -1044,9 +1038,9 @@ static int r_cmd_java_handle_field_info (RCore *core, const char *cmd) {
 	}
 
 	switch (*(cmd)) {
-		case 'c': return r_cmd_java_print_field_num_name (obj);
-		case 's': return r_cmd_java_print_field_summary (obj, idx);
-		case 'n': return r_cmd_java_print_field_name (obj, idx);
+	case 'c': return r_cmd_java_print_field_num_name (obj);
+	case 's': return r_cmd_java_print_field_summary (obj, idx);
+	case 'n': return r_cmd_java_print_field_name (obj, idx);
 	}
 	IFDBG r_cons_printf ("Command is (%s)\n", cmd);
 	eprintf ("[-] r_cmd_java: invalid command syntax.\n");
@@ -1074,9 +1068,9 @@ static int r_cmd_java_handle_method_info (RCore *core, const char *cmd) {
 	}
 
 	switch (*(cmd)) {
-		case 'c': return r_cmd_java_print_method_num_name (obj);
-		case 's': return r_cmd_java_print_method_summary (obj, idx);
-		case 'n': return r_cmd_java_print_method_name (obj, idx);
+	case 'c': return r_cmd_java_print_method_num_name (obj);
+	case 's': return r_cmd_java_print_method_summary (obj, idx);
+	case 'n': return r_cmd_java_print_method_name (obj, idx);
 	}
 
 	IFDBG r_cons_printf ("Command is (%s)\n", cmd);
@@ -1184,15 +1178,11 @@ static int r_cmd_java_handle_isvalid (RCore *core, const char *cmd) {
 				res = r_sz < sz ? false : true;
 				free (buf);
 				break;
-			}else {
+			} else {
 				sz <<= 1;
 			}
 		}
-		if (res) {
-			r_cons_printf ("True\n");
-		} else {
-			r_cons_printf ("False\n");
-		}
+		r_cons_printf ("%s\n", r_str_bool (res));
 	} else {
 		r_cmd_java_print_cmd_help (JAVA_CMDS + ISVALID_IDX);
 	}
@@ -1209,12 +1199,12 @@ static int r_cmd_java_handle_resolve_cp (RCore *core, const char *cmd) {
 	int res = false;
 	if (idx > 0 && obj) {
 		switch (c_type) {
-			case 't': return r_cmd_java_resolve_cp_type (obj, idx);
-			case 'c': return r_cmd_java_resolve_cp_idx (obj, idx);
-			case 'e': return r_cmd_java_resolve_cp_idx_b64 (obj, idx);
-			case 'a': return r_cmd_java_resolve_cp_address (obj, idx);
-			case 's': return r_cmd_java_resolve_cp_summary (obj, idx);
-			case 'k': return r_cmd_java_resolve_cp_to_key (obj, idx);
+		case 't': return r_cmd_java_resolve_cp_type (obj, idx);
+		case 'c': return r_cmd_java_resolve_cp_idx (obj, idx);
+		case 'e': return r_cmd_java_resolve_cp_idx_b64 (obj, idx);
+		case 'a': return r_cmd_java_resolve_cp_address (obj, idx);
+		case 's': return r_cmd_java_resolve_cp_summary (obj, idx);
+		case 'k': return r_cmd_java_resolve_cp_to_key (obj, idx);
 		}
 	} else if (obj && c_type == 'g') {
 		for (idx = 1; idx <=obj->cp_count; idx++) {
@@ -1247,9 +1237,9 @@ static int r_cmd_java_get_all_access_flags_value (const char *cmd) {
 	char *str = NULL;
 
 	switch (*(cmd)) {
-		case 'f': the_list = retrieve_all_field_access_string_and_value (); break;
-		case 'm': the_list = retrieve_all_method_access_string_and_value (); break;
-		case 'c': the_list = retrieve_all_class_access_string_and_value (); break;
+	case 'f': the_list = retrieve_all_field_access_string_and_value (); break;
+	case 'm': the_list = retrieve_all_method_access_string_and_value (); break;
+	case 'c': the_list = retrieve_all_class_access_string_and_value (); break;
 	}
 	if (!the_list) {
 		eprintf ("[-] r_cmd_java: incorrect syntax for the flags calculation.\n");
@@ -1257,9 +1247,9 @@ static int r_cmd_java_get_all_access_flags_value (const char *cmd) {
 		return false;
 	}
 	switch (*(cmd)) {
-		case 'f': r_cons_printf ("[=] Fields Access Flags List\n"); break;
-		case 'm': r_cons_printf ("[=] Methods Access Flags List\n"); break;
-		case 'c': r_cons_printf ("[=] Class Access Flags List\n");; break;
+	case 'f': r_cons_printf ("[=] Fields Access Flags List\n"); break;
+	case 'm': r_cons_printf ("[=] Methods Access Flags List\n"); break;
+	case 'c': r_cons_printf ("[=] Class Access Flags List\n");; break;
 	}
 
 	r_list_foreach (the_list, iter, str) {
@@ -1283,9 +1273,9 @@ static int r_cmd_java_handle_calc_flags (RCore *core, const char *cmd) {
 		const char *lcmd = *cmd+1 == ' '? cmd+2 : cmd+1;
 		IFDBG eprintf ("Seeing %s and accepting %s\n", cmd, lcmd);
 		switch (*(lcmd)) {
-			case 'f':
-			case 'm':
-			case 'c': res = r_cmd_java_get_all_access_flags_value (lcmd); break;
+		case 'f':
+		case 'm':
+		case 'c': res = r_cmd_java_get_all_access_flags_value (lcmd); break;
 		}
 		// Just print them all out
 		if (res == false) {
@@ -1317,18 +1307,18 @@ static int r_cmd_java_handle_flags_str (RCore *core, const char *cmd) {
 
 	if (p && f_type) {
 		switch (f_type) {
-			case 'm': flags_str = retrieve_method_access_string((ut16) flag_value); break;
-			case 'f': flags_str = retrieve_field_access_string((ut16) flag_value); break;
-			case 'c': flags_str = retrieve_class_method_access_string((ut16) flag_value); break;
-			default: flags_str = NULL;
+		case 'm': flags_str = retrieve_method_access_string((ut16) flag_value); break;
+		case 'f': flags_str = retrieve_field_access_string((ut16) flag_value); break;
+		case 'c': flags_str = retrieve_class_method_access_string((ut16) flag_value); break;
+		default: flags_str = NULL;
 		}
 	}
 
 	if (flags_str) {
 		switch (f_type) {
-			case 'm': r_cons_printf ("Method Access Flags String: "); break;
-			case 'f': r_cons_printf ("Field Access Flags String: "); break;
-			case 'c': r_cons_printf ("Class Access Flags String: "); break;
+		case 'm': r_cons_printf ("Method Access Flags String: "); break;
+		case 'f': r_cons_printf ("Field Access Flags String: "); break;
+		case 'c': r_cons_printf ("Class Access Flags String: "); break;
 		}
 		r_cons_println (flags_str);
 		free (flags_str);
@@ -1366,18 +1356,18 @@ static int r_cmd_java_handle_flags_str_at (RCore *core, const char *cmd) {
 
 	if (p && f_type) {
 		switch (f_type) {
-			case 'm': flags_str = retrieve_method_access_string((ut16) flag_value); break;
-			case 'f': flags_str = retrieve_field_access_string((ut16) flag_value); break;
-			case 'c': flags_str = retrieve_class_method_access_string((ut16) flag_value); break;
-			default: flags_str = NULL;
+		case 'm': flags_str = retrieve_method_access_string((ut16) flag_value); break;
+		case 'f': flags_str = retrieve_field_access_string((ut16) flag_value); break;
+		case 'c': flags_str = retrieve_class_method_access_string((ut16) flag_value); break;
+		default: flags_str = NULL;
 		}
 	}
 
 	if (flags_str) {
 		switch (f_type) {
-			case 'm': r_cons_printf ("Method Access Flags String: "); break;
-			case 'f': r_cons_printf ("Field Access Flags String: "); break;
-			case 'c': r_cons_printf ("Class Access Flags String: "); break;
+		case 'm': r_cons_printf ("Method Access Flags String: "); break;
+		case 'f': r_cons_printf ("Field Access Flags String: "); break;
+		case 'c': r_cons_printf ("Class Access Flags String: "); break;
 		}
 		r_cons_println (flags_str);
 		free (flags_str);
@@ -1408,15 +1398,13 @@ static int r_cmd_java_handle_set_flags (RCore * core, const char * input) {
 
 	ut64 addr = p && r_cmd_java_is_valid_input_num_value(core, p) ? r_cmd_java_get_input_num_value (core, p) : -1;
 	ut32 flag_value = -1;
-	char f_type = '?';
 	int res = false;
-
-	p = r_cmd_java_strtok (p+1, ' ', -1);
+	p = r_cmd_java_strtok (p + 1, ' ', -1);
 	if (!p || !*p) {
 		r_cmd_java_print_cmd_help (JAVA_CMDS+SET_ACC_FLAGS_IDX);
 		return true;
 	}
-	f_type = p && *p ? r_cmd_java_is_valid_java_mcf (*(++p)) : 0;
+	const char f_type = p && *p ? r_cmd_java_is_valid_java_mcf (*(++p)) : 0;
 
 	flag_value = r_cmd_java_is_valid_input_num_value(core, p) ? r_cmd_java_get_input_num_value (core, p) : -1;
 
@@ -1444,7 +1432,7 @@ static int r_cmd_java_handle_set_flags (RCore * core, const char * input) {
 	}
 
 	if (res) {
-		r_cmd_java_print_cmd_help (JAVA_CMDS+SET_ACC_FLAGS_IDX);
+		r_cmd_java_print_cmd_help (JAVA_CMDS + SET_ACC_FLAGS_IDX);
 		return res;
 	}
 
@@ -1454,10 +1442,10 @@ static int r_cmd_java_handle_set_flags (RCore * core, const char * input) {
 	IFDBG r_cons_printf ("Converting %s to flags\n",p);
 	if (f_type && flag_value != -1) {
 		switch (f_type) {
-			case 'f': flag_value = r_bin_java_calculate_field_access_value (p); break;
-			case 'm': flag_value = r_bin_java_calculate_method_access_value (p); break;
-			case 'c': flag_value = r_bin_java_calculate_class_access_value (p); break;
-			default: flag_value = -1;
+		case 'f': flag_value = r_bin_java_calculate_field_access_value (p); break;
+		case 'm': flag_value = r_bin_java_calculate_method_access_value (p); break;
+		case 'c': flag_value = r_bin_java_calculate_class_access_value (p); break;
+		default: flag_value = -1;
 		}
 	}
 	IFDBG r_cons_printf ("Current args: (flag_value: 0x%04x addr: 0x%"PFMT64x")\n.", flag_value, addr, res);
@@ -1466,7 +1454,7 @@ static int r_cmd_java_handle_set_flags (RCore * core, const char * input) {
 		IFDBG r_cons_printf ("Writing 0x%04x to 0x%"PFMT64x": %d.", flag_value, addr, res);
 	} else {
 		eprintf ("[-] r_cmd_java: invalid flag value or type provided .\n");
-		r_cmd_java_print_cmd_help (JAVA_CMDS+SET_ACC_FLAGS_IDX);
+		r_cmd_java_print_cmd_help (JAVA_CMDS + SET_ACC_FLAGS_IDX);
 		res = true;
 	}
 	return res;

--- a/libr/core/p/core_java.c
+++ b/libr/core/p/core_java.c
@@ -1395,18 +1395,16 @@ static char r_cmd_java_is_valid_java_mcf (char b) {
 static int r_cmd_java_handle_set_flags (RCore * core, const char * input) {
 	//#define SET_ACC_FLAGS_ARGS "< c | m | f> <addr> <d | <s <flag value separated by space> >"
 	const char *p = r_cmd_java_consumetok (input, ' ', -1);
-
-	ut64 addr = p && r_cmd_java_is_valid_input_num_value(core, p) ? r_cmd_java_get_input_num_value (core, p) : -1;
-	ut32 flag_value = -1;
-	int res = false;
+	ut64 addr = p && r_cmd_java_is_valid_input_num_value (core, p)
+		? r_cmd_java_get_input_num_value (core, p) : -1;
 	p = r_cmd_java_strtok (p + 1, ' ', -1);
 	if (!p || !*p) {
 		r_cmd_java_print_cmd_help (JAVA_CMDS+SET_ACC_FLAGS_IDX);
 		return true;
 	}
-	const char f_type = p && *p ? r_cmd_java_is_valid_java_mcf (*(++p)) : 0;
+	const char f_type = p && *p ? r_cmd_java_is_valid_java_mcf (*(++p)) : '?';
 
-	flag_value = r_cmd_java_is_valid_input_num_value(core, p) ? r_cmd_java_get_input_num_value (core, p) : -1;
+	int flag_value = r_cmd_java_is_valid_input_num_value(core, p) ? r_cmd_java_get_input_num_value (core, p) : -1;
 
 	if (flag_value == 16 && f_type == 'f') {
 		flag_value = -1;
@@ -1419,14 +1417,14 @@ static int r_cmd_java_handle_set_flags (RCore * core, const char * input) {
 	if (flag_value == -1) {
 		flag_value = r_cmd_java_is_valid_input_num_value (core, p) ? r_cmd_java_get_input_num_value (core, p) : -1;
 	}
-
+	bool res = false;
 	if (!input) {
 		eprintf ("[-] r_cmd_java: no address provided .\n");
 		res = true;
 	} else if (addr == -1) {
 		eprintf ("[-] r_cmd_java: no address provided .\n");
 		res = true;
-	} else if (!f_type && flag_value == -1) {
+	} else if (f_type == '?' && flag_value == -1) {
 		eprintf ("[-] r_cmd_java: no flag type provided .\n");
 		res = true;
 	}
@@ -1436,9 +1434,9 @@ static int r_cmd_java_handle_set_flags (RCore * core, const char * input) {
 		return res;
 	}
 
-	IFDBG r_cons_printf ("Writing to %c to 0x%"PFMT64x", %s.\n", f_type, addr, p);
+	IFDBG r_cons_printf ("Writing ftype '%c' to 0x%"PFMT64x", %s.\n", f_type, addr, p);
 
-	//  handling string based access flags (otherwise skip ahead)
+	// handling string based access flags (otherwise skip ahead)
 	IFDBG r_cons_printf ("Converting %s to flags\n",p);
 	if (f_type && flag_value != -1) {
 		switch (f_type) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -714,6 +714,7 @@ typedef struct r_anal_t {
 	int seggrn;
 	RFlagGetAtAddr flag_get;
 	REvent *ev;
+	bool use_ex;
 } RAnal;
 
 typedef struct r_anal_hint_t {

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -2645,7 +2645,9 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		if (section) {
 			section->name = strdup ("constant_pool");
 			section->size = bin->cp_size;
-			section->paddr = bin->cp_offset + baddr;
+			section->vsize = section->size;
+			section->paddr = 0x10; // XXX // bin->cp_offset; //  + baddr;
+			section->vaddr = baddr;
 			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
@@ -2657,6 +2659,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		if (section) {
 			section->name = strdup ("fields");
 			section->size = bin->fields_size;
+			section->vsize = section->size;
 			section->paddr = bin->fields_offset + baddr;
 			section->perm = R_PERM_R;
 			section->add = true;
@@ -2670,6 +2673,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 				if (section) {
 					section->name = r_str_newf ("attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
+					section->vsize = section->size;
 					section->paddr = fm_type->attr_offset + baddr;
 					section->perm = R_PERM_R;
 					section->add = true;
@@ -2683,6 +2687,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		if (section) {
 			section->name = strdup ("methods");
 			section->size = bin->methods_size;
+			section->vsize = section->size;
 			section->paddr = bin->methods_offset + baddr;
 			section->perm = R_PERM_RX;
 			section->add = true;
@@ -2696,8 +2701,9 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 				if (section) {
 					section->name = r_str_newf ("attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
+					section->vsize = section->size;
 					section->paddr = fm_type->attr_offset + baddr;
-					section->perm = R_PERM_R;
+					section->perm = R_PERM_R | R_PERM_X;
 					section->add = true;
 					r_list_append (sections, section);
 				}
@@ -2709,6 +2715,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		if (section) {
 			section->name = strdup ("interfaces");
 			section->size = bin->interfaces_size;
+			section->vsize = section->size;
 			section->paddr = bin->interfaces_offset + baddr;
 			section->perm = R_PERM_R;
 			section->add = true;
@@ -2721,6 +2728,7 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		if (section) {
 			section->name = strdup ("attributes");
 			section->size = bin->attrs_size;
+			section->vsize = section->size;
 			section->paddr = bin->attrs_offset + baddr;
 			section->perm = R_PERM_R;
 			section->add = true;

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -2634,6 +2634,7 @@ R_API RBinSymbol *r_bin_java_create_new_symbol_from_ref(RBinJavaCPTypeObj *obj, 
 	return sym;
 }
 
+// TODO: vaddr+vsize break things if set
 R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 	RBinSection *section = NULL;
 	RList *sections = r_list_newf (free);
@@ -2644,10 +2645,15 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		section = R_NEW0 (RBinSection);
 		if (section) {
 			section->name = strdup ("constant_pool");
+			section->paddr = bin->cp_offset + baddr;
 			section->size = bin->cp_size;
+#if 0
 			section->vsize = section->size;
-			section->paddr = 0x10; // XXX // bin->cp_offset; //  + baddr;
+			section->vaddr = 0x10; // XXX // bin->cp_offset; //  + baddr;
+#endif
 			section->vaddr = baddr;
+			// section->vaddr = section->paddr;
+			// section->vsize = section->size;
 			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
@@ -2659,8 +2665,11 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		if (section) {
 			section->name = strdup ("fields");
 			section->size = bin->fields_size;
-			section->vsize = section->size;
 			section->paddr = bin->fields_offset + baddr;
+#if 0
+			section->vsize = section->size;
+			section->vaddr = section->paddr;
+#endif
 			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
@@ -2673,7 +2682,10 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 				if (section) {
 					section->name = r_str_newf ("attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
+#if 0
 					section->vsize = section->size;
+					section->vaddr = section->paddr;
+#endif
 					section->paddr = fm_type->attr_offset + baddr;
 					section->perm = R_PERM_R;
 					section->add = true;
@@ -2686,9 +2698,10 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		section = R_NEW0 (RBinSection);
 		if (section) {
 			section->name = strdup ("methods");
-			section->size = bin->methods_size;
-			section->vsize = section->size;
 			section->paddr = bin->methods_offset + baddr;
+			section->size = bin->methods_size;
+			// section->vaddr = section->paddr;
+			// section->vsize = section->size;
 			section->perm = R_PERM_RX;
 			section->add = true;
 			r_list_append (sections, section);
@@ -2701,7 +2714,8 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 				if (section) {
 					section->name = r_str_newf ("attrs.%s", fm_type->name);
 					section->size = fm_type->size - (fm_type->file_offset - fm_type->attr_offset);
-					section->vsize = section->size;
+					// section->vsize = section->size;
+					// section->vaddr = section->paddr;
 					section->paddr = fm_type->attr_offset + baddr;
 					section->perm = R_PERM_R | R_PERM_X;
 					section->add = true;
@@ -2714,9 +2728,10 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		section = R_NEW0 (RBinSection);
 		if (section) {
 			section->name = strdup ("interfaces");
-			section->size = bin->interfaces_size;
-			section->vsize = section->size;
 			section->paddr = bin->interfaces_offset + baddr;
+			section->size = bin->interfaces_size;
+			// section->vaddr = section->paddr;
+			// section->vsize = section->size;
 			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);
@@ -2727,9 +2742,11 @@ R_API RList *r_bin_java_get_sections(RBinJavaObj *bin) {
 		section = R_NEW0 (RBinSection);
 		if (section) {
 			section->name = strdup ("attributes");
-			section->size = bin->attrs_size;
-			section->vsize = section->size;
 			section->paddr = bin->attrs_offset + baddr;
+			section->size = bin->attrs_size;
+			// section->vaddr = section->paddr;
+			// section->vsize = section->size;
+			section->perm = R_PERM_R;
 			section->perm = R_PERM_R;
 			section->add = true;
 			r_list_append (sections, section);

--- a/shlr/java/code.c
+++ b/shlr/java/code.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2019 - pancake */
+/* radare - LGPL - Copyright 2007-2016 - pancake */
 
 #include <r_types.h>
 #include <r_util.h>

--- a/shlr/java/code.c
+++ b/shlr/java/code.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2016 - pancake */
+/* radare - LGPL - Copyright 2007-2019 - pancake */
 
 #include <r_types.h>
 #include <r_util.h>

--- a/sys/rebuild.sh
+++ b/sys/rebuild.sh
@@ -43,6 +43,7 @@ RebuildIOSDebug() {
 RebuildJava() {
 	Rebuild shlr/java
 	Rebuild libr/asm
+	Rebuild libr/anal
 	Rebuild libr/bin
 	Rebuild libr/core
 }


### PR DESCRIPTION
* Current java implementation of the analysis is not working well
* RBin parser now puts the right section sizes
* Added anal.ex option to use extensions or not
* More to go