### PR TITLE
Syncing with r2hexagon

### DIFF
--- a/libr/anal/d/Makefile
+++ b/libr/anal/d/Makefile
@@ -30,6 +30,7 @@ F+= cc-powerpc-32
 F+= cc-powerpc-64
 F+= cc-xtensa-32
 F+= cc-riscv-64
+F+= cc-hexagon-32
 
 WIN_TYPES=
 WIN_TYPES+= bcrypt

--- a/libr/anal/d/cc-hexagon-32.sdb.txt
+++ b/libr/anal/d/cc-hexagon-32.sdb.txt
@@ -1,0 +1,11 @@
+default.cc=hexagon
+
+hexagon=cc
+cc.hexagon.arg0=r0
+cc.hexagon.arg1=r1
+cc.hexagon.arg2=r2
+cc.hexagon.arg3=r3
+cc.hexagon.arg4=r4
+cc.hexagon.arg5=r5
+cc.hexagon.argn=stack_rev
+cc.hexagon.ret=r0

--- a/libr/asm/arch/hexagon/hexagon_disas.c
+++ b/libr/asm/arch/hexagon/hexagon_disas.c
@@ -1767,6 +1767,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; p0 = cmp.eq (%s, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -1784,6 +1785,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (%s, Rx)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -1801,6 +1803,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (Rx, %s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2436,6 +2439,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = #-1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2453,6 +2457,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = 0x%x", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2470,6 +2475,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (%s, #-1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2487,6 +2493,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2504,6 +2511,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (Sp, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2521,6 +2529,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = and (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2538,6 +2547,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = and (%s, #255)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2556,6 +2566,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#0, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2574,6 +2585,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#0, %s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2592,6 +2604,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#1, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2610,6 +2623,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#2, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2628,6 +2642,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#3, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2646,6 +2661,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (%s, #0)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2661,6 +2677,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2676,6 +2693,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2691,6 +2709,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2706,6 +2725,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2723,6 +2743,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2740,6 +2761,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = sxtb (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2757,6 +2779,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = sxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2774,6 +2797,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = zxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -5803,7 +5827,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = #-1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = #-1", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fc00) == 0x20002800) {
@@ -5823,7 +5848,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = 0x%x", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = 0x%x", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003300) {
@@ -5843,7 +5869,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = add (%s, #-1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = add (%s, #-1)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003100) {
@@ -5863,7 +5890,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = add (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = add (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fc00) == 0x20002c00) {
@@ -5883,7 +5911,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = add (Sp, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = add (Sp, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003200) {
@@ -5903,7 +5932,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = and (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = and (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003700) {
@@ -5923,7 +5953,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = and (%s, #255)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = and (%s, #255)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fd18) == 0x20003c00) {
@@ -5944,7 +5975,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = combine (#0, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#0, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800fd08) == 0x20003d00) {
@@ -5965,7 +5997,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = combine (#0, %s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#0, %s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fd18) == 0x20003c08) {
@@ -5986,7 +6019,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = combine (#1, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#1, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800fd18) == 0x20003c10) {
@@ -6007,7 +6041,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = combine (#2, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#2, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800fd18) == 0x20003c18) {
@@ -6028,7 +6063,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = combine (#3, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#3, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800fd08) == 0x20003d08) {
@@ -6049,7 +6085,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = combine (%s, #0)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (%s, #0)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe70) == 0x20003a70) {
@@ -6067,7 +6104,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (! p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe70) == 0x20003a50) {
@@ -6085,7 +6123,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (! p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe70) == 0x20003a60) {
@@ -6103,7 +6142,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe70) == 0x20003a40) {
@@ -6121,7 +6161,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003900) {
@@ -6141,7 +6182,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; p0 = cmp.eq (%s, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; p0 = cmp.eq (%s, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003000) {
@@ -6161,7 +6203,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003500) {
@@ -6181,7 +6224,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = sxtb (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = sxtb (%s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003400) {
@@ -6201,7 +6245,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = sxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = sxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003600) {
@@ -6221,7 +6266,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = zxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = zxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe40) == 0x38003a00) {
@@ -6478,7 +6524,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Ry, 0x%x) ; %s = add (Rx, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					sprintf(hi->mnem, "%s = add (Ry, %d) ; %s = add (Rx, %d)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003800) {
@@ -6498,7 +6544,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Ry, 0x%x) ; %s = add (%s, Rx)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = add (Ry, %d) ; %s = add (%s, Rx)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x20003800) {
@@ -6518,7 +6564,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Ry, 0x%x) ; %s = add (Rx, %s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = add (Ry, %d) ; %s = add (Rx, %s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00ff00) == 0x38003800) {
@@ -7322,6 +7368,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memub (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -7341,6 +7388,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memw (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -7983,7 +8031,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = memub (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memub (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800f000) == 0x40000000) {
@@ -8005,7 +8054,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = memw (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memw (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xff00f000) == 0x58001000) {
@@ -8354,6 +8404,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8367,6 +8418,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; deallocframe", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8380,6 +8432,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8393,6 +8446,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8406,6 +8460,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8419,6 +8474,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8432,6 +8488,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8445,6 +8502,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8458,6 +8516,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8471,6 +8530,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8484,6 +8544,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -10796,6 +10857,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memb (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -10815,6 +10877,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -10834,6 +10897,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memuh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -10851,6 +10915,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x1f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memw (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -10869,6 +10934,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf8) >> 3) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memd (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -12536,7 +12602,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = memb (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memb (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800f800) == 0x40002000) {
@@ -12558,7 +12625,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = memh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800f800) == 0x40002800) {
@@ -12580,7 +12648,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = memuh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memuh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0x40003c00) {
@@ -12600,7 +12669,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x1f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = memw (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memw (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x40003e00) {
@@ -12621,7 +12691,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf8) >> 3) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; %s = memd (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memd (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc4) == 0x40003f40) {
@@ -12637,7 +12708,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc4) == 0x40003f00) {
@@ -12653,7 +12725,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; deallocframe", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; deallocframe", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003f45) {
@@ -12669,7 +12742,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (! p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003fc5) {
@@ -12685,7 +12759,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (! p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003f47) {
@@ -12701,7 +12776,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (! p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003fc7) {
@@ -12717,7 +12793,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (! p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003f44) {
@@ -12733,7 +12810,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003fc4) {
@@ -12749,7 +12827,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003f46) {
@@ -12765,7 +12844,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc7) == 0x40003fc6) {
@@ -12781,7 +12861,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; if (p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ffc4) == 0x40003fc0) {
@@ -12797,7 +12878,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x58003c00) {
@@ -14135,6 +14217,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memb (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -14154,6 +14237,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -14796,7 +14880,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memb (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memb (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800f000) == 0x60000000) {
@@ -14818,7 +14903,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memw (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00f000) == 0x78001000) {
@@ -15095,7 +15181,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].attr |= HEX_OP_REG_PAIR;
 					hi->ops[2].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = #-1 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
+					sprintf(hi->mnem, "%s = #-1 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe40f800) == 0x7a002000) {
@@ -15172,6 +15258,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_IMM;
 					hi->ops[2].op.imm = (((hi_u32) & 0x1f0) >> 4) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; allocframe (0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm);
 					break;
 				}
@@ -15189,6 +15276,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memb (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15206,6 +15294,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memb (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15227,7 +15316,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = 0x%x ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = 0x%x ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfc00f800) == 0x68002000) {
@@ -15246,6 +15336,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memh (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -15263,6 +15354,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15280,6 +15372,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15297,6 +15390,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -15333,7 +15427,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = %s ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = %s ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x70002800) {
@@ -15473,7 +15567,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (%s, #-1) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = add (%s, #-1) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x73002800) {
@@ -15526,7 +15620,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (%s, #1) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = add (%s, #1) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x71002800) {
@@ -15787,7 +15881,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Sp, 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = add (Sp, 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfc00f800) == 0x6c002000) {
@@ -15893,7 +15987,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = and (%s, #1) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = and (%s, #1) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x72002800) {
@@ -15946,7 +16040,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = and (%s, #255) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = and (%s, #255) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x77002800) {
@@ -16173,7 +16267,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = sxtb (%s) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = sxtb (%s) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x75002800) {
@@ -16313,7 +16407,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = sxth (%s) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = sxth (%s) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x74002800) {
@@ -16453,7 +16547,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = zxth (%s) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = zxth (%s) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x76002800) {
@@ -16631,7 +16725,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = combine (#0, 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = combine (#0, 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfd18f800) == 0x7c002000) {
@@ -16743,7 +16837,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = combine (#0, %s) ; memd (Sp + 0x%x) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = combine (#0, %s) ; memd (Sp + %d) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfd08fe00) == 0x7d002800) {
@@ -16927,7 +17021,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = combine (#1, 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = combine (#1, 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfd18f800) == 0x7c082000) {
@@ -17075,7 +17169,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = combine (#2, 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = combine (#2, 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfd18f800) == 0x7c102000) {
@@ -17223,7 +17317,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = combine (#3, 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = combine (#3, 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfd18f800) == 0x7c182000) {
@@ -17335,7 +17429,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = combine (%s, #0) ; memd (Sp + 0x%x) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = combine (%s, #0) ; memd (Sp + %d) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfd08fe00) == 0x7d082800) {
@@ -17481,7 +17575,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (%s, Rx) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = add (%s, Rx) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x78002800) {
@@ -17603,7 +17697,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_IMM;
 					hi->ops[2].op.imm = (((hi_u32) & 0x1f0) >> 4) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; allocframe (0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; allocframe (0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x60003200) {
@@ -17623,7 +17718,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memb (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memb (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x60003300) {
@@ -17643,7 +17739,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memb (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memb (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0x60002a00) {
@@ -17667,7 +17764,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800f800) == 0x60002000) {
@@ -17689,7 +17787,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memh (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memh (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x60003000) {
@@ -17709,7 +17808,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memw (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800ff00) == 0x60003100) {
@@ -17729,7 +17829,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memw (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0x60002800) {
@@ -17749,7 +17850,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, 0x%x) ; memw (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_reg(hi->ops[3].op.reg));
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x78003c00) {
@@ -17785,7 +17887,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = add (Rx, %s) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = add (Rx, %s) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x78002800) {
@@ -17951,7 +18053,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].attr |= HEX_OP_REG_PAIR;
 					hi->ops[2].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "if (! p0) %s = #0 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
+					sprintf(hi->mnem, "if (! p0) %s = #0 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe70f800) == 0x7a702000) {
@@ -18075,7 +18177,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].attr |= HEX_OP_REG_PAIR;
 					hi->ops[2].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "if (! p0.new) %s = #0 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
+					sprintf(hi->mnem, "if (! p0.new) %s = #0 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe70f800) == 0x7a502000) {
@@ -18199,7 +18301,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].attr |= HEX_OP_REG_PAIR;
 					hi->ops[2].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "if (p0) %s = #0 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
+					sprintf(hi->mnem, "if (p0) %s = #0 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe70f800) == 0x7a602000) {
@@ -18323,7 +18425,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].attr |= HEX_OP_REG_PAIR;
 					hi->ops[2].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "if (p0.new) %s = #0 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
+					sprintf(hi->mnem, "if (p0.new) %s = #0 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe70f800) == 0x7a402000) {
@@ -18421,7 +18523,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "p0 = cmp.eq (%s, 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "p0 = cmp.eq (%s, 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0x79002800) {
@@ -18979,7 +19081,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (%s + 0x%x) = %s ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "memb (%s + 0x%x) = %s ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf000fe00) == 0xb0002800) {
@@ -19135,7 +19237,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (%s + 0x%x) = %s ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "memw (%s + 0x%x) = %s ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf000fe00) == 0xa0002800) {
@@ -19294,7 +19396,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = memub (%s + 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "%s = memub (%s + 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf000fe00) == 0xd0000800) {
@@ -19450,7 +19552,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = memw (%s + 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "%s = memw (%s + 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf000fe00) == 0xc0000800) {
@@ -19609,7 +19711,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = memb (%s + 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "%s = memb (%s + 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0xd0002800) {
@@ -19765,7 +19867,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = memh (%s + 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "%s = memh (%s + 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0xc0002800) {
@@ -19921,7 +20023,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = memuh (%s + 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "%s = memuh (%s + 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0xc8002800) {
@@ -20107,7 +20209,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = memw (Sp + 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = memw (Sp + 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe00f800) == 0xdc002000) {
@@ -20251,7 +20353,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "%s = memd (Sp + 0x%x) ; memd (Sp + 0x%x) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "%s = memd (Sp + 0x%x) ; memd (Sp + %d) = %s", hex_get_sub_regpair(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00f800) == 0xde002000) {
@@ -20368,7 +20470,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].attr |= HEX_OP_REG_PAIR;
 					hi->ops[1].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "deallocframe ; memd (Sp + 0x%x) = %s", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg));
+					sprintf(hi->mnem, "deallocframe ; memd (Sp + %d) = %s", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xffc4f800) == 0xdf002000) {
@@ -20461,7 +20563,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (%s + 0x%x) = #0 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "memb (%s + 0x%x) = #0 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0xf2000800) {
@@ -20514,7 +20616,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (%s + 0x%x) = #1 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "memb (%s + 0x%x) = #1 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0xf3000800) {
@@ -20724,7 +20826,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_IMM;
 					hi->ops[2].op.imm = (((hi_u32) & 0x1f0) >> 4) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; allocframe (0x%x)", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hi->ops[2].op.imm);
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; allocframe (0x%x)", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00ff00) == 0xea001200) {
@@ -20745,7 +20847,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; memb (%s + 0x%x) = #0", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; memb (%s + 0x%x) = #0", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00ff00) == 0xea001300) {
@@ -20766,7 +20868,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; memb (%s + 0x%x) = #1", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; memb (%s + 0x%x) = #1", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00ff00) == 0xea001000) {
@@ -20787,7 +20889,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; memw (%s + 0x%x) = #0", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; memw (%s + 0x%x) = #0", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00ff00) == 0xea001100) {
@@ -20808,7 +20910,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; memw (%s + 0x%x) = #1", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; memw (%s + 0x%x) = #1", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00fe00) == 0xea000a00) {
@@ -20833,7 +20935,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; memd (Sp + 0x%x) = %s", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; memd (Sp + %d) = %s", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe00f800) == 0xea000000) {
@@ -20856,7 +20958,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; memh (%s + 0x%x) = %s", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; memh (%s + 0x%x) = %s", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe00fe00) == 0xea000800) {
@@ -20877,7 +20979,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (Sp + 0x%x) = %s ; memw (Sp + 0x%x) = %s", hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_reg(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "memd (Sp + %d) = %s ; memw (Sp + 0x%x) = %s", (st32) hi->ops[0].op.imm, hex_get_sub_regpair(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0xe0001c00) {
@@ -20917,7 +21019,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].attr |= HEX_OP_REG_PAIR;
 					hi->ops[4].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (%s + 0x%x) = %s ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
+					sprintf(hi->mnem, "memh (%s + 0x%x) = %s ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), (st32) hi->ops[3].op.imm, hex_get_sub_regpair(hi->ops[4].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xf800fe00) == 0xe0000800) {
@@ -21069,7 +21171,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (%s + 0x%x) = #0 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "memw (%s + 0x%x) = #0 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0xf0000800) {
@@ -21122,7 +21224,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (%s + 0x%x) = #1 ; memd (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "memw (%s + 0x%x) = #1 ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xff00fe00) == 0xf1000800) {
@@ -21417,7 +21519,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (Sp + 0x%x) = %s ; memd (Sp + 0x%x) = %s", hi->ops[0].op.imm, hex_get_sub_reg(hi->ops[1].op.reg), hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
+					sprintf(hi->mnem, "memw (Sp + 0x%x) = %s ; memd (Sp + %d) = %s", hi->ops[0].op.imm, hex_get_sub_reg(hi->ops[1].op.reg), (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
 				if ((hi_u32 & 0xfe00f800) == 0xe8000000) {
@@ -24678,7 +24780,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (R%d + 0x%x) = 0x%x", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "memb (R%d + 0x%x) = %d", hi->ops[0].op.reg, hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x4000000) {
@@ -24769,7 +24872,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memb (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) memb (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x8800000) {
@@ -24788,7 +24891,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memb (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d memb (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x9000000) {
@@ -24807,7 +24910,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memb (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) memb (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x9800000) {
@@ -24826,7 +24929,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memb (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new memb (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0xb400000) {
@@ -24875,7 +24978,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d + 0x%x) = 0x%x", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.imm);
+					hex_op_extend_off(&hi->ops[1], 1);
+					sprintf(hi->mnem, "memh (R%d + 0x%x) = %d", hi->ops[0].op.reg, hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x4400000) {
@@ -25038,7 +25142,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memh (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) memh (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x8a00000) {
@@ -25057,7 +25161,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memh (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d memh (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x9200000) {
@@ -25076,7 +25180,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memh (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) memh (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x9a00000) {
@@ -25095,7 +25199,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memh (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new memh (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0xb800000) {
@@ -25128,7 +25232,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (R%d + 0x%x) = 0x%x", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.imm);
+					hex_op_extend_off(&hi->ops[1], 2);
+					sprintf(hi->mnem, "memw (R%d + 0x%x) = %d", hi->ops[0].op.reg, hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x4800000) {
@@ -25219,7 +25324,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memw (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) memw (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x8c00000) {
@@ -25238,7 +25343,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memw (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d memw (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x9400000) {
@@ -25257,7 +25362,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memw (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) memw (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00000) == 0x9c00000) {
@@ -25276,7 +25381,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memw (R%d + 0x%x) = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new memw (R%d + 0x%x) = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				break;
@@ -25696,6 +25801,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32 & 0x6000000) >> 11) | ((hi_u32 & 0x1f0000) >> 7) | ((hi_u32 & 0x3fe0) >> 5)) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend_off(&hi->ops[1], 2);
 					sprintf(hi->mnem, "R%d = memw (gp + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.imm);
 					break;
 				}
@@ -27864,7 +27970,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = and (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = and (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc00000) == 0x6800000) {
@@ -27882,7 +27988,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = or (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = or (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf000000) == 0xf000000) {
@@ -27908,7 +28014,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f0000) >> 16); // Rs
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[1]);
-					sprintf(hi->mnem, "R%d = sub (0x%x, R%d)", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "R%d = sub (%d, R%d)", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02000) == 0xa00000) {
@@ -27972,7 +28078,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[1]);
-					sprintf(hi->mnem, "R%d = 0x%x", hi->ops[0].op.reg, hi->ops[1].op.imm);
+					sprintf(hi->mnem, "R%d = %d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe02000) == 0x600000) {
@@ -28015,7 +28121,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d:R%d = combine (R%d, 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = combine (R%d, %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf602000) == 0x3202000) {
@@ -28034,7 +28140,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f0000) >> 16); // Rs
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[1]);
-					sprintf(hi->mnem, "R%d:R%d = combine (0x%x, R%d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "R%d:R%d = combine (%d, R%d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xf800000) == 0xc000000) {
@@ -28055,7 +28161,8 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = combine (0x%x, 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.imm);
+					hex_op_extend(&hi->ops[1]);
+					sprintf(hi->mnem, "R%d:R%d = combine (%d, %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800000) == 0xc800000) {
@@ -28074,7 +28181,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.imm = (((hi_u32 & 0x1f0000) >> 15) | ((hi_u32 & 0x2000) >> 13));
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[1]);
-					sprintf(hi->mnem, "R%d:R%d = combine (0x%x, 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = combine (%d, 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf802000) == 0x3000000) {
@@ -28094,7 +28201,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[3]);
-					sprintf(hi->mnem, "R%d = mux (P%d, R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.pred, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "R%d = mux (P%d, R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.pred, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf802000) == 0x3800000) {
@@ -28114,7 +28221,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f0000) >> 16); // Rs
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = mux (P%d, 0x%x, R%d)", hi->ops[0].op.reg, hi->ops[1].op.pred, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = mux (P%d, %d, R%d)", hi->ops[0].op.reg, hi->ops[1].op.pred, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xe000000) == 0xa000000) {
@@ -28137,7 +28244,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = mux (P%d, 0x%x, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.pred, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "R%d = mux (P%d, %d, %d)", hi->ops[0].op.reg, hi->ops[1].op.pred, (st32) hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe02000) == 0x0) {
@@ -28181,7 +28288,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pu)
 					hex_op_extend(&hi->ops[3]);
-					sprintf(hi->mnem, "if (P%d) R%d = add (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) R%d = add (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf802000) == 0x4002000) {
@@ -28201,7 +28308,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pu.new)
 					hex_op_extend(&hi->ops[3]);
-					sprintf(hi->mnem, "if (P%d.new) R%d = add (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d = add (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf802000) == 0x4800000) {
@@ -28221,7 +28328,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pu 
 					hex_op_extend(&hi->ops[3]);
-					sprintf(hi->mnem, "if !P%d R%d = add (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d = add (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf802000) == 0x4802000) {
@@ -28241,7 +28348,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pu.new
 					hex_op_extend(&hi->ops[3]);
-					sprintf(hi->mnem, "if !P%d.new R%d = add (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d = add (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe02c00) == 0x2000) {
@@ -28483,7 +28590,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pu)
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "if (P%d) R%d = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "if (P%d) R%d = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf902000) == 0xe002000) {
@@ -28501,7 +28608,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pu.new)
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "if (P%d.new) R%d = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf902000) == 0xe800000) {
@@ -28519,7 +28626,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pu 
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "if !P%d R%d = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf902000) == 0xe802000) {
@@ -28537,7 +28644,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pu.new
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "if !P%d.new R%d = 0x%x", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d = %d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe02c00) == 0x802000) {
@@ -28667,7 +28774,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "P%d = cmp.eq (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = cmp.eq (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc0001c) == 0x5000010) {
@@ -28685,7 +28792,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "P%d = !cmp.eq (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = !cmp.eq (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc0001c) == 0x5400000) {
@@ -28703,7 +28810,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "P%d = cmp.gt (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = cmp.gt (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc0001c) == 0x5400010) {
@@ -28721,7 +28828,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "P%d = !cmp.gt (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = !cmp.gt (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe0001c) == 0x5800000) {
@@ -28769,7 +28876,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = cmp.eq (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = cmp.eq (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf602000) == 0x3602000) {
@@ -28787,7 +28894,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = !cmp.eq (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = !cmp.eq (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				break;
@@ -29068,7 +29175,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = add (clb (R%d:R%d), 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = add (clb (R%d:R%d), %d)", hi->ops[0].op.reg, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe000e0) == 0xc200000) {
@@ -29085,7 +29192,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = add (clb (R%d), 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = add (clb (R%d), %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe000e0) == 0xc000080) {
@@ -29429,7 +29536,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hi->pf |= HEX_PF_RAW; // :raw
-					sprintf(hi->mnem, "R%d = tableidxb (R%d, 0x%x, 0x%x) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "R%d = tableidxb (R%d, 0x%x, %d) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc00000) == 0x7400000) {
@@ -29449,7 +29556,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hi->pf |= HEX_PF_RAW; // :raw
-					sprintf(hi->mnem, "R%d = tableidxh (R%d, 0x%x, 0x%x) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "R%d = tableidxh (R%d, 0x%x, %d) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc00000) == 0x7800000) {
@@ -29469,7 +29576,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hi->pf |= HEX_PF_RAW; // :raw
-					sprintf(hi->mnem, "R%d = tableidxw (R%d, 0x%x, 0x%x) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "R%d = tableidxw (R%d, 0x%x, %d) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc00000) == 0x7c00000) {
@@ -29489,7 +29596,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hi->pf |= HEX_PF_RAW; // :raw
-					sprintf(hi->mnem, "R%d = tableidxd (R%d, 0x%x, 0x%x) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "R%d = tableidxd (R%d, 0x%x, %d) :raw", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe000e0) == 0x8000e0) {
@@ -31263,7 +31370,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[2], 3);
-					sprintf(hi->mnem, "R%d:R%d = memd (R%d + 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memd (R%d + %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x9c00000) {
@@ -31283,7 +31390,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memd (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d:R%d = memd (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x9c00200) {
@@ -31332,7 +31439,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memd (R%d ++ 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memd (R%d ++ %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xdc01000) {
@@ -31400,7 +31507,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pt)
-					sprintf(hi->mnem, "if (P%d) R%d:R%d = memd (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) R%d:R%d = memd (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xbc02800) {
@@ -31420,7 +31527,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pt 
-					sprintf(hi->mnem, "if !P%d R%d:R%d = memd (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d:R%d = memd (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xbc03000) {
@@ -31440,7 +31547,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pt.new)
-					sprintf(hi->mnem, "if (P%d.new) R%d:R%d = memd (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d:R%d = memd (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xbc03800) {
@@ -31460,7 +31567,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pt.new
-					sprintf(hi->mnem, "if !P%d.new R%d:R%d = memd (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d:R%d = memd (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xfc02080) {
@@ -31542,7 +31649,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = memb (R%d + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memb (R%d + %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x9000000) {
@@ -31561,7 +31668,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memb (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = memb (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x9000200) {
@@ -31607,7 +31714,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memb (R%d ++ 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memb (R%d ++ %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xd001000) {
@@ -31671,7 +31778,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pt)
-					sprintf(hi->mnem, "if (P%d) R%d = memb (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) R%d = memb (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb002800) {
@@ -31690,7 +31797,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pt 
-					sprintf(hi->mnem, "if !P%d R%d = memb (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d = memb (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb003000) {
@@ -31709,7 +31816,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pt.new)
-					sprintf(hi->mnem, "if (P%d.new) R%d = memb (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d = memb (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb003800) {
@@ -31728,7 +31835,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pt.new
-					sprintf(hi->mnem, "if !P%d.new R%d = memb (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d = memb (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xf002080) {
@@ -31806,7 +31913,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 10);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memb_fifo (R%d + 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memb_fifo (R%d + %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x8800000) {
@@ -31826,7 +31933,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memb_fifo (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d:R%d = memb_fifo (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x8800200) {
@@ -31874,7 +31981,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memb_fifo (R%d ++ 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memb_fifo (R%d ++ %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xc801000) {
@@ -31939,7 +32046,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 11);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memh_fifo (R%d + 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memh_fifo (R%d + %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x8400000) {
@@ -31959,7 +32066,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memh_fifo (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d:R%d = memh_fifo (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x8400200) {
@@ -32007,7 +32114,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memh_fifo (R%d ++ 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memh_fifo (R%d ++ %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xc401000) {
@@ -32072,7 +32179,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[2], 1);
-					sprintf(hi->mnem, "R%d = memh (R%d + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memh (R%d + %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x9400000) {
@@ -32091,7 +32198,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memh (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = memh (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x9400200) {
@@ -32137,7 +32244,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memh (R%d ++ 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memh (R%d ++ %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xd401000) {
@@ -32201,7 +32308,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pt)
-					sprintf(hi->mnem, "if (P%d) P%d = memh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.pred, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) P%d = memh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.pred, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb402800) {
@@ -32220,7 +32327,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pt 
-					sprintf(hi->mnem, "if !P%d R%d = memh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d = memh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb403000) {
@@ -32239,7 +32346,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pt.new)
-					sprintf(hi->mnem, "if (P%d.new) R%d = memh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d = memh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb403800) {
@@ -32258,7 +32365,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pt.new
-					sprintf(hi->mnem, "if !P%d.new R%d = memh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d = memh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xf402080) {
@@ -32336,7 +32443,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = memub (R%d + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memub (R%d + %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x9200000) {
@@ -32355,7 +32462,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memub (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = memub (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x9200200) {
@@ -32401,7 +32508,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memub (R%d ++ 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memub (R%d ++ %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xd201000) {
@@ -32465,7 +32572,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pt)
-					sprintf(hi->mnem, "if (P%d) R%d = memub (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) R%d = memub (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb202800) {
@@ -32484,7 +32591,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pt 
-					sprintf(hi->mnem, "if !P%d R%d = memub (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d = memub (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb203000) {
@@ -32503,7 +32610,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pt.new)
-					sprintf(hi->mnem, "if (P%d.new) R%d = memub (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d = memub (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb203800) {
@@ -32522,7 +32629,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 3);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pt.new
-					sprintf(hi->mnem, "if !P%d.new R%d = memub (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d = memub (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xf202080) {
@@ -32600,7 +32707,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[2], 1);
-					sprintf(hi->mnem, "R%d = memuh (R%d + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memuh (R%d + %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x9600000) {
@@ -32619,7 +32726,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memuh (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = memuh (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x9600200) {
@@ -32665,7 +32772,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memuh (R%d ++ 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memuh (R%d ++ %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xd601000) {
@@ -32729,7 +32836,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pt)
-					sprintf(hi->mnem, "if (P%d) R%d = memuh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) R%d = memuh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb602800) {
@@ -32748,7 +32855,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pt 
-					sprintf(hi->mnem, "if !P%d R%d = memuh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d = memuh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb603000) {
@@ -32767,7 +32874,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pt.new)
-					sprintf(hi->mnem, "if (P%d.new) R%d = memuh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d = memuh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb603800) {
@@ -32786,7 +32893,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pt.new
-					sprintf(hi->mnem, "if !P%d.new R%d = memuh (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d = memuh (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xf602080) {
@@ -32864,7 +32971,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[2], 2);
-					sprintf(hi->mnem, "R%d = memw (R%d + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memw (R%d + %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x9800000) {
@@ -32883,7 +32990,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memw (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = memw (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x9800200) {
@@ -32929,7 +33036,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memw (R%d ++ 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memw (R%d ++ %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xd801000) {
@@ -32993,7 +33100,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE; // if (Pt)
-					sprintf(hi->mnem, "if (P%d) R%d = memw (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d) R%d = memw (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb802800) {
@@ -33012,7 +33119,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE; // if !Pt 
-					sprintf(hi->mnem, "if !P%d R%d = memw (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d R%d = memw (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb803000) {
@@ -33031,7 +33138,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pt.new)
-					sprintf(hi->mnem, "if (P%d.new) R%d = memw (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if (P%d.new) R%d = memw (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03800) == 0xb803800) {
@@ -33050,7 +33157,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[3].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pt.new
-					sprintf(hi->mnem, "if !P%d.new R%d = memw (R%d ++ 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "if !P%d.new R%d = memw (R%d ++ %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xf802080) {
@@ -33203,7 +33310,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 11);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = membh (R%d + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = membh (R%d + %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0x9e00000) == 0x600000) {
@@ -33220,7 +33327,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 11);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memubh (R%d + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memubh (R%d + %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0x9e00000) == 0xa00000) {
@@ -33238,7 +33345,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 12);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memubh (R%d + 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memubh (R%d + %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0x9e00000) == 0xe00000) {
@@ -33256,7 +33363,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 12);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = membh (R%d + 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = membh (R%d + %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01200) == 0x8200000) {
@@ -33275,7 +33382,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = membh (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = membh (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x8200200) {
@@ -33308,7 +33415,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memubh (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = memubh (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x8600200) {
@@ -33342,7 +33449,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memubh (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d:R%d = memubh (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x8a00200) {
@@ -33377,7 +33484,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x2000) >> 13); // Mu
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = membh (R%d ++ 0x%x:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d:R%d = membh (R%d ++ %d:circ (R%d))", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01280) == 0x8e00200) {
@@ -33423,7 +33530,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = membh (R%d ++ 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = membh (R%d ++ %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03000) == 0xa601000) {
@@ -33454,7 +33561,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 4);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = memubh (R%d ++ 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = memubh (R%d ++ %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03000) == 0xaa01000) {
@@ -33487,7 +33594,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = memubh (R%d ++ 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = memubh (R%d ++ %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe03000) == 0xae01000) {
@@ -33520,7 +33627,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 5);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d:R%d = membh (R%d ++ 0x%x)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d:R%d = membh (R%d ++ %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01000) == 0xc201000) {
@@ -33774,7 +33881,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[1]);
-					sprintf(hi->mnem, "memb (R%d + 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memb (R%d + %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01882) == 0x9a00002) {
@@ -33807,7 +33914,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (R%d ++ 0x%x:circ (R%d)) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memb (R%d ++ %d:circ (R%d)) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xba00080) {
@@ -33838,7 +33945,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memb (R%d ++ %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01880) == 0xda00080) {
@@ -33902,7 +34009,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba02004) {
@@ -33921,7 +34028,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba02080) {
@@ -33940,7 +34047,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba02084) {
@@ -33959,7 +34066,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xfa00080) {
@@ -34033,7 +34140,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[1], 1);
-					sprintf(hi->mnem, "memh (R%d + 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memh (R%d + %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01882) == 0x9a00802) {
@@ -34066,7 +34173,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d ++ 0x%x:circ (R%d)) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memh (R%d ++ %d:circ (R%d)) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xba00880) {
@@ -34097,7 +34204,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memh (R%d ++ %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01880) == 0xda00880) {
@@ -34161,7 +34268,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba02804) {
@@ -34180,7 +34287,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba02880) {
@@ -34199,7 +34306,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba02884) {
@@ -34218,7 +34325,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xfa00880) {
@@ -34292,7 +34399,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[1], 2);
-					sprintf(hi->mnem, "memw (R%d + 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memw (R%d + %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01882) == 0x9a01002) {
@@ -34325,7 +34432,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (R%d ++ 0x%x:circ (R%d)) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memw (R%d ++ %d:circ (R%d)) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03880) == 0xba01080) {
@@ -34356,7 +34463,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memw (R%d ++ %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe01880) == 0xda01080) {
@@ -34420,7 +34527,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba03004) {
@@ -34439,7 +34546,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba03080) {
@@ -34458,7 +34565,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xba03084) {
@@ -34477,7 +34584,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe03884) == 0xfa01080) {
@@ -34491,6 +34598,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -34505,6 +34613,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -34519,6 +34628,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d.new) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -34533,6 +34643,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d.new memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -34552,7 +34663,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8);
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[1], 3);
-					sprintf(hi->mnem, "memd (R%d + 0x%x) = R%d:R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg + 1, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memd (R%d + %d) = R%d:R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg + 1, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00082) == 0x9c00002) {
@@ -34587,7 +34698,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (R%d ++ 0x%x:circ (R%d)) = R%d:R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memd (R%d ++ %d:circ (R%d)) = R%d:R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02080) == 0xbc00080) {
@@ -34621,7 +34732,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].attr |= HEX_OP_REG_PAIR;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8);
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memd (R%d ++ 0x%x) = R%d:R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg + 1, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memd (R%d ++ %d) = R%d:R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg + 1, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00080) == 0xdc00080) {
@@ -34689,7 +34800,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8);
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memd (R%d ++ 0x%x) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memd (R%d ++ %d) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xbc02004) {
@@ -34709,7 +34820,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8);
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memd (R%d ++ 0x%x) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memd (R%d ++ %d) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xbc02080) {
@@ -34729,7 +34840,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8);
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memd (R%d ++ 0x%x) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memd (R%d ++ %d) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xbc02084) {
@@ -34749,7 +34860,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8);
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memd (R%d ++ 0x%x) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memd (R%d ++ %d) = R%d:R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg + 1, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xfc00080) {
@@ -34827,7 +34938,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[1]);
-					sprintf(hi->mnem, "memb (R%d + 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memb (R%d + %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00082) == 0x9000002) {
@@ -34860,7 +34971,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (R%d ++ 0x%x:circ (R%d)) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memb (R%d ++ %d:circ (R%d)) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02080) == 0xb000080) {
@@ -34892,7 +35003,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memb (R%d ++ %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00080) == 0xd000080) {
@@ -34956,7 +35067,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb002004) {
@@ -34975,7 +35086,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb002080) {
@@ -34994,7 +35105,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb002084) {
@@ -35013,7 +35124,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memb (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memb (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xf000080) {
@@ -35087,7 +35198,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[1], 1);
-					sprintf(hi->mnem, "memh (R%d + 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memh (R%d + %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0x9e00000) == 0x1600000) {
@@ -35104,7 +35215,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d + 0x%x) = R%d.H", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memh (R%d + %d) = R%d.H", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00082) == 0x9400002) {
@@ -35137,7 +35248,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d ++ 0x%x:circ (R%d)) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memh (R%d ++ %d:circ (R%d)) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00082) == 0x9600002) {
@@ -35170,7 +35281,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d ++ 0x%x:circ (R%d)) = R%d.H", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memh (R%d ++ %d:circ (R%d)) = R%d.H", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02080) == 0xb400080) {
@@ -35202,7 +35313,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memh (R%d ++ %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02080) == 0xb600080) {
@@ -35233,7 +35344,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memh (R%d ++ 0x%x) = R%d.H", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memh (R%d ++ %d) = R%d.H", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00080) == 0xd400080) {
@@ -35341,7 +35452,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb402004) {
@@ -35360,7 +35471,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb402080) {
@@ -35379,7 +35490,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb402084) {
@@ -35398,7 +35509,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memh (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memh (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb602000) {
@@ -35417,7 +35528,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memh (R%d ++ 0x%x) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memh (R%d ++ %d) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb602004) {
@@ -35436,7 +35547,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memh (R%d ++ 0x%x) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memh (R%d ++ %d) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb602080) {
@@ -35455,7 +35566,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memh (R%d ++ 0x%x) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memh (R%d ++ %d) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb602084) {
@@ -35474,7 +35585,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memh (R%d ++ 0x%x) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memh (R%d ++ %d) = R%d.H", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xf400080) {
@@ -35604,7 +35715,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend_off(&hi->ops[1], 2);
-					sprintf(hi->mnem, "memw (R%d + 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memw (R%d + %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00082) == 0x9800002) {
@@ -35637,7 +35748,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (R%d ++ 0x%x:circ (R%d)) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "memw (R%d ++ %d:circ (R%d)) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02080) == 0xb800080) {
@@ -35669,7 +35780,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "memw (R%d ++ %d) = R%d", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe00080) == 0xd800080) {
@@ -35733,7 +35844,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
-					sprintf(hi->mnem, "if (P%d) memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d) memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb802004) {
@@ -35752,7 +35863,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
-					sprintf(hi->mnem, "if !P%d memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb802080) {
@@ -35771,7 +35882,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
-					sprintf(hi->mnem, "if (P%d.new) memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if (P%d.new) memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xb802084) {
@@ -35790,7 +35901,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
-					sprintf(hi->mnem, "if !P%d.new memw (R%d ++ 0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "if !P%d.new memw (R%d ++ %d) = R%d", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe02084) == 0xf800080) {
@@ -35804,6 +35915,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -35818,6 +35930,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -35832,6 +35945,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d.new) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -35846,6 +35960,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d.new memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -36179,7 +36294,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = add (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = add (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				break;
@@ -37454,7 +37569,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = lsl (0x%x, R%d)", hi->ops[0].op.reg, hi->ops[1].op.imm, hi->ops[2].op.reg);
+					sprintf(hi->mnem, "R%d = lsl (%d, R%d)", hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe000c0) == 0xb800000) {
@@ -38194,7 +38309,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[3]);
-					sprintf(hi->mnem, "R%d = add (R%d, add (R%d, 0x%x))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.reg, hi->ops[3].op.imm);
+					sprintf(hi->mnem, "R%d = add (R%d, add (R%d, %d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.reg, (st32) hi->ops[3].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf800000) == 0xb800000) {
@@ -38214,7 +38329,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].op.reg = (((hi_u32) & 0x1f) >> 0); // Ru
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d = add (R%d, sub (0x%x, R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm, hi->ops[3].op.reg);
+					sprintf(hi->mnem, "R%d = add (R%d, sub (%d, R%d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm, hi->ops[3].op.reg);
 					break;
 				}
 				if ((hi_u32 & 0xfe000e0) == 0x30000e0) {
@@ -38595,7 +38710,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 9);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d |= and (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d |= and (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc00000) == 0xa400000) {
@@ -38612,7 +38727,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 9);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d = or (R%d, and (Rx, 0x%x))", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d = or (R%d, and (Rx, %d))", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfc00000) == 0xa800000) {
@@ -38629,7 +38744,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 9);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "R%d |= or (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d |= or (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00080) == 0x5c00000) {
@@ -40072,7 +40187,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "P%d = cmpb.gt (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = cmpb.gt (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf601018) == 0xd400000) {
@@ -40105,7 +40220,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "P%d = cmph.eq (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = cmph.eq (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf600018) == 0xd200008) {
@@ -40123,7 +40238,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "P%d = cmph.gt (R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = cmph.gt (R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf601018) == 0xd400008) {
@@ -40267,7 +40382,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "P%d = vcmph.eq (R%d:R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = vcmph.eq (R%d:R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00018) == 0xc200008) {
@@ -40285,7 +40400,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "P%d = vcmph.gt (R%d:R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = vcmph.gt (R%d:R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01018) == 0xc400008) {
@@ -40397,7 +40512,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "P%d = vcmpb.gt (R%d:R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = vcmpb.gt (R%d:R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01018) == 0xc400000) {
@@ -40478,7 +40593,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "P%d = vcmpw.eq (R%d:R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = vcmpw.eq (R%d:R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe00018) == 0xc200010) {
@@ -40496,7 +40611,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
-					sprintf(hi->mnem, "P%d = vcmpw.gt (R%d:R%d, 0x%x)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "P%d = vcmpw.gt (R%d:R%d, %d)", hi->ops[0].op.pred, hi->ops[1].op.reg + 1, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe01018) == 0xc400010) {
@@ -40671,7 +40786,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d += add (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d += add (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xf802000) == 0x2800000) {
@@ -40689,7 +40804,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					}
 					hi->predicate = HEX_NOPRED;
 					hex_op_extend(&hi->ops[2]);
-					sprintf(hi->mnem, "R%d -= add (R%d, 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.reg, hi->ops[2].op.imm);
+					sprintf(hi->mnem, "R%d -= add (R%d, %d)", hi->ops[0].op.reg, hi->ops[1].op.reg, (st32) hi->ops[2].op.imm);
 					break;
 				}
 				if ((hi_u32 & 0xfe020e0) == 0xf000020) {


### PR DESCRIPTION
Changes have been:
- Signed values get now printed as decimal (and therefore with sign): https://github.com/radare/radare2/issues/14849
- Immediate extensions now expand also duplex containers + missing non-duplex extensions added: https://github.com/radareorg/r2hexagon/pull/7
- Calling convention added
