### PR TITLE
Fixed i4004 arch to be according to spec

### DIFF
--- a/libr/anal/p/anal_i4004.c
+++ b/libr/anal/p/anal_i4004.c
@@ -122,24 +122,29 @@ static int i4004_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case 1: //snprintf (basm, basz, "jcn %d 0x%02x", low, buf[1]); break;
 		op->type = R_ANAL_OP_TYPE_CJMP;
-		op->jump = buf[1];
+		op->jump = (addr & (~0xFF)) + buf[1];
 		op->fail = addr + rlen;
 		break;
 	case 2:
 		if (rlen == 1) {
 			snprintf (basm, basz, "scr r%d", (low & 0xe));
 		} else {
+			op->type = R_ANAL_OP_TYPE_MOV;
+			op->val = buf[1];
 			snprintf (basm, basz, "fim r%d, 0x%02x", (low & 0xe), buf[1]);
 		}
 		break;
 	case 3:
-		op->type = R_ANAL_OP_TYPE_MOV;
-		snprintf (basm, basz, "fin r%d", (low & 0xe));
+		if (low & 1 == 1) {
+			op->type = R_ANAL_OP_TYPE_RJMP;
+		} else {
+			op->type = R_ANAL_OP_TYPE_MOV;
+			snprintf (basm, basz, "fin r%d", (low & 0xe));
+		}
 		break;
 	case 4:
-		op->type = R_ANAL_OP_TYPE_CJMP;
+		op->type = R_ANAL_OP_TYPE_JMP;
 		op->jump = (ut16) (low<<8) | buf[1];
-		op->fail = addr + rlen;
 		break;
 	case 5: //snprintf (basm, basz, "jms 0x%03x", ((ut16)(low<<8) | buf[1])); break;
 		op->type = R_ANAL_OP_TYPE_CALL;
@@ -149,7 +154,11 @@ static int i4004_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case 6: //snprintf (basm, basz, "inc r%d", low); break;
 		op->type = R_ANAL_OP_TYPE_ADD;
 		break;
-	case 7: snprintf (basm, basz, "isz r%d, 0x%02x", low, buf[1]); break;
+	case 7: //snprintf (basm, basz, "isz r%d, 0x%02x", low, buf[1]); 
+		op->type = R_ANAL_OP_TYPE_CJMP;
+		op->fail = (addr & (~0xFF)) + buf[1];
+		op->jump = addr + rlen;
+		break;
 	case 8:
 		op->type = R_ANAL_OP_TYPE_ADD;
 		//snprintf (basm, basz, "add r%d", low); break;

--- a/libr/asm/arch/i4004/i4004dis.c
+++ b/libr/asm/arch/i4004/i4004dis.c
@@ -74,7 +74,13 @@ static int i4004dis (RAsmOp *op, const ut8 *buf, int len) {
 			buf_asm = sdb_fmt ("fim r%d, 0x%02x", (low & 0xe), buf[1]);
 		}
 		break;
-	case 3: buf_asm = sdb_fmt ("fin r%d", (low & 0xe)); break;
+	case 3: 
+		if (low & 1 == 1) {
+			buf_asm = sdb_fmt ("jin r%d", (low & 0xe));
+		} else {
+			buf_asm = sdb_fmt ("fin r%d", (low & 0xe)); 
+		}
+		break;
 	case 4: buf_asm = sdb_fmt ("jun 0x%03x", ((ut16)(low<<8) | buf[1])); break;
 	case 5: buf_asm = sdb_fmt ("jms 0x%03x", ((ut16)(low<<8) | buf[1])); break;
 	case 6: buf_asm = sdb_fmt ("inc r%d", low); break;


### PR DESCRIPTION
Radare is not handling jump instructions of the Intel 4004 architecture according to the specs. For additional details see [here](http://datasheets.chipdb.org/Intel/MCS-4/datashts/MCS4_Data_Sheet_Nov71.pdf) and [here](http://bitsavers.informatik.uni-stuttgart.de/components/intel/MCS4/MCS-4_Assembly_Language_Programming_Manual_Dec73.pdf).