### PR TITLE
Fix lgtm.yml

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,11 +1,4 @@
 extraction:
     cpp:
-        after_prepare:
-            - export GNU_MAKE=make
         configure:
-            command: "./configure"
-        before_index:
-            - export CS_COMMIT_ARCHIVE=1
-        index:
-            build_command:
-                - $GNU_MAKE -j2 -s
+            command: ./configure --with-syscapstone


### PR DESCRIPTION
It looks like c/c++ builds are currently failing with the current configuration, but that they succeeded in the past with this configuration: ([see build logs](https://lgtm.com/projects/g/radare/radare2/logs/rev/18b069ccf43cbb5e7ce17dd6276ea84389ecf958/lang:cpp/stage:Build%20child_18b069ccf43cbb5e7ce17dd6276ea84389ecf958), view "Analysis configuration")

```
extraction:
    cpp:
        configure:
            command: ./configure --with-syscapstone
```

At the time, it looks like the configuration was set on the LGTM side, and was not present in your repository, but since adding one, builds have started failing.

cc @XVilka

*(full disclosure, I work for Semmle)*