### PR TITLE
Fix grep in tasks ##cons

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -35,6 +35,8 @@ typedef struct {
 	void *event_interrupt_data;
 } RConsBreakStack;
 
+static void cons_grep_reset(RConsGrep *grep);
+
 static void break_stack_free(void *ptr) {
 	RConsBreakStack *b = (RConsBreakStack*)ptr;
 	free (b);
@@ -116,6 +118,8 @@ static void cons_context_init(RConsContext *context, R_NULLABLE RConsContext *pa
 		context->color_mode = COLOR_MODE_DISABLED;
 		r_cons_pal_init (context);
 	}
+
+	cons_grep_reset (&context->grep);
 }
 
 static void cons_context_deinit(RConsContext *context) {
@@ -787,29 +791,6 @@ R_API RConsContext *r_cons_context_new(R_NULLABLE RConsContext *parent) {
 	}
 	cons_context_init (context, parent);
 	return context;
-	/*
-	RStack *stack = r_stack_newf (6, cons_stack_free);
-	if (!stack) {
-		return NULL;
-	}
-
-	RConsStack *data = R_NEW0 (RConsStack);
-	if (!data) {
-		r_stack_free (stack);
-		return NULL;
-	}
-
-	data->grep = R_NEW0 (RConsGrep);
-	if (!data->grep) {
-		R_FREE (data);
-		r_stack_free (stack);
-		return NULL;
-	}
-	cons_grep_reset (data->grep);
-
-	r_stack_push (stack, data);
-
-	return stack;*/
 }
 
 R_API void r_cons_context_free(RConsContext *context) {


### PR DESCRIPTION
Tests: https://github.com/radare/radare2-regressions/pull/1895

Regression introduced by https://github.com/radare/radare2/pull/14563, though the pr itself is good.

You would get unwanted newlines before the output, which was especially annoying in Cutter's console where every command is run in a task.

![Bildschirmfoto vom 2019-07-21 12-24-07](https://user-images.githubusercontent.com/1460997/61590009-72cbd480-abb2-11e9-8fa9-cae5c3116152.png)
