### PR TITLE
Fix build with system capstone (--with-syscapstone)

### DIFF
--- a/shlr/capstone.mk
+++ b/shlr/capstone.mk
@@ -1,1 +1,5 @@
+ifeq ($(USE_CAPSTONE),1)
+LINK+=${CAPSTONE_LDFLAGS}
+else
 LINK+=$(SHLR)/capstone/libcapstone.a
+endif


### PR DESCRIPTION
Without this build with `--with-syscapstone` will fail. It also affects latest release (3.7.0).
