### PR TITLE
R2CON2019: fix heap buffer overflow in dietline autocomplete

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -651,7 +651,7 @@ static void selection_widget_select() {
 		if (sp) {
 			int delta = sp - I.buffer.data + 1;
 			I.buffer.length = R_MIN (delta + strlen (sel_widget->options[sel_widget->selection]), R_LINE_BUFSIZE - 1);
-			memcpy (I.buffer.data + delta, sel_widget->options[sel_widget->selection], I.buffer.length);
+			memcpy (I.buffer.data + delta, sel_widget->options[sel_widget->selection], strlen (sel_widget->options[sel_widget->selection]));
 			I.buffer.index = I.buffer.length;
 			return;
 		}


### PR DESCRIPTION
heap buffer overflow existed in dietline autocomplete, this fixes the issue.

detected by ASAN