### PR TITLE
remove err dp error message, which is triggered for no reason by afu

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1655,7 +1655,6 @@ R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dept
 		return false;
 	}
 	if (at == UT64_MAX || depth < 0) {
-		eprintf ("err dp\n");
 		return false;
 	}
 	if (r_cons_is_breaked ()) {


### PR DESCRIPTION
When using afu on code with jumps and calls, this error message is triggered. May be related to the fact, that afu does not iterate down into the referenced functions, which is as intended in my situation.
