### PR TITLE
Add auto-quoting and harden .<..> operator

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1216,7 +1216,12 @@ static int cmd_interpret(void *data, const char *input) {
 				}
 				if (*ptr) {
 					char *p = r_str_append (strdup (ptr), filter);
+					bool prev_one_cmd_pre_line = core->one_cmd_per_line;
+					if (p[0] == '\"') {
+						core->one_cmd_per_line = true;
+					}
 					r_core_cmd0 (core, p);
+					core->one_cmd_per_line = prev_one_cmd_pre_line;
 					free (p);
 				}
 				if (!eol) {
@@ -2623,6 +2628,10 @@ static int r_core_cmd_subst_i(RCore *core, char *cmd, char *colon, bool *tmpseek
 				break;
 			}
 			if (eos) {
+				break;
+			}
+			if (core->one_cmd_per_line) {
+				*p = '\0';
 				break;
 			}
 			if (haveQuote) {

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -518,6 +518,7 @@ typedef struct r_cons_t {
 	bool click_set;
 	int click_x;
 	int click_y;
+	bool auto_quote;
 	// TODO: move into instance? + avoid unnecessary copies
 } RCons;
 
@@ -852,6 +853,7 @@ R_API void r_cons_chop(void);
 R_API void r_cons_set_raw(bool b);
 R_API void r_cons_set_interactive(bool b);
 R_API void r_cons_set_last_interactive(void);
+R_API void r_cons_set_auto_quote(bool b);
 
 /* output */
 R_API int r_cons_printf(const char *format, ...);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -337,6 +337,7 @@ typedef struct r_core_t {
 	bool scr_gadgets;
 	bool log_events; // core.c:cb_event_handler : log actions from events if cfg.log.events is set
 	RList *ropchain;
+	bool one_cmd_per_line;
 
 	RMainCallback r_main_radare2;
 	// int (*r_main_radare2)(int argc, char **argv);


### PR DESCRIPTION
Hey there,

as @ps1337 already mentioned in https://github.com/radare/radare2/pull/14822 we came up with another mitigation strategy:
While replacing special characters and quoting, if done correctly, seem sufficient to prevent an attacker from injecting r2 commands, it seems to be a hard task. The hot-fix and similar commits for CVE-2019-14745 showed that this approach is error-prone because of the various file formats supported by radare2. That is, we propose to additionally add automatic quoting to all (or at least i<..>) commands that will be interpreted using the . operator. In addition we propose that if commands are quoted the . operator does only accept one command per line. That is, even if an attacker can break out of the quoting injected commands will be ignored. This PR implements this strategy.

The PR by itself already mitigates at least certain exploits of the CVE (such as [kaputty.zip](https://github.com/radare/radare2/files/3512169/kaputty.zip)). 


