### PR TITLE
Use op->disp instead of op->ptr for disp of x86 CMP (and ACMP)

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1119,12 +1119,14 @@ repeat:
 				cmpval = op.val;
 			}
 			break;
-		case R_ANAL_OP_TYPE_CMP:
-			if (op.disp) {
-				cmpval = op.disp;
+		case R_ANAL_OP_TYPE_CMP: {
+			ut64 val = is_x86 ? op.disp : op.ptr;
+			if (val) {
+				cmpval = val;
 				bb->cmpval = cmpval;
 				bb->cmpreg = op.reg;
 			}
+		}
 			break;
 		case R_ANAL_OP_TYPE_CJMP:
 		case R_ANAL_OP_TYPE_MCJMP:

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1120,8 +1120,8 @@ repeat:
 			}
 			break;
 		case R_ANAL_OP_TYPE_CMP:
-			if (op.ptr) {
-				cmpval = op.ptr;
+			if (op.disp) {
+				cmpval = op.disp;
 				bb->cmpval = cmpval;
 				bb->cmpreg = op.reg;
 			}

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -2350,14 +2350,17 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		}
 		switch (INSOP(0).type) {
 		case X86_OP_MEM:
-			op->ptr = INSOP(0).mem.disp;
+			op->disp = INSOP(0).mem.disp;
 			op->refptr = INSOP(0).size;
 			if (INSOP(0).mem.base == X86_REG_RIP) {
-				op->ptr += addr + insn->size;
+				op->ptr = addr + insn->size + op->disp;
 			} else if (INSOP(0).mem.base == X86_REG_RBP || INSOP(0).mem.base == X86_REG_EBP) {
 				op->stackop = R_ANAL_STACK_SET;
 				op->stackptr = regsz;
 				op->type |= R_ANAL_OP_TYPE_REG;
+			} else if (INSOP(0).mem.segment == X86_REG_INVALID && INSOP(0).mem.base == X86_REG_INVALID
+			           && INSOP(0).mem.index == X86_REG_INVALID && INSOP(0).mem.scale == 1) { // [<addr>]
+				op->ptr = op->disp;
 			}
 			if (INSOP(1).type == X86_OP_IMM) {
 				op->val = INSOP(1).imm;
@@ -2366,14 +2369,19 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		default:
 			switch (INSOP(1).type) {
 			case X86_OP_MEM:
-				op->ptr = INSOP(1).mem.disp;
+				op->disp = INSOP(1).mem.disp;
 				op->refptr = INSOP(1).size;
 				if (INSOP(1).mem.base == X86_REG_RIP) {
-					op->ptr += addr + insn->size;
+					op->ptr = addr + insn->size + op->disp;;
 				} else if (INSOP(1).mem.base == X86_REG_RBP || INSOP(1).mem.base == X86_REG_EBP) {
 					op->type |= R_ANAL_OP_TYPE_REG;
 					op->stackop = R_ANAL_STACK_SET;
 					op->stackptr = regsz;
+				} else if (INSOP(1).mem.segment == X86_REG_INVALID
+				           && INSOP(1).mem.base == X86_REG_INVALID
+				           && INSOP(1).mem.index == X86_REG_INVALID
+				           && INSOP(1).mem.scale == 1) { // [<addr>]
+					op->ptr = op->disp;
 				}
 				if (INSOP(0).type == X86_OP_IMM) {
 					op->val = INSOP(0).imm;

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -661,7 +661,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 						var_retype (anal, var, NULL, prev_type, addr, false, false);
 					}
 				}
-				if (chk_constraint && var && (type == R_ANAL_OP_TYPE_CMP && aop.ptr != UT64_MAX)
+				if (chk_constraint && var && (type == R_ANAL_OP_TYPE_CMP && aop.disp != UT64_MAX)
 						&& next_op && next_op->type == R_ANAL_OP_TYPE_CJMP) {
 					bool jmp = false;
 					RAnalOp *jmp_op = {0};

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1010,7 +1010,8 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 	core->parser->regsub = r_config_get_i (core->config, "asm.regsub");
 	core->parser->relsub_addr = 0;
 	if (core->parser->relsub
-	    && (ds->analop.type == R_ANAL_OP_TYPE_LEA || ds->analop.type == R_ANAL_OP_TYPE_MOV)
+	    && (ds->analop.type == R_ANAL_OP_TYPE_LEA || ds->analop.type == R_ANAL_OP_TYPE_MOV
+	        || ds->analop.type == R_ANAL_OP_TYPE_CMP)
 	    && ds->analop.ptr != UT64_MAX) {
 		core->parser->relsub_addr = ds->analop.ptr;
 	}


### PR DESCRIPTION
Following #14829.