### PR TITLE
add nf flag in ESIL generated for ARM thumb

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2231,7 +2231,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 		case ARM_INS_CMN:
 			break;
 		default:
-		        r_strbuf_appendf (&op->esil, ",$z,zf,:=");
+		        r_strbuf_appendf (&op->esil, ",$z,zf,:=,$s,nf,:=");
 		}
 	}
 


### PR DESCRIPTION
ESIL for ARM thumb was not setting NF (sign flag) for arithmetic instructions.