### PR TITLE
Add also bold to default palette items that are bright

### DIFF
--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -156,6 +156,7 @@ R_API void r_cons_pal_init(RConsContext *ctx) {
 	ctx->cpal.bin                = (RColor) RColor_CYAN;
 	ctx->cpal.btext              = (RColor) RColor_YELLOW;
 	ctx->cpal.call               = (RColor) RColor_BGREEN;
+	ctx->cpal.call.attr          = R_CONS_ATTR_BOLD;
 	ctx->cpal.ucall              = (RColor) RColor_GREEN;
 	ctx->cpal.ujmp               = (RColor) RColor_GREEN;
 	ctx->cpal.cjmp               = (RColor) RColor_GREEN;
@@ -172,6 +173,7 @@ R_API void r_cons_pal_init(RConsContext *ctx) {
 	ctx->cpal.help               = (RColor) RColor_GREEN;
 	ctx->cpal.input              = (RColor) RColor_WHITE;
 	ctx->cpal.invalid            = (RColor) RColor_BRED;
+	ctx->cpal.invalid.attr       = R_CONS_ATTR_BOLD;
 	ctx->cpal.jmp                = (RColor) RColor_GREEN;
 	ctx->cpal.label              = (RColor) RColor_CYAN;
 	ctx->cpal.math               = (RColor) RColor_YELLOW;
@@ -181,6 +183,7 @@ R_API void r_cons_pal_init(RConsContext *ctx) {
 	ctx->cpal.offset             = (RColor) RColor_GREEN;
 	ctx->cpal.other              = (RColor) RColor_WHITE;
 	ctx->cpal.pop                = (RColor) RColor_BMAGENTA;
+	ctx->cpal.pop.attr           = R_CONS_ATTR_BOLD;
 	ctx->cpal.prompt             = (RColor) RColor_YELLOW;
 	ctx->cpal.push               = (RColor) RColor_MAGENTA;
 	ctx->cpal.crypto             = (RColor) RColor_BGBLUE;
@@ -188,6 +191,7 @@ R_API void r_cons_pal_init(RConsContext *ctx) {
 	ctx->cpal.ret                = (RColor) RColor_RED;
 	ctx->cpal.swi                = (RColor) RColor_MAGENTA;
 	ctx->cpal.trap               = (RColor) RColor_BRED;
+	ctx->cpal.trap.attr          = R_CONS_ATTR_BOLD;
 
 	ctx->cpal.ai_read            = (RColor) RColor_GREEN;
 	ctx->cpal.ai_write           = (RColor) RColor_BLUE;


### PR DESCRIPTION
Added bold according to https://github.com/radare/radare2/pull/14232/files. This is done because there are Ansi16 color schemes that have poor color separation between normal and bright colors.