### PR TITLE
Fix MSVC warnings

### DIFF
--- a/libr/include/r_endian.h
+++ b/libr/include/r_endian.h
@@ -57,7 +57,7 @@ static inline ut16 r_read_at_be16(const void *src, size_t offset) {
 
 static inline void r_write_be16(void *dest, ut16 val) {
 	r_write_be8 (dest, val >> 8);
-	r_write_at_be8 (dest, val, sizeof (ut8));
+	r_write_at_be8 (dest, (ut8)val, sizeof (ut8));
 }
 
 static inline void r_write_at_be16(void *dest, ut16 val, size_t offset) {
@@ -106,7 +106,7 @@ static inline ut64 r_read_at_be64(const void *src, size_t offset) {
 
 static inline void r_write_be64(void *dest, ut64 val) {
 	r_write_be32 (dest, val >> 32);
-	r_write_at_be32 (dest, val, sizeof (ut32));
+	r_write_at_be32 (dest, (ut32)val, sizeof (ut32));
 }
 
 static inline void r_write_at_be64(void *dest, ut64 val, size_t offset) {
@@ -152,7 +152,7 @@ static inline ut16 r_read_at_le16(const void *src, size_t offset) {
 }
 
 static inline void r_write_le16(void *dest, ut16 val) {
-	r_write_le8 (dest, val);
+	r_write_le8 (dest, (ut8)val);
 	r_write_at_le8 (dest, val >> 8, sizeof (ut8));
 }
 
@@ -207,7 +207,7 @@ static inline ut64 r_read_at_le64(const void *src, size_t offset) {
 }
 
 static inline void r_write_le64(void *dest, ut64 val) {
-	r_write_le32 (dest, val);
+	r_write_le32 (dest, (ut32)val);
 	r_write_at_le32 (dest, val >> 32, sizeof (ut32));
 }
 
@@ -252,7 +252,7 @@ static inline ut16 r_read_at_me16(const void *src, size_t offset) {
 
 static inline void r_write_me16(void *dest, ut16 val) {
 	r_write_me8 (dest, val >> 8);
-	r_write_at_me8 (dest, val, sizeof (ut8));
+	r_write_at_me8 (dest, (ut8)val, sizeof (ut8));
 }
 
 static inline void r_write_at_me16(void *dest, ut16 val, size_t offset) {
@@ -299,7 +299,7 @@ static inline ut64 r_read_at_me64(const void *src, size_t offset) {
 }
 
 static inline void r_write_me64(void *dest, ut64 val) {
-	r_write_me32 (dest, val);
+	r_write_me32 (dest, (ut32)val);
 	r_write_at_me32 (dest, val >> 32, sizeof (ut32));
 }
 

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -146,7 +146,9 @@
   #ifdef _MSC_VER
   /* Must be included before windows.h */
   #include <winsock2.h>
+  #ifndef WIN32_LEAN_AND_MEAN
   #define WIN32_LEAN_AND_MEAN
+  #endif
   #endif
   typedef int socklen_t;
   #undef USE_SOCKETS

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -110,91 +110,91 @@ R_API RList *r_buf_nonempty_list(RBuffer *b);
 
 static inline ut16 r_buf_read_be16(RBuffer *b) {
 	ut8 buf[sizeof (ut16)];
-	int r = r_buf_read (b, buf, sizeof (buf));
+	int r = (int) r_buf_read (b, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_be16 (buf): UT16_MAX;
 }
 
 static inline ut16 r_buf_read_be16_at(RBuffer *b, ut64 addr) {
 	ut8 buf[sizeof (ut16)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_be16 (buf): UT16_MAX;
 }
 
 static inline ut32 r_buf_read_be32(RBuffer *b) {
 	ut8 buf[sizeof (ut32)];
-	int r = r_buf_read (b, buf, sizeof (buf));
+	int r = (int) r_buf_read (b, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_be32 (buf): UT32_MAX;
 }
 
 static inline ut32 r_buf_read_be32_at(RBuffer *b, ut64 addr) {
 	ut8 buf[sizeof (ut32)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_be32 (buf): UT32_MAX;
 }
 
 static inline ut64 r_buf_read_be64(RBuffer *b) {
 	ut8 buf[sizeof (ut64)];
-	int r = r_buf_read (b, buf, sizeof (buf));
+	int r = (int) r_buf_read (b, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_be64 (buf): UT64_MAX;
 }
 
 static inline ut64 r_buf_read_be64_at(RBuffer *b, ut64 addr) {
 	ut8 buf[sizeof (ut64)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_be64 (buf): UT64_MAX;
 }
 
 static inline ut16 r_buf_read_le16(RBuffer *b) {
 	ut8 buf[sizeof (ut16)];
-	int r = r_buf_read (b, buf, sizeof (buf));
+	int r = (int) r_buf_read (b, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_le16 (buf): UT16_MAX;
 }
 
 static inline ut16 r_buf_read_le16_at(RBuffer *b, ut64 addr) {
 	ut8 buf[sizeof (ut16)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_le16 (buf): UT16_MAX;
 }
 
 static inline ut32 r_buf_read_le32(RBuffer *b) {
 	ut8 buf[sizeof (ut32)];
-	int r = r_buf_read (b, buf, sizeof (buf));
+	int r = (int) r_buf_read (b, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_le32 (buf): UT32_MAX;
 }
 
 static inline ut32 r_buf_read_le32_at(RBuffer *b, ut64 addr) {
 	ut8 buf[sizeof (ut32)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_le32 (buf): UT32_MAX;
 }
 
 static inline ut64 r_buf_read_le64(RBuffer *b) {
 	ut8 buf[sizeof (ut64)];
-	int r = r_buf_read (b, buf, sizeof (buf));
+	int r = (int) r_buf_read (b, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_le64 (buf): UT64_MAX;
 }
 
 static inline ut64 r_buf_read_le64_at(RBuffer *b, ut64 addr) {
 	ut8 buf[sizeof (ut64)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_le64 (buf): UT64_MAX;
 }
 
 static inline ut16 r_buf_read_ble16_at(RBuffer *b, ut64 addr, bool big_endian) {
 	ut8 buf[sizeof (ut16)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_ble16 (buf, big_endian): UT16_MAX;
 }
 
 static inline ut32 r_buf_read_ble32_at(RBuffer *b, ut64 addr, bool big_endian) {
 	ut8 buf[sizeof (ut32)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_ble32 (buf, big_endian): UT32_MAX;
 }
 
 static inline ut64 r_buf_read_ble64_at(RBuffer *b, ut64 addr, bool big_endian) {
 	ut8 buf[sizeof (ut64)];
-	int r = r_buf_read_at (b, addr, buf, sizeof (buf));
+	int r = (int) r_buf_read_at (b, addr, buf, sizeof (buf));
 	return r == sizeof (buf)? r_read_ble64 (buf, big_endian): UT64_MAX;
 }
 


### PR DESCRIPTION
These lines lead to tons of warnigs when compiling Cutter (example: https://ci.appveyor.com/project/radare/cutter/branch/master/job/iec7gsa697rdrv9i#L3134)