### PR TITLE
Improve fs io

### DIFF
--- a/libr/fs/file.c
+++ b/libr/fs/file.c
@@ -24,10 +24,21 @@ R_API RFSFile* r_fs_file_new(RFSRoot* root, const char* path) {
 
 R_API void r_fs_file_free(RFSFile* file) {
 	if (file) {
+		free (file->path);
 		free (file->name);
 		free (file->data);
 		free (file);
 	}
+}
+
+R_API char* r_fs_file_copy_abs_path(RFSFile* file) {
+	if (!file) {
+		return NULL;
+	}
+	if (!strcmp (file->path, file->name)) {
+		return strdup (file->path);
+	}
+	return r_str_newf ("%s/%s", file->path, file->name);
 }
 
 // TODO: Use RFSRoot and pass it in the stack instead of heap? problematic with bindings

--- a/libr/fs/shell.c
+++ b/libr/fs/shell.c
@@ -4,7 +4,7 @@
 
 #define PROMPT_PATH_BUFSIZE 1024
 
-static bool handlePipes(RFS *fs, char *msg, const char *cwd) {
+static bool handlePipes(RFS *fs, char *msg, const ut8 *data, const char *cwd) {
 	char *red = strchr (msg, '>');
 	if (red) {
 		*red++ = 0;
@@ -15,10 +15,14 @@ static bool handlePipes(RFS *fs, char *msg, const char *cwd) {
 			free (red);
 			red = blu;
 		} else {
-		
 		}
 		RFSFile *f = r_fs_open (fs, red, true);
-		r_fs_write (fs, f, 0, (const ut8 *)msg, strlen (msg));
+		if (!f) {
+			eprintf ("Cannot open %s for writing\n", red);
+			free (red);
+			return true;
+		}
+		r_fs_write (fs, f, 0, data == NULL ? (const ut8 *) msg : data, strlen (msg));
 		free (red);
 		r_fs_close (fs, f);
 		r_fs_file_free (f);
@@ -107,7 +111,7 @@ R_API int r_fs_shell_prompt(RFSShell* shell, RFS* fs, const char* root) {
 			r_sandbox_system (buf + 1, 1);
 		} else if (!strncmp (buf, "echo", 4)) {
 			char *msg = r_str_trim_dup (buf + 4);
-			if (!handlePipes (fs, msg, path)) {
+			if (!handlePipes (fs, msg, NULL, path)) {
 				printf ("%s\n", msg);
 			}
 			free (msg);
@@ -216,7 +220,7 @@ R_API int r_fs_shell_prompt(RFSShell* shell, RFS* fs, const char* root) {
 					*p = '>';
 				}
 				r_fs_read (fs, file, 0, file->size);
-				if (!handlePipes (fs, (char *)file->data, path)) {
+				if (!handlePipes (fs, str, file->data, path)) {
 					write (1, file->data, file->size);
 				}
 				write (1, "\n", 1);

--- a/libr/include/r_fs.h
+++ b/libr/include/r_fs.h
@@ -130,11 +130,12 @@ R_API RList *r_fs_partitions(RFS* fs, const char *ptype, ut64 delta);
 R_API char *r_fs_name(RFS *fs, ut64 offset);
 R_API int r_fs_prompt(RFS *fs, const char *root);
 R_API bool r_fs_check(RFS *fs, const char *p);
-R_API int r_fs_shell_prompt(RFSShell *shell, RFS *fs, const char *root); 
+R_API int r_fs_shell_prompt(RFSShell *shell, RFS *fs, const char *root);
 
 /* file.c */
 R_API RFSFile *r_fs_file_new(RFSRoot *root, const char *path);
 R_API void r_fs_file_free(RFSFile *file);
+R_API char* r_fs_file_copy_abs_path(RFSFile* file);
 R_API RFSRoot *r_fs_root_new(const char *path, ut64 delta);
 R_API void r_fs_root_free(RFSRoot *root);
 R_API RFSPartition *r_fs_partition_new(int num, ut64 start, ut64 length);


### PR DESCRIPTION
- add `r_fs_file_copy_abs_path` to get the absolute path of a RFSFile, centralizing edge case handling
- use that in `fs_io_read`
- add missing `free (file->path)` in RFSFile destructor
- fix `handlePipes` for fs shell `cat` use case