### PR TITLE
Fixes #14859: Enter used to update seek in interactive graphs

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -4049,6 +4049,7 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	int o_scrinteractive = r_cons_is_interactive ();
 	int o_vmode = core->vmode;
 	int exit_graph = false, is_error = false;
+	int update_seek = false;
 	struct agraph_refresh_data *grd;
 	int okey, key;
 	RAnalFunction *fcn = NULL;
@@ -4248,9 +4249,13 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 				get_bbupdate (g, core, fcn);
 			}
 			break;
+		case 13:
+			agraph_update_seek (g, get_anode (g->curnode), true);
+			update_seek = true;
+			exit_graph = true;
+			break;
 		case '>':
 			if (fcn && r_cons_yesno ('y', "Compute function callgraph? (Y/n)")) {
-				// r_core_cmd0 (core, "ag-;.agc* @$FB;.axtg @$FB;aggi");
 				r_core_cmd0 (core, "ag-;.agc* @$FB;.axfg @$FB;aggi");
 			}
 			break;
@@ -4842,5 +4847,8 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 	}
 	r_config_hold_restore (hc);
 	r_config_hold_free (hc);
+	if (update_seek) {
+		return -1;
+	}
 	return !is_error;
 }

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7297,11 +7297,13 @@ static void cmd_agraph_print(RCore *core, const char *input) {
 			core->graph->layout = r_config_get_i (core->config, "graph.layout");
 			int ov = r_cons_is_interactive ();
 			core->graph->need_update_dim = true;
-			r_core_visual_graph (core, core->graph, NULL, true);
+			int update_seek = r_core_visual_graph (core, core->graph, NULL, true);
 			r_config_set_i (core->config, "scr.interactive", ov);
 			r_cons_show_cursor (true);
 			r_cons_enable_mouse (false);
-			r_core_seek (core, oseek, 0);
+			if (update_seek != -1) {
+				r_core_seek (core, oseek, 0);
+			}
 		} else {
 			eprintf ("This graph contains no nodes\n");
 		}


### PR DESCRIPTION
When in aggi mode, when pressed enter. The core->offset is not updated, thus forcing the update of the current seek