### PR TITLE
Fix memory leaks and other problems found by ASAN.

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -805,6 +805,7 @@ R_API void r_anal_merge_hint_ranges(RAnal *a) {
 			}
 			range_bits = bits;
 		}
+		ls_free (sdb_range);
 		a->merge_hints = false;
 	}
 }

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1844,12 +1844,13 @@ static bool esil_poke_some(RAnalEsil *esil) {
 					r_anal_esil_get_parm_size (esil, foo, &tmp, &regsize);
 					isregornum (esil, foo, &num64);
 					r_write_ble (b, num64, esil->anal->big_endian, regsize);
-					const ut32 written = r_anal_esil_mem_write (esil, ptr, b, regsize);
-					if (written != regsize) {
+					const int size_bytes = regsize / 8;
+					const ut32 written = r_anal_esil_mem_write (esil, ptr, b, size_bytes);
+					if (written != size_bytes) {
 						//eprintf ("Cannot write at 0x%08" PFMT64x "\n", ptr);
 						esil->trap = 1;
 					}
-					ptr += regsize/8;
+					ptr += size_bytes;
 					free (foo);
 				}
 			}

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -728,7 +728,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 	bool last_is_mov_lr_pc = false;
 	ut64 last_push_addr = UT64_MAX;
 	if (anal->limit && addr + idx < anal->limit->from) {
-		return R_ANAL_RET_END;
+		gotoBeach (R_ANAL_RET_END);
 	}
 	RAnalFunction *tmp_fcn = r_anal_get_fcn_in (anal, addr, 0);
 	if (tmp_fcn) {
@@ -782,7 +782,7 @@ repeat:
 			if (anal->verbose) {
 				eprintf ("Warning: FFFF opcode at 0x%08"PFMT64x "\n", at);
 			}
-			return R_ANAL_RET_ERROR;
+			gotoBeach (R_ANAL_RET_ERROR)
 		}
 		r_anal_op_fini (&op);
 		if ((oplen = r_anal_op (anal, &op, at, buf, bytes_read, R_ANAL_OP_MASK_ESIL | R_ANAL_OP_MASK_VAL | R_ANAL_OP_MASK_HINT)) < 1) {
@@ -935,7 +935,7 @@ repeat:
 					goto repeat;
 				}
 				if (skip_ret == 2) {
-					return R_ANAL_RET_END;
+					gotoBeach (R_ANAL_RET_END);
 				}
 			}
 			break;
@@ -964,7 +964,7 @@ repeat:
 					goto repeat;
 				}
 				if (skip_ret == 2) {
-					return R_ANAL_RET_END;
+					gotoBeach (R_ANAL_RET_END);
 				}
 			}
 			if (anal->opt.jmptbl) {
@@ -1054,7 +1054,7 @@ repeat:
 						goto repeat;
 					}
 					if (skip_ret == 2) {
-						return R_ANAL_RET_END;
+						gotoBeach (R_ANAL_RET_END);
 					}
 				}
 			}
@@ -1070,7 +1070,7 @@ repeat:
 				}
 			}
 			if (r_cons_is_breaked ()) {
-				return R_ANAL_RET_END;
+				gotoBeach (R_ANAL_RET_END);
 			}
 			if (anal->opt.jmpref) {
 				(void) r_anal_xrefs_set (anal, op.addr, op.jump, R_ANAL_REF_TYPE_CODE);
@@ -1175,15 +1175,14 @@ repeat:
 					FITFCNSZ ();
 					r_anal_fcn_bb (anal, fcn, op.jump, depth);
 					ret = r_anal_fcn_bb (anal, fcn, op.fail, depth);
-					return R_ANAL_RET_END;
+					gotoBeach (R_ANAL_RET_END);
 #else
 					// hardcoded jmp size // must be checked at the end wtf?
 					// always fitfcnsz and retend
 					if (op.jump > fcn->addr + JMP_IS_EOB_RANGE) {
 						ret = r_anal_fcn_bb (anal, fcn, op.fail, depth);
 						/* jump inside the same function */
-						FITFCNSZ ();
-						return R_ANAL_RET_END;
+						gotoBeach (R_ANAL_RET_END);
 #if JMP_IS_EOB_RANGE > 0
 					} else {
 						if (op.jump < addr - JMP_IS_EOB_RANGE && op.jump < addr) {
@@ -1206,8 +1205,7 @@ repeat:
 							bb->jump = op.jump;
 							bb->fail = UT64_MAX;
 						}
-						FITFCNSZ ();
-						return R_ANAL_RET_END;
+						gotoBeach (R_ANAL_RET_END);
 					}
 				}
 			}
@@ -1541,6 +1539,7 @@ R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int r
 		case R_META_TYPE_DATA:
 		case R_META_TYPE_STRING:
 		case R_META_TYPE_FORMAT:
+			r_list_free (list);
 			return 0;
 		}
 	}

--- a/libr/anal/reflines.c
+++ b/libr/anal/reflines.c
@@ -126,7 +126,7 @@ R_API RList *r_anal_reflines_get(RAnal *anal, ut64 addr, const ut8 *buf, ut64 le
 			if (mi) {
 				ptr += mi->size;
 				addr += mi->size;
-				free (mi->str);
+				r_meta_item_free (mi);
 				continue;
 			}
 		}

--- a/libr/core/blaze.c
+++ b/libr/core/blaze.c
@@ -42,16 +42,19 @@ static int __isdata(RCore *core, ut64 addr) {
 	RList *list = r_meta_find_list_in (core->anal, addr, -1, 4);
 	RListIter *iter;
 	RAnalMetaItem *meta;
+	int result = 0;
 	r_list_foreach (list, iter, meta) {
 		switch (meta->type) {
 		case R_META_TYPE_DATA:
 		case R_META_TYPE_STRING:
 		case R_META_TYPE_FORMAT:
-			return meta->size - (addr - meta->from);
+			result = meta->size - (addr - meta->from);
+			goto exit;
 		}
 	}
+exit:
 	r_list_free (list);
-	return 0;
+	return result;
 }
 
 static bool fcnAddBB (fcn_t *fcn, bb_t* block) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -898,6 +898,7 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 								break;
 							}
 							at += mi->size;
+							r_meta_item_free (mi);
 						}
 						// TODO: ensure next address is function after padding (nop or trap or wat)
 						// XXX noisy for test cases because we want to clear the stderr
@@ -4874,10 +4875,13 @@ repeat:
 				case R_META_TYPE_STRING:
 				case R_META_TYPE_FORMAT:
 					i += 4;
+					r_list_free (list);
 					goto repeat;
 				}
 			}
-			r_list_free (list);
+			if (list) {
+				r_list_free (list);
+			}
 		}
 		/* realign address if needed */
 		if (opalign > 0) {

--- a/libr/core/citem.c
+++ b/libr/core/citem.c
@@ -34,6 +34,7 @@ R_API RCoreItem *r_core_item_at (RCore *core, ut64 addr) {
 						ci->data = strdup (item->str);
 					}
 				}
+				r_meta_item_free (item);
 			}
 		}
 	}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6202,6 +6202,7 @@ static void _anal_calls(RCore *core, ut64 addr, ut64 addr_end, bool printCommand
 		if (hint && hint->bits) {
 			setBits = hint->bits;
 		}
+		r_anal_hint_free (hint);
 		if (setBits != core->assembler->bits) {
 			r_config_set_i (core->config, "asm.bits", setBits);
 		}

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -703,6 +703,7 @@ static int cmd_meta_others(RCore *core, const char *input) {
 			RAnalMetaItem *mi = r_meta_find (core->anal, addr, type, R_META_WHERE_HERE);
 			if (mi) {
 				r_meta_print (core->anal, mi, input[3], NULL, false);
+				r_meta_item_free (mi);
 			}
 			break;
 		} else if (input[2] == 'j') { // "Cs.j"
@@ -710,6 +711,7 @@ static int cmd_meta_others(RCore *core, const char *input) {
 			if (mi) {
 				r_meta_print (core->anal, mi, input[2], NULL, false);
 				r_cons_newline ();
+				r_meta_item_free (mi);
 			}
 			break;
 		}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1748,6 +1748,10 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 				append (echars, Color_INVERT);
 				hadflag = true;
 			}
+			if (meta) {
+				r_meta_item_free (meta);
+				meta = NULL;
+			}
 			// collect comments
 			comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr + j);
 			if (comment) {

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2950,6 +2950,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 					}
 					if (ami) {
 						r_core_seek_delta (core, ami->size);
+						r_meta_item_free (ami);
 					} else {
 						int distance = numbuf_pull ();
 						if (distance > 1) {

--- a/shlr/sdb/src/sdb.c
+++ b/shlr/sdb/src/sdb.c
@@ -585,7 +585,10 @@ static ut32 sdb_set_internal(Sdb* s, const char *key, char *val, int owned, ut32
 				return 0;
 			}
 			if (vlen == sdbkv_value_len (kv) && !strcmp (sdbkv_value (kv), val)) {
-				sdb_hook_call (s, key, val);
+				sdb_hook_call (s, key, sdbkv_value (kv));
+				if (owned) {
+					free (val);
+				}
 				return kv->cas;
 			}
 			kv->cas = cas = nextcas ();


### PR DESCRIPTION
Before: SUMMARY: AddressSanitizer: 717346 byte(s) leaked in 18522 allocation(s).
After: SUMMARY: AddressSanitizer: 100800 byte(s) leaked in 1853 allocation(s).