### PR TITLE
Fix some leaks found by ASAN.

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -901,7 +901,7 @@ beach:
 }
 
 R_API RList *r_meta_enumerate(RAnal *a, int type) {
-	RList *list = r_list_new ();
+	RList *list = r_list_newf (r_meta_item_free);
 	r_meta_list_cb (a, type, 0, meta_enumerate_cb, list, UT64_MAX);
 	return list;
 }

--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -624,6 +624,7 @@ R_API bool r_config_eval(RConfig *cfg, const char *str, bool many) {
 		return true;
 	}
 	__evalString (cfg, s);
+	free(s);
 	return true;
 }
 

--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -624,7 +624,7 @@ R_API bool r_config_eval(RConfig *cfg, const char *str, bool many) {
 		return true;
 	}
 	__evalString (cfg, s);
-	free(s);
+	free (s);
 	return true;
 }
 

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -669,6 +669,7 @@ R_API void r_cons_grepbuf() {
 		snprintf (cons->context->buffer, cons->context->buffer_len, "%d\n", cnt);
 		cons->context->buffer_len = strlen (cons->context->buffer);
 		cons->num->value = cons->lines;
+		r_strbuf_free (ob);
 		return;
 	}
 	

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4072,12 +4072,16 @@ R_API RCoreAnalStats* r_core_anal_get_stats(RCore *core, ut64 from, ut64 to, ut6
 			break;
 		}
 	}
+	r_list_free(metas);
 	// iter all comments
 	// iter all strings
 	return as;
 }
 
 R_API void r_core_anal_stats_free(RCoreAnalStats *s) {
+	if (s) {
+		free (s->block);
+	}
 	free (s);
 }
 

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4072,7 +4072,7 @@ R_API RCoreAnalStats* r_core_anal_get_stats(RCore *core, ut64 from, ut64 to, ut6
 			break;
 		}
 	}
-	r_list_free(metas);
+	r_list_free (metas);
 	// iter all comments
 	// iter all strings
 	return as;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1129,7 +1129,7 @@ static bool cb_cmdpdc(void *user, void *data) {
 	if (node->value[0] == '?') {
 		r_cons_printf ("pdc\n");
 		// spaguetti
-		check_decompiler("r2retdec");
+		check_decompiler ("r2retdec");
 		RListIter *iter;
 		RCorePlugin *cp;
 		r_list_foreach (core->rcmd->plist, iter, cp) {
@@ -1137,9 +1137,9 @@ static bool cb_cmdpdc(void *user, void *data) {
 				r_cons_printf ("pdg\n");
 			}
 		}
-		check_decompiler("r2ghidra");
-		check_decompiler("r2jadx");
-		check_decompiler("r2snow");
+		check_decompiler ("r2ghidra");
+		check_decompiler ("r2jadx");
+		check_decompiler ("r2snow");
 		RConfigNode *r2dec = r_config_node_get (core->config, "r2dec.asm");
 		if (r2dec) {
 			r_cons_printf ("pdd\n");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -115,11 +115,12 @@ static void rasm2_list(RCore *core, const char *arch, int fmt) {
 	char bits[32];
 	RAsmPlugin *h;
 	RListIter *iter;
-	PJ *pj = pj_new ();
-	if (!pj) {
-		return;
-	}
+	PJ *pj = NULL;
 	if (fmt == 'j') {
+		pj = pj_new ();
+		if (!pj) {
+			return;
+		}
 		pj_o (pj);
 	}
 	r_list_foreach (a->plugins, iter, h) {
@@ -1114,17 +1115,21 @@ static bool cb_cfg_fortunes_type(void *user, void *data) {
 	return true;
 }
 
+static void check_decompiler(const char* name) {
+	char *path = r_file_path (name);
+	if (path && path[0] == '/') {
+		r_cons_printf ("!*%s\n", name);
+	}
+	free (path);
+}
+
 static bool cb_cmdpdc(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *)data;
 	if (node->value[0] == '?') {
 		r_cons_printf ("pdc\n");
 		// spaguetti
-		char *retdec = r_file_path ("r2retdec");
-		if (retdec && *retdec == '/') {
-			r_cons_printf ("!*r2retdec\n");
-			free (retdec);
-		}
+		check_decompiler("r2retdec");
 		RListIter *iter;
 		RCorePlugin *cp;
 		r_list_foreach (core->rcmd->plist, iter, cp) {
@@ -1132,21 +1137,9 @@ static bool cb_cmdpdc(void *user, void *data) {
 				r_cons_printf ("pdg\n");
 			}
 		}
-		char *ghidra = r_file_path ("r2ghidra");
-		if (ghidra && *ghidra == '/') {
-			r_cons_printf ("!*r2ghidra\n");
-			free (ghidra);
-		}
-		char *r2jadx = r_file_path ("r2jadx");
-		if (r2jadx && *r2jadx == '/') {
-			r_cons_printf ("!*r2jadx\n");
-			free (r2jadx);
-		}
-		char *r2snow = r_file_path ("r2snow");
-		if (r2snow && *r2snow == '/') {
-			r_cons_printf (".!r2snow\n");
-			free (r2snow);
-		}
+		check_decompiler("r2ghidra");
+		check_decompiler("r2jadx");
+		check_decompiler("r2snow");
 		RConfigNode *r2dec = r_config_node_get (core->config, "r2dec.asm");
 		if (r2dec) {
 			r_cons_printf ("pdd\n");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7354,10 +7354,6 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 }
 
 static void cmd_anal_graph(RCore *core, const char *input) {
-	// Honor asm.graph=false in json as well
-	RConfigHold *hc = r_config_hold_new (core->config);
-	r_config_hold_i (hc, "asm.offset", NULL);
-	const bool o_graph_offset = r_config_get_i (core->config, "graph.offset");
 	core->graph->show_node_titles = r_config_get_i (core->config, "graph.ntitles");
 	switch (input[0]) {
 	case 'f': // "agf"
@@ -7399,13 +7395,18 @@ static void cmd_anal_graph(RCore *core, const char *input) {
 		case 'j': // "agfj"
 			r_core_anal_graph (core, r_num_math (core->num, input + 2), R_CORE_ANAL_JSON);
 			break;
-		case 'J': // "agfJ"
+		case 'J': {// "agfJ"
+			// Honor asm.graph=false in json as well
+			RConfigHold *hc = r_config_hold_new (core->config);
+			r_config_hold_i (hc, "asm.offset", NULL);
+			const bool o_graph_offset = r_config_get_i (core->config, "graph.offset");
 			r_config_set_i (core->config, "asm.offset", o_graph_offset);
 			r_core_anal_graph (core, r_num_math (core->num, input + 2),
 				R_CORE_ANAL_JSON | R_CORE_ANAL_JSON_FORMAT_DISASM);
 			r_config_hold_restore (hc);
 			r_config_hold_free (hc);
 			break;
+			}
 		case 'g':{ // "agfg"
 			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
 			r_core_print_bb_gml (core, fcn);


### PR DESCRIPTION
Before PR when opening and closing Cutter with basic executable:
`SUMMARY: AddressSanitizer: 811129 byte(s) leaked in 16725 allocation(s).`
After changes:
`SUMMARY: AddressSanitizer: 588035 byte(s) leaked in 15023 allocation(s).`