### PR TITLE
fix help message of ?

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -119,7 +119,7 @@ static const char *help_msg_root[] = {
 
 static const char *help_msg_question[] = {
 	"Usage: ?[?[?]] expression", "", "",
-	"?", " eip-0x804800", "show hex and dec result for this math expr",
+	"?", " eip-0x804800", "show all representation result for this math expr",
 	"?:", "", "list core cmd plugins",
 	"[cmd]?*", "", "recursive help for the given cmd",
 	"?!", " [cmd]", "run cmd if $? == 0",


### PR DESCRIPTION
This does not show only dec and hex

```
? 0x32-0x14
int32   30
uint32  30
hex     0x1e
octal   036
unit    30
segment 0000:001e
string  "\x1e"
fvalue: 30.0
float:  0.000000f
double: 0.000000
binary  0b00011110
trits   0t1010
```