### PR TITLE
Fix asm.varsub in a hacky way to fix the disasm output ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1071,8 +1071,8 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 						if (fi) {
 							strcpy (ox, fi->name);
 							strcat (ox, e);
-							free (e);
 						}
+						free (e);
 					}
 				}
 			}

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -587,7 +587,11 @@ static int filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, c
 		}
 		ptr = ptr2;
 	}
-	strncpy (str, data, len);
+	if (data != str) {
+		strncpy (str, data, len);
+	} else {
+		eprintf ("Invalid str/data inputs\n");
+	}
 	return false;
 }
 


### PR DESCRIPTION
test

```
$ cat /tmp/distest.r2
s 0x100001232
pd 1
f fin.dustrial=0x1000054d0
pd 1
s0x100001211
pd 1
```

[ls.zip](https://github.com/radare/radare2/files/3259702/ls.zip)
