### PR TITLE
Use _exit() in pipe child

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -26,8 +26,8 @@ R_API void r_sys_set_environ(char **e);
 R_API ut64 r_sys_now(void);
 R_API const char *r_time_to_string (ut64 ts);
 R_API int r_sys_fork(void);
-// immediately = false => exit(); true => _exit()
-R_API void r_sys_exit(int status, bool immediately);
+// nocleanup = false => exit(); true => _exit()
+R_API void r_sys_exit(int status, bool nocleanup);
 R_API bool r_sys_stop(void);
 R_API char *r_sys_pid_to_path(int pid);
 R_API int r_sys_run(const ut8 *buf, int len);

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -26,7 +26,8 @@ R_API void r_sys_set_environ(char **e);
 R_API ut64 r_sys_now(void);
 R_API const char *r_time_to_string (ut64 ts);
 R_API int r_sys_fork(void);
-R_API void r_sys_exit_immediately(int status); // _exit(int status)
+// immediately = false => exit(); true => _exit()
+R_API void r_sys_exit(int status, bool immediately);
 R_API bool r_sys_stop(void);
 R_API char *r_sys_pid_to_path(int pid);
 R_API int r_sys_run(const ut8 *buf, int len);

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -26,6 +26,7 @@ R_API void r_sys_set_environ(char **e);
 R_API ut64 r_sys_now(void);
 R_API const char *r_time_to_string (ut64 ts);
 R_API int r_sys_fork(void);
+R_API void r_sys_exit_immediately(int status); // _exit(int status)
 R_API bool r_sys_stop(void);
 R_API char *r_sys_pid_to_path(int pid);
 R_API int r_sys_run(const ut8 *buf, int len);

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -156,7 +156,7 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 		close (input[1]);
 		close (output[0]);
 		close (output[1]);
-		exit (0);
+		r_sys_exit_immediately (0);
 		return false;
 	} else {
 		/* parent */

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -158,7 +158,7 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 		close (output[1]);
 		fflush (stdout);
 		fflush (stderr);
-		r_sys_exit_immediately (0);
+		r_sys_exit (0, true);
 		return false;
 	} else {
 		/* parent */

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -156,6 +156,8 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 		close (input[1]);
 		close (output[0]);
 		close (output[1]);
+		fflush (stdout);
+		fflush (stderr);
 		r_sys_exit_immediately (0);
 		return false;
 	} else {

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -116,8 +116,8 @@ R_API int r_sys_fork() {
 #endif
 }
 
-R_API void r_sys_exit(int status, bool immediately) {
-	if (immediately) {
+R_API void r_sys_exit(int status, bool nocleanup) {
+	if (nocleanup) {
 		_exit (status);
 	} else {
 		exit (status);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -116,6 +116,10 @@ R_API int r_sys_fork() {
 #endif
 }
 
+R_API void r_sys_exit_immediately(int status) {
+	_exit (status);
+}
+
 /* TODO: import stuff fron bininfo/p/bininfo_addr2line */
 /* TODO: check endianness issues here */
 R_API ut64 r_sys_now(void) {

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -116,8 +116,12 @@ R_API int r_sys_fork() {
 #endif
 }
 
-R_API void r_sys_exit_immediately(int status) {
-	_exit (status);
+R_API void r_sys_exit(int status, bool immediately) {
+	if (immediately) {
+		_exit (status);
+	} else {
+		exit (status);
+	}
 }
 
 /* TODO: import stuff fron bininfo/p/bininfo_addr2line */


### PR DESCRIPTION
Using `exit()` here leads to atexit functions and C++ destructors to be called in the child process, which is incorrect and in Cutter ultimately makes the forked child processes to be stuck forever even after exiting Cutter.

Maybe `r_sys_exit_immediately()` will need some ifdefs since `_exit()` is not part of C standard, but right now I don't know a platform we support that doesn't have it.

Also maybe it is necessary to flush some streams before the call, as `man _exit` says:
```
Open stdio(3) streams are not flushed.
```
But perhaps someone else here can say more about whether this is necessary here.