### PR TITLE
Remove last load/load_bytes methods

### DIFF
--- a/libr/bin/obj.c
+++ b/libr/bin/obj.c
@@ -173,51 +173,6 @@ R_IPI RBinObject *r_bin_object_new(RBinFile *bf, RBinPlugin *plugin, ut64 basead
 			free (o);
 			return NULL;
 		}
-	} else if (plugin && plugin->load_bytes && (bytes_sz >= sz + offset)) {
-		// DEPRECATE
-		R_LOG_WARN ("Plugin %s should implement load_buffer method instead of load_bytes.\n", plugin->name);
-		// XXX more checking will be needed here
-		// only use LoadBytes if buffer offset != 0
-		// if (offset != 0 && bytes && plugin && plugin->load_bytes && (bytes_sz
-		// >= sz + offset) ) {
-		ut64 bsz = bytes_sz - offset;
-		if (sz < bsz) {
-			bsz = sz;
-		}
-		ut8 *bytes = malloc (sz);
-		if (!bytes) {
-			eprintf ("Cannot allocate %" PFMT64u " bytes\n", sz);
-			free (o);
-			return NULL;
-		}
-		r_buf_read_at (bf->buf, offset, bytes, sz);
-		// TODO: use r_buf_data meanwhile.. meh just kill it with fire
-		if (!plugin->load_bytes (bf, &o->bin_obj, bytes, sz, loadaddr, sdb)) {
-			if (bf->rbin->verbose) {
-				eprintf ("Error in r_bin_object_new: load_bytes failed for %s plugin\n", plugin->name);
-			}
-			sdb_free (o->kv);
-			free (bytes);
-			free (o);
-			return NULL;
-		}
-		free (bytes);
-	} else if (plugin->load) {
-		// DEPRECATE
-		R_LOG_WARN ("Plugin %s should implement load_buffer method instead of load.\n", plugin->name);
-		// XXX - haha, this is a hack.
-		// switching out the current object for the new
-		// one to be processed
-		RBinObject *old_o = bf->o;
-		bf->o = o;
-		if (plugin->load (bf)) {
-			//bf->sdb_info = o->kv;
-			// mark as do not walk
-			//sdb_ns_set (bf->sdb, "info", o->kv);
-		} else {
-			bf->o = old_o;
-		}
-		o->obj_size = sz;
 	} else {
 		R_LOG_WARN ("Plugin %s should implement load_buffer method.\n", plugin->name);
 		sdb_free (o->kv);

--- a/libr/bin/p/bin_fs.c
+++ b/libr/bin/p/bin_fs.c
@@ -51,12 +51,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 	return check_buffer (buf);
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	ut64 la = bf->o->loadaddr;
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, la, bf->sdb);
-}
-
 static void destroy(RBinFile *bf) {
 	//r_bin_fs_free ((struct r_bin_fs_obj_t*)bf->o->bin_obj);
 }
@@ -99,7 +93,6 @@ RBinPlugin r_bin_plugin_fs = {
 	.author = "pancake",
 	.version = "1.0",
 	.license = "LGPL3",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,

--- a/libr/bin/p/bin_mbn.c
+++ b/libr/bin/p/bin_mbn.c
@@ -78,13 +78,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 	return check_buffer (b);
 }
 
-static bool load(RBinFile *bf) {
-	if (bf && bf->buf) {
-		return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-	}
-	return false;
-}
-
 static ut64 baddr(RBinFile *bf) {
 	return sb.vaddr; // XXX
 }
@@ -194,8 +187,6 @@ RBinPlugin r_bin_plugin_mbn = {
 	.desc = "MBN/SBL bootloader things",
 	.license = "LGPL3",
 	.minstrlen = 10,
-	.load = &load,
-	// .load_bytes = &load_bytes,
 	.load_buffer = &load_buffer,
 	.size = &size,
 	.check_buffer = &check_buffer,

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -194,11 +194,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 	return false;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-}
-
 static RList *sections(RBinFile *bf) {
 	struct minidump_memory_descriptor *memory;
 	struct minidump_memory_descriptor64 *memory64;
@@ -493,7 +488,6 @@ RBinPlugin r_bin_plugin_mdmp = {
 	.imports = &imports,
 	.info = &info,
 	.libs = &libs,
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.mem = &mem,

--- a/libr/bin/p/bin_menuet.c
+++ b/libr/bin/p/bin_menuet.c
@@ -70,11 +70,6 @@ static bool load_buffer (RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr
 	return check_buffer (b);
 }
 
-static bool load(RBinFile *bf) {
-	ut64 la = (bf && bf->o)? bf->o->loadaddr: 0;
-	return load_buffer (bf, bf->o->bin_obj, bf->buf, la, bf->sdb);
-}
-
 static ut64 baddr(RBinFile *bf) {
 	return 0; // 0x800000;
 }
@@ -212,7 +207,6 @@ RBinPlugin r_bin_plugin_menuet = {
 	.name = "menuet",
 	.desc = "Menuet/KolibriOS bin plugin",
 	.license = "LGPL3",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.size = &size,
 	.check_buffer = &check_buffer,

--- a/libr/bin/p/bin_nin3ds.c
+++ b/libr/bin/p/bin_nin3ds.c
@@ -24,12 +24,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 	return false;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-	return check_buffer (bf->buf);
-}
-
 static RList *sections(RBinFile *bf) {
 	RList *ret = NULL;
 	RBinSection *sections[4] = {
@@ -137,7 +131,6 @@ RBinPlugin r_bin_plugin_nin3ds = {
 	.name = "nin3ds",
 	.desc = "Nintendo 3DS FIRM format r_bin plugin",
 	.license = "LGPL3",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.entries = &entries,

--- a/libr/bin/p/bin_ninds.c
+++ b/libr/bin/p/bin_ninds.c
@@ -31,11 +31,6 @@ static bool load_buffer (RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr
 	return (*bin_obj != NULL);
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-}
-
 static ut64 baddr(RBinFile *bf) {
 	return (ut64) loaded_header.arm9_ram_address;
 }
@@ -135,7 +130,6 @@ RBinPlugin r_bin_plugin_ninds = {
 	.name = "ninds",
 	.desc = "Nintendo DS format r_bin plugin",
 	.license = "LGPL3",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,

--- a/libr/bin/p/bin_ningb.c
+++ b/libr/bin/p/bin_ningb.c
@@ -15,9 +15,8 @@ static bool check_buffer(RBuffer *b) {
 	return false;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return check_buffer (bf->buf);
+static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
+	return check_buffer (buf);
 }
 
 static ut64 baddr(RBinFile *bf) {
@@ -288,7 +287,7 @@ RBinPlugin r_bin_plugin_ningb = {
 	.name = "ningb",
 	.desc = "Gameboy format r_bin plugin",
 	.license = "LGPL3",
-	.load = &load,
+	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.binsym = &binsym,

--- a/libr/bin/p/bin_ningba.c
+++ b/libr/bin/p/bin_ningba.c
@@ -14,9 +14,8 @@ static bool check_buffer(RBuffer *b) {
 	return !memcmp (lict, lic_gba, 156);
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return check_buffer (bf->buf);
+static bool load_buffer(RBinFile * bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
+	return check_buffer (buf);
 }
 
 static RList *entries(RBinFile *bf) {
@@ -87,7 +86,7 @@ RBinPlugin r_bin_plugin_ningba = {
 	.name = "ningba",
 	.desc = "Game Boy Advance format r_bin plugin",
 	.license = "LGPL3",
-	.load = &load,
+	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.entries = &entries,
 	.info = &info,

--- a/libr/bin/p/bin_nro.c
+++ b/libr/bin/p/bin_nro.c
@@ -53,12 +53,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 	return true;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->buf && bf->o, false);
-	const ut64 la = bf->o->loadaddr;
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, la, bf->sdb);
-}
-
 static RBinAddr *binsym(RBinFile *bf, int type) {
 	return NULL; // TODO
 }
@@ -262,7 +256,6 @@ RBinPlugin r_bin_plugin_nro = {
 	.name = "nro",
 	.desc = "Nintendo Switch NRO0 binaries",
 	.license = "MIT",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,

--- a/libr/bin/p/bin_omf.c
+++ b/libr/bin/p/bin_omf.c
@@ -13,11 +13,6 @@ static bool load_buffer (RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr
 	return *bin_obj != NULL;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-}
-
 static void destroy(RBinFile *bf) {
 	r_bin_free_all_omf_obj (bf->o->bin_obj);
 	bf->o->bin_obj = NULL;
@@ -154,7 +149,6 @@ RBinPlugin r_bin_plugin_omf = {
 	.name = "omf",
 	.desc = "omf bin plugin",
 	.license = "LGPL3",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -395,7 +395,6 @@ RBinPlugin r_bin_plugin_pe = {
 	.desc = "PE bin plugin",
 	.license = "LGPL3",
 	.get_sdb = &get_sdb,
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -28,11 +28,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 	return false;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-}
-
 static void destroy(RBinFile *bf) {
 	PE_(r_bin_pe_free) ((struct PE_(r_bin_pe_obj_t)*)bf->o->bin_obj);
 }

--- a/libr/bin/p/bin_pe64.c
+++ b/libr/bin/p/bin_pe64.c
@@ -135,7 +135,6 @@ RBinPlugin r_bin_plugin_pe64 = {
 	.desc = "PE64 (PE32+) bin plugin",
 	.license = "LGPL3",
 	.get_sdb = &get_sdb,
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -47,10 +47,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 	return check_buffer (b);
 }
 
-static bool load(RBinFile *bf) {
-	return check_buffer (bf->buf);
-}
-
 static ut64 baddr(RBinFile *bf) {
 	return 0LL;
 }
@@ -191,7 +187,6 @@ RBinPlugin r_bin_plugin_pebble = {
 	.name = "pebble",
 	.desc = "Pebble Watch App",
 	.license = "LGPL",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,

--- a/libr/bin/p/bin_sms.c
+++ b/libr/bin/p/bin_sms.c
@@ -32,8 +32,8 @@ static bool check_buffer(RBuffer *b) {
 	return false;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
-	return check_buffer (bf->buf);
+static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
+	return check_buffer (buf);
 }
 
 static RBinInfo *info(RBinFile *bf) {
@@ -103,7 +103,7 @@ RBinPlugin r_bin_plugin_sms = {
 	.name = "sms",
 	.desc = "SEGA MasterSystem/GameGear",
 	.license = "LGPL3",
-	.load_bytes = &load_bytes,
+	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.info = &info,
 	.minstrlen = 10,

--- a/libr/bin/p/bin_te.c
+++ b/libr/bin/p/bin_te.c
@@ -30,11 +30,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 	return true;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-}
-
 static void destroy(RBinFile *bf) {
 	r_bin_te_free ((struct r_bin_te_obj_t *) bf->o->bin_obj);
 }
@@ -157,7 +152,6 @@ RBinPlugin r_bin_plugin_te = {
 	.desc = "TE bin plugin", // Terse Executable format
 	.license = "LGPL3",
 	.get_sdb = &get_sdb,
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -35,11 +35,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 	return false;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-}
-
 static void destroy(RBinFile *bf) {
 	r_bin_wasm_destroy (bf);
 }
@@ -323,7 +318,6 @@ RBinPlugin r_bin_plugin_wasm = {
 	.name = "wasm",
 	.desc = "WebAssembly bin plugin",
 	.license = "MIT",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.size = &size,
 	.destroy = &destroy,

--- a/libr/bin/p/bin_z64.c
+++ b/libr/bin/p/bin_z64.c
@@ -88,11 +88,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 	return false;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return check_buffer (bf->buf);
-}
-
 static RList *entries(RBinFile *bf) {
 	RList /*<RBinAddr>*/ *ret = r_list_newf (free);
 	if (!ret) {
@@ -156,7 +151,6 @@ RBinPlugin r_bin_plugin_z64 = {
 	.name = "z64",
 	.desc = "Nintendo 64 binaries big endian r_bin plugin",
 	.license = "LGPL3",
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.baddr = baddr,

--- a/libr/bin/p/bin_zimg.c
+++ b/libr/bin/p/bin_zimg.c
@@ -17,11 +17,6 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 	return *bin_obj != NULL;
 }
 
-static bool load(RBinFile *bf) {
-	r_return_val_if_fail (bf && bf->o, false);
-	return load_buffer (bf, &bf->o->bin_obj, bf->buf, bf->o->loadaddr, bf->sdb);
-}
-
 static ut64 baddr(RBinFile *bf) {
 	return 0;
 }
@@ -63,7 +58,6 @@ RBinPlugin r_bin_plugin_zimg = {
 	.desc = "zimg format bin plugin",
 	.license = "LGPL3",
 	.get_sdb = &get_sdb,
-	.load = &load,
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -404,8 +404,6 @@ typedef struct r_bin_plugin_t {
 	int (*init)(void *user);
 	int (*fini)(void *user);
 	Sdb * (*get_sdb)(RBinFile *obj);
-	bool (*load)(RBinFile *arch);
-	bool (*load_bytes)(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb);
 	bool (*load_buffer)(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb);
 	ut64 (*size)(RBinFile *bin); // return ut64 maybe? meh
 	void (*destroy)(RBinFile *arch);


### PR DESCRIPTION
I guess the time has come to remove load/load_bytes from RBinPlugin :)

Hopefully this will allow to clean even further the `r_bin_object_new` function and others as well in the future.