### PR TITLE
initial band-aid fix for a UAF with two seperate desc pointers

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -13,6 +13,7 @@ typedef struct {
 #define UNSUPPORTED 0
 #define SUPPORTED 1
 
+static RIOGdb ** origriogdb = NULL;
 static libgdbr_t *desc = NULL;
 static ut8* reg_buf = NULL;
 static int buf_size = 0;
@@ -363,6 +364,7 @@ static int r_debug_gdb_attach(RDebug *dbg, int pid) {
 	if (d && d->plugin && d->plugin->name && d->data) {
 		if (!strcmp ("gdb", d->plugin->name)) {
 			RIOGdb *g = d->data;
+			origriogdb = (RIOGdb **)&d->data;	//TODO bit of a hack, please improve
 			support_sw_bp = UNKNOWN;
 			support_hw_bp = UNKNOWN;
 			int arch = r_sys_arch_id (dbg->arch);
@@ -1044,7 +1046,8 @@ static bool r_debug_gdb_kill(RDebug *dbg, int pid, int tid, int sig) {
 }
 
 static int r_debug_gdb_select(int pid, int tid) {
-	if (!desc) {
+	if (!desc  || !*origriogdb ) {
+		desc = NULL;	//TODO hacky fix, please improve. I would suggest using a **desc instead of a *desc, so it is automatically updated
 		return false;
 	}
 	return gdbr_select (desc, pid, tid) >= 0;

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -179,6 +179,9 @@ static int __close(RIODesc *fd) {
 	}
 	gdbr_disconnect (desc);
 	gdbr_cleanup (desc);
+	if (riogdb) {	//TODO is there a less band-aid fix to do this?
+		riogdb->data = NULL;
+	}
 	R_FREE (desc);
 	return -1;
 }


### PR DESCRIPTION
Two separate desc pointers (one in libr/debug/p/debug_gdb.c and one in libr/io/p/io_gdb.c) would result in a UAF during doo, because the debug_gdb.c one would never be nulled.

This is a band_aid fix for this. Please make it less of a kludge.


This issue can be replicated by attaching to any gdbserver session and running doo.