### PR TITLE
Show relocs as flags in disassembly for call and jmp instr.

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4782,7 +4782,11 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 	if (fcn) {
 		name = fcn->name;
 	} else if (f) {
-		RBinReloc *rel = r_core_getreloc (ds->core, addr, ds->analop.size);
+		RBinReloc *rel;
+		rel = r_core_getreloc (ds->core, ds->analop.addr, ds->analop.size);
+		if (!rel) {
+			rel = r_core_getreloc (ds->core, addr, ds->analop.size);
+		}
 		if (rel) {
 			if (rel && rel->import && rel->import->name) {
 				name = rel->import->name;


### PR DESCRIPTION
#14277
This only works for call and jmp instructions

![image](https://user-images.githubusercontent.com/23562137/61420841-bf758e00-a8da-11e9-9db6-ac6bb24ce8c2.png)
