### PR TITLE
#define ENABLE_VIRTUAL_TERMINAL_PROCESSING if it's not defined

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1917,7 +1917,6 @@ static int scr_ansicon(void *user, void *data) {
 		node->i_value = 1;
 	}
 	r_line_singleton ()->ansicon = r_cons_singleton ()->ansicon = node->i_value;
-# ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 	HANDLE streams[] = { GetStdHandle (STD_OUTPUT_HANDLE), GetStdHandle (STD_ERROR_HANDLE) };
 	DWORD mode;
 	int i;
@@ -1934,7 +1933,6 @@ static int scr_ansicon(void *user, void *data) {
 			                mode & ~ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 		}
 	}
-# endif
 	return true;
 }
 #endif

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -35,6 +35,9 @@ extern "C" {
 #include <windows.h>
 #include <wincon.h>
 #include <winuser.h>
+# ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+# define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+# endif
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
Blindfix for https://github.com/radare/radare2/issues/14101#issuecomment-496665065. It appears to be [an acceptable way](https://www.google.com/search?q=ENABLE_VIRTUAL_TERMINAL_PROCESSING+Windows.h) of doing things.