### PR TITLE
Dinamically find radare2 install dir on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,7 +55,7 @@ build_script:
   - cmd: if %builder% == vs2017_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH%" x64 && python sys\meson.py --release --shared --install="%DIST_FOLDER%" && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
 test_script:
-  - set PATH=%APPVEYOR_BUILD_FOLDER%\%DIST_FOLDER%;%PATH%
+  - set PATH=%APPVEYOR_BUILD_FOLDER%\%DIST_FOLDER%\bin;%PATH%
   - echo %PATH%
   - where radare2
   - radare2 -v

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2708,8 +2708,8 @@ R_API int r_core_config_init(RCore *core) {
 	{
 		char *pfx = r_sys_getenv("R2_PREFIX");
 #if __WINDOWS__
-		char invoke_dir[MAX_PATH];
-		if (!pfx && r_sys_get_src_dir_w32 (invoke_dir)) {
+		char *invoke_dir = r_sys_prefix (NULL);
+		if (!pfx && invoke_dir) {
 			pfx = strdup (invoke_dir);
 		}
 #endif

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -82,7 +82,7 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 #define r_sys_conv_win_to_utf8_l(buf, len) r_acp_to_utf8_l (buf, len)
 #endif
 R_API os_info *r_sys_get_winver();
-R_API int r_sys_get_src_dir_w32(char *buf);
+R_API char *r_sys_get_src_dir_w32();
 R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **output, int *outlen, char **sterr);
 R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE in, HANDLE out, HANDLE err);
 #endif

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1143,7 +1143,21 @@ R_API bool r_sys_tts(const char *txt, bool bg) {
 R_API const char *r_sys_prefix(const char *pfx) {
 	static char prefix[1024] = {0};
 	if (!*prefix) {
+#if __WINDOWS__
+		char *path = r_sys_cmd_str ("where radare2", NULL, NULL);
+		if (path && *path) {
+			char *dir, *tmp = dir = r_file_dirname (path);
+			dir = r_file_dirname (tmp);
+			if (dir) {
+				r_str_ncpy (prefix, dir, sizeof (prefix));
+			}
+			free (dir);
+			free (tmp);
+		}
+		free (path);
+#else
 		r_str_ncpy (prefix, R2_PREFIX, sizeof (prefix));
+#endif
 	}
 	if (pfx) {
 		if (strlen (pfx) >= sizeof (prefix) - 1) {

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1141,7 +1141,7 @@ R_API bool r_sys_tts(const char *txt, bool bg) {
 }
 
 R_API const char *r_sys_prefix(const char *pfx) {
-	static char prefix = NULL;
+	static char *prefix = NULL;
 	if (!prefix) {
 #if __WINDOWS__ && !CUTTER
 		char *path = r_sys_cmd_str ("where radare2", NULL, NULL);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1141,29 +1141,30 @@ R_API bool r_sys_tts(const char *txt, bool bg) {
 }
 
 R_API const char *r_sys_prefix(const char *pfx) {
-	static char prefix[1024] = {0};
-	if (!*prefix) {
+	static char prefix = NULL;
+	if (!prefix) {
 #if __WINDOWS__ && !CUTTER
 		char *path = r_sys_cmd_str ("where radare2", NULL, NULL);
 		if (path && *path) {
 			char *dir, *tmp = dir = r_file_dirname (path);
 			dir = r_file_dirname (tmp);
 			if (dir) {
-				r_str_ncpy (prefix, dir, sizeof (prefix));
+				prefix = strdup (dir);
 			}
 			free (dir);
 			free (tmp);
 		}
 		free (path);
+		if (!prefix) {
+			prefix = strdup (R2_PREFIX);
+		}
 #else
 		r_str_ncpy (prefix, R2_PREFIX, sizeof (prefix));
 #endif
 	}
 	if (pfx) {
-		if (strlen (pfx) >= sizeof (prefix) - 1) {
-			return NULL;
-		}
-		r_str_ncpy (prefix, pfx, sizeof (prefix) - 1);
+		free (prefix);
+		prefix = strdup (pfx);
 	}
 	return prefix;
 }

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1143,7 +1143,7 @@ R_API bool r_sys_tts(const char *txt, bool bg) {
 R_API const char *r_sys_prefix(const char *pfx) {
 	static char prefix[1024] = {0};
 	if (!*prefix) {
-#if __WINDOWS__
+#if __WINDOWS__ && !CUTTER
 		char *path = r_sys_cmd_str ("where radare2", NULL, NULL);
 		if (path && *path) {
 			char *dir, *tmp = dir = r_file_dirname (path);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1144,22 +1144,12 @@ R_API const char *r_sys_prefix(const char *pfx) {
 	static char *prefix = NULL;
 	if (!prefix) {
 #if __WINDOWS__ && !CUTTER
-		char *path = r_sys_cmd_str ("where radare2", NULL, NULL);
-		if (path && *path) {
-			char *dir, *tmp = dir = r_file_dirname (path);
-			dir = r_file_dirname (tmp);
-			if (dir) {
-				prefix = strdup (dir);
-			}
-			free (dir);
-			free (tmp);
-		}
-		free (path);
+		prefix = r_sys_get_src_dir_w32 ();
 		if (!prefix) {
 			prefix = strdup (R2_PREFIX);
 		}
 #else
-		r_str_ncpy (prefix, R2_PREFIX, sizeof (prefix));
+		prefix = strdup (R2_PREFIX);
 #endif
 	}
 	if (pfx) {

--- a/libr/util/w32-sys.c
+++ b/libr/util/w32-sys.c
@@ -69,7 +69,7 @@ beach:
 	return info;
 }
 
-R_API int r_sys_get_src_dir_w32(char *buf) {
+R_API char *r_sys_get_src_dir_w32() {
 	int i = 0;
 	TCHAR fullpath[MAX_PATH + 1];
 	TCHAR shortpath[MAX_PATH + 1];
@@ -77,20 +77,13 @@ R_API int r_sys_get_src_dir_w32(char *buf) {
 
 	if (!GetModuleFileName (NULL, fullpath, MAX_PATH + 1) ||
 		!GetShortPathName (fullpath, shortpath, MAX_PATH + 1)) {
-		return false;
+		return NULL;
 	}
 	path = r_sys_conv_win_to_utf8 (shortpath);
-	memcpy (buf, path, strlen(path) + 1);
-	free (path);
-	i = strlen (buf);
-	while(i > 0 && buf[i-1] != '/' && buf[i-1] != '\\') {
-		buf[--i] = 0;
-	}
-	// Remove the last separator in the path.
-	if(i > 0) {
-		buf[--i] = 0;
-	}
-	return true;
+	char *dir, *tmp = dir = r_file_dirname (path);
+	dir = r_file_dirname (tmp);
+	free (tmp);
+	return dir;
 }
 
 R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **output, int *outlen, char **sterr) {

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -164,14 +164,15 @@ def win_dist(args):
     PATH_FMT['BUILDDIR'] = builddir
 
     makedirs(r'{DIST}')
-    copy(r'{BUILDDIR}\binr\*\*.exe', r'{DIST}')
+    makedirs(r'{DIST}\bin')
+    copy(r'{BUILDDIR}\binr\*\*.exe', r'{DIST}\bin')
 
     r2_bat_fname = args.install + r'\r2.bat'
     log.debug('create "%s"', r2_bat_fname)
     with open(r2_bat_fname, 'w') as r2_bat:
         r2_bat.write('@"%s\\radare2" %%*\n' % os.path.abspath(args.install))
 
-    copy(r'{BUILDDIR}\libr\*\*.dll', r'{DIST}')
+    copy(r'{BUILDDIR}\libr\*\*.dll', r'{DIST}\bin')
     makedirs(r'{DIST}\{R2_LIBDIR}')
     if args.shared:
         copy(r'{BUILDDIR}\libr\*\*.lib', r'{DIST}\{R2_LIBDIR}')

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -170,7 +170,7 @@ def win_dist(args):
     r2_bat_fname = args.install + r'\r2.bat'
     log.debug('create "%s"', r2_bat_fname)
     with open(r2_bat_fname, 'w') as r2_bat:
-        r2_bat.write('@"%s\\radare2" %%*\n' % os.path.abspath(args.install))
+        r2_bat.write('@"%s\\bin\\radare2" %%*\n' % os.path.abspath(args.install))
 
     copy(r'{BUILDDIR}\libr\*\*.dll', r'{DIST}\bin')
     makedirs(r'{DIST}\{R2_LIBDIR}')


### PR DESCRIPTION
#10613
better #14315

Fixes types and etc not being loaded if radare2 is spawned outside of install dir