### PR TITLE
Make zignature comparison fuzzy ##signature

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3052,6 +3052,8 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("zign.refs", "true", "Use references for matching");
 	SETPREF ("zign.hash", "true", "Use Hash for matching");
 	SETPREF ("zign.autoload", "false", "Autoload all zignatures located in " R_JOIN_2_PATHS ("~", R2_HOME_ZIGNS));
+	SETPREF ("zign.diff.bthresh", "1.0", "Threshold for diffing zign bytes [0, 1] (see zc?)");
+	SETPREF ("zign.diff.gthresh", "1.0", "Threshold for diffing zign graphs [0, 1] (see zc?)");
 
 	/* diff */
 	SETCB ("diff.sort", "addr", &cb_diff_sort, "Specify function diff sorting column see (e diff.sort=?)");

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -81,6 +81,11 @@ typedef struct r_sign_search_t {
 	void *user;
 } RSignSearch;
 
+typedef struct r_sign_options_t {
+	double bytes_diff_threshold;
+	double graph_diff_threshold;
+} RSignOptions;
+
 #ifdef R_API
 R_API bool r_sign_add_bytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, const ut8 *mask);
 R_API bool r_sign_add_anal(RAnal *a, const char *name, ut64 size, const ut8 *bytes, ut64 at);
@@ -127,8 +132,11 @@ R_API int r_sign_is_flirt(RBuffer *buf);
 R_API void r_sign_flirt_dump(const RAnal *anal, const char *flirt_file);
 R_API void r_sign_flirt_scan(RAnal *anal, const char *flirt_file);
 
-R_API bool r_sign_diff(RAnal *a, const char *other_space_name);
-R_API bool r_sign_diff_by_name(RAnal *a, const char *other_space_name, bool not_matching);
+R_API bool r_sign_diff(RAnal *a, RSignOptions *options, const char *other_space_name);
+R_API bool r_sign_diff_by_name(RAnal *a, RSignOptions *options, const char *other_space_name, bool not_matching);
+
+R_API RSignOptions *r_sign_options_new(const char *bytes_thresh, const char *graph_thresh);
+R_API void r_sign_options_free(RSignOptions *options);
 #endif
 
 #ifdef __cplusplus

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -78,6 +78,7 @@ R_API int r_num_str_len(const char *str);
 R_API int r_num_str_split(char *str);
 R_API RList *r_num_str_split_list(char *str);
 R_API void *r_num_dup(ut64 n);
+R_API double r_num_get_float(RNum *num, const char *str);
 
 static inline st64 r_num_abs(st64 num) {
 	return num < 0 ? -num : num;


### PR DESCRIPTION
- it will match zignatures which similarity is >= the given threshold
- different thresholds for bytes and graph
- by default thresholds are 1.0, which means it matches only if it’s the exact same
- zign.diff.gthresh and zign.diff.bthresh are the new eval configs to control that
- the output of zc[n!] now contains the similarity value as well

Example:

```
[0x00000000]> . ./zignatures-CoreText-11.2.6-big
[0x00000000]> . ./zignatures-CoreText-11.2.5-big
[0x00000000]> zcn! CoreText1126~ G
Diff by name 3198 3196 (not maching)
0x184c507e8 0x187ad0818 0.95742 G CoreText1125:sym.sec.JapaneseCompositionRules::GetCharacterClass_unsigned_int
0x184c18138 0x187a98108 0.99996 G CoreText1125:sym.sec.TCFBase_TRubyAnnotation_::ClassDestruct_void_const
0x184c55ac8 0x187ad5af8 0.82722 G CoreText1125:sym.sec.OpenTypeReorderingOutput::finalizeOutput
0x184c4ca80 0x187acca50 0.99494 G CoreText1125:sym.sec.IndicShapingEngine::SetV1Features_unsigned_int
[0x00000000]> e zign.diff.gthresh=0.85
[0x00000000]> zcn! CoreText1126~ G
Diff by name 3198 3196 (not maching)
0x184c55ac8 0x187ad5af8 0.82722 G CoreText1125:sym.sec.OpenTypeReorderingOutput::finalizeOutput
[0x00000000]>
```