### PR TITLE
Handle the export flags to avoid de-syncing ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -1968,7 +1968,17 @@ static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, vo
 		if (len) {
 			ut64 flags = ULEB();
 			ut64 offset = ULEB();
-			if (iterator) {
+			bool skip = false;
+			if (flags & EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER) {
+				ULEB();
+				skip = true;
+				// TODO: handle this
+			} else if (flags & EXPORT_SYMBOL_FLAGS_REEXPORT) {
+				skip = true;
+				ur.p += strlen ((char*) ur.p) + 1;
+				// TODO: handle this
+			}
+			if (iterator && !skip) {
 				char * name = NULL;
 				RListIter *iter;
 				RTrieState *s;
@@ -1985,7 +1995,9 @@ static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, vo
 				iterator (bin, name, flags, offset, ctx);
 				R_FREE (name);
 			}
-			count++;
+			if (!skip) {
+				count++;
+			}
 		}
 		ut64 child_count = ULEB();
 		if (state->i == child_count) {

--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -431,7 +431,7 @@ enum {
 	SELF_LIBRARY_ORDINAL   = 0x0,
 	MAX_LIBRARY_ORDINAL    = 0xfd,
 	DYNAMIC_LOOKUP_ORDINAL = 0xfe,
-	EXECUTABLE_ORDINAL     = 0xff 
+	EXECUTABLE_ORDINAL     = 0xff
 };
 
 enum StabType {
@@ -1420,5 +1420,13 @@ sizeof(struct x86_thread_state_t) / sizeof(uint32_t);
 sizeof(struct x86_float_state_t) / sizeof(uint32_t);
 #define x86_EXCEPTION_STATE_COUNT \
 sizeof(struct x86_exception_state_t) / sizeof(uint32_t);
+
+#define EXPORT_SYMBOL_FLAGS_KIND_MASK 0x03
+#define EXPORT_SYMBOL_FLAGS_KIND_REGULAR 0x00
+#define EXPORT_SYMBOL_FLAGS_KIND_THREAD_LOCAL 0x01
+#define EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE 0x02
+#define EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION 0x04
+#define EXPORT_SYMBOL_FLAGS_REEXPORT 0x08
+#define EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER 0x10
 
 #endif


### PR DESCRIPTION
- skip reexports and “stub and resolver” exports for now, the semantics are different and need to be treated in a different way
- but advance the pointer accordingly, to avoid loosing sync while walking the trie (especially in dyld cache)