### PR TITLE
Use op->disp instead of op->ptr for disp of x86 MOV (and others)

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -35,6 +35,7 @@ R_API void r_anal_op_init(RAnalOp *op) {
 		op->ptr = UT64_MAX;
 		op->refptr = 0;
 		op->val = UT64_MAX;
+		op->disp = UT64_MAX;
 	}
 }
 

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1897,7 +1897,9 @@ static void op0_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 			op->type |= R_ANAL_OP_TYPE_REG;
 			op->stackop = R_ANAL_STACK_SET;
 			op->stackptr = regsz;
-		} else {
+		} else if (INSOP(0).mem.segment == X86_REG_INVALID && INSOP(0).mem.base == X86_REG_INVALID
+			   && INSOP(0).mem.index == X86_REG_INVALID && INSOP(0).mem.scale == 1) { // [<addr>]
+			op->ptr = op->disp;
 			if (op->ptr < 0x1000) {
 				op->ptr = UT64_MAX;
 			}
@@ -1928,6 +1930,9 @@ static void op1_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 			} else if (INSOP(1).mem.base == X86_REG_RBP || INSOP(1).mem.base == X86_REG_EBP) {
 				op->stackop = R_ANAL_STACK_GET;
 				op->stackptr = regsz;
+			} else if (INSOP(1).mem.segment == X86_REG_INVALID && INSOP(1).mem.base == X86_REG_INVALID
+			           && INSOP(1).mem.index == X86_REG_INVALID && INSOP(1).mem.scale == 1) { // [<addr>]
+				op->ptr = op->disp;
 			}
 			break;
 		case X86_OP_IMM:

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1889,10 +1889,10 @@ static void op0_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 	switch (INSOP(0).type) {
 	case X86_OP_MEM:
 		op->cycles = CYCLE_MEM;
-		op->ptr = INSOP(0).mem.disp;
+		op->disp = INSOP(0).mem.disp;
 		op->refptr = INSOP(0).size;
 		if (INSOP(0).mem.base == X86_REG_RIP) {
-			op->ptr += addr + insn->size;
+			op->ptr = addr + insn->size + op->disp;
 		} else if (INSOP(0).mem.base == X86_REG_RBP || INSOP(0).mem.base == X86_REG_EBP) {
 			op->type |= R_ANAL_OP_TYPE_REG;
 			op->stackop = R_ANAL_STACK_SET;
@@ -1921,10 +1921,10 @@ static void op1_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 	if (op->refptr < 1 || op->ptr == UT64_MAX) {
 		switch (INSOP(1).type) {
 		case X86_OP_MEM:
-			op->ptr = INSOP(1).mem.disp;
+			op->disp = INSOP(1).mem.disp;
 			op->refptr = INSOP(1).size;
 			if (INSOP(1).mem.base == X86_REG_RIP) {
-				op->ptr += addr + insn->size;
+				op->ptr = addr + insn->size + op->disp;
 			} else if (INSOP(1).mem.base == X86_REG_RBP || INSOP(1).mem.base == X86_REG_EBP) {
 				op->stackop = R_ANAL_STACK_GET;
 				op->stackptr = regsz;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1009,7 +1009,9 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
 	core->parser->regsub = r_config_get_i (core->config, "asm.regsub");
 	core->parser->relsub_addr = 0;
-	if (core->parser->relsub && ds->analop.type == R_ANAL_OP_TYPE_LEA && ds->analop.ptr != UT64_MAX) {
+	if (core->parser->relsub
+	    && (ds->analop.type == R_ANAL_OP_TYPE_LEA || ds->analop.type == R_ANAL_OP_TYPE_MOV)
+	    && ds->analop.ptr != UT64_MAX) {
 		core->parser->relsub_addr = ds->analop.ptr;
 	}
 	if (ds->varsub && ds->opstr) {


### PR DESCRIPTION
Following #14773 (more specifically https://github.com/radare/radare2/pull/14773/files#diff-7f6f82199b572cdbe767aa7a1ba9b436L2391).