### PR TITLE
Increase max code line length to 120 chars

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -57,7 +57,7 @@ default:
 }
 ```
 
-* Lines should be at most 78 chars. A tab is considered as 8 chars.
+* Lines should be at most 120 chars. A tab is considered as 8 chars.
 
 * Braces open on the same line as the for/while/if/else/function/etc. Closing
   braces are put on a line of their own, except in the else of an if statement


### PR DESCRIPTION
Why?

- A lot of code lines are already greater than 78 chars ([example code](https://github.com/radare/radare2/blob/657514849ee80f1a958ecb1a911aef1dfd35ed96/libr/core/disasm.c#L1362-L1365)). It's difficult to fit them into 78-char lines without excessive line-breaking or helper functions that reduce comprehension speed.
- The size of the GitHub code diff window is 128 chars ([example diff](https://github.com/radare/radare2/commit/62a54b8a89cc270b0dfd4118329e61a15b4235d6#diff-7b45b46dd8a84a924b91f34c2b1e6309L1195)). Anything beyond that requires scrolling to read the whole line, which reduces comprehension speed.