### PR TITLE
Add info that r2pm -i is also used for pkg update

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -692,8 +692,8 @@ suicide)
 Usage: r2pm [init|update|cmd] [...]
 Commands:
  -I,info                     information about repository and installed packages
- -i,install <pkgname>        install package in your home (pkgname=all)
- -gi,global-install <pkg>    install package system-wide
+ -i,install <pkgname>        install or update package in your home (pkgname=all)
+ -gi,global-install <pkg>    install or update package system-wide
  -gu,global-uninstall <pkg>  uninstall pkg from systemdir
  -u,uninstall <pkgname>      r2pm -u baleful (-uu to force)
  -l,list                     list installed pkgs


### PR DESCRIPTION
It is confusing that `r2pm update` only updates the database and the packages are not updated. Information about how to update a specific package is missing.

When the user searches for information how to update a particular package, e.g. using `r2pm -h`, the help provides information only how to install a package. This commit adds info that `r2pm -i` is also used for pkg update.