### PR TITLE
Update io->off when seeking in intel hex

### DIFF
--- a/libr/io/p/io_ihex.c
+++ b/libr/io/p/io_ihex.c
@@ -209,7 +209,8 @@ static ut64 __lseek(struct r_io_t *io, RIODesc *fd, ut64 offset, int whence) {
 		return -1;
 	}
 	rih = fd->data;
-	return r_buf_seek (rih->rbuf, offset, whence);
+	io->off = r_buf_seek (rih->rbuf, offset, whence);
+	return io->off;
 }
 
 static bool __plugin_open(RIO *io, const char *pathname, bool many) {


### PR DESCRIPTION
It seems like every other io plugin updates io->off when seeking and forces all reads to be from io->off, but ihex only does the latter, which seems to be breaking most high level read_at functions.

I noticed this when disassembling a hex file that used a lot of PC relative data loads -- the helpful comments at the end of the line to show the actual data being loaded were all just showing the opcode of the instruction that I started the disassembly on.