### PR TITLE
fix hexpairs search containing whitespace

### DIFF
--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -468,7 +468,11 @@ R_API int r_hex_str2binmask(const char *in, ut8 *out, ut8 *mask) {
 			memcpy (mask + ilen, "f0", 3);
 		}
 		for (ptr = mask; *ptr; ptr++) {
-			*ptr = (*ptr == '.') ? '0' : 'f';
+			if (IS_HEXCHAR (*ptr)) {
+				*ptr = 'f';
+			} else if (*ptr == '.') {
+				*ptr = '0';
+			}
 		}
 		len = r_hex_str2bin ((char*)mask, mask);
 		if (len < 0) {


### PR DESCRIPTION
* Symptom: Search often failes when hexpairs are separated by spaces, e.g. "01 02 03" vs. "010203".
* Affected: radare2 and rafind2 at least
* Description: While parse-function r_hex_str2bin handles whitespace, auto-generated binmask
	(function r_hex_str2binmask, called when no mask is provided) does not, creates oversized mask,
	increases byte count, finally causing search for additional undefined bytes.