### PR TITLE
Improve argument parsing in af and afr.

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3156,7 +3156,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 
 		// first undefine
 		if (input[0] && input[1] == ' ') {
-			name = strdup (input + 2);
+			name = strdup (r_str_trim_ro (input + 2));
 			uaddr = strchr (name, ' ');
 			if (uaddr) {
 				*uaddr++ = 0;


### PR DESCRIPTION
We now skip leading whitespace when looking for the first argument
to these commands (the function's name). Previously, the following
command
  af  fcn.foo @ 0x000affe
would try to define a function with an empty name at offset
"fcn.foo @ 0x000affe".