### PR TITLE
Add po[..] set of commands

### DIFF
--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -137,16 +137,15 @@ static bool __endian_swap(ut8 *buf, ut32 blocksize, ut8 len) {
 	return true;
 }
 
-R_API int r_core_write_op(RCore *core, const char *arg, char op) {
-	int i, j, ret = false;
+R_API ut8* r_core_transform_op(RCore *core, const char *arg, char op) {
+	int i, j;
 	ut64 len;
 	char *str = NULL;
 	ut8 *buf;
 
-	// XXX we can work with config.block instead of dupping it
 	buf = (ut8 *)malloc (core->blocksize);
 	if (!buf) {
-		goto beach;
+		return NULL;
 	}
 	memcpy (buf, core->block, core->blocksize);
 
@@ -284,10 +283,25 @@ R_API int r_core_write_op(RCore *core, const char *arg, char op) {
 		}
 	}
 
-	ret = r_core_write_at (core, core->offset, buf, core->blocksize);
-beach:
-	free (buf);
 	free (str);
+	return buf;
+beach:
+	free (str);
+	free (buf);
+	return NULL;
+}
+
+R_API int r_core_write_op(RCore *core, const char *arg, char op) {
+	int ret;
+	ut8 *buf;
+
+	buf = r_core_transform_op(core, arg, op);
+	if (!buf) {
+		return false;
+	}
+	ret = r_core_write_at(core, core->offset, buf, core->blocksize);
+
+	free(buf);
 	return ret;
 }
 

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2435,41 +2435,41 @@ static int cmd_print_pxA(RCore *core, int len, const char *input) {
 }
 
 static void cmd_print_op(RCore *core, const char *input) {
-     ut8 *buf;
-     if (!input[0])
-         return;
-     switch (input[1]) {
-     case 'a':
-     case 's':
-     case 'A':
-     case 'x':
-     case 'r':
-     case 'l':
-     case 'm':
-     case 'd':
-     case 'o':
-     case '2':
-     case '4':
-         if (input[2]) {  // parse val from arg
-             buf = r_core_transform_op (core, input+3, input[1]);
-         } else {  // use clipboard instead of val
-             buf = r_core_transform_op (core, NULL, input[1]);
-         }
-         break;
-     case 'n':
-         buf = r_core_transform_op (core, "ff", 'x');
-         break;
-     case '\0':
-     case '?':
-     default:
-         r_core_cmd_help (core, help_msg_po);
-         return;
-     }
-     if (buf) {
-	 r_print_hexdump(core->print, core->offset, buf,
-		 core->blocksize, 16, 1, 1);
-	 free (buf);
-     }
+	ut8 *buf;
+	if (!input[0])
+		return;
+	switch (input[1]) {
+	case 'a':
+	case 's':
+	case 'A':
+	case 'x':
+	case 'r':
+	case 'l':
+	case 'm':
+	case 'd':
+	case 'o':
+	case '2':
+	case '4':
+		if (input[2]) {  // parse val from arg
+			buf = r_core_transform_op (core, input+3, input[1]);
+		} else {  // use clipboard instead of val
+			buf = r_core_transform_op (core, NULL, input[1]);
+		}
+		break;
+	case 'n':
+		buf = r_core_transform_op (core, "ff", 'x');
+		break;
+	case '\0':
+	case '?':
+	default:
+		r_core_cmd_help (core, help_msg_po);
+		return;
+	}
+	if (buf) {
+		r_print_hexdump(core->print, core->offset, buf,
+				core->blocksize, 16, 1, 1);
+		free (buf);
+	}
 }
 
 static void printraw(RCore *core, int len, int mode) {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -213,6 +213,7 @@ static const char *help_msg_p[] = {
 	"ph", "[?][=|hash] ([len])", "calculate hash for a block",
 	"pj", "[?] [len]", "print as indented JSON",
 	"pm", "[?] [magic]", "print libmagic data (see pm? and /m?)",
+	"po", "[?] hex", "print operation applied to block (see po?)",
 	"pp", "[?][sz] [len]", "print patterns, see pp? for more help",
 	"pq", "[?][is] [len]", "print QR code with the first Nbytes",
 	"pr", "[?][glx] [len]", "print N raw bytes (in lines or hexblocks, 'g'unzip)",
@@ -439,6 +440,23 @@ static const char *help_msg_pif[] = {
 	"pifc", "", "print all calls from this function",
 	"pifcj", "", "print all calls from this function in JSON format",
 	"pifj", "", "print instructions of function in JSON format",
+};
+
+static const char *help_msg_po[] = {
+	"Usage:","po[24aAdlmorsx]"," [hexpairs] @ addr[!bsize]",
+	"po[24aAdlmorsx]","", "without hexpair values, clipboard is used",
+	"po2"," [val]","2=  2 byte endian swap",
+	"po4"," [val]", "4=  4 byte endian swap",
+	"poa"," [val]", "+=  addition (f.ex: poa 0102)",
+	"poA"," [val]","&=  and",
+	"pod"," [val]", "/=  divide",
+	"pol"," [val]","<<= shift left",
+	"pom"," [val]", "*=  multiply",
+	"poo"," [val]","|=  or",
+	"por"," [val]", ">>= shift right",
+	"pos"," [val]", "-=  substraction",
+	"pox"," [val]","^=  xor  (f.ex: pox 0x90)",
+	NULL
 };
 
 static const char *help_msg_ps[] = {
@@ -2414,6 +2432,44 @@ static int cmd_print_pxA(RCore *core, int len, const char *input) {
 	}
 
 	return true;
+}
+
+static void cmd_print_op(RCore *core, const char *input) {
+     ut8 *buf;
+     if (!input[0])
+         return;
+     switch (input[1]) {
+     case 'a':
+     case 's':
+     case 'A':
+     case 'x':
+     case 'r':
+     case 'l':
+     case 'm':
+     case 'd':
+     case 'o':
+     case '2':
+     case '4':
+         if (input[2]) {  // parse val from arg
+             buf = r_core_transform_op (core, input+3, input[1]);
+         } else {  // use clipboard instead of val
+             buf = r_core_transform_op (core, NULL, input[1]);
+         }
+         break;
+     case 'n':
+         buf = r_core_transform_op (core, "ff", 'x');
+         break;
+     case '\0':
+     case '?':
+     default:
+         r_core_cmd_help (core, help_msg_po);
+         return;
+     }
+     if (buf) {
+	 r_print_hexdump(core->print, core->offset, buf,
+		 core->blocksize, 16, 1, 1);
+	 free (buf);
+     }
 }
 
 static void printraw(RCore *core, int len, int mode) {
@@ -6179,6 +6235,9 @@ l = use_blocksize;
 			r_print_stereogram_print (core->print, res);
 			free (res);
 		}
+		break;
+	case 'o': // "po"
+		cmd_print_op(core, input);
 		break;
 	case 'x': // "px"
 	{

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2467,7 +2467,7 @@ static void cmd_print_op(RCore *core, const char *input) {
 	}
 	if (buf) {
 		r_print_hexdump(core->print, core->offset, buf,
-				core->blocksize, 16, 1, 1);
+			core->blocksize, 16, 1, 1);
 		free (buf);
 	}
 }
@@ -4819,9 +4819,10 @@ static int cmd_print(void *data, const char *input) {
 		const char *p = off? strchr (input + idx, ' '): NULL;
 		if (p) {
 			l = (int) r_num_math (core->num, p + 1);
-			/* except disasm and memoryfmt (pd, pm) */
+			/* except disasm and memoryfmt (pd, pm) and overlay (po) */
 			if (input[0] != 'd' && input[0] != 'D' && input[0] != 'm' &&
-				input[0] != 'a' && input[0] != 'f' && input[0] != 'i' && input[0] != 'I') {
+				input[0] != 'a' && input[0] != 'f' && input[0] != 'i' &&
+				input[0] != 'I' && input[0] != 'o') {
 				if (l < 0) {
 					off = core->offset + l;
 					len = l = -l;
@@ -4844,7 +4845,7 @@ static int cmd_print(void *data, const char *input) {
 		len = core->blocksize;
 	}
 
-	if (input[0] != 'd' && input[0] != 'm' && input[0] != 'a' && input[0] != 'f') {
+	if (input[0] != 'd' && input[0] != 'm' && input[0] != 'a' && input[0] != 'f' && input[0] != 'o') {
 		n = core->blocksize_max;
 		i = (int) n;
 		if (i != n) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -518,6 +518,7 @@ R_API int r_core_seek_delta(RCore *core, st64 addr);
 R_API int r_core_extend_at(RCore *core, ut64 addr, int size);
 R_API bool r_core_write_at(RCore *core, ut64 addr, const ut8 *buf, int size);
 R_API int r_core_write_op(RCore *core, const char *arg, char op);
+R_API ut8* r_core_transform_op(RCore *core, const char *arg, char op);
 R_API int r_core_set_file_by_fd (RCore * core, ut64 bin_fd);
 R_API int r_core_set_file_by_name (RBin * bin, const char * name);
 R_API ut32 r_core_file_cur_fd (RCore *core);


### PR DESCRIPTION
This adds the functionality from #14758. 

The code mostly borrows from `wo` but there are several options in `wo` that I decided not to include because the command doesn't really depend on the data block (i.e. `e`, `p`, `R`, `w`). I haven't (yet) implemented encryption and decryption.