### PR TITLE
Fix gdb reg write byte order

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -1,5 +1,6 @@
 /* radare - LGPL - Copyright 2009-2018 - pancake, defragger */
 
+#include <r_core.h>
 #include <r_asm.h>
 #include <r_debug.h>
 #include <libgdbr.h>
@@ -311,6 +312,21 @@ static int r_debug_gdb_reg_write(RDebug *dbg, int type, const ut8 *buf, int size
 		}
 		ut64 val = r_reg_get_value (dbg->reg, current);
 		int bytes = bits / 8;
+		if (r_config_get_i(((RCore*)dbg->corebind.core)->config, "cfg.bigendian")) {
+			// TODO: validate that it's correct for all kinds of archs
+			switch (bytes) {
+				case 2:
+					val = r_swap_ut16(val);
+					break;
+				case 4:
+					val = r_swap_ut32(val);
+					break;
+				case 8:
+				default:
+					val = r_swap_ut64(val);
+					break;
+			}
+		}
 		gdbr_write_reg (desc, current->name, (char*)&val, bytes);
 	}
 	return true;

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -312,19 +312,19 @@ static int r_debug_gdb_reg_write(RDebug *dbg, int type, const ut8 *buf, int size
 		}
 		ut64 val = r_reg_get_value (dbg->reg, current);
 		int bytes = bits / 8;
-		if (r_config_get_i(((RCore*)dbg->corebind.core)->config, "cfg.bigendian")) {
+		if (r_config_get_i (((RCore*)dbg->corebind.core)->config, "cfg.bigendian")) {
 			// TODO: validate that it's correct for all kinds of archs
 			switch (bytes) {
-				case 2:
-					val = r_swap_ut16(val);
-					break;
-				case 4:
-					val = r_swap_ut32(val);
-					break;
-				case 8:
-				default:
-					val = r_swap_ut64(val);
-					break;
+			case 2:
+				val = r_swap_ut16 (val);
+				break;
+			case 4:
+				val = r_swap_ut32 (val);
+				break;
+			case 8:
+			default:
+				val = r_swap_ut64 (val);
+				break;
 			}
 		}
 		gdbr_write_reg (desc, current->name, (char*)&val, bytes);

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -1101,7 +1101,7 @@ RDebugPlugin r_debug_plugin_gdb = {
 	.name = "gdb",
 	/* TODO: Add support for more architectures here */
 	.license = "LGPL3",
-	.arch = "x86,arm,sh,mips,avr,lm32,v850",
+	.arch = "x86,arm,sh,mips,avr,lm32,v850,ba2",
 	.bits = R_SYS_BITS_16 | R_SYS_BITS_32 | R_SYS_BITS_64,
 	.step = r_debug_gdb_step,
 	.cont = r_debug_gdb_continue,

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -305,6 +305,10 @@ static int r_debug_gdb_reg_write(RDebug *dbg, int type, const ut8 *buf, int size
 	}
 
 	RRegItem* current = NULL;
+	// We default to little endian if there's no way to get the configuration,
+	// since this was the behaviour prior to the change.
+	bool bigendian = dbg->corebind.core && \
+					 dbg->corebind.cfggeti (dbg->corebind.core, "cfg.bigendian");
 	for (;;) {
 		current = r_reg_next_diff (dbg->reg, type, reg_buf, buflen, current, bits);
 		if (!current) {
@@ -312,7 +316,7 @@ static int r_debug_gdb_reg_write(RDebug *dbg, int type, const ut8 *buf, int size
 		}
 		ut64 val = r_reg_get_value (dbg->reg, current);
 		int bytes = bits / 8;
-		if (r_config_get_i (((RCore*)dbg->corebind.core)->config, "cfg.bigendian")) {
+		if (bigendian) {
 			// TODO: validate that it's correct for all kinds of archs
 			switch (bytes) {
 			case 2:

--- a/libr/debug/p/gdb.mk
+++ b/libr/debug/p/gdb.mk
@@ -21,6 +21,7 @@ LDFLAGS+=-L$(LTOP)/anal -lr_anal
 LDFLAGS+=-L$(LTOP)/reg -lr_reg
 LDFLAGS+=-L$(LTOP)/bp -lr_bp
 LDFLAGS+=-L$(LTOP)/io -lr_io
+LDFLAGS+=-L$(LTOP)/config -lr_config
 
 OBJ_GDB=debug_gdb.o
 

--- a/libr/debug/p/gdb.mk
+++ b/libr/debug/p/gdb.mk
@@ -21,7 +21,6 @@ LDFLAGS+=-L$(LTOP)/anal -lr_anal
 LDFLAGS+=-L$(LTOP)/reg -lr_reg
 LDFLAGS+=-L$(LTOP)/bp -lr_bp
 LDFLAGS+=-L$(LTOP)/io -lr_io
-LDFLAGS+=-L$(LTOP)/config -lr_config
 
 OBJ_GDB=debug_gdb.o
 

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -743,7 +743,7 @@ int gdbr_write_register(libgdbr_t *g, int index, char *value, int len) {
 		return -1;
 	}
 	reg_cache.valid = false;
-	ret = snprintf (command, sizeof (command) - 1, "%s%d=", CMD_WRITEREG, index);
+	ret = snprintf (command, sizeof (command) - 1, "%s%x=", CMD_WRITEREG, index);
 	if (len + ret >= sizeof (command)) {
 		eprintf ("command is too small\n");
 		return -1;


### PR DESCRIPTION
Two fixes:
1. Byte order of the written value is target-defined. Use `cfg.bigendian` for now. Possibly get it from target later?
2. Register number in write command (`P`) should be hexadecimal.

Hope it doesn't ruin other archs - but it complies with the definitions of the protocol (https://sourceware.org/gdb/onlinedocs/gdb/Packets.html#Packets), so should actually fix existing problems that nobody reported.