### PR TITLE
Fix #14939: Replace assertions about missing RReg profile registers with warnings

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -405,8 +405,20 @@ static int internal_esil_reg_write_no_null (RAnalEsil *esil, const char *regname
 	const char *pc = r_reg_get_name (esil->anal->reg, R_REG_NAME_PC);
 	const char *sp = r_reg_get_name (esil->anal->reg, R_REG_NAME_SP);
 	const char *bp = r_reg_get_name (esil->anal->reg, R_REG_NAME_BP);
+
 	//trick to protect strcmp from segfaulting with out making the condition complex
-	r_return_val_if_fail (pc && sp && bp, -1);
+	if (!pc) {
+		pc = "pc";
+		eprintf ("Warning: RReg profile does not contain PC register\n");
+	}
+	if (!sp) {
+		sp = "sp";
+		eprintf ("Warning: RReg profile does not contain SP register\n");
+	}
+	if (!bp) {
+		bp = "bp";
+		eprintf ("Warning: RReg profile does not contain BP register\n");
+	}
 	if (reg && reg->name && ((strcmp (reg->name , pc) && strcmp (reg->name, sp) && strcmp(reg->name, bp)) || num)) { //I trust k-maps
 		r_reg_set_value (esil->anal->reg, reg, num);
 		return true;

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -406,18 +406,17 @@ static int internal_esil_reg_write_no_null (RAnalEsil *esil, const char *regname
 	const char *sp = r_reg_get_name (esil->anal->reg, R_REG_NAME_SP);
 	const char *bp = r_reg_get_name (esil->anal->reg, R_REG_NAME_BP);
 
-	//trick to protect strcmp from segfaulting with out making the condition complex
 	if (!pc) {
-		pc = "pc";
 		eprintf ("Warning: RReg profile does not contain PC register\n");
+		return false;
 	}
 	if (!sp) {
-		sp = "sp";
 		eprintf ("Warning: RReg profile does not contain SP register\n");
+		return false;
 	}
 	if (!bp) {
-		bp = "bp";
 		eprintf ("Warning: RReg profile does not contain BP register\n");
+		return false;
 	}
 	if (reg && reg->name && ((strcmp (reg->name , pc) && strcmp (reg->name, sp) && strcmp(reg->name, bp)) || num)) { //I trust k-maps
 		r_reg_set_value (esil->anal->reg, reg, num);


### PR DESCRIPTION
I am not sure if I did it right. Waiting for your feedback.