### PR TITLE
Hide the shift overflow warnings under esil.verbose

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -17,14 +17,6 @@ if (esil) {\
 	} \
 }
 
-/* internal helper functions */
-static void err(RAnalEsil *esil, const char *msg) {
-	if (esil->verbose) {
-		eprintf ("0x%08" PFMT64x " %s\n", esil->address, msg);
-	}
-}
-#define ERR(x) err(esil,x)
-
 /* Returns the number that has bits + 1 least significant bits set. */
 static inline ut64 genmask(int bits) {
 	ut64 m = UT64_MAX;
@@ -36,6 +28,8 @@ static inline ut64 genmask(int bits) {
 	}
 	return m;
 }
+
+#define ERR(x) if (esil->verbose) { eprintf ("%s\n", x); }
 
 static bool isnum(RAnalEsil *esil, const char *str, ut64 *num) {
 	if (!esil || !str) {
@@ -488,7 +482,9 @@ R_API int r_anal_esil_get_parm_size(RAnalEsil *esil, const char *str, ut64 *num,
 		}
 		return true;
 	default:
-		IFDBG eprintf ("Invalid arg (%s)\n", str);
+		if (esil->verbose) {
+			eprintf ("Invalid arg (%s)\n", str);
+		}
 		esil->parse_stop = 1;
 		break;
 	}
@@ -1108,7 +1104,9 @@ static bool esil_lsreq(RAnalEsil *esil) {
 	if (dst && r_anal_esil_reg_read (esil, dst, &num, NULL)) {
 		if (src && r_anal_esil_get_parm (esil, src, &num2)) {
 			if (num2 > 63) {
-				eprintf ("Invalid shift at 0x%08"PFMT64x"\n", esil->address);
+				if (esil->verbose) {
+					eprintf ("Invalid shift at 0x%08"PFMT64x"\n", esil->address);
+				}
 				num2 = 63;
 			}
 			esil->old = num;
@@ -1192,7 +1190,9 @@ static bool esil_asreq(RAnalEsil *esil) {
 			// r_anal_esil_pushnum (esil, res);
 			ret = true;
 		} else {
-			ERR ("esil_asr: empty stack");
+			if (esil->verbose) {
+				eprintf ("esil_asr: empty stack");
+			}
 		}
 	}
 	free (param);
@@ -3075,7 +3075,7 @@ R_API int r_anal_esil_condition(RAnalEsil *esil, const char *str) {
 		}
 		free (popped);
 	} else {
-		ERR ("ESIL stack is empty");
+		eprintf ("Warning: Cannot pop because The ESIL stack is empty");
 		return -1;
 	}
 	return ret;


### PR DESCRIPTION
by @radare 
Seems forgotten