### PR TITLE
Implement r_malloc, r_free, etc. in .c

### DIFF
--- a/libr/include/r_util/r_alloc.h
+++ b/libr/include/r_util/r_alloc.h
@@ -38,10 +38,10 @@ R_API void r_free(void *p);
 
 #else
 
-#define r_malloc(x) malloc((x))
-#define r_calloc(x,y) calloc((x),(y))
-#define r_realloc(x,y) realloc((x),(y))
-#define r_free(x) free((x))
+R_API void *r_malloc(size_t sz);
+R_API void *r_calloc(size_t count, size_t sz);
+R_API void *r_realloc(void *p, size_t sz);
+R_API void r_free(void *p);
 
 #define _r_malloc r_malloc
 #define _r_calloc r_calloc

--- a/libr/util/alloc.c
+++ b/libr/util/alloc.c
@@ -56,6 +56,25 @@ R_API void r_free(void *p) {
 	return _r_free (p);
 }
 #endif
+
+#else
+
+R_API void *r_malloc(size_t sz) {
+	return malloc (sz);
+}
+
+R_API void *r_calloc(size_t count, size_t sz) {
+	return calloc (count, sz);
+}
+
+R_API void *r_realloc(void *p, size_t sz) {
+	return realloc (p, sz);
+}
+
+R_API void r_free(void *p) {
+	return free (p);
+}
+
 #endif
 
 R_API void* r_malloc_aligned(size_t size, size_t alignment) {


### PR DESCRIPTION
This is necessary for Cutter, because we must match the right `free()` for memory allocated from r2. Just calling free directly causes crashes on Windows.