### PR TITLE
WIP: Really basic implementation of esil.timeout.

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2804,8 +2804,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("esil.stack.pattern", "0", "Specify fill pattern to initialize the stack (0, w, d, i)");
 	SETI ("esil.addr.size", 64, "Maximum address size in accessed by the ESIL VM");
 	SETPREF ("esil.breakoninvalid", "false", "Break esil execution when instruction is invalid");
-  SETI ("esil.timeout", 0, "A timeout (in seconds) for when we should give up emulating");
-	
+	SETI ("esil.timeout", 0, "A timeout (in seconds) for when we should give up emulating");
 	/* asm */
 	//asm.os needs to be first, since other asm.* depend on it
 	n = NODECB ("asm.os", R_SYS_OS, &cb_asmos);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2804,7 +2804,8 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("esil.stack.pattern", "0", "Specify fill pattern to initialize the stack (0, w, d, i)");
 	SETI ("esil.addr.size", 64, "Maximum address size in accessed by the ESIL VM");
 	SETPREF ("esil.breakoninvalid", "false", "Break esil execution when instruction is invalid");
-
+  SETI ("esil.timeout", 0, "A timeout (in seconds) for when we should give up emulating");
+	
 	/* asm */
 	//asm.os needs to be first, since other asm.* depend on it
 	n = NODECB ("asm.os", R_SYS_OS, &cb_asmos);
@@ -3031,7 +3032,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("cfg.sandbox", "false", &cb_cfgsanbox, "Sandbox mode disables systems and open on upper directories");
 	SETPREF ("cfg.wseek", "false", "Seek after write");
 	SETCB ("cfg.bigendian", "false", &cb_bigendian, "Use little (false) or big (true) endianness");
-	
+
 	/* log */
 	// R2_LOGLEVEL / log.level
 	p = r_sys_getenv ("R2_LOGLEVEL");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3828,8 +3828,7 @@ R_API int r_core_esil_step(RCore *core, ut64 until_addr, const char *until_expr,
 	if (!esil) {
 		initializeEsil (core);
 	}
-	if (esiltimeout)
-	{
+	if (esiltimeout) {
 		startTime = clock();
 	}
 	ut64 addr = r_reg_getv (core->anal->reg, name);
@@ -3840,12 +3839,10 @@ repeat:
 		return_tail (0);
 	}
 	//Break if we have exceeded esil.timeout
-	if (esiltimeout)
-	{
+	if (esiltimeout) {
 		endTime = clock();
 		double elapsedTime = ((double)endTime-startTime) / CLOCKS_PER_SEC;
-		if (elapsedTime >= esiltimeout)
-		{
+		if (elapsedTime >= esiltimeout) {
 			eprintf ("[ESIL] Timeout exceeded.\n");
 			return_tail (0);
 		}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3841,7 +3841,8 @@ repeat:
 	//Break if we have exceeded esil.timeout
 	if (esiltimeout) {
 		ut64 elapsedTime = r_sys_now () - startTime;
-		if (elapsedTime >= (esiltimeout * 1000000)) {
+		elapsedTime >>= 20;
+		if (elapsedTime >= esiltimeout) {
 			eprintf ("[ESIL] Timeout exceeded.\n");
 			return_tail (0);
 		}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1206,7 +1206,7 @@ static int var_cmd(RCore *core, const char *str) {
 		r_anal_var_list_show (core->anal, fcn, type, str[1], pj);
 		r_cons_println (pj_string (pj));
 		pj_free (pj);
-	} 
+	}
 		break;
 	case '.':
 		r_anal_var_list_show (core->anal, fcn, core->offset, 0, NULL);
@@ -3403,7 +3403,7 @@ static void __anal_reg_list(RCore *core, int type, int bits, char mode) {
 // XXX dup from drp :OOO
 void cmd_anal_reg(RCore *core, const char *str) {
 	if (0) {
-		/* enable this block when dr and ar use the same code but just using 
+		/* enable this block when dr and ar use the same code but just using
 		   core->dbg->reg or core->anal->reg and removing all the debugger
 		   dependent code */
 		RReg *reg = core->dbg->reg;
@@ -3823,8 +3823,14 @@ R_API int r_core_esil_step(RCore *core, ut64 until_addr, const char *until_expr,
 	RAnalEsil *esil = core->anal->esil;
 	const char *name = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 	bool breakoninvalid = r_config_get_i (core->config, "esil.breakoninvalid");
+	int esiltimeout = r_config_get_i (core->config, "esil.timeout");
+	clock_t startTime, endTime;
 	if (!esil) {
 		initializeEsil (core);
+	}
+	if (esiltimeout)
+	{
+		startTime = clock();
 	}
 	ut64 addr = r_reg_getv (core->anal->reg, name);
 	r_cons_break_push (NULL, NULL);
@@ -3832,6 +3838,17 @@ repeat:
 	if (r_cons_is_breaked ()) {
 		eprintf ("[+] ESIL emulation interrupted at 0x%08" PFMT64x "\n", addr);
 		return_tail (0);
+	}
+	//Break if we have exceeded esil.timeout
+	if (esiltimeout)
+	{
+		endTime = clock();
+		double elapsedTime = ((double)endTime-startTime) / CLOCKS_PER_SEC;
+		if (elapsedTime >= esiltimeout)
+		{
+			eprintf ("[ESIL] Timeout exceeded.\n");
+			return_tail (0);
+		}
 	}
 	if (!esil) {
 		addr = initializeEsil (core);
@@ -4484,7 +4501,7 @@ static void showmem (RList *list) {
 		RListIter *iter;
 		r_list_foreach (list, iter, item) {
 			r_cons_printf (" 0x%08"PFMT64x, item->addr);
-			
+
 		}
 	}
 	r_cons_newline ();
@@ -4512,7 +4529,7 @@ static void showmem_json (RList *list, PJ *pj) {
 			pj_n (pj, item->addr);
 		}
 	}
-	
+
 	pj_end (pj);
 }
 
@@ -4659,7 +4676,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 			pj_k (pj, "@W");
 			showmem_json (mymemxsw, pj);
 		}
-		
+
 		pj_end (pj);
 		r_cons_println (pj_string (pj));
 		pj_free (pj);
@@ -4687,7 +4704,7 @@ static bool cmd_aea(RCore* core, int mode, ut64 addr, int length) {
 			showmem (mymemxsw);
 		}
 	}
-	
+
 	r_list_free (mymemxsr);
 	r_list_free (mymemxsw);
 	mymemxsr = NULL;
@@ -8200,7 +8217,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 						goto jacuzzi;
 					}
 				}
-				
+
 				oldstr = r_print_rowlog (core->print, "Analyze len bytes of instructions for references (aar)");
 				(void)r_core_anal_refs (core, ""); // "aar"
 				r_print_rowlog_done (core->print, oldstr);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3829,7 +3829,7 @@ R_API int r_core_esil_step(RCore *core, ut64 until_addr, const char *until_expr,
 		initializeEsil (core);
 	}
 	if (esiltimeout) {
-		startTime = r_sys_now();
+		startTime = r_sys_now ();
 	}
 	ut64 addr = r_reg_getv (core->anal->reg, name);
 	r_cons_break_push (NULL, NULL);
@@ -3841,7 +3841,7 @@ repeat:
 	//Break if we have exceeded esil.timeout
 	if (esiltimeout) {
 		ut64 elapsedTime = r_sys_now () - startTime;
-		if (elapsedTime >= (esiltimeout * CLOCKS_PER_SEC)) {
+		if (elapsedTime >= (esiltimeout * 1000000)) {
 			eprintf ("[ESIL] Timeout exceeded.\n");
 			return_tail (0);
 		}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3824,12 +3824,12 @@ R_API int r_core_esil_step(RCore *core, ut64 until_addr, const char *until_expr,
 	const char *name = r_reg_get_name (core->anal->reg, R_REG_NAME_PC);
 	bool breakoninvalid = r_config_get_i (core->config, "esil.breakoninvalid");
 	int esiltimeout = r_config_get_i (core->config, "esil.timeout");
-	clock_t startTime, endTime;
+	ut64 startTime;
 	if (!esil) {
 		initializeEsil (core);
 	}
 	if (esiltimeout) {
-		startTime = clock();
+		startTime = r_sys_now();
 	}
 	ut64 addr = r_reg_getv (core->anal->reg, name);
 	r_cons_break_push (NULL, NULL);
@@ -3840,9 +3840,8 @@ repeat:
 	}
 	//Break if we have exceeded esil.timeout
 	if (esiltimeout) {
-		endTime = clock();
-		double elapsedTime = ((double)endTime-startTime) / CLOCKS_PER_SEC;
-		if (elapsedTime >= esiltimeout) {
+		ut64 elapsedTime = r_sys_now () - startTime;
+		if (elapsedTime >= (esiltimeout * CLOCKS_PER_SEC)) {
 			eprintf ("[ESIL] Timeout exceeded.\n");
 			return_tail (0);
 		}


### PR DESCRIPTION
Hey @trufae,

Here's a really dumb/super basic hack for the problem we discussed with aesu/aecu etc running for too much time. Not sure if you want to do something more intelligent but it works. 

Essentially, we offer the user to configure `esil.timeout` in the variables and if this value is >0 then we start a timer and each time we loop we check if the timeout has passed.

<img width="370" alt="Screenshot 2019-06-13 at 20 16 12" src="https://user-images.githubusercontent.com/5285945/59460940-21dcf980-8e18-11e9-8ff6-f294b38ab6fd.png">

This isn't perfect because we could be in the middle of evaluating an expression as the timeout passed. Ideally it would be handled in a thread but this gets more complex.

Is this alright, i noticed you do timeouts differently here:
https://github.com/radare/radare2/blob/master/libr/cons/cons.c#L385-L395

Do we want to use `r_sys_now()` instead of `clock()`?