### PR TITLE
Always bracket addr operand of mov indirect

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1008,6 +1008,7 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 	/* initialize */
 	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
 	core->parser->regsub = r_config_get_i (core->config, "asm.regsub");
+	core->parser->analop = &ds->analop;
 	core->parser->relsub_addr = 0;
 	if (core->parser->relsub && ds->analop.type == R_ANAL_OP_TYPE_LEA && ds->analop.ptr != UT64_MAX) {
 		core->parser->relsub_addr = ds->analop.ptr;

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -35,6 +35,7 @@ typedef struct r_parse_t {
 	char* (*get_op_ireg)(void *user, ut64 addr);
 	RAnalBind analb;
 	RFlagGetAtAddr flag_get; // XXX
+	RAnalOp *analop;
 } RParse;
 
 typedef struct r_parse_plugin_t {

--- a/libr/parse/filter.c
+++ b/libr/parse/filter.c
@@ -237,8 +237,7 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 							ptr2--;
 						}
 						char *right = ptr2;
-						for (; *right && right > data
-						       && !(*right == ']' && *(right - 1) != 0x1b); right++) {
+						for (; *right && *right != ']'; right++) {
 							;
 						}
 						if (*right == ']') {

--- a/libr/parse/filter.c
+++ b/libr/parse/filter.c
@@ -236,7 +236,8 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 						ptr -= prefix - (left + 1);
 						ptr2 -= prefix - (left + 1);
 					}
-					if ((p->analop && p->analop->type == R_ANAL_OP_TYPE_LEA) || arm
+					if ((p->analop && p->analop->type == R_ANAL_OP_TYPE_LEA)
+					    || (arm && p->relsub_addr)
 					    || /* HACK for axt */ (x86 && r_str_startswith (data, "lea "))) {
 						// remove brackets
 						if (*left == '[') {


### PR DESCRIPTION
As shown by https://github.com/kazarmy/radare2-regressions/commit/9dcb19a3df4ec3e8b85883afc289f5c1e67fe88c#diff-4ac1f05bd792e07121bb84917a9bdad8R617.