### PR TITLE
Clear also attributes on screen clear under scr.ansicon=0

### DIFF
--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -34,7 +34,8 @@ static void __clear_w32() {
 	}
 	FillConsoleOutputCharacter (hStdout, ' ',
 		csbi.dwSize.X * csbi.dwSize.Y, startCoords, &dummy);
-	FillConsoleOutputAttribute (hStdout, 0,
+	FillConsoleOutputAttribute (hStdout,
+		FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY,
 		csbi.dwSize.X * csbi.dwSize.Y, startCoords, &dummy);
 }
 

--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -34,6 +34,8 @@ static void __clear_w32() {
 	}
 	FillConsoleOutputCharacter (hStdout, ' ',
 		csbi.dwSize.X * csbi.dwSize.Y, startCoords, &dummy);
+	FillConsoleOutputAttribute (hStdout, 0,
+		csbi.dwSize.X * csbi.dwSize.Y, startCoords, &dummy);
 }
 
 R_API void r_cons_w32_gotoxy(int fd, int x, int y) {


### PR DESCRIPTION
Fixes the following problem:

(In Visual mode)
![eip_highlight_1](https://user-images.githubusercontent.com/12002672/60269536-37c2e200-9921-11e9-9247-8339378d1f22.PNG)

(After quitting Visual mode ... the eip highlight isn't cleared)
![eip_highlight_2](https://user-images.githubusercontent.com/12002672/60269571-5032fc80-9921-11e9-8a65-ea20474e18c0.PNG)
