### PR TITLE
Fix bound check for hud scrolling with arrow keys.

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1653,7 +1653,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 					/* arrows */
 					case 'A':	// up arrow
 						if (I.hud) {
-							if (I.hud->top_entry_n + 1 < I.hud->current_entry_n) {
+							if (I.hud->top_entry_n > 0) {
 								I.hud->top_entry_n--;
 							}
 						} else if (I.sel_widget) {
@@ -1668,7 +1668,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 						break;
 					case 'B':	// down arrow
 						if (I.hud) {
-							if (I.hud->top_entry_n >= 0) {
+							if (I.hud->top_entry_n + 1 < I.hud->current_entry_n) {
 								I.hud->top_entry_n++;
 							}
 						} else if (I.sel_widget) {


### PR DESCRIPTION
Before changes it was possible to scroll past the end of list in hud and impossible to scroll back.