### PR TITLE
fixing esil =[*] (poke multiple regs/values)

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1823,7 +1823,7 @@ static bool esil_poke_some(RAnalEsil *esil) {
 	int i, regsize;
 	ut64 ptr, regs = 0, tmp;
 	char *count, *dst = r_anal_esil_pop (esil);
-#define BYTES_SIZE 64
+
 	if (dst && r_anal_esil_get_parm_size (esil, dst, &tmp, &regsize)) {
 		// reg
 		isregornum (esil, dst, &ptr);
@@ -1831,7 +1831,7 @@ static bool esil_poke_some(RAnalEsil *esil) {
 		if (count) {
 			isregornum (esil, count, &regs);
 			if (regs > 0) {
-				ut8 b[BYTES_SIZE];
+				ut8 b[8] = {0};
 				ut64 num64;
 				for (i = 0; i < regs; i++) {
 					char *foo = r_anal_esil_pop (esil);
@@ -1841,16 +1841,15 @@ static bool esil_poke_some(RAnalEsil *esil) {
 						free (count);
 						return true;
 					}
+					r_anal_esil_get_parm_size (esil, foo, &tmp, &regsize);
 					isregornum (esil, foo, &num64);
-					/* TODO: implement peek here */
-					// read from $dst
 					r_write_ble (b, num64, esil->anal->big_endian, regsize);
-					const ut32 written = r_anal_esil_mem_write (esil, ptr, b, BYTES_SIZE);
-					if (written != BYTES_SIZE) {
+					const ut32 written = r_anal_esil_mem_write (esil, ptr, b, regsize);
+					if (written != regsize) {
 						//eprintf ("Cannot write at 0x%08" PFMT64x "\n", ptr);
 						esil->trap = 1;
 					}
-					ptr += BYTES_SIZE;
+					ptr += regsize/8;
 					free (foo);
 				}
 			}

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1564,12 +1564,12 @@ PUSH { r4, r5, r6, r7, lr }
 4,sp,-=,r5,sp,=[4],
 4,sp,-=,r4,sp,=[4]
 
-20,sp,-=,r4,r5,r6,r7,lr,5,sp,=[*]
+20,sp,-=,lr,r7,r6,r5,r4,5,sp,=[*]
 #endif
 		r_strbuf_setf (&op->esil, "%d,sp,-=,",
 			4 * insn->detail->arm.op_count);
-		for (i=0; i<insn->detail->arm.op_count; i++) {
-			r_strbuf_appendf (&op->esil, "%s,", REG (i));
+		for (i=insn->detail->arm.op_count; i>0; i--) {
+			r_strbuf_appendf (&op->esil, "%s,", REG (i-1));
 		}
 		r_strbuf_appendf (&op->esil, "%d,sp,=[*]",
 			insn->detail->arm.op_count);
@@ -1592,11 +1592,11 @@ PUSH { r4, r5, r6, r7, lr }
 	case ARM_INS_POP:
 #if 0
 POP { r4,r5, r6}
-r4,r5,r6,3,sp,[*],12,sp,+=
+r6,r5,r4,3,sp,[*],12,sp,+=
 #endif
 		r_strbuf_setf (&op->esil, "");
-		for (i=0; i<insn->detail->arm.op_count; i++) {
-			r_strbuf_appendf (&op->esil, "%s,", REG (i));
+		for (i=insn->detail->arm.op_count; i>0; i--) {
+			r_strbuf_appendf (&op->esil, "%s,", REG (i-1));
 		}
 		r_strbuf_appendf (&op->esil, "%d,sp,[*],",
 			insn->detail->arm.op_count);


### PR DESCRIPTION
Fixed esil implementation of =[*] to properly process constructs like `32,sp,-=,r1,r2,r3,r4,r5,r6,r7,lr,8,sp,=[*]`
Fixes #10631, also related to issue #10632 