### PR TITLE
Add frame pointer to AVR register profile

### DIFF
--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -1920,6 +1920,7 @@ static int set_reg_profile(RAnal *anal) {
 	const char *p =
 		"=PC	pcl\n"
 		"=SP	sp\n"
+		"=BP    y\n"
 // explained in http://www.nongnu.org/avr-libc/user-manual/FAQ.html
 // and http://www.avrfreaks.net/forum/function-calling-convention-gcc-generated-assembly-file
 		"=A0	r25\n"


### PR DESCRIPTION
Lack of BP alias causes assertion fail in `libr/anal/esil.c:internal_esil_reg_write_no_null(...)` 
`WARNING: internal_esil_reg_write_no_null: assertion 'pc && sp && bp' failed (line 409)`