### PR TITLE
Add e_machine values

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1992,7 +1992,7 @@ ut64 Elf_(r_bin_elf_get_main_offset)(ELFOBJ *bin) {
 	}
 #endif
 	/* linux64 pie main -- probably buggy in some cases */
-	int bo = 29; // Begin offset may vary depending on the entry prelude
+	int bo = 29; // Begin offset may vary depending on the entry prelude 
 	if (buf[0] == 0xf3 && buf[1] == 0x0f && buf[2] == 0x1e && buf[3] == 0xfa) {
 		// Change begin offset if binary starts with 'endbr64'
 		bo = 33;
@@ -2486,7 +2486,7 @@ ut8 *Elf_(r_bin_elf_grab_regstate)(ELFOBJ *bin, int *len) {
 				continue;
 			}
 			int bits = Elf_(r_bin_elf_get_bits)(bin);
-			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr): sizeof (Elf32_Nhdr);
+			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr) : sizeof (Elf32_Nhdr);
 			void *elf_nhdr = calloc (elf_nhdr_size, 1);
 			bool regs_found = false;
 			ut64 offset = 0;
@@ -2597,7 +2597,7 @@ static size_t get_relocs_num(ELFOBJ *bin) {
 	if (!bin->g_sections) {
 		return 0;
 	}
-	size = bin->is_rela == DT_REL ? sizeof (Elf_(Rel)): sizeof (Elf_(Rela));
+	size = bin->is_rela == DT_REL ? sizeof (Elf_(Rel)) : sizeof (Elf_(Rela));
 	for (i = 0; !bin->g_sections[i].last; i++) {
 		if (sectionIsInvalid (bin, &bin->g_sections[i])) {
 			continue;
@@ -2700,7 +2700,7 @@ RBinElfReloc* Elf_(r_bin_elf_get_relocs)(ELFOBJ *bin) {
 				break;
 			}
 			if (!bin->is_rela) {
-				rela = is_rela? DT_RELA: DT_REL;
+				rela = is_rela? DT_RELA : DT_REL;
 			} else {
 				rela = bin->is_rela;
 			}
@@ -3262,7 +3262,7 @@ static void _set_arm_thumb_bits(struct Elf_(r_bin_elf_obj_t) *bin, RBinSymbol **
 	int len = strlen (ptr->name);
 	if (ptr->name[0] == '$' && (len >= 2 && !ptr->name[2])) {
 		switch (ptr->name[1]) {
-		case 'a': //arm
+		case 'a' : //arm
 			ptr->bits = 32;
 			break;
 		case 't': //thumb
@@ -3314,7 +3314,7 @@ RBinSymbol *Elf_(_r_bin_elf_convert_symbol)(struct Elf_(r_bin_elf_obj_t) *bin,
 	if (!(ptr = R_NEW0 (RBinSymbol))) {
 		return NULL;
 	}
-	ptr->name = symbol->name[0] ? r_str_newf (namefmt, &symbol->name[0]): strdup ("");
+	ptr->name = symbol->name[0] ? r_str_newf (namefmt, &symbol->name[0]) : strdup ("");
 	ptr->forwarder = r_str_const ("NONE");
 	ptr->bind = r_str_const (symbol->bind);
 	ptr->type = r_str_const (symbol->type);
@@ -3538,7 +3538,7 @@ static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type
 	if (!ret) {
 		return Elf_(get_phdr_symbols) (bin, type);
 	}
-	ret[ret_ctr].last = 1; // ugly dirty hack:D
+	ret[ret_ctr].last = 1; // ugly dirty hack :D
 	int max = -1;
 	RBinElfSymbol *aux = NULL;
 	nsym = Elf_(fix_symbols) (bin, ret_ctr, type, &ret);
@@ -3787,8 +3787,8 @@ static bool get_nt_file_maps (ELFOBJ *bin, RList *core_maps) {
 		Elf_(Phdr) *p = &bin->phdr[ph];
 		if (p->p_type == PT_NOTE) {
 			int bits = Elf_(r_bin_elf_get_bits)(bin);
-			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr): sizeof (Elf32_Nhdr);
-			int size_of = (bits == 64) ? sizeof (ut64): sizeof (ut32);
+			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr) : sizeof (Elf32_Nhdr);
+			int size_of = (bits == 64) ? sizeof (ut64) : sizeof (ut32);
 			void *elf_nhdr = calloc (elf_nhdr_size, 1);
 			ut64 offset = 0;
 			bool found = false;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2135,8 +2135,9 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 	case EM_LANAI:
 		return strdup ("lanai");
 	case EM_VIDEOCORE3:
-	case EM_VIDEOCORE4:
-		return strdup ("vc4");
+		return strdup ("vc3");
+	// case EM_VIDEOCORE4:
+		// return strdup ("vc4");
 	case EM_MSP430:
 		return strdup ("msp430");
 	case EM_SH:
@@ -2148,6 +2149,8 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 	default: return strdup ("x86");
 	}
 }
+
+// http://www.sco.com/developers/gabi/latest/ch4.eheader.html
 
 char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	switch (bin->ehdr.e_machine) {
@@ -2198,8 +2201,8 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_X86_64:        return strdup ("AMD x86-64 architecture");
 	case EM_LANAI:         return strdup ("32bit LANAI architecture");
 	case EM_PDSP:          return strdup ("Sony DSP Processor");
-	case EM_PDP10          return strdup ("Digital Equipment Corp. PDP-10");
-	case EM_PDP11          return strdup ("Digital Equipment Corp. PDP-11");
+	case EM_PDP10:         return strdup ("Digital Equipment Corp. PDP-10");
+	case EM_PDP11:         return strdup ("Digital Equipment Corp. PDP-11");
 	case EM_FX66:          return strdup ("Siemens FX66 microcontroller");
 	case EM_ST9PLUS:       return strdup ("STMicroelectronics ST9+ 8/16 mc");
 	case EM_ST7:           return strdup ("STmicroelectronics ST7 8 bit mc");
@@ -2251,7 +2254,7 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_STXP7X:        return strdup ("STMicroelectronics STxP7x family of configurable and extensible RISC processors");
 	case EM_NDS32:         return strdup ("Andes Technology compact code size embedded RISC processor family");
 	case EM_ECOG1:         return strdup ("Cyan Technology eCOG1X family");
-	case EM_ECOG1X:        return strdup ("Cyan Technology eCOG1X family");
+	// case EM_ECOG1X:        return strdup ("Cyan Technology eCOG1X family");
 	case EM_MAXQ30:        return strdup ("Dallas Semiconductor MAXQ30 Core Micro-controllers");
 	case EM_XIMO16:        return strdup ("New Japan Radio (NJR) 16-bit DSP Processor");
 	case EM_MANIK:         return strdup ("M2000 Reconfigurable RISC Microprocessor");
@@ -2265,14 +2268,12 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_SLE9X:         return strdup ("Infineon Technologies SLE9X core");
 	case EM_L10M:          return strdup ("Intel L10M");
 	case EM_K10M:          return strdup ("Intel K10M");
-	case reserved:         return strdup ("Reserved for future Intel use");
-	case EM_AARCH64:       return strdup ("ARM 64-bit architecture (AARCH64)");
-	case reserved:         return strdup ("Reserved for future ARM use");
+	// case EM_AARCH64:       return strdup ("ARM 64-bit architecture (AARCH64)");
 	case EM_AVR32:         return strdup ("Atmel Corporation 32-bit microprocessor family");
 	case EM_STM8:          return strdup ("STMicroeletronics STM8 8-bit microcontroller");
 	case EM_TILE64:        return strdup ("Tilera TILE64 multicore architecture family");
 	case EM_TILEPRO:       return strdup ("Tilera TILEPro multicore architecture family");
-	case EM_MICROBLAZE:    return strdup ("Xilinx MicroBlaze 32-bit RISC soft processor core");
+	// case EM_MICROBLAZE:    return strdup ("Xilinx MicroBlaze 32-bit RISC soft processor core");
 	case EM_CUDA:          return strdup ("NVIDIA CUDA architecture");
 	case EM_TILEGX:        return strdup ("Tilera TILE-Gx multicore architecture family");
 	case EM_CLOUDSHIELD:   return strdup ("CloudShield architecture family");
@@ -2308,7 +2309,6 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_FT32:          return strdup ("FTDI Chip FT32 high performance 32-bit RISC architecture");
 	case EM_MOXIE:         return strdup ("Moxie processor family");
 	case EM_AMDGPU:        return strdup ("AMD GPU architecture");
-	case EM_RISCV:         return strdup ("RISC-V");
 
 	default:             return r_str_newf ("<unknown>: 0x%x", bin->ehdr.e_machine);
 	}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1992,7 +1992,7 @@ ut64 Elf_(r_bin_elf_get_main_offset)(ELFOBJ *bin) {
 	}
 #endif
 	/* linux64 pie main -- probably buggy in some cases */
-	int bo = 29; // Begin offset may vary depending on the entry prelude 
+	int bo = 29; // Begin offset may vary depending on the entry prelude
 	if (buf[0] == 0xf3 && buf[1] == 0x0f && buf[2] == 0x1e && buf[3] == 0xfa) {
 		// Change begin offset if binary starts with 'endbr64'
 		bo = 33;
@@ -2151,88 +2151,165 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 
 char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	switch (bin->ehdr.e_machine) {
-	case EM_NONE:        return strdup ("No machine");
-	case EM_M32:         return strdup ("AT&T WE 32100");
-	case EM_SPARC:       return strdup ("SUN SPARC");
-	case EM_386:         return strdup ("Intel 80386");
-	case EM_68K:         return strdup ("Motorola m68k family");
-	case EM_88K:         return strdup ("Motorola m88k family");
-	case EM_860:         return strdup ("Intel 80860");
-	case EM_MIPS:        return strdup ("MIPS R3000");
-	case EM_S370:        return strdup ("IBM System/370");
-	case EM_MIPS_RS3_LE: return strdup ("MIPS R3000 little-endian");
-	case EM_PARISC:      return strdup ("HPPA");
-	case EM_VPP500:      return strdup ("Fujitsu VPP500");
-	case EM_SPARC32PLUS: return strdup ("Sun's \"v8plus\"");
-	case EM_960:         return strdup ("Intel 80960");
-	case EM_PPC:         return strdup ("PowerPC");
-	case EM_PPC64:       return strdup ("PowerPC 64-bit");
-	case EM_S390:        return strdup ("IBM S390");
-	case EM_V800:        return strdup ("NEC V800 series");
-	case EM_FR20:        return strdup ("Fujitsu FR20");
-	case EM_RH32:        return strdup ("TRW RH-32");
-	case EM_RCE:         return strdup ("Motorola RCE");
-	case EM_ARM:         return strdup ("ARM");
-	case EM_BLACKFIN:    return strdup ("Analog Devices Blackfin");
-	case EM_FAKE_ALPHA:  return strdup ("Digital Alpha");
-	case EM_SH:          return strdup ("Hitachi SH");
-	case EM_SPARCV9:     return strdup ("SPARC v9 64-bit");
-	case EM_TRICORE:     return strdup ("Siemens Tricore");
-	case EM_ARC:         return strdup ("Argonaut RISC Core");
-	case EM_H8_300:      return strdup ("Hitachi H8/300");
-	case EM_H8_300H:     return strdup ("Hitachi H8/300H");
-	case EM_H8S:         return strdup ("Hitachi H8S");
-	case EM_H8_500:      return strdup ("Hitachi H8/500");
-	case EM_IA_64:       return strdup ("Intel Merced");
-	case EM_MIPS_X:      return strdup ("Stanford MIPS-X");
-	case EM_COLDFIRE:    return strdup ("Motorola Coldfire");
-	case EM_68HC12:      return strdup ("Motorola M68HC12");
-	case EM_MMA:         return strdup ("Fujitsu MMA Multimedia Accelerator");
-	case EM_PCP:         return strdup ("Siemens PCP");
-	case EM_NCPU:        return strdup ("Sony nCPU embeeded RISC");
-	case EM_NDR1:        return strdup ("Denso NDR1 microprocessor");
-	case EM_STARCORE:    return strdup ("Motorola Start*Core processor");
-	case EM_ME16:        return strdup ("Toyota ME16 processor");
-	case EM_ST100:       return strdup ("STMicroelectronic ST100 processor");
-	case EM_TINYJ:       return strdup ("Advanced Logic Corp. Tinyj emb.fam");
-	case EM_X86_64:      return strdup ("AMD x86-64 architecture");
-	case EM_LANAI:       return strdup ("32bit LANAI architecture");
-	case EM_PDSP:        return strdup ("Sony DSP Processor");
-	case EM_FX66:        return strdup ("Siemens FX66 microcontroller");
-	case EM_ST9PLUS:     return strdup ("STMicroelectronics ST9+ 8/16 mc");
-	case EM_ST7:         return strdup ("STmicroelectronics ST7 8 bit mc");
-	case EM_68HC16:      return strdup ("Motorola MC68HC16 microcontroller");
-	case EM_68HC11:      return strdup ("Motorola MC68HC11 microcontroller");
-	case EM_68HC08:      return strdup ("Motorola MC68HC08 microcontroller");
-	case EM_68HC05:      return strdup ("Motorola MC68HC05 microcontroller");
-	case EM_SVX:         return strdup ("Silicon Graphics SVx");
-	case EM_ST19:        return strdup ("STMicroelectronics ST19 8 bit mc");
-	case EM_VAX:         return strdup ("Digital VAX");
-	case EM_CRIS:        return strdup ("Axis Communications 32-bit embedded processor");
-	case EM_JAVELIN:     return strdup ("Infineon Technologies 32-bit embedded processor");
-	case EM_FIREPATH:    return strdup ("Element 14 64-bit DSP Processor");
-	case EM_ZSP:         return strdup ("LSI Logic 16-bit DSP Processor");
-	case EM_MMIX:        return strdup ("Donald Knuth's educational 64-bit processor");
-	case EM_HUANY:       return strdup ("Harvard University machine-independent object files");
-	case EM_PRISM:       return strdup ("SiTera Prism");
-	case EM_AVR:         return strdup ("Atmel AVR 8-bit microcontroller");
-	case EM_FR30:        return strdup ("Fujitsu FR30");
-	case EM_D10V:        return strdup ("Mitsubishi D10V");
-	case EM_D30V:        return strdup ("Mitsubishi D30V");
-	case EM_V850:        return strdup ("NEC v850");
-	case EM_M32R:        return strdup ("Mitsubishi M32R");
-	case EM_MN10300:     return strdup ("Matsushita MN10300");
-	case EM_MN10200:     return strdup ("Matsushita MN10200");
-	case EM_PJ:          return strdup ("picoJava");
-	case EM_OPENRISC:    return strdup ("OpenRISC 32-bit embedded processor");
-	case EM_ARC_A5:      return strdup ("ARC Cores Tangent-A5");
-	case EM_XTENSA:      return strdup ("Tensilica Xtensa Architecture");
-	case EM_AARCH64:     return strdup ("ARM aarch64");
-	case EM_PROPELLER:   return strdup ("Parallax Propeller");
-	case EM_MICROBLAZE:  return strdup ("Xilinx MicroBlaze");
-	case EM_RISCV:       return strdup ("RISC V");
-	case EM_VIDEOCORE3:  return strdup ("VideoCore III");
-	case EM_VIDEOCORE4:  return strdup ("VideoCore IV");
+	case EM_NONE:          return strdup ("No machine");
+	case EM_M32:           return strdup ("AT&T WE 32100");
+	case EM_SPARC:         return strdup ("SUN SPARC");
+	case EM_386:           return strdup ("Intel 80386");
+	case EM_68K:           return strdup ("Motorola m68k family");
+	case EM_88K:           return strdup ("Motorola m88k family");
+	case EM_860:           return strdup ("Intel 80860");
+	case EM_MIPS:          return strdup ("MIPS R3000");
+	case EM_S370:          return strdup ("IBM System/370");
+	case EM_MIPS_RS3_LE:   return strdup ("MIPS R3000 little-endian");
+	case EM_PARISC:        return strdup ("HPPA");
+	case EM_VPP500:        return strdup ("Fujitsu VPP500");
+	case EM_SPARC32PLUS:   return strdup ("Sun's \"v8plus\"");
+	case EM_960:           return strdup ("Intel 80960");
+	case EM_PPC:           return strdup ("PowerPC");
+	case EM_PPC64:         return strdup ("PowerPC 64-bit");
+	case EM_S390:          return strdup ("IBM S390");
+	case EM_V800:          return strdup ("NEC V800 series");
+	case EM_FR20:          return strdup ("Fujitsu FR20");
+	case EM_RH32:          return strdup ("TRW RH-32");
+	case EM_RCE:           return strdup ("Motorola RCE");
+	case EM_ARM:           return strdup ("ARM");
+	case EM_BLACKFIN:      return strdup ("Analog Devices Blackfin");
+	case EM_FAKE_ALPHA:    return strdup ("Digital Alpha");
+	case EM_SH:            return strdup ("Hitachi SH");
+	case EM_SPARCV9:       return strdup ("SPARC v9 64-bit");
+	case EM_TRICORE:       return strdup ("Siemens Tricore");
+	case EM_ARC:           return strdup ("Argonaut RISC Core");
+	case EM_H8_300:        return strdup ("Hitachi H8/300");
+	case EM_H8_300H:       return strdup ("Hitachi H8/300H");
+	case EM_H8S:           return strdup ("Hitachi H8S");
+	case EM_H8_500:        return strdup ("Hitachi H8/500");
+	case EM_IA_64:         return strdup ("Intel Merced");
+	case EM_MIPS_X:        return strdup ("Stanford MIPS-X");
+	case EM_COLDFIRE:      return strdup ("Motorola Coldfire");
+	case EM_68HC12:        return strdup ("Motorola M68HC12");
+	case EM_MMA:           return strdup ("Fujitsu MMA Multimedia Accelerator");
+	case EM_PCP:           return strdup ("Siemens PCP");
+	case EM_NCPU:          return strdup ("Sony nCPU embeeded RISC");
+	case EM_NDR1:          return strdup ("Denso NDR1 microprocessor");
+	case EM_STARCORE:      return strdup ("Motorola Start*Core processor");
+	case EM_ME16:          return strdup ("Toyota ME16 processor");
+	case EM_ST100:         return strdup ("STMicroelectronic ST100 processor");
+	case EM_TINYJ:         return strdup ("Advanced Logic Corp. Tinyj emb.fam");
+	case EM_X86_64:        return strdup ("AMD x86-64 architecture");
+	case EM_LANAI:         return strdup ("32bit LANAI architecture");
+	case EM_PDSP:          return strdup ("Sony DSP Processor");
+	case EM_PDP10          return strdup ("Digital Equipment Corp. PDP-10");
+	case EM_PDP11          return strdup ("Digital Equipment Corp. PDP-11");
+	case EM_FX66:          return strdup ("Siemens FX66 microcontroller");
+	case EM_ST9PLUS:       return strdup ("STMicroelectronics ST9+ 8/16 mc");
+	case EM_ST7:           return strdup ("STmicroelectronics ST7 8 bit mc");
+	case EM_68HC16:        return strdup ("Motorola MC68HC16 microcontroller");
+	case EM_68HC11:        return strdup ("Motorola MC68HC11 microcontroller");
+	case EM_68HC08:        return strdup ("Motorola MC68HC08 microcontroller");
+	case EM_68HC05:        return strdup ("Motorola MC68HC05 microcontroller");
+	case EM_SVX:           return strdup ("Silicon Graphics SVx");
+	case EM_ST19:          return strdup ("STMicroelectronics ST19 8 bit mc");
+	case EM_VAX:           return strdup ("Digital VAX");
+	case EM_CRIS:          return strdup ("Axis Communications 32-bit embedded processor");
+	case EM_JAVELIN:       return strdup ("Infineon Technologies 32-bit embedded processor");
+	case EM_FIREPATH:      return strdup ("Element 14 64-bit DSP Processor");
+	case EM_ZSP:           return strdup ("LSI Logic 16-bit DSP Processor");
+	case EM_MMIX:          return strdup ("Donald Knuth's educational 64-bit processor");
+	case EM_HUANY:         return strdup ("Harvard University machine-independent object files");
+	case EM_PRISM:         return strdup ("SiTera Prism");
+	case EM_AVR:           return strdup ("Atmel AVR 8-bit microcontroller");
+	case EM_FR30:          return strdup ("Fujitsu FR30");
+	case EM_D10V:          return strdup ("Mitsubishi D10V");
+	case EM_D30V:          return strdup ("Mitsubishi D30V");
+	case EM_V850:          return strdup ("NEC v850");
+	case EM_M32R:          return strdup ("Mitsubishi M32R");
+	case EM_MN10300:       return strdup ("Matsushita MN10300");
+	case EM_MN10200:       return strdup ("Matsushita MN10200");
+	case EM_PJ:            return strdup ("picoJava");
+	case EM_OPENRISC:      return strdup ("OpenRISC 32-bit embedded processor");
+	case EM_ARC_A5:        return strdup ("ARC Cores Tangent-A5");
+	case EM_XTENSA:        return strdup ("Tensilica Xtensa Architecture");
+	case EM_AARCH64:       return strdup ("ARM aarch64");
+	case EM_PROPELLER:     return strdup ("Parallax Propeller");
+	case EM_MICROBLAZE:    return strdup ("Xilinx MicroBlaze");
+	case EM_RISCV:         return strdup ("RISC V");
+	case EM_VIDEOCORE3:    return strdup ("VideoCore III");
+	// case EM_VIDEOCORE4:    return strdup ("VideoCore IV");  // Nonstandard
+	case EM_LATTICEMICO32: return strdup ("RISC processor for Lattice FPGA architecture");
+	case EM_SE_C17:        return strdup ("Seiko Epson C17 family");
+	case EM_TI_C6000:      return strdup ("The Texas Instruments TMS320C6000 DSP family");
+	case EM_TI_C2000:      return strdup ("The Texas Instruments TMS320C2000 DSP family");
+	case EM_TI_C5500:      return strdup ("The Texas Instruments TMS320C55x DSP family");
+	case EM_TI_ARP32:      return strdup ("Texas Instruments Application Specific RISC Processor, 32bit fetch");
+	case EM_TI_PRU:        return strdup ("Texas Instruments Programmable Realtime Unit");
+	case EM_MMDSP_PLUS:    return strdup ("STMicroelectronics 64bit VLIW Data Signal Processor");
+	case EM_CYPRESS_M8C:   return strdup ("Cypress M8C microprocessor");
+	case EM_R32C:          return strdup ("Renesas R32C series microprocessors");
+	case EM_TRIMEDIA:      return strdup ("NXP Semiconductors TriMedia architecture family");
+	// case EM_QDSP6:         return strdup ("QUALCOMM DSP6 Processor");  // Nonstandard
+	case EM_8051:          return strdup ("Intel 8051 and variants");
+	case EM_STXP7X:        return strdup ("STMicroelectronics STxP7x family of configurable and extensible RISC processors");
+	case EM_NDS32:         return strdup ("Andes Technology compact code size embedded RISC processor family");
+	case EM_ECOG1:         return strdup ("Cyan Technology eCOG1X family");
+	case EM_ECOG1X:        return strdup ("Cyan Technology eCOG1X family");
+	case EM_MAXQ30:        return strdup ("Dallas Semiconductor MAXQ30 Core Micro-controllers");
+	case EM_XIMO16:        return strdup ("New Japan Radio (NJR) 16-bit DSP Processor");
+	case EM_MANIK:         return strdup ("M2000 Reconfigurable RISC Microprocessor");
+	case EM_CRAYNV2:       return strdup ("Cray Inc. NV2 vector architecture");
+	case EM_RX:            return strdup ("Renesas RX family");
+	case EM_METAG:         return strdup ("Imagination Technologies META processor architecture");
+	case EM_MCST_ELBRUS:   return strdup ("MCST Elbrus general purpose hardware architecture");
+	case EM_ECOG16:        return strdup ("Cyan Technology eCOG16 family");
+	case EM_CR16:          return strdup ("National Semiconductor CompactRISC CR16 16-bit microprocessor");
+	case EM_ETPU:          return strdup ("Freescale Extended Time Processing Unit");
+	case EM_SLE9X:         return strdup ("Infineon Technologies SLE9X core");
+	case EM_L10M:          return strdup ("Intel L10M");
+	case EM_K10M:          return strdup ("Intel K10M");
+	case reserved:         return strdup ("Reserved for future Intel use");
+	case EM_AARCH64:       return strdup ("ARM 64-bit architecture (AARCH64)");
+	case reserved:         return strdup ("Reserved for future ARM use");
+	case EM_AVR32:         return strdup ("Atmel Corporation 32-bit microprocessor family");
+	case EM_STM8:          return strdup ("STMicroeletronics STM8 8-bit microcontroller");
+	case EM_TILE64:        return strdup ("Tilera TILE64 multicore architecture family");
+	case EM_TILEPRO:       return strdup ("Tilera TILEPro multicore architecture family");
+	case EM_MICROBLAZE:    return strdup ("Xilinx MicroBlaze 32-bit RISC soft processor core");
+	case EM_CUDA:          return strdup ("NVIDIA CUDA architecture");
+	case EM_TILEGX:        return strdup ("Tilera TILE-Gx multicore architecture family");
+	case EM_CLOUDSHIELD:   return strdup ("CloudShield architecture family");
+	case EM_COREA_1ST:     return strdup ("KIPO-KAIST Core-A 1st generation processor family");
+	case EM_COREA_2ND:     return strdup ("KIPO-KAIST Core-A 2nd generation processor family");
+	case EM_ARC_COMPACT2:  return strdup ("Synopsys ARCompact V2");
+	case EM_OPEN8:         return strdup ("Open8 8-bit RISC soft processor core");
+	case EM_RL78:          return strdup ("Renesas RL78 family");
+	case EM_VIDEOCORE5:    return strdup ("Broadcom VideoCore V processor");
+	case EM_78KOR:         return strdup ("Renesas 78KOR family");
+	case EM_56800EX:       return strdup ("Freescale 56800EX Digital Signal Controller (DSC)");
+	case EM_BA1:           return strdup ("Beyond BA1 CPU architecture");
+	case EM_BA2:           return strdup ("Beyond BA2 CPU architecture");
+	case EM_XCORE:         return strdup ("XMOS xCORE processor family");
+	case EM_MCHP_PIC:      return strdup ("Microchip 8-bit PIC(r) family");
+	case EM_INTEL205:      return strdup ("Reserved by Intel");
+	case EM_INTEL206:      return strdup ("Reserved by Intel");
+	case EM_INTEL207:      return strdup ("Reserved by Intel");
+	case EM_INTEL208:      return strdup ("Reserved by Intel");
+	case EM_INTEL209:      return strdup ("Reserved by Intel");
+	case EM_KM32:          return strdup ("KM211 KM32 32-bit processor");
+	case EM_KMX32:         return strdup ("KM211 KMX32 32-bit processor");
+	case EM_KMX16:         return strdup ("KM211 KMX16 16-bit processor");
+	case EM_KMX8:          return strdup ("KM211 KMX8 8-bit processor");
+	case EM_KVARC:         return strdup ("KM211 KVARC processor");
+	case EM_CDP:           return strdup ("Paneve CDP architecture family");
+	case EM_COGE:          return strdup ("Cognitive Smart Memory Processor");
+	case EM_COOL:          return strdup ("Bluechip Systems CoolEngine");
+	case EM_NORC:          return strdup ("Nanoradio Optimized RISC");
+	case EM_CSR_KALIMBA:   return strdup ("CSR Kalimba architecture family");
+	case EM_Z80:           return strdup ("Zilog Z80");
+	case EM_VISIUM:        return strdup ("Controls and Data Services VISIUMcore processor");
+	case EM_FT32:          return strdup ("FTDI Chip FT32 high performance 32-bit RISC architecture");
+	case EM_MOXIE:         return strdup ("Moxie processor family");
+	case EM_AMDGPU:        return strdup ("AMD GPU architecture");
+	case EM_RISCV:         return strdup ("RISC-V");
+
 	default:             return r_str_newf ("<unknown>: 0x%x", bin->ehdr.e_machine);
 	}
 }
@@ -2409,7 +2486,7 @@ ut8 *Elf_(r_bin_elf_grab_regstate)(ELFOBJ *bin, int *len) {
 				continue;
 			}
 			int bits = Elf_(r_bin_elf_get_bits)(bin);
-			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr) : sizeof (Elf32_Nhdr);
+			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr): sizeof (Elf32_Nhdr);
 			void *elf_nhdr = calloc (elf_nhdr_size, 1);
 			bool regs_found = false;
 			ut64 offset = 0;
@@ -2520,7 +2597,7 @@ static size_t get_relocs_num(ELFOBJ *bin) {
 	if (!bin->g_sections) {
 		return 0;
 	}
-	size = bin->is_rela == DT_REL ? sizeof (Elf_(Rel)) : sizeof (Elf_(Rela));
+	size = bin->is_rela == DT_REL ? sizeof (Elf_(Rel)): sizeof (Elf_(Rela));
 	for (i = 0; !bin->g_sections[i].last; i++) {
 		if (sectionIsInvalid (bin, &bin->g_sections[i])) {
 			continue;
@@ -2623,7 +2700,7 @@ RBinElfReloc* Elf_(r_bin_elf_get_relocs)(ELFOBJ *bin) {
 				break;
 			}
 			if (!bin->is_rela) {
-				rela = is_rela? DT_RELA : DT_REL;
+				rela = is_rela? DT_RELA: DT_REL;
 			} else {
 				rela = bin->is_rela;
 			}
@@ -3185,7 +3262,7 @@ static void _set_arm_thumb_bits(struct Elf_(r_bin_elf_obj_t) *bin, RBinSymbol **
 	int len = strlen (ptr->name);
 	if (ptr->name[0] == '$' && (len >= 2 && !ptr->name[2])) {
 		switch (ptr->name[1]) {
-		case 'a' : //arm
+		case 'a': //arm
 			ptr->bits = 32;
 			break;
 		case 't': //thumb
@@ -3237,7 +3314,7 @@ RBinSymbol *Elf_(_r_bin_elf_convert_symbol)(struct Elf_(r_bin_elf_obj_t) *bin,
 	if (!(ptr = R_NEW0 (RBinSymbol))) {
 		return NULL;
 	}
-	ptr->name = symbol->name[0] ? r_str_newf (namefmt, &symbol->name[0]) : strdup ("");
+	ptr->name = symbol->name[0] ? r_str_newf (namefmt, &symbol->name[0]): strdup ("");
 	ptr->forwarder = r_str_const ("NONE");
 	ptr->bind = r_str_const (symbol->bind);
 	ptr->type = r_str_const (symbol->type);
@@ -3461,7 +3538,7 @@ static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type
 	if (!ret) {
 		return Elf_(get_phdr_symbols) (bin, type);
 	}
-	ret[ret_ctr].last = 1; // ugly dirty hack :D
+	ret[ret_ctr].last = 1; // ugly dirty hack:D
 	int max = -1;
 	RBinElfSymbol *aux = NULL;
 	nsym = Elf_(fix_symbols) (bin, ret_ctr, type, &ret);
@@ -3710,8 +3787,8 @@ static bool get_nt_file_maps (ELFOBJ *bin, RList *core_maps) {
 		Elf_(Phdr) *p = &bin->phdr[ph];
 		if (p->p_type == PT_NOTE) {
 			int bits = Elf_(r_bin_elf_get_bits)(bin);
-			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr) : sizeof (Elf32_Nhdr);
-			int size_of = (bits == 64) ? sizeof (ut64) : sizeof (ut32);
+			int elf_nhdr_size = (bits == 64) ? sizeof (Elf64_Nhdr): sizeof (Elf32_Nhdr);
+			int size_of = (bits == 64) ? sizeof (ut64): sizeof (ut32);
 			void *elf_nhdr = calloc (elf_nhdr_size, 1);
 			ut64 offset = 0;
 			bool found = false;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1992,7 +1992,7 @@ ut64 Elf_(r_bin_elf_get_main_offset)(ELFOBJ *bin) {
 	}
 #endif
 	/* linux64 pie main -- probably buggy in some cases */
-	int bo = 29; // Begin offset may vary depending on the entry prelude 
+	int bo = 29; // Begin offset may vary depending on the entry prelude
 	if (buf[0] == 0xf3 && buf[1] == 0x0f && buf[2] == 0x1e && buf[3] == 0xfa) {
 		// Change begin offset if binary starts with 'endbr64'
 		bo = 33;
@@ -2135,9 +2135,8 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 	case EM_LANAI:
 		return strdup ("lanai");
 	case EM_VIDEOCORE3:
-		return strdup ("vc3");
-	// case EM_VIDEOCORE4:
-		// return strdup ("vc4");
+	case EM_VIDEOCORE4:
+		return strdup ("vc4");
 	case EM_MSP430:
 		return strdup ("msp430");
 	case EM_SH:
@@ -2237,7 +2236,7 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_MICROBLAZE:    return strdup ("Xilinx MicroBlaze");
 	case EM_RISCV:         return strdup ("RISC V");
 	case EM_VIDEOCORE3:    return strdup ("VideoCore III");
-	// case EM_VIDEOCORE4:    return strdup ("VideoCore IV");  // Nonstandard
+	case EM_VIDEOCORE4:    return strdup ("VideoCore IV");
 	case EM_LATTICEMICO32: return strdup ("RISC processor for Lattice FPGA architecture");
 	case EM_SE_C17:        return strdup ("Seiko Epson C17 family");
 	case EM_TI_C6000:      return strdup ("The Texas Instruments TMS320C6000 DSP family");
@@ -2249,12 +2248,12 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_CYPRESS_M8C:   return strdup ("Cypress M8C microprocessor");
 	case EM_R32C:          return strdup ("Renesas R32C series microprocessors");
 	case EM_TRIMEDIA:      return strdup ("NXP Semiconductors TriMedia architecture family");
-	// case EM_QDSP6:         return strdup ("QUALCOMM DSP6 Processor");  // Nonstandard
+	case EM_QDSP6:         return strdup ("QUALCOMM DSP6 Processor");  // Nonstandard
 	case EM_8051:          return strdup ("Intel 8051 and variants");
 	case EM_STXP7X:        return strdup ("STMicroelectronics STxP7x family of configurable and extensible RISC processors");
 	case EM_NDS32:         return strdup ("Andes Technology compact code size embedded RISC processor family");
 	case EM_ECOG1:         return strdup ("Cyan Technology eCOG1X family");
-	// case EM_ECOG1X:        return strdup ("Cyan Technology eCOG1X family");
+	// case EM_ECOG1X:        return strdup ("Cyan Technology eCOG1X family");  // Nonstandard
 	case EM_MAXQ30:        return strdup ("Dallas Semiconductor MAXQ30 Core Micro-controllers");
 	case EM_XIMO16:        return strdup ("New Japan Radio (NJR) 16-bit DSP Processor");
 	case EM_MANIK:         return strdup ("M2000 Reconfigurable RISC Microprocessor");
@@ -2268,12 +2267,12 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_SLE9X:         return strdup ("Infineon Technologies SLE9X core");
 	case EM_L10M:          return strdup ("Intel L10M");
 	case EM_K10M:          return strdup ("Intel K10M");
-	// case EM_AARCH64:       return strdup ("ARM 64-bit architecture (AARCH64)");
+	// case EM_AARCH64:       return strdup ("ARM 64-bit architecture (AARCH64)");  // Nonstandard
 	case EM_AVR32:         return strdup ("Atmel Corporation 32-bit microprocessor family");
 	case EM_STM8:          return strdup ("STMicroeletronics STM8 8-bit microcontroller");
 	case EM_TILE64:        return strdup ("Tilera TILE64 multicore architecture family");
 	case EM_TILEPRO:       return strdup ("Tilera TILEPro multicore architecture family");
-	// case EM_MICROBLAZE:    return strdup ("Xilinx MicroBlaze 32-bit RISC soft processor core");
+	// case EM_MICROBLAZE:    return strdup ("Xilinx MicroBlaze 32-bit RISC soft processor core");  // Nonstandard
 	case EM_CUDA:          return strdup ("NVIDIA CUDA architecture");
 	case EM_TILEGX:        return strdup ("Tilera TILE-Gx multicore architecture family");
 	case EM_CLOUDSHIELD:   return strdup ("CloudShield architecture family");
@@ -2284,7 +2283,7 @@ char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {
 	case EM_RL78:          return strdup ("Renesas RL78 family");
 	case EM_VIDEOCORE5:    return strdup ("Broadcom VideoCore V processor");
 	case EM_78KOR:         return strdup ("Renesas 78KOR family");
-	case EM_56800EX:       return strdup ("Freescale 56800EX Digital Signal Controller (DSC)");
+	// case EM_56800EX:       return strdup ("Freescale 56800EX Digital Signal Controller (DSC)");  // Nonstandard
 	case EM_BA1:           return strdup ("Beyond BA1 CPU architecture");
 	case EM_BA2:           return strdup ("Beyond BA2 CPU architecture");
 	case EM_XCORE:         return strdup ("XMOS xCORE processor family");

--- a/libr/bin/format/elf/elf_specs.h
+++ b/libr/bin/format/elf/elf_specs.h
@@ -71,7 +71,7 @@
 
 #define EM_PROPELLER           0x5072
 #define EM_LANAI               0x8123
-// #define EM_VIDEOCORE4          200  // Nonstandard
+#define EM_VIDEOCORE4          200
 
 #define EM_PDP10               64         /* Digital Equipment Corp. PDP-10 */
 #define EM_PDP11               65         /* Digital Equipment Corp. PDP-11 */

--- a/libr/bin/format/elf/elf_specs.h
+++ b/libr/bin/format/elf/elf_specs.h
@@ -95,6 +95,8 @@
 #define EM_EXCESS              111        /* eXcess: 16/32/64-bit configurable embedded CPU */
 #define EM_DXP                 112        /* Icera Semiconductor Inc. Deep Execution Processor */
 
+// http://www.sco.com/developers/gabi/latest/ch4.eheader.html
+
 #define EM_CRX                 114        /* National Semiconductor CompactRISC CRX microprocessor */
 #define EM_XGATE               115        /* Motorola XGATE embedded processor */
 #define EM_C166                116        /* Infineon C16x/XC16x processor */

--- a/libr/bin/format/elf/elf_specs.h
+++ b/libr/bin/format/elf/elf_specs.h
@@ -10,9 +10,9 @@
 #undef ELF_M_SYM
 #undef ELF_M_SIZE
 #undef ELF_M_INFO
-	
+
 #ifdef R_BIN_ELF64
-# define Elf_(name) Elf64_##name 
+# define Elf_(name) Elf64_##name
 # define ELF_ST_BIND       ELF64_ST_BIND
 # define ELF_ST_TYPE       ELF64_ST_TYPE
 # define ELF_ST_INFO       ELF64_ST_INFO
@@ -23,8 +23,8 @@
 # define ELF_M_SYM         ELF64_M_SYM
 # define ELF_M_SIZE        ELF64_M_SIZE
 # define ELF_M_INFO        ELF64_M_INFO
-#else       
-# define Elf_(name) Elf32_##name 
+#else
+# define Elf_(name) Elf32_##name
 # define ELF_ST_BIND       ELF32_ST_BIND
 # define ELF_ST_TYPE       ELF32_ST_TYPE
 # define ELF_ST_INFO       ELF32_ST_INFO
@@ -35,7 +35,7 @@
 # define ELF_M_SYM         ELF32_M_SYM
 # define ELF_M_SIZE        ELF32_M_SIZE
 # define ELF_M_INFO        ELF32_M_INFO
-#endif      
+#endif
 
 /* MingW doesn't define __BEGIN_DECLS / __END_DECLS. */
 #ifndef __BEGIN_DECLS
@@ -58,7 +58,7 @@
 #ifndef _INCLUDE_ELF_SPECS_H
 #define _INCLUDE_ELF_SPECS_H
 
-#define ELF_STRING_LENGTH 256 
+#define ELF_STRING_LENGTH 256
 
 // not strictly ELF, but close enough:
 #define        CGCMAG          "\177CGC"
@@ -69,15 +69,118 @@
 #define ELFOSABI_OPENVMS       13      /* OpenVMS  */
 #define ELFOSABI_ARM_AEABI     64      /* ARM EABI */
 
-#define EM_BLACKFIN            106             /* Analog Devices Blackfin */
-#define EM_MCST_ELBRUS         175
 #define EM_PROPELLER           0x5072
-#define EM_RISCV               243
 #define EM_LANAI               0x8123
-#define EM_VIDEOCORE           95 // XXX dupe for EM_NUM
-#define EM_VIDEOCORE3          137
-#define EM_VIDEOCORE4          200
-#define EM_MSP430              0x69
+// #define EM_VIDEOCORE4          200  // Nonstandard
+
+#define EM_PDP10               64         /* Digital Equipment Corp. PDP-10 */
+#define EM_PDP11               65         /* Digital Equipment Corp. PDP-11 */
+
+#define EM_VIDEOCORE           95         /* Alphamosaic VideoCore processor */  // XXX dupe for EM_NUM
+#define EM_TMM_GPP             96         /* Thompson Multimedia General Purpose Processor */
+#define EM_NS32K               97         /* National Semiconductor 32000 series */
+#define EM_TPC                 98         /* Tenor Network TPC processor */
+#define EM_SNP1K               99         /* Trebia SNP 1000 processor */
+#define EM_ST200               100        /* STMicroelectronics (www.st.com) ST200 microcontroller */
+#define EM_IP2K                101        /* Ubicom IP2xxx microcontroller family */
+#define EM_MAX                 102        /* MAX Processor */
+#define EM_CR                  103        /* National Semiconductor CompactRISC microprocessor */
+#define EM_F2MC16              104        /* Fujitsu F2MC16 */
+#define EM_MSP430              105        /* Texas Instruments embedded microcontroller msp430 */
+#define EM_BLACKFIN            106        /* Analog Devices Blackfin (DSP) processor */
+#define EM_SE_C33              107        /* S1C33 Family of Seiko Epson processors */
+#define EM_SEP                 108        /* Sharp embedded microprocessor */
+#define EM_ARCA                109        /* Arca RISC Microprocessor */
+#define EM_UNICORE             110        /* Microprocessor series from PKU-Unity Ltd. and MPRC of Peking University */
+#define EM_EXCESS              111        /* eXcess: 16/32/64-bit configurable embedded CPU */
+#define EM_DXP                 112        /* Icera Semiconductor Inc. Deep Execution Processor */
+
+#define EM_CRX                 114        /* National Semiconductor CompactRISC CRX microprocessor */
+#define EM_XGATE               115        /* Motorola XGATE embedded processor */
+#define EM_C166                116        /* Infineon C16x/XC16x processor */
+#define EM_M16C                117        /* Renesas M16C series microprocessors */
+#define EM_DSPIC30F            118        /* Microchip Technology dsPIC30F Digital Signal Controller */
+#define EM_CE                  119        /* Freescale Communication Engine RISC core */
+#define EM_M32C                120        /* Renesas M32C series microprocessors */
+#define EM_TSK3000             131        /* Altium TSK3000 core */
+#define EM_RS08                132        /* Freescale RS08 embedded processor */
+#define EM_SHARC               133        /* Analog Devices SHARC family of 32-bit DSP processors */
+#define EM_ECOG2               134        /* Cyan Technology eCOG2 microprocessor */
+#define EM_SCORE7              135        /* Sunplus S+core7 RISC processor */
+#define EM_DSP24               136        /* New Japan Radio (NJR) 24-bit DSP Processor */
+#define EM_VIDEOCORE3          137        /* Broadcom VideoCore III processor */
+#define EM_LATTICEMICO32       138        /* RISC processor for Lattice FPGA architecture */
+#define EM_SE_C17              139        /* Seiko Epson C17 family */
+#define EM_TI_C6000            140        /* The Texas Instruments TMS320C6000 DSP family */
+#define EM_TI_C2000            141        /* The Texas Instruments TMS320C2000 DSP family */
+#define EM_TI_C5500            142        /* The Texas Instruments TMS320C55x DSP family */
+#define EM_TI_ARP32            143        /* Texas Instruments Application Specific RISC Processor, 32bit fetch */
+#define EM_TI_PRU              144        /* Texas Instruments Programmable Realtime Unit */
+#define EM_MMDSP_PLUS          160        /* STMicroelectronics 64bit VLIW Data Signal Processor */
+#define EM_CYPRESS_M8C         161        /* Cypress M8C microprocessor */
+#define EM_R32C                162        /* Renesas R32C series microprocessors */
+#define EM_TRIMEDIA            163        /* NXP Semiconductors TriMedia architecture family */
+// #define EM_QDSP6               164        /* QUALCOMM DSP6 Processor */  // Nonstandard
+#define EM_8051                165        /* Intel 8051 and variants */
+#define EM_STXP7X              166        /* STMicroelectronics STxP7x family of configurable and extensible RISC processors */
+#define EM_NDS32               167        /* Andes Technology compact code size embedded RISC processor family */
+#define EM_ECOG1               168        /* Cyan Technology eCOG1X family */
+#define EM_MAXQ30              169        /* Dallas Semiconductor MAXQ30 Core Micro-controllers */
+#define EM_XIMO16              170        /* New Japan Radio (NJR) 16-bit DSP Processor */
+#define EM_MANIK               171        /* M2000 Reconfigurable RISC Microprocessor */
+#define EM_CRAYNV2             172        /* Cray Inc. NV2 vector architecture */
+#define EM_RX                  173        /* Renesas RX family */
+#define EM_METAG               174        /* Imagination Technologies META processor architecture */
+#define EM_MCST_ELBRUS         175        /* MCST Elbrus general purpose hardware architecture */
+#define EM_ECOG16              176        /* Cyan Technology eCOG16 family */
+#define EM_CR16                177        /* National Semiconductor CompactRISC CR16 16-bit microprocessor */
+#define EM_ETPU                178        /* Freescale Extended Time Processing Unit */
+#define EM_SLE9X               179        /* Infineon Technologies SLE9X core */
+#define EM_L10M                180        /* Intel L10M */
+#define EM_K10M                181        /* Intel K10M */
+#define EM_AARCH64             183        /* ARM 64-bit architecture (AARCH64) */
+#define EM_AVR32               185        /* Atmel Corporation 32-bit microprocessor family */
+#define EM_STM8                186        /* STMicroeletronics STM8 8-bit microcontroller */
+#define EM_TILE64              187        /* Tilera TILE64 multicore architecture family */
+#define EM_TILEPRO             188        /* Tilera TILEPro multicore architecture family */
+#define EM_MICROBLAZE          189        /* Xilinx MicroBlaze 32-bit RISC soft processor core */
+#define EM_CUDA                190        /* NVIDIA CUDA architecture */
+#define EM_TILEGX              191        /* Tilera TILE-Gx multicore architecture family */
+#define EM_CLOUDSHIELD         192        /* CloudShield architecture family */
+#define EM_COREA_1ST           193        /* KIPO-KAIST Core-A 1st generation processor family */
+#define EM_COREA_2ND           194        /* KIPO-KAIST Core-A 2nd generation processor family */
+#define EM_ARC_COMPACT2        195        /* Synopsys ARCompact V2 */
+#define EM_OPEN8               196        /* Open8 8-bit RISC soft processor core */
+#define EM_RL78                197        /* Renesas RL78 family */
+#define EM_VIDEOCORE5          198        /* Broadcom VideoCore V processor */
+#define EM_78KOR               199        /* Renesas 78KOR family */
+#define EM_56800EX             200        /* Freescale 56800EX Digital Signal Controller (DSC) */
+#define EM_BA1                 201        /* Beyond BA1 CPU architecture */
+#define EM_BA2                 202        /* Beyond BA2 CPU architecture */
+#define EM_XCORE               203        /* XMOS xCORE processor family */
+#define EM_MCHP_PIC            204        /* Microchip 8-bit PIC(r) family */
+#define EM_INTEL205            205        /* Reserved by Intel */
+#define EM_INTEL206            206        /* Reserved by Intel */
+#define EM_INTEL207            207        /* Reserved by Intel */
+#define EM_INTEL208            208        /* Reserved by Intel */
+#define EM_INTEL209            209        /* Reserved by Intel */
+#define EM_KM32                210        /* KM211 KM32 32-bit processor */
+#define EM_KMX32               211        /* KM211 KMX32 32-bit processor */
+#define EM_KMX16               212        /* KM211 KMX16 16-bit processor */
+#define EM_KMX8                213        /* KM211 KMX8 8-bit processor */
+#define EM_KVARC               214        /* KM211 KVARC processor */
+#define EM_CDP                 215        /* Paneve CDP architecture family */
+#define EM_COGE                216        /* Cognitive Smart Memory Processor */
+#define EM_COOL                217        /* Bluechip Systems CoolEngine */
+#define EM_NORC                218        /* Nanoradio Optimized RISC */
+#define EM_CSR_KALIMBA         219        /* CSR Kalimba architecture family */
+#define EM_Z80                 220        /* Zilog Z80 */
+#define EM_VISIUM              221        /* Controls and Data Services VISIUMcore processor */
+#define EM_FT32                222        /* FTDI Chip FT32 high performance 32-bit RISC architecture */
+#define EM_MOXIE               223        /* Moxie processor family */
+#define EM_AMDGPU              224        /* AMD GPU architecture */
+#define EM_RISCV               243        /* RISC-V */
+
 
 // specific OpenBSD sections
 #ifndef PT_OPENBSD_RANDOMIZE

--- a/libr/bin/format/elf/elf_specs.h
+++ b/libr/bin/format/elf/elf_specs.h
@@ -122,7 +122,7 @@
 #define EM_CYPRESS_M8C         161        /* Cypress M8C microprocessor */
 #define EM_R32C                162        /* Renesas R32C series microprocessors */
 #define EM_TRIMEDIA            163        /* NXP Semiconductors TriMedia architecture family */
-// #define EM_QDSP6               164        /* QUALCOMM DSP6 Processor */  // Nonstandard
+#define EM_QDSP6               164        /* QUALCOMM DSP6 Processor */  // Nonstandard
 #define EM_8051                165        /* Intel 8051 and variants */
 #define EM_STXP7X              166        /* STMicroelectronics STxP7x family of configurable and extensible RISC processors */
 #define EM_NDS32               167        /* Andes Technology compact code size embedded RISC processor family */

--- a/libr/bin/format/elf/glibc_elf.h
+++ b/libr/bin/format/elf/glibc_elf.h
@@ -222,6 +222,8 @@ typedef struct
 #define EM_X86_64	62		/* AMD x86-64 architecture */
 #define EM_PDSP		63		/* Sony DSP Processor */
 
+// http://www.sco.com/developers/gabi/2003-12-17/ch4.eheader.html
+
 #define EM_FX66		66		/* Siemens FX66 microcontroller */
 #define EM_ST9PLUS	67		/* STMicroelectronics ST9+ 8/16 mc */
 #define EM_ST7		68		/* STmicroelectronics ST7 8 bit mc */

--- a/libr/bin/format/elf/glibc_elf.h
+++ b/libr/bin/format/elf/glibc_elf.h
@@ -222,8 +222,6 @@ typedef struct
 #define EM_X86_64	62		/* AMD x86-64 architecture */
 #define EM_PDSP		63		/* Sony DSP Processor */
 
-// http://www.sco.com/developers/gabi/2003-12-17/ch4.eheader.html
-
 #define EM_FX66		66		/* Siemens FX66 microcontroller */
 #define EM_ST9PLUS	67		/* STMicroelectronics ST9+ 8/16 mc */
 #define EM_ST7		68		/* STmicroelectronics ST7 8 bit mc */


### PR DESCRIPTION
I've run into a few cases in which rabin2 didn't recognize the e_machine value in an elf header, this PR adds a bunch from http://www.sco.com/developers/gabi/latest/ch4.eheader.html, which was the most complete source I could find.