### PR TITLE
Fix memory leaks part 2

### DIFF
--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -96,23 +96,19 @@ R_API void r_bin_filter_sym(RBinFile *bf, HtPP *ht, ut64 vaddr, RBinSymbol *sym)
 	if (!res) {
 		return;
 	}
+	sym->dup_count = 0;
 
 	const char *oname = sdb_fmt ("o.%" PFMT64x ".%s", 0, name);
-	ut32 *dup_count = ht_pp_find (ht, oname, NULL);
-	if (!dup_count) {
-		dup_count = R_NEW0 (ut32);
-		if (!dup_count) {
-			return;
-		}
-		if (!ht_pp_insert (ht, oname, dup_count)) {
-			R_FREE (dup_count);
+	RBinSymbol *prev_sym = ht_pp_find (ht, oname, NULL);
+	if (!prev_sym) {
+		if (!ht_pp_insert (ht, oname, sym)) {
 			R_LOG_WARN ("Failed to insert dup_count in ht");
 			return;
 		}
-		*dup_count = -1;
+	} else {
+		sym->dup_count = prev_sym->dup_count + 1;
+		ht_pp_update(ht, oname, sym);
 	}
-	*dup_count += 1;
-	sym->dup_count = *dup_count;
 }
 
 R_API void r_bin_filter_symbols(RBinFile *bf, RList *list) {

--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -107,7 +107,7 @@ R_API void r_bin_filter_sym(RBinFile *bf, HtPP *ht, ut64 vaddr, RBinSymbol *sym)
 		}
 	} else {
 		sym->dup_count = prev_sym->dup_count + 1;
-		ht_pp_update(ht, oname, sym);
+		ht_pp_update (ht, oname, sym);
 	}
 }
 

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1353,7 +1353,9 @@ static HtUP *rel_cache_new(ELFOBJ *bin) {
 			goto out;
 		}
 
-		ht_up_insert (rel_cache, REL_SYM, rel);
+		if (!ht_up_insert (rel_cache, REL_SYM, rel)) {
+			free (rel);
+		}
 	}
 	return rel_cache;
 out:

--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -147,7 +147,6 @@ static void __cons_pal_update_event(RConsContext *ctx) {
 
 R_API void r_cons_pal_init(RConsContext *ctx) {
 	memset (&ctx->cpal, 0, sizeof (ctx->cpal));
-	memset (&ctx->pal, 0, sizeof (ctx->pal));
 
 	ctx->cpal.b0x00              = (RColor) RColor_GREEN;
 	ctx->cpal.b0x7f              = (RColor) RColor_CYAN;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -403,7 +403,7 @@ static bool bin_raw_strings(RCore *r, int mode, int va) {
 	}
 	RList *l = r_bin_raw_strings (bf, 0);
 	_print_strings (r, l, mode, va);
-	r_list_free(l);
+	r_list_free (l);
 	if (new_bf) {
 		r_buf_free (bf->buf);
 		bf->buf = NULL;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -403,6 +403,7 @@ static bool bin_raw_strings(RCore *r, int mode, int va) {
 	}
 	RList *l = r_bin_raw_strings (bf, 0);
 	_print_strings (r, l, mode, va);
+	r_list_free(l);
 	if (new_bf) {
 		r_buf_free (bf->buf);
 		bf->buf = NULL;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3171,8 +3171,12 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("dir.source", "", &cb_dirsrc, "Path to find source files");
 	SETPREF ("dir.types", "/usr/include", "Default path to look for cparse type files");
 	SETPREF ("dir.libs", "", "Specify path to find libraries to load when bin.libs=true");
-	SETCB ("dir.home", r_sys_getenv (R_SYS_HOME), &cb_dirhome, "Path for the home directory");
-	SETCB ("dir.tmp", r_sys_getenv (R_SYS_TMP), &cb_dirtmp, "Path of the tmp directory");
+	p = r_sys_getenv (R_SYS_HOME);
+	SETCB ("dir.home", p, &cb_dirhome, "Path for the home directory");
+	free (p);
+	p = r_sys_getenv (R_SYS_TMP);
+	SETCB ("dir.tmp", p, &cb_dirtmp, "Path of the tmp directory");
+	free (p);
 #if __ANDROID__
 	SETPREF ("dir.projects", "/data/data/org.radare.radare2installer/radare2/projects", "Default path for projects");
 #else

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3031,6 +3031,8 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 			to = t;
 		}
 	}
+	r_list_free(list);
+	list = NULL;
 	ut64 piece = R_MAX ((to - from) / R_MAX (cols, w), 1);
 	RCoreAnalStats *as = r_core_anal_get_stats (core, from, to, piece);
 	if (!as) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3031,7 +3031,7 @@ static int cmd_print_blocks(RCore *core, const char *input) {
 			to = t;
 		}
 	}
-	r_list_free(list);
+	r_list_free (list);
 	list = NULL;
 	ut64 piece = R_MAX ((to - from) / R_MAX (cols, w), 1);
 	RCoreAnalStats *as = r_core_anal_get_stats (core, from, to, piece);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1262,27 +1262,29 @@ static void print_rop(RCore *core, RList *hitlist, char mode, bool *json_first) 
 				char *opstr_n = r_str_newf (" %s", R_STRBUF_SAFEGET (&analop.esil));
 				r_list_append (ropList, (void *) opstr_n);
 			}
+			char *asm_op_hex = r_asm_op_get_hex (&asmop);
 			if (colorize) {
 				char *buf_asm = r_print_colorize_opcode (core->print, r_asm_op_get_asm (&asmop),
 					core->cons->context->pal.reg, core->cons->context->pal.num, false, 0);
 				otype = r_print_color_op_type (core->print, analop.type);
 				if (comment) {
 					r_cons_printf ("  0x%08"PFMT64x " %18s%s  %s%s ; %s\n",
-						hit->addr, r_asm_op_get_hex (&asmop), otype, buf_asm, Color_RESET, comment);
+						hit->addr, asm_op_hex, otype, buf_asm, Color_RESET, comment);
 				} else {
 					r_cons_printf ("  0x%08"PFMT64x " %18s%s  %s%s\n",
-						hit->addr, r_asm_op_get_hex (&asmop), otype, buf_asm, Color_RESET);
+						hit->addr, asm_op_hex, otype, buf_asm, Color_RESET);
 				}
 				free (buf_asm);
 			} else {
 				if (comment) {
 					r_cons_printf ("  0x%08"PFMT64x " %18s  %s ; %s\n",
-						hit->addr, r_asm_op_get_hex (&asmop), r_asm_op_get_asm (&asmop), comment);
+						hit->addr, asm_op_hex, r_asm_op_get_asm (&asmop), comment);
 				} else {
 					r_cons_printf ("  0x%08"PFMT64x " %18s  %s\n",
-						hit->addr, r_asm_op_get_hex (&asmop), r_asm_op_get_asm (&asmop));
+						hit->addr, asm_op_hex, r_asm_op_get_asm (&asmop));
 				}
 			}
+			free (asm_op_hex);
 			free (buf);
 		}
 		if (db && hit) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4615,8 +4615,10 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 					}
 				}
 				ds_comment_end (ds, "");
+				r_list_free(list);
 				break;
 			} else {
+				r_list_free(list);
 				// function name not resolved
 				nargs = DEFAULT_NARGS;
 				if (fcn) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4618,10 +4618,10 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 					}
 				}
 				ds_comment_end (ds, "");
-				r_list_free(list);
+				r_list_free (list);
 				break;
 			} else {
-				r_list_free(list);
+				r_list_free (list);
 				// function name not resolved
 				nargs = DEFAULT_NARGS;
 				if (fcn) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2412,9 +2412,12 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 				break;
 			// case R_META_TYPE_DATA:
 			//	break;
-			default:
-				r_asm_op_set_asm (&ds->asmop, sdb_fmt (".hex %s", r_asm_op_get_hex (&ds->asmop)));
+			default: {
+				char *op_hex = r_asm_op_get_hex (&ds->asmop);
+				r_asm_op_set_asm (&ds->asmop, sdb_fmt (".hex %s", op_hex));
+				free (op_hex);
 				break;
+			}
 			}
 			ds->oplen = sz; //ds->asmop.size;
 			return i;
@@ -3088,7 +3091,7 @@ static void ds_print_show_bytes(RDisasmState *ds) {
 			pad[j] = '\0';
 			str = strdup ("");
 		} else {
-			str = strdup (r_asm_op_get_hex (&ds->asmop));
+			str = r_asm_op_get_hex (&ds->asmop);
 			if (r_str_ansi_len (str) > ds->nb) {
 				char *p = (char *)r_str_ansi_chrn (str, ds->nb);
 				if (p)  {
@@ -5892,7 +5895,11 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		pj_ki (pj, "size", ds->analop.size);
 		pj_ks (pj, "opcode", opstr);
 		pj_ks (pj, "disasm", str);
-		pj_ks (pj, "bytes", r_asm_op_get_hex (&asmop));
+		{
+			char *hex = r_asm_op_get_hex (&asmop);
+			pj_ks (pj, "bytes", hex);
+			free (hex);
+		}
 		pj_ks (pj, "family", r_anal_op_family_to_string (ds->analop.family));
 		pj_ks (pj, "type", r_anal_optype_to_string (ds->analop.type));
 		// indicate a relocated address
@@ -6077,7 +6084,7 @@ R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mo
 					char *sp = strchr (str, ' ');
 					if (sp) {
 						char *end = sp + 60 + 1;
-						const char *src = r_asm_op_get_hex (&asmop);
+						char *src = r_asm_op_get_hex (&asmop);
 						char *dst = sp + 1 + (i * 2);
 						int len = strlen (src);
 						if (dst < end) {
@@ -6087,19 +6094,26 @@ R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mo
 							}
 							memcpy (dst, src, len);
 						}
+						free (src);
 					}
 					r_cons_strcat (str);
 					free (str);
 				}
 				break;
-			case 'j':
+			case 'j': {
+				char *op_hex = r_asm_op_get_hex (&asmop);
 				r_cons_printf ("{\"addr\":%08"PFMT64d",\"bytes\":\"%s\",\"inst\":\"%s\"}%s",
-					addr + i, r_asm_op_get_hex (&asmop), r_asm_op_get_asm (&asmop), ",");
+					addr + i, op_hex, r_asm_op_get_asm (&asmop), ",");
+				free (op_hex);
 				break;
-			default:
+			}
+			default: {
+				char *op_hex = r_asm_op_get_hex (&asmop);
 				r_cons_printf ("0x%08"PFMT64x" %20s  %s\n",
-						addr + i, r_asm_op_get_hex (&asmop),
+						addr + i, op_hex,
 						r_asm_op_get_asm (&asmop));
+				free (op_hex);
+			}
 			}
 		}
 	}
@@ -6323,7 +6337,9 @@ toro:
 			r_cons_println ("invalid"); // ???");
 		} else {
 			if (show_bytes) {
-				r_cons_printf ("%20s  ", r_asm_op_get_hex (&asmop));
+				char *op_hex = r_asm_op_get_hex (&asmop);
+				r_cons_printf ("%20s  ", op_hex);
+				free (op_hex);
 			}
 			ret = asmop.size;
 			if (!asm_immtrim && (decode || esil)) {

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -154,9 +154,11 @@ R_API bool r_core_visual_esil(RCore *core) {
 		r_cons_printf ("r2's esil debugger:\n\n");
 		r_cons_printf ("pos: %d\n", x);
 		{
-			char *res = r_print_hexpair (core->print, r_asm_op_get_hex (&asmop), -1);
+			char *op_hex = r_asm_op_get_hex (&asmop);
+			char *res = r_print_hexpair (core->print, op_hex, -1);
 			r_cons_printf ("hex: %s\n"Color_RESET, res);
 			free (res);
+			free (op_hex);
 		}
 		{
 			char *op = colorize_asm_string (core, r_asm_op_get_asm (&asmop), analopType, core->offset);
@@ -297,9 +299,11 @@ R_API bool r_core_visual_bit_editor(RCore *core) {
 		r_cons_printf ("r2's bit editor:\n\n");
 		r_cons_printf ("offset: 0x%08"PFMT64x"\n"Color_RESET, core->offset + cur);
 		{
-			char *res = r_print_hexpair (core->print, r_asm_op_get_hex (&asmop), -1);
+			char *op_hex = r_asm_op_get_hex (&asmop);
+			char *res = r_print_hexpair (core->print, op_hex, -1);
 			r_cons_printf ("hex: %s\n"Color_RESET, res);
 			free (res);
+			free (op_hex);
 		}
 		r_cons_printf ("len: %d\n", asmop.size);
 		{
@@ -395,9 +399,11 @@ R_API bool r_core_visual_bit_editor(RCore *core) {
 		case 'Q':
 		case 'q':
 			{
-				char *res = r_print_hexpair (core->print, r_asm_op_get_hex (&asmop), -1);
+				char *op_hex = r_asm_op_get_hex (&asmop);
+				char *res = r_print_hexpair (core->print, op_hex, -1);
 				r_core_cmdf (core, "wx %02x%02x%02x%02x", buf[0], buf[1], buf[2], buf[3]);
 				free (res);
+				free (op_hex);
 			}
 			return false;
 		case 'H':

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -361,9 +361,11 @@ static int rasm_disasm(RAsmState *as, char *buf, ut64 offset, int len, int bits,
 				op.size = 1;
 				r_asm_op_set_asm (&op, "invalid");
 			}
+			char *op_hex = r_asm_op_get_hex (&op);
 			printf ("0x%08" PFMT64x "  %2d %24s  %s\n",
-				as->a->pc, op.size, r_asm_op_get_hex (&op),
+				as->a->pc, op.size, op_hex,
 				r_asm_op_get_asm (&op));
+			free (op_hex);
 			ret += op.size;
 			r_asm_set_pc (as->a, offset + ret);
 		}


### PR DESCRIPTION
SUMMARY: AddressSanitizer: 255295 byte(s) leaked in 6418 allocation(s).