### PR TITLE
Improve Mach-O header fields ##bin

### DIFF
--- a/libr/bin/d/macho
+++ b/libr/bin/d/macho
@@ -1,10 +1,34 @@
-pf.mach0_header xxxxddx magic cputype cpusubtype filetype ncmds sizeofcmds flags
-pf.mach0_segment xd[16]zxxxxoodx cmd cmdsize segname vmaddr vmsize fileoff filesize maxprot initprot nsects flags
-pf.mach0_symtab_command xdxdxd cmd cmdsize symoff nsyms stroff strsize
-pf.mach0_dysymtab_command xdddddddddddxdxdxxxd cmd cmdsize ilocalsym nlocalsym iextdefsym nextdefsym iundefsym nundefsym tocoff ntoc moddtaboff nmodtab extrefsymoff nextrefsyms inddirectsymoff nindirectsyms extreloff nextrel locreloff nlocrel
-pf.mach0_section [16]z16[z]xxxxxdxxx sectname segname addr size offset align reloff nreloc flags reserved1 reserved2
-pf.mach0_dylib xxxx name timestamp current_version compatibility_version
-pf.mach0_dylib_command xx? cmd cmdsize (mach0_dylib)dylib
-pf.mach0_uuid_command xx[16]b cmd cmdsize uuid
-pf.mach0_rpath_command xxx cmd cmdsize path
-pf.mach0_entry_point_command xxqq cmd cmdsize entryoff stacksize
+"td enum mach0_build_platform {MACOS=1, IOS=2, TVOS=3, WATCHOS=4, BRIDGEOS=5, IOSMAC=6, IOSSIMULATOR=7, TVOSSIMULATOR=8, WATCHOSSIMULATOR=9};"
+"td enum mach0_build_tool {CLANG=1, SWIFT=2, LD=3};"
+"td enum mach0_load_command_type { LC_SEGMENT=0x00000001ULL, LC_SYMTAB=0x00000002ULL, LC_SYMSEG=0x00000003ULL, LC_THREAD=0x00000004ULL, LC_UNIXTHREAD=0x00000005ULL, LC_LOADFVMLIB=0x00000006ULL, LC_IDFVMLIB=0x00000007ULL, LC_IDENT=0x00000008ULL, LC_FVMFILE=0x00000009ULL, LC_PREPAGE=0x0000000aULL, LC_DYSYMTAB=0x0000000bULL, LC_LOAD_DYLIB=0x0000000cULL, LC_ID_DYLIB=0x0000000dULL, LC_LOAD_DYLINKER=0x0000000eULL, LC_ID_DYLINKER=0x0000000fULL, LC_PREBOUND_DYLIB=0x00000010ULL, LC_ROUTINES=0x00000011ULL, LC_SUB_FRAMEWORK=0x00000012ULL, LC_SUB_UMBRELLA=0x00000013ULL, LC_SUB_CLIENT=0x00000014ULL, LC_SUB_LIBRARY=0x00000015ULL, LC_TWOLEVEL_HINTS=0x00000016ULL, LC_PREBIND_CKSUM=0x00000017ULL, LC_LOAD_WEAK_DYLIB=0x80000018ULL, LC_SEGMENT_64=0x00000019ULL, LC_ROUTINES_64=0x0000001aULL, LC_UUID=0x0000001bULL, LC_RPATH=0x8000001cULL, LC_CODE_SIGNATURE=0x0000001dULL, LC_SEGMENT_SPLIT_INFO=0x0000001eULL, LC_REEXPORT_DYLIB=0x8000001fULL, LC_LAZY_LOAD_DYLIB=0x00000020ULL, LC_ENCRYPTION_INFO=0x00000021ULL, LC_DYLD_INFO=0x00000022ULL, LC_DYLD_INFO_ONLY=0x80000022ULL, LC_LOAD_UPWARD_DYLIB=0x80000023ULL, LC_VERSION_MIN_MACOSX=0x00000024ULL, LC_VERSION_MIN_IPHONEOS=0x00000025ULL, LC_FUNCTION_STARTS=0x00000026ULL, LC_DYLD_ENVIRONMENT=0x00000027ULL, LC_MAIN=0x80000028ULL, LC_DATA_IN_CODE=0x00000029ULL, LC_SOURCE_VERSION=0x0000002aULL, LC_DYLIB_CODE_SIGN_DRS=0x0000002bULL, LC_ENCRYPTION_INFO_64=0x0000002cULL, LC_LINKER_OPTION=0x0000002dULL, LC_LINKER_OPTIMIZATION_HINT=0x0000002eULL, LC_VERSION_MIN_TVOS=0x0000002fULL, LC_VERSION_MIN_WATCHOS=0x00000030ULL, LC_NOTE=0x00000031ULL, LC_BUILD_VERSION=0x00000032ULL };"
+"td enum mach0_header_filetype {MH_OBJECT=1, MH_EXECUTE=2, MH_FVMLIB=3, MH_CORE=4, MH_PRELOAD=5, MH_DYLIB=6, MH_DYLINKER=7, MH_BUNDLE=8, MH_DYLIB_STUB=9, MH_DSYM=10, MH_KEXT_BUNDLE=11};"
+"td enum mach0_header_flags {MH_NOUNDEFS=1, MH_INCRLINK=2,MH_DYLDLINK=4,MH_BINDATLOAD=8,MH_PREBOUND=0x10, MH_SPLIT_SEGS=0x20,MH_LAZY_INIT=0x40,MH_TWOLEVEL=0x80, MH_FORCE_FLAT=0x100,MH_NOMULTIDEFS=0x200,MH_NOFIXPREBINDING=0x400, MH_PREBINDABLE=0x800, MH_ALLMODSBOUND=0x1000, MH_SUBSECTIONS_VIA_SYMBOLS=0x2000, MH_CANONICAL=0x4000,MH_WEAK_DEFINES=0x8000, MH_BINDS_TO_WEAK=0x10000,MH_ALLOW_STACK_EXECUTION=0x20000, MH_ROOT_SAFE=0x40000,MH_SETUID_SAFE=0x80000, MH_NO_REEXPORTED_DYLIBS=0x100000,MH_PIE=0x200000, MH_DEAD_STRIPPABLE_DYLIB=0x400000, MH_HAS_TLV_DESCRIPTORS=0x800000, MH_NO_HEAP_EXECUTION=0x1000000};"
+"td enum mach0_section_types {S_REGULAR=0, S_ZEROFILL=1, S_CSTRING_LITERALS=2, S_4BYTE_LITERALS=3, S_8BYTE_LITERALS=4, S_LITERAL_POINTERS=5, S_NON_LAZY_SYMBOL_POINTERS=6, S_LAZY_SYMBOL_POINTERS=7, S_SYMBOL_STUBS=8, S_MOD_INIT_FUNC_POINTERS=9, S_MOD_TERM_FUNC_POINTERS=0xa, S_COALESCED=0xb, S_GB_ZEROFILL=0xc, S_INTERPOSING=0xd, S_16BYTE_LITERALS=0xe, S_DTRACE_DOF=0xf, S_LAZY_DYLIB_SYMBOL_POINTERS=0x10, S_THREAD_LOCAL_REGULAR=0x11, S_THREAD_LOCAL_ZEROFILL=0x12, S_THREAD_LOCAL_VARIABLES=0x13, S_THREAD_LOCAL_VARIABLE_POINTERS=0x14, S_THREAD_LOCAL_INIT_FUNCTION_POINTERS=0x15, S_INIT_FUNC_OFFSETS=0x16};"
+"td enum mach0_section_attrs {S_ATTR_PURE_INSTRUCTIONS=0x800000ULL, S_ATTR_NO_TOC=0x400000ULL, S_ATTR_STRIP_STATIC_SYMS=0x200000ULL, S_ATTR_NO_DEAD_STRIP=0x100000ULL, S_ATTR_LIVE_SUPPORT=0x080000ULL, S_ATTR_SELF_MODIFYING_CODE=0x040000ULL, S_ATTR_DEBUG=0x020000ULL, S_ATTR_SOME_INSTRUCTIONS=0x000004ULL, S_ATTR_EXT_RELOC=0x000002ULL, S_ATTR_LOC_RELOC=0x000001ULL};"
+pf.mach0_header xxx[4]Edd[4]B magic cputype cpusubtype (mach0_header_filetype)filetype ncmds sizeofcmds (mach0_header_flags)flags
+pf.mach0_segment [4]Ed[16]zxxxxoodx (mach0_load_command_type)cmd cmdsize segname vmaddr vmsize fileoff filesize maxprot initprot nsects flags
+pf.mach0_segment64 [4]Ed[16]zqqqqoodx (mach0_load_command_type)cmd cmdsize segname vmaddr vmsize fileoff filesize maxprot initprot nsects flags
+pf.mach0_symtab_command [4]Edxdxd (mach0_load_command_type)cmd cmdsize symoff nsyms stroff strsize
+pf.mach0_dysymtab_command [4]Edddddddddddxdxdxxxd (mach0_load_command_type)cmd cmdsize ilocalsym nlocalsym iextdefsym nextdefsym iundefsym nundefsym tocoff ntoc moddtaboff nmodtab extrefsymoff nextrefsyms inddirectsymoff nindirectsyms extreloff nextrel locreloff nlocrel
+pf.mach0_section [16]z[16]zxxxxxx[1]E[3]Bxx sectname segname addr size offset align reloff nreloc (mach0_section_types)flags_type (mach0_section_attrs)flags_attr reserved1 reserved2
+pf.mach0_section64 [16]z[16]zqqxxxx[1]E[3]Bxxx sectname segname addr size offset align reloff nreloc (mach0_section_types)flags_type (mach0_section_attrs)flags_attr reserved1 reserved2 reserved3
+pf.mach0_dylib xxxxz name_offset timestamp current_version compatibility_version name
+pf.mach0_dylib_command [4]Ed? (mach0_load_command_type)cmd cmdsize (mach0_dylib)dylib
+pf.mach0_id_dylib_command [4]Ed? (mach0_load_command_type)cmd cmdsize (mach0_dylib)dylib
+pf.mach0_uuid_command [4]Ed[16]b (mach0_load_command_type)cmd cmdsize uuid
+pf.mach0_rpath_command [4]Edxz (mach0_load_command_type)cmd cmdsize path_offset path
+pf.mach0_entry_point_command [4]Edqq (mach0_load_command_type)cmd cmdsize entryoff stacksize
+pf.mach0_encryption_info64_command [4]Edxddx (mach0_load_command_type)cmd cmdsize offset size id padding
+pf.mach0_encryption_info_command [4]Edxdd (mach0_load_command_type)cmd cmdsize offset size id
+pf.mach0_code_signature_command [4]Edxd (mach0_load_command_type)cmd cmdsize offset size
+pf.mach0_dyld_info_only_command [4]Edxdxdxdxdxd (mach0_load_command_type)cmd cmdsize rebase_off rebase_size bind_off bind_size weak_bind_off weak_bind_size lazy_bind_off lazy_bind_size export_off export_size
+pf.mach0_load_dylinker_command [4]Edxz (mach0_load_command_type)cmd cmdsize name_offset name
+pf.mach0_id_dylinker_command [4]Edxz (mach0_load_command_type)cmd cmdsize name_offset name
+pf.mach0_build_version_command [4]Ed[4]Exxd (mach0_load_command_type)cmd cmdsize (mach0_build_platform)platform minos sdk ntools
+pf.mach0_build_version_tool [4]Ex (mach0_build_tool)tool version
+pf.mach0_source_version_command [4]Edq (mach0_load_command_type)cmd cmdsize version
+pf.mach0_function_starts_command [4]Edxd (mach0_load_command_type)cmd cmdsize offset size
+pf.mach0_data_in_code_command [4]Edxd (mach0_load_command_type)cmd cmdsize offset size
+pf.mach0_version_min_command [4]Edxx (mach0_load_command_type)cmd cmdsize version reserved
+pf.mach0_segment_split_info_command [4]Edxd (mach0_load_command_type)cmd cmdsize offset size
+pf.mach0_unixthread_command [4]Eddd (mach0_load_command_type)cmd cmdsize flavor count

--- a/libr/util/format.c
+++ b/libr/util/format.c
@@ -1880,7 +1880,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 	const char *argend;
 	int viewflags = 0;
 	char *oarg = NULL;
-    char *internal_format = NULL;
+	char *internal_format = NULL;
 
 	/* Load format from name into fmt */
 	if (!formatname) {

--- a/libr/util/format.c
+++ b/libr/util/format.c
@@ -1344,11 +1344,7 @@ static void r_print_format_nulltermwidestring(const RPrint* p, const int len, in
 static void r_print_format_bitfield(const RPrint* p, ut64 seeki, char *fmtname,
 		char *fieldname, ut64 addr, int mode, int size) {
 	char *bitfield = NULL;
-	switch (size) {
-	case 1: addr &= UT8_MAX; break;
-	case 2: addr &= UT16_MAX; break;
-	case 4: addr &= UT32_MAX; break;
-	}
+	addr &= (1ULL << (size * 8)) - 1;
 	if (MUSTSEE && !SEEVALUE) {
 		p->cb_printf ("0x%08"PFMT64x" = ", seeki);
 	}
@@ -1357,13 +1353,13 @@ static void r_print_format_bitfield(const RPrint* p, ut64 seeki, char *fmtname,
 		if (MUSTSEEJSON) {
 			p->cb_printf ("\"%s\"}", bitfield);
 		} else if (MUSTSEE) {
-			p->cb_printf (" %s (bitfield) = %s\n", fieldname, bitfield);
+			p->cb_printf ("%s (bitfield) = %s\n", fieldname, bitfield);
 		}
 	} else {
 		if (MUSTSEEJSON) {
 			p->cb_printf ("\"`tb %s 0x%x`\"}", fmtname, addr);
 		} else if (MUSTSEE) {
-			p->cb_printf (" %s (bitfield) = `tb %s 0x%x`\n",
+			p->cb_printf ("%s (bitfield) = `tb %s 0x%x`\n",
 				fieldname, fmtname, addr);
 		}
 	}
@@ -1373,11 +1369,7 @@ static void r_print_format_bitfield(const RPrint* p, ut64 seeki, char *fmtname,
 static void r_print_format_enum(const RPrint* p, ut64 seeki, char *fmtname,
 		char *fieldname, ut64 addr, int mode, int size) {
 	char *enumvalue = NULL;
-	switch (size) {
-	case 1: addr &= UT8_MAX; break;
-	case 2: addr &= UT16_MAX; break;
-	case 4: addr &= UT32_MAX; break;
-	}
+	addr &= (1ULL << (size * 8)) - 1;
 	if (MUSTSEE && !SEEVALUE) {
 		p->cb_printf ("0x%08"PFMT64x" = ", seeki);
 	}
@@ -1633,15 +1625,11 @@ int r_print_format_struct_size(const char *f, RPrint *p, int mode, int n) {
 		case 'B':
 		case 'E':
 			if (tabsize_set) {
-				switch (tabsize) {
-				case 1: size += 1; break;
-				case 2: size += 2; break;
-				case 4: size += 4; break;
-				case 8: size += 8; break;
-				default:
+				if (tabsize < 1 || tabsize > 8) {
 					eprintf ("Unknown enum format size: %d\n", tabsize);
 					break;
 				}
+				size += tabsize;
 			} else {
 				size += 4; // Assuming by default enum as int
 			}
@@ -1892,6 +1880,7 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 	const char *argend;
 	int viewflags = 0;
 	char *oarg = NULL;
+    char *internal_format = NULL;
 
 	/* Load format from name into fmt */
 	if (!formatname) {
@@ -1901,6 +1890,8 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 	if (!fmt) {
 		fmt = formatname;
 	}
+	internal_format = strdup (fmt);
+	fmt = internal_format;
 	while (*fmt && IS_WHITECHAR (*fmt)) {
 		fmt++;
 	}
@@ -1910,11 +1901,13 @@ R_API int r_print_format(RPrint *p, ut64 seek, const ut8* b, const int len,
 	nexti = nargs = i = j = 0;
 
 	if (len < 1) {
+		free (internal_format);
 		return 0;
 	}
 	// len+2 to save space for the null termination in wide strings
 	ut8 *buf = calloc (1, len + 2);
 	if (!buf) {
+		free (internal_format);
 		return 0;
 	}
 	memcpy (buf, b, len);
@@ -2685,6 +2678,7 @@ beach:
 	if (slide == 0) {
 		oldslide = 0;
 	}
+	free (internal_format);
 	free (oarg);
 	free (buf);
 	free (field);


### PR DESCRIPTION
Plus:
- improve macho format definitions
- allow enums and bitfields with arbitrary size
- avoid modifying the format string argument inside r_print_format()

tweaked tests: https://github.com/radare/radare2-regressions/pull/1905

Samples:
```
$ r2 ~/shit/ls
 -- r2 is a great OS, but a terrible hex editor
[0x1000011e0]> iH
pf.mach0_header @ 0x100000000
0x100000000  Magic       0xfeedfacf
0x100000004  CpuType     0x1000007
0x100000008  CpuSubType  0x80000003
0x10000000c  FileType    0x2
0x100000010  nCmds       18
0x100000014  sizeOfCmds  1800
0x100000018  Flags       0x200085
pf.mach0_segment64 @ 0x100000020
0x100000020  cmd       0 0x19 LC_SEGMENT_64
0x100000024  cmdsize     72
0x100000028  name        __PAGEZERO
pf.mach0_segment64 @ 0x100000068
0x100000068  cmd       1 0x19 LC_SEGMENT_64
0x10000006c  cmdsize     552
0x100000070  name        __TEXT
pf.mach0_section64 @ 0x1000000b0
pf.mach0_section64 @ 0x100000100
pf.mach0_section64 @ 0x100000150
pf.mach0_section64 @ 0x1000001a0
pf.mach0_section64 @ 0x1000001f0
pf.mach0_section64 @ 0x100000240
pf.mach0_segment64 @ 0x100000290
0x100000290  cmd       2 0x19 LC_SEGMENT_64
0x100000294  cmdsize     632
0x100000298  name        __DATA
pf.mach0_section64 @ 0x1000002d8
pf.mach0_section64 @ 0x100000328
pf.mach0_section64 @ 0x100000378
pf.mach0_section64 @ 0x1000003c8
pf.mach0_section64 @ 0x100000418
pf.mach0_section64 @ 0x100000468
pf.mach0_section64 @ 0x1000004b8
pf.mach0_segment64 @ 0x100000508
0x100000508  cmd       3 0x19 LC_SEGMENT_64
0x10000050c  cmdsize     72
0x100000510  name        __LINKEDIT
pf.mach0_dyld_info_only_command @ 0x100000550
0x100000550  cmd       4 0x80000022 LC_DYLD_INFO_ONLY
0x100000554  cmdsize     48
pf.mach0_symtab_command @ 0x100000580
0x100000580  cmd       5 0x2 LC_SYMTAB
0x100000584  cmdsize     24
pf.mach0_dysymtab_command @ 0x100000598
0x100000598  cmd       6 0xb LC_DYSYMTAB
0x10000059c  cmdsize     80
pf.mach0_load_dylinker_command @ 0x1000005e8
0x1000005e8  cmd       7 0xe LC_LOAD_DYLINKER
0x1000005ec  cmdsize     32
pf.mach0_uuid_command @ 0x100000608
0x100000608  cmd       8 0x1b LC_UUID
0x10000060c  cmdsize     24
0x100000610  uuid        2ed4c584ffcf38baad0a7c0707c05c6b
pf.mach0_version_min_command @ 0x100000620
0x100000620  cmd       9 0x24 LC_VERSION_MIN_MACOSX
0x100000624  cmdsize     16
pf.mach0_source_version_command @ 0x100000630
0x100000630  cmd      10 0x2a LC_SOURCE_VERSION
0x100000634  cmdsize     16
pf.mach0_entry_point_command @ 0x100000640
0x100000640  cmd      11 0x80000028 LC_MAIN
0x100000644  cmdsize     24
0x100000648  entry0      0x11e0
0x100000650  stacksize   0x0
pf.mach0_dylib_command @ 0x100000658
0x100000658  cmd      12 0xc LC_LOAD_DYLIB
0x10000065c  cmdsize     48
0x100000668  current     1.0.0
0x10000066c  compat      1.0.0
0x100000670  load_dylib  /usr/lib/libutil.dylib
pf.mach0_dylib_command @ 0x100000688
0x100000688  cmd      13 0xc LC_LOAD_DYLIB
0x10000068c  cmdsize     56
0x100000698  current     5.4.0
0x10000069c  compat      5.4.0
0x1000006a0  load_dylib  /usr/lib/libncurses.5.4.dylib
pf.mach0_dylib_command @ 0x1000006c0
0x1000006c0  cmd      14 0xc LC_LOAD_DYLIB
0x1000006c4  cmdsize     56
0x1000006d0  current     1238.0.0
0x1000006d4  compat      1.0.0
0x1000006d8  load_dylib  /usr/lib/libSystem.B.dylib
pf.mach0_function_starts_command @ 0x1000006f8
0x1000006f8  cmd      15 0x26 LC_FUNCTION_STARTS
0x1000006fc  cmdsize     16
pf.mach0_data_in_code_command @ 0x100000708
0x100000708  cmd      16 0x29 LC_DATA_IN_CODE
0x10000070c  cmdsize     16
pf.mach0_code_signature_command @ 0x100000718
0x100000718  cmd      17 0x1d LC_CODE_SIGNATURE
0x10000071c  cmdsize     16
0x100000720  dataoff     0x000071d0
0x100000724  datasize    9488
# wtf mach0.sign 9488 @ 0x71d0

[0x1000011e0]> pfo macho
[0x1000011e0]> pf.mach0_section64 @ 0x1000002d8
   sectname : 0x1000002d8 = "__got"
    segname : 0x1000002e8 = "__DATA"
       addr : 0x1000002f8 = (qword)0x0000000100005000
       size : 0x100000300 = (qword)0x0000000000000028
     offset : 0x100000308 = 0x00005000
      align : 0x10000030c = 0x00000003
     reloff : 0x100000310 = 0x00000000
     nreloc : 0x100000314 = 0x00000000
 flags_type : 0x100000318 = flags_type (enum mach0_section_types) = 0x6 ; S_NON_LAZY_SYMBOL_POINTERS
 flags_attr : 0x100000319 = flags_attr (bitfield) = 0x00000000 :
  reserved1 : 0x10000031c = 0x0000004c
  reserved2 : 0x100000320 = 0x00000000
  reserved3 : 0x100000324 = 0x00000000
[0x1000011e0]>
```

```
[0x1000011e0]> .iH*
[0x1000011e0]> pd @ 0x100000000
            ;-- segment.TEXT:
            ;-- __mh_execute_header:
            ;-- header.header:
            0x100000000 pf mach0_header # size=1
      magic : 0x100000000 = 0xfeedfacf
    cputype : 0x100000004 = 0x01000007
 cpusubtype : 0x100000008 = 0x80000003
   filetype : 0x10000000c = filetype (enum mach0_header_filetype) = 0x2 ; MH_EXECUTE
      ncmds : 0x100000010 = 18
 sizeofcmds : 0x100000014 = 1800
      flags : 0x100000018 = flags (bitfield) = 0x00200085 : MH_NOUNDEFS | MH_DYLDLINK | MH_TWOLEVEL | MH_PIE ; mach0_header
            0x100000001      fa             cli
            0x100000002      ed             in eax, dx
            0x100000003      fe07           inc byte [rdi]
            0x100000005      0000           add byte [rax], al
            0x100000007      0103           add dword [rbx], eax
            0x100000009      0000           add byte [rax], al
            0x10000000b      800200         add byte [rdx], 0
            0x10000000e      0000           add byte [rax], al
            0x100000010      1200           adc al, byte [rax]
            0x100000012      0000           add byte [rax], al
            0x100000014      0807           or byte [rdi], al
            0x100000016      0000           add byte [rax], al
            0x100000018      8500           test dword [rax], eax
            0x10000001a      2000           and byte [rax], al
            0x10000001c      0000           add byte [rax], al
            0x10000001e      0000           add byte [rax], al
            ;-- header.load_command_0_LC_SEGMENT_64:
            0x100000020 pf mach0_segment64 # size=1
      cmd : 0x100000020 = cmd (enum mach0_load_command_type) = 0x19 ; LC_SEGMENT_64
  cmdsize : 0x100000024 = 72
  segname : 0x100000028 = "__PAGEZERO"
   vmaddr : 0x100000038 = (qword)0x0000000000000000
   vmsize : 0x100000040 = (qword)0x0000000100000000
  fileoff : 0x100000048 = (qword)0x0000000000000000
 filesize : 0x100000050 = (qword)0x0000000000000000
  maxprot : 0x100000058 = (octal)  000000000
 initprot : 0x10000005c = (octal)  000000000
   nsects : 0x100000060 = 0
    flags : 0x100000064 = 0x00000000 ; mach0_segment64
            0x100000021      0000           add byte [rax], al
            0x100000023      004800         add byte [rax], cl
            0x100000026      0000           add byte [rax], al
            0x100000028      5f             pop rdi
            0x100000029      5f             pop rdi
            0x10000002a      50             push rax
            0x10000002b      4147455a       pop r10
            0x10000002f      4552           push r10
            0x100000031      4f0000         add byte [r8], r8b
            0x100000034      0000           add byte [rax], al
            0x100000036      0000           add byte [rax], al
            0x100000038      0000           add byte [rax], al
            0x10000003a      0000           add byte [rax], al
            0x10000003c      0000           add byte [rax], al
            0x10000003e      0000           add byte [rax], al
            0x100000040      0000           add byte [rax], al
            0x100000042      0000           add byte [rax], al
            0x100000044      0100           add dword [rax], eax
            0x100000046      0000           add byte [rax], al
            0x100000048      0000           add byte [rax], al
            0x10000004a      0000           add byte [rax], al
            0x10000004c      0000           add byte [rax], al
            0x10000004e      0000           add byte [rax], al
            0x100000050      0000           add byte [rax], al
            0x100000052      0000           add byte [rax], al
            0x100000054      0000           add byte [rax], al
            0x100000056      0000           add byte [rax], al
            0x100000058      0000           add byte [rax], al
            0x10000005a      0000           add byte [rax], al
            0x10000005c      0000           add byte [rax], al
            0x10000005e      0000           add byte [rax], al
            0x100000060      0000           add byte [rax], al
            0x100000062      0000           add byte [rax], al
            0x100000064      0000           add byte [rax], al
            0x100000066      0000           add byte [rax], al
            ;-- header.load_command_1_LC_SEGMENT_64:
            0x100000068 pf mach0_segment64 # size=1
      cmd : 0x100000068 = cmd (enum mach0_load_command_type) = 0x19 ; LC_SEGMENT_64
  cmdsize : 0x10000006c = 552
  segname : 0x100000070 = "__TEXT"
   vmaddr : 0x100000080 = (qword)0x0000000100000000
   vmsize : 0x100000088 = (qword)0x0000000000005000
  fileoff : 0x100000090 = (qword)0x0000000000000000
 filesize : 0x100000098 = (qword)0x0000000000005000
  maxprot : 0x1000000a0 = (octal)  000000007
 initprot : 0x1000000a4 = (octal)  000000005
   nsects : 0x1000000a8 = 6
    flags : 0x1000000ac = 0x00000000 ; mach0_segment64
            0x100000069      0000           add byte [rax], al
            0x10000006b      0028           add byte [rax], ch
            0x10000006d      0200           add al, byte [rax]
            0x10000006f      005f5f         add byte [rdi + 0x5f], bl
            0x100000072      54             push rsp
            0x100000073      4558           pop r8
            0x100000075      54             push rsp
            0x100000076      0000           add byte [rax], al
            0x100000078      0000           add byte [rax], al
            0x10000007a      0000           add byte [rax], al
[0x1000011e0]>
```