### PR TITLE
Propagate noreturn information

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -388,6 +388,7 @@ R_API RAnalFunction *r_anal_fcn_new() {
 	fcn->diff = r_anal_diff_new ();
 	fcn->has_changed = true;
 	fcn->bp_frame = true;
+	fcn->is_noreturn = false;
 	r_tinyrange_init (&fcn->bbr);
 	fcn->meta.min = UT64_MAX;
 	return fcn;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1226,6 +1226,10 @@ repeat:
 			(void) r_anal_xrefs_set (anal, op.addr, op.ptr, R_ANAL_REF_TYPE_CALL);
 
 			if (op.ptr != UT64_MAX && r_anal_noreturn_at (anal, op.ptr)) {
+				RAnalFunction *f = r_anal_get_fcn_at(anal, op.ptr, 0);
+				if (f) {
+					f->is_noreturn = true;
+				}
 				gotoBeach (R_ANAL_RET_END);
 			}
 			break;
@@ -1235,6 +1239,10 @@ repeat:
 			(void) r_anal_xrefs_set (anal, op.addr, op.jump, R_ANAL_REF_TYPE_CALL);
 
 			if (r_anal_noreturn_at (anal, op.jump)) {
+				RAnalFunction *f = r_anal_get_fcn_at(anal, op.jump, 0);
+				if (f) {
+					f->is_noreturn = true;
+				}
 				gotoBeach (R_ANAL_RET_END);
 			}
 			break;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5206,9 +5206,7 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 	todo = r_list_new ();
 	done = r_list_new ();
 
-	if (!todo || !done) {
-		return;
-	}
+	r_return_if_fail (todo && done);
 
 	// find known noreturn functions to propagate
 	r_list_foreach (core->anal->fcns, iter, f) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5263,8 +5263,10 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 
 			if (!r_list_contains(done, f->addr) && is_noreturn_function (core, f)) {
 				r_anal_noreturn_add (core->anal, NULL, f->addr);
-				r_list_append (todo, f);
-				r_list_append (done, f->addr);
+				if (f->addr) {
+					r_list_append (todo, f);
+					r_list_append (done, f->addr);
+				}
 			}
 
 			r_anal_op_free (xrefop);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5247,6 +5247,11 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 				continue;
 			}
 
+			// skip recursing refereces
+			if (xrefop->jump == f->addr || xrefop->ptr == f->addr) {
+				continue;
+			}
+
 			int depth = r_config_get_i (core->config, "anal.depth");
 			ut64 addr = f->addr;
 

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5218,7 +5218,7 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 
 	// find known noreturn functions to propagate
 	r_list_foreach (core->anal->fcns, iter, f) {
-		if (r_anal_noreturn_at (core->anal, f->addr)) {
+		if (f->is_noreturn) {
 			r_list_append (todo, f);
 		}
 	}
@@ -5266,6 +5266,7 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 			bool found = false;
 			found = ht_uu_find (done, f->addr, &found);
 			if (f->addr && !found && is_noreturn_function (core, f)) {
+				f->is_noreturn = true;
 				r_anal_noreturn_add (core->anal, NULL, f->addr);
 				r_list_append (todo, f);
 				ht_uu_insert (done, f->addr, 1);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5176,7 +5176,7 @@ static bool is_noreturn_function(RCore *core, RAnalFunction *f) {
 	r_list_foreach (f->bbs, iter, bb) {
 		ut64 opaddr;
 
-		opaddr = r_anal_bb_opaddr_i(bb, bb->ninstr - 1);
+		opaddr = r_anal_bb_opaddr_i (bb, bb->ninstr - 1);
 		if (opaddr == UT64_MAX) {
 			return false;
 		}
@@ -5191,10 +5191,10 @@ static bool is_noreturn_function(RCore *core, RAnalFunction *f) {
 		switch (op->type & R_ANAL_OP_TYPE_MASK) {
 			case R_ANAL_OP_TYPE_ILL:
 			case R_ANAL_OP_TYPE_RET:
-				free(op);
+				free (op);
 				return false;
 		}
-		free(op);
+		free (op);
 	}
 	return true;
 }

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5269,6 +5269,7 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 
 			r_anal_op_free (xrefop);
 		}
+		r_list_free(xrefs);
 	}
 	r_list_free (todo);
 	r_list_free (done);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5257,12 +5257,10 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 				continue;
 			}
 
-			if (!r_list_contains(done, f->addr) && is_noreturn_function (core, f)) {
+			if (f->addr && !r_list_contains(done, f->addr) && is_noreturn_function (core, f)) {
 				r_anal_noreturn_add (core->anal, NULL, f->addr);
-				if (f->addr) {
-					r_list_append (todo, f);
-					r_list_append (done, f->addr);
-				}
+				r_list_append (todo, f);
+				r_list_append (done, f->addr);
 			}
 
 			r_anal_op_free (xrefop);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5206,6 +5206,10 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 	todo = r_list_new ();
 	done = r_list_new ();
 
+	if (!todo || !done) {
+		return;
+	}
+
 	// find known noreturn functions to propagate
 	r_list_foreach (core->anal->fcns, iter, f) {
 		if (r_anal_noreturn_at (core->anal, f->addr)) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5213,10 +5213,6 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 		}
 	}
 
-	if (!r_list_length (todo)) {
-		return;
-	}
-
 	while(r_list_length (todo)) {
 		RAnalFunction *noretf = r_list_pop (todo);
 		if (!noretf) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5241,7 +5241,7 @@ R_API void r_core_anal_propagate_noreturn(RCore *core) {
 			}
 
 			f = r_anal_get_fcn_in (core->anal, xref->addr, 0);
-			if (!f || (f->type != R_ANAL_FCN_TYPE_FCN && f->type != R_ANAL_FCN_TYPE_SYM && f->type != R_ANAL_FCN_TYPE_NULL)) {
+			if (!f || (f->type != R_ANAL_FCN_TYPE_FCN && f->type != R_ANAL_FCN_TYPE_SYM)) {
 				continue;
 			}
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3438,6 +3438,7 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			}
 			free (name);
 		}
+		r_core_anal_propagate_noreturn(core);
 #if 0
 		// XXX THIS IS VERY SLOW
 		if (core->anal->opt.vars) {
@@ -8461,6 +8462,11 @@ static int cmd_anal_all(RCore *core, const char *input) {
 				oldstr = r_print_rowlog (core->print, "Type matching analysis for all functions (aaft)");
 				r_core_cmd0 (core, "aaft");
 				r_print_rowlog_done (core->print, oldstr);
+
+				oldstr = r_print_rowlog (core->print, "Propagate noreturn information");
+				r_print_rowlog_done (core->print, oldstr);
+				r_core_anal_propagate_noreturn(core);
+
 				oldstr = r_print_rowlog (core->print, "Use -AA or aaaa to perform additional experimental analysis.");
 				r_print_rowlog_done (core->print, oldstr);
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -288,6 +288,7 @@ typedef struct r_anal_function_t {
 	bool is_pure;
 	bool has_changed; // true if function may have changed since last anaysis TODO: set this attribute where necessary
 	bool bp_frame;
+	bool is_noreturn; // true if function does not return
 	RAnalType *args; // list of arguments
 	ut8 *fingerprint; // TODO: make is fuzzy and smarter
 	RAnalDiff *diff;
@@ -300,7 +301,6 @@ typedef struct r_anal_function_t {
 	RBNode rb;
 	RBNode addr_rb;
 	RList *imports; // maybe bound to class?
-	bool is_noreturn;
 } RAnalFunction;
 
 typedef struct r_anal_func_arg_t {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -300,6 +300,7 @@ typedef struct r_anal_function_t {
 	RBNode rb;
 	RBNode addr_rb;
 	RList *imports; // maybe bound to class?
+	bool is_noreturn;
 } RAnalFunction;
 
 typedef struct r_anal_func_arg_t {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -924,6 +924,7 @@ R_API void r_core_autocomplete_free(RCoreAutocomplete *obj);
 R_API void r_core_autocomplete_reload (RCore *core);
 R_API RCoreAutocomplete *r_core_autocomplete_find(RCoreAutocomplete *parent, const char* cmd, bool exact);
 R_API bool r_core_autocomplete_remove(RCoreAutocomplete *parent, const char* cmd);
+R_API void r_core_anal_propagate_noreturn(RCore *core);
 
 /* PLUGINS */
 extern RCorePlugin r_core_plugin_java;


### PR DESCRIPTION
this patch allow for detection of noreturn functions.

before:

```
┌──────────────────────────────────────────────────┐ 
│ [0x40113f]                                       │ 
│ (fcn) main 45                                    │ 
│   int main (int argc, char **argv, char **envp); │ 
│ ; var char **var_10h @ rbp-0x10                  │ 
│ ; var signed int var_4h @ rbp-0x4                │ 
│ ; arg signed int argc @ rdi                      │ 
│ ; arg char **argv @ rsi                          │ 
│ ; DATA XREF from entry0 @ 0x401071               │ 
│ push rbp                                         │ 
│ mov rbp, rsp                                     │ 
│ sub rsp, 0x10                                    │ 
│ ; argc                                           │ 
│ mov dword [rbp - var_4h], edi                    │ 
│ ; argv                                           │ 
│ mov qword [rbp - var_10h], rsi                   │ 
│ cmp dword [rbp - var_4h], 1                      │ 
│    ; unlikely                                    │ 
│ jle 0x40115e                                     │ 
└──────────────────────────────────────────────────┘ 
        f t                                          
        │ │                                          
        │ └───────────────────────┐                  
        └───┐                     │                  
            │                     │                  
        ┌────────────────────┐    │                  
        │  0x401154 [oc]     │    │                  
        │ mov eax, 0         │    │                  
        │    ; sym.f1        │    │                  
        │ call sym.f1;[ob]   │    │                  
        └────────────────────┘    │                  
            v                     │                  
            │                     │                  
            └─┐ ┌─────────────────┘                  
              │ │                                    
        ┌──────────────────────────────────┐         
        │  0x40115e [oe]                   │         
        │ ; const char *s                  │         
        │ ; CODE XREF from main @ 0x401152 │         
        │ ; 0x402010                       │         
        │ ; "hello world!"                 │         
        │    ; str.hello_world             │         
        │ mov edi, str.hello_world         │         
        │    ; sym.imp.puts                │         
        │    ; int puts("hello world!")    │         
        │ ; int puts(const char *s)        │         
        │ call sym.imp.puts;[od]           │         
        │ nop                              │         
        │ nop                              │         
        │ leave                            │         
        │ ret                              │         
        └──────────────────────────────────┘         

```

after:
```
                                                               
 ┌──────────────────────────────────────────────────┐          
 │ [0x40113f]                                       │          
 │ (fcn) main 45                                    │          
 │   int main (int argc, char **argv, char **envp); │          
 │ ; var int32_t var_10h @ rbp-0x10                 │          
 │ ; var int32_t var_4h @ rbp-0x4                   │          
 │ ; arg signed int argc @ rdi                      │          
 │ ; arg char **argv @ rsi                          │          
 │ ; DATA XREF from entry0 @ 0x401071               │          
 │ push rbp                                         │          
 │ mov rbp, rsp                                     │          
 │ sub rsp, 0x10                                    │          
 │ ; argc                                           │          
 │ mov dword [rbp - var_4h], edi                    │          
 │ ; argv                                           │          
 │ mov qword [rbp - var_10h], rsi                   │          
 │ cmp dword [rbp - var_4h], 1                      │          
 │    ; unlikely                                    │          
 │ jle 0x40115e                                     │          
 └──────────────────────────────────────────────────┘          
         f t                                                   
         │ │                                                   
         │ └──────────────────┐                                
    ┌────┘                    │                                
    │                         │                                
┌────────────────────┐    ┌──────────────────────────────────┐ 
│  0x401154 [oc]     │    │  0x40115e [oe]                   │ 
│ mov eax, 0         │    │ ; const char *s                  │ 
│    ; sym.f1        │    │ ; CODE XREF from main @ 0x401152 │ 
│ call sym.f1;[ob]   │    │ ; 0x402010                       │ 
└────────────────────┘    │ ; "hello world!"                 │ 
                          │    ; str.hello_world             │ 
                          │ mov edi, str.hello_world         │ 
                          │    ; sym.imp.puts                │ 
                          │    ; int puts("hello world!")    │ 
                          │ ; int puts(const char *s)        │ 
                          │ call sym.imp.puts;[od]           │ 
                          │ nop                              │ 
                          │ nop                              │ 
                          │ leave                            │ 
                          │ ret                              │ 
                          └──────────────────────────────────┘ 
```
where `sym.f1` is :
```
┌ (fcn) sym.f1 9                                               
│   sym.f1 ();                                                 
│           ; CALL XREF from main @ 0x401159                   
│           0x00401136      55             push rbp            
│           0x00401137      4889e5         mov rbp, rsp        
└           0x0040113a      e8f1feffff     call sym.imp.abort  
```