### PR TITLE
Update Mach-O hardcoded format definitions ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -143,6 +143,141 @@ static ut64 pa2va(RBinFile *bf, ut64 offset) {
 	return offset_to_vaddr (bin, offset);
 }
 
+static void init_sdb_formats(struct MACH0_(obj_t) *bin) {
+	/*
+	 * These definitions are used by r2 -nn
+	 * must be kept in sync with libr/bin/d/macho
+	 */
+	sdb_set (bin->kv, "mach0_build_platform.cparse",
+		"enum mach0_build_platform" "{MACOS=1, IOS=2, TVOS=3, WATCHOS=4, BRIDGEOS=5, IOSMAC=6, IOSSIMULATOR=7, TVOSSIMULATOR=8, WATCHOSSIMULATOR=9};",
+		0);
+	sdb_set (bin->kv, "mach0_build_tool.cparse",
+		"enum mach0_build_tool" "{CLANG=1, SWIFT=2, LD=3};",
+		0);
+	sdb_set (bin->kv, "mach0_load_command_type.cparse",
+		"enum mach0_load_command_type" "{ LC_SEGMENT=0x00000001ULL, LC_SYMTAB=0x00000002ULL, LC_SYMSEG=0x00000003ULL, LC_THREAD=0x00000004ULL, LC_UNIXTHREAD=0x00000005ULL, LC_LOADFVMLIB=0x00000006ULL, LC_IDFVMLIB=0x00000007ULL, LC_IDENT=0x00000008ULL, LC_FVMFILE=0x00000009ULL, LC_PREPAGE=0x0000000aULL, LC_DYSYMTAB=0x0000000bULL, LC_LOAD_DYLIB=0x0000000cULL, LC_ID_DYLIB=0x0000000dULL, LC_LOAD_DYLINKER=0x0000000eULL, LC_ID_DYLINKER=0x0000000fULL, LC_PREBOUND_DYLIB=0x00000010ULL, LC_ROUTINES=0x00000011ULL, LC_SUB_FRAMEWORK=0x00000012ULL, LC_SUB_UMBRELLA=0x00000013ULL, LC_SUB_CLIENT=0x00000014ULL, LC_SUB_LIBRARY=0x00000015ULL, LC_TWOLEVEL_HINTS=0x00000016ULL, LC_PREBIND_CKSUM=0x00000017ULL, LC_LOAD_WEAK_DYLIB=0x80000018ULL, LC_SEGMENT_64=0x00000019ULL, LC_ROUTINES_64=0x0000001aULL, LC_UUID=0x0000001bULL, LC_RPATH=0x8000001cULL, LC_CODE_SIGNATURE=0x0000001dULL, LC_SEGMENT_SPLIT_INFO=0x0000001eULL, LC_REEXPORT_DYLIB=0x8000001fULL, LC_LAZY_LOAD_DYLIB=0x00000020ULL, LC_ENCRYPTION_INFO=0x00000021ULL, LC_DYLD_INFO=0x00000022ULL, LC_DYLD_INFO_ONLY=0x80000022ULL, LC_LOAD_UPWARD_DYLIB=0x80000023ULL, LC_VERSION_MIN_MACOSX=0x00000024ULL, LC_VERSION_MIN_IPHONEOS=0x00000025ULL, LC_FUNCTION_STARTS=0x00000026ULL, LC_DYLD_ENVIRONMENT=0x00000027ULL, LC_MAIN=0x80000028ULL, LC_DATA_IN_CODE=0x00000029ULL, LC_SOURCE_VERSION=0x0000002aULL, LC_DYLIB_CODE_SIGN_DRS=0x0000002bULL, LC_ENCRYPTION_INFO_64=0x0000002cULL, LC_LINKER_OPTION=0x0000002dULL, LC_LINKER_OPTIMIZATION_HINT=0x0000002eULL, LC_VERSION_MIN_TVOS=0x0000002fULL, LC_VERSION_MIN_WATCHOS=0x00000030ULL, LC_NOTE=0x00000031ULL, LC_BUILD_VERSION=0x00000032ULL };",
+		0);
+	sdb_set (bin->kv, "mach0_header_filetype.cparse",
+		"enum mach0_header_filetype" "{MH_OBJECT=1, MH_EXECUTE=2, MH_FVMLIB=3, MH_CORE=4, MH_PRELOAD=5, MH_DYLIB=6, MH_DYLINKER=7, MH_BUNDLE=8, MH_DYLIB_STUB=9, MH_DSYM=10, MH_KEXT_BUNDLE=11};",
+		0);
+	sdb_set (bin->kv, "mach0_header_flags.cparse",
+		"enum mach0_header_flags" "{MH_NOUNDEFS=1, MH_INCRLINK=2,MH_DYLDLINK=4,MH_BINDATLOAD=8,MH_PREBOUND=0x10, MH_SPLIT_SEGS=0x20,MH_LAZY_INIT=0x40,MH_TWOLEVEL=0x80, MH_FORCE_FLAT=0x100,MH_NOMULTIDEFS=0x200,MH_NOFIXPREBINDING=0x400, MH_PREBINDABLE=0x800, MH_ALLMODSBOUND=0x1000, MH_SUBSECTIONS_VIA_SYMBOLS=0x2000, MH_CANONICAL=0x4000,MH_WEAK_DEFINES=0x8000, MH_BINDS_TO_WEAK=0x10000,MH_ALLOW_STACK_EXECUTION=0x20000, MH_ROOT_SAFE=0x40000,MH_SETUID_SAFE=0x80000, MH_NO_REEXPORTED_DYLIBS=0x100000,MH_PIE=0x200000, MH_DEAD_STRIPPABLE_DYLIB=0x400000, MH_HAS_TLV_DESCRIPTORS=0x800000, MH_NO_HEAP_EXECUTION=0x1000000};",
+		0);
+	sdb_set (bin->kv, "mach0_section_types.cparse",
+		"enum mach0_section_types" "{S_REGULAR=0, S_ZEROFILL=1, S_CSTRING_LITERALS=2, S_4BYTE_LITERALS=3, S_8BYTE_LITERALS=4, S_LITERAL_POINTERS=5, S_NON_LAZY_SYMBOL_POINTERS=6, S_LAZY_SYMBOL_POINTERS=7, S_SYMBOL_STUBS=8, S_MOD_INIT_FUNC_POINTERS=9, S_MOD_TERM_FUNC_POINTERS=0xa, S_COALESCED=0xb, S_GB_ZEROFILL=0xc, S_INTERPOSING=0xd, S_16BYTE_LITERALS=0xe, S_DTRACE_DOF=0xf, S_LAZY_DYLIB_SYMBOL_POINTERS=0x10, S_THREAD_LOCAL_REGULAR=0x11, S_THREAD_LOCAL_ZEROFILL=0x12, S_THREAD_LOCAL_VARIABLES=0x13, S_THREAD_LOCAL_VARIABLE_POINTERS=0x14, S_THREAD_LOCAL_INIT_FUNCTION_POINTERS=0x15, S_INIT_FUNC_OFFSETS=0x16};",
+		0);
+	sdb_set (bin->kv, "mach0_section_attrs.cparse",
+		"enum mach0_section_attrs" "{S_ATTR_PURE_INSTRUCTIONS=0x800000ULL, S_ATTR_NO_TOC=0x400000ULL, S_ATTR_STRIP_STATIC_SYMS=0x200000ULL, S_ATTR_NO_DEAD_STRIP=0x100000ULL, S_ATTR_LIVE_SUPPORT=0x080000ULL, S_ATTR_SELF_MODIFYING_CODE=0x040000ULL, S_ATTR_DEBUG=0x020000ULL, S_ATTR_SOME_INSTRUCTIONS=0x000004ULL, S_ATTR_EXT_RELOC=0x000002ULL, S_ATTR_LOC_RELOC=0x000001ULL};",
+		0);
+	sdb_set (bin->kv, "mach0_header.format",
+		"xxx[4]Edd[4]B "
+		"magic cputype cpusubtype (mach0_header_filetype)filetype ncmds sizeofcmds (mach0_header_flags)flags",
+		0);
+	sdb_set (bin->kv, "mach0_segment.format",
+		"[4]Ed[16]zxxxxoodx "
+		"(mach0_load_command_type)cmd cmdsize segname vmaddr vmsize fileoff filesize maxprot initprot nsects flags",
+		0);
+	sdb_set (bin->kv, "mach0_segment64.format",
+		"[4]Ed[16]zqqqqoodx "
+		"(mach0_load_command_type)cmd cmdsize segname vmaddr vmsize fileoff filesize maxprot initprot nsects flags",
+		0);
+	sdb_set (bin->kv, "mach0_symtab_command.format",
+		"[4]Edxdxd "
+		"(mach0_load_command_type)cmd cmdsize symoff nsyms stroff strsize",
+		0);
+	sdb_set (bin->kv, "mach0_dysymtab_command.format",
+		"[4]Edddddddddddxdxdxxxd "
+		"(mach0_load_command_type)cmd cmdsize ilocalsym nlocalsym iextdefsym nextdefsym iundefsym nundefsym tocoff ntoc moddtaboff nmodtab extrefsymoff nextrefsyms inddirectsymoff nindirectsyms extreloff nextrel locreloff nlocrel",
+		0);
+	sdb_set (bin->kv, "mach0_section.format",
+		"[16]z[16]zxxxxxx[1]E[3]Bxx "
+		"sectname segname addr size offset align reloff nreloc (mach0_section_types)flags_type (mach0_section_attrs)flags_attr reserved1 reserved2", 0);
+	sdb_set (bin->kv, "mach0_section64.format",
+		"[16]z[16]zqqxxxx[1]E[3]Bxxx "
+		"sectname segname addr size offset align reloff nreloc (mach0_section_types)flags_type (mach0_section_attrs)flags_attr reserved1 reserved2 reserved3",
+		0);
+	sdb_set (bin->kv, "mach0_dylib.format",
+		"xxxxz "
+		"name_offset timestamp current_version compatibility_version name",
+		0);
+	sdb_set (bin->kv, "mach0_dylib_command.format",
+		"[4]Ed? "
+		"(mach0_load_command_type)cmd cmdsize (mach0_dylib)dylib",
+		0);
+	sdb_set (bin->kv, "mach0_id_dylib_command.format",
+		"[4]Ed? "
+		"(mach0_load_command_type)cmd cmdsize (mach0_dylib)dylib",
+		0);
+	sdb_set (bin->kv, "mach0_uuid_command.format",
+		"[4]Ed[16]b "
+		"(mach0_load_command_type)cmd cmdsize uuid",
+		0);
+	sdb_set (bin->kv, "mach0_rpath_command.format",
+		"[4]Edxz "
+		"(mach0_load_command_type)cmd cmdsize path_offset path",
+		0);
+	sdb_set (bin->kv, "mach0_entry_point_command.format",
+		"[4]Edqq "
+		"(mach0_load_command_type)cmd cmdsize entryoff stacksize",
+		0);
+	sdb_set (bin->kv, "mach0_encryption_info64_command.format",
+		"[4]Edxddx "
+		"(mach0_load_command_type)cmd cmdsize offset size id padding",
+		0);
+	sdb_set (bin->kv, "mach0_encryption_info_command.format",
+		"[4]Edxdd "
+		"(mach0_load_command_type)cmd cmdsize offset size id",
+		0);
+	sdb_set (bin->kv, "mach0_code_signature_command.format",
+		"[4]Edxd "
+		"(mach0_load_command_type)cmd cmdsize offset size",
+		0);
+	sdb_set (bin->kv, "mach0_dyld_info_only_command.format",
+		"[4]Edxdxdxdxdxd "
+		"(mach0_load_command_type)cmd cmdsize rebase_off rebase_size bind_off bind_size weak_bind_off weak_bind_size lazy_bind_off lazy_bind_size export_off export_size",
+		0);
+	sdb_set (bin->kv, "mach0_load_dylinker_command.format",
+		"[4]Edxz "
+		"(mach0_load_command_type)cmd cmdsize name_offset name",
+		0);
+	sdb_set (bin->kv, "mach0_id_dylinker_command.format",
+		"[4]Edxzi "
+		"(mach0_load_command_type)cmd cmdsize name_offset name",
+		0);
+	sdb_set (bin->kv, "mach0_build_version_command.format",
+		"[4]Ed[4]Exxd "
+		"(mach0_load_command_type)cmd cmdsize (mach0_build_platform)platform minos sdk ntools",
+		0);
+	sdb_set (bin->kv, "mach0_build_version_tool.format",
+		"[4]Ex "
+		"(mach0_build_tool)tool version",
+		0);
+	sdb_set (bin->kv, "mach0_source_version_command.format",
+		"[4]Edq "
+		"(mach0_load_command_type)cmd cmdsize version",
+		0);
+	sdb_set (bin->kv, "mach0_function_starts_command.format",
+		"[4]Edxd "
+		"(mach0_load_command_type)cmd cmdsize offset size",
+		0);
+	sdb_set (bin->kv, "mach0_data_in_code_command.format",
+		"[4]Edxd "
+		"(mach0_load_command_type)cmd cmdsize offset size",
+		0);
+	sdb_set (bin->kv, "mach0_version_min_command.format",
+		"[4]Edxx "
+		"(mach0_load_command_type)cmd cmdsize version reserved",
+		0);
+	sdb_set (bin->kv, "mach0_segment_split_info_command.format",
+		"[4]Edxd "
+		"(mach0_load_command_type)cmd cmdsize offset size",
+		0);
+	sdb_set (bin->kv, "mach0_unixthread_command.format",
+		"[4]Eddd "
+		"(mach0_load_command_type)cmd cmdsize flavor count",
+		0);
+}
+
 static bool init_hdr(struct MACH0_(obj_t) *bin) {
 	ut8 magicbytes[4] = {0};
 	ut8 machohdrbytes[sizeof (struct MACH0_(mach_header))] = {0};
@@ -181,46 +316,8 @@ static bool init_hdr(struct MACH0_(obj_t) *bin) {
 #if R_BIN_MACH064
 	bin->hdr.reserved = r_read_ble (&machohdrbytes[28], bin->big_endian, 32);
 #endif
-	sdb_set (bin->kv, "mach0_header.format",
-		"xxx[4]Edd[4]B "
-		"magic cputype cpusubtype (mach_filetype)filetype ncmds sizeofcmds (mach_flags)flags", 0);
+	init_sdb_formats (bin);
 	sdb_num_set (bin->kv, "mach0_header.offset", 0, 0); // wat about fatmach0?
-	sdb_set (bin->kv, "mach_filetype.cparse", "enum mach_filetype{MH_OBJECT=1,"
-			"MH_EXECUTE=2, MH_FVMLIB=3, MH_CORE=4, MH_PRELOAD=5, MH_DYLIB=6,"
-			"MH_DYLINKER=7, MH_BUNDLE=8, MH_DYLIB_STUB=9, MH_DSYM=10,"
-			"MH_KEXT_BUNDLE=11}"
-			,0);
-	sdb_set (bin->kv, "mach_flags.cparse", "enum mach_flags{MH_NOUNDEFS=1,"
-			"MH_INCRLINK=2,MH_DYLDLINK=4,MH_BINDATLOAD=8,MH_PREBOUND=0x10,"
-			"MH_SPLIT_SEGS=0x20,MH_LAZY_INIT=0x40,MH_TWOLEVEL=0x80,"
-			"MH_FORCE_FLAT=0x100,MH_NOMULTIDEFS=0x200,MH_NOFIXPREBINDING=0x400,"
-			"MH_PREBINDABLE=0x800, MH_ALLMODSBOUND=0x1000,"
-			"MH_SUBSECTIONS_VIA_SYMBOLS=0x2000,"
-			"MH_CANONICAL=0x4000,MH_WEAK_DEFINES=0x8000,"
-			"MH_BINDS_TO_WEAK=0x10000,MH_ALLOW_STACK_EXECUTION=0x20000,"
-			"MH_ROOT_SAFE=0x40000,MH_SETUID_SAFE=0x80000,"
-			"MH_NO_REEXPORTED_DYLIBS=0x100000,MH_PIE=0x200000,"
-			"MH_DEAD_STRIPPABLE_DYLIB=0x400000,"
-			"MH_HAS_TLV_DESCRIPTORS=0x800000,"
-			"MH_NO_HEAP_EXECUTION=0x1000000 }",0);
-	sdb_set (bin->kv, "mach_load_command_type.cparse", "enum mach_load_command_type {"
-			"LC_SEGMENT=0x00000001ULL, LC_SYMTAB=0x00000002ULL, LC_SYMSEG=0x00000003ULL,"
-			"LC_THREAD=0x00000004ULL, LC_UNIXTHREAD=0x00000005ULL, LC_LOADFVMLIB=0x00000006ULL,"
-			"LC_IDFVMLIB=0x00000007ULL, LC_IDENT=0x00000008ULL, LC_FVMFILE=0x00000009ULL,"
-			"LC_PREPAGE=0x0000000aULL, LC_DYSYMTAB=0x0000000bULL, LC_LOAD_DYLIB=0x0000000cULL,"
-			"LC_ID_DYLIB=0x0000000dULL, LC_LOAD_DYLINKER=0x0000000eULL, LC_ID_DYLINKER=0x0000000fULL,"
-			"LC_PREBOUND_DYLIB=0x00000010ULL, LC_ROUTINES=0x00000011ULL, LC_SUB_FRAMEWORK=0x00000012ULL,"
-			"LC_SUB_UMBRELLA=0x00000013ULL, LC_SUB_CLIENT=0x00000014ULL, LC_SUB_LIBRARY=0x00000015ULL,"
-			"LC_TWOLEVEL_HINTS=0x00000016ULL, LC_PREBIND_CKSUM=0x00000017ULL, LC_LOAD_WEAK_DYLIB=0x80000018ULL,"
-			"LC_SEGMENT_64=0x00000019ULL, LC_ROUTINES_64=0x0000001aULL, LC_UUID=0x0000001bULL,"
-			"LC_RPATH=0x8000001cULL, LC_CODE_SIGNATURE=0x0000001dULL, LC_SEGMENT_SPLIT_INFO=0x0000001eULL,"
-			"LC_REEXPORT_DYLIB=0x8000001fULL, LC_LAZY_LOAD_DYLIB=0x00000020ULL, LC_ENCRYPTION_INFO=0x00000021ULL,"
-			"LC_DYLD_INFO=0x00000022ULL, LC_DYLD_INFO_ONLY=0x80000022ULL, LC_LOAD_UPWARD_DYLIB=0x80000023ULL,"
-			"LC_VERSION_MIN_MACOSX=0x00000024ULL, LC_VERSION_MIN_IPHONEOS=0x00000025ULL, LC_FUNCTION_STARTS=0x00000026ULL,"
-			"LC_DYLD_ENVIRONMENT=0x00000027ULL, LC_MAIN=0x80000028ULL, LC_DATA_IN_CODE=0x00000029ULL,"
-			"LC_SOURCE_VERSION=0x0000002aULL, LC_DYLIB_CODE_SIGN_DRS=0x0000002bULL, LC_ENCRYPTION_INFO_64=0x0000002cULL,"
-			"LC_LINKER_OPTION=0x0000002dULL, LC_LINKER_OPTIMIZATION_HINT=0x0000002eULL, LC_VERSION_MIN_TVOS=0x0000002fULL,"
-			"LC_VERSION_MIN_WATCHOS=0x00000030ULL, LC_NOTE=0x00000031ULL, LC_BUILD_VERSION=0x00000032ULL };",0);
 	return true;
 }
 
@@ -283,12 +380,13 @@ static bool parse_segments(struct MACH0_(obj_t) *bin, ut64 off) {
 	i += sizeof (ut32);
 	bin->segs[j].flags = r_read_ble32 (&segcom[i], bin->big_endian);
 
+#if R_BIN_MACH064
+	sdb_num_set (bin->kv, sdb_fmt ("mach0_segment64_%d.offset", j), off, 0);
+#else
 	sdb_num_set (bin->kv, sdb_fmt ("mach0_segment_%d.offset", j), off, 0);
+#endif
+
 	sdb_num_set (bin->kv, "mach0_segments.count", 0, 0);
-	sdb_set (bin->kv, "mach0_segment.format",
-		"[4]Ed[16]zxxxxoodx "
-		"(mach_load_command_type)cmd cmdsize segname vmaddr vmsize "
-		"fileoff filesize maxprot initprot nsects flags", 0);
 
 	if (bin->segs[j].nsects > 0) {
 		sect = bin->nsects;
@@ -345,6 +443,14 @@ static bool parse_segments(struct MACH0_(obj_t) *bin, ut64 off) {
 			i += 16;
 			memcpy (&bin->sects[k].segname, &sec[i], 16);
 			i += 16;
+
+			sdb_num_set (bin->kv, sdb_fmt ("mach0_section_%.16s_%.16s.offset", &bin->sects[k].segname, &bin->sects[k].sectname), offset, 0);
+#if R_BIN_MACH064
+			sdb_set (bin->kv, sdb_fmt ("mach0_section_%.16s_%.16s.format", &bin->sects[k].segname, &bin->sects[k].sectname), "mach0_section64", 0);
+#else
+			sdb_set (bin->kv, sdb_fmt ("mach0_section_%.16s_%.16s.format", &bin->sects[k].segname, &bin->sects[k].sectname), "mach0_section", 0);
+#endif
+
 #if R_BIN_MACH064
 			bin->sects[k].addr = r_read_ble64 (&sec[i], bin->big_endian);
 			i += sizeof (ut64);
@@ -1448,9 +1554,13 @@ static int init_items(struct MACH0_(obj_t) *bin) {
 			break;
 		}
 
-		// TODO: a different format for each cmd
 		sdb_num_set (bin->kv, sdb_fmt ("mach0_cmd_%d.offset", i), off, 0);
-		sdb_set (bin->kv, sdb_fmt ("mach0_cmd_%d.format", i), "[4]Ed (mach_load_command_type)cmd size", 0);
+		const char *format_name = cmd_to_pf_definition (lc.cmd);
+		if (format_name) {
+			sdb_set (bin->kv, sdb_fmt ("mach0_cmd_%d.format", i), format_name, 0);
+		} else {
+			sdb_set (bin->kv, sdb_fmt ("mach0_cmd_%d.format", i), "[4]Ed (mach_load_command_type)cmd size", 0);
+		}
 
 		//bprintf ("%d\n", lc.cmd);
 		switch (lc.cmd) {

--- a/libr/util/format.c
+++ b/libr/util/format.c
@@ -1528,7 +1528,11 @@ int r_print_format_struct_size(const char *f, RPrint *p, int mode, int n) {
 	if (n >= 5) {  // This is the nesting level, is this not a bit arbitrary?!
 		return 0;
 	}
-	char *o = strdup (f);
+	const char *fmt2 = sdb_get (p->formats, f, NULL);
+	if (!fmt2) {
+		fmt2 = f;
+	}
+	char *o = strdup (fmt2);
 	if (!o) {
 		return -1;
 	}


### PR DESCRIPTION
- they’re now aligned with libr/bin/d/macho
- also tweaked r_print_format_struct_size to work with referenced format names

tweaked tests: https://github.com/radare/radare2-regressions/pull/1907

Samples:

```
$ r2 -nn ~/shit/ls
 -- If you're not satisfied by our product, we'll be happy to refund you.
[0x00000000]> pd1@@mach0_cmd*
            ;-- mach0_cmd_0:
            ;-- mach0_segment64_0:
            0x00000020 pf mach0_segment64 # size=72
      cmd : 0x00000020 = cmd (enum mach0_load_command_type) = 0x19 ; LC_SEGMENT_64
  cmdsize : 0x00000024 = 72
  segname : 0x00000028 = "__PAGEZERO"
   vmaddr : 0x00000038 = (qword)0x0000000000000000
   vmsize : 0x00000040 = (qword)0x0000000100000000
  fileoff : 0x00000048 = (qword)0x0000000000000000
 filesize : 0x00000050 = (qword)0x0000000000000000
  maxprot : 0x00000058 = (octal)  000000000
 initprot : 0x0000005c = (octal)  000000000
   nsects : 0x00000060 = 0
    flags : 0x00000064 = 0x00000000
            ;-- mach0_cmd_1:
            ;-- mach0_segment64_1:
            0x00000068 pf mach0_segment64 # size=72
      cmd : 0x00000068 = cmd (enum mach0_load_command_type) = 0x19 ; LC_SEGMENT_64
  cmdsize : 0x0000006c = 552
  segname : 0x00000070 = "__TEXT"
   vmaddr : 0x00000080 = (qword)0x0000000100000000
   vmsize : 0x00000088 = (qword)0x0000000000005000
  fileoff : 0x00000090 = (qword)0x0000000000000000
 filesize : 0x00000098 = (qword)0x0000000000005000
  maxprot : 0x000000a0 = (octal)  000000007
 initprot : 0x000000a4 = (octal)  000000005
   nsects : 0x000000a8 = 6
    flags : 0x000000ac = 0x00000000
            ;-- mach0_cmd_2:
            ;-- mach0_segment64_2:
            0x00000290 pf mach0_segment64 # size=72
      cmd : 0x00000290 = cmd (enum mach0_load_command_type) = 0x19 ; LC_SEGMENT_64
  cmdsize : 0x00000294 = 632
  segname : 0x00000298 = "__DATA"
   vmaddr : 0x000002a8 = (qword)0x0000000100005000
   vmsize : 0x000002b0 = (qword)0x0000000000001000
  fileoff : 0x000002b8 = (qword)0x0000000000005000
 filesize : 0x000002c0 = (qword)0x0000000000001000
  maxprot : 0x000002c8 = (octal)  000000007
 initprot : 0x000002cc = (octal)  000000003
   nsects : 0x000002d0 = 7
    flags : 0x000002d4 = 0x00000000
            ;-- mach0_cmd_3:
            ;-- mach0_segment64_3:
            0x00000508 pf mach0_segment64 # size=72
      cmd : 0x00000508 = cmd (enum mach0_load_command_type) = 0x19 ; LC_SEGMENT_64
  cmdsize : 0x0000050c = 72
  segname : 0x00000510 = "__LINKEDIT"
   vmaddr : 0x00000520 = (qword)0x0000000100006000
   vmsize : 0x00000528 = (qword)0x0000000000004000
  fileoff : 0x00000530 = (qword)0x0000000000006000
 filesize : 0x00000538 = (qword)0x00000000000036e0
  maxprot : 0x00000540 = (octal)  000000007
 initprot : 0x00000544 = (octal)  000000001
   nsects : 0x00000548 = 0
    flags : 0x0000054c = 0x00000000
            ;-- mach0_cmd_4:
            0x00000550 pf mach0_dyld_info_only_command # size=48
            cmd : 0x00000550 = cmd (enum mach0_load_command_type) = 0x80000022 ; LC_DYLD_INFO_ONLY
        cmdsize : 0x00000554 = 48
     rebase_off : 0x00000558 = 0x00006000
    rebase_size : 0x0000055c = 24
       bind_off : 0x00000560 = 0x00006018
      bind_size : 0x00000564 = 104
  weak_bind_off : 0x00000568 = 0x00000000
 weak_bind_size : 0x0000056c = 0
  lazy_bind_off : 0x00000570 = 0x00006080
 lazy_bind_size : 0x00000574 = 1376
     export_off : 0x00000578 = 0x000065e0
    export_size : 0x0000057c = 32
            ;-- mach0_cmd_5:
            0x00000580 pf mach0_symtab_command # size=24
     cmd : 0x00000580 = cmd (enum mach0_load_command_type) = 0x2 ; LC_SYMTAB
 cmdsize : 0x00000584 = 24
  symoff : 0x00000588 = 0x00006638
   nsyms : 0x0000058c = 84
  stroff : 0x00000590 = 0x00006df4
 strsize : 0x00000594 = 976
            ;-- mach0_cmd_6:
            0x00000598 pf mach0_dysymtab_command # size=80
             cmd : 0x00000598 = cmd (enum mach0_load_command_type) = 0xb ; LC_DYSYMTAB
         cmdsize : 0x0000059c = 80
       ilocalsym : 0x000005a0 = 0
       nlocalsym : 0x000005a4 = 1
      iextdefsym : 0x000005a8 = 1
      nextdefsym : 0x000005ac = 1
       iundefsym : 0x000005b0 = 2
       nundefsym : 0x000005b4 = 82
          tocoff : 0x000005b8 = 0
            ntoc : 0x000005bc = 0
      moddtaboff : 0x000005c0 = 0
         nmodtab : 0x000005c4 = 0
    extrefsymoff : 0x000005c8 = 0x00000000
     nextrefsyms : 0x000005cc = 0
 inddirectsymoff : 0x000005d0 = 0x00006b78
   nindirectsyms : 0x000005d4 = 159
       extreloff : 0x000005d8 = 0x00000000
         nextrel : 0x000005dc = 0x00000000
       locreloff : 0x000005e0 = 0x00000000
         nlocrel : 0x000005e4 = 0
            ;-- mach0_cmd_7:
            0x000005e8 pf mach0_load_dylinker_command # size=13
         cmd : 0x000005e8 = cmd (enum mach0_load_command_type) = 0xe ; LC_LOAD_DYLINKER
     cmdsize : 0x000005ec = 32
 name_offset : 0x000005f0 = 0x0000000c
        name : 0x000005f4 = "/usr/lib/dyld"
            ;-- mach0_cmd_8:
            0x00000608 pf mach0_uuid_command # size=24
     cmd : 0x00000608 = cmd (enum mach0_load_command_type) = 0x1b ; LC_UUID
 cmdsize : 0x0000060c = 24
    uuid : 0x00000610 = [ 0x2e, 0xd4, 0xc5, 0x84, 0xff, 0xcf, 0x38, 0xba, 0xad, 0x0a, 0x7c, 0x07, 0x07, 0xc0, 0x5c, 0x6b ]
            ;-- mach0_cmd_9:
            0x00000620 pf mach0_version_min_command # size=16
      cmd : 0x00000620 = cmd (enum mach0_load_command_type) = 0x24 ; LC_VERSION_MIN_MACOSX
  cmdsize : 0x00000624 = 16
  version : 0x00000628 = 0x000a0c00
 reserved : 0x0000062c = 0x000a0c00
            ;-- mach0_cmd_10:
            0x00000630 pf mach0_source_version_command # size=16
     cmd : 0x00000630 = cmd (enum mach0_load_command_type) = 0x2a ; LC_SOURCE_VERSION
 cmdsize : 0x00000634 = 16
 version : 0x00000638 = (qword)0x0001080500100000
            ;-- mach0_cmd_11:
            0x00000640 pf mach0_entry_point_command # size=24
       cmd : 0x00000640 = cmd (enum mach0_load_command_type) = 0x80000028 ; LC_MAIN
   cmdsize : 0x00000644 = 24
  entryoff : 0x00000648 = (qword)0x00000000000011e0
 stacksize : 0x00000650 = (qword)0x0000000000000000
            ;-- mach0_cmd_12:
            0x00000658 pf mach0_dylib_command # size=25
     cmd : 0x00000658 = cmd (enum mach0_load_command_type) = 0xc ; LC_LOAD_DYLIB
 cmdsize : 0x0000065c = 48
   dylib :
                struct<mach0_dylib>
                                 name_offset : 0x00000660 = 0x00000018
                                   timestamp : 0x00000664 = 0x00000002
                             current_version : 0x00000668 = 0x00010000
                       compatibility_version : 0x0000066c = 0x00010000
                                        name : 0x00000670 = "/usr/lib/libutil.dylib"
            ;-- mach0_cmd_13:
            0x00000688 pf mach0_dylib_command # size=25
     cmd : 0x00000688 = cmd (enum mach0_load_command_type) = 0xc ; LC_LOAD_DYLIB
 cmdsize : 0x0000068c = 56
   dylib :
                struct<mach0_dylib>
                                 name_offset : 0x00000690 = 0x00000018
                                   timestamp : 0x00000694 = 0x00000002
                             current_version : 0x00000698 = 0x00050400
                       compatibility_version : 0x0000069c = 0x00050400
                                        name : 0x000006a0 = "/usr/lib/libncurses.5.4.dylib"
            ;-- mach0_cmd_14:
            0x000006c0 pf mach0_dylib_command # size=25
     cmd : 0x000006c0 = cmd (enum mach0_load_command_type) = 0xc ; LC_LOAD_DYLIB
 cmdsize : 0x000006c4 = 56
   dylib :
                struct<mach0_dylib>
                                 name_offset : 0x000006c8 = 0x00000018
                                   timestamp : 0x000006cc = 0x00000002
                             current_version : 0x000006d0 = 0x04d60000
                       compatibility_version : 0x000006d4 = 0x00010000
                                        name : 0x000006d8 = "/usr/lib/libSystem.B.dylib"
            ;-- mach0_cmd_15:
            0x000006f8 pf mach0_function_starts_command # size=16
     cmd : 0x000006f8 = cmd (enum mach0_load_command_type) = 0x26 ; LC_FUNCTION_STARTS
 cmdsize : 0x000006fc = 16
  offset : 0x00000700 = 0x00006600
    size : 0x00000704 = 56
            ;-- mach0_cmd_16:
            0x00000708 pf mach0_data_in_code_command # size=16
     cmd : 0x00000708 = cmd (enum mach0_load_command_type) = 0x29 ; LC_DATA_IN_CODE
 cmdsize : 0x0000070c = 16
  offset : 0x00000710 = 0x00006638
    size : 0x00000714 = 0
            ;-- mach0_cmd_17:
            0x00000718 pf mach0_code_signature_command # size=16
     cmd : 0x00000718 = cmd (enum mach0_load_command_type) = 0x1d ; LC_CODE_SIGNATURE
 cmdsize : 0x0000071c = 16
  offset : 0x00000720 = 0x000071d0
    size : 0x00000724 = 9488
[0x00000000]>
```