### PR TITLE
Fix #14530 - Implementation of i.~{} aka RCoreItem ##anal

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -1,6 +1,5 @@
 /* radare - LGPL - Copyright 2008-2018 - nibble, pancake */
 
-// TODO: rename to r_anal_meta_get() ??
 #if 0
     TODO
     ====

--- a/libr/core/Makefile
+++ b/libr/core/Makefile
@@ -9,7 +9,7 @@ DEPS+=r_reg r_search r_syscall r_socket r_fs r_magic r_crypto
 OBJS=core.o cmd.o cfile.o cconfig.o visual.o cio.o yank.o libs.o agraph.o
 OBJS+=fortune.o hack.o vasm.o patch.o cbin.o corelog.o rtr.o cmd_api.o
 OBJS+=carg.o canal.o project.o gdiff.o casm.o disasm.o plugin.o
-OBJS+=vmenus.o vmenus_graph.o vmenus_zigns.o zdiff.o
+OBJS+=vmenus.o vmenus_graph.o vmenus_zigns.o zdiff.o citem.o
 OBJS+=task.o panels.o pseudo.o vmarks.o anal_tp.o anal_objc.o blaze.o cundo.o
 OBJS+=esil_data_flow.o
 

--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -468,14 +468,13 @@ static int is_hit_inrange(RCoreAsmHit *hit, ut64 start_range, ut64 end_range){
 
 R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 	RAsmOp op;
-	// len = n * 32;
 	// if (n > core->blocksize) n = core->blocksize;
 	ut64 at;
 	ut32 idx = 0, hit_count;
 	int numinstr, asmlen, ii;
 	const int addrbytes = core->io->addrbytes;
 	RAsmCode *c;
-	RList *hits = r_core_asm_hit_list_new();
+	RList *hits = r_core_asm_hit_list_new ();
 	if (!hits) {
 		return NULL;
 	}
@@ -504,14 +503,14 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		if (r_cons_is_breaked ()) {
 			break;
 		}
-		c = r_asm_mdisassemble (core->assembler, buf+(len-idx), idx);
+		c = r_asm_mdisassemble (core->assembler, buf + len - idx, idx);
 		if (strstr (c->assembly, "invalid") || strstr (c->assembly, ".byte")) {
 			r_asm_code_free(c);
 			continue;
 		}
 		numinstr = 0;
 		asmlen = strlen (c->assembly);
-		for(ii = 0; ii < asmlen; ++ii) {
+		for (ii = 0; ii < asmlen; ++ii) {
 			if (c->assembly[ii] == '\n') {
 				++numinstr;
 			}

--- a/libr/core/citem.c
+++ b/libr/core/citem.c
@@ -1,0 +1,87 @@
+/* radare - LGPL - Copyright 2019 - pancake */
+
+#include <r_core.h>
+
+R_API RCoreItem *r_core_item_at (RCore *core, ut64 addr) {
+	RCoreItem *ci = R_NEW0 (RCoreItem);
+	ci->addr = addr;
+	RIOMap *map = r_io_map_get (core->io, addr);
+	if (map) {
+		ci->perm = map->perm;
+		// TODO: honor section perms too?
+		if (map->perm & R_PERM_X) {
+			// if theres a meta consider it data
+			RAnalMetaItem *item = r_meta_find (core->anal, addr, R_META_TYPE_ANY, 0);
+			if (item) {
+				switch (item->type) {
+				case R_META_TYPE_DATA:
+					ci->type = "data";
+					ci->size = item->size;
+					ci->data = r_core_cmd_strf (core, "pdi 1 @e:asm.flags=0@e:asm.lines=0@e:scr.color=0@0x%08"PFMT64x, addr);
+					r_str_trim (ci->data);
+					break;
+				case R_META_TYPE_FORMAT:
+					ci->type = "format"; // struct :?
+					ci->size = item->size;
+					break;
+				case R_META_TYPE_STRING:
+					ci->type = "string";
+					ci->size = item->size;
+					break;
+				}
+				if (item->str) {
+					if (!ci->data) {
+						ci->data = strdup (item->str);
+					}
+				}
+			}
+		}
+	}
+	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, 1);
+	if (fcn) {
+		ci->fcnname = strdup (fcn->name);
+	}
+	RBinObject *o = r_bin_cur_object (core->bin);
+	RBinSection *sec = r_bin_get_section_at (o, addr, core->io->va);
+	if (sec) {
+		ci->sectname = strdup (sec->name);
+	}
+	if (!ci->data) {
+		RAnalOp* op = r_core_anal_op (core, addr, R_ANAL_OP_MASK_ESIL | R_ANAL_OP_MASK_HINT);
+		if (op) {
+			if (!ci->data) {
+				if (op->mnemonic) {
+					ci->data = strdup (op->mnemonic);
+				} else {
+					ci->data = r_core_cmd_strf (core, "pi 1 @e:scr.color=0@0x%08"PFMT64x, addr);
+					r_str_trim (ci->data);
+				}
+			}
+			ci->size = op->size;
+			r_anal_op_free (op);
+		}
+	}
+	char *cmt = r_core_cmd_strf (core, "CC.@0x%08"PFMT64x, addr);
+	if (cmt) {
+		if (*cmt) {
+			ci->comment = strdup (cmt);
+			r_str_trim (ci->comment);
+		}
+		free (cmt);
+	}
+	if (!ci->type) {
+		ci->type = "code";
+	}
+	ci->next = ci->addr + ci->size;
+	char *prev = r_core_cmd_strf (core, "pd -1@e:asm.lines=0~[0]");
+	r_str_trim (prev);
+	ci->prev = r_num_get (NULL, prev);
+	free (prev);
+	return ci;
+}
+
+R_API void r_core_item_free (RCoreItem *ci) {
+	free (ci->data);
+	free (ci);
+}
+

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1545,14 +1545,13 @@ R_API int r_core_bb_starts_in_middle(RCore *core, ut64 at, int oplen) {
 static void ds_print_show_cursor(RDisasmState *ds) {
 	RCore *core = ds->core;
 	char res[] = "     ";
-	void *p;
 	if (!ds->show_marks) {
 		return;
 	}
 	int q = core->print->cur_enabled &&
 		ds->cursor >= ds->index &&
 		ds->cursor < (ds->index + ds->asmop.size);
-	p = r_bp_get_at (core->dbg->bp, ds->at);
+	RBreakpointItem *p = r_bp_get_at (core->dbg->bp, ds->at);
 	if (ds->midflags) {
 		(void)handleMidFlags (core, ds, false);
 	}
@@ -2718,7 +2717,7 @@ static bool ds_print_data_type(RDisasmState *ds, const ut8 *buf, int ib, int siz
 	// adjust alignment
 	r_cons_printf ("  ");
 	ut64 n = r_read_ble (buf, core->print->big_endian, size * 8);
-	if (r_config_get_i (core->config, "scr.interactive")) {
+	if (r_config_get_i (core->config, "asm.marks")) {
 		int q = core->print->cur_enabled &&
 			ds->cursor >= ds->index &&
 			ds->cursor < (ds->index + size);

--- a/libr/core/meson.build
+++ b/libr/core/meson.build
@@ -4,6 +4,7 @@ r_core_sources = [
   'esil_data_flow.c',
   'casm.c',
   'blaze.c',
+  'citem.c',
   'canal.c',
   'carg.c',
   'cbin.c',

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -141,6 +141,7 @@ typedef struct r_core_file_t {
 	ut8 alive;
 } RCoreFile;
 
+
 typedef struct r_core_times_t {
 	ut64 loadlibs_init_time;
 	ut64 loadlibs_time;
@@ -332,6 +333,24 @@ typedef struct r_core_t {
 	bool log_events; // core.c:cb_event_handler : log actions from events if cfg.log.events is set
 	RList *ropchain;
 } RCore;
+
+// maybe move into RAnal
+typedef struct r_core_item_t {
+	const char *type;
+	ut64 addr;
+	ut64 next;
+	ut64 prev;
+	int size;
+	int perm;
+	char *data;
+	char *comment;
+	char *sectname;
+	char *fcnname;
+} RCoreItem;
+
+
+R_API RCoreItem *r_core_item_at (RCore *core, ut64 addr);
+R_API void r_core_item_free (RCoreItem *ci);
 
 R_API int r_core_bind(RCore *core, RCoreBind *bnd);
 


### PR DESCRIPTION
```
[0x1000011e8]> i.~{}
{
  "type": "code",
  "perm": "r-x",
  "size": 1,
  "addr": 4294971880,
  "next": 4294971881,
  "prev": 4294971875,
  "sectname": "0.__TEXT.__text",
  "data": "push rbp"
}

[0x1000011e8]> Cd 4
[0x1000011e8]> CC hello world
[0x1000011e8]> i.~{}
{
  "type": "data",
  "perm": "r-x",
  "size": 4,
  "addr": 4294971880,
  "next": 4294971884,
  "prev": 4294971875,
  "sectname": "0.__TEXT.__text",
  "comment": "hello world",
  "data": ".dword 0x56415741"
}
```