### PR TITLE
Display operand of EBC push/pop instructions

### DIFF
--- a/libr/asm/arch/ebc/ebc_disas.c
+++ b/libr/asm/arch/ebc/ebc_disas.c
@@ -619,7 +619,7 @@ static int decode_push_pop(const ut8 *bytes, ebc_command_t *cmd) {
 			CHK_SNPRINTF (cmd->operands, EBC_OPERANDS_MAXLEN, "%s %u",
 				op1c, immed);
 		}
-	} else {
+    } else {
         CHK_SNPRINTF (cmd->operands, EBC_OPERANDS_MAXLEN, "%s",	op1c);
     }
 

--- a/libr/asm/arch/ebc/ebc_disas.c
+++ b/libr/asm/arch/ebc/ebc_disas.c
@@ -619,7 +619,9 @@ static int decode_push_pop(const ut8 *bytes, ebc_command_t *cmd) {
 			CHK_SNPRINTF (cmd->operands, EBC_OPERANDS_MAXLEN, "%s %u",
 				op1c, immed);
 		}
-	}
+	} else {
+        CHK_SNPRINTF (cmd->operands, EBC_OPERANDS_MAXLEN, "%s",	op1c);
+    }
 
 	return ret;
 }


### PR DESCRIPTION
Previously, if no immediate data was specified, the operand was not displayed.