### PR TITLE
WIP: emacs keybindings

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -30,6 +30,8 @@ typedef enum {
 	CONTROL_MODE
 } RViMode; 
 
+bool enable_yank_pop = false;
+
 static inline bool is_word_break_char(char ch, bool mode) {
 	int i;
 	if (mode == MAJOR_BREAK) {
@@ -67,6 +69,7 @@ static void backward_kill_word() {
 		len = I.buffer.index - i + 1;
 		free (I.clipboard);
 		I.clipboard = r_str_ndup (I.buffer.data + i, len);
+		r_line_clipboard_push (I.clipboard);
 		memmove (I.buffer.data + i, I.buffer.data + I.buffer.index,
 				I.buffer.length - I.buffer.index + 1);
 		I.buffer.length = strlen (I.buffer.data);
@@ -94,6 +97,7 @@ static void backward_kill_Word() {
 		len = I.buffer.index - i + 1;
 		free (I.clipboard);
 		I.clipboard = r_str_ndup (I.buffer.data + i, len);
+		r_line_clipboard_push (I.clipboard);
 		memmove (I.buffer.data + i, I.buffer.data + I.buffer.index,
 				I.buffer.length - I.buffer.index + 1);
 		I.buffer.length = strlen (I.buffer.data);
@@ -115,6 +119,7 @@ static void kill_word() {
 	len = i - I.buffer.index + 1;
 	free (I.clipboard);
 	I.clipboard = r_str_ndup (I.buffer.data + I.buffer.index, len);
+	r_line_clipboard_push (I.clipboard);
 	memmove (I.buffer.data + I.buffer.index, I.buffer.data + i, len);
 	I.buffer.length = strlen (I.buffer.data);
 }
@@ -133,6 +138,7 @@ static void kill_Word() {
 	len = i - I.buffer.index + 1;
 	free (I.clipboard);
 	I.clipboard = r_str_ndup (I.buffer.data + I.buffer.index, len);
+	r_line_clipboard_push (I.clipboard);
 	memmove (I.buffer.data + I.buffer.index, I.buffer.data + i, len);
 	I.buffer.length = strlen (I.buffer.data);
 }
@@ -146,6 +152,7 @@ static void paste() {
 		memmove (cursor + len, cursor, dist);
 		memcpy (cursor, I.clipboard, len);
 		I.buffer.index += len;
+		enable_yank_pop = true;
 	}
 }
 
@@ -171,6 +178,7 @@ static void unix_word_rubout() {
 		len = I.buffer.index - i + 1;
 		free (I.clipboard);
 		I.clipboard = r_str_ndup (I.buffer.data + i, len);
+		r_line_clipboard_push (I.clipboard);
 		memmove (I.buffer.data + i,
 			I.buffer.data + I.buffer.index,
 			I.buffer.length - I.buffer.index + 1);
@@ -1055,6 +1063,7 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 		case 21:// ^U - cut
 			free (I.clipboard);
 			I.clipboard = strdup (I.buffer.data);
+			r_line_clipboard_push (I.clipboard);
 			I.buffer.data[0] = '\0';
 			I.buffer.length = 0;
 			I.buffer.index = 0;
@@ -1093,6 +1102,9 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 			unix_word_rubout ();
 			break;
 		case 24:// ^X -- do nothing but store in prev = *buf
+			strncpy (I.buffer.data, I.buffer.data + I.buffer.index, I.buffer.length);
+			I.buffer.length -= I.buffer.index;
+			I.buffer.index = 0;
 			break;
 		case 25:// ^Y - paste
 			paste ();
@@ -1268,6 +1280,19 @@ _end:
 	return I.buffer.data[0] != '\0'? I.buffer.data: r_line_nullstr;
 }
 #endif
+
+static inline void rotate_kill_ring () {
+	if (enable_yank_pop) {
+		I.buffer.index -= strlen (r_list_get_n (I.kill_ring, I.kill_ring_ptr));
+		I.buffer.data[I.buffer.index] = 0;
+		I.kill_ring_ptr -= 1;
+		if (I.kill_ring_ptr < 0) {
+			I.kill_ring_ptr = I.kill_ring->length - 1;
+		}
+		I.clipboard = r_list_get_n (I.kill_ring, I.kill_ring_ptr);
+		paste ();
+	}
+}
 
 static inline void delete_next_char () {
 	if (I.buffer.length == I.buffer.index) {
@@ -1658,6 +1683,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 	int rows, columns = r_cons_get_size (&rows) - 2;
 	const char *gcomp_line = "";
 	static int gcomp_idx = 0;
+	static bool yank_flag = 0;
 	static int gcomp = 0;
 	signed char buf[10];
 #if USE_UTF8
@@ -1700,6 +1726,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 	}
 	r_cons_break_push (NULL, NULL);
 	for (;;) {
+		yank_flag = 0;
 		if (r_cons_is_breaked ()) {
 			break;
 		}
@@ -1886,6 +1913,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		case 21:// ^U - cut
 			free (I.clipboard);
 			I.clipboard = strdup (I.buffer.data);
+			r_line_clipboard_push (I.clipboard);
 			I.buffer.data[0] = '\0';
 			I.buffer.length = 0;
 			I.buffer.index = 0;
@@ -1893,10 +1921,24 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		case 23:// ^W ^w unix-word-rubout
 			unix_word_rubout ();
 			break;
-		case 24:// ^X -- do nothing but store in prev = *buf
+		case 24:// ^X
+			strncpy (I.buffer.data, I.buffer.data + I.buffer.index, I.buffer.length);
+			I.buffer.length -= I.buffer.index;
+			I.buffer.index = 0;
 			break;
 		case 25:// ^Y - paste
 			paste ();
+			yank_flag = 1;
+			break;
+		case 29:  // ^^ - rotate kill ring 
+			rotate_kill_ring ();
+			yank_flag = enable_yank_pop ? 1 : 0;
+			break;
+		case 20:  // ^t Kill from point to the end of the current word,
+			kill_word ();
+			break;
+		case 15: // ^o kill backward
+			backward_kill_word ();	
 			break;
 		case 14:// ^n
 			if (I.sel_widget) {
@@ -2348,6 +2390,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 			}
 			fflush (stdout);
 		}
+		enable_yank_pop = yank_flag ? 1 : 0;
 		if (I.hud) {
 			goto _end;
 		}

--- a/libr/cons/line.c
+++ b/libr/cons/line.c
@@ -16,6 +16,9 @@ R_API RLine *r_line_new(void) {
 	I.prompt = strdup ("> ");
 	I.contents = NULL;
 	I.vi_mode = false;
+	I.clipboard = NULL;
+	I.kill_ring = r_list_newf (NULL);
+	I.kill_ring_ptr = -1;
 #if __WINDOWS__
 	I.ansicon = r_cons_is_ansicon ();
 #endif
@@ -32,6 +35,11 @@ R_API void r_line_free(void) {
 	I.prompt = NULL;
 	r_line_hist_free ();
 	r_line_completion_fini (&I.completion);
+}
+
+R_API void r_line_clipboard_push (const char *str) {
+	I.kill_ring_ptr += 1;
+	r_list_insert (I.kill_ring, I.kill_ring_ptr, strdup (str));
 }
 
 // handle const or dynamic prompts?

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -1011,6 +1011,8 @@ struct r_line_t {
 	int echo;
 	int has_echo;
 	char *prompt;
+	RList/*<str>*/ *kill_ring;
+	int kill_ring_ptr;
 	char *clipboard;
 	int disable;
 	void *user;
@@ -1038,6 +1040,7 @@ R_API void r_line_free(void);
 R_API char *r_line_get_prompt(void);
 R_API void r_line_set_prompt(const char *prompt);
 R_API int r_line_dietline_init(void);
+R_API void r_line_clipboard_push (const char *str);
 R_API void r_line_hist_free(void);
 
 typedef int (RLineReadCallback)(void *user, const char *line);


### PR DESCRIPTION
* [x] kill-line (C-k) Kill the text from point to the end of the line.
* [x] backward-kill-line (C-x Rubout) - Kill backward from the cursor to the beginning of the current line.
* [x] kill-whole-line (C-u) Kill all characters on the current line, no matter where point is. By default, this is unbound.
* [x] kill-word (C-t) - Kill from point to the end of the current word, or if between words, to the end of the next word. Word boundaries are the same as forward-word.
* [x] backward-kill-word (M-DEL)Kill the word behind point. Word boundaries are the same as backward-word.
* [x] shell-backward-kill-word (C-o) Kill the word behind point. Word boundaries are the same as shell-backward-word.
* [x] unix-word-rubout (C-w)Kill the word behind point, using white space as a word boundary. The killed text is saved on the kill-ring.
* [x] yank (C-y) Yank the top of the kill ring into the buffer at point.
* [x] yank-pop (C-z) Rotate the kill-ring, and yank the new top. You can only do this if the prior command is yank or yank-pop.