### PR TITLE
Fix afl* not saving function bits

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2768,6 +2768,9 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	if (fcn->folded) {
 		r_cons_printf ("afF @ 0x%08"PFMT64x"\n", fcn->addr);
 	}
+	if (fcn->bits != 0) {
+		r_cons_printf ("afB %d @ 0x%08"PFMT64x"\n", fcn->bits, fcn->addr);
+	}
 	fcn_list_bbs (fcn);
 	/* show variables  and arguments */
 	r_core_cmdf (core, "afvb* @ 0x%"PFMT64x"\n", fcn->addr);


### PR DESCRIPTION
This fixes cases where saving and loading a project of a mixed-mode
binary (e.g. ARM with Thumb parts) reverted functions back to only one
of the modes.