### PR TITLE
[rio] fix r_io_cache_commit to commit all lines

### DIFF
--- a/libr/io/cache.c
+++ b/libr/io/cache.c
@@ -61,7 +61,7 @@ R_API void r_io_cache_commit(RIO *io, ut64 from, ut64 to) {
 				eprintf ("Error writing change at 0x%08"PFMT64x"\n", r_itv_begin (c->itv));
 			}
 			io->cached = cached;
-			break; // XXX old behavior, revisit this
+			// break; // XXX old behavior, revisit this
 		}
 	}
 }


### PR DESCRIPTION
commenting out the line fixes https://github.com/radare/radare2/issues/14484
what was the old behavior ?