### PR TITLE
Improve error messages used by afn and afr.

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3022,7 +3022,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 				eprintf ("Usage: afn newname [off]   # set new name to given function\n");
 			} else {
 				if (!*name || !setFunctionName (core, off, name, false)) {
-					eprintf ("Cannot find function '%s' at 0x%08" PFMT64x "\n", name, off);
+					eprintf ("Cannot find function at 0x%08" PFMT64x "\n", off);
 				}
 			}
 			free (name);
@@ -3230,7 +3230,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 		}
 		if (name) {
 			if (*name && !setFunctionName (core, addr, name, true)) {
-				eprintf ("Cannot find function '%s' at 0x%08" PFMT64x "\n", name, (ut64)addr);
+				eprintf ("Cannot find function at 0x%08" PFMT64x "\n", (ut64)addr);
 			}
 			free (name);
 		}


### PR DESCRIPTION
When renaming a function fails because no such function exists
at the given address, don't include the new name in the error message
as it is unrelated to the cause of the error.