### PR TITLE
Add *BSD SourceHut builds

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,0 +1,17 @@
+image: freebsd/latest
+packages:
+    - devel/meson
+    - devel/pkgconf
+    - devel/gmake
+    - devel/llvm
+    - ftp/wget
+environment:
+    CXX: clang++
+    CC: clang
+sources:
+    - https://github.com/radare/radare2
+tasks:
+    - build: |
+        cd radare2
+        ./configure
+        gmake

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,0 +1,17 @@
+image: openbsd/latest
+packages:
+    - devel/meson
+    - devel/pkgconf
+    - devel/gmake
+    - devel/llvm
+environment:
+    CXX: clang++
+    CC: clang
+sources:
+    - https://github.com/radare/radare2
+tasks:
+    - build: |
+        cd radare2
+        ./configure
+        gmake
+


### PR DESCRIPTION
SourceHut allows to setup FreeBSD and OpenBSD CI right now, and NetBSD should be available soon.