### PR TITLE
Fix inverse video esc handling in r_cons_w32_print

### DIFF
--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -238,8 +238,8 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, bool vmode) {
 				continue;
 				// invert off
 			} else if (ptr[0]=='7'&&ptr[1]=='m') {
-				SetConsoleTextAttribute (hConsole, bg|fg|128);
-				inv = 128;
+				SetConsoleTextAttribute (hConsole, bg|fg|COMMON_LVB_REVERSE_VIDEO);
+				inv = COMMON_LVB_REVERSE_VIDEO;
 				esc = 0;
 				ptr = ptr + 1;
 				str = ptr + 1;


### PR DESCRIPTION
Before:
![inv_vid_before](https://user-images.githubusercontent.com/12002672/57992256-bdaf6a00-7ae5-11e9-9505-be06ef86631f.PNG)

After:
![inv_vid_after](https://user-images.githubusercontent.com/12002672/57992303-f3ece980-7ae5-11e9-8600-1600ea39569b.PNG)
