### PR TITLE
WIP: Fix #14499: bin.str.validchars: Valid string chars during string detection

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -215,7 +215,7 @@ static int string_scan_range(RList *list, RBinFile *bf, int min,
 		}
 
 		tmp[i++] = '\0';
-		if (runes < min && runes >= 2 && str_type == R_STRING_TYPE_ASCII) {
+		if (runes < min && runes >= 2 && str_type == R_STRING_TYPE_ASCII && needle < to) {
 			// back up past the \0 to the last char just in case it starts a wide string
 			needle -= 2;
 		}

--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -179,7 +179,7 @@ static int string_scan_range(RList *list, RBinFile *bf, int min,
 			}
 
 			/* Invalid sequence detected */
-			if (!rc) {
+			if (!rc || (bf->rbin->strvalidchars == R_STRING_VALID_ASCII && r > 0x7f)) {
 				needle++;
 				break;
 			}
@@ -215,6 +215,10 @@ static int string_scan_range(RList *list, RBinFile *bf, int min,
 		}
 
 		tmp[i++] = '\0';
+		if (runes < min && runes >= 2 && str_type == R_STRING_TYPE_ASCII) {
+			// back up past the \0 to the last char just in case it starts a wide string
+			needle -= 2;
+		}
 
 		if (runes >= min) {
 			// reduce false positives

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2329,6 +2329,25 @@ static bool cb_binprefix(void *user, void *data) {
 	return true;
 }
 
+static bool cb_strvalidchars(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	if (node->value[0] == '?') {
+		print_node_options (node);
+		return false;
+	}
+	if (core->bin) {
+		int v = !strcmp (node->value, "ascii") ? R_STRING_VALID_ASCII : R_STRING_VALID_ALL;
+		ut64 old_v = core->bin->strvalidchars;
+		core->bin->strvalidchars = v;
+		if (v != old_v) {
+			r_core_bin_refresh_strings (core);
+		}
+		return true;
+	}
+	return true;
+}
+
 static bool cb_binmaxstrbuf(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -3034,8 +3053,11 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("bin.b64str", "false", "Try to debase64 the strings");
 	SETCB ("bin.at", "false", &cb_binat, "RBin.cur depends on RCore.offset");
 	SETPREF ("bin.libs", "false", "Try to load libraries after loading main binary");
+	n = NODECB ("bin.str.validchars", "all", &cb_strvalidchars);
+	SETDESC (n, "Valid string chars during string detection");
+	SETOPTIONS (n, "ascii", "all", NULL);
 	n = NODECB ("bin.str.filter", "", &cb_strfilter);
-	SETDESC (n, "Filter strings");
+	SETDESC (n, "Filter strings (after string detection)");
 	SETOPTIONS (n, "a", "8", "p", "e", "u", "i", "U", "f", NULL);
 	SETCB ("bin.filter", "true", &cb_binfilter, "Filter symbol names to fix dupped names");
 	SETCB ("bin.force", "", &cb_binforce, "Force that rbin plugin");

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -308,6 +308,7 @@ typedef struct r_bin_t {
 	int minstrlen;
 	int maxstrlen;
 	ut64 maxstrbuf;
+	int strvalidchars;
 	int rawstr;
 	Sdb *sdb;
 	RIDStorage *ids;

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -17,6 +17,11 @@ typedef enum {
 	R_STRING_ENC_GUESS = 'g',
 } RStrEnc;
 
+enum {
+	R_STRING_VALID_ALL = 0,
+	R_STRING_VALID_ASCII = 'A'
+};
+
 typedef int (*RStrRangeCallback) (void *, int);
 
 static inline void r_str_rmch(char *s, char ch) {


### PR DESCRIPTION
To fix #14499 using `e bin.str.validchars=ascii`. Currently only options are `ascii` and `all`.