### PR TITLE
Fix memleak when closing bin file

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -683,7 +683,7 @@ R_API void r_bin_file_free(void /*RBinFile*/ *_bf) {
 		bf->sdb_addrinfo = NULL;
 	}
 	free (bf->file);
-	bf->o = NULL;
+	r_bin_object_free (bf->o);
 	r_list_free (bf->xtr_data);
 	if (bf->id != -1) {
 		// TODO: use r_storage api


### PR DESCRIPTION
Before:
`SUMMARY: AddressSanitizer: 44126 byte(s) leaked in 465 allocation(s).`
Now:
`SUMMARY: AddressSanitizer: 19393 byte(s) leaked in 7 allocation(s).`