### PR TITLE
Avoid disassembling the same instruction twice on rop search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1126,6 +1126,7 @@ static RList *construct_rop_gadget(RCore *core, ut64 addr, ut8 *buf, int buflen,
 			goto ret;
 		}
 		free (opst);
+		aop.mnemonic = NULL;
 		nb_instr++;
 	}
 ret:


### PR DESCRIPTION
This improves performance a bit, but for some archs r_anal_op doesn't provide mnemonics, so we have to call r_asm_disassemble