### PR TITLE
Track pushed register (note: immediately after lea/mov) to resolve push-ret

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1199,11 +1199,11 @@ repeat:
 					last_is_mov_lr_pc = true;
 				}
 			}
-			// Is this a mov into a register?
-			if (op.dst && op.dst->reg && op.dst->reg->name) {
+			// Is this a mov of immediate value into a register?
+			if (op.dst && op.dst->reg && op.dst->reg->name && op.val > 0 && op.val != UT64_MAX) {
 				free (last_reg_mov_lea_name);
 				if ((last_reg_mov_lea_name = strdup (op.dst->reg->name))) {
-					last_reg_mov_lea_val = op.ptr;
+					last_reg_mov_lea_val = op.val;
 					last_is_reg_mov_lea = true;
 				}
 			}

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -380,7 +380,7 @@ static struct optype {
 	{ R_ANAL_OP_TYPE_IRJMP , "ujmp" }, // needs to be changed
 	{ R_ANAL_OP_TYPE_UNK   , "unk" },
 	{ R_ANAL_OP_TYPE_UPUSH , "upush" },
-	{ R_ANAL_OP_TYPE_RPUSH , "upush" },
+	{ R_ANAL_OP_TYPE_RPUSH , "rpush" },
 	{ R_ANAL_OP_TYPE_XCHG  , "xchg" },
 	{ R_ANAL_OP_TYPE_XOR   , "xor" },
 	{ R_ANAL_OP_TYPE_CASE  , "case" },
@@ -466,6 +466,7 @@ R_API const char *r_anal_optype_to_string(int t) {
 	case R_ANAL_OP_TYPE_IRJMP : return "ujmp"; // needs to be changed
 	case R_ANAL_OP_TYPE_UNK   : return "unk";
 	case R_ANAL_OP_TYPE_UPUSH : return "upush";
+	case R_ANAL_OP_TYPE_RPUSH : return "rpush";
 	case R_ANAL_OP_TYPE_XCHG  : return "xchg";
 	case R_ANAL_OP_TYPE_XOR   : return "xor";
 	case R_ANAL_OP_TYPE_CASE  : return "case";

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -380,6 +380,7 @@ static struct optype {
 	{ R_ANAL_OP_TYPE_IRJMP , "ujmp" }, // needs to be changed
 	{ R_ANAL_OP_TYPE_UNK   , "unk" },
 	{ R_ANAL_OP_TYPE_UPUSH , "upush" },
+	{ R_ANAL_OP_TYPE_RPUSH , "upush" },
 	{ R_ANAL_OP_TYPE_XCHG  , "xchg" },
 	{ R_ANAL_OP_TYPE_XOR   , "xor" },
 	{ R_ANAL_OP_TYPE_CASE  , "case" },
@@ -520,6 +521,7 @@ R_API char *r_anal_op_to_string(RAnal *anal, RAnalOp *op) {
 		break;
 	case R_ANAL_OP_TYPE_PUSH:
 	case R_ANAL_OP_TYPE_UPUSH:
+	case R_ANAL_OP_TYPE_RPUSH:
 		snprintf (ret, sizeof (ret), "push %s", a0);
 		break;
 	case R_ANAL_OP_TYPE_POP:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1873,8 +1873,8 @@ static void op_fillval(RAnal *a, RAnalOp *op, csh *handle, cs_insn *insn) {
 		set_src_dst (op->src[1], handle, insn, 2);
 		set_src_dst (op->src[2], handle, insn, 3);
 		break;
-	case R_ANAL_OP_TYPE_PUSH:
-		if (INSOP (0).type == X86_OP_REG) {
+	case R_ANAL_OP_TYPE_UPUSH:
+		if ((op->type & R_ANAL_OP_TYPE_REG)) {
 			CREATE_SRC_DST (op);
 			set_src_dst (op->src[0], handle, insn, 0);
 		}
@@ -2410,7 +2410,7 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 			op->cycles = CYCLE_REG + CYCLE_MEM;
 			break;
 		case X86_OP_REG:
-			op->type = R_ANAL_OP_TYPE_PUSH;
+			op->type = R_ANAL_OP_TYPE_RPUSH;
 			op->cycles = CYCLE_REG + CYCLE_MEM;
 			break;
 		default:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1873,6 +1873,12 @@ static void op_fillval(RAnal *a, RAnalOp *op, csh *handle, cs_insn *insn) {
 		set_src_dst (op->src[1], handle, insn, 2);
 		set_src_dst (op->src[2], handle, insn, 3);
 		break;
+	case R_ANAL_OP_TYPE_PUSH:
+		if (INSOP (0).type == X86_OP_REG) {
+			CREATE_SRC_DST (op);
+			set_src_dst (op->src[0], handle, insn, 0);
+		}
+		break;
 	default:
 		break;
 	}
@@ -2400,6 +2406,10 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		switch (INSOP(0).type) {
 		case X86_OP_IMM:
 			op->val = op->ptr = INSOP(0).imm;
+			op->type = R_ANAL_OP_TYPE_PUSH;
+			op->cycles = CYCLE_REG + CYCLE_MEM;
+			break;
+		case X86_OP_REG:
 			op->type = R_ANAL_OP_TYPE_PUSH;
 			op->cycles = CYCLE_REG + CYCLE_MEM;
 			break;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2163,6 +2163,7 @@ static int cmd_print_pxA(RCore *core, int len, const char *input) {
 			break;
 		case R_ANAL_OP_TYPE_PUSH:
 		case R_ANAL_OP_TYPE_UPUSH:
+		case R_ANAL_OP_TYPE_RPUSH:
 			bgcolor = pal->push;
 			fgcolor = Color_WHITE;
 			text = "->";

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -424,6 +424,7 @@ typedef enum {
 	R_ANAL_OP_TYPE_SWI   = 11,  /* syscall, software interrupt */
 	R_ANAL_OP_TYPE_CSWI  = 11 | R_ANAL_OP_TYPE_COND,  /* syscall, software interrupt */
 	R_ANAL_OP_TYPE_UPUSH = 12, /* unknown push of data into stack */
+	R_ANAL_OP_TYPE_RPUSH = R_ANAL_OP_TYPE_UPUSH | R_ANAL_OP_TYPE_REG, /* push register */
 	R_ANAL_OP_TYPE_PUSH  = 13,  /* push value into stack */
 	R_ANAL_OP_TYPE_POP   = 14,   /* pop value from stack to register */
 	R_ANAL_OP_TYPE_CMP   = 15,  /* compare something */

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1840,6 +1840,7 @@ R_API const char* r_print_color_op_type(RPrint *p, ut64 anal_type) {
 		return pal->mov;
 	case R_ANAL_OP_TYPE_PUSH:
 	case R_ANAL_OP_TYPE_UPUSH:
+	case R_ANAL_OP_TYPE_RPUSH:
 	case R_ANAL_OP_TYPE_LOAD:
 		return pal->push;
 	case R_ANAL_OP_TYPE_POP:


### PR DESCRIPTION
Somewhat fixes #13845 .

This only works if the previous instruction before push is a reg mov / lea. A more generic solution would be tracking registers inside the RAnal struct, but I think ESIL should handle that.

Also, sorry for the long absence... real life is a bitch sometimes.