### PR TITLE
Refactor is* and fix Injection harder

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2158,7 +2158,7 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 				if (!flagname) {
 					goto next;
 				}
-				r_cons_printf ("f %s%s%s %u 0x%08" PFMT64x "\n",
+				r_cons_printf ("\"f %s%s%s %u 0x%08" PFMT64x "\"\n",
 					r->bin->prefix ? r->bin->prefix : "", r->bin->prefix ? "." : "",
 					flagname, symbol->size, addr);
 				free(flagname);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1833,6 +1833,16 @@ static const char *getPrefixFor(const char *s) {
 	return "sym";
 }
 
+static char *construct_symbol_flagname(const char *pfx, const char *symname) {
+#define MAXFLAG_LEN 128
+	char *r = r_str_newf ("%s.%s", pfx, symname);
+	if (!r) {
+		return NULL;
+	}
+	r_name_filter (r, MAXFLAG_LEN);
+	return r;
+}
+
 typedef struct {
 	const char *pfx; // prefix for flags
 	char *name;      // raw symbol name
@@ -1846,17 +1856,14 @@ typedef struct {
 } SymName;
 
 static void snInit(RCore *r, SymName *sn, RBinSymbol *sym, const char *lang) {
-#define MAXFLAG_LEN 128
 	int bin_demangle = lang != NULL;
 	bool keep_lib = r_config_get_i (r->config, "bin.demangle.libs");
-	const char *pfx;
 	if (!r || !sym || !sym->name) {
 		return;
 	}
-	pfx = getPrefixFor (sym->type);
 	sn->name = strdup (sym->name);
-	sn->nameflag = r_str_newf ("%s.%s", pfx, r_bin_symbol_name (sym));
-	r_name_filter (sn->nameflag, MAXFLAG_LEN);
+	const char *pfx = getPrefixFor (sym->type);
+	sn->nameflag = construct_symbol_flagname(pfx, r_bin_symbol_name (sym));
 	if (sym->classname && sym->classname[0]) {
 		sn->classname = strdup (sym->classname);
 		sn->classflag = r_str_newf ("sym.%s.%s", sn->classname, sn->name);
@@ -1876,8 +1883,7 @@ static void snInit(RCore *r, SymName *sn, RBinSymbol *sym, const char *lang) {
 	if (bin_demangle && sym->paddr) {
 		sn->demname = r_bin_demangle (r->bin->cur, lang, sn->name, sym->vaddr, keep_lib);
 		if (sn->demname) {
-			sn->demflag = r_str_newf ("%s.%s", pfx, sn->demname);
-			r_name_filter (sn->demflag, -1);
+			sn->demflag = construct_symbol_flagname (pfx, sn->demname);
 		}
 	}
 }
@@ -2125,53 +2131,55 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 		} else if (IS_MODE_RAD (mode)) {
 			/* Skip special symbols because we do not flag them and
 			 * they shouldn't be printed in the rad format either */
-			if (!is_special_symbol (symbol)) {
-				RBinFile *binfile;
-				RBinPlugin *plugin;
-				char *name = strdup (sn.demname? sn.demname: r_symbol_name);
-				r_name_filter (name, -1);
-				if (!strncmp (name, "imp.", 4)) {
-					if (lastfs != 'i') {
-						r_cons_printf ("fs imports\n");
-					}
-					lastfs = 'i';
-				} else {
-					if (lastfs != 's') {
-						r_cons_printf ("fs %s\n",
-							exponly? "exports": "symbols");
-					}
-					lastfs = 's';
+			if (is_special_symbol (symbol)) {
+				goto next;
+			}
+			RBinFile *binfile;
+			RBinPlugin *plugin;
+			const char *name = sn.demname? sn.demname: r_symbol_name;
+			if (!name) {
+				goto next;
+			}
+			if (!strncmp (name, "imp.", 4)) {
+				if (lastfs != 'i') {
+					r_cons_printf ("fs imports\n");
 				}
-				if (r->bin->prefix) {
-					r_cons_printf ("\"f %s.sym.%s %u 0x%08" PFMT64x "\"\n",
-						r->bin->prefix, r_bin_symbol_name (symbol), symbol->size, addr);
-				} else {
-					if (*name) {
-						r_cons_printf ("\"f sym.%s %u 0x%08" PFMT64x "\"\n",
-							r_bin_symbol_name (symbol), symbol->size, addr);
-					} else {
-						// we don't want unnamed symbol flags
-					}
+				lastfs = 'i';
+			} else {
+				if (lastfs != 's') {
+					r_cons_printf ("fs %s\n",
+						exponly? "exports": "symbols");
 				}
-				binfile = r_bin_cur (r->bin);
-				plugin = r_bin_file_cur_plugin (binfile);
-				if (plugin && plugin->name) {
-					if (r_str_startswith (plugin->name, "pe")) {
-						char *module = strdup (r_symbol_name);
-						char *p = strstr (module, ".dll_");
-						if (p && strstr (module, "imp.")) {
-							const char *symname = p + 5;
-							*p = 0;
-							if (r->bin->prefix) {
-								r_cons_printf ("k bin/pe/%s/%d=%s.%s\n",
-									module, symbol->ordinal, r->bin->prefix, symname);
-							} else {
-								r_cons_printf ("k bin/pe/%s/%d=%s\n",
-									module, symbol->ordinal, symname);
-							}
+				lastfs = 's';
+			}
+			if (r->bin->prefix || *name) { // we don't want unnamed symbol flags
+				char *flagname = construct_symbol_flagname ("sym", name);
+				if (!flagname) {
+					goto next;
+				}
+				r_cons_printf ("f %s%s%s %u 0x%08" PFMT64x "\n",
+					r->bin->prefix ? r->bin->prefix : "", r->bin->prefix ? "." : "",
+					flagname, symbol->size, addr);
+				free(flagname);
+			}
+			binfile = r_bin_cur (r->bin);
+			plugin = r_bin_file_cur_plugin (binfile);
+			if (plugin && plugin->name) {
+				if (r_str_startswith (plugin->name, "pe")) {
+					char *module = strdup (r_symbol_name);
+					char *p = strstr (module, ".dll_");
+					if (p && strstr (module, "imp.")) {
+						const char *symname = p + 5;
+						*p = 0;
+						if (r->bin->prefix) {
+							r_cons_printf ("k bin/pe/%s/%d=%s.%s\n",
+								module, symbol->ordinal, r->bin->prefix, symname);
+						} else {
+							r_cons_printf ("k bin/pe/%s/%d=%s\n",
+								module, symbol->ordinal, symname);
 						}
-						free (module);
 					}
+					free (module);
 				}
 			}
 		} else {
@@ -2188,6 +2196,7 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 			r_cons_printf (" 0x%08"PFMT64x" %6s %6s %4d%s%s\n",
 			               addr, bind, type, symbol->size, *name? " ": "", name);
 		}
+next:
 		snFini (&sn);
 		i++;
 		free (r_symbol_name);


### PR DESCRIPTION
After https://github.com/radare/radare2/pull/14690 it is still possible to do injection through is* using a symbol name containing a `"`.
For example: [ls.gz](https://github.com/radare/radare2/files/3496619/ls.gz) execute `.is*` or `ood` on this bin, cc @ps1337 

This patch makes the names in is* more consistent with the actual flag names and also fixes a leak.

The diff looks a bit wild because of indentation changes, the significant changes are around the `construct_symbol_flagname()` calls.