### PR TITLE
Fix io/self vm mapping late calculations.

### DIFF
--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -569,9 +569,9 @@ bool bsd_proc_vmmaps(RIO *io, int pid) {
 		return false;
 	}
 
+	size = size * 4 / 3;
 	ut8 *p = malloc (size);
 	if (p) {
-		size = size * 4 / 3;
 		s = sysctl (mib, 4, p, &size, NULL, 0);
 		if (s == -1) {
 			eprintf ("sysctl failed: %s\n", strerror (errno));
@@ -676,9 +676,9 @@ exit:
 		return false;
 	}
 
+	size = size * 4 / 3;
 	ut8 *p = malloc (size);
 	if (p) {
-		size = size * 4 / 3;
 		s = sysctl (mib, 5, p, &size, NULL, 0);
 		if (s == -1) {
 			eprintf ("sysctl failed: %s\n", strerror (errno));


### PR DESCRIPTION
Calculation must be done before getting the aligned data, most likely missing few
entries...