### PR TITLE
Set scr.ansicon=1 if running under Windows 10 Creators Update or later

### DIFF
--- a/libr/cons/line.c
+++ b/libr/cons/line.c
@@ -16,7 +16,7 @@ R_API RLine *r_line_new() {
 	I.prompt = strdup ("> ");
 	I.contents = NULL;
 #if __WINDOWS__
-	I.ansicon = r_sys_getenv ("ANSICON");
+	I.ansicon = r_cons_get_ansicon ();
 #endif
 	if (!r_line_dietline_init ()) {
 		eprintf ("error: r_line_dietline_init\n");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -714,6 +714,7 @@ R_API int r_cons_pipe_open(const char *file, int fdn, int append);
 R_API void r_cons_pipe_close(int fd);
 
 #if __WINDOWS__
+R_API int r_cons_get_ansicon();
 R_API void r_cons_w32_gotoxy(int fd, int x, int y);
 R_API int r_cons_w32_print(const ut8 *ptr, int len, bool vmode);
 R_API int r_cons_win_printf(bool vmode, const char *fmt, ...);


### PR DESCRIPTION
Detection of Windows version is done [via registry keys](https://blog.yaakov.online/finding-operating-system-version/). Windows 10 Creators Update [introduced 24-bit color support in cmd.exe](https://devblogs.microsoft.com/commandline/windows-10-creators-update-whats-new-in-bashwsl-windows-console/). Its release id [is 1703](https://pureinfotech.com/what-windows-10-creators-update/).