### PR TITLE
Fix isq. should do the same as is.q

### DIFF
--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -689,6 +689,9 @@ static int cmd_info(void *data, const char *input) {
 			} else if (input[1] == 'q' && input[2] == 'q') {
 				mode = R_MODE_SIMPLEST;
 				RBININFO ("symbols", R_CORE_BIN_ACC_SYMBOLS, input + 1, (obj && obj->symbols)? r_list_length (obj->symbols): 0);
+			} else if (input[1] == 'q' && input[2] == '.') {
+				mode = R_MODE_SIMPLE;
+				RBININFO ("symbols", R_CORE_BIN_ACC_SYMBOLS, input + 2, 0);
 			} else {
 				RBININFO ("symbols", R_CORE_BIN_ACC_SYMBOLS, input + 1, (obj && obj->symbols)? r_list_length (obj->symbols): 0);
 			}


### PR DESCRIPTION
As described in issue #14478 

> isq. Should do the same is.q

Tests were implemented and are awating approval; see PR [#1878](https://github.com/radare/radare2-regressions/pull/1878) of radare2-regressions 

