### PR TITLE
bin_symbols: Add quoting

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2137,11 +2137,11 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 					lastfs = 's';
 				}
 				if (r->bin->prefix) {
-					r_cons_printf ("f %s.sym.%s %u 0x%08" PFMT64x "\n",
+					r_cons_printf ("\"f %s.sym.%s %u 0x%08" PFMT64x "\"\n",
 						r->bin->prefix, r_bin_symbol_name (symbol), symbol->size, addr);
 				} else {
 					if (*name) {
-						r_cons_printf ("f sym.%s %u 0x%08" PFMT64x "\n",
+						r_cons_printf ("\"f sym.%s %u 0x%08" PFMT64x "\"\n",
 							r_bin_symbol_name (symbol), symbol->size, addr);
 					} else {
 						// we don't want unnamed symbol flags


### PR DESCRIPTION
Hello there. Since @blenk92  and me looked at potential issues for the PwnDebian challenge, we are proposing a fix regarding quoting for the `is` / `is*` commands.

This fixes the output, so that
```
f sym.imp.__sprintf_chk 16 0x00000000
```

becomes

```
"f sym.imp.__sprintf_chk 16 0x5562473eb000"
```

when executing `is*`.

Greetings