### PR TITLE
Fix `~??` command (grep help)

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3020,7 +3020,10 @@ next2:
 escape_backtick:
 	// TODO must honor " and `
 
-	if (r_str_endswith (cmd, "~?") && cmd[2] == '\0') {
+    // match ~? and ~?? help
+	if (strncmp(cmd, "~?", 2) == 0 &&
+        ((cmd[2] == '\0') || (cmd[2] == '?' && cmd[3] == '\0'))) {
+
 		r_cons_grep_help ();
 		r_list_free (tmpenvs);
 		return true;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3019,11 +3019,7 @@ next2:
 	}
 escape_backtick:
 	// TODO must honor " and `
-
-    // match ~? and ~?? help
-	if (strncmp(cmd, "~?", 2) == 0 &&
-        ((cmd[2] == '\0') || (cmd[2] == '?' && cmd[3] == '\0'))) {
-
+	if (*cmd != '"' && strstr (cmd, "~?") {
 		r_cons_grep_help ();
 		r_list_free (tmpenvs);
 		return true;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3019,7 +3019,7 @@ next2:
 	}
 escape_backtick:
 	// TODO must honor " and `
-	if (*cmd != '"' && strstr (cmd, "~?") {
+	if (*cmd != '"' && strstr (cmd, "~?")) {
 		r_cons_grep_help ();
 		r_list_free (tmpenvs);
 		return true;


### PR DESCRIPTION
Docs and internal help claims that grep help available via `~??` command, but in fact it's available via `~?`. This change makes grep help available via both `~?` (for backward compatibility) and `~??`. 