### PR TITLE
Don't run ldconfig when installing into /usr

### DIFF
--- a/sys/ldconfig.sh
+++ b/sys/ldconfig.sh
@@ -4,7 +4,7 @@ if test -w $LD ; then
 	if type ldconfig > /dev/null 2>&1 ; then
 		mkdir -p $LD
 		P=$(awk -F= '/^LIBDIR/{print $2}' config-user.mk)
-		D="$(dirname "$P")"/"$(basename "$P")"
+		D="$(dirname "$P")"
 		if [ /usr != "$D" ]; then
 			echo "$P" > "$LD/radare.conf"
 			# do not update symlinks to avoid r2 install issues


### PR DESCRIPTION
It seems that commit 7e5f1f5851ea41f615bf956c54d4f48abfcf46ad attempted to prevent /etc/ld.so.conf.d/radare.conf from being added and ldconfig from being necessary when the user installs into /usr instead of /usr/local. This patch achieves that behaviour.