### PR TITLE
notify user on hardware breakpoint hit

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2009-2018 - pancake, jduck, TheLemonMan, saucec0de */
 
 #include <r_debug.h>
+#include <r_drx.h>
 #include <r_core.h>
 #include <signal.h>
 
@@ -47,7 +48,7 @@ R_API void r_debug_bp_update(RDebug *dbg) {
 
 static int r_debug_drx_at(RDebug *dbg, ut64 addr) {
 	if (dbg && dbg->h && dbg->h->drx) {
-		return dbg->h->drx (dbg, 0, addr, 0, 0, 0);
+		return dbg->h->drx (dbg, 0, addr, 0, 0, 0, DRX_API_GET_BP);
 	}
 	return -1;
 }
@@ -1626,20 +1627,20 @@ R_API int r_debug_map_protect(RDebug *dbg, ut64 addr, int size, int perms) {
 
 R_API void r_debug_drx_list(RDebug *dbg) {
 	if (dbg && dbg->h && dbg->h->drx) {
-		dbg->h->drx (dbg, 0, 0, 0, 0, 0);
+		dbg->h->drx (dbg, 0, 0, 0, 0, 0, DRX_API_LIST);
 	}
 }
 
 R_API int r_debug_drx_set(RDebug *dbg, int idx, ut64 addr, int len, int rwx, int g) {
 	if (dbg && dbg->h && dbg->h->drx) {
-		return dbg->h->drx (dbg, idx, addr, len, rwx, g);
+		return dbg->h->drx (dbg, idx, addr, len, rwx, g, DRX_API_SET_BP);
 	}
 	return false;
 }
 
 R_API int r_debug_drx_unset(RDebug *dbg, int idx) {
 	if (dbg && dbg->h && dbg->h->drx) {
-		return dbg->h->drx (dbg, idx, 0, -1, 0, 0);
+		return dbg->h->drx (dbg, idx, 0, -1, 0, 0, DRX_API_REMOVE_BP);
 	}
 	return false;
 }

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -110,8 +110,8 @@ static int r_debug_bp_hit(RDebug *dbg, RRegItem *pc_ri, ut64 pc, RBreakpointItem
 			b = r_bp_get_at (dbg->bp, pc);
 			if (!b) {
 				/* handle the case of hw breakpoints - notify the user */
-				int drx_reg_idx = r_debug_drx_at(dbg, pc);
-				if ( drx_reg_idx != -1){
+				int drx_reg_idx = r_debug_drx_at (dbg, pc);
+				if (drx_reg_idx != -1) {
 					eprintf ("hit hardware breakpoint %d at: %" PFMT64x "\n",
 						drx_reg_idx, pc);
 				}

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1506,31 +1506,6 @@ static int r_debug_native_init (RDebug *dbg) {
 #endif
 }
 
-static int r_debug_native_drx_get_at(RDebug *dbg, ut64 addr){
-
-#if __i386__ || __x86_64__
-	drxt regs[8] = {0};
-	// sync drx regs
-#define R dbg->reg
-	regs[0] = r_reg_getv (R, "dr0");
-	regs[1] = r_reg_getv (R, "dr1");
-	regs[2] = r_reg_getv (R, "dr2");
-	regs[3] = r_reg_getv (R, "dr3");
-/*
-	RESERVED
-	regs[4] = r_reg_getv (R, "dr4");
-	regs[5] = r_reg_getv (R, "dr5");
-*/
-	regs[6] = r_reg_getv (R, "dr6");
-	regs[7] = r_reg_getv (R, "dr7");
-
-	return drx_get_at((drxt*)&regs, addr);
-#endif
-
-	//TODO: other architectures
-	return -1;
-}
-
 static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, int g) {
 #if __i386__ || __x86_64__
 	drxt regs[8] = {0};

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1506,6 +1506,31 @@ static int r_debug_native_init (RDebug *dbg) {
 #endif
 }
 
+static int r_debug_native_drx_get_at(RDebug *dbg, ut64 addr){
+
+#if __i386__ || __x86_64__
+	drxt regs[8] = {0};
+	// sync drx regs
+#define R dbg->reg
+	regs[0] = r_reg_getv (R, "dr0");
+	regs[1] = r_reg_getv (R, "dr1");
+	regs[2] = r_reg_getv (R, "dr2");
+	regs[3] = r_reg_getv (R, "dr3");
+/*
+	RESERVED
+	regs[4] = r_reg_getv (R, "dr4");
+	regs[5] = r_reg_getv (R, "dr5");
+*/
+	regs[6] = r_reg_getv (R, "dr6");
+	regs[7] = r_reg_getv (R, "dr7");
+
+	return drx_get_at((drxt*)&regs, addr);
+#endif
+
+	//TODO: other architectures
+	return -1;
+}
+
 static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, int g) {
 #if __i386__ || __x86_64__
 	drxt regs[8] = {0};
@@ -1524,8 +1549,14 @@ static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, i
 	regs[7] = r_reg_getv (R, "dr7");
 
 	if (sz == 0) {
-		drx_list ((drxt*)&regs);
-		return false;
+		if (addr != 0){
+			/* get the index of the breakpoint at addr */
+			return drx_get_at((drxt*)&regs, addr);
+		} else {
+			/* print the list of breakpoints */
+			drx_list ((drxt*)&regs);
+			return false;
+		}
 	}
 	if (sz < 0) { // remove
 		drx_set (regs, n, addr, -1, 0, 0);

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1524,9 +1524,9 @@ static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, i
 	regs[7] = r_reg_getv (R, "dr7");
 
 	if (sz == 0) {
-		if (addr != 0){
+		if (addr != 0) {
 			/* get the index of the breakpoint at addr */
-			return drx_get_at((drxt*)&regs, addr);
+			return drx_get_at ((drxt*)&regs, addr);
 		} else {
 			/* print the list of breakpoints */
 			drx_list ((drxt*)&regs);

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -2,6 +2,7 @@
 
 #include <r_userconf.h>
 #include <r_debug.h>
+#include <r_drx.h>
 #include <r_asm.h>
 #include <r_core.h>
 #include <r_reg.h>
@@ -1506,9 +1507,14 @@ static int r_debug_native_init (RDebug *dbg) {
 #endif
 }
 
-static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, int g) {
+static void sync_drx_regs (RDebug *dbg, drxt *regs, size_t num_regs) {
 #if __i386__ || __x86_64__
-	drxt regs[8] = {0};
+	/* sanity check, we rely on this assumption */
+	if (num_regs != NUM_DRX_REGISTERS) {
+		eprintf ("drx: Unsupported number of registers for get_debug_regs\n");
+		return;
+	}
+
 	// sync drx regs
 #define R dbg->reg
 	regs[0] = r_reg_getv (R, "dr0");
@@ -1522,30 +1528,64 @@ static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, i
 */
 	regs[6] = r_reg_getv (R, "dr6");
 	regs[7] = r_reg_getv (R, "dr7");
+#else
+	eprintf ("drx sync_drx_regs: Unsupported platform\n");
+#endif
+}
 
-	if (sz == 0) {
-		if (addr != 0) {
-			/* get the index of the breakpoint at addr */
-			return drx_get_at ((drxt*)&regs, addr);
-		} else {
-			/* print the list of breakpoints */
-			drx_list ((drxt*)&regs);
-			return false;
-		}
+static void set_drx_regs (RDebug *dbg, drxt *regs, size_t num_regs) {
+#if __i386__ || __x86_64__
+	/* sanity check, we rely on this assumption */
+	if (num_regs != NUM_DRX_REGISTERS){
+		eprintf ("drx: Unsupported number of registers for get_debug_regs\n");
+		return;
 	}
-	if (sz < 0) { // remove
-		drx_set (regs, n, addr, -1, 0, 0);
-	} else {
-		drx_set (regs, n, addr, sz, rwx, g);
-	}
-	r_reg_setv (R, "dr0", regs[0]);
+
+#define R dbg->reg
+ 	r_reg_setv (R, "dr0", regs[0]);
 	r_reg_setv (R, "dr1", regs[1]);
 	r_reg_setv (R, "dr2", regs[2]);
 	r_reg_setv (R, "dr3", regs[3]);
 	r_reg_setv (R, "dr6", regs[6]);
 	r_reg_setv (R, "dr7", regs[7]);
+#else
+	eprintf ("drx set_drx_regs: Unsupported platform\n");
+#endif
+}
 
-	return true;
+static int r_debug_native_drx (RDebug *dbg, int n, ut64 addr, int sz, int rwx, int g, int api_type) {
+#if __i386__ || __x86_64__
+	int retval = false;
+	drxt regs[NUM_DRX_REGISTERS] = {0};
+	// sync drx regs
+	sync_drx_regs (dbg, regs, NUM_DRX_REGISTERS);
+
+	switch (api_type) {
+	case DRX_API_LIST:
+		drx_list (regs);
+		retval = false;
+	case DRX_API_GET_BP:
+		/* get the index of the breakpoint at addr */
+		retval = drx_get_at (regs, addr);
+	case DRX_API_REMOVE_BP:
+		/* remove hardware breakpoint */
+		drx_set (regs, n, addr, -1, 0, 0);
+		retval = true;
+		break;
+	case DRX_API_SET_BP:
+		/* set hardware breakpoint */
+		drx_set (regs, n, addr, sz, rwx, g);
+		retval = true;
+		break;
+	default:
+		/* this should not happen, someone misused the API */
+		eprintf ("drx: Unsupported api type in r_debug_native_drx\n");
+		retval = false;
+	}
+
+	set_drx_regs (dbg, regs, NUM_DRX_REGISTERS);
+
+	return retval;
 #else
 	eprintf ("drx: Unsupported platform\n");
 #endif

--- a/libr/debug/p/native/drx.c
+++ b/libr/debug/p/native/drx.c
@@ -166,11 +166,10 @@ int drx_get_at(drxt *drx, ut64 at_addr) {
 		}
 		rwx = len = g = en = 0;
 		addr = drx_get (drx, i, &rwx, &len, &g, &en);
-		if (addr == at_addr){
+		if (addr == at_addr) {
 			return i;
 		}
 	}
-
 	return -1;
 }
 

--- a/libr/debug/p/native/drx.c
+++ b/libr/debug/p/native/drx.c
@@ -156,6 +156,24 @@ int drx_next(drxt *drx) {
 	return -1;
 }
 
+int drx_get_at(drxt *drx, ut64 at_addr) {
+	ut64 addr;
+	int i, rwx, len, g, en;
+
+	for (i = 0; i < 8; i++) {
+		if (i == 4 || i == 5) {
+			continue;
+		}
+		rwx = len = g = en = 0;
+		addr = drx_get (drx, i, &rwx, &len, &g, &en);
+		if (addr == at_addr){
+			return i;
+		}
+	}
+
+	return -1;
+}
+
 void drx_list(drxt *drx) {
 	ut64 addr;
 	int i, rwx, len, g, en;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -396,7 +396,7 @@ typedef struct r_debug_plugin_t {
 	int (*map_dealloc)(RDebug *dbg, ut64 addr, int size);
 	int (*map_protect)(RDebug *dbg, ut64 addr, int size, int perms);
 	int (*init)(RDebug *dbg);
-	int (*drx)(RDebug *dbg, int n, ut64 addr, int size, int rwx, int g);
+	int (*drx)(RDebug *dbg, int n, ut64 addr, int size, int rwx, int g, int api_type);
 	RDebugDescPlugin desc;
 	// TODO: use RList here
 } RDebugPlugin;

--- a/libr/include/r_drx.h
+++ b/libr/include/r_drx.h
@@ -1,0 +1,15 @@
+#ifndef R2_DRX_H
+#define R2_DRX_H
+
+enum {
+  DRX_API_LIST = 0,
+  DRX_API_GET_BP = 1,
+  DRX_API_SET_BP = 2,
+  DRX_API_REMOVE_BP = 3,
+};
+
+#if __i386__ || __x86_64__
+#define NUM_DRX_REGISTERS 8
+#endif
+
+#endif


### PR DESCRIPTION
When the debugger hits an hardware breakpoint it does not notify the user, for example, by printing to the screen that a breakpoint was hit. This makes debugging code using hardware break points cumbersome and difficult to follow, as it is hard to tell what caused the debugger to stop. This pull request prints a line to the console whenever an hardware break point is hit - the line contains the breakpoint number and its location.

example:

[0x7fb4ada16100]> drx 0 main 1 e
[0x7fb4ada16100]> dc
hit hardware breakpoint 0 at: 55e241008060