### PR TITLE
Hotfix pd arch bits

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -299,7 +299,7 @@ static const char *help_msg_pc[] = {
 };
 
 static const char *help_msg_pd[] = {
-	"Usage:", "p[dD][ajbrfils] [sz]", " # Print Disassembly",
+	"Usage:", "p[dD][ajbrfils] [len]", " # Print Disassembly",
 	"NOTE: ", "len", "parameter can be negative",
 	"NOTE: ", "", "Pressing ENTER on empty command will repeat last print command in next page",
 	"pd", " -N", "disassemble N instructions backward",

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -299,7 +299,7 @@ static const char *help_msg_pc[] = {
 };
 
 static const char *help_msg_pd[] = {
-	"Usage:", "p[dD][ajbrfils] [sz] [arch] [bits]", " # Print Disassembly",
+	"Usage:", "p[dD][ajbrfils] [sz]", " # Print Disassembly",
 	"NOTE: ", "len", "parameter can be negative",
 	"NOTE: ", "", "Pressing ENTER on empty command will repeat last print command in next page",
 	"pd", " -N", "disassemble N instructions backward",


### PR DESCRIPTION
Since `pd 5 arm 16 @ 0xaddr` is no longer supported and `pd 5 @0xaddr@a:arm@b:16` is the preferred way of doing this, removing leftover instructions in `pd?`.

Renamed `[sz]` to `[len]` to be consistent with other hints in `p?`.

Before:

```
[0x00000000]> pd?
Usage: p[dD][ajbrfils] [sz] [arch] [bits]   # Print Disassembly
```

After:

```
[0x00000000]> pd?
Usage: p[dD][ajbrfils] [len]   # Print Disassembly
```