### PR TITLE
Support struct/enum/union before name in ctypes parse

### DIFF
--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -88,6 +88,12 @@ struct r_parse_ctype_type_t {
 
 	union {
 		struct {
+			enum {
+				R_PARSE_CTYPE_IDENTIFIER_KIND_UNSPECIFIED,
+				R_PARSE_CTYPE_IDENTIFIER_KIND_STRUCT,
+				R_PARSE_CTYPE_IDENTIFIER_KIND_UNION,
+				R_PARSE_CTYPE_IDENTIFIER_KIND_ENUM
+			} kind;
 			char *name;
 			bool is_const;
 		} identifier;

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -78,22 +78,25 @@ R_API void r_parse_c_reset(RParse *p);
 
 typedef struct r_parse_ctype_t RParseCType;
 
+typedef enum {
+	R_PARSE_CTYPE_TYPE_KIND_IDENTIFIER,
+	R_PARSE_CTYPE_TYPE_KIND_POINTER,
+	R_PARSE_CTYPE_TYPE_KIND_ARRAY
+} RParseCTypeTypeKind;
+
+typedef enum {
+	R_PARSE_CTYPE_IDENTIFIER_KIND_UNSPECIFIED,
+	R_PARSE_CTYPE_IDENTIFIER_KIND_STRUCT,
+	R_PARSE_CTYPE_IDENTIFIER_KIND_UNION,
+	R_PARSE_CTYPE_IDENTIFIER_KIND_ENUM
+} RParseCTypeTypeIdentifierKind;
+
 typedef struct r_parse_ctype_type_t RParseCTypeType;
 struct r_parse_ctype_type_t {
-	enum {
-		R_PARSE_CTYPE_TYPE_KIND_IDENTIFIER,
-		R_PARSE_CTYPE_TYPE_KIND_POINTER,
-		R_PARSE_CTYPE_TYPE_KIND_ARRAY
-	} kind;
-
+	RParseCTypeTypeKind kind;
 	union {
 		struct {
-			enum {
-				R_PARSE_CTYPE_IDENTIFIER_KIND_UNSPECIFIED,
-				R_PARSE_CTYPE_IDENTIFIER_KIND_STRUCT,
-				R_PARSE_CTYPE_IDENTIFIER_KIND_UNION,
-				R_PARSE_CTYPE_IDENTIFIER_KIND_ENUM
-			} kind;
+			RParseCTypeTypeIdentifierKind kind;
 			char *name;
 			bool is_const;
 		} identifier;


### PR DESCRIPTION
Now also supported: `struct something`, `union something` and `enum something`

Test: https://github.com/radare/radare2-regressions/pull/1903