### PR TITLE
cmd_debug.c: Make addroflib use basenames

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1469,12 +1469,12 @@ static ut64 addroflib(RCore *core, const char *libname) {
 	// RList *list = r_debug_native_modules_get (core->dbg);
 	RList *list = r_debug_modules_list (core->dbg);
 	r_list_foreach (list, iter, map) {
-		if (strstr (map->name, libname)) {
+		if (strstr (r_file_basename(map->name), libname)) {
 			return map->addr;
 		}
 	}
 	r_list_foreach (core->dbg->maps, iter, map) {
-		if (strstr (map->name, libname)) {
+		if (strstr (r_file_basename(map->name), libname)) {
 			return map->addr;
 		}
 	}


### PR DESCRIPTION
Hey there :)

I've noticed a small bug where the `addroflib` function returns the wrong lib address. Consider the following example:

Working:
```
r2  -c "dcu main; dmi libc~system"  -d /bin/ls
[...]
1421 0x00047850 0x7fa986cc1850   WEAK   FUNC   45 system
[...]
``` 

**Not** working:

```
r2  -c "dcu main; dmi libc~system"  -d /tmp/libc/ls
--> Nothing found
``` 

This happens because `addroflib` matches the search query `libc` using `strstr` on the full library path, hence the `/tmp/libc/ls` gets picked over the actual libc path. This causes `dmi` to be executed on `/tmp/libc/ls` instead of the `libc.so` file.

In my opinion this should match on the library *name* instead of the full path, as suggested by:
```
[0x00000000]> dmi?
Usage: dmi    # List/Load Symbols
| dmi[libname] [symname]  List symbols of target lib
```
This says lib**name** so I think this should be using the basename instead. 


Also: I thought about adding a small warning in case multiple things matched because a user can't be sure to which result the printed stuff belongs to. Of course, this would make the `dmi` process a bit slower since it can't break early on the first matching lib. 

Cheers <3