### PR TITLE
asm.cmt.fcnrefs: Show name/flag of function ref in disasm (true, false, nodup)

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3038,6 +3038,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.marks", "true", "Show marks before the disassembly");
 	SETPREF ("asm.cmt.refs", "false", "Show flag and comments from refs in disasm");
 	SETPREF ("asm.cmt.patch", "false", "Show patch comments in disasm");
+	SETPREF ("asm.cmt.funrefs", "nodup", "Show name/flag of function ref in disasm (true, false, nodup)");
 	SETPREF ("asm.cmt.off", "nodup", "Show offset comment in disasm (true, false, nodup)");
 	SETPREF ("asm.payloads", "false", "Show payload bytes in disasm");
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3038,7 +3038,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("asm.marks", "true", "Show marks before the disassembly");
 	SETPREF ("asm.cmt.refs", "false", "Show flag and comments from refs in disasm");
 	SETPREF ("asm.cmt.patch", "false", "Show patch comments in disasm");
-	SETPREF ("asm.cmt.funrefs", "nodup", "Show name/flag of function ref in disasm (true, false, nodup)");
+	SETPREF ("asm.cmt.fcnrefs", "nodup", "Show name/flag of function ref in disasm (true, false, nodup)");
 	SETPREF ("asm.cmt.off", "nodup", "Show offset comment in disasm (true, false, nodup)");
 	SETPREF ("asm.payloads", "false", "Show payload bytes in disasm");
 

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -160,7 +160,7 @@ typedef struct {
 	int stackFd;
 	bool show_xrefs;
 	bool show_cmtrefs;
-	const char *show_cmtfunrefs;
+	const char *show_cmtfcnrefs;
 	const char *show_cmtoff;
 	bool show_functions;
 	bool show_marks;
@@ -753,7 +753,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->show_xrefs = r_config_get_i (core->config, "asm.xrefs");
 	ds->show_cmtrefs = r_config_get_i (core->config, "asm.cmt.refs");
 	ds->cmtfold = r_config_get_i (core->config, "asm.cmt.fold");
-	ds->show_cmtfunrefs = r_config_get (core->config, "asm.cmt.funrefs");
+	ds->show_cmtfcnrefs = r_config_get (core->config, "asm.cmt.fcnrefs");
 	ds->show_cmtoff = r_config_get (core->config, "asm.cmt.off");
 	ds->show_functions = r_config_get_i (core->config, "asm.functions");
 	ds->nbytes = r_config_get_i (core->config, "asm.nbytes");
@@ -3283,12 +3283,12 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 		return;
 	}
 	RAnalFunction *f = fcnIn (ds, ds->analop.jump, R_ANAL_FCN_TYPE_NULL);
-	if (!f && ds->core->flags && strcmp (ds->show_cmtfunrefs, "false")) {
+	if (!f && ds->core->flags && strcmp (ds->show_cmtfcnrefs, "false")) {
 		const char *arch;
 		RFlagItem *flag = r_flag_get_by_spaces (ds->core->flags, ds->analop.jump,
 		                                        R_FLAGS_FS_CLASSES, R_FLAGS_FS_SYMBOLS, NULL);
 		if (flag && flag->name
-		    && (!strcmp (ds->show_cmtfunrefs, "true") || (ds->opstr && !strstr (ds->opstr, flag->name)))
+		    && (!strcmp (ds->show_cmtfcnrefs, "true") || (ds->opstr && !strstr (ds->opstr, flag->name)))
 		    && (r_str_startswith (flag->name, "sym.") || r_str_startswith (flag->name, "method."))
 		    && (arch = r_config_get (ds->core->config, "asm.arch")) && strcmp (arch, "dalvik")) {
 			ds_begin_comment (ds);
@@ -3315,8 +3315,8 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 		} else if (delta < 0) {
 			ds_begin_comment (ds);
 			ds_comment (ds, true, "; %s-0x%x", f->name, -delta);
-		} else if (strcmp (ds->show_cmtfunrefs, "false")
-		           && (!strcmp (ds->show_cmtfunrefs, "true")
+		} else if (strcmp (ds->show_cmtfcnrefs, "false")
+		           && (!strcmp (ds->show_cmtfcnrefs, "true")
 		               || (ds->opstr && !strstr (ds->opstr, f->name)))) {
 			ds_begin_comment (ds);
 			ds_comment (ds, true, "; %s", f->name);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3309,14 +3309,16 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 		if (f == f2) {
 			return;
 		}
-		ds_begin_comment (ds);
 		if (delta > 0) {
+			ds_begin_comment (ds);
 			ds_comment (ds, true, "; %s+0x%x", f->name, delta);
 		} else if (delta < 0) {
+			ds_begin_comment (ds);
 			ds_comment (ds, true, "; %s-0x%x", f->name, -delta);
 		} else if (strcmp (ds->show_cmtfunrefs, "false")
 		           && (!strcmp (ds->show_cmtfunrefs, "true")
 		               || (ds->opstr && !strstr (ds->opstr, f->name)))) {
+			ds_begin_comment (ds);
 			ds_comment (ds, true, "; %s", f->name);
 		}
 	}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4140,6 +4140,7 @@ R_API void r_core_visual_disasm_down(RCore *core, RAsmOp *op, int *cols) {
 
 R_API int r_core_visual(RCore *core, const char *input) {
 	const char *teefile;
+	const char *orig_cmtfunrefs;
 	ut64 scrseek;
 	int flags, ch;
 	bool skip;
@@ -4173,6 +4174,8 @@ R_API int r_core_visual(RCore *core, const char *input) {
 		input += len;
 	}
 	core->vmode = true;
+	orig_cmtfunrefs = r_config_get (core->config, "asm.cmt.funrefs");
+	r_config_set (core->config, "asm.cmt.funrefs", "false");
 
 	// disable tee in cons
 	teefile = r_cons_singleton ()->teefile;
@@ -4303,6 +4306,7 @@ dodo:
 		r_core_block_size (core, obs);
 	}
 	r_cons_singleton ()->teefile = teefile;
+	r_config_set (core->config, "asm.cmt.funrefs", orig_cmtfunrefs);
 	r_cons_set_cup (false);
 	r_cons_clear00 ();
 	core->vmode = false;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4140,7 +4140,7 @@ R_API void r_core_visual_disasm_down(RCore *core, RAsmOp *op, int *cols) {
 
 R_API int r_core_visual(RCore *core, const char *input) {
 	const char *teefile;
-	const char *orig_cmtfunrefs;
+	const char *orig_cmtfcnrefs;
 	ut64 scrseek;
 	int flags, ch;
 	bool skip;
@@ -4174,8 +4174,8 @@ R_API int r_core_visual(RCore *core, const char *input) {
 		input += len;
 	}
 	core->vmode = true;
-	orig_cmtfunrefs = r_config_get (core->config, "asm.cmt.funrefs");
-	r_config_set (core->config, "asm.cmt.funrefs", "false");
+	orig_cmtfcnrefs = r_config_get (core->config, "asm.cmt.fcnrefs");
+	r_config_set (core->config, "asm.cmt.fcnrefs", "false");
 
 	// disable tee in cons
 	teefile = r_cons_singleton ()->teefile;
@@ -4306,7 +4306,7 @@ dodo:
 		r_core_block_size (core, obs);
 	}
 	r_cons_singleton ()->teefile = teefile;
-	r_config_set (core->config, "asm.cmt.funrefs", orig_cmtfunrefs);
+	r_config_set (core->config, "asm.cmt.fcnrefs", orig_cmtfcnrefs);
 	r_cons_set_cup (false);
 	r_cons_clear00 ();
 	core->vmode = false;


### PR DESCRIPTION
Separate config var so that i can disable it in Visual mode specifically for functions.