### PR TITLE
Introducing /cc for case insensitive instruction search

### DIFF
--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -191,7 +191,7 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 			}
 			if (matches && tokens[matchcount]) {
 				if (mode == 'c') { // check for case insensitivity
-					matches = !r_str_ncasecmp(opst, tokens[matchcount], strlen(tokens[matchcount]));
+					matches = !r_str_ncasecmp (opst, tokens[matchcount], strlen (tokens[matchcount]));
 				} else if (!regexp) {
 					matches = strstr (opst, tokens[matchcount]) != NULL;
 				} else {

--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -191,7 +191,7 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 			}
 			if (matches && tokens[matchcount]) {
 				if (mode == 'c') { // check for case insensitivity
-					matches = !r_str_casecmp(opst, tokens[matchcount]);
+					matches = !r_str_ncasecmp(opst, tokens[matchcount], strlen(tokens[matchcount]));
 				} else if (!regexp) {
 					matches = strstr (opst, tokens[matchcount]) != NULL;
 				} else {

--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -190,7 +190,9 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 				matches = strcmp (opst, "invalid") && strcmp (opst, "unaligned");
 			}
 			if (matches && tokens[matchcount]) {
-				if (!regexp) {
+				if (mode == 'c') { // check for case insensitivity
+					matches = !r_str_casecmp(opst, tokens[matchcount]);
+				} else if (!regexp) {
 					matches = strstr (opst, tokens[matchcount]) != NULL;
 				} else {
 					rx = r_regex_new (tokens[matchcount], "");

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -28,6 +28,7 @@ static const char *help_msg_slash[] = {
 	"/ce", "[j] rsp,rbp", "search for esil expressions matching",
 	"/ci", "[j] 0x300", "find all the instructions using that immediate",
 	"/ci", "[j] 0x300 0x500", "find all the instructions using an immediate",
+	"/cc ", "instr", "search for instruction 'instr' ignoring case",
 	"/C", "[ar]", "search for crypto materials",
 	"/d", " 101112", "search for a deltified sequence of bytes",
 	"/e", " /E.F/i", "match regular expression",
@@ -74,6 +75,7 @@ static const char *help_msg_slash_c[] = {
 	"/ca ", "instr", "search for instruction 'instr' (in all offsets)",
 	"/ce ", "esil", "search for esil expressions matching substring",
 	"/ci", "[j] 0x300", "find all the instructions using that immediate",
+	"/cc ", "instr", "search for instruction 'instr' ignoring case",
 	"/c/ ", "instr", "search for instruction that matches regexp 'instr'",
 	"/c/a ", "instr", "search for every byte instruction that matches regexp 'instr'",
 	"/c ", "instr1;instr2", "search for instruction 'instr1' followed by 'instr2'",
@@ -3790,6 +3792,8 @@ reread:
 			do_asm_search (core, &param, input + 1, 'i', search_itv);
 		} else if (input[1] == 'e') { // "/ce"
 			do_asm_search (core, &param, input + 1, 'e', search_itv);
+		} else if (input[1] == 'c') { // "/cc"
+			do_asm_search (core, &param, input + 1, 'c', search_itv);
 		} else { // "/c"
 			do_asm_search (core, &param, input, 0, search_itv);
 		}


### PR DESCRIPTION
This pull request introduces `/cc` to search for instruction while ignoring **C**ase. (`/ci` is occupied but searching immediate value).

This PR will help fixing https://github.com/radareorg/cutter/issues/1594

```
$ r2 -n /bin/true
[0x00000000]> /c jmp rsp
0x00004d0b   # 2: jmp rsp
0x00004d5b   # 2: jmp rsp
[0x00000000]>
[0x00000000]>
[0x00000000]> /c JMP RSP
[0x00000000]>
[0x00000000]>
[0x00000000]> /c jmp rsp
0x00004d0b   # 2: jmp rsp
0x00004d5b   # 2: jmp rsp
[0x00000000]>
[0x00000000]>
[0x00000000]> /cc JMP RSP
0x00004d0b   # 2: jmp rsp
0x00004d5b   # 2: jmp rsp
[0x00000000]>
[0x00000000]>
[0x00000000]> /cc jmP rSP
0x00004d0b   # 2: jmp rsp
0x00004d5b   # 2: jmp rsp
[0x00000000]>
[0x00000000]>
[0x00000000]> /cc jmp r
0x00001425   # 2: jmp rax
0x00001473   # 2: jmp rax
0x00004d0b   # 2: jmp rsp
0x00004d5b   # 2: jmp rsp
0x0000528b   # 2: jmp rcx
[0x00000000]>
[0x00000000]>
[0x00000000]> /cc jmp R
0x00001425   # 2: jmp rax
0x00001473   # 2: jmp rax
0x00004d0b   # 2: jmp rsp
0x00004d5b   # 2: jmp rsp
0x0000528b   # 2: jmp rcx

```