### PR TITLE
Fixes #14652: Fixes visual hud regressions

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -888,7 +888,11 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 				: 0;
 			break;
 		case 38:	// up arrow
-			if (I.sel_widget) {
+			if (I.hud) {
+				if (I.hud->top_entry_n + 1 < I.hud->current_entry_n) {
+					I.hud->top_entry_n++;
+				}
+			} else if (I.sel_widget) {
 				selection_widget_up (1);
 				selection_widget_draw ();
 			} else if (gcomp) {
@@ -904,7 +908,11 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 				: I.buffer.length;
 			break;
 		case 40:// down arrow
-			if (I.sel_widget) {
+			if (I.hud) {
+				if (I.hud->top_entry_n >= 0) {
+					I.hud->top_entry_n--;
+				}
+			} else if (I.sel_widget) {
 				selection_widget_down (1);
 				selection_widget_draw ();
 			} else if (gcomp) {
@@ -1110,7 +1118,11 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 			paste ();
 			break;
 		case 14:// ^n
-			if (I.sel_widget) {
+			if (I.hud) {
+				if (I.hud->top_entry_n + 1 < I.hud->current_entry_n) {
+					I.hud->top_entry_n++;
+				}
+			} else if (I.sel_widget) {
 				selection_widget_down (1);
 				selection_widget_draw ();
 			} else if (gcomp) {
@@ -1122,7 +1134,11 @@ R_API const char *r_line_readline_cb_win(RLineReadCallback cb, void *user) {
 			}
 			break;
 		case 16:// ^p
-			if (I.sel_widget) {
+			if (I.hud) {
+				if (I.hud->top_entry_n >= 0) {
+					I.hud->top_entry_n--;
+				}
+			} else if (I.sel_widget) {
 				selection_widget_down (1);
 				selection_widget_draw ();
 			} else if (gcomp) {
@@ -1941,7 +1957,11 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 			backward_kill_word ();	
 			break;
 		case 14:// ^n
-			if (I.sel_widget) {
+			if (I.hud) {
+				if (I.hud->top_entry_n + 1 < I.hud->current_entry_n) {
+					I.hud->top_entry_n++;
+				}
+			} else if (I.sel_widget) {
 				selection_widget_down (1);
 				selection_widget_draw ();
 			} else if (gcomp) {
@@ -1953,7 +1973,11 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 			}
 			break;
 		case 16:// ^p
-			if (I.sel_widget) {
+			if (I.hud) {
+				if (I.hud->top_entry_n >= 0) {
+					I.hud->top_entry_n--;
+				}
+			} else if (I.sel_widget) {
 				selection_widget_up (1);
 				selection_widget_draw ();
 			} else if (gcomp) {
@@ -2041,8 +2065,8 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 						buf[1] = r_cons_readchar ();
 						if (I.hud) {
 							I.hud->top_entry_n += (rows - 1);
-							if (I.hud->top_entry_n + 1 >= I.hud->current_entry_n) {
-								I.hud->top_entry_n = I.hud->current_entry_n;
+							if (I.hud->top_entry_n >= I.hud->current_entry_n) {
+								I.hud->top_entry_n = I.hud->current_entry_n - 1;
 							}
 						}
 						if (I.sel_widget) {
@@ -2066,8 +2090,8 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 					/* arrows */
 					case 'A':	// up arrow
 						if (I.hud) {
-							if (I.hud->top_entry_n >= 0) {
-								I.hud->top_entry_n--;
+							if (I.hud->top_entry_n + 1 < I.hud->current_entry_n) {
+								I.hud->top_entry_n++;
 							}
 						} else if (I.sel_widget) {
 							selection_widget_up (1);
@@ -2081,8 +2105,8 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 						break;
 					case 'B':	// down arrow
 						if (I.hud) {
-							if (I.hud->top_entry_n + 1 < I.hud->current_entry_n) {
-								I.hud->top_entry_n++;
+							if (I.hud->top_entry_n >= 0) {
+								I.hud->top_entry_n--;
 							}
 						} else if (I.sel_widget) {
 							selection_widget_down (1);

--- a/libr/cons/hud.c
+++ b/libr/cons/hud.c
@@ -202,6 +202,7 @@ R_API char *r_cons_hud(RList *list, const char *prompt) {
 	user_input [0] = 0;
 	hud->top_entry_n = 0;
 	r_cons_show_cursor (false);
+	r_cons_enable_mouse (false);
 	r_cons_clear ();
 
 	// Repeat until the user exits the hud
@@ -255,6 +256,7 @@ R_API char *r_cons_hud(RList *list, const char *prompt) {
 				if (selected_entry) {
 					R_FREE (I(line)->hud);
 					I(line)->echo = true;
+					r_cons_enable_mouse (true);
 					r_cons_show_cursor (true);
 					return strdup (selected_entry);
 				} 
@@ -267,6 +269,7 @@ _beach:
 	R_FREE (I(line)->hud);
 	I(line)->echo = true;
 	r_cons_show_cursor (true);
+	r_cons_enable_mouse (true);
 	ht_pp_free (ht);
 	return NULL;
 }


### PR DESCRIPTION
Fixes: 
* up/down are inverted correctly
* it is possible to not possible to scroll beyond the end with page up
* Mouse is disabled in hud mode
* change the ^p/^n behavior to go to prev/next line.