### PR TITLE
Use void in function prototypes

### DIFF
--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -116,7 +116,7 @@ R_API int r_cmd_call_long(RCmd *cmd, const char *input);
 R_API char **r_cmd_args(RCmd *cmd, int *argc);
 
 /* r_cmd_macro */
-R_API RCmdMacroItem *r_cmd_macro_item_new();
+R_API RCmdMacroItem *r_cmd_macro_item_new(void);
 R_API void r_cmd_macro_item_free(RCmdMacroItem *item);
 R_API void r_cmd_macro_init(RCmdMacro *mac);
 R_API int r_cmd_macro_add(RCmdMacro *mac, const char *name);

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -111,7 +111,7 @@ struct r_parse_ctype_type_t {
 	};
 };
 
-R_API RParseCType *r_parse_ctype_new();
+R_API RParseCType *r_parse_ctype_new(void);
 R_API void r_parse_ctype_free(RParseCType *ctype);
 R_API RParseCTypeType *r_parse_ctype_parse(RParseCType *ctype, const char *str, char **error);
 R_API void r_parse_ctype_type_free(RParseCTypeType *type);

--- a/libr/include/r_util/pj.h
+++ b/libr/include/r_util/pj.h
@@ -13,7 +13,7 @@ typedef struct pj_t {
 } PJ;
 
 /* lifecycle */
-R_API PJ *pj_new();
+R_API PJ *pj_new(void);
 R_API void pj_free(PJ *j);
 R_API char *pj_drain(PJ *j);
 R_API const char *pj_string(PJ *pj);

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -31,7 +31,7 @@ typedef struct _os_info {
 
 R_API char **r_sys_get_environ(void);
 R_API void r_sys_set_environ(char **e);
-R_API os_info *r_sys_get_osinfo();
+R_API os_info *r_sys_get_osinfo(void);
 R_API ut64 r_sys_now(void);
 R_API const char *r_time_to_string (ut64 ts);
 R_API int r_sys_fork(void);
@@ -82,8 +82,8 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, char **output, 
 #define r_sys_conv_win_to_utf8(buf) r_acp_to_utf8 (buf)
 #define r_sys_conv_win_to_utf8_l(buf, len) r_acp_to_utf8_l (buf, len)
 #endif
-R_API os_info *r_sys_get_winver();
-R_API char *r_sys_get_src_dir_w32();
+R_API os_info *r_sys_get_winver(void);
+R_API char *r_sys_get_src_dir_w32(void);
 R_API bool r_sys_cmd_str_full_w32(const char *cmd, const char *input, char **output, int *outlen, char **sterr);
 R_API bool r_sys_create_child_proc_w32(const char *cmdline, HANDLE in, HANDLE out, HANDLE err);
 #endif


### PR DESCRIPTION
Small PR that fixes -Wstrict-prototypes warnings.