### PR TITLE
Fixed logic in 2-byte endian swap used by "wo2"

### DIFF
--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -240,20 +240,21 @@ R_API ut8* r_core_transform_op(RCore *core, const char *arg, char op) {
 		} else {
 			eprintf ("Invalid word size. Use 1, 2, 4 or 8\n");
 		}
-	} else if (op=='2' || op=='4') {
-		op -= '0';
-		// if i < core->blocksize would pass the test but buf[i+3] goes beyond the buffer
-		if (core->blocksize > 3) {
-			for (i=0; i<core->blocksize-3; i+=op) {
-				/* endian swap */
-				ut8 tmp = buf[i];
+	} else if (op == '2' || op == '4') {
+		int inc = op - '0';
+		ut8 tmp;
+		for (i = 0; i <= core->blocksize - inc; i += inc) {
+			if (inc == 2) {
+				tmp = buf[i];
+				buf[i] = buf[i+1];
+				buf[i+1] = tmp;
+			} else if (inc == 4) {
+				tmp = buf[i];
 				buf[i] = buf[i+3];
 				buf[i+3] = tmp;
-				if (op == 4) {
-					tmp = buf[i + 1];
-					buf[i + 1] = buf[i + 2];
-					buf[i + 2] = tmp;
-				}
+				tmp = buf[i+1];
+				buf[i+1] = buf[i+2];
+				buf[i+2] = tmp;
 			}
 		}
 	} else {


### PR DESCRIPTION
This fixes  #14937

```
$ build/binr/radare2/radare2 -
[0x00000000]> b 8
[0x00000000]> wx 0102030405060708
[0x00000000]> wo2
[0x00000000]> p8
0201040306050807
[0x00000000]> wx 1020304000000000
[0x00000000]> p8 4
10203040
[0x00000000]> wo2
[0x00000000]> p8 4
20104030
[0x00000000]> p8 8
2010403000000000
[0x00000000]> wx 10203040
[0x00000000]> wo4
[0x00000000]> p8 8
4030201000000000
```