### PR TITLE
Fix wrong realloc in r_asm_massemble

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -766,7 +766,7 @@ R_API RAsmCode *r_asm_massemble(RAsm *a, const char *assembly) {
 		ctr++;
 		if (ctr >= tokens_size) {
 			const int new_tokens_size = tokens_size * 2;
-			char **new_tokens = realloc (tokens, new_tokens_size);
+			char **new_tokens = realloc (tokens, sizeof (char*) * new_tokens_size);
 			if (new_tokens) {
 				tokens_size = new_tokens_size;
 				tokens = new_tokens;


### PR DESCRIPTION
In line 694 a buffer of size (sizeof(char*)*32) is allocated. Later on,
this buffer is realloced to 64. This decreases the size of the allocated
buffer instead of increase. This may lead to memory corruption.

### Work environment

| Questions                                            | Answers
|------------------------------------------------------|--------------------
| OS/arch/bits (mandatory)                             |  Manjaro X86_64
| File format of the file you reverse (mandatory)      | asm
| Architecture/bits of the file (mandatory)            | x86/32
| r2 -v full output, **not truncated** (mandatory)     | radare2 3.7.0-git 22339 @ linux-x86-64 git.3.6.0-86-g4232ac176 commit: 4232ac1763fb533e5a1088732c01fa5394814cd7 build: 2019-07-05__22:40:52

### Expected behavior
```
$ rasm2 -a x86 -b 32 -f test.txt
e83600000089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c089c05c83c44060ebfa
```

### Actual behavior
```
$ rasm2 -a x86 -b 32 -f test.txt
malloc(): invalid next size (unsorted)
[1]    30538 abort (core dumped)  rasm2 -a x86 -b 32 -f test.txt
```

### Steps to reproduce the behavior 
Assemble the file [test.txt](https://github.com/radare/radare2/files/3364101/test.txt) as shown above