### PR TITLE
Fixes for path autocompletion on Windows

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -727,7 +727,7 @@ R_API void r_line_autocomplete() {
 			}
 			memcpy (p, argv[0], largv0);
 
-			if (p[largv0 - 1] != '/') {
+			if (p[largv0 - 1] != R_SYS_DIR[0]) {
 				p[largv0] = ' ';
 				if (!len_t) {
 					p[largv0 + 1] = '\0';


### PR DESCRIPTION
* Accept both '\\' and '/' as path separators
* Accept paths starting with '\\' or '/' as meaning root of cwd
* Other fixes