### PR TITLE
Added ba2 so that the gdbserver backend connects correctly

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -1101,7 +1101,7 @@ RDebugPlugin r_debug_plugin_gdb = {
 	.name = "gdb",
 	/* TODO: Add support for more architectures here */
 	.license = "LGPL3",
-	.arch = "x86,arm,sh,mips,avr,lm32,v850",
+	.arch = "x86,arm,sh,mips,avr,lm32,v850,ba2",
 	.bits = R_SYS_BITS_16 | R_SYS_BITS_32 | R_SYS_BITS_64,
 	.step = r_debug_gdb_step,
 	.cont = r_debug_gdb_continue,


### PR DESCRIPTION
This PR is in regards to issue #14987 

Basically, if new architectures are added via plugins (or even integrated directly into radare2, come to think of it), the `debug_gdb` backend won't connect correctly, as the supported architectures are hardcoded.

This PR can be used to discuss how to solve this issue elegantly. Here are my thoughts:

The easy solution - we just add more architectures to the list. However, does it not defeat the purpose of this list, if the mainline version of radare2's `debug_gdb` backend indicates support for obscure architectures that aren't integrated into the core, and require additional plugins?

The "correct" solution - use a custom debug plugin that mirrors the original `debug_gdb` functionality. That sounds like a terrible idea to me, as it's a maintenance headache in the best case (if we manage to thinly wrap `debug_gdb`), and a huge amount of code duplication in the worst case (if we have to copy it).

Another idea that pops to mind is to add some sort of custom option - either a config variable or an option that can be passed as part of the URI to `debug_gdb`, that will force it to accept the arch even though it's not listed as supported. This could work.

However, this whole thing is complicated by register profiles. I still haven't explored this enough, so can't comment with confidence - but I can definitely say there are issues there:
1. Using `dr` to set a register value with a wrong register name crashes radare2. Maybe not directly relevant to this issue, but shouldn't happen, nonetheless.
2. After defining functions, radare2 begins complaining about setting register profiles. Still not sure what this is about - will have to dig deeper.