### PR TITLE
Default scr.breaklines to true

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3429,7 +3429,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("scr.wheel", "true", "Mouse wheel in Visual; temporaryly disable/reenable by right click/Enter)");
 	// DEPRECATED: USES hex.cols now SETI ("scr.colpos", 80, "Column position of cmd.cprompt in visual");
 	SETCB ("scr.breakword", "", &cb_scrbreakword, "Emulate console break (^C) when a word is printed (useful for pD)");
-	SETCB ("scr.breaklines", "false", &cb_breaklines, "Break lines in Visual instead of truncating them");
+	SETCB ("scr.breaklines", "true", &cb_breaklines, "Break lines in Visual instead of truncating them");
 	SETCB ("scr.gadgets", "true", &cb_scr_gadgets, "Run pg in prompt, visual and panels");
 	SETICB ("scr.columns", 0, &cb_scrcolumns, "Force console column count (width)");
 	SETPREF ("scr.dumpcols", "false", "Prefer pC commands before p ones");


### PR DESCRIPTION
Otherwise calls to really-long symbol names would go off the screen in Visual mode and this might upset people who are not aware of this config var.