### PR TITLE
Fix renaming R_ANAL_FCN_INT-type functions

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2406,7 +2406,8 @@ static bool setFunctionName(RCore *core, ut64 off, const char *_name, bool prefi
 	r_return_val_if_fail (core && _name, false);
 	char *name = getFunctionName (core, off, _name, prefix);
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, off,
-			R_ANAL_FCN_TYPE_FCN | R_ANAL_FCN_TYPE_SYM | R_ANAL_FCN_TYPE_LOC);
+			R_ANAL_FCN_TYPE_FCN | R_ANAL_FCN_TYPE_SYM |
+			R_ANAL_FCN_TYPE_LOC | R_ANAL_FCN_TYPE_INT);
 	if (!fcn) {
 		free (name);
 		return false;


### PR DESCRIPTION
Currently R_ANAL_FCN_TYPE_INT functions (interrupt handlers) can't be renamed.

```
[0x00000000]> pdf
╭ (loc) int.00000000 6
│   int.00000000 ();
│           0x00000000      0f93           push r16
│           0x00000002      0f91           pop r16
╰           0x00000004      1895           reti

[0x00000000]> afn foobar
Cannot find function at 0x00000000

[0x00000000]> afi~type
type: int
```