### PR TITLE
 R2CON2019 Link to r2lrn and r2golf in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ radare2 is portable.
 
 To learn more on radare2 you may want to read the [official radare2 book](https://radare.gitbooks.io/radare2book/content/).
 
+You can also use [r2lrn](https://github.com/0ki/r2lrn) or r2golf for a hands-on learning experience.
+
 ## Operating Systems
 
 Windows (since XP), GNU/Linux, OS X, [Net|Free|Open]BSD,


### PR DESCRIPTION
Better yet, fork https://github.com/0ki/r2lrn and make r2lrn and r2golf a (part of the) official repo.